### PR TITLE
[Transform] Make `_reset` action stop transforms without force first

### DIFF
--- a/docs/changelog/104870.yaml
+++ b/docs/changelog/104870.yaml
@@ -1,0 +1,7 @@
+pr: 104870
+summary: Make `_reset` action stop transforms without force first
+area: Transform
+type: bug
+issues:
+ - 100596
+ - 104825

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
@@ -90,6 +90,7 @@ public class TestFeatureResetIT extends TransformRestTestCase {
 
         putTransform(continuousTransformId, Strings.toString(config), RequestOptions.DEFAULT);
 
+        // Sleep for a few seconds so that we cover transform being stopped at various stages.
         Thread.sleep(randomLongBetween(0, 5_000));
 
         startTransform(continuousTransformId, RequestOptions.DEFAULT);

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TestFeatureResetIT.java
@@ -57,7 +57,6 @@ public class TestFeatureResetIT extends TransformRestTestCase {
         cleanUp();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104825")
     @SuppressWarnings("unchecked")
     public void testTransformFeatureReset() throws Exception {
         String indexName = "basic-crud-reviews";
@@ -90,6 +89,9 @@ public class TestFeatureResetIT extends TransformRestTestCase {
             .build();
 
         putTransform(continuousTransformId, Strings.toString(config), RequestOptions.DEFAULT);
+
+        Thread.sleep(randomLongBetween(0, 5_000));
+
         startTransform(continuousTransformId, RequestOptions.DEFAULT);
 
         assertOK(client().performRequest(new Request(HttpPost.METHOD_NAME, "/_features/_reset")));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -442,10 +442,11 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
         ActionListener<StopTransformAction.Response> afterStoppingTransforms = ActionListener.wrap(
             afterForceStoppingTransforms::onResponse,
             e -> {
-                logger.warn("Exception while trying to stop the transforms, will try again with force=true", e);
+                logger.info("Error while trying to stop the transforms, will try again with force=true", e);
                 StopTransformAction.Request forceStopTransformsRequest = new StopTransformAction.Request(
                     Metadata.ALL,
                     true,
+                    // Set force=true to make sure all the transforms persistent tasks are stopped.
                     true,
                     null,
                     true,
@@ -459,7 +460,9 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
             StopTransformAction.Request stopTransformsRequest = new StopTransformAction.Request(
                 Metadata.ALL,
                 true,
+                // Set force=false in order to let transforms finish gracefully.
                 false,
+                // Do not give it too much time. If there is a problem, there will be another try with force=true.
                 TimeValue.timeValueSeconds(10),
                 true,
                 false


### PR DESCRIPTION
This PR fixes `_reset` action the following way:
- the `_reset` action now tries to `_stop` the transform **without** `force` but with timeout
- only when this fails, it re-tries, this time **with** `force` set to `true`

Additionally, this PR unmutes the `TestFeatureResetIT` test case.

This PR will be backported to `8.12` once the test runs without failure for a week in main.

Closes https://github.com/elastic/elasticsearch/issues/100596
Closes https://github.com/elastic/elasticsearch/issues/104825