### PR TITLE
Use a regex rather than a string match

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/60_fail.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/60_fail.yml
@@ -108,7 +108,7 @@ teardown:
   - match: { items.0.update._id: "3" }
   - match: { items.0.update.status: 500 }
   - match: { items.0.update.error.type: fail_processor_exception }
-  - match: { items.0.update.error.reason: error-message }
+  - match: { items.0.update.error.reason: /error-message/ }
 
   - do:
       catch: missing


### PR DESCRIPTION
Fixes an exception from CI. In all my local testing the `error.reason` is `"error-message"`, but in some circumstances in CI the `error.reason` is `"fail_processor_exception: error-message"`. I don't understand why that is, but this unbreaks CI until I can investigate further.

Quick followup to https://github.com/elastic/elasticsearch/pull/104585