### PR TITLE
Speedup slicing from CompositeBytesReference

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -148,16 +148,17 @@ public final class CompositeBytesReference extends AbstractBytesReference {
         // for slices we only need to find the start and the end reference
         // adjust them and pass on the references in between as they are fully contained
         final int to = from + length;
-        final int limit = getOffsetIndex(to - 1);
         final int start = getOffsetIndex(from);
-        final BytesReference[] inSlice = new BytesReference[1 + (limit - start)];
-        for (int i = 0, j = start; i < inSlice.length; i++) {
-            inSlice[i] = references[j++];
+        int limit = start;
+        for (int i = start + 1; i < offsets.length && offsets[i] < to; i++) {
+            limit = i;
         }
         int inSliceOffset = from - offsets[start];
-        if (inSlice.length == 1) {
-            return inSlice[0].slice(inSliceOffset, length);
+        if (start == limit) {
+            return references[start].slice(inSliceOffset, length);
         }
+        final BytesReference[] inSlice = new BytesReference[1 + (limit - start)];
+        System.arraycopy(references, start, inSlice, 0, inSlice.length);
         // now adjust slices in front and at the end
         inSlice[0] = inSlice[0].slice(inSliceOffset, inSlice[0].length() - inSliceOffset);
         inSlice[inSlice.length - 1] = inSlice[inSlice.length - 1].slice(0, to - offsets[limit]);

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -158,7 +158,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
 
             @Override
             public ReleasableBytesReference readReleasableBytesReference() throws IOException {
-                final int len = readArraySize();
+                final int len = readVInt();
                 return retainAndSkip(len);
             }
 


### PR DESCRIPTION
Motivated by some small regressions we've see where reading a slice was slower than reading a freshly allocated `BytesReference` copy due to the overhead of finding offsets and creating an intermediary array.

A few things here:
1. we don't allocate when slicing so no need for the non-zero-cost bounds checks from readArraySize, just read a vint.
2. we can skip creating an array in the slice method for the common single buffer case, this shows up quite hot in the profile
3. Binary search isn't all that useful for finding the end offset in the sub references when we already have the start offset. Even for very long buffers and long slices forward searching should be faster on modern CPUs.
