### PR TITLE
Clean up ActionType subclasses in ent search

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/DeleteAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/DeleteAnalyticsCollectionAction.java
@@ -26,14 +26,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class DeleteAnalyticsCollectionAction extends ActionType<AcknowledgedResponse> {
+public class DeleteAnalyticsCollectionAction {
 
-    public static final DeleteAnalyticsCollectionAction INSTANCE = new DeleteAnalyticsCollectionAction();
     public static final String NAME = "cluster:admin/xpack/application/analytics/delete";
+    public static final ActionType<AcknowledgedResponse> INSTANCE = new ActionType<>(NAME);
 
-    private DeleteAnalyticsCollectionAction() {
-        super(NAME);
-    }
+    private DeleteAnalyticsCollectionAction() {/* no instances */}
 
     public static class Request extends MasterNodeRequest<Request> implements ToXContentObject {
         private final String collectionName;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionAction.java
@@ -28,14 +28,12 @@ import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class GetAnalyticsCollectionAction extends ActionType<GetAnalyticsCollectionAction.Response> {
+public class GetAnalyticsCollectionAction {
 
-    public static final GetAnalyticsCollectionAction INSTANCE = new GetAnalyticsCollectionAction();
     public static final String NAME = "cluster:admin/xpack/application/analytics/get";
+    public static final ActionType<GetAnalyticsCollectionAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    private GetAnalyticsCollectionAction() {
-        super(NAME);
-    }
+    private GetAnalyticsCollectionAction() {/* no instances */}
 
     public static class Request extends MasterNodeReadRequest<Request> implements ToXContentObject {
         private final String[] names;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -36,15 +36,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventAction.Response> {
-
-    public static final PostAnalyticsEventAction INSTANCE = new PostAnalyticsEventAction();
+public class PostAnalyticsEventAction {
 
     public static final String NAME = "cluster:admin/xpack/application/analytics/post_event";
+    public static final ActionType<PostAnalyticsEventAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    private PostAnalyticsEventAction() {
-        super(NAME);
-    }
+    private PostAnalyticsEventAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements AnalyticsEvent.Context, ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionAction.java
@@ -25,14 +25,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class PutAnalyticsCollectionAction extends ActionType<PutAnalyticsCollectionAction.Response> {
+public class PutAnalyticsCollectionAction {
 
-    public static final PutAnalyticsCollectionAction INSTANCE = new PutAnalyticsCollectionAction();
     public static final String NAME = "cluster:admin/xpack/application/analytics/put";
+    public static final ActionType<PutAnalyticsCollectionAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public PutAnalyticsCollectionAction() {
-        super(NAME);
-    }
+    private PutAnalyticsCollectionAction() {/* no instances */}
 
     public static class Request extends MasterNodeRequest<Request> implements ToXContentObject {
         private final String name;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/DeleteConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/DeleteConnectorAction.java
@@ -26,14 +26,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class DeleteConnectorAction extends ActionType<AcknowledgedResponse> {
+public class DeleteConnectorAction {
 
-    public static final DeleteConnectorAction INSTANCE = new DeleteConnectorAction();
     public static final String NAME = "cluster:admin/xpack/connector/delete";
+    public static final ActionType<AcknowledgedResponse> INSTANCE = new ActionType<>(NAME);
 
-    private DeleteConnectorAction() {
-        super(NAME);
-    }
+    private DeleteConnectorAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/GetConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/GetConnectorAction.java
@@ -27,14 +27,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class GetConnectorAction extends ActionType<GetConnectorAction.Response> {
+public class GetConnectorAction {
 
-    public static final GetConnectorAction INSTANCE = new GetConnectorAction();
     public static final String NAME = "cluster:admin/xpack/connector/get";
+    public static final ActionType<GetConnectorAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    private GetConnectorAction() {
-        super(NAME);
-    }
+    private GetConnectorAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
@@ -28,14 +28,12 @@ import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class ListConnectorAction extends ActionType<ListConnectorAction.Response> {
+public class ListConnectorAction {
 
-    public static final ListConnectorAction INSTANCE = new ListConnectorAction();
     public static final String NAME = "cluster:admin/xpack/connector/list";
+    public static final ActionType<ListConnectorAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public ListConnectorAction() {
-        super(NAME);
-    }
+    private ListConnectorAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/PostConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/PostConnectorAction.java
@@ -36,14 +36,12 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class PostConnectorAction extends ActionType<PostConnectorAction.Response> {
+public class PostConnectorAction {
 
-    public static final PostConnectorAction INSTANCE = new PostConnectorAction();
     public static final String NAME = "cluster:admin/xpack/connector/post";
+    public static final ActionType<PostConnectorAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public PostConnectorAction() {
-        super(NAME);
-    }
+    private PostConnectorAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/PutConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/PutConnectorAction.java
@@ -36,14 +36,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class PutConnectorAction extends ActionType<PutConnectorAction.Response> {
+public class PutConnectorAction {
 
-    public static final PutConnectorAction INSTANCE = new PutConnectorAction();
     public static final String NAME = "cluster:admin/xpack/connector/put";
+    public static final ActionType<PutConnectorAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public PutConnectorAction() {
-        super(NAME);
-    }
+    private PutConnectorAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorConfigurationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorConfigurationAction.java
@@ -34,14 +34,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class UpdateConnectorConfigurationAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorConfigurationAction {
 
-    public static final UpdateConnectorConfigurationAction INSTANCE = new UpdateConnectorConfigurationAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_configuration";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorConfigurationAction() {
-        super(NAME);
-    }
+    private UpdateConnectorConfigurationAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorErrorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorErrorAction.java
@@ -31,14 +31,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class UpdateConnectorErrorAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorErrorAction {
 
-    public static final UpdateConnectorErrorAction INSTANCE = new UpdateConnectorErrorAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_error";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorErrorAction() {
-        super(NAME);
-    }
+    private UpdateConnectorErrorAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringAction.java
@@ -32,14 +32,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class UpdateConnectorFilteringAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorFilteringAction {
 
-    public static final UpdateConnectorFilteringAction INSTANCE = new UpdateConnectorFilteringAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_filtering";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorFilteringAction() {
-        super(NAME);
-    }
+    private UpdateConnectorFilteringAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorLastSeenAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorLastSeenAction.java
@@ -22,14 +22,12 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class UpdateConnectorLastSeenAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorLastSeenAction {
 
-    public static final UpdateConnectorLastSeenAction INSTANCE = new UpdateConnectorLastSeenAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_last_seen";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorLastSeenAction() {
-        super(NAME);
-    }
+    private UpdateConnectorLastSeenAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorLastSyncStatsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorLastSyncStatsAction.java
@@ -34,14 +34,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class UpdateConnectorLastSyncStatsAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorLastSyncStatsAction {
 
-    public static final UpdateConnectorLastSyncStatsAction INSTANCE = new UpdateConnectorLastSyncStatsAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_last_sync_stats";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorLastSyncStatsAction() {
-        super(NAME);
-    }
+    private UpdateConnectorLastSyncStatsAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorNameAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorNameAction.java
@@ -31,14 +31,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class UpdateConnectorNameAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorNameAction {
 
-    public static final UpdateConnectorNameAction INSTANCE = new UpdateConnectorNameAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_name";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorNameAction() {
-        super(NAME);
-    }
+    private UpdateConnectorNameAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorNativeAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorNativeAction.java
@@ -30,14 +30,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class UpdateConnectorNativeAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorNativeAction {
 
-    public static final UpdateConnectorNativeAction INSTANCE = new UpdateConnectorNativeAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_native";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorNativeAction() {
-        super(NAME);
-    }
+    private UpdateConnectorNativeAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorPipelineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorPipelineAction.java
@@ -31,14 +31,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class UpdateConnectorPipelineAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorPipelineAction {
 
-    public static final UpdateConnectorPipelineAction INSTANCE = new UpdateConnectorPipelineAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_pipeline";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorPipelineAction() {
-        super(NAME);
-    }
+    private UpdateConnectorPipelineAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorSchedulingAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorSchedulingAction.java
@@ -31,14 +31,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class UpdateConnectorSchedulingAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorSchedulingAction {
 
-    public static final UpdateConnectorSchedulingAction INSTANCE = new UpdateConnectorSchedulingAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_scheduling";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorSchedulingAction() {
-        super(NAME);
-    }
+    private UpdateConnectorSchedulingAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorServiceTypeAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorServiceTypeAction.java
@@ -30,14 +30,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class UpdateConnectorServiceTypeAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorServiceTypeAction {
 
-    public static final UpdateConnectorServiceTypeAction INSTANCE = new UpdateConnectorServiceTypeAction();
     public static final String NAME = "cluster:admin/xpack/connector/update_service_type";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorServiceTypeAction() {
-        super(NAME);
-    }
+    private UpdateConnectorServiceTypeAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretAction.java
@@ -9,13 +9,10 @@ package org.elasticsearch.xpack.application.connector.secrets.action;
 
 import org.elasticsearch.action.ActionType;
 
-public class GetConnectorSecretAction extends ActionType<GetConnectorSecretResponse> {
+public class GetConnectorSecretAction {
 
     public static final String NAME = "cluster:admin/xpack/connector/secret/get";
+    public static final ActionType<GetConnectorSecretResponse> INSTANCE = new ActionType<>(NAME);
 
-    public static final GetConnectorSecretAction INSTANCE = new GetConnectorSecretAction();
-
-    private GetConnectorSecretAction() {
-        super(NAME);
-    }
+    private GetConnectorSecretAction() {/* no instances */}
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/PostConnectorSecretAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/PostConnectorSecretAction.java
@@ -9,13 +9,9 @@ package org.elasticsearch.xpack.application.connector.secrets.action;
 
 import org.elasticsearch.action.ActionType;
 
-public class PostConnectorSecretAction extends ActionType<PostConnectorSecretResponse> {
-
+public class PostConnectorSecretAction {
     public static final String NAME = "cluster:admin/xpack/connector/secret/post";
+    public static final ActionType<PostConnectorSecretResponse> INSTANCE = new ActionType<>(NAME);
 
-    public static final PostConnectorSecretAction INSTANCE = new PostConnectorSecretAction();
-
-    private PostConnectorSecretAction() {
-        super(NAME);
-    }
+    private PostConnectorSecretAction() {/* no instances */}
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/CancelConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/CancelConnectorSyncJobAction.java
@@ -27,14 +27,12 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobConstants.EMPTY_CONNECTOR_SYNC_JOB_ID_ERROR_MESSAGE;
 
-public class CancelConnectorSyncJobAction extends ActionType<ConnectorUpdateActionResponse> {
+public class CancelConnectorSyncJobAction {
 
-    public static final CancelConnectorSyncJobAction INSTANCE = new CancelConnectorSyncJobAction();
     public static final String NAME = "cluster:admin/xpack/connector/sync_job/cancel";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<ConnectorUpdateActionResponse>(NAME);
 
-    private CancelConnectorSyncJobAction() {
-        super(NAME);
-    }
+    private CancelConnectorSyncJobAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         public static final ParseField CONNECTOR_SYNC_JOB_ID_FIELD = new ParseField("connector_sync_job_id");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/CheckInConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/CheckInConnectorSyncJobAction.java
@@ -27,14 +27,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class CheckInConnectorSyncJobAction extends ActionType<ConnectorUpdateActionResponse> {
+public class CheckInConnectorSyncJobAction {
 
-    public static final CheckInConnectorSyncJobAction INSTANCE = new CheckInConnectorSyncJobAction();
     public static final String NAME = "cluster:admin/xpack/connector/sync_job/check_in";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    private CheckInConnectorSyncJobAction() {
-        super(NAME);
-    }
+    private CheckInConnectorSyncJobAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         public static final ParseField CONNECTOR_SYNC_JOB_ID_FIELD = new ParseField("connector_sync_job_id");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/DeleteConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/DeleteConnectorSyncJobAction.java
@@ -27,14 +27,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class DeleteConnectorSyncJobAction extends ActionType<AcknowledgedResponse> {
+public class DeleteConnectorSyncJobAction {
 
-    public static final DeleteConnectorSyncJobAction INSTANCE = new DeleteConnectorSyncJobAction();
     public static final String NAME = "cluster:admin/xpack/connector/sync_job/delete";
+    public static final ActionType<AcknowledgedResponse> INSTANCE = new ActionType<>(NAME);
 
-    private DeleteConnectorSyncJobAction() {
-        super(NAME);
-    }
+    private DeleteConnectorSyncJobAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         public static final ParseField CONNECTOR_SYNC_JOB_ID_FIELD = new ParseField("connector_sync_job_id");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/GetConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/GetConnectorSyncJobAction.java
@@ -28,14 +28,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class GetConnectorSyncJobAction extends ActionType<GetConnectorSyncJobAction.Response> {
+public class GetConnectorSyncJobAction {
 
-    public static final GetConnectorSyncJobAction INSTANCE = new GetConnectorSyncJobAction();
     public static final String NAME = "cluster:admin/xpack/connector/sync_job/get";
+    public static final ActionType<GetConnectorSyncJobAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    private GetConnectorSyncJobAction() {
-        super(NAME);
-    }
+    private GetConnectorSyncJobAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         private final String connectorSyncJobId;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
@@ -30,14 +30,12 @@ import java.util.Objects;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class ListConnectorSyncJobsAction extends ActionType<ListConnectorSyncJobsAction.Response> {
+public class ListConnectorSyncJobsAction {
 
-    public static final ListConnectorSyncJobsAction INSTANCE = new ListConnectorSyncJobsAction();
     public static final String NAME = "cluster:admin/xpack/connector/sync_job/list";
+    public static final ActionType<ListConnectorSyncJobsAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public ListConnectorSyncJobsAction() {
-        super(NAME);
-    }
+    private ListConnectorSyncJobsAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         public static final ParseField CONNECTOR_ID_FIELD = new ParseField("connector_id");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/PostConnectorSyncJobAction.java
@@ -35,15 +35,12 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class PostConnectorSyncJobAction extends ActionType<PostConnectorSyncJobAction.Response> {
-
-    public static final PostConnectorSyncJobAction INSTANCE = new PostConnectorSyncJobAction();
+public class PostConnectorSyncJobAction {
 
     public static final String NAME = "cluster:admin/xpack/connector/sync_job/post";
+    public static final ActionType<PostConnectorSyncJobAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    private PostConnectorSyncJobAction() {
-        super(NAME);
-    }
+    private PostConnectorSyncJobAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         public static final String EMPTY_CONNECTOR_ID_ERROR_MESSAGE = "[id] of the connector cannot be null or empty";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobErrorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobErrorAction.java
@@ -32,15 +32,14 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class UpdateConnectorSyncJobErrorAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorSyncJobErrorAction {
 
-    public static final UpdateConnectorSyncJobErrorAction INSTANCE = new UpdateConnectorSyncJobErrorAction();
     public static final String NAME = "cluster:admin/xpack/connector/sync_job/update_error";
-    public static final String ERROR_EMPTY_MESSAGE = "[error] of the connector sync job cannot be null or empty";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    private UpdateConnectorSyncJobErrorAction() {
-        super(NAME);
-    }
+    private UpdateConnectorSyncJobErrorAction() {/* no instances */}
+
+    public static final String ERROR_EMPTY_MESSAGE = "[error] of the connector sync job cannot be null or empty";
 
     public static class Request extends ActionRequest implements ToXContentObject {
         private static final ConstructingObjectParser<Request, String> PARSER = new ConstructingObjectParser<>(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobIngestionStatsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobIngestionStatsAction.java
@@ -38,14 +38,12 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobConstants.EMPTY_CONNECTOR_SYNC_JOB_ID_ERROR_MESSAGE;
 
-public class UpdateConnectorSyncJobIngestionStatsAction extends ActionType<ConnectorUpdateActionResponse> {
+public class UpdateConnectorSyncJobIngestionStatsAction {
 
-    public static final UpdateConnectorSyncJobIngestionStatsAction INSTANCE = new UpdateConnectorSyncJobIngestionStatsAction();
     public static final String NAME = "cluster:admin/xpack/connector/sync_job/update_stats";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
 
-    public UpdateConnectorSyncJobIngestionStatsAction() {
-        super(NAME);
-    }
+    private UpdateConnectorSyncJobIngestionStatsAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         public static final ParseField CONNECTOR_SYNC_JOB_ID_FIELD = new ParseField("connector_sync_job_id");

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/DeleteQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/DeleteQueryRulesetAction.java
@@ -26,14 +26,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class DeleteQueryRulesetAction extends ActionType<AcknowledgedResponse> {
+public class DeleteQueryRulesetAction {
 
-    public static final DeleteQueryRulesetAction INSTANCE = new DeleteQueryRulesetAction();
     public static final String NAME = "cluster:admin/xpack/query_rules/delete";
+    public static final ActionType<AcknowledgedResponse> INSTANCE = new ActionType<>(NAME);
 
-    private DeleteQueryRulesetAction() {
-        super(NAME);
-    }
+    private DeleteQueryRulesetAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         private final String rulesetId;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetAction.java
@@ -29,14 +29,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class GetQueryRulesetAction extends ActionType<GetQueryRulesetAction.Response> {
+public class GetQueryRulesetAction {
 
-    public static final GetQueryRulesetAction INSTANCE = new GetQueryRulesetAction();
     public static final String NAME = "cluster:admin/xpack/query_rules/get";
+    public static final ActionType<GetQueryRulesetAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    private GetQueryRulesetAction() {
-        super(NAME);
-    }
+    private GetQueryRulesetAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         private final String rulesetId;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/ListQueryRulesetsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/ListQueryRulesetsAction.java
@@ -28,14 +28,12 @@ import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class ListQueryRulesetsAction extends ActionType<ListQueryRulesetsAction.Response> {
+public class ListQueryRulesetsAction {
 
-    public static final ListQueryRulesetsAction INSTANCE = new ListQueryRulesetsAction();
     public static final String NAME = "cluster:admin/xpack/query_rules/list";
+    public static final ActionType<ListQueryRulesetsAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public ListQueryRulesetsAction() {
-        super(NAME);
-    }
+    private ListQueryRulesetsAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         private final PageParams pageParams;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetAction.java
@@ -33,14 +33,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class PutQueryRulesetAction extends ActionType<PutQueryRulesetAction.Response> {
+public class PutQueryRulesetAction {
 
-    public static final PutQueryRulesetAction INSTANCE = new PutQueryRulesetAction();
     public static final String NAME = "cluster:admin/xpack/query_rules/put";
+    public static final ActionType<PutQueryRulesetAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public PutQueryRulesetAction() {
-        super(NAME);
-    }
+    private PutQueryRulesetAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/DeleteSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/DeleteSearchApplicationAction.java
@@ -25,14 +25,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class DeleteSearchApplicationAction extends ActionType<AcknowledgedResponse> {
+public class DeleteSearchApplicationAction {
 
-    public static final DeleteSearchApplicationAction INSTANCE = new DeleteSearchApplicationAction();
     public static final String NAME = "cluster:admin/xpack/application/search_application/delete";
+    public static final ActionType<AcknowledgedResponse> INSTANCE = new ActionType<>(NAME);
 
-    private DeleteSearchApplicationAction() {
-        super(NAME);
-    }
+    private DeleteSearchApplicationAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         private final String name;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/GetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/GetSearchApplicationAction.java
@@ -27,14 +27,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class GetSearchApplicationAction extends ActionType<GetSearchApplicationAction.Response> {
+public class GetSearchApplicationAction {
 
-    public static final GetSearchApplicationAction INSTANCE = new GetSearchApplicationAction();
     public static final String NAME = "cluster:admin/xpack/application/search_application/get";
+    public static final ActionType<GetSearchApplicationAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    private GetSearchApplicationAction() {
-        super(NAME);
-    }
+    private GetSearchApplicationAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
         private final String name;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationAction.java
@@ -32,14 +32,12 @@ import java.util.Objects;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
-public class ListSearchApplicationAction extends ActionType<ListSearchApplicationAction.Response> {
+public class ListSearchApplicationAction {
 
-    public static final ListSearchApplicationAction INSTANCE = new ListSearchApplicationAction();
     public static final String NAME = "cluster:admin/xpack/application/search_application/list";
+    public static final ActionType<ListSearchApplicationAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public ListSearchApplicationAction() {
-        super(NAME);
-    }
+    private ListSearchApplicationAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/PutSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/PutSearchApplicationAction.java
@@ -30,14 +30,12 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class PutSearchApplicationAction extends ActionType<PutSearchApplicationAction.Response> {
+public class PutSearchApplicationAction {
 
-    public static final PutSearchApplicationAction INSTANCE = new PutSearchApplicationAction();
     public static final String NAME = "cluster:admin/xpack/application/search_application/put";
+    public static final ActionType<PutSearchApplicationAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public PutSearchApplicationAction() {
-        super(NAME);
-    }
+    private PutSearchApplicationAction() {/* no instances */}
 
     public static class Request extends ActionRequest implements ToXContentObject {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/QuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/QuerySearchApplicationAction.java
@@ -10,13 +10,10 @@ package org.elasticsearch.xpack.application.search.action;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.search.SearchResponse;
 
-public class QuerySearchApplicationAction extends ActionType<SearchResponse> {
+public class QuerySearchApplicationAction {
 
-    public static final QuerySearchApplicationAction INSTANCE = new QuerySearchApplicationAction();
     public static final String NAME = "indices:data/read/xpack/application/search_application/search";
+    public static final ActionType<SearchResponse> INSTANCE = new ActionType<>(NAME);
 
-    public QuerySearchApplicationAction() {
-        super(NAME);
-    }
-
+    private QuerySearchApplicationAction() {/* no instances */}
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RenderSearchApplicationQueryAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RenderSearchApplicationQueryAction.java
@@ -19,14 +19,12 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Objects;
 
-public class RenderSearchApplicationQueryAction extends ActionType<RenderSearchApplicationQueryAction.Response> {
+public class RenderSearchApplicationQueryAction {
 
-    public static final RenderSearchApplicationQueryAction INSTANCE = new RenderSearchApplicationQueryAction();
     public static final String NAME = "cluster:admin/xpack/application/search_application/render_query";
+    public static final ActionType<RenderSearchApplicationQueryAction.Response> INSTANCE = new ActionType<>(NAME);
 
-    public RenderSearchApplicationQueryAction() {
-        super(NAME);
-    }
+    private RenderSearchApplicationQueryAction() {/* no instances */}
 
     public static class Response extends ActionResponse implements ToXContentObject, NamedWriteable {
 


### PR DESCRIPTION
Aligns the actions in the enterprise search module with the docs added
in #104139.