### PR TITLE
Release resources in BestBucketsDeferringCollector earlier

### DIFF
--- a/docs/changelog/104893.yaml
+++ b/docs/changelog/104893.yaml
@@ -1,0 +1,5 @@
+pr: 104893
+summary: Release resources in `BestBucketsDeferringCollector` earlier
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -40,7 +40,11 @@ import java.util.function.LongUnaryOperator;
  * this collector.
  */
 public class BestBucketsDeferringCollector extends DeferringBucketCollector {
-    record Entry(AggregationExecutionContext aggCtx, PackedLongValues docDeltas, PackedLongValues buckets) {
+    private static class Entry {
+        AggregationExecutionContext aggCtx;
+        PackedLongValues docDeltas;
+        PackedLongValues buckets;
+
         Entry(AggregationExecutionContext aggCtx, PackedLongValues docDeltas, PackedLongValues buckets) {
             this.aggCtx = Objects.requireNonNull(aggCtx);
             this.docDeltas = Objects.requireNonNull(docDeltas);
@@ -200,6 +204,9 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
                 // collection was terminated prematurely
                 // continue with the following leaf
             }
+            // release resources
+            entry.buckets = null;
+            entry.docDeltas = null;
         }
         collector.postCollection();
     }


### PR DESCRIPTION
BestBucketsDeferringCollector holds the documents and buckets in memory to be replayed to the children aggregations. These objects can get large and they are not backed by BigArrays so let's release them as soon as they are consume.