### PR TITLE
[Connector API] Add job type filtering support for List connector sync jobs API

### DIFF
--- a/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
+++ b/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
@@ -35,6 +35,9 @@ Returns information about all stored connector sync jobs ordered by their creati
 `connector_id`::
 (Optional, string) The connector id the fetched sync jobs need to have.
 
+`job_type`::
+(Optional, job type) A comma-separated list of job types.
+
 [[list-connector-sync-jobs-api-example]]
 ==== {api-examples-title}
 
@@ -66,6 +69,13 @@ The following example lists connector sync jobs (the first 100 per default) for 
 [source,console]
 ----
 GET _connector/_sync_job?connector_id=connector-1
+----
+// TEST[skip:there's no way to clean up after this code snippet, as we don't know the ids of sync jobs ahead of time]
+
+The following example lists connector sync jobs (the first 100 per default) for the connector with job type `full` or `incremental`:
+[source,console]
+----
+GET _connector/_sync_job?job_type=full,incremental
 ----
 // TEST[skip:there's no way to clean up after this code snippet, as we don't know the ids of sync jobs ahead of time]
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector_sync_job.list.json
@@ -39,6 +39,10 @@
       "connector_id": {
         "type": "string",
         "description": "Id of the connector to fetch the sync jobs for"
+      },
+      "job_type": {
+        "type": "list",
+        "description": "A comma-separated list of job types"
       }
     }
   }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
@@ -167,6 +167,13 @@ setup:
   - match: { results.0.id: $sync-job-one-id }
 
 ---
+"List Connector Sync Jobs - with invalid job status":
+  - do:
+      catch: bad_request
+      connector_sync_job.list:
+        status: invalid_job_status
+
+---
 "List Connector Sync Jobs - Get jobs with single job type":
   - do:
       connector_sync_job.post:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
@@ -221,6 +221,13 @@ setup:
   - match: { results.1.id: $sync-job-two-id }
 
 ---
+"List Connector Sync Jobs - with invalid job type":
+  - do:
+      catch: bad_request
+      connector_sync_job.list:
+        job_type: invalid_job_type,incremental
+
+---
 "List Connector Sync Jobs - empty list":
   - do:
       connector_sync_job.list: { }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
@@ -166,6 +166,52 @@ setup:
   - match: { count: 1 }
   - match: { results.0.id: $sync-job-one-id }
 
+---
+"List Connector Sync Jobs - Get jobs with single job type":
+  - do:
+      connector_sync_job.post:
+        body:
+          id: connector-one
+          job_type: full
+          trigger_method: scheduled
+  - set: { id: sync-job-one-id }
+  - do:
+      connector_sync_job.post:
+        body:
+          id: connector-one
+          job_type: incremental
+          trigger_method: scheduled
+  - set: { id: sync-job-two-id }
+  - do:
+      connector_sync_job.list:
+        connector_id: connector-one
+        job_type: full
+  - match: { count: 1 }
+  - match: { results.0.id: $sync-job-one-id }
+
+---
+"List Connector Sync Jobs - Get jobs with single job type":
+  - do:
+      connector_sync_job.post:
+        body:
+          id: connector-one
+          job_type: full
+          trigger_method: scheduled
+  - set: { id: sync-job-one-id }
+  - do:
+      connector_sync_job.post:
+        body:
+          id: connector-one
+          job_type: incremental
+          trigger_method: scheduled
+  - set: { id: sync-job-two-id }
+  - do:
+      connector_sync_job.list:
+        connector_id: connector-one
+        job_type: full,incremental
+  - match: { count: 2 }
+  - match: { results.0.id: $sync-job-one-id }
+  - match: { results.1.id: $sync-job-two-id }
 
 ---
 "List Connector Sync Jobs - empty list":

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
@@ -190,7 +190,7 @@ setup:
   - match: { results.0.id: $sync-job-one-id }
 
 ---
