### PR TITLE
Mute tests that regularly leak SearchHits

### DIFF
--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -122,6 +122,7 @@ public class RatedRequestsTests extends ESTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104570")
     public void testXContentParsingIsNotLenient() throws IOException {
         RatedRequest testItem = createTestItem(randomBoolean());
         XContentType xContentType = randomFrom(XContentType.values());

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.rankeval;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
@@ -122,8 +123,9 @@ public class RatedRequestsTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104570")
     public void testXContentParsingIsNotLenient() throws IOException {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/104570", Constants.WINDOWS);
+
         RatedRequest testItem = createTestItem(randomBoolean());
         XContentType xContentType = randomFrom(XContentType.values());
         BytesReference originalBytes = toShuffledXContent(testItem, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
@@ -41,6 +41,7 @@ public final class TransportRankEvalActionTests extends ESTestCase {
     /**
      * Test that request parameters like indicesOptions or searchType from ranking evaluation request are transfered to msearch request
      */
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104570")
     public void testTransferRequestParameters() throws Exception {
         String indexName = "test_index";
         List<RatedRequest> specifications = new ArrayList<>();

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.rankeval;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.MultiSearchRequest;
 import org.elasticsearch.action.search.MultiSearchResponse;
@@ -41,8 +42,9 @@ public final class TransportRankEvalActionTests extends ESTestCase {
     /**
      * Test that request parameters like indicesOptions or searchType from ranking evaluation request are transfered to msearch request
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104570")
     public void testTransferRequestParameters() throws Exception {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/104570", Constants.WINDOWS);
+
         String indexName = "test_index";
         List<RatedRequest> specifications = new ArrayList<>();
         specifications.add(


### PR DESCRIPTION
- [GitHub Issue](https://github.com/elastic/elasticsearch/issues/104570)
- [Test history](https://es-delivery-stats.elastic.dev/app/dashboards#/view/dcec9e60-72ac-11ee-8f39-55975ded9e63?_g=(refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now)))
- This test is failing 54/2247 during the last week