### PR TITLE
Remove ParsedAggregations from transform module tests

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformInfoTransportActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformInfoTransportActionTests.java
@@ -9,9 +9,9 @@ package org.elasticsearch.xpack.transform;
 
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.transport.TransportService;
@@ -42,7 +42,7 @@ public class TransformInfoTransportActionTests extends ESTestCase {
     }
 
     public void testParseSearchAggs() {
-        Aggregations emptyAggs = new Aggregations(Collections.emptyList());
+        InternalAggregations emptyAggs = InternalAggregations.from(Collections.emptyList());
         SearchResponse withEmptyAggs = mock(SearchResponse.class);
         when(withEmptyAggs.getAggregations()).thenReturn(emptyAggs);
 
@@ -69,19 +69,19 @@ public class TransformInfoTransportActionTests extends ESTestCase {
         );
 
         int currentStat = 1;
-        List<Aggregation> aggs = new ArrayList<>(PROVIDED_STATS.length);
+        List<InternalAggregation> aggs = new ArrayList<>(PROVIDED_STATS.length);
         for (String statName : PROVIDED_STATS) {
             aggs.add(buildAgg(statName, currentStat++));
         }
-        Aggregations aggregations = new Aggregations(aggs);
+        InternalAggregations aggregations = InternalAggregations.from(aggs);
         SearchResponse withAggs = mock(SearchResponse.class);
         when(withAggs.getAggregations()).thenReturn(aggregations);
 
         assertThat(TransformInfoTransportAction.parseSearchAggs(withAggs), equalTo(expectedStats));
     }
 