-"List Connector Sync Jobs - Get jobs with single job type":
+"List Connector Sync Jobs - Get jobs with multiple job types":
   - do:
       connector_sync_job.post:
         body:

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
@@ -13,6 +13,8 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -107,7 +109,9 @@ public class ListConnectorSyncJobsAction {
             return Objects.equals(pageParams, request.pageParams)
                 && Objects.equals(connectorId, request.connectorId)
                 && connectorSyncStatus == request.connectorSyncStatus
-                && connectorSyncJobTypeList == request.connectorSyncJobTypeList;
+                && connectorSyncJobTypeList == null
+                    ? request.connectorSyncJobTypeList == null
+                    : connectorSyncJobTypeList.equals(request.connectorSyncJobTypeList);
         }
 
         @Override
@@ -133,6 +137,9 @@ public class ListConnectorSyncJobsAction {
         }
 
         public static ListConnectorSyncJobsAction.Request parse(XContentParser parser) {
+            Logger logger = LogManager.getLogger(Request.class);
+            logger.info("parser: " + parser);
+            logger.info("PARSER: " + PARSER);
             return PARSER.apply(parser, null);
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
@@ -21,10 +21,12 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobSearchResult;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobType;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -44,18 +46,26 @@ public class ListConnectorSyncJobsAction {
         private final PageParams pageParams;
         private final String connectorId;
         private final ConnectorSyncStatus connectorSyncStatus;
+        private final List<ConnectorSyncJobType> connectorSyncJobTypeList;
 
         public Request(StreamInput in) throws IOException {
             super(in);
             this.pageParams = new PageParams(in);
             this.connectorId = in.readOptionalString();
             this.connectorSyncStatus = in.readOptionalEnum(ConnectorSyncStatus.class);
+            this.connectorSyncJobTypeList = stringToEnumList(in.readOptionalStringCollectionAsList());
         }
 
-        public Request(PageParams pageParams, String connectorId, ConnectorSyncStatus connectorSyncStatus) {
+        public Request(
+            PageParams pageParams,
+            String connectorId,
+            ConnectorSyncStatus connectorSyncStatus,
+            List<ConnectorSyncJobType> connectorSyncJobTypeList
+        ) {
             this.pageParams = pageParams;
             this.connectorId = connectorId;
             this.connectorSyncStatus = connectorSyncStatus;
+            this.connectorSyncJobTypeList = connectorSyncJobTypeList;
         }
 
         public PageParams getPageParams() {
@@ -70,6 +80,10 @@ public class ListConnectorSyncJobsAction {
             return connectorSyncStatus;
         }
 
+        public List<ConnectorSyncJobType> getConnectorSyncJobTypeList() {
+            return connectorSyncJobTypeList;
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             // Pagination validation is done as part of PageParams constructor
@@ -82,6 +96,7 @@ public class ListConnectorSyncJobsAction {
             pageParams.writeTo(out);
             out.writeOptionalString(connectorId);
             out.writeOptionalEnum(connectorSyncStatus);
+            out.writeOptionalStringCollection(enumToStringList(connectorSyncJobTypeList));
         }
 
         @Override
@@ -91,12 +106,13 @@ public class ListConnectorSyncJobsAction {
             Request request = (Request) o;
             return Objects.equals(pageParams, request.pageParams)
                 && Objects.equals(connectorId, request.connectorId)
-                && connectorSyncStatus == request.connectorSyncStatus;
+                && connectorSyncStatus == request.connectorSyncStatus
+                && connectorSyncJobTypeList == request.connectorSyncJobTypeList;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(pageParams, connectorId, connectorSyncStatus);
+            return Objects.hash(pageParams, connectorId, connectorSyncStatus, connectorSyncJobTypeList);
         }
 
         private static final ConstructingObjectParser<ListConnectorSyncJobsAction.Request, String> PARSER = new ConstructingObjectParser<>(
@@ -104,7 +120,8 @@ public class ListConnectorSyncJobsAction {
             p -> new ListConnectorSyncJobsAction.Request(
                 (PageParams) p[0],
                 (String) p[1],
-                p[2] != null ? ConnectorSyncStatus.fromString((String) p[2]) : null
+                p[2] != null ? ConnectorSyncStatus.fromString((String) p[2]) : null,
+                p[3] != null ? Arrays.stream(((String) p[3]).split(",")).map(ConnectorSyncJobType::fromString).toList() : null
             )
         );
 
@@ -112,6 +129,7 @@ public class ListConnectorSyncJobsAction {
             PARSER.declareObject(constructorArg(), (p, c) -> PageParams.fromXContent(p), PAGE_PARAMS_FIELD);
             PARSER.declareString(optionalConstructorArg(), CONNECTOR_ID_FIELD);
             PARSER.declareString(optionalConstructorArg(), ConnectorSyncJob.STATUS_FIELD);
+            PARSER.declareString(optionalConstructorArg(), ConnectorSyncJob.JOB_TYPE_FIELD);
         }
 
         public static ListConnectorSyncJobsAction.Request parse(XContentParser parser) {
@@ -125,9 +143,24 @@ public class ListConnectorSyncJobsAction {
                 builder.field(PAGE_PARAMS_FIELD.getPreferredName(), pageParams);
                 builder.field(CONNECTOR_ID_FIELD.getPreferredName(), connectorId);
                 builder.field(ConnectorSyncJob.STATUS_FIELD.getPreferredName(), connectorSyncStatus);
+                builder.field(ConnectorSyncJob.JOB_TYPE_FIELD.getPreferredName(), connectorSyncJobTypeList);
             }
             builder.endObject();
             return builder;
+        }
+
+        private List<ConnectorSyncJobType> stringToEnumList(List<String> jobTypeList) {
+            if (jobTypeList == null) {
+                return null;
+            }
+            return jobTypeList.stream().map(ConnectorSyncJobType::fromString).toList();
+        }
+
+        private List<String> enumToStringList(List<ConnectorSyncJobType> jobTypeList) {
+            if (jobTypeList == null) {
+                return null;
+            }
+            return jobTypeList.stream().map(ConnectorSyncJobType::name).toList();
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
@@ -13,8 +13,6 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -137,9 +135,6 @@ public class ListConnectorSyncJobsAction {
         }
 
         public static ListConnectorSyncJobsAction.Request parse(XContentParser parser) {
-            Logger logger = LogManager.getLogger(Request.class);
-            logger.info("parser: " + parser);
-            logger.info("PARSER: " + PARSER);
             return PARSER.apply(parser, null);
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -119,13 +118,14 @@ public class ListConnectorSyncJobsAction {
             return Objects.hash(pageParams, connectorId, connectorSyncStatus, connectorSyncJobTypeList);
         }
 
+        @SuppressWarnings("unchecked")
         private static final ConstructingObjectParser<ListConnectorSyncJobsAction.Request, String> PARSER = new ConstructingObjectParser<>(
             "list_connector_sync_jobs_request",
             p -> new ListConnectorSyncJobsAction.Request(
                 (PageParams) p[0],
                 (String) p[1],
                 p[2] != null ? ConnectorSyncStatus.fromString((String) p[2]) : null,
-                p[3] != null ? Arrays.stream(((String) p[3]).split(",")).map(ConnectorSyncJobType::fromString).toList() : null
+                p[3] != null ? ((List<String>) p[3]).stream().map(ConnectorSyncJobType::fromString).toList() : null
             )
         );
 
@@ -133,7 +133,7 @@ public class ListConnectorSyncJobsAction {
             PARSER.declareObject(constructorArg(), (p, c) -> PageParams.fromXContent(p), PAGE_PARAMS_FIELD);
             PARSER.declareString(optionalConstructorArg(), CONNECTOR_ID_FIELD);
             PARSER.declareString(optionalConstructorArg(), ConnectorSyncJob.STATUS_FIELD);
-            PARSER.declareString(optionalConstructorArg(), ConnectorSyncJob.JOB_TYPE_FIELD);
+            PARSER.declareStringArray(optionalConstructorArg(), ConnectorSyncJob.JOB_TYPE_FIELD);
         }
 
         public static ListConnectorSyncJobsAction.Request parse(XContentParser parser) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/RestListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/RestListConnectorSyncJobsAction.java
@@ -16,9 +16,11 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobType;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 @ServerlessScope(Scope.PUBLIC)
@@ -40,11 +42,16 @@ public class RestListConnectorSyncJobsAction extends BaseRestHandler {
         String connectorId = restRequest.param(ListConnectorSyncJobsAction.Request.CONNECTOR_ID_FIELD.getPreferredName());
         String statusString = restRequest.param(ConnectorSyncJob.STATUS_FIELD.getPreferredName());
         ConnectorSyncStatus status = statusString != null ? ConnectorSyncStatus.fromString(statusString) : null;
+        String jobTypeString = restRequest.param(ConnectorSyncJob.JOB_TYPE_FIELD.getPreferredName());
+        List<ConnectorSyncJobType> jobTypeList = jobTypeString != null
+            ? Arrays.stream(jobTypeString.split(",")).map(ConnectorSyncJobType::fromString).toList()
+            : null;
 
         ListConnectorSyncJobsAction.Request request = new ListConnectorSyncJobsAction.Request(
             new PageParams(from, size),
             connectorId,
-            status
+            status,
+            jobTypeList
         );
 
         return channel -> client.execute(ListConnectorSyncJobsAction.INSTANCE, request, new RestToXContentListener<>(channel));

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/RestListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/RestListConnectorSyncJobsAction.java
@@ -42,9 +42,9 @@ public class RestListConnectorSyncJobsAction extends BaseRestHandler {
         String connectorId = restRequest.param(ListConnectorSyncJobsAction.Request.CONNECTOR_ID_FIELD.getPreferredName());
         String statusString = restRequest.param(ConnectorSyncJob.STATUS_FIELD.getPreferredName());
         ConnectorSyncStatus status = statusString != null ? ConnectorSyncStatus.fromString(statusString) : null;
-        String jobTypeString = restRequest.param(ConnectorSyncJob.JOB_TYPE_FIELD.getPreferredName());
-        List<ConnectorSyncJobType> jobTypeList = jobTypeString != null
-            ? Arrays.stream(jobTypeString.split(",")).map(ConnectorSyncJobType::fromString).toList()
+        String[] jobTypeStringArray = restRequest.paramAsStringArray(ConnectorSyncJob.JOB_TYPE_FIELD.getPreferredName(), null);
+        List<ConnectorSyncJobType> jobTypeList = jobTypeStringArray != null
+            ? Arrays.stream(jobTypeStringArray).map(ConnectorSyncJobType::fromString).toList()
             : null;
 
         ListConnectorSyncJobsAction.Request request = new ListConnectorSyncJobsAction.Request(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/TransportListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/TransportListConnectorSyncJobsAction.java
@@ -18,7 +18,10 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobIndexService;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobType;
 import org.elasticsearch.xpack.core.action.util.PageParams;
+
+import java.util.List;
 
 public class TransportListConnectorSyncJobsAction extends HandledTransportAction<
     ListConnectorSyncJobsAction.Request,
@@ -51,12 +54,14 @@ public class TransportListConnectorSyncJobsAction extends HandledTransportAction
         final PageParams pageParams = request.getPageParams();
         final String connectorId = request.getConnectorId();
         final ConnectorSyncStatus syncStatus = request.getConnectorSyncStatus();
+        final List<ConnectorSyncJobType> jobTypeList = request.getConnectorSyncJobTypeList();
 
         connectorSyncJobIndexService.listConnectorSyncJobs(
             pageParams.getFrom(),
             pageParams.getSize(),
             connectorId,
             syncStatus,
+            jobTypeList,
             listener.map(r -> new ListConnectorSyncJobsAction.Response(r.connectorSyncJobs(), r.totalResults()))
         );
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.application.connector.filtering.FilteringRuleCond
 import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
 import org.elasticsearch.xpack.application.connector.filtering.FilteringValidationInfo;
 import org.elasticsearch.xpack.application.connector.filtering.FilteringValidationState;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobType;
 import org.elasticsearch.xpack.core.scheduler.Cron;
 
 import java.io.IOException;
@@ -334,6 +335,11 @@ public final class ConnectorTestUtils {
 
     public static ConnectorSyncStatus getRandomSyncStatus() {
         ConnectorSyncStatus[] values = ConnectorSyncStatus.values();
+        return values[randomInt(values.length - 1)];
+    }
+
+    public static ConnectorSyncJobType getRandomSyncJobType() {
+        ConnectorSyncJobType[] values = ConnectorSyncJobType.values();
         return values[randomInt(values.length - 1)];
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -279,9 +280,9 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
             syncJobs.add(syncJob);
         }
 
-        ConnectorSyncJobIndexService.ConnectorSyncJobsResult firstTwoSyncJobs = awaitListConnectorSyncJobs(0, 2, null, null);
-        ConnectorSyncJobIndexService.ConnectorSyncJobsResult nextTwoSyncJobs = awaitListConnectorSyncJobs(2, 2, null, null);
-        ConnectorSyncJobIndexService.ConnectorSyncJobsResult lastSyncJobs = awaitListConnectorSyncJobs(4, 100, null, null);
+        ConnectorSyncJobIndexService.ConnectorSyncJobsResult firstTwoSyncJobs = awaitListConnectorSyncJobs(0, 2, null, null, null);
+        ConnectorSyncJobIndexService.ConnectorSyncJobsResult nextTwoSyncJobs = awaitListConnectorSyncJobs(2, 2, null, null, null);
+        ConnectorSyncJobIndexService.ConnectorSyncJobsResult lastSyncJobs = awaitListConnectorSyncJobs(4, 100, null, null, null);
 
         ConnectorSyncJob firstSyncJob = ConnectorSyncJob.fromXContentBytes(
             firstTwoSyncJobs.connectorSyncJobs().get(0).getSourceRef(),
@@ -354,7 +355,8 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
             0,
             100,
             null,
-            ConnectorSyncStatus.PENDING
+            ConnectorSyncStatus.PENDING,
+            null
         );
         long numberOfResults = connectorSyncJobsResult.totalResults();
         String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getDocId();
@@ -379,6 +381,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
             0,
             100,
             connectorOneId,
+            null,
             null
         );
 
@@ -393,8 +396,147 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(connectorIdOfReturnedSyncJob, equalTo(connectorOneId));
     }
 
+    public void testListConnectorSyncJobs_WithJobTypeFull_GivenOnePerType_ExpectOneFull() throws Exception {
+        PostConnectorSyncJobAction.Request requestOne = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.FULL
+        );
+        PostConnectorSyncJobAction.Request requestTwo = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.INCREMENTAL
+        );
+        PostConnectorSyncJobAction.Request requestThree = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.ACCESS_CONTROL
+        );
+
+        PostConnectorSyncJobAction.Response responseOne = awaitPutConnectorSyncJob(requestOne);
+        awaitPutConnectorSyncJob(requestTwo);
+        awaitPutConnectorSyncJob(requestThree);
+
+        String syncJobOneId = responseOne.getId();
+
+        ConnectorSyncJobIndexService.ConnectorSyncJobsResult connectorSyncJobsResult = awaitListConnectorSyncJobs(
+            0,
+            100,
+            null,
+            null,
+            Collections.singletonList(ConnectorSyncJobType.FULL)
+        );
+        long numberOfResults = connectorSyncJobsResult.totalResults();
+        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getId();
+
+        assertThat(numberOfResults, equalTo(1L));
+        assertThat(idOfReturnedSyncJob, equalTo(syncJobOneId));
+    }
+
+    public void testListConnectorSyncJobs_WithJobTypeIncremental_GivenOnePerType_ExpectOneIncremental() throws Exception {
+        PostConnectorSyncJobAction.Request requestOne = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.FULL
+        );
+        PostConnectorSyncJobAction.Request requestTwo = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.INCREMENTAL
+        );
+        PostConnectorSyncJobAction.Request requestThree = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.ACCESS_CONTROL
+        );
+
+        awaitPutConnectorSyncJob(requestOne);
+        PostConnectorSyncJobAction.Response responseTwo = awaitPutConnectorSyncJob(requestTwo);
+        awaitPutConnectorSyncJob(requestThree);
+
+        String syncJobTwoId = responseTwo.getId();
+
+        ConnectorSyncJobIndexService.ConnectorSyncJobsResult connectorSyncJobsResult = awaitListConnectorSyncJobs(
+            0,
+            100,
+            null,
+            null,
+            Collections.singletonList(ConnectorSyncJobType.INCREMENTAL)
+        );
+        long numberOfResults = connectorSyncJobsResult.totalResults();
+        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getId();
+
+        assertThat(numberOfResults, equalTo(1L));
+        assertThat(idOfReturnedSyncJob, equalTo(syncJobTwoId));
+    }
+
+    public void testListConnectorSyncJobs_WithJobTypeAccessControl_GivenOnePerType_ExpectOneAccessControl() throws Exception {
+        PostConnectorSyncJobAction.Request requestOne = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.FULL
+        );
+        PostConnectorSyncJobAction.Request requestTwo = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.INCREMENTAL
+        );
+        PostConnectorSyncJobAction.Request requestThree = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.ACCESS_CONTROL
+        );
+
+        awaitPutConnectorSyncJob(requestOne);
+        awaitPutConnectorSyncJob(requestTwo);
+        PostConnectorSyncJobAction.Response responseThree = awaitPutConnectorSyncJob(requestThree);
+
+        String syncJobThreeId = responseThree.getId();
+
+        ConnectorSyncJobIndexService.ConnectorSyncJobsResult connectorSyncJobsResult = awaitListConnectorSyncJobs(
+            0,
+            100,
+            null,
+            null,
+            Collections.singletonList(ConnectorSyncJobType.ACCESS_CONTROL)
+        );
+        long numberOfResults = connectorSyncJobsResult.totalResults();
+        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getId();
+
+        assertThat(numberOfResults, equalTo(1L));
+        assertThat(idOfReturnedSyncJob, equalTo(syncJobThreeId));
+    }
+
+    public void testListConnectorSyncJobs_WithJobTypeFullAndIncremental_GivenOnePerType_ExpectOneFullOneIncremental() throws Exception {
+        PostConnectorSyncJobAction.Request requestOne = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.FULL
+        );
+        PostConnectorSyncJobAction.Request requestTwo = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.INCREMENTAL
+        );
+        PostConnectorSyncJobAction.Request requestThree = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId,
+            ConnectorSyncJobType.ACCESS_CONTROL
+        );
+
+        PostConnectorSyncJobAction.Response responseOne = awaitPutConnectorSyncJob(requestOne);
+        PostConnectorSyncJobAction.Response responseTwo = awaitPutConnectorSyncJob(requestTwo);
+        awaitPutConnectorSyncJob(requestThree);
+
+        String syncJobOneId = responseOne.getId();
+        String syncJobTwoId = responseTwo.getId();
+
+        ConnectorSyncJobIndexService.ConnectorSyncJobsResult connectorSyncJobsResult = awaitListConnectorSyncJobs(
+            0,
+            100,
+            null,
+            null,
+            Arrays.asList(ConnectorSyncJobType.FULL, ConnectorSyncJobType.INCREMENTAL)
+        );
+        long numberOfResults = connectorSyncJobsResult.totalResults();
+        String idOfReturnedSyncJobOne = connectorSyncJobsResult.connectorSyncJobs().get(0).getId();
+        String idOfReturnedSyncJobTwo = connectorSyncJobsResult.connectorSyncJobs().get(1).getId();
+
+        assertThat(numberOfResults, equalTo(2L));
+        assertThat(idOfReturnedSyncJobOne, equalTo(syncJobOneId));
+        assertThat(idOfReturnedSyncJobTwo, equalTo(syncJobTwoId));
+    }
+
     public void testListConnectorSyncJobs_WithNoSyncJobs_ReturnEmptyResult() throws Exception {
-        ConnectorSyncJobIndexService.ConnectorSyncJobsResult firstOneHundredSyncJobs = awaitListConnectorSyncJobs(0, 100, null, null);
+        ConnectorSyncJobIndexService.ConnectorSyncJobsResult firstOneHundredSyncJobs = awaitListConnectorSyncJobs(0, 100, null, null, null);
 
         assertThat(firstOneHundredSyncJobs.connectorSyncJobs().size(), equalTo(0));
         assertThat(firstOneHundredSyncJobs.totalResults(), equalTo(0L));
@@ -632,13 +774,14 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         int from,
         int size,
         String connectorId,
-        ConnectorSyncStatus syncStatus
+        ConnectorSyncStatus syncStatus,
+        List<ConnectorSyncJobType> jobTypeList
     ) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<ConnectorSyncJobIndexService.ConnectorSyncJobsResult> result = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
 
