### PR TITLE
[ML] Fix incorrect logger for class TransportDeleteInferenceModelAction

### DIFF
--- a/docs/changelog/104882.yaml
+++ b/docs/changelog/104882.yaml
@@ -1,0 +1,5 @@
+pr: 104882
+summary: Fix incorrect logger for class `TransportDeleteInferenceModelAction`
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/104882.yaml
+++ b/docs/changelog/104882.yaml
@@ -1,5 +1,0 @@
-pr: 104882
-summary: Fix incorrect logger for class `TransportDeleteInferenceModelAction`
-area: Machine Learning
-type: bug
-issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteInferenceModelAction.java
@@ -32,7 +32,7 @@ import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 
 public class TransportDeleteInferenceModelAction extends AcknowledgedTransportMasterNodeAction<DeleteInferenceModelAction.Request> {
 
-    private static final Logger logger = LogManager.getLogger(TransportPutInferenceModelAction.class);
+    private static final Logger logger = LogManager.getLogger(TransportDeleteInferenceModelAction.class);
 
     private final ModelRegistry modelRegistry;
     private final InferenceServiceRegistry serviceRegistry;


### PR DESCRIPTION
I just noticed that we were getting the wrong logger (using the wrong class) in TransportDeleteInferenceModelAction.