-    private static Aggregation buildAgg(String name, double value) {
-        NumericMetricsAggregation.SingleValue agg = mock(NumericMetricsAggregation.SingleValue.class);
+    private static InternalAggregation buildAgg(String name, double value) {
+        InternalNumericMetricsAggregation.SingleValue agg = mock(InternalNumericMetricsAggregation.SingleValue.class);
         when(agg.getName()).thenReturn(name);
         when(agg.value()).thenReturn(value);
         return agg;

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -21,52 +21,18 @@ import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.PipelineAggregatorBuilders;
 import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
-import org.elasticsearch.search.aggregations.bucket.composite.ParsedComposite;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.search.aggregations.bucket.range.InternalRange;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
-import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedStringTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
-import org.elasticsearch.search.aggregations.metrics.AvgAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.CardinalityAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.GeoBounds;
 import org.elasticsearch.search.aggregations.metrics.GeoCentroid;
 import org.elasticsearch.search.aggregations.metrics.InternalMultiValueAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
-import org.elasticsearch.search.aggregations.metrics.MaxAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.MinAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
-import org.elasticsearch.search.aggregations.metrics.ParsedAvg;
-import org.elasticsearch.search.aggregations.metrics.ParsedCardinality;
-import org.elasticsearch.search.aggregations.metrics.ParsedExtendedStats;
-import org.elasticsearch.search.aggregations.metrics.ParsedMax;
-import org.elasticsearch.search.aggregations.metrics.ParsedMin;
-import org.elasticsearch.search.aggregations.metrics.ParsedScriptedMetric;
-import org.elasticsearch.search.aggregations.metrics.ParsedStats;
-import org.elasticsearch.search.aggregations.metrics.ParsedSum;
-import org.elasticsearch.search.aggregations.metrics.ParsedValueCount;
+import org.elasticsearch.search.aggregations.metrics.InternalScriptedMetric;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
 import org.elasticsearch.search.aggregations.metrics.Percentiles;
-import org.elasticsearch.search.aggregations.metrics.ScriptedMetric;
-import org.elasticsearch.search.aggregations.metrics.ScriptedMetricAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.StatsAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
-import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder;
-import org.elasticsearch.search.aggregations.pipeline.BucketScriptPipelineAggregationBuilder;
-import org.elasticsearch.search.aggregations.pipeline.ParsedSimpleValue;
-import org.elasticsearch.search.aggregations.pipeline.ParsedStatsBucket;
-import org.elasticsearch.search.aggregations.pipeline.StatsBucketPipelineAggregationBuilder;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xcontent.ContextParser;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
@@ -77,8 +43,6 @@ import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.xpack.transform.transforms.pivot.AggregationResultUtils.BucketKeyExtractor;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -86,8 +50,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -97,42 +59,12 @@ import static org.mockito.Mockito.when;
 
 public class AggregationResultUtilsTests extends ESTestCase {
 
-    private final NamedXContentRegistry namedXContentRegistry = new NamedXContentRegistry(namedXContents);
-
-    private final String KEY = Aggregation.CommonFields.KEY.getPreferredName();
-    private final String DOC_COUNT = Aggregation.CommonFields.DOC_COUNT.getPreferredName();
-
-    // aggregations potentially useful for writing tests, to be expanded as necessary
-    private static final List<NamedXContentRegistry.Entry> namedXContents;
-    static {
-        Map<String, ContextParser<Object, ? extends Aggregation>> map = new HashMap<>();
-        map.put(CardinalityAggregationBuilder.NAME, (p, c) -> ParsedCardinality.fromXContent(p, (String) c));
-        map.put(MinAggregationBuilder.NAME, (p, c) -> ParsedMin.fromXContent(p, (String) c));
-        map.put(MaxAggregationBuilder.NAME, (p, c) -> ParsedMax.fromXContent(p, (String) c));
-        map.put(SumAggregationBuilder.NAME, (p, c) -> ParsedSum.fromXContent(p, (String) c));
-        map.put(AvgAggregationBuilder.NAME, (p, c) -> ParsedAvg.fromXContent(p, (String) c));
-        map.put(BucketScriptPipelineAggregationBuilder.NAME, (p, c) -> ParsedSimpleValue.fromXContent(p, (String) c));
-        map.put(ScriptedMetricAggregationBuilder.NAME, (p, c) -> ParsedScriptedMetric.fromXContent(p, (String) c));
-        map.put(ValueCountAggregationBuilder.NAME, (p, c) -> ParsedValueCount.fromXContent(p, (String) c));
-        map.put(StatsAggregationBuilder.NAME, (p, c) -> ParsedStats.fromXContent(p, (String) c));
-        map.put(StatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedStatsBucket.fromXContent(p, (String) c));
-        map.put(ExtendedStatsAggregationBuilder.NAME, (p, c) -> ParsedExtendedStats.fromXContent(p, (String) c));
-        map.put(StringTerms.NAME, (p, c) -> ParsedStringTerms.fromXContent(p, (String) c));
-        map.put(LongTerms.NAME, (p, c) -> ParsedLongTerms.fromXContent(p, (String) c));
-        map.put(DoubleTerms.NAME, (p, c) -> ParsedDoubleTerms.fromXContent(p, (String) c));
-
-        namedXContents = map.entrySet()
-            .stream()
-            .map(entry -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField(entry.getKey()), entry.getValue()))
-            .collect(Collectors.toList());
-    }
-
     class TestMultiValueAggregation extends InternalMultiValueAggregation {
 
         private final Map<String, String> values;
 
         TestMultiValueAggregation(String name, Map<String, String> values) {
-            super(name, emptyMap());
+            super(name, Map.of());
             this.values = values;
         }
 
@@ -143,7 +75,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
 
         @Override
         public List<String> getValuesAsStrings(String name) {
-            return Collections.singletonList(values.get(name).toString());
+            return List.of(values.get(name).toString());
         }
 
         @Override
@@ -182,7 +114,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         private final Map<String, Double> values;
 
         TestNumericMultiValueAggregation(String name, Map<String, Double> values) {
-            super(name, null, emptyMap());
+            super(name, null, Map.of());
             this.values = values;
         }
 
@@ -217,11 +149,6 @@ public class AggregationResultUtilsTests extends ESTestCase {
         }
     }
 
-    @Override
-    protected NamedXContentRegistry xContentRegistry() {
-        return namedXContentRegistry;
-    }
-
     public void testExtractCompositeAggregationResults() throws IOException {
         String targetField = randomAlphaOfLengthBetween(5, 10);
 
@@ -230,25 +157,35 @@ public class AggregationResultUtilsTests extends ESTestCase {
             """, targetField));
 
         String aggName = randomAlphaOfLengthBetween(5, 10);
-        String aggTypedName = "avg#" + aggName;
-        Collection<AggregationBuilder> aggregationBuilders = Collections.singletonList(AggregationBuilders.avg(aggName));
+        List<AggregationBuilder> aggregationBuilders = List.of(AggregationBuilders.avg(aggName));
 
-        Map<String, Object> input = asMap(
-            "buckets",
-            asList(
-                asMap(KEY, asMap(targetField, "ID1"), aggTypedName, asMap("value", 42.33), DOC_COUNT, 8),
-                asMap(KEY, asMap(targetField, "ID2"), aggTypedName, asMap("value", 28.99), DOC_COUNT, 3),
-                asMap(KEY, asMap(targetField, "ID3"), aggTypedName, asMap("value", Double.NaN), DOC_COUNT, 0)
+        InternalComposite input = createComposite(
+            List.of(
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID1"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 42.33))),
+                    8L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 28.99))),
+                    3L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID3"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, Double.NaN))),
+                    0L
+                )
             )
         );
 
-        List<Map<String, Object>> expected = asList(
+        List<Map<String, Object>> expected = List.of(
             asMap(targetField, "ID1", aggName, 42.33),
             asMap(targetField, "ID2", aggName, 28.99),
             asMap(targetField, "ID3", aggName, null)
         );
         Map<String, String> fieldTypeMap = asStringMap(targetField, "keyword", aggName, "double");
-        executeTest(groupBy, aggregationBuilders, Collections.emptyList(), input, fieldTypeMap, expected, 11);
+        executeTest(groupBy, aggregationBuilders, List.of(), input, fieldTypeMap, expected, 11);
     }
 
     public void testExtractCompositeAggregationResultsMultipleGroups() throws IOException {
@@ -271,26 +208,41 @@ public class AggregationResultUtilsTests extends ESTestCase {
 
         String aggName = randomAlphaOfLengthBetween(5, 10);
         String aggTypedName = "avg#" + aggName;
-        Collection<AggregationBuilder> aggregationBuilders = Collections.singletonList(AggregationBuilders.avg(aggName));
+        List<AggregationBuilder> aggregationBuilders = List.of(AggregationBuilders.avg(aggName));
 
-        Map<String, Object> input = asMap(
-            "buckets",
-            asList(
-                asMap(KEY, asMap(targetField, "ID1", targetField2, "ID1_2"), aggTypedName, asMap("value", 42.33), DOC_COUNT, 1),
-                asMap(KEY, asMap(targetField, "ID1", targetField2, "ID2_2"), aggTypedName, asMap("value", 8.4), DOC_COUNT, 2),
-                asMap(KEY, asMap(targetField, "ID2", targetField2, "ID1_2"), aggTypedName, asMap("value", 28.99), DOC_COUNT, 3),
-                asMap(KEY, asMap(targetField, "ID3", targetField2, "ID2_2"), aggTypedName, asMap("value", Double.NaN), DOC_COUNT, 0)
+        InternalComposite input = createComposite(
+            List.of(
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID1", targetField2, "ID1_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 42.33))),
+                    1L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID1", targetField2, "ID2_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 8.4))),
+                    2L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID2", targetField2, "ID1_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 28.99))),
+                    3L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID3", targetField2, "ID2_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, Double.NaN))),
+                    0L
+                )
             )
         );
 
-        List<Map<String, Object>> expected = asList(
+        List<Map<String, Object>> expected = List.of(
             asMap(targetField, "ID1", targetField2, "ID1_2", aggName, 42.33),
             asMap(targetField, "ID1", targetField2, "ID2_2", aggName, 8.4),
             asMap(targetField, "ID2", targetField2, "ID1_2", aggName, 28.99),
             asMap(targetField, "ID3", targetField2, "ID2_2", aggName, null)
         );
         Map<String, String> fieldTypeMap = asStringMap(aggName, "double", targetField, "keyword", targetField2, "keyword");
-        executeTest(groupBy, aggregationBuilders, Collections.emptyList(), input, fieldTypeMap, expected, 6);
+        executeTest(groupBy, aggregationBuilders, List.of(), input, fieldTypeMap, expected, 6);
     }
 
     public void testExtractCompositeAggregationResultsMultiAggregations() throws IOException {
@@ -306,56 +258,38 @@ public class AggregationResultUtilsTests extends ESTestCase {
             }""", targetField));
 
         String aggName = randomAlphaOfLengthBetween(5, 10);
-        String aggTypedName = "avg#" + aggName;
 
         String aggName2 = randomAlphaOfLengthBetween(5, 10) + "_2";
-        String aggTypedName2 = "max#" + aggName2;
 
-        Collection<AggregationBuilder> aggregationBuilders = asList(AggregationBuilders.avg(aggName), AggregationBuilders.max(aggName2));
+        List<AggregationBuilder> aggregationBuilders = List.of(AggregationBuilders.avg(aggName), AggregationBuilders.max(aggName2));
 
-        Map<String, Object> input = asMap(
-            "buckets",
-            asList(
-                asMap(
-                    KEY,
+        InternalComposite input = createComposite(
+            List.of(
+                createInternalCompositeBucket(
                     asMap(targetField, "ID1"),
-                    aggTypedName,
-                    asMap("value", 42.33),
-                    aggTypedName2,
-                    asMap("value", 9.9),
-                    DOC_COUNT,
-                    111
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 42.33), createSingleMetricAgg(aggName2, 9.9))),
+                    111L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID2"),
-                    aggTypedName,
-                    asMap("value", 28.99),
-                    aggTypedName2,
-                    asMap("value", 222.33),
-                    DOC_COUNT,
-                    88
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 28.99), createSingleMetricAgg(aggName2, 222.33))),
+                    88L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID3"),
-                    aggTypedName,
-                    asMap("value", 12.55),
-                    aggTypedName2,
-                    asMap("value", Double.NaN),
-                    DOC_COUNT,
-                    1
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 12.55), createSingleMetricAgg(aggName2, Double.NaN))),
+                    1L
                 )
             )
         );
 
