### PR TITLE
Remove Aggregations class usages from ML module tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -37,7 +37,7 @@ import java.util.function.DoubleConsumer;
 /**
  * Implementation of {@link Histogram}.
  */
-public final class InternalHistogram extends InternalMultiBucketAggregation<InternalHistogram, InternalHistogram.Bucket>
+public class InternalHistogram extends InternalMultiBucketAggregation<InternalHistogram, InternalHistogram.Bucket>
     implements
         Histogram,
         HistogramFactory {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/ParsedCategorization.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/categorization/ParsedCategorization.java
@@ -12,7 +12,8 @@ import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.ParsedMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -137,7 +138,7 @@ class ParsedCategorization extends ParsedMultiBucketAggregation<ParsedCategoriza
             XContentParser.Token token;
             String currentFieldName = parser.currentName();
 
-            List<Aggregation> aggregations = new ArrayList<>();
+            List<InternalAggregation> aggregations = new ArrayList<>();
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
                 if (token == XContentParser.Token.FIELD_NAME) {
                     currentFieldName = parser.currentName();
@@ -160,13 +161,13 @@ class ParsedCategorization extends ParsedMultiBucketAggregation<ParsedCategoriza
                         XContentParserUtils.parseTypedKeysObject(
                             parser,
                             Aggregation.TYPED_KEYS_DELIMITER,
-                            Aggregation.class,
+                            InternalAggregation.class,
                             aggregations::add
                         );
                     }
                 }
             }
