### PR TITLE
Introduce `ChunkedLoggingStreamTestUtils`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -16,7 +16,7 @@ import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRes
 import org.elasticsearch.action.admin.cluster.node.hotthreads.TransportNodesHotThreadsAction;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.ReferenceDocs;
-import org.elasticsearch.common.logging.ChunkedLoggingStreamTests;
+import org.elasticsearch.common.logging.ChunkedLoggingStreamTestUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.monitor.jvm.HotThreads;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -188,7 +188,7 @@ public class HotThreadsIT extends ESIntegTestCase {
     public void testLogLocalHotThreads() {
         final var level = randomFrom(Level.TRACE, Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
         assertThat(
-            ChunkedLoggingStreamTests.getDecodedLoggedBody(
+            ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(
                 logger,
                 level,
                 getTestName(),

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LagDetectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LagDetectorTests.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.common.ReferenceDocs;
-import org.elasticsearch.common.logging.ChunkedLoggingStreamTests;
+import org.elasticsearch.common.logging.ChunkedLoggingStreamTestUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.TimeValue;
@@ -259,7 +259,7 @@ public class LagDetectorTests extends ESTestCase {
         final var expectedBody = randomUnicodeOfLengthBetween(1, 20000);
         assertEquals(
             expectedBody,
-            ChunkedLoggingStreamTests.getDecodedLoggedBody(
+            ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(
                 LogManager.getLogger(LOGGER_NAME),
                 Level.DEBUG,
                 "hot threads from node ["

--- a/server/src/test/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTests.java
@@ -11,29 +11,16 @@ package org.elasticsearch.common.logging;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.core.CheckedRunnable;
-import org.elasticsearch.core.Streams;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.stream.IntStream;
-import java.util.zip.GZIPInputStream;
-
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class ChunkedLoggingStreamTests extends ESTestCase {
 
@@ -56,7 +43,7 @@ public class ChunkedLoggingStreamTests extends ESTestCase {
         final var prefix = randomAlphaOfLength(10);
         final var level = randomFrom(Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
         final var referenceDocs = randomFrom(ReferenceDocs.values());
-        assertEquals(expectedBody, getLoggedBody(logger, level, prefix, referenceDocs, () -> {
+        assertEquals(expectedBody, ChunkedLoggingStreamTestUtils.getLoggedBody(logger, level, prefix, referenceDocs, () -> {
             try (var stream = new ChunkedLoggingStream(logger, level, prefix, referenceDocs)) {
                 writeRandomly(stream, bytes);
             }
@@ -68,117 +55,14 @@ public class ChunkedLoggingStreamTests extends ESTestCase {
         final var bytes = randomByteArrayOfLength(between(0, 10000));
         final var level = randomFrom(Level.DEBUG, Level.INFO, Level.WARN, Level.ERROR);
         final var referenceDocs = randomFrom(ReferenceDocs.values());
-        assertEquals(new BytesArray(bytes), getDecodedLoggedBody(logger, level, "prefix", referenceDocs, () -> {
-            try (var stream = ChunkedLoggingStream.create(logger, level, "prefix", referenceDocs)) {
-                writeRandomly(stream, bytes);
-            }
-        }));
-    }
-
-    private static String getLoggedBody(
-        Logger captureLogger,
-        final Level level,
-        String prefix,
-        final ReferenceDocs referenceDocs,
-        CheckedRunnable<Exception> runnable
-    ) {
-        class ChunkReadingAppender extends AbstractAppender {
-            final StringBuilder encodedResponseBuilder = new StringBuilder();
-            int chunks;
-            boolean seenTotal;
-
-            ChunkReadingAppender() {
-                super("mock", null, null, false, Property.EMPTY_ARRAY);
-            }
-
-            @Override
-            public void append(LogEvent event) {
-                if (event.getLevel() != level) {
-                    return;
+        assertEquals(
+            new BytesArray(bytes),
+            ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(logger, level, "prefix", referenceDocs, () -> {
+                try (var stream = ChunkedLoggingStream.create(logger, level, "prefix", referenceDocs)) {
+                    writeRandomly(stream, bytes);
                 }
-                if (event.getLoggerName().equals(captureLogger.getName()) == false) {
-                    return;
-                }
-                assertFalse(seenTotal);
-                final var message = event.getMessage().getFormattedMessage();
-                final var onePartPrefix = prefix + " (gzip compressed and base64-encoded; for details see " + referenceDocs + "): ";
-                final var partPrefix = prefix + " [part " + (chunks + 1) + "]: ";
-                if (message.startsWith(partPrefix)) {
-                    chunks += 1;
-                    final var chunk = message.substring(partPrefix.length());
-                    assertThat(chunk.length(), lessThanOrEqualTo(ChunkedLoggingStream.CHUNK_SIZE));
-                    encodedResponseBuilder.append(chunk);
-                } else if (message.startsWith(onePartPrefix)) {
-                    assertEquals(0, chunks);
-                    chunks += 1;
-                    final var chunk = message.substring(onePartPrefix.length());
-                    assertThat(chunk.length(), lessThanOrEqualTo(ChunkedLoggingStream.CHUNK_SIZE));
-                    encodedResponseBuilder.append(chunk);
-                    seenTotal = true;
-                } else {
-                    assertEquals(
-                        prefix
-                            + " (gzip compressed, base64-encoded, and split into "
-                            + chunks
-                            + " parts on preceding log lines; for details see "
-                            + referenceDocs
-                            + ")",
-                        message
-                    );
-                    assertThat(chunks, greaterThan(1));
-                    seenTotal = true;
-                }
-            }
-        }
-
-        final var appender = new ChunkReadingAppender();
-        try {
-            appender.start();
-            Loggers.addAppender(captureLogger, appender);
-            runnable.run();
-        } catch (Exception e) {
-            fail(e);
-        } finally {
-            Loggers.removeAppender(captureLogger, appender);
-            appender.stop();
-        }
-
-        assertThat(appender.chunks, greaterThan(0));
-        assertTrue(appender.seenTotal);
-
-        return appender.encodedResponseBuilder.toString();
-    }
-
-    /**
-     * Test utility function which captures the logged output from a {@link ChunkedLoggingStream}, combines the chunks, Base64-decodes it
-     * and Gzip-decompresses it to retrieve the original data.
-     *
-     * @param captureLogger The logger whose output should be captured.
-     * @param level         The log level for the data.
-     * @param prefix        The prefix used by the logging stream.
-     * @param referenceDocs A link to the reference docs about the output.
-     * @param runnable      The action which emits the logs.
-     * @return              A {@link BytesReference} containing the captured data.
-     */
-    public static BytesReference getDecodedLoggedBody(
-        Logger captureLogger,
-        Level level,
-        String prefix,
-        ReferenceDocs referenceDocs,
-        CheckedRunnable<Exception> runnable
-    ) {
-        final var loggedBody = getLoggedBody(captureLogger, level, prefix, referenceDocs, runnable);
-
-        try (
-            var bytesStreamOutput = new BytesStreamOutput();
-            var byteArrayInputStream = new ByteArrayInputStream(Base64.getDecoder().decode(loggedBody));
-            var gzipInputStream = new GZIPInputStream(byteArrayInputStream)
-        ) {
-            Streams.copy(gzipInputStream, bytesStreamOutput);
-            return bytesStreamOutput.bytes();
-        } catch (Exception e) {
-            return fail(e);
-        }
+            })
+        );
     }
 
     private static void writeRandomly(OutputStream stream, byte[] bytes) throws IOException {

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStream;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
-import org.elasticsearch.common.logging.ChunkedLoggingStreamTests;
+import org.elasticsearch.common.logging.ChunkedLoggingStreamTestUtils;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
@@ -708,7 +708,7 @@ public class DefaultRestChannelTests extends ESTestCase {
         var responseBody = new BytesArray(randomUnicodeOfLengthBetween(1, 100).getBytes(StandardCharsets.UTF_8));
         assertEquals(
             responseBody,
-            ChunkedLoggingStreamTests.getDecodedLoggedBody(
+            ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(
                 LogManager.getLogger(HttpTracerTests.HTTP_BODY_TRACER_LOGGER),
                 Level.TRACE,
                 "[" + request.getRequestId() + "] response body",
@@ -720,7 +720,7 @@ public class DefaultRestChannelTests extends ESTestCase {
         final var isClosed = new AtomicBoolean();
         assertEquals(
             responseBody,
-            ChunkedLoggingStreamTests.getDecodedLoggedBody(
+            ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(
                 LogManager.getLogger(HttpTracerTests.HTTP_BODY_TRACER_LOGGER),
                 Level.TRACE,
                 "[" + request.getRequestId() + "] response body",

--- a/server/src/test/java/org/elasticsearch/http/HttpTracerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpTracerTests.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.logging.ChunkedLoggingStreamTests;
+import org.elasticsearch.common.logging.ChunkedLoggingStreamTestUtils;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
@@ -98,7 +98,7 @@ public class HttpTracerTests extends ESTestCase {
 
         assertEquals(
             responseBody,
-            ChunkedLoggingStreamTests.getDecodedLoggedBody(
+            ChunkedLoggingStreamTestUtils.getDecodedLoggedBody(
                 LogManager.getLogger(HTTP_BODY_TRACER_LOGGER),
                 Level.TRACE,
                 "[" + request.getRequestId() + "] request body",

--- a/test/framework/src/main/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTestUtils.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.core.Streams;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Assert;
+
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
+import java.util.zip.GZIPInputStream;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+public class ChunkedLoggingStreamTestUtils {
+
+    /**
+     * Test utility function which captures the logged output from a {@link ChunkedLoggingStream}, combines the chunks, Base64-decodes it
+     * and Gzip-decompresses it to retrieve the original data.
+     *
+     * @param captureLogger The logger whose output should be captured.
+     * @param level         The log level for the data.
+     * @param prefix        The prefix used by the logging stream.
+     * @param referenceDocs A link to the reference docs about the output.
+     * @param runnable      The action which emits the logs.
+     * @return              A {@link BytesReference} containing the captured data.
+     */
+    public static BytesReference getDecodedLoggedBody(
+        Logger captureLogger,
+        Level level,
+        String prefix,
+        ReferenceDocs referenceDocs,
+        CheckedRunnable<Exception> runnable
+    ) {
+        final var loggedBody = getLoggedBody(captureLogger, level, prefix, referenceDocs, runnable);
+
+        try (
+            var bytesStreamOutput = new BytesStreamOutput();
+            var byteArrayInputStream = new ByteArrayInputStream(Base64.getDecoder().decode(loggedBody));
+            var gzipInputStream = new GZIPInputStream(byteArrayInputStream)
+        ) {
+            Streams.copy(gzipInputStream, bytesStreamOutput);
+            return bytesStreamOutput.bytes();
+        } catch (Exception e) {
+            return ESTestCase.fail(e);
+        }
+    }
+
+    static String getLoggedBody(
+        Logger captureLogger,
+        final Level level,
+        String prefix,
+        final ReferenceDocs referenceDocs,
+        CheckedRunnable<Exception> runnable
+    ) {
+        class ChunkReadingAppender extends AbstractAppender {
+            final StringBuilder encodedResponseBuilder = new StringBuilder();
+            int chunks;
+            boolean seenTotal;
+
+            ChunkReadingAppender() {
+                super("mock", null, null, false, Property.EMPTY_ARRAY);
+            }
+
+            @Override
+            public void append(LogEvent event) {
+                if (event.getLevel() != level) {
+                    return;
+                }
+                if (event.getLoggerName().equals(captureLogger.getName()) == false) {
+                    return;
+                }
+                Assert.assertFalse(seenTotal);
+                final var message = event.getMessage().getFormattedMessage();
+                final var onePartPrefix = prefix + " (gzip compressed and base64-encoded; for details see " + referenceDocs + "): ";
+                final var partPrefix = prefix + " [part " + (chunks + 1) + "]: ";
+                if (message.startsWith(partPrefix)) {
+                    chunks += 1;
+                    final var chunk = message.substring(partPrefix.length());
+                    ESTestCase.assertThat(chunk.length(), lessThanOrEqualTo(ChunkedLoggingStream.CHUNK_SIZE));
+                    encodedResponseBuilder.append(chunk);
+                } else if (message.startsWith(onePartPrefix)) {
+                    Assert.assertEquals(0, chunks);
+                    chunks += 1;
+                    final var chunk = message.substring(onePartPrefix.length());
+                    ESTestCase.assertThat(chunk.length(), lessThanOrEqualTo(ChunkedLoggingStream.CHUNK_SIZE));
+                    encodedResponseBuilder.append(chunk);
+                    seenTotal = true;
+                } else {
+                    Assert.assertEquals(
+                        prefix
+                            + " (gzip compressed, base64-encoded, and split into "
+                            + chunks
+                            + " parts on preceding log lines; for details see "
+                            + referenceDocs
+                            + ")",
+                        message
+                    );
+                    ESTestCase.assertThat(chunks, greaterThan(1));
+                    seenTotal = true;
+                }
+            }
+        }
+
+        final var appender = new ChunkReadingAppender();
+        try {
+            appender.start();
+            Loggers.addAppender(captureLogger, appender);
+            runnable.run();
+        } catch (Exception e) {
+            ESTestCase.fail(e);
+        } finally {
+            Loggers.removeAppender(captureLogger, appender);
+            appender.stop();
+        }
+
+        ESTestCase.assertThat(appender.chunks, greaterThan(0));
+        Assert.assertTrue(appender.seenTotal);
+
+        return appender.encodedResponseBuilder.toString();
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/logging/ChunkedLoggingStreamTestUtils.java
@@ -28,7 +28,12 @@ import java.util.zip.GZIPInputStream;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
+/**
+ * Utility for capturing and decoding the data logged by a {@link ChunkedLoggingStream}.
+ */
 public class ChunkedLoggingStreamTestUtils {
+
+    private ChunkedLoggingStreamTestUtils() {/* no instances */}
 
     /**
      * Test utility function which captures the logged output from a {@link ChunkedLoggingStream}, combines the chunks, Base64-decodes it


### PR DESCRIPTION
Today the test utilities for extracting data logged by a
`ChunkedLoggingStream` are in the `:server` test suite which renders
them inaccessible to the test suites of other modules. This commit moves
them to `:test:framework`.