### PR TITLE
Remove xpack info/usage `ActionType` subclasses

### DIFF
--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierTelemetryPlugin.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/cluster/routing/allocation/DataTierTelemetryPlugin.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.cluster.routing.allocation;
 
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -24,7 +25,9 @@ import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackInfoFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
 
 import java.nio.file.Path;
@@ -52,7 +55,7 @@ public class DataTierTelemetryPlugin extends LocalStateCompositeXPackPlugin {
         }
 
         @Override
-        protected List<XPackUsageFeatureAction> usageActions() {
+        protected List<ActionType<XPackUsageFeatureResponse>> usageActions() {
             return Collections.singletonList(XPackUsageFeatureAction.DATA_TIERS);
         }
     }
@@ -69,7 +72,7 @@ public class DataTierTelemetryPlugin extends LocalStateCompositeXPackPlugin {
         }
 
         @Override
-        protected List<XPackInfoFeatureAction> infoActions() {
+        protected List<ActionType<XPackInfoFeatureResponse>> infoActions() {
             return Collections.singletonList(XPackInfoFeatureAction.DATA_TIERS);
         }
     }

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/rest/action/DataTiersUsageRestCancellationIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/rest/action/DataTiersUsageRestCancellationIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.rest.action;
 
 import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -33,6 +34,7 @@ import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
 import org.elasticsearch.xpack.core.datatiers.NodesDataTiersUsageTransportAction;
 
@@ -129,7 +131,7 @@ public class DataTiersUsageRestCancellationIT extends ESIntegTestCase {
         }
 
         @Override
-        protected List<XPackUsageFeatureAction> usageActions() {
+        protected List<ActionType<XPackUsageFeatureResponse>> usageActions() {
             return List.of(XPackUsageFeatureAction.DATA_TIERS);
         }
     }

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/rest/action/XPackUsageRestCancellationIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/rest/action/XPackUsageRestCancellationIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.TransportAction;
@@ -37,7 +38,6 @@ import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackUsageAction;
-import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureTransportAction;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
@@ -53,6 +53,7 @@ import java.util.concurrent.CountDownLatch;
 import static org.elasticsearch.action.support.ActionTestUtils.wrapAsRestResponseListener;
 import static org.elasticsearch.test.TaskAssertions.assertAllCancellableTasksAreCancelled;
 import static org.elasticsearch.test.TaskAssertions.assertAllTasksHaveFinished;
+import static org.elasticsearch.xpack.core.action.XPackUsageFeatureAction.xpackUsageFeatureAction;
 import static org.hamcrest.core.IsEqual.equalTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