-            bucket.setAggregations(new Aggregations(aggregations));
+            bucket.setAggregations(InternalAggregations.from(aggregations));
             return bucket;
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationDataExtractorTests.java
@@ -17,9 +17,9 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.datafeed.SearchInterval;
@@ -119,7 +119,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
     }
 
     public void testExtraction() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(
                 1000L,
                 3,
@@ -189,7 +189,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
 
     public void testExtractionGivenResponseHasEmptyAggs() throws IOException {
         TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
-        Aggregations emptyAggs = AggregationTestUtils.createAggs(Collections.emptyList());
+        InternalAggregations emptyAggs = AggregationTestUtils.createAggs(Collections.emptyList());
         SearchResponse response = createSearchResponse(emptyAggs);
         extractor.setNextResponse(response);
 
@@ -215,12 +215,12 @@ public class AggregationDataExtractorTests extends ESTestCase {
     public void testExtractionGivenResponseHasMultipleTopLevelAggs() {
         TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
 
-        Histogram histogram1 = mock(Histogram.class);
+        InternalHistogram histogram1 = mock(InternalHistogram.class);
         when(histogram1.getName()).thenReturn("hist_1");
-        Histogram histogram2 = mock(Histogram.class);
+        InternalHistogram histogram2 = mock(InternalHistogram.class);
         when(histogram2.getName()).thenReturn("hist_2");
 
-        Aggregations aggs = AggregationTestUtils.createAggs(Arrays.asList(histogram1, histogram2));
+        InternalAggregations aggs = AggregationTestUtils.createAggs(Arrays.asList(histogram1, histogram2));
         SearchResponse response = createSearchResponse(aggs);
         extractor.setNextResponse(response);
 
@@ -240,7 +240,7 @@ public class AggregationDataExtractorTests extends ESTestCase {
 
     public void testExtractionGivenCancelHalfWay() throws IOException {
         int buckets = 1200;
-        List<Histogram.Bucket> histogramBuckets = new ArrayList<>(buckets);
+        List<InternalHistogram.Bucket> histogramBuckets = new ArrayList<>(buckets);
         long timestamp = 1000;
         for (int i = 0; i < buckets; i++) {
             histogramBuckets.add(
@@ -312,16 +312,16 @@ public class AggregationDataExtractorTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private SearchResponse createSearchResponse(String histogramName, List<Histogram.Bucket> histogramBuckets) {
-        Histogram histogram = mock(Histogram.class);
+    private SearchResponse createSearchResponse(String histogramName, List<InternalHistogram.Bucket> histogramBuckets) {
+        InternalHistogram histogram = mock(InternalHistogram.class);
         when(histogram.getName()).thenReturn(histogramName);
-        when((List<Histogram.Bucket>) histogram.getBuckets()).thenReturn(histogramBuckets);
+        when(histogram.getBuckets()).thenReturn(histogramBuckets);
 
-        Aggregations searchAggs = AggregationTestUtils.createAggs(Collections.singletonList(histogram));
+        InternalAggregations searchAggs = AggregationTestUtils.createAggs(Collections.singletonList(histogram));
         return createSearchResponse(searchAggs);
     }
 
-    private SearchResponse createSearchResponse(Aggregations aggregations) {
+    private SearchResponse createSearchResponse(InternalAggregations aggregations) {
         SearchResponse searchResponse = mock(SearchResponse.class);
         when(searchResponse.status()).thenReturn(RestStatus.OK);
         when(searchResponse.getScrollId()).thenReturn(randomAlphaOfLength(1000));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
@@ -9,19 +9,18 @@ package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
-import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.search.aggregations.metrics.Avg;
-import org.elasticsearch.search.aggregations.metrics.GeoCentroid;
+import org.elasticsearch.search.aggregations.metrics.InternalAvg;
+import org.elasticsearch.search.aggregations.metrics.InternalGeoCentroid;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
 import org.elasticsearch.search.aggregations.metrics.Max;
-import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
 import org.elasticsearch.search.aggregations.metrics.Percentile;
-import org.elasticsearch.search.aggregations.metrics.Percentiles;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,25 +35,25 @@ public final class AggregationTestUtils {
 
     private AggregationTestUtils() {}
 
-    static Histogram.Bucket createHistogramBucket(long timestamp, long docCount, List<Aggregation> subAggregations) {
-        Histogram.Bucket bucket = mock(Histogram.Bucket.class);
+    static InternalHistogram.Bucket createHistogramBucket(long timestamp, long docCount, List<InternalAggregation> subAggregations) {
+        InternalHistogram.Bucket bucket = mock(InternalHistogram.Bucket.class);
         when(bucket.getKey()).thenReturn(timestamp);
         when(bucket.getDocCount()).thenReturn(docCount);
-        Aggregations aggs = createAggs(subAggregations);
+        InternalAggregations aggs = createAggs(subAggregations);
         when(bucket.getAggregations()).thenReturn(aggs);
         return bucket;
     }
 
-    static CompositeAggregation.Bucket createCompositeBucket(
+    static InternalComposite.InternalBucket createCompositeBucket(
         long timestamp,
         String dateValueSource,
         long docCount,
-        List<Aggregation> subAggregations,
+        List<InternalAggregation> subAggregations,
         List<Tuple<String, String>> termValues
     ) {
-        CompositeAggregation.Bucket bucket = mock(CompositeAggregation.Bucket.class);
+        InternalComposite.InternalBucket bucket = mock(InternalComposite.InternalBucket.class);
         when(bucket.getDocCount()).thenReturn(docCount);
-        Aggregations aggs = createAggs(subAggregations);
+        InternalAggregations aggs = createAggs(subAggregations);
         when(bucket.getAggregations()).thenReturn(aggs);
         Map<String, Object> bucketKey = new HashMap<>();
         bucketKey.put(dateValueSource, timestamp);
@@ -65,34 +64,34 @@ public final class AggregationTestUtils {
         return bucket;
     }
 
-    static SingleBucketAggregation createSingleBucketAgg(String name, long docCount, List<Aggregation> subAggregations) {
-        SingleBucketAggregation singleBucketAggregation = mock(SingleBucketAggregation.class);
+    static InternalSingleBucketAggregation createSingleBucketAgg(String name, long docCount, List<InternalAggregation> subAggregations) {
+        InternalSingleBucketAggregation singleBucketAggregation = mock(InternalSingleBucketAggregation.class);
         when(singleBucketAggregation.getName()).thenReturn(name);
         when(singleBucketAggregation.getDocCount()).thenReturn(docCount);
         when(singleBucketAggregation.getAggregations()).thenReturn(createAggs(subAggregations));
         return singleBucketAggregation;
     }
 
-    static Histogram.Bucket createHistogramBucket(long timestamp, long docCount) {
+    static InternalHistogram.Bucket createHistogramBucket(long timestamp, long docCount) {
         return createHistogramBucket(timestamp, docCount, Collections.emptyList());
     }
 
-    static Aggregations createAggs(List<Aggregation> aggsList) {
-        return new Aggregations(aggsList);
+    static InternalAggregations createAggs(List<InternalAggregation> aggsList) {
+        return InternalAggregations.from(aggsList);
     }
 
     @SuppressWarnings("unchecked")
-    static Histogram createHistogramAggregation(String name, List<Histogram.Bucket> histogramBuckets) {
-        Histogram histogram = mock(Histogram.class);
-        when((List<Histogram.Bucket>) histogram.getBuckets()).thenReturn(histogramBuckets);
+    static InternalHistogram createHistogramAggregation(String name, List<InternalHistogram.Bucket> histogramBuckets) {
+        InternalHistogram histogram = mock(InternalHistogram.class);
+        when(histogram.getBuckets()).thenReturn(histogramBuckets);
         when(histogram.getName()).thenReturn(name);
         return histogram;
     }
 
     @SuppressWarnings("unchecked")
-    static CompositeAggregation createCompositeAggregation(String name, List<CompositeAggregation.Bucket> buckets) {
-        CompositeAggregation compositeAggregation = mock(CompositeAggregation.class);
-        when((List<CompositeAggregation.Bucket>) compositeAggregation.getBuckets()).thenReturn(buckets);
+    static InternalComposite createCompositeAggregation(String name, List<InternalComposite.InternalBucket> buckets) {
+        InternalComposite compositeAggregation = mock(InternalComposite.class);
+        when(compositeAggregation.getBuckets()).thenReturn(buckets);
         when(compositeAggregation.getName()).thenReturn(name);
         return compositeAggregation;
 
@@ -102,16 +101,16 @@ public final class AggregationTestUtils {
         return new Max(name, value, DocValueFormat.RAW, null);
     }
 
-    static Avg createAvg(String name, double value) {
-        Avg avg = mock(Avg.class);
+    static InternalAvg createAvg(String name, double value) {
+        InternalAvg avg = mock(InternalAvg.class);
         when(avg.getName()).thenReturn(name);
         when(avg.value()).thenReturn(value);
         when(avg.getValue()).thenReturn(value);
         return avg;
     }
 
-    static GeoCentroid createGeoCentroid(String name, long count, double lat, double lon) {
-        GeoCentroid centroid = mock(GeoCentroid.class);
+    static InternalGeoCentroid createGeoCentroid(String name, long count, double lat, double lon) {
+        InternalGeoCentroid centroid = mock(InternalGeoCentroid.class);
         when(centroid.count()).thenReturn(count);
         when(centroid.getName()).thenReturn(name);
         GeoPoint point = count > 0 ? new GeoPoint(lat, lon) : null;
@@ -119,23 +118,23 @@ public final class AggregationTestUtils {
         return centroid;
     }
 
-    static NumericMetricsAggregation.SingleValue createSingleValue(String name, double value) {
-        NumericMetricsAggregation.SingleValue singleValue = mock(NumericMetricsAggregation.SingleValue.class);
+    static InternalNumericMetricsAggregation.SingleValue createSingleValue(String name, double value) {
+        InternalNumericMetricsAggregation.SingleValue singleValue = mock(InternalNumericMetricsAggregation.SingleValue.class);
         when(singleValue.getName()).thenReturn(name);
         when(singleValue.value()).thenReturn(value);
         return singleValue;
     }
 
     @SuppressWarnings("unchecked")
-    static Terms createTerms(String name, Term... terms) {
-        Terms termsAgg = mock(Terms.class);
+    static StringTerms createTerms(String name, Term... terms) {
+        StringTerms termsAgg = mock(StringTerms.class);
         when(termsAgg.getName()).thenReturn(name);
-        List<Terms.Bucket> buckets = new ArrayList<>();
+        List<StringTerms.Bucket> buckets = new ArrayList<>();
         for (Term term : terms) {
             StringTerms.Bucket bucket = mock(StringTerms.Bucket.class);
             when(bucket.getKey()).thenReturn(term.key);
             when(bucket.getDocCount()).thenReturn(term.count);
-            List<Aggregation> numericAggs = new ArrayList<>();
+            List<InternalAggregation> numericAggs = new ArrayList<>();
             if (term.hasBuckekAggs()) {
                 when(bucket.getAggregations()).thenReturn(createAggs(term.bucketAggs));
             } else {
@@ -143,18 +142,18 @@ public final class AggregationTestUtils {
                     numericAggs.add(createSingleValue(keyValue.getKey(), keyValue.getValue()));
                 }
                 if (numericAggs.isEmpty() == false) {
-                    Aggregations aggs = createAggs(numericAggs);
+                    InternalAggregations aggs = createAggs(numericAggs);
                     when(bucket.getAggregations()).thenReturn(aggs);
                 }
             }
             buckets.add(bucket);
         }
-        when((List<Terms.Bucket>) termsAgg.getBuckets()).thenReturn(buckets);
+        when(termsAgg.getBuckets()).thenReturn(buckets);
         return termsAgg;
     }
 
-    static Percentiles createPercentiles(String name, double... values) {
-        Percentiles percentiles = mock(Percentiles.class);
+    static InternalTDigestPercentiles createPercentiles(String name, double... values) {
+        InternalTDigestPercentiles percentiles = mock(InternalTDigestPercentiles.class);
         when(percentiles.getName()).thenReturn(name);
         List<Percentile> percentileList = new ArrayList<>();
         for (double value : values) {
@@ -168,7 +167,7 @@ public final class AggregationTestUtils {
         String key;
         long count;
         Map<String, Double> values;
-        List<Aggregation> bucketAggs;
+        List<InternalAggregation> bucketAggs;
 
         Term(String key, long count) {
             this(key, count, Collections.emptyMap());
@@ -184,7 +183,7 @@ public final class AggregationTestUtils {
             this.values = values;
         }
 
-        Term(String key, long count, List<Aggregation> bucketAggs) {
+        Term(String key, long count, List<InternalAggregation> bucketAggs) {
             this(key, count);
             this.bucketAggs = bucketAggs;
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessorTests.java
@@ -8,10 +8,10 @@ package org.elasticsearch.xpack.ml.datafeed.extractor.aggregation;
 
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
+import org.elasticsearch.search.aggregations.bucket.histogram.InternalHistogram;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.Max;
@@ -60,22 +60,22 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenMultipleDateHistogramsOrComposite() {
-        Aggregation nestedBucket;
+        InternalAggregation nestedBucket;
         if (randomBoolean()) {
-            List<Histogram.Bucket> nestedHistogramBuckets = Arrays.asList(
+            List<InternalHistogram.Bucket> nestedHistogramBuckets = Arrays.asList(
                 createHistogramBucket(1000L, 3, Collections.singletonList(createMax("metric1", 1200))),
                 createHistogramBucket(2000L, 5, Collections.singletonList(createMax("metric1", 2800)))
             );
             nestedBucket = createHistogramAggregation("buckets", nestedHistogramBuckets);
         } else {
-            List<CompositeAggregation.Bucket> nestedCompositebuckets = Arrays.asList(
+            List<InternalComposite.InternalBucket> nestedCompositebuckets = Arrays.asList(
                 createCompositeBucket(1000L, "time", 3, Collections.singletonList(createMax("metric1", 1200)), Collections.emptyList()),
                 createCompositeBucket(2000L, "time", 5, Collections.singletonList(createMax("metric1", 2800)), Collections.emptyList())
             );
             nestedBucket = createCompositeAggregation("buckets", nestedCompositebuckets);
         }
 
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 3, Arrays.asList(createMax("time", 1000L), nestedBucket))
         );
 
@@ -93,7 +93,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenMaxTimeIsMissing() {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(createHistogramBucket(1000L, 3), createHistogramBucket(2000L, 5));
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(createHistogramBucket(1000L, 3), createHistogramBucket(2000L, 5));
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -101,7 +101,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
         );
         assertThat(e.getMessage(), containsString("Missing max aggregation for time_field [time]"));
 
-        List<CompositeAggregation.Bucket> compositeBuckets = Arrays.asList(
+        List<InternalComposite.InternalBucket> compositeBuckets = Arrays.asList(
             createCompositeBucket(1000L, "time", 3, Collections.emptyList(), Collections.emptyList()),
             createCompositeBucket(2000L, "time", 5, Collections.emptyList(), Collections.emptyList())
         );
@@ -111,8 +111,8 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenNonMaxTimeAgg() {
-        List<Aggregation> aggs = Collections.singletonList(createTerms("time", new Term("a", 1), new Term("b", 2)));
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalAggregation> aggs = Collections.singletonList(createTerms("time", new Term("a", 1), new Term("b", 2)));
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 3, aggs),
             createHistogramBucket(2000L, 5, aggs)
         );
@@ -123,7 +123,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
         );
         assertThat(e.getMessage(), containsString("Missing max aggregation for time_field [time]"));
 
-        List<CompositeAggregation.Bucket> compositeBuckets = Arrays.asList(
+        List<InternalComposite.InternalBucket> compositeBuckets = Arrays.asList(
             createCompositeBucket(1000L, "time", 3, aggs, Collections.emptyList()),
             createCompositeBucket(2000L, "time", 5, aggs, Collections.emptyList())
         );
@@ -133,7 +133,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenHistogramOnly() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 3, Collections.singletonList(createMax("timestamp", 1200))),
             createHistogramBucket(2000L, 5, Collections.singletonList(createMax("timestamp", 2800)))
         );
@@ -146,7 +146,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenHistogramOnlyAndNoDocCount() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 3, Collections.singletonList(createMax("time", 1000))),
             createHistogramBucket(2000L, 5, Collections.singletonList(createMax("time", 2000)))
         );
@@ -160,7 +160,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
 
     public void testProcessGivenCompositeOnly() throws IOException {
         compositeAggValueSource = "timestamp";
-        List<CompositeAggregation.Bucket> compositeBuckets = Arrays.asList(
+        List<InternalComposite.InternalBucket> compositeBuckets = Arrays.asList(
             createCompositeBucket(1000L, "timestamp", 3, Collections.singletonList(createMax("timestamp", 1200)), Collections.emptyList()),
             createCompositeBucket(2000L, "timestamp", 5, Collections.singletonList(createMax("timestamp", 2800)), Collections.emptyList())
         );
@@ -173,7 +173,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenCompositeOnlyAndNoDocCount() throws IOException {
-        List<CompositeAggregation.Bucket> compositeBuckets = Arrays.asList(
+        List<InternalComposite.InternalBucket> compositeBuckets = Arrays.asList(
             createCompositeBucket(1000L, "time", 3, Collections.singletonList(createMax("time", 1000)), Collections.emptyList()),
             createCompositeBucket(2000L, "time", 5, Collections.singletonList(createMax("time", 2000)), Collections.emptyList())
         );
@@ -187,7 +187,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
 
     public void testProcessGivenCompositeWithDocAndTerms() throws IOException {
         compositeAggValueSource = "timestamp";
-        List<CompositeAggregation.Bucket> compositeBuckets = Arrays.asList(
+        List<InternalComposite.InternalBucket> compositeBuckets = Arrays.asList(
             createCompositeBucket(
                 1000L,
                 "timestamp",
@@ -218,22 +218,21 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenTopLevelAggIsNotHistogram() throws IOException {
-
-        List<Histogram.Bucket> histogramABuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramABuckets = Arrays.asList(
             createHistogramBucket(1000L, 3, Arrays.asList(createMax("time", 1000), createSingleValue("my_value", 1.0))),
             createHistogramBucket(2000L, 4, Arrays.asList(createMax("time", 2000), createSingleValue("my_value", 2.0))),
             createHistogramBucket(3000L, 5, Arrays.asList(createMax("time", 3000), createSingleValue("my_value", 3.0)))
         );
-        Histogram histogramA = createHistogramAggregation("buckets", histogramABuckets);
+        InternalHistogram histogramA = createHistogramAggregation("buckets", histogramABuckets);
 
-        List<Histogram.Bucket> histogramBBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBBuckets = Arrays.asList(
             createHistogramBucket(1000L, 6, Arrays.asList(createMax("time", 1000), createSingleValue("my_value", 10.0))),
             createHistogramBucket(2000L, 7, Arrays.asList(createMax("time", 2000), createSingleValue("my_value", 20.0))),
             createHistogramBucket(3000L, 8, Arrays.asList(createMax("time", 3000), createSingleValue("my_value", 30.0)))
         );
-        Histogram histogramB = createHistogramAggregation("buckets", histogramBBuckets);
+        InternalHistogram histogramB = createHistogramAggregation("buckets", histogramBBuckets);
 
-        Terms terms = createTerms(
+        StringTerms terms = createTerms(
             "my_field",
             new Term("A", 20, Collections.singletonList(histogramA)),
             new Term("B", 2, Collections.singletonList(histogramB))
@@ -250,7 +249,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenSingleMetricPerHistogram() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 3, Arrays.asList(createMax("time", 1000), createSingleValue("my_value", 1.0))),
             createHistogramBucket(
                 2000L,
@@ -269,7 +268,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenTermsPerHistogram() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(
                 1000L,
                 4,
@@ -301,7 +300,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenSingleMetricPerSingleTermsPerHistogram() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(
                 1000L,
                 4,
@@ -368,7 +367,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
         Map<String, Double> b4NumericAggs = new LinkedHashMap<>();
         b4NumericAggs.put("my_value", 421.0);
         b4NumericAggs.put("my_value2", 422.0);
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(
                 1000L,
                 4,
@@ -415,10 +414,10 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenUnsupportedAggregationUnderHistogram() {
-        Histogram.Bucket histogramBucket = createHistogramBucket(1000L, 2);
-        Aggregation anotherHistogram = mock(Aggregation.class);
+        InternalHistogram.Bucket histogramBucket = createHistogramBucket(1000L, 2);
+        InternalAggregation anotherHistogram = mock(InternalAggregation.class);
         when(anotherHistogram.getName()).thenReturn("nested-agg");
-        Aggregations subAggs = createAggs(Arrays.asList(createMax("time", 1000), anotherHistogram));
+        InternalAggregations subAggs = createAggs(Arrays.asList(createMax("time", 1000), anotherHistogram));
         when(histogramBucket.getAggregations()).thenReturn(subAggs);
 
         IllegalArgumentException e = expectThrows(
@@ -429,12 +428,12 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenMultipleBucketAggregations() {
-        Histogram.Bucket histogramBucket = createHistogramBucket(1000L, 2);
-        Terms terms1 = mock(Terms.class);
+        InternalHistogram.Bucket histogramBucket = createHistogramBucket(1000L, 2);
+        StringTerms terms1 = mock(StringTerms.class);
         when(terms1.getName()).thenReturn("terms_1");
-        Terms terms2 = mock(Terms.class);
+        StringTerms terms2 = mock(StringTerms.class);
         when(terms2.getName()).thenReturn("terms_2");
-        Aggregations subAggs = createAggs(Arrays.asList(createMax("time", 1000), terms1, terms2));
+        InternalAggregations subAggs = createAggs(Arrays.asList(createMax("time", 1000), terms1, terms2));
         when(histogramBucket.getAggregations()).thenReturn(subAggs);
 
         IllegalArgumentException e = expectThrows(
@@ -445,9 +444,9 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenMixedBucketAndLeafAggregationsAtSameLevel_BucketFirst() throws IOException {
-        Terms terms = createTerms("terms", new Term("a", 1), new Term("b", 2));
+        StringTerms terms = createTerms("terms", new Term("a", 1), new Term("b", 2));
         Max maxAgg = createMax("max_value", 1200);
-        Histogram.Bucket histogramBucket = createHistogramBucket(1000L, 2, Arrays.asList(terms, createMax("time", 1000), maxAgg));
+        InternalHistogram.Bucket histogramBucket = createHistogramBucket(1000L, 2, Arrays.asList(terms, createMax("time", 1000), maxAgg));
 
         String json = aggToString(Sets.newHashSet("terms", "max_value"), histogramBucket);
         assertThat(json, equalTo("""
@@ -457,8 +456,8 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
 
     public void testProcessGivenMixedBucketAndLeafAggregationsAtSameLevel_LeafFirst() throws IOException {
         Max maxAgg = createMax("max_value", 1200);
-        Terms terms = createTerms("terms", new Term("a", 1), new Term("b", 2));
-        Histogram.Bucket histogramBucket = createHistogramBucket(1000L, 2, Arrays.asList(createMax("time", 1000), maxAgg, terms));
+        StringTerms terms = createTerms("terms", new Term("a", 1), new Term("b", 2));
+        InternalHistogram.Bucket histogramBucket = createHistogramBucket(1000L, 2, Arrays.asList(createMax("time", 1000), maxAgg, terms));
 
         String json = aggToString(Sets.newHashSet("terms", "max_value"), histogramBucket);
         assertThat(json, equalTo("""
@@ -467,7 +466,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenBucketAndLeafAggregationsButBucketNotInFields() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(
                 1000L,
                 4,
@@ -507,7 +506,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenSinglePercentilesPerHistogram() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 4, Arrays.asList(createMax("time", 1000), createPercentiles("my_field", 1.0))),
             createHistogramBucket(2000L, 7, Arrays.asList(createMax("time", 2000), createPercentiles("my_field", 2.0))),
             createHistogramBucket(
@@ -528,7 +527,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenMultiplePercentilesPerHistogram() {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 4, Arrays.asList(createMax("time", 1000), createPercentiles("my_field", 1.0))),
             createHistogramBucket(2000L, 7, Arrays.asList(createMax("time", 2000), createPercentiles("my_field", 2.0, 5.0))),
             createHistogramBucket(3000L, 10, Arrays.asList(createMax("time", 3000), createPercentiles("my_field", 3.0))),
@@ -556,25 +555,25 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
         when(termsAgg.getName()).thenReturn("bar");
         assertFalse(processor.bucketAggContainsRequiredAgg(termsAgg));
 
-        Terms nestedTermsAgg = mock(Terms.class);
+        StringTerms nestedTermsAgg = mock(StringTerms.class);
         when(nestedTermsAgg.getBuckets()).thenReturn(Collections.emptyList());
         when(nestedTermsAgg.getName()).thenReturn("nested_terms");
 
         StringTerms.Bucket bucket = mock(StringTerms.Bucket.class);
-        when(bucket.getAggregations()).thenReturn(new Aggregations(Collections.singletonList(nestedTermsAgg)));
+        when(bucket.getAggregations()).thenReturn(InternalAggregations.from(Collections.singletonList(nestedTermsAgg)));
         when((List<Terms.Bucket>) termsAgg.getBuckets()).thenReturn(Collections.singletonList(bucket));
         assertFalse(processor.bucketAggContainsRequiredAgg(termsAgg));
 
         Max max = mock(Max.class);
         when(max.getName()).thenReturn("foo");
         StringTerms.Bucket nestedTermsBucket = mock(StringTerms.Bucket.class);
-        when(nestedTermsBucket.getAggregations()).thenReturn(new Aggregations(Collections.singletonList(max)));
-        when((List<Terms.Bucket>) nestedTermsAgg.getBuckets()).thenReturn(Collections.singletonList(nestedTermsBucket));
+        when(nestedTermsBucket.getAggregations()).thenReturn(InternalAggregations.from(Collections.singletonList(max)));
+        when(nestedTermsAgg.getBuckets()).thenReturn(Collections.singletonList(nestedTermsBucket));
         assertTrue(processor.bucketAggContainsRequiredAgg(termsAgg));
     }
 
     public void testBucketBeforeStartIsPruned() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 4, Arrays.asList(createMax("time", 1000), createPercentiles("my_field", 1.0))),
             createHistogramBucket(2000L, 7, Arrays.asList(createMax("time", 2000), createPercentiles("my_field", 2.0))),
             createHistogramBucket(3000L, 10, Arrays.asList(createMax("time", 3000), createPercentiles("my_field", 3.0))),
@@ -591,7 +590,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testBucketsBeforeStartArePruned() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 4, Arrays.asList(createMax("time", 1000), createPercentiles("my_field", 1.0))),
             createHistogramBucket(2000L, 7, Arrays.asList(createMax("time", 2000), createPercentiles("my_field", 2.0))),
             createHistogramBucket(3000L, 10, Arrays.asList(createMax("time", 3000), createPercentiles("my_field", 3.0))),
@@ -607,7 +606,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testSingleBucketAgg() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(
                 1000L,
                 4,
@@ -636,8 +635,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testSingleBucketAgg_failureWithSubMultiBucket() {
-
-        List<Histogram.Bucket> histogramBuckets = Collections.singletonList(
+        List<InternalHistogram.Bucket> histogramBuckets = Collections.singletonList(
             createHistogramBucket(
                 1000L,
                 4,
@@ -661,7 +659,7 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testGeoCentroidAgg() throws IOException {
-        List<Histogram.Bucket> histogramBuckets = Arrays.asList(
+        List<InternalHistogram.Bucket> histogramBuckets = Arrays.asList(
             createHistogramBucket(1000L, 4, Arrays.asList(createMax("time", 1000), createGeoCentroid("geo_field", 4, 92.1, 93.1))),
             createHistogramBucket(2000L, 7, Arrays.asList(createMax("time", 2000), createGeoCentroid("geo_field", 0, -1, -1)))
         );
@@ -672,16 +670,16 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
             {"time":2000,"doc_count":7}"""));
     }
 
-    private String aggToString(Set<String> fields, Histogram.Bucket bucket) throws IOException {
+    private String aggToString(Set<String> fields, InternalHistogram.Bucket bucket) throws IOException {
         return aggToString(fields, Collections.singletonList(bucket));
     }
 
-    private String aggToString(Set<String> fields, List<Histogram.Bucket> buckets) throws IOException {
-        Histogram histogram = createHistogramAggregation("buckets", buckets);
+    private String aggToString(Set<String> fields, List<InternalHistogram.Bucket> buckets) throws IOException {
+        InternalHistogram histogram = createHistogramAggregation("buckets", buckets);
         return aggToString(fields, createAggs(Collections.singletonList(histogram)));
     }
 
-    private String aggToString(Set<String> fields, Aggregations aggregations) throws IOException {
+    private String aggToString(Set<String> fields, InternalAggregations aggregations) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
         AggregationToJsonProcessor processor = new AggregationToJsonProcessor(
@@ -697,8 +695,8 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
         return outputStream.toString(StandardCharsets.UTF_8.name());
     }
 
-    private String aggToStringComposite(Set<String> fields, List<CompositeAggregation.Bucket> buckets) throws IOException {
-        CompositeAggregation compositeAggregation = createCompositeAggregation("buckets", buckets);
+    private String aggToStringComposite(Set<String> fields, List<InternalComposite.InternalBucket> buckets) throws IOException {
+        InternalComposite compositeAggregation = createCompositeAggregation("buckets", buckets);
         return aggToString(fields, createAggs(Collections.singletonList(compositeAggregation)));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
@@ -345,7 +345,11 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private SearchResponse createSearchResponse(String aggName, List<InternalComposite.InternalBucket> buckets, Map<String, Object> afterKey) {
+    private SearchResponse createSearchResponse(
+        String aggName,
+        List<InternalComposite.InternalBucket> buckets,
+        Map<String, Object> afterKey
+    ) {
         InternalComposite compositeAggregation = mock(InternalComposite.class);
         when(compositeAggregation.getName()).thenReturn(aggName);
         when(compositeAggregation.afterKey()).thenReturn(afterKey);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/CompositeAggregationDataExtractorTests.java
@@ -19,10 +19,10 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.ESTestCase;
@@ -127,7 +127,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
     }
 
     public void testExtraction() throws IOException {
-        List<CompositeAggregation.Bucket> compositeBucket = Arrays.asList(
+        List<InternalComposite.InternalBucket> compositeBucket = Arrays.asList(
             createCompositeBucket(
                 1000L,
                 "time_bucket",
@@ -208,7 +208,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
 
     public void testExtractionGivenResponseHasEmptyAggs() throws IOException {
         TestDataExtractor extractor = new TestDataExtractor(1000L, 2000L);
-        Aggregations emptyAggs = AggregationTestUtils.createAggs(Collections.emptyList());
+        InternalAggregations emptyAggs = AggregationTestUtils.createAggs(Collections.emptyList());
         SearchResponse response = createSearchResponse(emptyAggs);
         extractor.setNextResponse(response);
 
@@ -231,7 +231,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
 
     public void testExtractionCancelOnFirstPage() throws IOException {
         int numBuckets = 10;
-        List<CompositeAggregation.Bucket> buckets = new ArrayList<>(numBuckets);
+        List<InternalComposite.InternalBucket> buckets = new ArrayList<>(numBuckets);
         long timestamp = 1000;
         for (int i = 0; i < numBuckets; i++) {
             buckets.add(
@@ -260,7 +260,7 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
 
     public void testExtractionGivenCancelHalfWay() throws IOException {
         int numBuckets = 10;
-        List<CompositeAggregation.Bucket> buckets = new ArrayList<>(numBuckets);
+        List<InternalComposite.InternalBucket> buckets = new ArrayList<>(numBuckets);
         long timestamp = 1000;
         for (int i = 0; i < numBuckets; i++) {
             buckets.add(
@@ -345,17 +345,17 @@ public class CompositeAggregationDataExtractorTests extends ESTestCase {
     }
 
     @SuppressWarnings("unchecked")
-    private SearchResponse createSearchResponse(String aggName, List<CompositeAggregation.Bucket> buckets, Map<String, Object> afterKey) {
-        CompositeAggregation compositeAggregation = mock(CompositeAggregation.class);
+    private SearchResponse createSearchResponse(String aggName, List<InternalComposite.InternalBucket> buckets, Map<String, Object> afterKey) {
+        InternalComposite compositeAggregation = mock(InternalComposite.class);
         when(compositeAggregation.getName()).thenReturn(aggName);
         when(compositeAggregation.afterKey()).thenReturn(afterKey);
-        when((List<CompositeAggregation.Bucket>) compositeAggregation.getBuckets()).thenReturn(buckets);
+        when(compositeAggregation.getBuckets()).thenReturn(buckets);
 
-        Aggregations searchAggs = AggregationTestUtils.createAggs(Collections.singletonList(compositeAggregation));
+        InternalAggregations searchAggs = AggregationTestUtils.createAggs(Collections.singletonList(compositeAggregation));
         return createSearchResponse(searchAggs);
     }
 
-    private SearchResponse createSearchResponse(Aggregations aggregations) {
+    private SearchResponse createSearchResponse(InternalAggregations aggregations) {
         SearchResponse searchResponse = mock(SearchResponse.class);
         when(searchResponse.status()).thenReturn(RestStatus.OK);
         when(searchResponse.getScrollId()).thenReturn(randomAlphaOfLength(1000));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/chunked/ChunkedDataExtractorTests.java
@@ -19,8 +19,8 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.search.aggregations.metrics.Min;
 import org.elasticsearch.test.ESTestCase;
@@ -559,7 +559,7 @@ public class ChunkedDataExtractorTests extends ESTestCase {
         SearchHits searchHits = SearchHits.unpooled(hits, new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), 1);
         when(searchResponse.getHits()).thenReturn(searchHits);
 
-        List<Aggregation> aggs = new ArrayList<>();
+        List<InternalAggregation> aggs = new ArrayList<>();
         Min min = mock(Min.class);
         when(min.value()).thenReturn((double) earliestTime);
         when(min.getName()).thenReturn("earliest_time");
@@ -568,8 +568,7 @@ public class ChunkedDataExtractorTests extends ESTestCase {
         when(max.value()).thenReturn((double) latestTime);
         when(max.getName()).thenReturn("latest_time");
         aggs.add(max);
-        Aggregations aggregations = new Aggregations(aggs) {
-        };
+        InternalAggregations aggregations = InternalAggregations.from(aggs);
         when(searchResponse.getAggregations()).thenReturn(aggregations);
         return searchResponse;
     }
@@ -580,7 +579,7 @@ public class ChunkedDataExtractorTests extends ESTestCase {
         SearchHits searchHits = SearchHits.empty(new TotalHits(0, TotalHits.Relation.EQUAL_TO), 1);
         when(searchResponse.getHits()).thenReturn(searchHits);
 
-        List<Aggregation> aggs = new ArrayList<>();
+        List<InternalAggregation> aggs = new ArrayList<>();
         Min min = mock(Min.class);
         when(min.value()).thenReturn(Double.POSITIVE_INFINITY);
         when(min.getName()).thenReturn("earliest_time");
@@ -589,8 +588,7 @@ public class ChunkedDataExtractorTests extends ESTestCase {
         when(max.value()).thenReturn(Double.POSITIVE_INFINITY);
         when(max.getName()).thenReturn("latest_time");
         aggs.add(max);
-        Aggregations aggregations = new Aggregations(aggs) {
-        };
+        InternalAggregations aggregations = InternalAggregations.from(aggs);
         when(searchResponse.getAggregations()).thenReturn(aggregations);
         return searchResponse;
     }


### PR DESCRIPTION
One side effect of the removal of ParseAggregations is that we are able to remove the `Aggregations` class and simplify the aggregations framework API. In order to do that we need to remove the usage son the ML tests as it is heavily used. The trick ids to mock InternalAggregation instead of aggregation.

relates https://github.com/elastic/elasticsearch/issues/104789