-        connectorSyncJobIndexService.listConnectorSyncJobs(from, size, connectorId, syncStatus, new ActionListener<>() {
+        connectorSyncJobIndexService.listConnectorSyncJobs(from, size, connectorId, syncStatus, jobTypeList, new ActionListener<>() {
             @Override
             public void onResponse(ConnectorSyncJobIndexService.ConnectorSyncJobsResult connectorSyncJobsResult) {
                 result.set(connectorSyncJobsResult);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -428,7 +428,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
             Collections.singletonList(ConnectorSyncJobType.FULL)
         );
         long numberOfResults = connectorSyncJobsResult.totalResults();
-        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getId();
+        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getDocId();
 
         assertThat(numberOfResults, equalTo(1L));
         assertThat(idOfReturnedSyncJob, equalTo(syncJobOneId));
@@ -462,7 +462,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
             Collections.singletonList(ConnectorSyncJobType.INCREMENTAL)
         );
         long numberOfResults = connectorSyncJobsResult.totalResults();
-        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getId();
+        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getDocId();
 
         assertThat(numberOfResults, equalTo(1L));
         assertThat(idOfReturnedSyncJob, equalTo(syncJobTwoId));
@@ -496,7 +496,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
             Collections.singletonList(ConnectorSyncJobType.ACCESS_CONTROL)
         );
         long numberOfResults = connectorSyncJobsResult.totalResults();
-        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getId();
+        String idOfReturnedSyncJob = connectorSyncJobsResult.connectorSyncJobs().get(0).getDocId();
 
         assertThat(numberOfResults, equalTo(1L));
         assertThat(idOfReturnedSyncJob, equalTo(syncJobThreeId));
@@ -531,8 +531,8 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
             Arrays.asList(ConnectorSyncJobType.FULL, ConnectorSyncJobType.INCREMENTAL)
         );
         long numberOfResults = connectorSyncJobsResult.totalResults();
-        String idOfReturnedSyncJobOne = connectorSyncJobsResult.connectorSyncJobs().get(0).getId();
-        String idOfReturnedSyncJobTwo = connectorSyncJobsResult.connectorSyncJobs().get(1).getId();
+        String idOfReturnedSyncJobOne = connectorSyncJobsResult.connectorSyncJobs().get(0).getDocId();
+        String idOfReturnedSyncJobTwo = connectorSyncJobsResult.connectorSyncJobs().get(1).getDocId();
 
         assertThat(numberOfResults, equalTo(2L));
         assertThat(idOfReturnedSyncJobOne, equalTo(syncJobOneId));

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -333,11 +333,15 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
     }
 
     public void testListConnectorSyncJobs_WithStatusPending_GivenOnePendingTwoCancelled_ExpectOnePending() throws Exception {
-        String connectorId = connectorOneId;
-
-        PostConnectorSyncJobAction.Request requestOne = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(connectorId);
-        PostConnectorSyncJobAction.Request requestTwo = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(connectorId);
-        PostConnectorSyncJobAction.Request requestThree = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(connectorId);
+        PostConnectorSyncJobAction.Request requestOne = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId
+        );
+        PostConnectorSyncJobAction.Request requestTwo = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId
+        );
+        PostConnectorSyncJobAction.Request requestThree = ConnectorSyncJobTestUtils.getRandomPostConnectorSyncJobActionRequest(
+            connectorOneId
+        );
 
         PostConnectorSyncJobAction.Response responseOne = awaitPutConnectorSyncJob(requestOne);
         PostConnectorSyncJobAction.Response responseTwo = awaitPutConnectorSyncJob(requestTwo);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -358,7 +358,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         ConnectorSyncJobIndexService.ConnectorSyncJobsResult connectorSyncJobsResult = awaitListConnectorSyncJobs(
             0,
             100,
-            connectorOneId,
+            null,
             ConnectorSyncStatus.PENDING,
             null
         );

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -358,7 +358,7 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         ConnectorSyncJobIndexService.ConnectorSyncJobsResult connectorSyncJobsResult = awaitListConnectorSyncJobs(
             0,
             100,
-            null,
+            connectorOneId,
             ConnectorSyncStatus.PENDING,
             null
         );

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.application.search.SearchApplicationTestUtils;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
@@ -124,6 +125,13 @@ public class ConnectorSyncJobTestUtils {
         );
     }
 