-        List<Map<String, Object>> expected = asList(
+        List<Map<String, Object>> expected = List.of(
             asMap(targetField, "ID1", aggName, 42.33, aggName2, 9.9),
             asMap(targetField, "ID2", aggName, 28.99, aggName2, 222.33),
             asMap(targetField, "ID3", aggName, 12.55, aggName2, null)
         );
         Map<String, String> fieldTypeMap = asStringMap(targetField, "keyword", aggName, "double", aggName2, "double");
-        executeTest(groupBy, aggregationBuilders, Collections.emptyList(), input, fieldTypeMap, expected, 200);
+        executeTest(groupBy, aggregationBuilders, List.of(), input, fieldTypeMap, expected, 200);
     }
 
     public void testExtractCompositeAggregationResultsMultiAggregationsAndTypes() throws IOException {
@@ -377,60 +311,43 @@ public class AggregationResultUtilsTests extends ESTestCase {
             }""", targetField, targetField2));
 
         String aggName = randomAlphaOfLengthBetween(5, 10);
-        String aggTypedName = "avg#" + aggName;
 
         String aggName2 = randomAlphaOfLengthBetween(5, 10) + "_2";
-        String aggTypedName2 = "max#" + aggName2;
 
-        Collection<AggregationBuilder> aggregationBuilders = asList(AggregationBuilders.avg(aggName), AggregationBuilders.max(aggName2));
+        List<AggregationBuilder> aggregationBuilders = List.of(AggregationBuilders.avg(aggName), AggregationBuilders.max(aggName2));
 
-        Map<String, Object> input = asMap(
-            "buckets",
-            asList(
-                asMap(
-                    KEY,
+        InternalComposite input = createComposite(
+            List.of(
+                createInternalCompositeBucket(
                     asMap(targetField, "ID1", targetField2, "ID1_2"),
-                    aggTypedName,
-                    asMap("value", 42.33),
-                    aggTypedName2,
-                    asMap("value", 9.9, "value_as_string", "9.9F"),
-                    DOC_COUNT,
-                    1
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 42.33), createSingleMetricAgg(aggName2, 9.9, "9.9F"))),
+                    1L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID1", targetField2, "ID2_2"),
-                    aggTypedName,
-                    asMap("value", 8.4),
-                    aggTypedName2,
-                    asMap("value", 222.33, "value_as_string", "222.33F"),
-                    DOC_COUNT,
-                    2
+                    InternalAggregations.from(
+                        List.of(createSingleMetricAgg(aggName, 8.4), createSingleMetricAgg(aggName2, 222.33, "222.33F"))
+                    ),
+                    2L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID2", targetField2, "ID1_2"),
-                    aggTypedName,
-                    asMap("value", 28.99),
-                    aggTypedName2,
-                    asMap("value", -2.44, "value_as_string", "-2.44F"),
-                    DOC_COUNT,
-                    3
+                    InternalAggregations.from(
+                        List.of(createSingleMetricAgg(aggName, 28.99), createSingleMetricAgg(aggName2, -2.44, "-2.44F"))
+                    ),
+                    3L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID3", targetField2, "ID2_2"),
-                    aggTypedName,
-                    asMap("value", 12.55),
-                    aggTypedName2,
-                    asMap("value", Double.NaN, "value_as_string", "NaN"),
-                    DOC_COUNT,
-                    4
+                    InternalAggregations.from(
+                        List.of(createSingleMetricAgg(aggName, 12.55), createSingleMetricAgg(aggName2, Double.NaN, "NaN"))
+                    ),
+                    4L
                 )
             )
         );
 
-        List<Map<String, Object>> expected = asList(
+        List<Map<String, Object>> expected = List.of(
             asMap(targetField, "ID1", targetField2, "ID1_2", aggName, 42.33, aggName2, "9.9F"),
             asMap(targetField, "ID1", targetField2, "ID2_2", aggName, 8.4, aggName2, "222.33F"),
             asMap(targetField, "ID2", targetField2, "ID1_2", aggName, 28.99, aggName2, "-2.44F"),
@@ -446,7 +363,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
             targetField2,
             "keyword"
         );
-        executeTest(groupBy, aggregationBuilders, Collections.emptyList(), input, fieldTypeMap, expected, 10);
+        executeTest(groupBy, aggregationBuilders, List.of(), input, fieldTypeMap, expected, 10);
     }
 
     public void testExtractCompositeAggregationResultsWithDynamicType() throws IOException {
@@ -468,49 +385,42 @@ public class AggregationResultUtilsTests extends ESTestCase {
             }""", targetField, targetField2));
 
         String aggName = randomAlphaOfLengthBetween(5, 10);
-        String aggTypedName = "scripted_metric#" + aggName;
 
-        Collection<AggregationBuilder> aggregationBuilders = asList(AggregationBuilders.scriptedMetric(aggName));
+        List<AggregationBuilder> aggregationBuilders = List.of(AggregationBuilders.scriptedMetric(aggName));
 
