### PR TITLE
Misc cleanups in o.e.a.bulk

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkAction.java
@@ -9,17 +9,11 @@
 package org.elasticsearch.action.bulk;
 
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.transport.TransportRequestOptions;
 
 public class BulkAction extends ActionType<BulkResponse> {
 
     public static final BulkAction INSTANCE = new BulkAction();
     public static final String NAME = "indices:data/write/bulk";
-
-    private static final TransportRequestOptions TRANSPORT_REQUEST_OPTIONS = TransportRequestOptions.of(
-        null,
-        TransportRequestOptions.Type.BULK
-    );
 
     private BulkAction() {
         super(NAME);

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkShardResponse.java
@@ -34,10 +34,6 @@ public class BulkShardResponse extends ReplicationResponse implements WriteRespo
         this.responses = responses;
     }
 
-    public ShardId getShardId() {
-        return shardId;
-    }
-
     public BulkItemResponse[] getResponses() {
         return responses;
     }
@@ -60,6 +56,6 @@ public class BulkShardResponse extends ReplicationResponse implements WriteRespo
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         shardId.writeTo(out);
-        out.writeArray((o, item) -> item.writeThin(out), responses);
+        out.writeArray((o, item) -> item.writeThin(o), responses);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateRequest.java
@@ -57,7 +57,7 @@ public class UpdateRequest extends InstanceShardOperationRequest<UpdateRequest>
 
     private static final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(UpdateRequest.class);
 
-    private static ObjectParser<UpdateRequest, Void> PARSER;
+    private static final ObjectParser<UpdateRequest, Void> PARSER;
 
     private static final ParseField SCRIPT_FIELD = new ParseField("script");
     private static final ParseField SCRIPTED_UPSERT_FIELD = new ParseField("scripted_upsert");


### PR DESCRIPTION
Just some trivial cleanup. Fix accidental use of capturing lambda when writing out bulk shard response, removed dead constant from action, and make the parser a constant.
