### PR TITLE
Permit empty chunks in HTTP response

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.http.netty4;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.ESNetty4IntegTestCase;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
+import org.elasticsearch.common.collect.Iterators;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.recycler.Recycler;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestResponse.TEXT_CONTENT_TYPE;
+import static org.hamcrest.Matchers.containsString;
+
+public class Netty4ChunkedEncodingIT extends ESNetty4IntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.concatLists(List.of(YieldsChunksPlugin.class), super.nodePlugins());
+    }
+
+    @Override
+    protected boolean addMockHttpTransport() {
+        return false; // enable http
+    }
+
+    private static final String expectedBody = """
+        chunk-0
+        chunk-1
+        chunk-2
+        """;
+
+    public void testLotsOfBasic() throws IOException {
+        for (int i = 0 ; i < 10000; i++) {
+            testBasic();
+        }
+    }
+
+    public void testBasic() throws IOException {
+        final var response = getRestClient().performRequest(new Request("GET", YieldsChunksPlugin.ROUTE));
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertThat(response.getEntity().getContentType().toString(), containsString(TEXT_CONTENT_TYPE));
+        assertTrue(response.getEntity().isChunked());
+        final String body;
+        try (var reader = new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8)) {
+            body = Streams.copyToString(reader);
+        }
+        assertEquals(expectedBody, body);
+    }
+
+    public static class YieldsChunksPlugin extends Plugin implements ActionPlugin {
+        static final String ROUTE = "/_test/yields_chunks";
+
+        public static class Request extends ActionRequest {
+            @Override
+            public ActionRequestValidationException validate() {
+                return null;
+            }
+        }
+
+        private static Iterator<BytesReference> emptyChunks() {
+            return Iterators.forRange(0, between(0, 2), i -> BytesArray.EMPTY);
+        }
+
+        @Override
+        public Collection<RestHandler> getRestHandlers(
+            Settings settings,
+            NamedWriteableRegistry namedWriteableRegistry,
+            RestController restController,
+            ClusterSettings clusterSettings,
+            IndexScopedSettings indexScopedSettings,
+            SettingsFilter settingsFilter,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            Supplier<DiscoveryNodes> nodesInCluster
+        ) {
+            return List.of(new BaseRestHandler() {
+                @Override
+                public String getName() {
+                    return ROUTE;
+                }
+
+                @Override
+                public List<Route> routes() {
+                    return List.of(new Route(GET, ROUTE));
+                }
+
+                @Override
+                protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+                    return channel -> channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBody() {
+
+                        final Iterator<BytesReference> chunkIterator = Iterators.concat(
+                            emptyChunks(),
+                            Iterators.flatMap(
+                                Iterators.forRange(0, 3, i -> "chunk-" + i + '\n'),
+                                chunk -> Iterators.concat(Iterators.single(new BytesArray(chunk)), emptyChunks())
+                            )
+                        );
+
+                        @Override
+                        public boolean isDone() {
+                            return chunkIterator.hasNext() == false;
+                        }
+
+                        @Override
+                        public ReleasableBytesReference encodeChunk(int sizeHint, Recycler<BytesRef> recycler) {
+                            final var page = recycler.obtain(); // just to ensure nothing is leaked
+                            return new ReleasableBytesReference(chunkIterator.next(), page);
+                        }
+
+                        @Override
+                        public String getResponseContentTypeString() {
+                            return TEXT_CONTENT_TYPE;
+                        }
+                    }, null));
+                }
+            });
+        }
+    }
+}

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
@@ -76,8 +76,8 @@ public class Netty4ChunkedEncodingIT extends ESNetty4IntegTestCase {
         getAndCheckBodyContents(YieldsChunksPlugin.EMPTY_ROUTE, "");
     }
 