-        Map<String, Object> input = asMap(
-            "buckets",
-            asList(
-                asMap(
-                    KEY,
+        InternalComposite input = createComposite(
+            List.of(
+                createInternalCompositeBucket(
                     asMap(targetField, "ID1", targetField2, "ID1_2"),
-                    aggTypedName,
-                    asMap("value", asMap("field", 123.0)),
-                    DOC_COUNT,
-                    1
+                    InternalAggregations.from(List.of(createScriptedMetric(aggName, asMap("field", 123.0)))),
+                    1L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID1", targetField2, "ID2_2"),
-                    aggTypedName,
-                    asMap("value", asMap("field", 1.0)),
-                    DOC_COUNT,
-                    2
+                    InternalAggregations.from(List.of(createScriptedMetric(aggName, asMap("field", 1.0)))),
+                    2L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID2", targetField2, "ID1_2"),
-                    aggTypedName,
-                    asMap("value", asMap("field", 2.13)),
-                    DOC_COUNT,
-                    3
+                    InternalAggregations.from(List.of(createScriptedMetric(aggName, asMap("field", 2.13)))),
+                    3L
                 ),
-                asMap(KEY, asMap(targetField, "ID3", targetField2, "ID2_2"), aggTypedName, asMap("value", null), DOC_COUNT, 0)
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID3", targetField2, "ID2_2"),
+                    InternalAggregations.from(List.of(createScriptedMetric(aggName, null))),
+                    0L
+                )
             )
         );
 
-        List<Map<String, Object>> expected = asList(
+        List<Map<String, Object>> expected = List.of(
             asMap(targetField, "ID1", targetField2, "ID1_2", aggName, asMap("field", 123.0)),
             asMap(targetField, "ID1", targetField2, "ID2_2", aggName, asMap("field", 1.0)),
             asMap(targetField, "ID2", targetField2, "ID1_2", aggName, asMap("field", 2.13)),
             asMap(targetField, "ID3", targetField2, "ID2_2", aggName, null)
         );
         Map<String, String> fieldTypeMap = asStringMap(targetField, "keyword", targetField2, "keyword");
-        executeTest(groupBy, aggregationBuilders, Collections.emptyList(), input, fieldTypeMap, expected, 6);
+        executeTest(groupBy, aggregationBuilders, List.of(), input, fieldTypeMap, expected, 6);
     }
 
     public void testExtractCompositeAggregationResultsWithPipelineAggregation() throws IOException {
@@ -532,66 +442,47 @@ public class AggregationResultUtilsTests extends ESTestCase {
             }""", targetField, targetField2));
 
         String aggName = randomAlphaOfLengthBetween(5, 10);
-        String aggTypedName = "avg#" + aggName;
         String pipelineAggName = randomAlphaOfLengthBetween(5, 10) + "_2";
-        String pipelineAggTypedName = "bucket_script#" + pipelineAggName;
 
-        Collection<AggregationBuilder> aggregationBuilders = asList(AggregationBuilders.scriptedMetric(aggName));
-        Collection<PipelineAggregationBuilder> pipelineAggregationBuilders = asList(
-            PipelineAggregatorBuilders.bucketScript(
-                pipelineAggName,
-                Collections.singletonMap("param_1", aggName),
-                new Script("return params.param_1")
-            )
+        List<AggregationBuilder> aggregationBuilders = List.of(AggregationBuilders.scriptedMetric(aggName));
+        List<PipelineAggregationBuilder> pipelineAggregationBuilders = List.of(
+            PipelineAggregatorBuilders.bucketScript(pipelineAggName, Map.of("param_1", aggName), new Script("return params.param_1"))
         );
 
-        Map<String, Object> input = asMap(
-            "buckets",
-            asList(
-                asMap(
-                    KEY,
+        InternalComposite input = createComposite(
+            List.of(
+                createInternalCompositeBucket(
                     asMap(targetField, "ID1", targetField2, "ID1_2"),
-                    aggTypedName,
-                    asMap("value", 123.0),
-                    pipelineAggTypedName,
-                    asMap("value", 123.0),
-                    DOC_COUNT,
-                    1
+                    InternalAggregations.from(
+                        List.of(createSingleMetricAgg(aggName, 123.0), createSingleMetricAgg(pipelineAggName, 123.0, "123.0"))
+                    ),
+                    1L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID1", targetField2, "ID2_2"),
-                    aggTypedName,
-                    asMap("value", 1.0),
-                    pipelineAggTypedName,
-                    asMap("value", 1.0),
-                    DOC_COUNT,
-                    2
+                    InternalAggregations.from(
+                        List.of(createSingleMetricAgg(aggName, 1.0), createSingleMetricAgg(pipelineAggName, 1.0, "1.0"))
+                    ),
+                    2L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID2", targetField2, "ID1_2"),
-                    aggTypedName,
-                    asMap("value", 2.13),
-                    pipelineAggTypedName,
-                    asMap("value", 2.13),
-                    DOC_COUNT,
-                    3
+                    InternalAggregations.from(
+                        List.of(createSingleMetricAgg(aggName, 2.13), createSingleMetricAgg(pipelineAggName, 2.13, "2.13"))
+                    ),
+                    3L
                 ),
-                asMap(
-                    KEY,
+                createInternalCompositeBucket(
                     asMap(targetField, "ID3", targetField2, "ID2_2"),
-                    aggTypedName,
-                    asMap("value", 12.0),
-                    pipelineAggTypedName,
-                    asMap("value", Double.NaN),
-                    DOC_COUNT,
-                    4
+                    InternalAggregations.from(
+                        List.of(createSingleMetricAgg(aggName, 12.0), createSingleMetricAgg(pipelineAggName, Double.NaN, "NaN"))
+                    ),
+                    4L
                 )
             )
         );
 
-        List<Map<String, Object>> expected = asList(
+        List<Map<String, Object>> expected = List.of(
             asMap(targetField, "ID1", targetField2, "ID1_2", aggName, 123.0, pipelineAggName, 123.0),
             asMap(targetField, "ID1", targetField2, "ID2_2", aggName, 1.0, pipelineAggName, 1.0),
             asMap(targetField, "ID2", targetField2, "ID1_2", aggName, 2.13, pipelineAggName, 2.13),
@@ -620,28 +511,58 @@ public class AggregationResultUtilsTests extends ESTestCase {
             }""", targetField, targetField2));
 
         String aggName = randomAlphaOfLengthBetween(5, 10);
-        String aggTypedName = "avg#" + aggName;
-        Collection<AggregationBuilder> aggregationBuilders = Collections.singletonList(AggregationBuilders.avg(aggName));
+        List<AggregationBuilder> aggregationBuilders = List.of(AggregationBuilders.avg(aggName));
 
-        Map<String, Object> inputFirstRun = asMap(
-            "buckets",
-            asList(
-                asMap(KEY, asMap(targetField, "ID1", targetField2, "ID1_2"), aggTypedName, asMap("value", 42.33), DOC_COUNT, 1),
-                asMap(KEY, asMap(targetField, "ID1", targetField2, "ID2_2"), aggTypedName, asMap("value", 8.4), DOC_COUNT, 2),
-                asMap(KEY, asMap(targetField, "ID2", targetField2, "ID1_2"), aggTypedName, asMap("value", 28.99), DOC_COUNT, 3),
-                asMap(KEY, asMap(targetField, "ID3", targetField2, "ID2_2"), aggTypedName, asMap("value", 12.55), DOC_COUNT, 4)
+        InternalComposite inputFirstRun = createComposite(
+            List.of(
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID1", targetField2, "ID1_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 42.33))),
+                    1L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID1", targetField2, "ID2_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 8.4))),
+                    2L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID2", targetField2, "ID1_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 28.99))),
+                    3L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID3", targetField2, "ID2_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 12.55))),
+                    4L
+                )
             )
         );
 
