### PR TITLE
Fix problematic assertions in unit tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -197,6 +197,7 @@ public class MetadataTests extends ESTestCase {
             Map<String, List<DataStreamAlias>> aliases = metadata.findDataStreamAliases(request.aliases(), new String[] { "index", "d2" });
             assertEquals(1, aliases.size());
             List<DataStreamAlias> found = aliases.get("d2");
+            assertThat(found, transformedItemsMatch(DataStreamAlias::getAlias, containsInAnyOrder("alias2", "alias2-part2")));
         }
 
         // test exclusion
@@ -206,10 +207,12 @@ public class MetadataTests extends ESTestCase {
                 request.aliases(),
                 new String[] { "index", "d1", "d2", "d3", "d4" }
             );
+            assertThat(aliases.get("d2"), transformedItemsMatch(DataStreamAlias::getAlias, containsInAnyOrder("alias2", "alias2-part2")));
             assertThat(aliases.get("d1"), transformedItemsMatch(DataStreamAlias::getAlias, contains("alias1")));
 
             request.aliases("*", "-alias1");
             aliases = metadata.findDataStreamAliases(request.aliases(), new String[] { "index", "d1", "d2", "d3", "d4" });
+            assertThat(aliases.get("d2"), transformedItemsMatch(DataStreamAlias::getAlias, containsInAnyOrder("alias2", "alias2-part2")));
             assertNull(aliases.get("d1"));
         }
     }
@@ -237,6 +240,8 @@ public class MetadataTests extends ESTestCase {
 
         assertEquals(1, aliases.get("d1").size());
         assertEquals(2, aliases.get("d2").size());
+
+        assertThat(aliases.get("d2"), transformedItemsMatch(DataStreamAlias::getAlias, containsInAnyOrder("alias2", "alias2-part2")));
     }
 
     public void testFindAliasWithExclusion() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -197,7 +197,6 @@ public class MetadataTests extends ESTestCase {
             Map<String, List<DataStreamAlias>> aliases = metadata.findDataStreamAliases(request.aliases(), new String[] { "index", "d2" });
             assertEquals(1, aliases.size());
             List<DataStreamAlias> found = aliases.get("d2");
-            assertThat(found, transformedItemsMatch(DataStreamAlias::getAlias, contains("alias2", "alias2-part2")));
         }
 
         // test exclusion
@@ -207,12 +206,10 @@ public class MetadataTests extends ESTestCase {
                 request.aliases(),
                 new String[] { "index", "d1", "d2", "d3", "d4" }
             );
-            assertThat(aliases.get("d2"), transformedItemsMatch(DataStreamAlias::getAlias, contains("alias2", "alias2-part2")));
             assertThat(aliases.get("d1"), transformedItemsMatch(DataStreamAlias::getAlias, contains("alias1")));
 
             request.aliases("*", "-alias1");
             aliases = metadata.findDataStreamAliases(request.aliases(), new String[] { "index", "d1", "d2", "d3", "d4" });
-            assertThat(aliases.get("d2"), transformedItemsMatch(DataStreamAlias::getAlias, contains("alias2", "alias2-part2")));
             assertNull(aliases.get("d1"));
         }
     }
@@ -240,8 +237,6 @@ public class MetadataTests extends ESTestCase {
 
         assertEquals(1, aliases.get("d1").size());
         assertEquals(2, aliases.get("d2").size());
-
-        assertThat(aliases.get("d2"), transformedItemsMatch(DataStreamAlias::getAlias, contains("alias2", "alias2-part2")));
     }
 
     public void testFindAliasWithExclusion() {


### PR DESCRIPTION
This fixes some problematic assertions that use `transformedItemsMatch` on lists that can be changing in order. Will fix in another PR to ensure good test coverage.

The `8.12.1` PR is already fixing this so no backport is necessary.

Relates to #104145 