### PR TITLE
HasAggregations#getAggregations return InternalAggregators instead of Aggregators

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -109,7 +108,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 
@@ -416,7 +415,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
         long docCount = 0;
         for (Bucket bucket : buckets) {
             docCount += bucket.docCount;
-            aggregations.add((InternalAggregations) bucket.getAggregations());
+            aggregations.add(bucket.getAggregations());
         }
         InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
         return new InternalAutoDateHistogram.Bucket(buckets.get(0).key, docCount, format, aggs);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/HasAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/HasAggregations.java
@@ -10,6 +10,6 @@ package org.elasticsearch.search.aggregations;
 
 public interface HasAggregations {
 
-    Aggregations getAggregations();
+    InternalAggregations getAggregations();
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -168,7 +168,7 @@ public abstract class InternalMultiBucketAggregation<
         boolean modified = false;
         List<B> newBuckets = new ArrayList<>();
         for (B bucket : getBuckets()) {
-            InternalAggregations rewritten = rewriter.apply((InternalAggregations) bucket.getAggregations());
+            InternalAggregations rewritten = rewriter.apply(bucket.getAggregations());
             if (rewritten == null) {
                 newBuckets.add(bucket);
                 continue;
@@ -188,7 +188,7 @@ public abstract class InternalMultiBucketAggregation<
     @Override
     public void forEachBucket(Consumer<InternalAggregations> consumer) {
         for (B bucket : getBuckets()) {
-            consumer.accept((InternalAggregations) bucket.getAggregations());
+            consumer.accept(bucket.getAggregations());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalOrder.java
@@ -72,8 +72,8 @@ public abstract class InternalOrder extends BucketOrder {
         @Override
         public Comparator<Bucket> comparator() {
             return (lhs, rhs) -> {
-                final SortValue l = path.resolveValue(((InternalAggregations) lhs.getAggregations()));
-                final SortValue r = path.resolveValue(((InternalAggregations) rhs.getAggregations()));
+                final SortValue l = path.resolveValue(lhs.getAggregations());
+                final SortValue r = path.resolveValue(rhs.getAggregations());
                 int compareResult = l.compareTo(r);
                 return order == SortOrder.ASC ? compareResult : -compareResult;
             };

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketsAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketsAggregation.java
@@ -9,8 +9,8 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.HasAggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.util.List;
@@ -43,7 +43,7 @@ public interface MultiBucketsAggregation extends Aggregation {
          * @return  The sub-aggregations of this bucket
          */
         @Override
-        Aggregations getAggregations();
+        InternalAggregations getAggregations();
 
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/SingleBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/SingleBucketAggregation.java
@@ -9,8 +9,8 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.HasAggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 
 /**
  * A single bucket aggregation
@@ -26,5 +26,5 @@ public interface SingleBucketAggregation extends Aggregation, HasAggregations {
      * @return  The sub-aggregations of this bucket
      */
     @Override
-    Aggregations getAggregations();
+    InternalAggregations getAggregations();
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -441,7 +440,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGridBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGridBucket.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.bucket.geogrid;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -61,7 +60,7 @@ public abstract class InternalGeoGridBucket extends InternalMultiBucketAggregati
     }
 
     @Override
-    public Aggregations getAggregations() {
+    public InternalAggregations getAggregations() {
         return aggregations;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -113,7 +112,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 
@@ -399,7 +398,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         long docCount = 0;
         for (Bucket bucket : buckets) {
             docCount += bucket.docCount;
-            aggregations.add((InternalAggregations) bucket.getAggregations());
+            aggregations.add(bucket.getAggregations());
         }
         InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
         return createBucket(buckets.get(0).key, docCount, aggs);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -107,7 +106,7 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 
@@ -354,7 +353,7 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
         long docCount = 0;
         for (Bucket bucket : buckets) {
             docCount += bucket.docCount;
-            aggregations.add((InternalAggregations) bucket.getAggregations());
+            aggregations.add(bucket.getAggregations());
         }
         InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
         return createBucket(buckets.get(0).key, docCount, aggs);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -152,7 +151,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 
@@ -318,7 +317,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
             min = Math.min(min, bucket.bounds.min);
             max = Math.max(max, bucket.bounds.max);
             sum += bucket.docCount * bucket.centroid;
-            aggregations.add((InternalAggregations) bucket.getAggregations());
+            aggregations.add(bucket.getAggregations());
         }
         InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
         double centroid = sum / docCount;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -117,7 +116,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -105,7 +105,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
                     docCountError += bucket.getDocCountError();
                 }
             }
-            aggregationsList.add((InternalAggregations) bucket.getAggregations());
+            aggregationsList.add(bucket.getAggregations());
         }
         InternalAggregations aggs = InternalAggregations.reduce(aggregationsList, context);
         return createBucket(docCount, aggs, docCountError, buckets.get(0));
@@ -346,7 +346,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
                 .map(
                     b -> createBucket(
                         samplingContext.scaleUp(b.getDocCount()),
-                        InternalAggregations.finalizeSampling((InternalAggregations) b.getAggregations(), samplingContext),
+                        InternalAggregations.finalizeSampling(b.getAggregations(), samplingContext),
                         b.getShowDocCountError() ? samplingContext.scaleUp(b.getDocCountError()) : 0,
                         b
                     )

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -80,7 +79,7 @@ public abstract class InternalRareTerms<A extends InternalRareTerms<A, B>, B ext
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -123,7 +122,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalOrder;
@@ -128,7 +127,7 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -245,7 +245,7 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
                 new DoubleTerms.Bucket(
                     bucket.getKeyAsNumber().doubleValue(),
                     bucket.getDocCount(),
-                    (InternalAggregations) bucket.getAggregations(),
+                    bucket.getAggregations(),
                     longTerms.showTermDocCountError,
                     longTerms.showTermDocCountError ? bucket.getDocCountError() : 0,
                     decimalFormat

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-public final class InternalCardinality extends InternalNumericMetricsAggregation.SingleValue implements Cardinality {
+public class InternalCardinality extends InternalNumericMetricsAggregation.SingleValue implements Cardinality {
     private final AbstractHyperLogLogPlusPlus counts;
 
     InternalCardinality(String name, AbstractHyperLogLogPlusPlus counts, Map<String, Object> metadata) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpersTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/pipeline/BucketHelpersTests.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.search.aggregations.pipeline;
 
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
@@ -76,7 +76,7 @@ public class BucketHelpersTests extends ESTestCase {
             }
 
             @Override
-            public Aggregations getAggregations() {
+            public InternalAggregations getAggregations() {
                 return null;
             }
 
@@ -156,7 +156,7 @@ public class BucketHelpersTests extends ESTestCase {
             }
 
             @Override
-            public Aggregations getAggregations() {
+            public InternalAggregations getAggregations() {
                 return null;
             }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -14,7 +14,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationErrors;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
@@ -118,7 +117,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/MockAggregations.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/MockAggregations.java
@@ -6,13 +6,15 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe.evaluation;
 
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.filter.Filters;
+import org.elasticsearch.search.aggregations.bucket.filter.InternalFilters;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
-import org.elasticsearch.search.aggregations.metrics.Cardinality;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStats;
-import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
+import org.elasticsearch.search.aggregations.metrics.InternalCardinality;
+import org.elasticsearch.search.aggregations.metrics.InternalNumericMetricsAggregation;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,16 +29,16 @@ public final class MockAggregations {
         return mockTerms(name, Collections.emptyList(), 0);
     }
 
-    public static Terms mockTerms(String name, List<Terms.Bucket> buckets, long sumOfOtherDocCounts) {
-        Terms agg = mock(Terms.class);
+    public static StringTerms mockTerms(String name, List<StringTerms.Bucket> buckets, long sumOfOtherDocCounts) {
+        StringTerms agg = mock(StringTerms.class);
         when(agg.getName()).thenReturn(name);
         doReturn(buckets).when(agg).getBuckets();
         when(agg.getSumOfOtherDocCounts()).thenReturn(sumOfOtherDocCounts);
         return agg;
     }
 
-    public static Terms.Bucket mockTermsBucket(String key, Aggregations subAggs) {
-        Terms.Bucket bucket = mock(Terms.Bucket.class);
+    public static StringTerms.Bucket mockTermsBucket(String key, InternalAggregations subAggs) {
+        StringTerms.Bucket bucket = mock(StringTerms.Bucket.class);
         when(bucket.getKeyAsString()).thenReturn(key);
         when(bucket.getAggregations()).thenReturn(subAggs);
         return bucket;
@@ -46,21 +48,21 @@ public final class MockAggregations {
         return mockFilters(name, Collections.emptyList());
     }
 
-    public static Filters mockFilters(String name, List<Filters.Bucket> buckets) {
-        Filters agg = mock(Filters.class);
+    public static InternalFilters mockFilters(String name, List<Filters.Bucket> buckets) {
+        InternalFilters agg = mock(InternalFilters.class);
         when(agg.getName()).thenReturn(name);
         doReturn(buckets).when(agg).getBuckets();
         return agg;
     }
 
-    public static Filters.Bucket mockFiltersBucket(String key, long docCount, Aggregations subAggs) {
-        Filters.Bucket bucket = mockFiltersBucket(key, docCount);
+    public static InternalFilters.InternalBucket mockFiltersBucket(String key, long docCount, InternalAggregations subAggs) {
+        InternalFilters.InternalBucket bucket = mockFiltersBucket(key, docCount);
         when(bucket.getAggregations()).thenReturn(subAggs);
         return bucket;
     }
 
-    public static Filters.Bucket mockFiltersBucket(String key, long docCount) {
-        Filters.Bucket bucket = mock(Filters.Bucket.class);
+    public static InternalFilters.InternalBucket mockFiltersBucket(String key, long docCount) {
+        InternalFilters.InternalBucket bucket = mock(InternalFilters.InternalBucket.class);
         when(bucket.getKeyAsString()).thenReturn(key);
         when(bucket.getDocCount()).thenReturn(docCount);
         return bucket;
@@ -73,15 +75,15 @@ public final class MockAggregations {
         return agg;
     }
 
-    public static NumericMetricsAggregation.SingleValue mockSingleValue(String name, double value) {
-        NumericMetricsAggregation.SingleValue agg = mock(NumericMetricsAggregation.SingleValue.class);
+    public static InternalNumericMetricsAggregation.SingleValue mockSingleValue(String name, double value) {
+        InternalNumericMetricsAggregation.SingleValue agg = mock(InternalNumericMetricsAggregation.SingleValue.class);
         when(agg.getName()).thenReturn(name);
         when(agg.value()).thenReturn(value);
         return agg;
     }
 
-    public static Cardinality mockCardinality(String name, long value) {
-        Cardinality agg = mock(Cardinality.class);
+    public static InternalCardinality mockCardinality(String name, long value) {
+        InternalCardinality agg = mock(InternalCardinality.class);
         when(agg.getName()).thenReturn(name);
         when(agg.getValue()).thenReturn(value);
         return agg;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AccuracyTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/AccuracyTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.ml.dataframe.evaluation.classification;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.dataframe.evaluation.EvaluationFields;
@@ -64,11 +65,14 @@ public class AccuracyTests extends AbstractXContentSerializingTestCase<Accuracy>
     }
 
     public void testProcess() {
-        Aggregations aggs = new Aggregations(
+        InternalAggregations aggs = InternalAggregations.from(
             List.of(
                 mockTerms(
                     "accuracy_" + MulticlassConfusionMatrix.STEP_1_AGGREGATE_BY_ACTUAL_CLASS,
-                    List.of(mockTermsBucket("dog", new Aggregations(List.of())), mockTermsBucket("cat", new Aggregations(List.of()))),
+                    List.of(
+                        mockTermsBucket("dog", InternalAggregations.from(List.of())),
+                        mockTermsBucket("cat", InternalAggregations.from(List.of()))
+                    ),
                     100L
                 ),
                 mockCardinality("accuracy_" + MulticlassConfusionMatrix.STEP_1_CARDINALITY_OF_ACTUAL_CLASS, 1000L),
@@ -78,7 +82,7 @@ public class AccuracyTests extends AbstractXContentSerializingTestCase<Accuracy>
                         mockFiltersBucket(
                             "dog",
                             30,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         "accuracy_" + MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -94,7 +98,7 @@ public class AccuracyTests extends AbstractXContentSerializingTestCase<Accuracy>
                         mockFiltersBucket(
                             "cat",
                             70,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         "accuracy_" + MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -129,7 +133,10 @@ public class AccuracyTests extends AbstractXContentSerializingTestCase<Accuracy>
             List.of(
                 mockTerms(
                     "accuracy_" + MulticlassConfusionMatrix.STEP_1_AGGREGATE_BY_ACTUAL_CLASS,
-                    List.of(mockTermsBucket("dog", new Aggregations(List.of())), mockTermsBucket("cat", new Aggregations(List.of()))),
+                    List.of(
+                        mockTermsBucket("dog", InternalAggregations.from(List.of())),
+                        mockTermsBucket("cat", InternalAggregations.from(List.of()))
+                    ),
                     100L
                 ),
                 mockCardinality("accuracy_" + MulticlassConfusionMatrix.STEP_1_CARDINALITY_OF_ACTUAL_CLASS, 1001L),
@@ -139,7 +146,7 @@ public class AccuracyTests extends AbstractXContentSerializingTestCase<Accuracy>
                         mockFiltersBucket(
                             "dog",
                             30,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         "accuracy_" + MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -155,7 +162,7 @@ public class AccuracyTests extends AbstractXContentSerializingTestCase<Accuracy>
                         mockFiltersBucket(
                             "cat",
                             70,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         "accuracy_" + MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrixTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/MulticlassConfusionMatrixTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -105,7 +106,10 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
             List.of(
                 mockTerms(
                     MulticlassConfusionMatrix.STEP_1_AGGREGATE_BY_ACTUAL_CLASS,
-                    List.of(mockTermsBucket("dog", new Aggregations(List.of())), mockTermsBucket("cat", new Aggregations(List.of()))),
+                    List.of(
+                        mockTermsBucket("dog", InternalAggregations.from(List.of())),
+                        mockTermsBucket("cat", InternalAggregations.from(List.of()))
+                    ),
                     0L
                 ),
                 mockCardinality(MulticlassConfusionMatrix.STEP_1_CARDINALITY_OF_ACTUAL_CLASS, 2L),
@@ -115,7 +119,7 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
                         mockFiltersBucket(
                             "dog",
                             30,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -131,7 +135,7 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
                         mockFiltersBucket(
                             "cat",
                             70,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -172,7 +176,10 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
             List.of(
                 mockTerms(
                     MulticlassConfusionMatrix.STEP_1_AGGREGATE_BY_ACTUAL_CLASS,
-                    List.of(mockTermsBucket("dog", new Aggregations(List.of())), mockTermsBucket("cat", new Aggregations(List.of()))),
+                    List.of(
+                        mockTermsBucket("dog", InternalAggregations.from(List.of())),
+                        mockTermsBucket("cat", InternalAggregations.from(List.of()))
+                    ),
                     100L
                 ),
                 mockCardinality(MulticlassConfusionMatrix.STEP_1_CARDINALITY_OF_ACTUAL_CLASS, 5L),
@@ -182,7 +189,7 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
                         mockFiltersBucket(
                             "dog",
                             30,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -198,7 +205,7 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
                         mockFiltersBucket(
                             "cat",
                             85,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -235,15 +242,15 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
     }
 
     public void testProcess_MoreThanTwoStepsNeeded() {
-        Aggregations aggsStep1 = new Aggregations(
+        InternalAggregations aggsStep1 = InternalAggregations.from(
             List.of(
                 mockTerms(
                     MulticlassConfusionMatrix.STEP_1_AGGREGATE_BY_ACTUAL_CLASS,
                     List.of(
-                        mockTermsBucket("ant", new Aggregations(List.of())),
-                        mockTermsBucket("cat", new Aggregations(List.of())),
-                        mockTermsBucket("dog", new Aggregations(List.of())),
-                        mockTermsBucket("fox", new Aggregations(List.of()))
+                        mockTermsBucket("ant", InternalAggregations.from(List.of())),
+                        mockTermsBucket("cat", InternalAggregations.from(List.of())),
+                        mockTermsBucket("dog", InternalAggregations.from(List.of())),
+                        mockTermsBucket("fox", InternalAggregations.from(List.of()))
                     ),
                     0L
                 ),
@@ -258,7 +265,7 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
                         mockFiltersBucket(
                             "ant",
                             46,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -276,7 +283,7 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
                         mockFiltersBucket(
                             "cat",
                             86,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -303,7 +310,7 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
                         mockFiltersBucket(
                             "dog",
                             126,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,
@@ -321,7 +328,7 @@ public class MulticlassConfusionMatrixTests extends AbstractXContentSerializingT
                         mockFiltersBucket(
                             "fox",
                             166,
-                            new Aggregations(
+                            InternalAggregations.from(
                                 List.of(
                                     mockFilters(
                                         MulticlassConfusionMatrix.STEP_2_AGGREGATE_BY_PREDICTED_CLASS,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -175,7 +174,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
         }
 
         @Override
-        public Aggregations getAggregations() {
+        public InternalAggregations getAggregations() {
             return aggregations;
         }
 
@@ -323,7 +322,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
             for (InternalAggregation aggregation : aggregations) {
                 InternalCategorizationAggregation categorizationAggregation = (InternalCategorizationAggregation) aggregation;
                 for (Bucket bucket : categorizationAggregation.buckets) {
-                    categorizer.mergeWireCategory(bucket.serializableCategory).addSubAggs((InternalAggregations) bucket.getAggregations());
+                    categorizer.mergeWireCategory(bucket.serializableCategory).addSubAggs(bucket.getAggregations());
                     if (reduceContext.isCanceled().get()) {
                         break;
                     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointAggregator.java
@@ -19,7 +19,6 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers;
 import org.elasticsearch.search.aggregations.pipeline.SiblingPipelineAggregator;
 import org.elasticsearch.xpack.ml.aggs.MlAggsHelper;
@@ -137,7 +136,7 @@ public class ChangePointAggregator extends SiblingPipelineAggregator {
         ChangePointBucket changePointBucket = null;
         if (change.changePoint() >= 0) {
             changePointBucket = extractBucket(bucketsPaths()[0], aggregations, change.changePoint()).map(
-                b -> new ChangePointBucket(b.getKey(), b.getDocCount(), (InternalAggregations) b.getAggregations())
+                b -> new ChangePointBucket(b.getKey(), b.getDocCount(), b.getAggregations())
             ).orElse(null);
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointBucket.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/changepoint/ChangePointBucket.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.ml.aggs.changepoint;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -68,7 +67,7 @@ public class ChangePointBucket extends InternalMultiBucketAggregation.InternalBu
     }
 
     @Override
-    public Aggregations getAggregations() {
+    public InternalAggregations getAggregations() {
         return aggregations;
     }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/IndexerUtilsTests.java
@@ -19,10 +19,10 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.DateHistogramValuesSourceBuilder;
@@ -306,7 +306,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
             keys = shuffleMap(keys, Collections.emptySet());
             when(bucket.getKey()).thenReturn(keys);
 
-            List<Aggregation> list = new ArrayList<>(3);
+            List<InternalAggregation> list = new ArrayList<>(3);
             InternalNumericMetricsAggregation.SingleValue mockAgg = mock(InternalNumericMetricsAggregation.SingleValue.class);
             when(mockAgg.getName()).thenReturn("123");
             list.add(mockAgg);
@@ -321,7 +321,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
 
             Collections.shuffle(list, random());
 
-            Aggregations aggs = new Aggregations(list);
+            InternalAggregations aggs = InternalAggregations.from(list);
             when(bucket.getAggregations()).thenReturn(aggs);
             when(bucket.getDocCount()).thenReturn(1L);
 
@@ -357,7 +357,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
             keys = shuffleMap(keys, Collections.emptySet());
             when(bucket.getKey()).thenReturn(keys);
 
-            List<Aggregation> list = new ArrayList<>(3);
+            List<InternalAggregation> list = new ArrayList<>(3);
             InternalNumericMetricsAggregation.SingleValue mockAgg = mock(InternalNumericMetricsAggregation.SingleValue.class);
             when(mockAgg.getName()).thenReturn("123");
             list.add(mockAgg);
@@ -372,7 +372,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
 
             Collections.shuffle(list, random());
 
-            Aggregations aggs = new Aggregations(list);
+            InternalAggregations aggs = InternalAggregations.from(list);
             when(bucket.getAggregations()).thenReturn(aggs);
             when(bucket.getDocCount()).thenReturn(1L);
 
@@ -400,7 +400,7 @@ public class IndexerUtilsTests extends AggregatorTestCase {
             keys.put("abc.histogram", null);
             when(bucket.getKey()).thenReturn(keys);
 
-            Aggregations aggs = new Aggregations(Collections.emptyList());
+            InternalAggregations aggs = InternalAggregations.from(Collections.emptyList());
             when(bucket.getAggregations()).thenReturn(aggs);
             when(bucket.getDocCount()).thenReturn(1L);
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -658,7 +658,7 @@ public class RollupIndexerStateTests extends ESTestCase {
                         }
 
                         @Override
-                        public Aggregations getAggregations() {
+                        public InternalAggregations getAggregations() {
                             return InternalAggregations.EMPTY;
                         }
 
@@ -788,7 +788,7 @@ public class RollupIndexerStateTests extends ESTestCase {
                         }
 
                         @Override
-                        public Aggregations getAggregations() {
+                        public InternalAggregations getAggregations() {
                             return InternalAggregations.EMPTY;
                         }
 
@@ -967,7 +967,7 @@ public class RollupIndexerStateTests extends ESTestCase {
                         }
 
                         @Override
-                        public Aggregations getAggregations() {
+                        public InternalAggregations getAggregations() {
                             return InternalAggregations.EMPTY;
                         }
 

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.logging.HeaderWarning;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
@@ -382,7 +383,7 @@ public class Querier {
             }
 
             @Override
-            public Aggregations getAggregations() {
+            public InternalAggregations getAggregations() {
                 throw new SqlIllegalArgumentException("No group-by/aggs defined");
             }
         });

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/CompositeKeyExtractorTests.java
@@ -7,7 +7,7 @@
 package org.elasticsearch.xpack.sql.execution.search.extractor;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.execution.search.extractor.BucketExtractor;
@@ -76,7 +76,7 @@ public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCa
     }
 
     public void testExtractBucketCount() {
-        Bucket bucket = new TestBucket(emptyMap(), randomLong(), new Aggregations(emptyList()));
+        Bucket bucket = new TestBucket(emptyMap(), randomLong(), InternalAggregations.from(emptyList()));
         CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.COUNT, randomZone(), NULL);
         assertEquals(bucket.getDocCount(), extractor.extract(bucket));
     }
@@ -85,7 +85,7 @@ public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCa
         CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, UTC, NULL);
 
         Object value = new Object();
-        Bucket bucket = new TestBucket(singletonMap(extractor.key(), value), randomLong(), new Aggregations(emptyList()));
+        Bucket bucket = new TestBucket(singletonMap(extractor.key(), value), randomLong(), InternalAggregations.from(emptyList()));
         assertEquals(value, extractor.extract(bucket));
     }
 
@@ -93,7 +93,7 @@ public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCa
         CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomZone(), DATETIME);
 
         long millis = System.currentTimeMillis();
-        Bucket bucket = new TestBucket(singletonMap(extractor.key(), millis), randomLong(), new Aggregations(emptyList()));
+        Bucket bucket = new TestBucket(singletonMap(extractor.key(), millis), randomLong(), InternalAggregations.from(emptyList()));
         assertEquals(DateUtils.asDateTimeWithMillis(millis, extractor.zoneId()), extractor.extract(bucket));
     }
 
@@ -101,7 +101,7 @@ public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCa
         CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomZone(), DATETIME);
 
         Object value = new Object();
-        Bucket bucket = new TestBucket(singletonMap(extractor.key(), value), randomLong(), new Aggregations(emptyList()));
+        Bucket bucket = new TestBucket(singletonMap(extractor.key(), value), randomLong(), InternalAggregations.from(emptyList()));
         SqlIllegalArgumentException exception = expectThrows(SqlIllegalArgumentException.class, () -> extractor.extract(bucket));
         assertEquals("Invalid date key returned: " + value, exception.getMessage());
     }
@@ -109,7 +109,7 @@ public class CompositeKeyExtractorTests extends AbstractSqlWireSerializingTestCa
     public void testExtractUnsignedLong() {
         CompositeKeyExtractor extractor = new CompositeKeyExtractor(randomAlphaOfLength(16), Property.VALUE, randomZone(), UNSIGNED_LONG);
         Long value = randomLong();
-        Bucket bucket = new TestBucket(singletonMap(extractor.key(), value), randomLong(), new Aggregations(emptyList()));
+        Bucket bucket = new TestBucket(singletonMap(extractor.key(), value), randomLong(), InternalAggregations.from(emptyList()));
         assertEquals(BigInteger.valueOf(value).and(UNSIGNED_LONG_MAX), extractor.extract(bucket));
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/MetricAggExtractorTests.java
@@ -7,8 +7,8 @@
 package org.elasticsearch.xpack.sql.execution.search.extractor;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.execution.search.extractor.BucketExtractor;
@@ -75,7 +75,7 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
     }
 
     public void testNoAggs() {
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(emptyList()));
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(emptyList()));
         MetricAggExtractor extractor = randomMetricAggExtractor();
         SqlIllegalArgumentException exception = expectThrows(SqlIllegalArgumentException.class, () -> extractor.extract(bucket));
         assertEquals("Cannot find an aggregation named " + extractor.name(), exception.getMessage());
@@ -85,8 +85,8 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
         MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null);
 
         double value = randomDouble();
-        Aggregation agg = new TestSingleValueAggregation(extractor.name(), singletonList(extractor.property()), value);
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        InternalAggregation agg = new TestSingleValueAggregation(extractor.name(), singletonList(extractor.property()), value);
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(value, extractor.extract(bucket));
     }
 
@@ -95,20 +95,20 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
         MetricAggExtractor extractor = new MetricAggExtractor("my_date_field", "property", "innerKey", zoneId, DATETIME);
 
         double value = randomDouble();
-        Aggregation agg = new TestSingleValueAggregation(extractor.name(), singletonList(extractor.property()), value);
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        InternalAggregation agg = new TestSingleValueAggregation(extractor.name(), singletonList(extractor.property()), value);
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(DateUtils.asDateTimeWithMillis((long) value, zoneId), extractor.extract(bucket));
     }
 
     public void testSingleValueInnerKey() {
         MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null);
         double innerValue = randomDouble();
-        Aggregation agg = new TestSingleValueAggregation(
+        InternalAggregation agg = new TestSingleValueAggregation(
             extractor.name(),
             singletonList(extractor.property()),
             singletonMap(extractor.innerKey(), innerValue)
         );
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(innerValue, extractor.extract(bucket));
     }
 
@@ -117,12 +117,12 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
         MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", zoneId, DATE);
 
         double innerValue = randomDouble();
-        Aggregation agg = new TestSingleValueAggregation(
+        InternalAggregation agg = new TestSingleValueAggregation(
             extractor.name(),
             singletonList(extractor.property()),
             singletonMap(extractor.innerKey(), innerValue)
         );
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(DateUtils.asDateTimeWithMillis((long) innerValue, zoneId), extractor.extract(bucket));
     }
 
@@ -130,8 +130,8 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
         MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", null);
 
         double value = randomDouble();
-        Aggregation agg = new TestMultiValueAggregation(extractor.name(), singletonMap(extractor.property(), value));
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        InternalAggregation agg = new TestMultiValueAggregation(extractor.name(), singletonMap(extractor.property(), value));
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(value, extractor.extract(bucket));
     }
 
@@ -140,8 +140,8 @@ public class MetricAggExtractorTests extends AbstractSqlWireSerializingTestCase<
         MetricAggExtractor extractor = new MetricAggExtractor("field", "property", "innerKey", zoneId, DATETIME);
 
         double value = randomDouble();
-        Aggregation agg = new TestMultiValueAggregation(extractor.name(), singletonMap(extractor.property(), value));
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        InternalAggregation agg = new TestMultiValueAggregation(extractor.name(), singletonMap(extractor.property(), value));
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(DateUtils.asDateTimeWithMillis((long) value, zoneId), extractor.extract(bucket));
     }
 

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestBucket.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TestBucket.java
@@ -6,7 +6,7 @@
  */
 package org.elasticsearch.xpack.sql.execution.search.extractor;
 
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation.Bucket;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -17,9 +17,9 @@ class TestBucket implements Bucket {
 
     private final Map<String, Object> key;
     private final long count;
-    private final Aggregations aggs;
+    private final InternalAggregations aggs;
 
-    TestBucket(Map<String, Object> key, long count, Aggregations aggs) {
+    TestBucket(Map<String, Object> key, long count, InternalAggregations aggs) {
         this.key = key;
         this.count = count;
         this.aggs = aggs;
@@ -46,7 +46,7 @@ class TestBucket implements Bucket {
     }
 
     @Override
-    public Aggregations getAggregations() {
+    public InternalAggregations getAggregations() {
         return aggs;
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/execution/search/extractor/TopHitsAggExtractorTests.java
@@ -11,8 +11,8 @@ import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.io.stream.Writeable.Reader;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregation;
-import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.metrics.InternalTopHits;
 import org.elasticsearch.test.ESTestCase;
@@ -63,7 +63,7 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
     }
 
     public void testNoAggs() {
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(emptyList()));
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(emptyList()));
         TopHitsAggExtractor extractor = randomTopHitsAggExtractor();
         SqlIllegalArgumentException exception = expectThrows(SqlIllegalArgumentException.class, () -> extractor.extract(bucket));
         assertEquals("Cannot find an aggregation named " + extractor.name(), exception.getMessage());
@@ -72,8 +72,8 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
     public void testZeroNullValue() {
         TopHitsAggExtractor extractor = randomTopHitsAggExtractor();
 
-        Aggregation agg = new InternalTopHits(extractor.name(), 0, 0, null, SearchHits.EMPTY_WITH_TOTAL_HITS, null);
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        InternalAggregation agg = new InternalTopHits(extractor.name(), 0, 0, null, SearchHits.EMPTY_WITH_TOTAL_HITS, null);
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertNull(extractor.extract(bucket));
     }
 
@@ -81,8 +81,8 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
         TopHitsAggExtractor extractor = new TopHitsAggExtractor("topHitsAgg", DataTypes.KEYWORD, UTC);
 
         String value = "Str_Value";
-        Aggregation agg = new InternalTopHits(extractor.name(), 0, 1, null, searchHitsOf(value), null);
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        InternalAggregation agg = new InternalTopHits(extractor.name(), 0, 1, null, searchHitsOf(value), null);
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(value, extractor.extract(bucket));
     }
 
@@ -91,7 +91,7 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
         TopHitsAggExtractor extractor = new TopHitsAggExtractor("topHitsAgg", DataTypes.DATETIME, zoneId);
 
         long value = 123456789L;
-        Aggregation agg = new InternalTopHits(
+        InternalAggregation agg = new InternalTopHits(
             extractor.name(),
             0,
             1,
@@ -99,7 +99,7 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
             searchHitsOf(StringUtils.toString(DateUtils.asDateTimeWithMillis(value, zoneId))),
             null
         );
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(DateUtils.asDateTimeWithMillis(value, zoneId), extractor.extract(bucket));
     }
 
@@ -108,8 +108,8 @@ public class TopHitsAggExtractorTests extends AbstractSqlWireSerializingTestCase
         Object value = bi.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) <= 0 ? bi.longValue() : bi;
 
         TopHitsAggExtractor extractor = new TopHitsAggExtractor(randomAlphaOfLength(10), DataTypes.UNSIGNED_LONG, randomZone());
-        Aggregation agg = new InternalTopHits(extractor.name(), 0, 1, null, searchHitsOf(value), null);
-        Bucket bucket = new TestBucket(emptyMap(), 0, new Aggregations(singletonList(agg)));
+        InternalAggregation agg = new InternalTopHits(extractor.name(), 0, 1, null, searchHitsOf(value), null);
+        Bucket bucket = new TestBucket(emptyMap(), 0, InternalAggregations.from(singletonList(agg)));
         assertEquals(bi, extractor.extract(bucket));
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationResultUtilsTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.PipelineAggregatorBuilders;
-import org.elasticsearch.search.aggregations.bucket.SingleBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.search.aggregations.bucket.range.InternalRange;
 import org.elasticsearch.search.aggregations.bucket.range.Range;
@@ -951,14 +951,16 @@ public class AggregationResultUtilsTests extends ESTestCase {
         );
     }
 
-    public static SingleBucketAggregation createSingleBucketAgg(String name, long docCount, Aggregation... subAggregations) {
-        SingleBucketAggregation agg = mock(SingleBucketAggregation.class);
+    public static InternalSingleBucketAggregation createSingleBucketAgg(
+        String name,
+        long docCount,
+        InternalAggregation... subAggregations
+    ) {
+        InternalSingleBucketAggregation agg = mock(InternalSingleBucketAggregation.class);
         when(agg.getDocCount()).thenReturn(docCount);
         when(agg.getName()).thenReturn(name);
         if (subAggregations != null) {
-            org.elasticsearch.search.aggregations.Aggregations subAggs = new org.elasticsearch.search.aggregations.Aggregations(
-                List.of(subAggregations)
-            );
+            InternalAggregations subAggs = InternalAggregations.from(List.of(subAggregations));
             when(agg.getAggregations()).thenReturn(subAggs);
         } else {
             when(agg.getAggregations()).thenReturn(null);


### PR DESCRIPTION
Currently our Aggregator hold InternalAggregator so it makes more sense to return InternalAggregators from this method. It eliminates a few castings we have over the place. 