-        Map<String, Object> inputSecondRun = asMap(
-            "buckets",
-            asList(
-                asMap(KEY, asMap(targetField, "ID1", targetField2, "ID1_2"), aggTypedName, asMap("value", 433.33), DOC_COUNT, 12),
-                asMap(KEY, asMap(targetField, "ID1", targetField2, "ID2_2"), aggTypedName, asMap("value", 83.4), DOC_COUNT, 32),
-                asMap(KEY, asMap(targetField, "ID2", targetField2, "ID1_2"), aggTypedName, asMap("value", 21.99), DOC_COUNT, 2),
-                asMap(KEY, asMap(targetField, "ID3", targetField2, "ID2_2"), aggTypedName, asMap("value", 122.55), DOC_COUNT, 44)
+        InternalComposite inputSecondRun = createComposite(
+            List.of(
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID1", targetField2, "ID1_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 433.33))),
+                    12L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID1", targetField2, "ID2_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 83.4))),
+                    32L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID2", targetField2, "ID1_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 21.99))),
+                    2L
+                ),
+                createInternalCompositeBucket(
+                    asMap(targetField, "ID3", targetField2, "ID2_2"),
+                    InternalAggregations.from(List.of(createSingleMetricAgg(aggName, 122.55))),
+                    44L
+                )
             )
         );
+
         TransformIndexerStats stats = new TransformIndexerStats();
         TransformProgress progress = new TransformProgress();
 
@@ -650,7 +571,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         List<Map<String, Object>> resultFirstRun = runExtraction(
             groupBy,
             aggregationBuilders,
-            Collections.emptyList(),
+            List.of(),
             inputFirstRun,
             fieldTypeMap,
             stats,
@@ -659,7 +580,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         List<Map<String, Object>> resultSecondRun = runExtraction(
             groupBy,
             aggregationBuilders,
-            Collections.emptyList(),
+            List.of(),
             inputSecondRun,
             fieldTypeMap,
             stats,
@@ -724,53 +645,52 @@ public class AggregationResultUtilsTests extends ESTestCase {
         assertThat(exception.getMessage(), equalTo("mixed object types of nested and non-nested fields [foo.bar]"));
     }
 
-    public static NumericMetricsAggregation.SingleValue createSingleMetricAgg(String name, Double value, String valueAsString) {
-        NumericMetricsAggregation.SingleValue agg = mock(NumericMetricsAggregation.SingleValue.class);
+    public static InternalNumericMetricsAggregation.SingleValue createSingleMetricAgg(String name, Double value) {
+        InternalNumericMetricsAggregation.SingleValue agg = mock(InternalNumericMetricsAggregation.SingleValue.class);
         when(agg.value()).thenReturn(value);
-        when(agg.getValueAsString()).thenReturn(valueAsString);
         when(agg.getName()).thenReturn(name);
+        return agg;
+    }
+
+    public static InternalNumericMetricsAggregation.SingleValue createSingleMetricAgg(String name, Double value, String valueAsString) {
+        InternalNumericMetricsAggregation.SingleValue agg = createSingleMetricAgg(name, value);
+        when(agg.getValueAsString()).thenReturn(valueAsString);
         return agg;
     }
 
     public void testSingleValueAggExtractor() {
         Aggregation agg = createSingleMetricAgg("metric", Double.NaN, "NaN");
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("metric", "double"), ""), is(nullValue()));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of("metric", "double"), ""), is(nullValue()));
 
         agg = createSingleMetricAgg("metric", Double.POSITIVE_INFINITY, "NaN");
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("metric", "double"), ""), is(nullValue()));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of("metric", "double"), ""), is(nullValue()));
 
         agg = createSingleMetricAgg("metric", 100.0, "100.0");
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("metric", "double"), ""), equalTo(100.0));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of("metric", "double"), ""), equalTo(100.0));
 
         agg = createSingleMetricAgg("metric", 100.0, "one_hundred");
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("metric", "double"), ""), equalTo(100.0));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of("metric", "double"), ""), equalTo(100.0));
 
         agg = createSingleMetricAgg("metric", 100.0, "one_hundred");
-        assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("metric", "string"), ""),
-            equalTo("one_hundred")
-        );
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of("metric", "string"), ""), equalTo("one_hundred"));
 
         agg = createSingleMetricAgg("metric", 100.0, "one_hundred");
-        assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("metric", "unsigned_long"), ""),
-            equalTo(100L)
-        );
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of("metric", "unsigned_long"), ""), equalTo(100L));
     }
 
     public void testMultiValueAggExtractor() {
-        Aggregation agg = new TestMultiValueAggregation("mv_metric", Collections.singletonMap("ip", "192.168.1.1"));
+        Aggregation agg = new TestMultiValueAggregation("mv_metric", Map.of("ip", "192.168.1.1"));
 
         assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("mv_metric.ip", "ip"), ""),
-            equalTo(Collections.singletonMap("ip", "192.168.1.1"))
+            AggregationResultUtils.getExtractor(agg).value(agg, Map.of("mv_metric.ip", "ip"), ""),
+            equalTo(Map.of("ip", "192.168.1.1"))
         );
 
-        agg = new TestMultiValueAggregation("mv_metric", Collections.singletonMap("top_answer", "fortytwo"));
+        agg = new TestMultiValueAggregation("mv_metric", Map.of("top_answer", "fortytwo"));
 
         assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("mv_metric.written_answer", "written_answer"), ""),
-            equalTo(Collections.singletonMap("top_answer", "fortytwo"))
+            AggregationResultUtils.getExtractor(agg).value(agg, Map.of("mv_metric.written_answer", "written_answer"), ""),
+            equalTo(Map.of("top_answer", "fortytwo"))
         );
 
         agg = new TestMultiValueAggregation("mv_metric", Map.of("ip", "192.168.1.1", "top_answer", "fortytwo"));
@@ -782,21 +702,18 @@ public class AggregationResultUtilsTests extends ESTestCase {
     }
 
     public void testNumericMultiValueAggExtractor() {
-        Aggregation agg = new TestNumericMultiValueAggregation(
-            "mv_metric",
-            Collections.singletonMap("approx_answer", Double.valueOf(42.2))
-        );
+        Aggregation agg = new TestNumericMultiValueAggregation("mv_metric", Map.of("approx_answer", 42.2));
 
         assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("mv_metric.approx_answer", "double"), ""),
-            equalTo(Collections.singletonMap("approx_answer", Double.valueOf(42.2)))
+            AggregationResultUtils.getExtractor(agg).value(agg, Map.of("mv_metric.approx_answer", "double"), ""),
+            equalTo(Map.of("approx_answer", Double.valueOf(42.2)))
         );
 
-        agg = new TestNumericMultiValueAggregation("mv_metric", Collections.singletonMap("exact_answer", Double.valueOf(42.0)));
+        agg = new TestNumericMultiValueAggregation("mv_metric", Map.of("exact_answer", 42.0));
 
         assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.singletonMap("mv_metric.exact_answer", "long"), ""),