+    public static PostConnectorSyncJobAction.Request getRandomPostConnectorSyncJobActionRequest(
+        String connectorId,
+        ConnectorSyncJobType jobType
+    ) {
+        return new PostConnectorSyncJobAction.Request(connectorId, jobType, randomFrom(ConnectorSyncJobTriggerMethod.values()));
+    }
+
     public static PostConnectorSyncJobAction.Response getRandomPostConnectorSyncJobActionResponse() {
         return new PostConnectorSyncJobAction.Response(randomAlphaOfLength(10));
     }
@@ -182,7 +190,8 @@ public class ConnectorSyncJobTestUtils {
         return new ListConnectorSyncJobsAction.Request(
             SearchApplicationTestUtils.randomPageParams(),
             randomAlphaOfLength(10),
-            ConnectorTestUtils.getRandomSyncStatus()
+            ConnectorTestUtils.getRandomSyncStatus(),
+            Collections.singletonList(ConnectorTestUtils.getRandomSyncJobType())
         );
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsActionRequestBWCSerializingTests.java
@@ -12,11 +12,13 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobType;
 import org.elasticsearch.xpack.application.search.SearchApplicationTestUtils;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 
 import java.io.IOException;
+import java.util.Collections;
 
 public class ListConnectorSyncJobsActionRequestBWCSerializingTests extends AbstractBWCSerializationTestCase<
     ListConnectorSyncJobsAction.Request> {
@@ -30,8 +32,9 @@ public class ListConnectorSyncJobsActionRequestBWCSerializingTests extends Abstr
         PageParams pageParams = SearchApplicationTestUtils.randomPageParams();
         String connectorId = randomAlphaOfLength(10);
         ConnectorSyncStatus syncStatus = ConnectorTestUtils.getRandomSyncStatus();
+        ConnectorSyncJobType syncJobType = ConnectorTestUtils.getRandomSyncJobType();
 
-        return new ListConnectorSyncJobsAction.Request(pageParams, connectorId, syncStatus);
+        return new ListConnectorSyncJobsAction.Request(pageParams, connectorId, syncStatus, Collections.singletonList(syncJobType));
     }
 
     @Override
@@ -52,7 +55,8 @@ public class ListConnectorSyncJobsActionRequestBWCSerializingTests extends Abstr
         return new ListConnectorSyncJobsAction.Request(
             instance.getPageParams(),
             instance.getConnectorId(),
-            instance.getConnectorSyncStatus()
+            instance.getConnectorSyncStatus(),
+            instance.getConnectorSyncJobTypeList()
         );
     }
 }


### PR DESCRIPTION
This PR adds job type filtering support for [List connector sync jobs API](https://www.elastic.co/guide/en/elasticsearch/reference/current/list-connector-sync-jobs-api.html).

Users will be able to filter sync jobs by one or multiple job types. e.g.:

```
GET _connector/_sync_job?job_type=full,incremental
```