@@ -100,8 +101,8 @@ public class XPackUsageRestCancellationIT extends ESIntegTestCase {
     }
 
     public static class BlockingUsageActionXPackPlugin extends LocalStateCompositeXPackPlugin {
-        public static final XPackUsageFeatureAction BLOCKING_XPACK_USAGE = new XPackUsageFeatureAction("blocking_xpack_usage");
-        public static final XPackUsageFeatureAction NON_BLOCKING_XPACK_USAGE = new XPackUsageFeatureAction("regular_xpack_usage");
+        public static final ActionType<XPackUsageFeatureResponse> BLOCKING_XPACK_USAGE = xpackUsageFeatureAction("blocking_xpack_usage");
+        public static final ActionType<XPackUsageFeatureResponse> NON_BLOCKING_XPACK_USAGE = xpackUsageFeatureAction("regular_xpack_usage");
 
         public BlockingUsageActionXPackPlugin(Settings settings, Path configPath) {
             super(settings, configPath);
@@ -135,7 +136,7 @@ public class XPackUsageRestCancellationIT extends ESIntegTestCase {
         }
 
         @Override
-        protected List<XPackUsageFeatureAction> usageActions() {
+        protected List<ActionType<XPackUsageFeatureResponse>> usageActions() {
             return List.of(BlockingUsageActionXPackPlugin.BLOCKING_XPACK_USAGE, BlockingUsageActionXPackPlugin.NON_BLOCKING_XPACK_USAGE);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackInfoAction.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -31,7 +32,7 @@ public class TransportXPackInfoAction extends HandledTransportAction<XPackInfoRe
 
     private final LicenseService licenseService;
     private final NodeClient client;
-    private final List<XPackInfoFeatureAction> infoActions;
+    private final List<ActionType<XPackInfoFeatureResponse>> infoActions;
 
     @SuppressWarnings("this-escape")
     @Inject
@@ -48,7 +49,7 @@ public class TransportXPackInfoAction extends HandledTransportAction<XPackInfoRe
     }
 
     // overrideable for tests
-    protected List<XPackInfoFeatureAction> infoActions() {
+    protected List<ActionType<XPackInfoFeatureResponse>> infoActions() {
         return XPackInfoFeatureAction.ALL;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/TransportXPackUsageAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -28,7 +29,7 @@ import java.util.List;
 public class TransportXPackUsageAction extends TransportMasterNodeAction<XPackUsageRequest, XPackUsageResponse> {
 
     private final NodeClient client;
-    private final List<XPackUsageFeatureAction> usageActions;
+    private final List<ActionType<XPackUsageFeatureResponse>> usageActions;
 
     @SuppressWarnings("this-escape")
     @Inject
@@ -56,7 +57,7 @@ public class TransportXPackUsageAction extends TransportMasterNodeAction<XPackUs
     }
 
     // overrideable for tests
-    protected List<XPackUsageFeatureAction> usageActions() {
+    protected List<ActionType<XPackUsageFeatureResponse>> usageActions() {
         return XPackUsageFeatureAction.ALL;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoAction.java
@@ -10,16 +10,14 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.RemoteClusterActionType;
 import org.elasticsearch.protocol.xpack.XPackInfoResponse;
 
-public class XPackInfoAction extends ActionType<XPackInfoResponse> {
+public class XPackInfoAction {
 
     public static final String NAME = "cluster:monitor/xpack/info";
-    public static final XPackInfoAction INSTANCE = new XPackInfoAction();
+    public static final ActionType<XPackInfoResponse> INSTANCE = new ActionType<>(NAME);
     public static final RemoteClusterActionType<XPackInfoResponse> REMOTE_TYPE = new RemoteClusterActionType<>(
         NAME,
         XPackInfoResponse::new
     );
 
-    public XPackInfoAction() {
-        super(NAME);
-    }
+    private XPackInfoAction() {/* no instances */}
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackInfoFeatureAction.java
@@ -9,9 +9,6 @@ package org.elasticsearch.xpack.core.action;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.xpack.core.XPackField;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -21,79 +18,69 @@ import java.util.List;
  * {@link XPackInfoAction} implementation iterates over the {@link #ALL} list of actions to form
  * the complete info result.
  */
-public class XPackInfoFeatureAction extends ActionType<XPackInfoFeatureResponse> {
+public class XPackInfoFeatureAction {
 
     private static final String BASE_NAME = "cluster:monitor/xpack/info/";
 
-    public static final XPackInfoFeatureAction SECURITY = new XPackInfoFeatureAction(XPackField.SECURITY);
-    public static final XPackInfoFeatureAction MONITORING = new XPackInfoFeatureAction(XPackField.MONITORING);
-    public static final XPackInfoFeatureAction WATCHER = new XPackInfoFeatureAction(XPackField.WATCHER);
-    public static final XPackInfoFeatureAction GRAPH = new XPackInfoFeatureAction(XPackField.GRAPH);
-    public static final XPackInfoFeatureAction MACHINE_LEARNING = new XPackInfoFeatureAction(XPackField.MACHINE_LEARNING);
-    public static final XPackInfoFeatureAction LOGSTASH = new XPackInfoFeatureAction(XPackField.LOGSTASH);
-    public static final XPackInfoFeatureAction EQL = new XPackInfoFeatureAction(XPackField.EQL);
-    public static final XPackInfoFeatureAction ESQL = new XPackInfoFeatureAction(XPackField.ESQL);
-    public static final XPackInfoFeatureAction SQL = new XPackInfoFeatureAction(XPackField.SQL);
-    public static final XPackInfoFeatureAction ROLLUP = new XPackInfoFeatureAction(XPackField.ROLLUP);
-    public static final XPackInfoFeatureAction INDEX_LIFECYCLE = new XPackInfoFeatureAction(XPackField.INDEX_LIFECYCLE);
-    public static final XPackInfoFeatureAction SNAPSHOT_LIFECYCLE = new XPackInfoFeatureAction(XPackField.SNAPSHOT_LIFECYCLE);
-    public static final XPackInfoFeatureAction CCR = new XPackInfoFeatureAction(XPackField.CCR);
-    public static final XPackInfoFeatureAction TRANSFORM = new XPackInfoFeatureAction(XPackField.TRANSFORM);
-    public static final XPackInfoFeatureAction VOTING_ONLY = new XPackInfoFeatureAction(XPackField.VOTING_ONLY);
-    public static final XPackInfoFeatureAction FROZEN_INDICES = new XPackInfoFeatureAction(XPackField.FROZEN_INDICES);
-    public static final XPackInfoFeatureAction SPATIAL = new XPackInfoFeatureAction(XPackField.SPATIAL);
-    public static final XPackInfoFeatureAction ANALYTICS = new XPackInfoFeatureAction(XPackField.ANALYTICS);
-    public static final XPackInfoFeatureAction ENRICH = new XPackInfoFeatureAction(XPackField.ENRICH);
-    public static final XPackInfoFeatureAction SEARCHABLE_SNAPSHOTS = new XPackInfoFeatureAction(XPackField.SEARCHABLE_SNAPSHOTS);
-    public static final XPackInfoFeatureAction DATA_STREAMS = new XPackInfoFeatureAction(XPackField.DATA_STREAMS);
-    public static final XPackInfoFeatureAction DATA_TIERS = new XPackInfoFeatureAction(XPackField.DATA_TIERS);
-    public static final XPackInfoFeatureAction AGGREGATE_METRIC = new XPackInfoFeatureAction(XPackField.AGGREGATE_METRIC);
-    public static final XPackInfoFeatureAction ARCHIVE = new XPackInfoFeatureAction(XPackField.ARCHIVE);
-    public static final XPackInfoFeatureAction ENTERPRISE_SEARCH = new XPackInfoFeatureAction(XPackField.ENTERPRISE_SEARCH);
-    public static final XPackInfoFeatureAction UNIVERSAL_PROFILING = new XPackInfoFeatureAction(XPackField.UNIVERSAL_PROFILING);
+    public static final ActionType<XPackInfoFeatureResponse> SECURITY = xpackInfoFeatureAction(XPackField.SECURITY);
+    public static final ActionType<XPackInfoFeatureResponse> MONITORING = xpackInfoFeatureAction(XPackField.MONITORING);
+    public static final ActionType<XPackInfoFeatureResponse> WATCHER = xpackInfoFeatureAction(XPackField.WATCHER);
+    public static final ActionType<XPackInfoFeatureResponse> GRAPH = xpackInfoFeatureAction(XPackField.GRAPH);
+    public static final ActionType<XPackInfoFeatureResponse> MACHINE_LEARNING = xpackInfoFeatureAction(XPackField.MACHINE_LEARNING);
+    public static final ActionType<XPackInfoFeatureResponse> LOGSTASH = xpackInfoFeatureAction(XPackField.LOGSTASH);
+    public static final ActionType<XPackInfoFeatureResponse> EQL = xpackInfoFeatureAction(XPackField.EQL);
+    public static final ActionType<XPackInfoFeatureResponse> ESQL = xpackInfoFeatureAction(XPackField.ESQL);
+    public static final ActionType<XPackInfoFeatureResponse> SQL = xpackInfoFeatureAction(XPackField.SQL);
+    public static final ActionType<XPackInfoFeatureResponse> ROLLUP = xpackInfoFeatureAction(XPackField.ROLLUP);
+    public static final ActionType<XPackInfoFeatureResponse> INDEX_LIFECYCLE = xpackInfoFeatureAction(XPackField.INDEX_LIFECYCLE);
+    public static final ActionType<XPackInfoFeatureResponse> SNAPSHOT_LIFECYCLE = xpackInfoFeatureAction(XPackField.SNAPSHOT_LIFECYCLE);
+    public static final ActionType<XPackInfoFeatureResponse> CCR = xpackInfoFeatureAction(XPackField.CCR);
+    public static final ActionType<XPackInfoFeatureResponse> TRANSFORM = xpackInfoFeatureAction(XPackField.TRANSFORM);
+    public static final ActionType<XPackInfoFeatureResponse> VOTING_ONLY = xpackInfoFeatureAction(XPackField.VOTING_ONLY);
+    public static final ActionType<XPackInfoFeatureResponse> FROZEN_INDICES = xpackInfoFeatureAction(XPackField.FROZEN_INDICES);
+    public static final ActionType<XPackInfoFeatureResponse> SPATIAL = xpackInfoFeatureAction(XPackField.SPATIAL);
+    public static final ActionType<XPackInfoFeatureResponse> ANALYTICS = xpackInfoFeatureAction(XPackField.ANALYTICS);
+    public static final ActionType<XPackInfoFeatureResponse> ENRICH = xpackInfoFeatureAction(XPackField.ENRICH);
+    public static final ActionType<XPackInfoFeatureResponse> SEARCHABLE_SNAPSHOTS = xpackInfoFeatureAction(XPackField.SEARCHABLE_SNAPSHOTS);
+    public static final ActionType<XPackInfoFeatureResponse> DATA_STREAMS = xpackInfoFeatureAction(XPackField.DATA_STREAMS);
+    public static final ActionType<XPackInfoFeatureResponse> DATA_TIERS = xpackInfoFeatureAction(XPackField.DATA_TIERS);
+    public static final ActionType<XPackInfoFeatureResponse> AGGREGATE_METRIC = xpackInfoFeatureAction(XPackField.AGGREGATE_METRIC);
+    public static final ActionType<XPackInfoFeatureResponse> ARCHIVE = xpackInfoFeatureAction(XPackField.ARCHIVE);
+    public static final ActionType<XPackInfoFeatureResponse> ENTERPRISE_SEARCH = xpackInfoFeatureAction(XPackField.ENTERPRISE_SEARCH);
+    public static final ActionType<XPackInfoFeatureResponse> UNIVERSAL_PROFILING = xpackInfoFeatureAction(XPackField.UNIVERSAL_PROFILING);
 
-    public static final List<XPackInfoFeatureAction> ALL;
-    static {
-        final List<XPackInfoFeatureAction> actions = new ArrayList<>();
-        actions.addAll(
-            Arrays.asList(
-                SECURITY,
-                MONITORING,
-                WATCHER,
-                GRAPH,
-                MACHINE_LEARNING,
-                LOGSTASH,
-                EQL,
-                ESQL,
-                SQL,
-                ROLLUP,
-                INDEX_LIFECYCLE,
-                SNAPSHOT_LIFECYCLE,
-                CCR,
-                TRANSFORM,
-                VOTING_ONLY,
-                FROZEN_INDICES,
-                SPATIAL,
-                ANALYTICS,
-                ENRICH,
-                DATA_STREAMS,
-                SEARCHABLE_SNAPSHOTS,
-                DATA_TIERS,
-                AGGREGATE_METRIC,
-                ARCHIVE,
-                ENTERPRISE_SEARCH,
-                UNIVERSAL_PROFILING
-            )
-        );
-        ALL = Collections.unmodifiableList(actions);
+    public static final List<ActionType<XPackInfoFeatureResponse>> ALL = List.of(
+        SECURITY,
+        MONITORING,
+        WATCHER,
+        GRAPH,
+        MACHINE_LEARNING,
+        LOGSTASH,
+        EQL,
+        ESQL,
+        SQL,
+        ROLLUP,
+        INDEX_LIFECYCLE,
+        SNAPSHOT_LIFECYCLE,
+        CCR,
+        TRANSFORM,
+        VOTING_ONLY,
+        FROZEN_INDICES,
+        SPATIAL,
+        ANALYTICS,
+        ENRICH,
+        DATA_STREAMS,
+        SEARCHABLE_SNAPSHOTS,
+        DATA_TIERS,
+        AGGREGATE_METRIC,
+        ARCHIVE,
+        ENTERPRISE_SEARCH,
+        UNIVERSAL_PROFILING
+    );
+
+    public static ActionType<XPackInfoFeatureResponse> xpackInfoFeatureAction(String suffix) {
+        return new ActionType<>(BASE_NAME + suffix);
     }
 
-    private XPackInfoFeatureAction(String name) {
-        super(BASE_NAME + name);
-    }
-
-    @Override
-    public String toString() {
-        return "ActionType [" + name() + "]";
-    }
+    private XPackInfoFeatureAction() {/* no instances */}
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageAction.java
@@ -8,12 +8,10 @@ package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionType;
 
-public class XPackUsageAction extends ActionType<XPackUsageResponse> {
+public class XPackUsageAction {
 
     public static final String NAME = "cluster:monitor/xpack/usage";
-    public static final XPackUsageAction INSTANCE = new XPackUsageAction();
+    public static final ActionType<XPackUsageResponse> INSTANCE = new ActionType<>(NAME);
 
-    public XPackUsageAction() {
-        super(NAME);
-    }
+    private XPackUsageAction() {/* no instances */}
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageFeatureAction.java
@@ -18,42 +18,48 @@ import java.util.List;
  * {@link XPackUsageAction} implementation iterates over the {@link #ALL} list of actions to form
  * the complete usage result.
  */
-public class XPackUsageFeatureAction extends ActionType<XPackUsageFeatureResponse> {
+public final class XPackUsageFeatureAction {
+
+    private XPackUsageFeatureAction() {/* no instances */}
 
     private static final String BASE_NAME = "cluster:monitor/xpack/usage/";
 
-    public static final XPackUsageFeatureAction SECURITY = new XPackUsageFeatureAction(XPackField.SECURITY);
-    public static final XPackUsageFeatureAction MONITORING = new XPackUsageFeatureAction(XPackField.MONITORING);
-    public static final XPackUsageFeatureAction WATCHER = new XPackUsageFeatureAction(XPackField.WATCHER);
-    public static final XPackUsageFeatureAction GRAPH = new XPackUsageFeatureAction(XPackField.GRAPH);
-    public static final XPackUsageFeatureAction MACHINE_LEARNING = new XPackUsageFeatureAction(XPackField.MACHINE_LEARNING);
-    public static final XPackUsageFeatureAction INFERENCE = new XPackUsageFeatureAction(XPackField.INFERENCE);
-    public static final XPackUsageFeatureAction LOGSTASH = new XPackUsageFeatureAction(XPackField.LOGSTASH);
-    public static final XPackUsageFeatureAction EQL = new XPackUsageFeatureAction(XPackField.EQL);
-    public static final XPackUsageFeatureAction ESQL = new XPackUsageFeatureAction(XPackField.ESQL);
-    public static final XPackUsageFeatureAction SQL = new XPackUsageFeatureAction(XPackField.SQL);
-    public static final XPackUsageFeatureAction ROLLUP = new XPackUsageFeatureAction(XPackField.ROLLUP);
-    public static final XPackUsageFeatureAction INDEX_LIFECYCLE = new XPackUsageFeatureAction(XPackField.INDEX_LIFECYCLE);
-    public static final XPackUsageFeatureAction SNAPSHOT_LIFECYCLE = new XPackUsageFeatureAction(XPackField.SNAPSHOT_LIFECYCLE);
-    public static final XPackUsageFeatureAction CCR = new XPackUsageFeatureAction(XPackField.CCR);
-    public static final XPackUsageFeatureAction TRANSFORM = new XPackUsageFeatureAction(XPackField.TRANSFORM);
-    public static final XPackUsageFeatureAction VOTING_ONLY = new XPackUsageFeatureAction(XPackField.VOTING_ONLY);
-    public static final XPackUsageFeatureAction FROZEN_INDICES = new XPackUsageFeatureAction(XPackField.FROZEN_INDICES);
-    public static final XPackUsageFeatureAction SPATIAL = new XPackUsageFeatureAction(XPackField.SPATIAL);
-    public static final XPackUsageFeatureAction ANALYTICS = new XPackUsageFeatureAction(XPackField.ANALYTICS);
-    public static final XPackUsageFeatureAction ENRICH = new XPackUsageFeatureAction(XPackField.ENRICH);
-    public static final XPackUsageFeatureAction SEARCHABLE_SNAPSHOTS = new XPackUsageFeatureAction(XPackField.SEARCHABLE_SNAPSHOTS);
-    public static final XPackUsageFeatureAction DATA_STREAMS = new XPackUsageFeatureAction(XPackField.DATA_STREAMS);
-    public static final XPackUsageFeatureAction DATA_STREAM_LIFECYCLE = new XPackUsageFeatureAction(XPackField.DATA_STREAM_LIFECYCLE);
-    public static final XPackUsageFeatureAction DATA_TIERS = new XPackUsageFeatureAction(XPackField.DATA_TIERS);
-    public static final XPackUsageFeatureAction AGGREGATE_METRIC = new XPackUsageFeatureAction(XPackField.AGGREGATE_METRIC);
-    public static final XPackUsageFeatureAction ARCHIVE = new XPackUsageFeatureAction(XPackField.ARCHIVE);
-    public static final XPackUsageFeatureAction HEALTH = new XPackUsageFeatureAction(XPackField.HEALTH_API);
-    public static final XPackUsageFeatureAction REMOTE_CLUSTERS = new XPackUsageFeatureAction(XPackField.REMOTE_CLUSTERS);
-    public static final XPackUsageFeatureAction ENTERPRISE_SEARCH = new XPackUsageFeatureAction(XPackField.ENTERPRISE_SEARCH);
-    public static final XPackUsageFeatureAction UNIVERSAL_PROFILING = new XPackUsageFeatureAction(XPackField.UNIVERSAL_PROFILING);
+    public static final ActionType<XPackUsageFeatureResponse> SECURITY = xpackUsageFeatureAction(XPackField.SECURITY);
+    public static final ActionType<XPackUsageFeatureResponse> MONITORING = xpackUsageFeatureAction(XPackField.MONITORING);
+    public static final ActionType<XPackUsageFeatureResponse> WATCHER = xpackUsageFeatureAction(XPackField.WATCHER);
+    public static final ActionType<XPackUsageFeatureResponse> GRAPH = xpackUsageFeatureAction(XPackField.GRAPH);
+    public static final ActionType<XPackUsageFeatureResponse> MACHINE_LEARNING = xpackUsageFeatureAction(XPackField.MACHINE_LEARNING);
+    public static final ActionType<XPackUsageFeatureResponse> INFERENCE = xpackUsageFeatureAction(XPackField.INFERENCE);
+    public static final ActionType<XPackUsageFeatureResponse> LOGSTASH = xpackUsageFeatureAction(XPackField.LOGSTASH);
+    public static final ActionType<XPackUsageFeatureResponse> EQL = xpackUsageFeatureAction(XPackField.EQL);
+    public static final ActionType<XPackUsageFeatureResponse> ESQL = xpackUsageFeatureAction(XPackField.ESQL);
+    public static final ActionType<XPackUsageFeatureResponse> SQL = xpackUsageFeatureAction(XPackField.SQL);
+    public static final ActionType<XPackUsageFeatureResponse> ROLLUP = xpackUsageFeatureAction(XPackField.ROLLUP);
+    public static final ActionType<XPackUsageFeatureResponse> INDEX_LIFECYCLE = xpackUsageFeatureAction(XPackField.INDEX_LIFECYCLE);
+    public static final ActionType<XPackUsageFeatureResponse> SNAPSHOT_LIFECYCLE = xpackUsageFeatureAction(XPackField.SNAPSHOT_LIFECYCLE);
+    public static final ActionType<XPackUsageFeatureResponse> CCR = xpackUsageFeatureAction(XPackField.CCR);
+    public static final ActionType<XPackUsageFeatureResponse> TRANSFORM = xpackUsageFeatureAction(XPackField.TRANSFORM);
+    public static final ActionType<XPackUsageFeatureResponse> VOTING_ONLY = xpackUsageFeatureAction(XPackField.VOTING_ONLY);
+    public static final ActionType<XPackUsageFeatureResponse> FROZEN_INDICES = xpackUsageFeatureAction(XPackField.FROZEN_INDICES);
+    public static final ActionType<XPackUsageFeatureResponse> SPATIAL = xpackUsageFeatureAction(XPackField.SPATIAL);
+    public static final ActionType<XPackUsageFeatureResponse> ANALYTICS = xpackUsageFeatureAction(XPackField.ANALYTICS);
+    public static final ActionType<XPackUsageFeatureResponse> ENRICH = xpackUsageFeatureAction(XPackField.ENRICH);
+    public static final ActionType<XPackUsageFeatureResponse> SEARCHABLE_SNAPSHOTS = xpackUsageFeatureAction(
+        XPackField.SEARCHABLE_SNAPSHOTS
+    );
+    public static final ActionType<XPackUsageFeatureResponse> DATA_STREAMS = xpackUsageFeatureAction(XPackField.DATA_STREAMS);
+    public static final ActionType<XPackUsageFeatureResponse> DATA_STREAM_LIFECYCLE = xpackUsageFeatureAction(
+        XPackField.DATA_STREAM_LIFECYCLE
+    );
+    public static final ActionType<XPackUsageFeatureResponse> DATA_TIERS = xpackUsageFeatureAction(XPackField.DATA_TIERS);
+    public static final ActionType<XPackUsageFeatureResponse> AGGREGATE_METRIC = xpackUsageFeatureAction(XPackField.AGGREGATE_METRIC);
+    public static final ActionType<XPackUsageFeatureResponse> ARCHIVE = xpackUsageFeatureAction(XPackField.ARCHIVE);
+    public static final ActionType<XPackUsageFeatureResponse> HEALTH = xpackUsageFeatureAction(XPackField.HEALTH_API);
+    public static final ActionType<XPackUsageFeatureResponse> REMOTE_CLUSTERS = xpackUsageFeatureAction(XPackField.REMOTE_CLUSTERS);
+    public static final ActionType<XPackUsageFeatureResponse> ENTERPRISE_SEARCH = xpackUsageFeatureAction(XPackField.ENTERPRISE_SEARCH);
+    public static final ActionType<XPackUsageFeatureResponse> UNIVERSAL_PROFILING = xpackUsageFeatureAction(XPackField.UNIVERSAL_PROFILING);
 
-    static final List<XPackUsageFeatureAction> ALL = List.of(
+    static final List<ActionType<XPackUsageFeatureResponse>> ALL = List.of(
         AGGREGATE_METRIC,
         ANALYTICS,
         CCR,
@@ -85,13 +91,7 @@ public class XPackUsageFeatureAction extends ActionType<XPackUsageFeatureRespons
         UNIVERSAL_PROFILING
     );
 
-    // public for testing
-    public XPackUsageFeatureAction(String name) {
-        super(BASE_NAME + name);
-    }
-
-    @Override
-    public String toString() {
-        return "ActionType [" + name() + "]";
+    public static ActionType<XPackUsageFeatureResponse> xpackUsageFeatureAction(String suffix) {
+        return new ActionType<>(BASE_NAME + suffix);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/action/XPackUsageRequestBuilder.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.action;
 
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeOperationRequestBuilder;
 import org.elasticsearch.client.internal.ElasticsearchClient;
 import org.elasticsearch.protocol.xpack.XPackUsageRequest;
@@ -19,7 +20,7 @@ public class XPackUsageRequestBuilder extends MasterNodeOperationRequestBuilder<
         this(client, XPackUsageAction.INSTANCE);
     }
 
-    public XPackUsageRequestBuilder(ElasticsearchClient client, XPackUsageAction action) {
+    public XPackUsageRequestBuilder(ElasticsearchClient client, ActionType<XPackUsageResponse> action) {
         super(client, action, new XPackUsageRequest());
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/action/TransportXPackInfoActionTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.license.License;
@@ -48,9 +49,9 @@ public class TransportXPackInfoActionTests extends ESTestCase {
         LicenseService licenseService = mock(LicenseService.class);
 
         NodeClient client = mock(NodeClient.class);
-        Map<XPackInfoFeatureAction, FeatureSet> featureSets = new HashMap<>();
+        Map<ActionType<XPackInfoFeatureResponse>, FeatureSet> featureSets = new HashMap<>();
         int featureSetCount = randomIntBetween(0, 5);
-        for (XPackInfoFeatureAction infoAction : randomSubsetOf(featureSetCount, XPackInfoFeatureAction.ALL)) {
+        for (ActionType<XPackInfoFeatureResponse> infoAction : randomSubsetOf(featureSetCount, XPackInfoFeatureAction.ALL)) {
             FeatureSet featureSet = new FeatureSet(randomAlphaOfLength(5), randomBoolean(), randomBoolean());
             featureSets.put(infoAction, featureSet);
             when(client.executeLocally(eq(infoAction), any(ActionRequest.class), any(ActionListener.class))).thenAnswer(answer -> {
@@ -68,7 +69,7 @@ public class TransportXPackInfoActionTests extends ESTestCase {
             client
         ) {
             @Override
-            protected List<XPackInfoFeatureAction> infoActions() {
+            protected List<ActionType<XPackInfoFeatureResponse>> infoActions() {
                 return new ArrayList<>(featureSets.keySet());
             }
         };

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/LocalStateEnrich.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/LocalStateEnrich.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.enrich;
 
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -19,6 +20,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackInfoFeatureResponse;
 
 import java.nio.file.Path;
 import java.util.Collections;
@@ -49,7 +51,7 @@ public class LocalStateEnrich extends LocalStateCompositeXPackPlugin {
         }
 
         @Override
-        protected List<XPackInfoFeatureAction> infoActions() {
+        protected List<ActionType<XPackInfoFeatureResponse>> infoActions() {
             return Collections.singletonList(XPackInfoFeatureAction.ENRICH);
         }
     }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersEnrichIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/CrossClustersEnrichIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
@@ -29,6 +30,7 @@ import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackInfoFeatureResponse;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.core.enrich.action.DeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
@@ -163,7 +165,7 @@ public class CrossClustersEnrichIT extends AbstractMultiClustersTestCase {
             }
 
             @Override
-            protected List<XPackInfoFeatureAction> infoActions() {
+            protected List<ActionType<XPackInfoFeatureResponse>> infoActions() {
                 return Collections.singletonList(XPackInfoFeatureAction.ENRICH);
             }
         }

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EnrichIT.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.action;
 
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
@@ -32,6 +33,7 @@ import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackInfoFeatureResponse;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.core.enrich.action.DeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
@@ -339,7 +341,7 @@ public class EnrichIT extends AbstractEsqlIntegTestCase {
             }
 
             @Override
-            protected List<XPackInfoFeatureAction> infoActions() {
+            protected List<ActionType<XPackInfoFeatureResponse>> infoActions() {
                 return Collections.singletonList(XPackInfoFeatureAction.ENRICH);
             }
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.test.ESTestCase;
@@ -229,13 +228,13 @@ public class MachineLearningTests extends ESTestCase {
             assertThat(restHandlers, not(hasItem(instanceOf(RestGetTrainedModelsAction.class))));
             assertThat(restHandlers, not(hasItem(instanceOf(RestGetDataFrameAnalyticsAction.class))));
             assertThat(restHandlers, not(hasItem(instanceOf(RestStartTrainedModelDeploymentAction.class))));
-            List<?> actions = machineLearning.getActions().stream().map(ActionPlugin.ActionHandler::getAction).toList();
-            assertThat(actions, hasItem(instanceOf(XPackUsageFeatureAction.class)));
-            assertThat(actions, hasItem(instanceOf(MlInfoAction.class)));
-            assertThat(actions, hasItem(instanceOf(GetJobsAction.class)));
-            assertThat(actions, not(hasItem(instanceOf(GetTrainedModelsAction.class))));
-            assertThat(actions, not(hasItem(instanceOf(GetDataFrameAnalyticsAction.class))));
-            assertThat(actions, not(hasItem(instanceOf(StartTrainedModelDeploymentAction.class))));
+            List<Object> actions = machineLearning.getActions().stream().map(h -> (Object) h.getAction()).toList();
+            assertThat(actions, hasItem(XPackUsageFeatureAction.MACHINE_LEARNING));
+            assertThat(actions, hasItem(MlInfoAction.INSTANCE));
+            assertThat(actions, hasItem(GetJobsAction.INSTANCE));
+            assertThat(actions, not(hasItem(GetTrainedModelsAction.INSTANCE)));
+            assertThat(actions, not(hasItem(GetDataFrameAnalyticsAction.INSTANCE)));
+            assertThat(actions, not(hasItem(StartTrainedModelDeploymentAction.INSTANCE)));
         }
     }
 
@@ -249,13 +248,13 @@ public class MachineLearningTests extends ESTestCase {
             assertThat(restHandlers, hasItem(instanceOf(RestGetTrainedModelsAction.class)));
             assertThat(restHandlers, hasItem(instanceOf(RestGetDataFrameAnalyticsAction.class)));
             assertThat(restHandlers, not(hasItem(instanceOf(RestStartTrainedModelDeploymentAction.class))));
-            List<?> actions = machineLearning.getActions().stream().map(ActionPlugin.ActionHandler::getAction).toList();
-            assertThat(actions, hasItem(instanceOf(XPackUsageFeatureAction.class)));
-            assertThat(actions, hasItem(instanceOf(MlInfoAction.class)));
-            assertThat(actions, not(hasItem(instanceOf(GetJobsAction.class))));
-            assertThat(actions, hasItem(instanceOf(GetTrainedModelsAction.class)));
-            assertThat(actions, hasItem(instanceOf(GetDataFrameAnalyticsAction.class)));
-            assertThat(actions, not(hasItem(instanceOf(StartTrainedModelDeploymentAction.class))));
+            List<Object> actions = machineLearning.getActions().stream().map(h -> (Object) h.getAction()).toList();
+            assertThat(actions, hasItem(XPackUsageFeatureAction.MACHINE_LEARNING));
+            assertThat(actions, hasItem(MlInfoAction.INSTANCE));
+            assertThat(actions, not(hasItem(GetJobsAction.INSTANCE)));
+            assertThat(actions, hasItem(GetTrainedModelsAction.INSTANCE));
+            assertThat(actions, hasItem(GetDataFrameAnalyticsAction.INSTANCE));
+            assertThat(actions, not(hasItem(StartTrainedModelDeploymentAction.INSTANCE)));
         }
     }
 
@@ -269,13 +268,13 @@ public class MachineLearningTests extends ESTestCase {
             assertThat(restHandlers, hasItem(instanceOf(RestGetTrainedModelsAction.class)));
             assertThat(restHandlers, not(hasItem(instanceOf(RestGetDataFrameAnalyticsAction.class))));
             assertThat(restHandlers, hasItem(instanceOf(RestStartTrainedModelDeploymentAction.class)));
-            List<?> actions = machineLearning.getActions().stream().map(ActionPlugin.ActionHandler::getAction).toList();
-            assertThat(actions, hasItem(instanceOf(XPackUsageFeatureAction.class)));
-            assertThat(actions, hasItem(instanceOf(MlInfoAction.class)));
-            assertThat(actions, not(hasItem(instanceOf(GetJobsAction.class))));
-            assertThat(actions, hasItem(instanceOf(GetTrainedModelsAction.class)));
-            assertThat(actions, not(hasItem(instanceOf(GetDataFrameAnalyticsAction.class))));
-            assertThat(actions, hasItem(instanceOf(StartTrainedModelDeploymentAction.class)));
+            List<Object> actions = machineLearning.getActions().stream().map(h -> (Object) h.getAction()).toList();
+            assertThat(actions, hasItem(XPackUsageFeatureAction.MACHINE_LEARNING));
+            assertThat(actions, hasItem(MlInfoAction.INSTANCE));
+            assertThat(actions, not(hasItem(GetJobsAction.INSTANCE)));
+            assertThat(actions, hasItem(GetTrainedModelsAction.INSTANCE));
+            assertThat(actions, not(hasItem(GetDataFrameAnalyticsAction.INSTANCE)));
+            assertThat(actions, hasItem(StartTrainedModelDeploymentAction.INSTANCE));
         }
     }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/LocalStateMonitoring.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/LocalStateMonitoring.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.monitoring;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.TransportAction;
@@ -28,6 +29,7 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
 import org.elasticsearch.xpack.core.ccr.AutoFollowStats;
 import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
@@ -57,7 +59,7 @@ public class LocalStateMonitoring extends LocalStateCompositeXPackPlugin {
         }
 
         @Override
-        protected List<XPackUsageFeatureAction> usageActions() {
+        protected List<ActionType<XPackUsageFeatureResponse>> usageActions() {
             return Collections.singletonList(XPackUsageFeatureAction.MONITORING);
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/LocalStateSecurity.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security;
 
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -26,7 +27,9 @@ import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.action.TransportXPackInfoAction;
 import org.elasticsearch.xpack.core.action.TransportXPackUsageAction;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackInfoFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
+import org.elasticsearch.xpack.core.action.XPackUsageFeatureResponse;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
 import org.elasticsearch.xpack.core.security.SecurityExtension;
 import org.elasticsearch.xpack.core.ssl.SSLService;
@@ -53,7 +56,7 @@ public class LocalStateSecurity extends LocalStateCompositeXPackPlugin implement
         }
 
         @Override
-        protected List<XPackUsageFeatureAction> usageActions() {
+        protected List<ActionType<XPackUsageFeatureResponse>> usageActions() {
             return Collections.singletonList(XPackUsageFeatureAction.SECURITY);
         }
     }
@@ -70,7 +73,7 @@ public class LocalStateSecurity extends LocalStateCompositeXPackPlugin implement
         }
 
         @Override
-        protected List<XPackInfoFeatureAction> infoActions() {
+        protected List<ActionType<XPackInfoFeatureResponse>> infoActions() {
             return Collections.singletonList(XPackInfoFeatureAction.SECURITY);
         }
     }


### PR DESCRIPTION
Just use `ActionType` directly in this area of the codebase.