### PR TITLE
Change release version lookup to an instance method

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -102,7 +102,8 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     }
 
     /**
-     * Returns a string representing the Elasticsearch release version of this transport version, if valid for this deployment.
+     * Returns a string representing the Elasticsearch release version of this transport version,
+     * if applicable for this deployment, otherwise the raw version number.
      */
     public String toReleaseVersion() {
         return TransportVersions.VERSION_LOOKUP.apply(id);

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -101,6 +101,13 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
         return TransportVersion.fromId(Integer.parseInt(str));
     }
 
+    /**
+     * Returns a string representing the Elasticsearch release version of this transport version, if valid for this deployment.
+     */
+    public String toReleaseVersion() {
+        return TransportVersions.VERSION_LOOKUP.apply(id);
+    }
+
     @Override
     public String toString() {
         return Integer.toString(id);

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -286,11 +286,7 @@ public class TransportVersions {
         return VERSION_IDS.values();
     }
 
-    private static final IntFunction<String> VERSION_LOOKUP = ReleaseVersions.generateVersionsLookup(TransportVersions.class);
-
-    public static String toReleaseVersion(TransportVersion version) {
-        return VERSION_LOOKUP.apply(version.id());
-    }
+    static final IntFunction<String> VERSION_LOOKUP = ReleaseVersions.generateVersionsLookup(TransportVersions.class);
 
     // no instance
     private TransportVersions() {}

--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -143,6 +143,13 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
         return builder.value(id);
     }
 
+    /**
+     * Returns a string representing the Elasticsearch release version of this index version, if valid for this deployment.
+     */
+    public String toReleaseVersion() {
+        return IndexVersions.VERSION_LOOKUP.apply(id);
+    }
+
     @Override
     public String toString() {
         return Integer.toString(id);

--- a/server/src/main/java/org/elasticsearch/index/IndexVersion.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersion.java
@@ -144,7 +144,8 @@ public record IndexVersion(int id, Version luceneVersion) implements VersionId<I
     }
 
     /**
-     * Returns a string representing the Elasticsearch release version of this index version, if valid for this deployment.
+     * Returns a string representing the Elasticsearch release version of this index version,
+     * if applicable for this deployment, otherwise the raw version number.
      */
     public String toReleaseVersion() {
         return IndexVersions.VERSION_LOOKUP.apply(id);

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -207,9 +207,8 @@ public class IndexVersions {
         return VERSION_IDS.values();
     }
 
-    private static final IntFunction<String> VERSION_LOOKUP = ReleaseVersions.generateVersionsLookup(IndexVersions.class);
+    static final IntFunction<String> VERSION_LOOKUP = ReleaseVersions.generateVersionsLookup(IndexVersions.class);
 
-    public static String toReleaseVersion(IndexVersion version) {
-        return VERSION_LOOKUP.apply(version.id());
-    }
+    // no instance
+    private IndexVersions() {}
 }


### PR DESCRIPTION
It's simpler as an instance method on `xxxVersion` than a static method on `xxxVersions`