-            equalTo(Collections.singletonMap("exact_answer", Long.valueOf(42)))
+            AggregationResultUtils.getExtractor(agg).value(agg, Map.of("mv_metric.exact_answer", "long"), ""),
+            equalTo(Map.of("exact_answer", 42L))
         );
 
         agg = new TestNumericMultiValueAggregation(
@@ -813,27 +730,28 @@ public class AggregationResultUtilsTests extends ESTestCase {
         assertThat(
             AggregationResultUtils.getExtractor(agg)
                 .value(agg, Map.of("filter.mv_metric.approx_answer", "double", "filter.mv_metric.exact_answer", "long"), "filter"),
-            equalTo(Map.of("approx_answer", Double.valueOf(42.2), "exact_answer", Long.valueOf(42)))
+            equalTo(Map.of("approx_answer", 42.2, "exact_answer", Long.valueOf(42)))
         );
     }
 
-    private ScriptedMetric createScriptedMetric(Object returnValue) {
-        ScriptedMetric agg = mock(ScriptedMetric.class);
+    private InternalScriptedMetric createScriptedMetric(String name, Object returnValue) {
+        InternalScriptedMetric agg = mock(InternalScriptedMetric.class);
+        when(agg.getName()).thenReturn(name);
         when(agg.aggregation()).thenReturn(returnValue);
         return agg;
     }
 
     @SuppressWarnings("unchecked")
     public void testScriptedMetricAggExtractor() {
-        Aggregation agg = createScriptedMetric(null);
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), is(nullValue()));
+        Aggregation agg = createScriptedMetric("name", null);
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), is(nullValue()));
 
-        agg = createScriptedMetric(Collections.singletonList("values"));
-        Object val = AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), "");
+        agg = createScriptedMetric("name", List.of("values"));
+        Object val = AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), "");
         assertThat((List<String>) val, hasItem("values"));
 
-        agg = createScriptedMetric(Collections.singletonMap("key", 100));
-        val = AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), "");
+        agg = createScriptedMetric("name", Map.of("key", 100));
+        val = AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), "");
         assertThat(((Map<String, Object>) val).get("key"), equalTo(100));
     }
 
@@ -846,13 +764,13 @@ public class AggregationResultUtilsTests extends ESTestCase {
 
     public void testGeoCentroidAggExtractor() {
         Aggregation agg = createGeoCentroid(null, 0);
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), is(nullValue()));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), is(nullValue()));
 
         agg = createGeoCentroid(new GeoPoint(100.0, 101.0), 0);
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), is(nullValue()));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), is(nullValue()));
 
         agg = createGeoCentroid(new GeoPoint(100.0, 101.0), randomIntBetween(1, 100));
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), equalTo("100.0, 101.0"));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), equalTo("100.0, 101.0"));
     }
 
     private GeoBounds createGeoBounds(GeoPoint tl, GeoPoint br) {
@@ -866,10 +784,10 @@ public class AggregationResultUtilsTests extends ESTestCase {
     public void testGeoBoundsAggExtractor() {
         final int numberOfRuns = 25;
         Aggregation agg = createGeoBounds(null, new GeoPoint(100.0, 101.0));
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), is(nullValue()));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), is(nullValue()));
 
         agg = createGeoBounds(new GeoPoint(100.0, 101.0), null);
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), is(nullValue()));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), is(nullValue()));
 
         String type = "point";
         for (int i = 0; i < numberOfRuns; i++) {
@@ -877,9 +795,9 @@ public class AggregationResultUtilsTests extends ESTestCase {
             expectedObject.put("type", type);
             double lat = randomDoubleBetween(-90.0, 90.0, false);
             double lon = randomDoubleBetween(-180.0, 180.0, false);
-            expectedObject.put("coordinates", asList(lon, lat));
+            expectedObject.put("coordinates", List.of(lon, lat));
             agg = createGeoBounds(new GeoPoint(lat, lon), new GeoPoint(lat, lon));
-            assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), equalTo(expectedObject));
+            assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), equalTo(expectedObject));
         }
 
         type = "linestring";
@@ -894,7 +812,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
                 lon2 = randomDoubleBetween(-180.0, 180.0, false);
             }
             agg = createGeoBounds(new GeoPoint(lat, lon), new GeoPoint(lat2, lon2));
-            Object val = AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), "");
+            Object val = AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), "");
             Map<String, Object> geoJson = (Map<String, Object>) val;
             assertThat(geoJson.get("type"), equalTo(type));
             List<Double[]> coordinates = (List<Double[]>) geoJson.get("coordinates");
@@ -918,18 +836,18 @@ public class AggregationResultUtilsTests extends ESTestCase {
                 lon2 = randomDoubleBetween(-180.0, 180.0, false);
             }
             agg = createGeoBounds(new GeoPoint(lat, lon), new GeoPoint(lat2, lon2));
-            Object val = AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), "");
+            Object val = AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), "");
             Map<String, Object> geoJson = (Map<String, Object>) val;
             assertThat(geoJson.get("type"), equalTo(type));
             List<List<Double[]>> coordinates = (List<List<Double[]>>) geoJson.get("coordinates");
             assertThat(coordinates.size(), equalTo(1));
             assertThat(coordinates.get(0).size(), equalTo(5));
-            List<List<Double>> expected = asList(
-                asList(lon, lat),
-                asList(lon2, lat),
-                asList(lon2, lat2),
-                asList(lon, lat2),
-                asList(lon, lat)
+            List<List<Double>> expected = List.of(
+                List.of(lon, lat),
+                List.of(lon2, lat),
+                List.of(lon2, lat2),
+                List.of(lon, lat2),
+                List.of(lon, lat)
             );
             for (int j = 0; j < 5; j++) {
                 Double[] coordinate = coordinates.get(0).get(j);
@@ -938,6 +856,28 @@ public class AggregationResultUtilsTests extends ESTestCase {
                 assertThat(coordinate[1], equalTo(expected.get(j).get(1)));
             }
         }
+    }
+
+    private static InternalComposite createComposite(List<InternalComposite.InternalBucket> buckets) {
+        InternalComposite composite = mock(InternalComposite.class);
+
+        when(composite.getBuckets()).thenReturn(buckets);
+        when(composite.getName()).thenReturn("my_feature");
+        Map<String, Object> afterKey = buckets.get(buckets.size() - 1).getKey();
+        when(composite.afterKey()).thenReturn(afterKey);
+        return composite;
+    }
+
+    private static InternalComposite.InternalBucket createInternalCompositeBucket(
+        Map<String, Object> key,
+        InternalAggregations aggregations,
+        long docCount
+    ) {
+        InternalComposite.InternalBucket bucket = mock(InternalComposite.InternalBucket.class);
+        when(bucket.getDocCount()).thenReturn(docCount);
+        when(bucket.getAggregations()).thenReturn(aggregations);
+        when(bucket.getKey()).thenReturn(key);
+        return bucket;
     }
 
     public static Percentiles createPercentilesAgg(String name, List<Percentile> percentiles) {
@@ -951,17 +891,17 @@ public class AggregationResultUtilsTests extends ESTestCase {
     public void testPercentilesAggExtractor() {
         Aggregation agg = createPercentilesAgg(
             "p_agg",
-            asList(new Percentile(1, 0), new Percentile(50, 22.2), new Percentile(99, 43.3), new Percentile(99.5, 100.3))
+            List.of(new Percentile(1, 0), new Percentile(50, 22.2), new Percentile(99, 43.3), new Percentile(99.5, 100.3))
         );
         assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""),
+            AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""),
             equalTo(asMap("1", 0.0, "50", 22.2, "99", 43.3, "99_5", 100.3))
         );
     }
 
     public void testPercentilesAggExtractorNaN() {
-        Aggregation agg = createPercentilesAgg("p_agg", asList(new Percentile(1, Double.NaN), new Percentile(50, Double.NaN)));
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), equalTo(asMap("1", null, "50", null)));
+        Aggregation agg = createPercentilesAgg("p_agg", List.of(new Percentile(1, Double.NaN), new Percentile(50, Double.NaN)));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), equalTo(asMap("1", null, "50", null)));
     }
 
     @SuppressWarnings("unchecked")
