### PR TITLE
Remove some usages of Aggregations in rollup module tests

### DIFF
--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/RollupResponseTranslationTests.java
@@ -187,7 +187,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
         when(filter.getName()).thenReturn("filter_foo");
         aggTree.add(filter);
 
-        Aggregations mockAggsWithout = InternalAggregations.from(aggTree);
+        InternalAggregations mockAggsWithout = InternalAggregations.from(aggTree);
         when(responseWithout.getAggregations()).thenReturn(mockAggsWithout);
 
         MultiSearchResponse msearch = new MultiSearchResponse(
@@ -458,7 +458,7 @@ public class RollupResponseTranslationTests extends AggregatorTestCase {
         when(filter.getName()).thenReturn("filter_foo");
         aggTree.add(filter);
 
-        Aggregations mockAggsWithout = InternalAggregations.from(aggTree);
+        InternalAggregations mockAggsWithout = InternalAggregations.from(aggTree);
         when(responseWithout.getAggregations()).thenReturn(mockAggsWithout);
         MultiSearchResponse.Item rolledResponse = new MultiSearchResponse.Item(responseWithout, null);
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerIndexingTests.java
@@ -44,10 +44,10 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.query.SearchExecutionContextHelper;
 import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -860,7 +860,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                 .iterator()
                 .next();
 
-            CompositeAggregation result = null;
+            InternalComposite result = null;
             try {
                 result = searchAndReduce(reader, new AggTestConfig(aggBuilder, fieldTypes).withQuery(query));
             } catch (IOException e) {
@@ -870,7 +870,7 @@ public class RollupIndexerIndexingTests extends AggregatorTestCase {
                 listener,
                 new SearchResponse(
                     SearchHits.EMPTY_WITH_TOTAL_HITS,
-                    new Aggregations(Collections.singletonList(result)),
+                    InternalAggregations.from(Collections.singletonList(result)),
                     null,
                     false,
                     null,

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -15,13 +15,11 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.InternalAggregations;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.rollup.ConfigTestHelpers;
 import org.elasticsearch.xpack.core.rollup.RollupField;
@@ -31,7 +29,6 @@ import org.elasticsearch.xpack.core.rollup.job.RollupJobConfig;
 import org.hamcrest.Matchers;
 import org.mockito.stubbing.Answer;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +43,9 @@ import java.util.function.Function;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class RollupIndexerStateTests extends ESTestCase {
     private static class EmptyRollupIndexer extends RollupIndexer {
@@ -71,38 +70,12 @@ public class RollupIndexerStateTests extends ESTestCase {
 
         @Override
         protected void doNextSearch(long waitTimeInNanos, ActionListener<SearchResponse> nextPhase) {
-            // TODO Should use InternalComposite constructor but it is package protected in core.
-            Aggregations aggs = new Aggregations(Collections.singletonList(new CompositeAggregation() {
-                @Override
-                public List<? extends Bucket> getBuckets() {
-                    return Collections.emptyList();
-                }
+            InternalComposite composite = mock(InternalComposite.class);
+            when(composite.getBuckets()).thenReturn(List.of());
+            when(composite.getName()).thenReturn(AGGREGATION_NAME);
 
-                @Override
-                public Map<String, Object> afterKey() {
-                    return null;
-                }
+            InternalAggregations aggs = InternalAggregations.from(List.of(composite));
 
-                @Override
-                public String getName() {
-                    return AGGREGATION_NAME;
-                }
-
-                @Override
-                public String getType() {
-                    return null;
-                }
-
-                @Override
-                public Map<String, Object> getMetadata() {
-                    return null;
-                }
-
-                @Override
-                public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                    return null;
-                }
-            }));
             ActionListener.respondAndRelease(
                 nextPhase,
                 new SearchResponse(
@@ -442,41 +415,16 @@ public class RollupIndexerStateTests extends ESTestCase {
                     } catch (InterruptedException e) {
                         throw new IllegalStateException(e);
                     }
-                    // TODO Should use InternalComposite constructor but it is package protected in core.
-                    Aggregations aggs = new Aggregations(Collections.singletonList(new CompositeAggregation() {
-                        @Override
-                        public List<? extends Bucket> getBuckets() {
-                            // Abort immediately before we are attempting to finish the job because the response
-                            // was empty
-                            state.set(IndexerState.ABORTING);
-                            return Collections.emptyList();
-                        }
 
-                        @Override
-                        public Map<String, Object> afterKey() {
-                            return null;
-                        }
+                    InternalComposite composite = mock(InternalComposite.class);
+                    when(composite.getBuckets()).thenAnswer(invocation -> {
+                        state.set(IndexerState.ABORTING);
+                        return List.of();
+                    });
+                    when(composite.getName()).thenReturn(AGGREGATION_NAME);
 
-                        @Override
-                        public String getName() {
-                            return AGGREGATION_NAME;
-                        }
+                    InternalAggregations aggs = InternalAggregations.from(List.of(composite));
 
-                        @Override
-                        public String getType() {
-                            return null;
-                        }
-
-                        @Override
-                        public Map<String, Object> getMetadata() {
-                            return null;
-                        }
-
-                        @Override
-                        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                            return null;
-                        }
-                    }));
                     ActionListener.respondAndRelease(
                         nextPhase,
                         new SearchResponse(
@@ -638,64 +586,18 @@ public class RollupIndexerStateTests extends ESTestCase {
         RollupJob job = new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random()), Collections.emptyMap());
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
         Function<SearchRequest, SearchResponse> searchFunction = searchRequest -> {
-            Aggregations aggs = new Aggregations(Collections.singletonList(new CompositeAggregation() {
-                @Override
-                public List<? extends Bucket> getBuckets() {
-                    Bucket b = new Bucket() {
-                        @Override
-                        public Map<String, Object> getKey() {
-                            return Collections.singletonMap("foo", "bar");
-                        }
 
-                        @Override
-                        public String getKeyAsString() {
-                            return null;
-                        }
+            InternalComposite.InternalBucket bucket = mock(InternalComposite.InternalBucket.class);
+            when(bucket.getKey()).thenReturn(Map.of("foo", "bar"));
+            when(bucket.getDocCount()).thenReturn(1L);
+            when(bucket.getAggregations()).thenReturn(InternalAggregations.EMPTY);
 
-                        @Override
-                        public long getDocCount() {
-                            return 1;
-                        }
+            InternalComposite composite = mock(InternalComposite.class);
+            when(composite.getBuckets()).thenReturn(List.of(bucket));
+            when(composite.getName()).thenReturn(RollupField.NAME);
 
-                        @Override
-                        public InternalAggregations getAggregations() {
-                            return InternalAggregations.EMPTY;
-                        }
+            InternalAggregations aggs = InternalAggregations.from(List.of(composite));
 
-                        @Override
-                        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                            return null;
-                        }
-                    };
-
-                    return Collections.singletonList(b);
-                }
-
-                @Override
-                public Map<String, Object> afterKey() {
-                    return null;
-                }
-
-                @Override
-                public String getName() {
-                    return RollupField.NAME;
-                }
-
-                @Override
-                public String getType() {
-                    return null;
-                }
-
-                @Override
-                public Map<String, Object> getMetadata() {
-                    return null;
-                }
-
-                @Override
-                public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                    return null;
-                }
-            }));
             return new SearchResponse(
                 SearchHits.EMPTY_WITH_TOTAL_HITS,
                 aggs,
@@ -767,65 +669,20 @@ public class RollupIndexerStateTests extends ESTestCase {
         RollupJob job = new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random()), Collections.emptyMap());
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
         Function<SearchRequest, SearchResponse> searchFunction = searchRequest -> {
-            Aggregations aggs = new Aggregations(Collections.singletonList(new CompositeAggregation() {
-                @Override
-                public List<? extends Bucket> getBuckets() {
-                    Bucket b = new Bucket() {
-                        @Override
-                        public Map<String, Object> getKey() {
-                            state.set(IndexerState.STOPPING); // <- Force a stop so we can see how error + non-INDEXING state is handled
-                            return Collections.singletonMap("foo", "bar");  // This will throw an exception
-                        }
 
-                        @Override
-                        public String getKeyAsString() {
-                            return null;
-                        }
+            InternalComposite.InternalBucket bucket = mock(InternalComposite.InternalBucket.class);
+            when(bucket.getKey()).thenAnswer(invocation -> {
+                state.set(IndexerState.STOPPING); // <- Force a stop so we can see how error + non-INDEXING state is handled
+                return Collections.singletonMap("foo", "bar");  // This will throw an exception
+            });
+            when(bucket.getDocCount()).thenReturn(1L);
+            when(bucket.getAggregations()).thenReturn(InternalAggregations.EMPTY);
 
-                        @Override
-                        public long getDocCount() {
-                            return 1;
-                        }
+            InternalComposite composite = mock(InternalComposite.class);
+            when(composite.getBuckets()).thenReturn(List.of(bucket));
+            when(composite.getName()).thenReturn(RollupField.NAME);
 
-                        @Override
-                        public InternalAggregations getAggregations() {
-                            return InternalAggregations.EMPTY;
-                        }
-
-                        @Override
-                        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                            return null;
-                        }
-                    };
-
-                    return Collections.singletonList(b);
-                }
-
-                @Override
-                public Map<String, Object> afterKey() {
-                    return null;
-                }
-
-                @Override
-                public String getName() {
-                    return RollupField.NAME;
-                }
-
-                @Override
-                public String getType() {
-                    return null;
-                }
-
-                @Override
-                public Map<String, Object> getMetadata() {
-                    return null;
-                }
-
-                @Override
-                public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                    return null;
-                }
-            }));
+            InternalAggregations aggs = InternalAggregations.from(List.of(composite));
             return new SearchResponse(
                 SearchHits.EMPTY_WITH_TOTAL_HITS,
                 aggs,
@@ -947,64 +804,18 @@ public class RollupIndexerStateTests extends ESTestCase {
         RollupJob job = new RollupJob(ConfigTestHelpers.randomRollupJobConfig(random()), Collections.emptyMap());
         AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STOPPED);
         Function<SearchRequest, SearchResponse> searchFunction = searchRequest -> {
-            Aggregations aggs = new Aggregations(Collections.singletonList(new CompositeAggregation() {
-                @Override
-                public List<? extends Bucket> getBuckets() {
-                    Bucket b = new Bucket() {
-                        @Override
-                        public Map<String, Object> getKey() {
-                            return Collections.singletonMap("foo.terms", "bar");
-                        }
 
-                        @Override
-                        public String getKeyAsString() {
-                            return null;
-                        }
+            InternalComposite.InternalBucket bucket = mock(InternalComposite.InternalBucket.class);
+            when(bucket.getKey()).thenReturn(Map.of("foo.terms", "bar"));
+            when(bucket.getDocCount()).thenReturn(1L);
+            when(bucket.getAggregations()).thenReturn(InternalAggregations.EMPTY);
 
-                        @Override
-                        public long getDocCount() {
-                            return 1;
-                        }
+            InternalComposite composite = mock(InternalComposite.class);
+            when(composite.getName()).thenReturn(RollupField.NAME);
+            when(composite.getBuckets()).thenReturn(List.of(bucket));
 
-                        @Override
-                        public InternalAggregations getAggregations() {
-                            return InternalAggregations.EMPTY;
-                        }
+            InternalAggregations aggs = InternalAggregations.from(List.of(composite));
 
-                        @Override
-                        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                            return null;
-                        }
-                    };
-
-                    return Collections.singletonList(b);
-                }
-
-                @Override
-                public Map<String, Object> afterKey() {
-                    return null;
-                }
-
-                @Override
-                public String getName() {
-                    return RollupField.NAME;
-                }
-
-                @Override
-                public String getType() {
-                    return null;
-                }
-
-                @Override
-                public Map<String, Object> getMetadata() {
-                    return null;
-                }
-
-                @Override
-                public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                    return null;
-                }
-            }));
             return new SearchResponse(
                 SearchHits.EMPTY_WITH_TOTAL_HITS,
                 aggs,

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupIndexerStateTests.java
@@ -418,6 +418,8 @@ public class RollupIndexerStateTests extends ESTestCase {
 
                     InternalComposite composite = mock(InternalComposite.class);
                     when(composite.getBuckets()).thenAnswer(invocation -> {
+                        // Abort immediately before we are attempting to finish the job because the response
+                        // was empty
                         state.set(IndexerState.ABORTING);
                         return List.of();
                     });

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -23,8 +23,8 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.composite.InternalComposite;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
@@ -608,10 +608,10 @@ public class RollupJobTaskTests extends ESTestCase {
             assertTrue(threadContext.getHeaders().isEmpty());
             SearchResponse r = mock(SearchResponse.class);
             when(r.getShardFailures()).thenReturn(ShardSearchFailure.EMPTY_ARRAY);
-            CompositeAggregation compositeAgg = mock(CompositeAggregation.class);
+            InternalComposite compositeAgg = mock(InternalComposite.class);
             when(compositeAgg.getBuckets()).thenReturn(Collections.emptyList());
             when(compositeAgg.getName()).thenReturn(RollupField.NAME);
-            Aggregations aggs = new Aggregations(Collections.singletonList(compositeAgg));
+            InternalAggregations aggs = InternalAggregations.from(Collections.singletonList(compositeAgg));
             when(r.getAggregations()).thenReturn(aggs);
 
             // Wait before progressing
@@ -717,10 +717,10 @@ public class RollupJobTaskTests extends ESTestCase {
 
             SearchResponse r = mock(SearchResponse.class);
             when(r.getShardFailures()).thenReturn(ShardSearchFailure.EMPTY_ARRAY);
-            CompositeAggregation compositeAgg = mock(CompositeAggregation.class);
+            InternalComposite compositeAgg = mock(InternalComposite.class);
             when(compositeAgg.getBuckets()).thenReturn(Collections.emptyList());
             when(compositeAgg.getName()).thenReturn(RollupField.NAME);
-            Aggregations aggs = new Aggregations(Collections.singletonList(compositeAgg));
+            InternalAggregations aggs = InternalAggregations.from(Collections.singletonList(compositeAgg));
             when(r.getAggregations()).thenReturn(aggs);
 
             // Wait before progressing
@@ -827,10 +827,10 @@ public class RollupJobTaskTests extends ESTestCase {
 
             SearchResponse r = mock(SearchResponse.class);
             when(r.getShardFailures()).thenReturn(ShardSearchFailure.EMPTY_ARRAY);
-            CompositeAggregation compositeAgg = mock(CompositeAggregation.class);
+            InternalComposite compositeAgg = mock(InternalComposite.class);
             when(compositeAgg.getBuckets()).thenReturn(Collections.emptyList());
             when(compositeAgg.getName()).thenReturn(RollupField.NAME);
-            Aggregations aggs = new Aggregations(Collections.singletonList(compositeAgg));
+            InternalAggregations aggs = InternalAggregations.from(Collections.singletonList(compositeAgg));
             when(r.getAggregations()).thenReturn(aggs);
 
             // Wait before progressing


### PR DESCRIPTION
Replaces some usages from  Aggregations to InternalAggregations and simplifies the test by using mocks.