-    private static void getAndCheckBodyContents(String chunksRoute, String expectedBody) throws IOException {
-        final var response = getRestClient().performRequest(new Request("GET", chunksRoute));
+    private static void getAndCheckBodyContents(String route, String expectedBody) throws IOException {
+        final var response = getRestClient().performRequest(new Request("GET", route));
         assertEquals(200, response.getStatusLine().getStatusCode());
         assertThat(response.getEntity().getContentType().toString(), containsString(TEXT_CONTENT_TYPE));
         if (Strings.hasLength(expectedBody)) {

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
@@ -10,12 +10,11 @@ package org.elasticsearch.http.netty4;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ESNetty4IntegTestCase;
-import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.bytes.ReleasableBytesReference;
@@ -32,6 +31,7 @@ import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -62,17 +62,27 @@ public class Netty4ChunkedEncodingIT extends ESNetty4IntegTestCase {
         return false; // enable http
     }
 
-    private static final String expectedBody = """
+    private static final String EXPECTED_NONEMPTY_BODY = """
         chunk-0
         chunk-1
         chunk-2
         """;
 
-    public void testBasic() throws IOException {
-        final var response = getRestClient().performRequest(new Request("GET", YieldsChunksPlugin.ROUTE));
+    public void testNonemptyResponse() throws IOException {
+        getAndCheckBodyContents(YieldsChunksPlugin.CHUNKS_ROUTE, EXPECTED_NONEMPTY_BODY);
+    }
+
+    public void testEmptyResponse() throws IOException {
+        getAndCheckBodyContents(YieldsChunksPlugin.EMPTY_ROUTE, "");
+    }
+
+    private static void getAndCheckBodyContents(String chunksRoute, String expectedBody) throws IOException {
+        final var response = getRestClient().performRequest(new Request("GET", chunksRoute));
         assertEquals(200, response.getStatusLine().getStatusCode());
         assertThat(response.getEntity().getContentType().toString(), containsString(TEXT_CONTENT_TYPE));
-        assertTrue(response.getEntity().isChunked());
+        if (Strings.hasLength(expectedBody)) {
+            assertTrue(response.getEntity().isChunked());
+        } // else we might have no chunks to send which doesn't need chunked-encoding
         final String body;
         try (var reader = new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8)) {
             body = Streams.copyToString(reader);
@@ -81,14 +91,8 @@ public class Netty4ChunkedEncodingIT extends ESNetty4IntegTestCase {
     }
 
     public static class YieldsChunksPlugin extends Plugin implements ActionPlugin {
-        static final String ROUTE = "/_test/yields_chunks";
-
-        public static class Request extends ActionRequest {
-            @Override
-            public ActionRequestValidationException validate() {
-                return null;
-            }
-        }
+        static final String CHUNKS_ROUTE = "/_test/yields_chunks";
+        static final String EMPTY_ROUTE = "/_test/yields_only_empty_chunks";
 
         private static Iterator<BytesReference> emptyChunks() {
             return Iterators.forRange(0, between(0, 2), i -> BytesArray.EMPTY);
@@ -108,44 +112,63 @@ public class Netty4ChunkedEncodingIT extends ESNetty4IntegTestCase {
             return List.of(new BaseRestHandler() {
                 @Override
                 public String getName() {
-                    return ROUTE;
+                    return CHUNKS_ROUTE;
                 }
 
                 @Override
                 public List<Route> routes() {
-                    return List.of(new Route(GET, ROUTE));
+                    return List.of(new Route(GET, CHUNKS_ROUTE));
                 }
 
                 @Override
                 protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
-                    return channel -> channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBody() {
-
-                        final Iterator<BytesReference> chunkIterator = Iterators.concat(
+                    return channel -> sendChunksResponse(
+                        channel,
+                        Iterators.concat(
                             emptyChunks(),
                             Iterators.flatMap(
                                 Iterators.forRange(0, 3, i -> "chunk-" + i + '\n'),
                                 chunk -> Iterators.concat(Iterators.single(new BytesArray(chunk)), emptyChunks())
                             )
-                        );
+                        )
+                    );
+                }
+            }, new BaseRestHandler() {
+                @Override
+                public String getName() {
+                    return EMPTY_ROUTE;
+                }
 
-                        @Override
-                        public boolean isDone() {
-                            return chunkIterator.hasNext() == false;
-                        }
+                @Override
+                public List<Route> routes() {
+                    return List.of(new Route(GET, EMPTY_ROUTE));
+                }
 
-                        @Override
-                        public ReleasableBytesReference encodeChunk(int sizeHint, Recycler<BytesRef> recycler) {
-                            final var page = recycler.obtain(); // just to ensure nothing is leaked
-                            return new ReleasableBytesReference(chunkIterator.next(), page);
-                        }
-
-                        @Override
-                        public String getResponseContentTypeString() {
-                            return TEXT_CONTENT_TYPE;
-                        }
-                    }, null));
+                @Override
+                protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+                    return channel -> sendChunksResponse(channel, emptyChunks());
                 }
             });
+        }
+
+        private static void sendChunksResponse(RestChannel channel, Iterator<BytesReference> chunkIterator) {
+            channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBody() {
+                @Override
+                public boolean isDone() {
+                    return chunkIterator.hasNext() == false;
+                }
+
+                @Override
+                public ReleasableBytesReference encodeChunk(int sizeHint, Recycler<BytesRef> recycler) {
+                    final var page = recycler.obtain(); // just to ensure nothing is leaked
+                    return new ReleasableBytesReference(chunkIterator.next(), page);
+                }
+
+                @Override
+                public String getResponseContentTypeString() {
+                    return TEXT_CONTENT_TYPE;
+                }
+            }, null));
         }
     }
 }

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
@@ -68,12 +68,6 @@ public class Netty4ChunkedEncodingIT extends ESNetty4IntegTestCase {
         chunk-2
         """;
 
-    public void testLotsOfBasic() throws IOException {
-        for (int i = 0 ; i < 10000; i++) {
-            testBasic();
-        }
-    }
-
     public void testBasic() throws IOException {
         final var response = getRestClient().performRequest(new Request("GET", YieldsChunksPlugin.ROUTE));
         assertEquals(200, response.getStatusLine().getStatusCode());

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
@@ -324,7 +324,6 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
             Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE,
             serverTransport.recycler()
         );
-        assert bytes.length() > 0 : "serialization should not produce empty buffers";
         final ByteBuf content = Netty4Utils.toByteBuf(bytes);
         final boolean done = body.isDone();
         final ChannelFuture f = ctx.write(done ? new DefaultLastHttpContent(content) : new DefaultHttpContent(content));

--- a/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
+++ b/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBody.java
@@ -144,7 +144,7 @@ public interface ChunkedRestResponseBody {
 
     /**
      * Create a chunked response body to be written to a specific {@link RestChannel} from a stream of text chunks, each represented as a
-     * consumer of a {@link Writer}. The last chunk that the iterator yields must write at least one byte.
+     * consumer of a {@link Writer}.
      */
     static ChunkedRestResponseBody fromTextChunks(String contentType, Iterator<CheckedConsumer<Writer, IOException>> chunkIterator) {
         return new ChunkedRestResponseBody() {


### PR DESCRIPTION
Today we assert that the chunks sent to the network layer are all
nonempty. In practice this will mostly be the case, but it's a little
onerous to ask the caller to ensure this since the caller might not know
how much data it can serialize without just trying it. In principle we
could do this before calling `encodeChunk`, obtaining an appropriate
recycler via other means, but it's going to happen so rarely that it
seems best to just accept that sometimes we might see an empty chunk.
This commit removes the assertion in the network layer since the code as
written already correctly handles empty chunks in the response body.