@@ -975,7 +915,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
     public void testRangeAggExtractor() {
         Aggregation agg = createRangeAgg(
             "p_agg",
-            asList(
+            List.of(
                 new InternalRange.Bucket(null, Double.NEGATIVE_INFINITY, 10.5, 10, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
                 new InternalRange.Bucket(null, 10.5, 19.5, 30, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
                 new InternalRange.Bucket(null, 19.5, 200, 30, InternalAggregations.EMPTY, false, DocValueFormat.RAW),
@@ -987,7 +927,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
             )
         );
         assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""),
+            AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""),
             equalTo(
                 asMap(
                     "*-10_5",
@@ -1017,7 +957,7 @@ public class AggregationResultUtilsTests extends ESTestCase {
         when(agg.getName()).thenReturn(name);
         if (subAggregations != null) {
             org.elasticsearch.search.aggregations.Aggregations subAggs = new org.elasticsearch.search.aggregations.Aggregations(
-                asList(subAggregations)
+                List.of(subAggregations)
             );
             when(agg.getAggregations()).thenReturn(subAggs);
         } else {
@@ -1028,13 +968,10 @@ public class AggregationResultUtilsTests extends ESTestCase {
 
     public void testSingleBucketAggExtractor() {
         Aggregation agg = createSingleBucketAgg("sba", 42L);
-        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""), equalTo(42L));
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), equalTo(42L));
 
         agg = createSingleBucketAgg("sba1", 42L, createSingleMetricAgg("sub1", 100.0, "100.0"));
-        assertThat(
-            AggregationResultUtils.getExtractor(agg).value(agg, Collections.emptyMap(), ""),
-            equalTo(Collections.singletonMap("sub1", 100.0))
-        );
+        assertThat(AggregationResultUtils.getExtractor(agg).value(agg, Map.of(), ""), equalTo(Map.of("sub1", 100.0)));
 
         agg = createSingleBucketAgg(
             "sba2",
@@ -1097,17 +1034,15 @@ public class AggregationResultUtilsTests extends ESTestCase {
 
     private void executeTest(
         GroupConfig groups,
-        Collection<AggregationBuilder> aggregationBuilders,
-        Collection<PipelineAggregationBuilder> pipelineAggregationBuilders,
-        Map<String, Object> input,
+        List<AggregationBuilder> aggregationBuilders,
+        List<PipelineAggregationBuilder> pipelineAggregationBuilders,
+        InternalComposite input,
         Map<String, String> fieldTypeMap,
         List<Map<String, Object>> expected,
         long expectedDocCounts
-    ) throws IOException {
+    ) {
         TransformIndexerStats stats = new TransformIndexerStats();
         TransformProgress progress = new TransformProgress();
-        XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
-        builder.map(input);
 
         List<Map<String, Object>> result = runExtraction(
             groups,
@@ -1131,30 +1066,23 @@ public class AggregationResultUtilsTests extends ESTestCase {
 
     private List<Map<String, Object>> runExtraction(
         GroupConfig groups,
-        Collection<AggregationBuilder> aggregationBuilders,
-        Collection<PipelineAggregationBuilder> pipelineAggregationBuilders,
-        Map<String, Object> input,
+        List<AggregationBuilder> aggregationBuilders,
+        List<PipelineAggregationBuilder> pipelineAggregationBuilders,
+        InternalComposite input,
         Map<String, String> fieldTypeMap,
         TransformIndexerStats stats,
         TransformProgress progress
-    ) throws IOException {
-
-        XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
-        builder.map(input);
-
-        try (XContentParser parser = createParser(builder)) {
-            CompositeAggregation agg = ParsedComposite.fromXContent(parser, "my_feature");
-            return AggregationResultUtils.extractCompositeAggregationResults(
-                agg,
-                groups,
-                aggregationBuilders,
-                pipelineAggregationBuilders,
-                fieldTypeMap,
-                stats,
-                progress,
-                true
-            ).collect(Collectors.toList());
-        }
+    ) {
+        return AggregationResultUtils.extractCompositeAggregationResults(
+            input,
+            groups,
+            aggregationBuilders,
+            pipelineAggregationBuilders,
+            fieldTypeMap,
+            stats,
+            progress,
+            true
+        ).collect(Collectors.toList());
     }
 
     private GroupConfig parseGroupConfig(String json) throws IOException {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollectorTests.java
@@ -12,9 +12,9 @@ import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
@@ -27,7 +27,6 @@ import org.elasticsearch.xpack.core.transform.transforms.pivot.TermsGroupSource;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.TermsGroupSourceTests;
 import org.elasticsearch.xpack.transform.transforms.Function.ChangeCollector;
 import org.elasticsearch.xpack.transform.transforms.pivot.CompositeBucketsChangeCollector.FieldCollector;
-import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -92,25 +91,25 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
 
         ChangeCollector collector = CompositeBucketsChangeCollector.buildChangeCollector(groups, null);
 
-        CompositeAggregation composite = mock(CompositeAggregation.class);
+        InternalComposite composite = mock(InternalComposite.class);
         when(composite.getName()).thenReturn("_transform_change_collector");
-        when(composite.getBuckets()).thenAnswer((Answer<List<CompositeAggregation.Bucket>>) invocationOnMock -> {
-            List<CompositeAggregation.Bucket> compositeBuckets = new ArrayList<>();
-            CompositeAggregation.Bucket bucket = mock(CompositeAggregation.Bucket.class);
+        when(composite.getBuckets()).thenAnswer(invocationOnMock -> {
+            List<InternalComposite.InternalBucket> compositeBuckets = new ArrayList<>();
+            InternalComposite.InternalBucket bucket = mock(InternalComposite.InternalBucket.class);
             when(bucket.getKey()).thenReturn(Collections.singletonMap("id", "id1"));
             compositeBuckets.add(bucket);
 
-            bucket = mock(CompositeAggregation.Bucket.class);
+            bucket = mock(InternalComposite.InternalBucket.class);
             when(bucket.getKey()).thenReturn(Collections.singletonMap("id", "id2"));
             compositeBuckets.add(bucket);
 
-            bucket = mock(CompositeAggregation.Bucket.class);
+            bucket = mock(InternalComposite.InternalBucket.class);
             when(bucket.getKey()).thenReturn(Collections.singletonMap("id", "id3"));
             compositeBuckets.add(bucket);
 
             return compositeBuckets;
         });
-        Aggregations aggs = new Aggregations(Collections.singletonList(composite));
+        InternalAggregations aggs = InternalAggregations.from(Collections.singletonList(composite));
 
         SearchResponse response = new SearchResponse(
             SearchHits.EMPTY_WITH_TOTAL_HITS,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/DateHistogramFieldCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/DateHistogramFieldCollectorTests.java
@@ -12,10 +12,10 @@ import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
-import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation.SingleValue;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation.SingleValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.DateHistogramGroupSource;
@@ -60,8 +60,8 @@ public class DateHistogramFieldCollectorTests extends ESTestCase {
 
     @Before
     public void setupDateHistogramFieldCollectorTest() {
-        minTimestamp = mock(NumericMetricsAggregation.SingleValue.class);
-        maxTimestamp = mock(NumericMetricsAggregation.SingleValue.class);
+        minTimestamp = mock(InternalNumericMetricsAggregation.SingleValue.class);
+        maxTimestamp = mock(InternalNumericMetricsAggregation.SingleValue.class);
 
         when(minTimestamp.getName()).thenReturn("_transform_change_collector.output_timestamp.min");
         when(maxTimestamp.getName()).thenReturn("_transform_change_collector.output_timestamp.max");
@@ -173,7 +173,7 @@ public class DateHistogramFieldCollectorTests extends ESTestCase {
     private static SearchResponse buildSearchResponse(SingleValue minTimestamp, SingleValue maxTimestamp) {
         return new SearchResponse(
             SearchHits.EMPTY_WITH_TOTAL_HITS,
-            new Aggregations(Arrays.asList(minTimestamp, maxTimestamp)),
+            InternalAggregations.from(Arrays.asList(minTimestamp, maxTimestamp)),
             null,
             false,
             null,

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
@@ -25,8 +25,8 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchModule;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -268,30 +268,30 @@ public class PivotTests extends ESTestCase {
             }
         };
 
-        Aggregations aggs = null;
+        InternalAggregations aggs = null;
         assertThat(pivot.processSearchResponse(searchResponseFromAggs(aggs), null, null, null, null, null), is(nullValue()));
 
-        aggs = new Aggregations(List.of());
+        aggs = InternalAggregations.from(List.of());
         assertThat(pivot.processSearchResponse(searchResponseFromAggs(aggs), null, null, null, null, null), is(nullValue()));
 
-        CompositeAggregation compositeAgg = mock(CompositeAggregation.class);
+        InternalComposite compositeAgg = mock(InternalComposite.class);
         when(compositeAgg.getName()).thenReturn("_transform");
         when(compositeAgg.getBuckets()).thenReturn(List.of());
         when(compositeAgg.afterKey()).thenReturn(null);
-        aggs = new Aggregations(List.of(compositeAgg));
+        aggs = InternalAggregations.from(List.of(compositeAgg));
         assertThat(pivot.processSearchResponse(searchResponseFromAggs(aggs), null, null, null, null, null), is(nullValue()));
 
         when(compositeAgg.getBuckets()).thenReturn(List.of());
         when(compositeAgg.afterKey()).thenReturn(Map.of("key", "value"));
-        aggs = new Aggregations(List.of(compositeAgg));
+        aggs = InternalAggregations.from(List.of(compositeAgg));
         // Empty bucket list is *not* a stop condition for composite agg processing.
         assertThat(pivot.processSearchResponse(searchResponseFromAggs(aggs), null, null, null, null, null), is(notNullValue()));
 
-        CompositeAggregation.Bucket bucket = mock(CompositeAggregation.Bucket.class);
-        List<? extends CompositeAggregation.Bucket> buckets = List.of(bucket);
+        InternalComposite.InternalBucket bucket = mock(InternalComposite.InternalBucket.class);
+        List<InternalComposite.InternalBucket> buckets = List.of(bucket);
         doReturn(buckets).when(compositeAgg).getBuckets();
         when(compositeAgg.afterKey()).thenReturn(null);
-        aggs = new Aggregations(List.of(compositeAgg));
+        aggs = InternalAggregations.from(List.of(compositeAgg));
         assertThat(pivot.processSearchResponse(searchResponseFromAggs(aggs), null, null, null, null, null), is(nullValue()));
     }
 
@@ -350,7 +350,7 @@ public class PivotTests extends ESTestCase {
         assertThat(responseHolder.get(), is(empty()));
     }
 
-    private static SearchResponse searchResponseFromAggs(Aggregations aggs) {
+    private static SearchResponse searchResponseFromAggs(InternalAggregations aggs) {
         return new SearchResponse(
             SearchHits.EMPTY_WITH_TOTAL_HITS,
             aggs,
@@ -434,7 +434,7 @@ public class PivotTests extends ESTestCase {
             ActionListener<Response> listener
         ) {
             SearchResponse response = mock(SearchResponse.class);
-            when(response.getAggregations()).thenReturn(new Aggregations(List.of()));
+            when(response.getAggregations()).thenReturn(InternalAggregations.from(List.of()));
             listener.onResponse((Response) response);
         }
     }
@@ -452,8 +452,8 @@ public class PivotTests extends ESTestCase {
             ActionListener<Response> listener
         ) {
             SearchResponse response = mock(SearchResponse.class);
-            CompositeAggregation compositeAggregation = mock(CompositeAggregation.class);
-            when(response.getAggregations()).thenReturn(new Aggregations(List.of(compositeAggregation)));
+            InternalComposite compositeAggregation = mock(InternalComposite.class);
+            when(response.getAggregations()).thenReturn(InternalAggregations.from(List.of(compositeAggregation)));
             when(compositeAggregation.getBuckets()).thenReturn(new ArrayList<>());
             listener.onResponse((Response) response);
         }


### PR DESCRIPTION
Parsed aggregations is an abstraction added to support the High level rest client. As this client has been removed, it is not needed anymore and it os going to be removed. Therefore we are removing the usage in transform test.

In addition this PR removes any usage of `Aggregations` class as the plan is to remove it as well as it is not needed. It is replace with the usage of `InternalAggregations`.

relates https://github.com/elastic/elasticsearch/issues/104789