### PR TITLE
SearchHit explicitly saves and uses source content-type

### DIFF
--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
@@ -323,7 +323,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
                 builder.map(Map.of("data", chunk));
                 builder.flush();
                 ByteArrayOutputStream outputStream = (ByteArrayOutputStream) builder.getOutputStream();
-                hit.sourceRef(new BytesArray(outputStream.toByteArray()));
+                hit.sourceRef(new BytesArray(outputStream.toByteArray()), XContentType.SMILE);
             } catch (IOException ex) {
                 throw new UncheckedIOException(ex);
             }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/AsyncBulkByScrollActionTests.java
@@ -567,7 +567,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
         action.start();
 
         // create a simulated response.
-        SearchHit hit = SearchHit.unpooled(0, "id").sourceRef(new BytesArray("{}"));
+        SearchHit hit = SearchHit.unpooled(0, "id").sourceRef(new BytesArray("{}"), XContentType.JSON);
         SearchHits hits = SearchHits.unpooled(
             IntStream.range(0, 100).mapToObj(i -> hit).toArray(SearchHit[]::new),
             new TotalHits(0, TotalHits.Relation.EQUAL_TO),

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentType;
 import org.junit.After;
 import org.junit.Before;
 
@@ -162,7 +163,7 @@ public class ClientScrollableHitSourceTests extends ESTestCase {
 
     private SearchResponse createSearchResponse() {
         // create a simulated response.
-        SearchHit hit = SearchHit.unpooled(0, "id").sourceRef(new BytesArray("{}"));
+        SearchHit hit = SearchHit.unpooled(0, "id").sourceRef(new BytesArray("{}"), XContentType.JSON);
         SearchHits hits = SearchHits.unpooled(
             IntStream.range(0, randomIntBetween(0, 20)).mapToObj(i -> hit).toArray(SearchHit[]::new),
             new TotalHits(0, TotalHits.Relation.EQUAL_TO),

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -165,6 +165,7 @@ public class TransportVersions {
     public static final TransportVersion REQUIRE_DATA_STREAM_ADDED = def(8_578_00_0);
     public static final TransportVersion ML_INFERENCE_COHERE_EMBEDDINGS_ADDED = def(8_579_00_0);
     public static final TransportVersion DESIRED_NODE_VERSION_OPTIONAL_STRING = def(8_580_00_0);
+    public static final TransportVersion SEARCH_HIT_CONTENT_TYPE_ADDED = def(8_581_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/XContentHelper.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.plugins.internal.DocumentParsingObserver;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -719,10 +720,11 @@ public class XContentHelper {
 
     /**
      * Serialises new XContentType VND_ values in a bwc manner
-     * TODO remove in ES v9
+     *
      * @param out stream output of the destination node
      * @param xContentType an instance to serialize
      */
+    @UpdateForV9 // Remove in ES v9
     public static void writeTo(StreamOutput out, XContentType xContentType) throws IOException {
         if (out.getTransportVersion().before(TransportVersions.V_8_0_0)) {
             // when sending an enumeration to <v8 node it does not have new VND_ XContentType instances

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -354,7 +354,12 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
         out.writeVLong(primaryTerm);
         out.writeBytesReference(source);
         if (out.getTransportVersion().onOrAfter(TransportVersions.SEARCH_HIT_CONTENT_TYPE_ADDED)) {
-            out.writeOptionalEnum(sourceContentType);
+            if (sourceContentType == null) {
+                out.writeBoolean(false);
+            } else {
+                out.writeBoolean(true);
+                XContentHelper.writeTo(out, sourceContentType);
+            }
         }
         if (explanation == null) {
             out.writeBoolean(false);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchSourcePhase.java
@@ -62,7 +62,7 @@ public final class FetchSourcePhase implements FetchSubPhase {
 
                 // If this is a parent document and there are no source filters, then add the source as-is.
                 if (nestedHit == false && fetchSourceContext.hasFilter() == false) {
-                    hitContext.hit().sourceRef(source.internalSourceRef());
+                    hitContext.hit().sourceRef(source.internalSourceRef(), source.sourceContentType());
                     fastPath++;
                     return;
                 }
@@ -72,7 +72,7 @@ public final class FetchSourcePhase implements FetchSubPhase {
                 if (nestedHit) {
                     source = extractNested(source, hitContext.hit().getNestedIdentity());
                 }
-                hitContext.hit().sourceRef(source.internalSourceRef());
+                hitContext.hit().sourceRef(source.internalSourceRef(), source.sourceContentType());
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -85,7 +85,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
             }
         }
         if (frequently()) {
-            hit.sourceRef(RandomObjects.randomSource(random(), xContentType));
+            hit.sourceRef(RandomObjects.randomSource(random(), xContentType), xContentType);
         }
         if (randomBoolean()) {
             hit.version(randomLong());
@@ -326,7 +326,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
     public void testHasSource() {
         SearchHit searchHit = SearchHit.unpooled(randomInt());
         assertFalse(searchHit.hasSource());
-        searchHit.sourceRef(new BytesArray("{}"));
+        searchHit.sourceRef(new BytesArray("{}"), XContentType.JSON);
         assertTrue(searchHit.hasSource());
     }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTopHitsTests.java
@@ -255,7 +255,7 @@ public class InternalTopHitsTests extends InternalAggregationTestCase<InternalTo
     public void testGetProperty() {
         // Create a SearchHit containing: { "foo": 1000.0 } and use it to initialize an InternalTopHits instance.
         SearchHit hit = SearchHit.unpooled(0);
-        hit = hit.sourceRef(Source.fromMap(Map.of("foo", 1000.0), XContentType.YAML).internalSourceRef());
+        hit = hit.sourceRef(Source.fromMap(Map.of("foo", 1000.0), XContentType.YAML).internalSourceRef(), XContentType.YAML);
         hit.sortValues(new Object[] { 10.0 }, new DocValueFormat[] { DocValueFormat.RAW });
         hit.score(1.0f);
         SearchHits hits = SearchHits.unpooled(new SearchHit[] { hit }, null, 0);

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichShardMultiSearchAction.java
@@ -265,7 +265,7 @@ public class EnrichShardMultiSearchAction extends ActionType<MultiSearchResponse
                             return context.getFieldType(field);
                         });
                         final SearchHit hit = new SearchHit(scoreDoc.doc, visitor.id());
-                        hit.sourceRef(filterSource(fetchSourceContext, visitor.source()));
+                        hit.sourceRef(filterSource(fetchSourceContext, visitor.source()), XContentType.SMILE);
                         hits[j] = hit;
                     }
                     items[i] = new MultiSearchResponse.Item(createSearchResponse(topDocs, hits), null);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.model.TestModel;
 import org.junit.After;
 import org.junit.Before;
@@ -141,9 +142,9 @@ public class ModelRegistryTests extends ESTestCase {
             """;
 
         var inferenceHit = SearchHit.createFromMap(Map.of("_index", ".inference"));
-        inferenceHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(config))));
+        inferenceHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(config))), XContentType.JSON);
         var inferenceSecretsHit = SearchHit.createFromMap(Map.of("_index", ".secrets-inference"));
-        inferenceSecretsHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(secrets))));
+        inferenceSecretsHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(secrets))), XContentType.JSON);
 
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceHit, inferenceSecretsHit }));
 
@@ -172,7 +173,7 @@ public class ModelRegistryTests extends ESTestCase {
             """;
 
         var inferenceHit = SearchHit.createFromMap(Map.of("_index", ".inference"));
-        inferenceHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(config))));
+        inferenceHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(config))), XContentType.JSON);
 
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceHit }));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoinerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/process/DataFrameRowsJoinerTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.ml.dataframe.extractor.DataFrameDataExtractor;
 import org.elasticsearch.xpack.ml.dataframe.process.results.RowResults;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
@@ -310,7 +311,7 @@ public class DataFrameRowsJoinerTests extends ESTestCase {
 
     private static SearchHit newHit(String json) {
         SearchHit hit = SearchHit.unpooled(randomInt(), randomAlphaOfLength(10));
-        hit.sourceRef(new BytesArray(json));
+        hit.sourceRef(new BytesArray(json), XContentType.JSON);
         return hit;
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -914,26 +914,26 @@ public class JobResultsProviderTests extends ESTestCase {
         SearchResponse response = mock(SearchResponse.class);
         List<SearchHit> list = new ArrayList<>();
 
-        try (var jsonBuilder = XContentFactory.jsonBuilder()) {
-            for (Map<String, Object> map : source) {
-                Map<String, Object> _source = new HashMap<>(map);
+        for (Map<String, Object> map : source) {
+            Map<String, Object> _source = new HashMap<>(map);
 
-                Map<String, DocumentField> fields = new HashMap<>();
-                fields.put("field_1", new DocumentField("field_1", Collections.singletonList("foo")));
-                fields.put("field_2", new DocumentField("field_2", Collections.singletonList("foo")));
+            Map<String, DocumentField> fields = new HashMap<>();
+            fields.put("field_1", new DocumentField("field_1", Collections.singletonList("foo")));
+            fields.put("field_2", new DocumentField("field_2", Collections.singletonList("foo")));
 
-                SearchHit hit = new SearchHit(123, String.valueOf(map.hashCode()));
-                hit.addDocumentFields(fields, Collections.emptyMap());
+            SearchHit hit = new SearchHit(123, String.valueOf(map.hashCode()));
+            hit.addDocumentFields(fields, Collections.emptyMap());
+            try (var jsonBuilder = XContentFactory.jsonBuilder()) {
                 hit.sourceRef(BytesReference.bytes(jsonBuilder.map(_source)), jsonBuilder.contentType());
-
-                list.add(hit);
             }
-            SearchHits hits = new SearchHits(list.toArray(SearchHits.EMPTY), new TotalHits(source.size(), TotalHits.Relation.EQUAL_TO), 1);
-            when(response.getHits()).thenReturn(hits.asUnpooled());
-            hits.decRef();
 
-            return response;
+            list.add(hit);
         }
+        SearchHits hits = new SearchHits(list.toArray(SearchHits.EMPTY), new TotalHits(source.size(), TotalHits.Relation.EQUAL_TO), 1);
+        when(response.getHits()).thenReturn(hits.asUnpooled());
+        hits.decRef();
+
+        return response;
     }
 
     private Client getBasicMockedClient() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -914,24 +914,26 @@ public class JobResultsProviderTests extends ESTestCase {
         SearchResponse response = mock(SearchResponse.class);
         List<SearchHit> list = new ArrayList<>();
 
-        for (Map<String, Object> map : source) {
-            Map<String, Object> _source = new HashMap<>(map);
+        try (var jsonBuilder = XContentFactory.jsonBuilder()) {
+            for (Map<String, Object> map : source) {
+                Map<String, Object> _source = new HashMap<>(map);
 
-            Map<String, DocumentField> fields = new HashMap<>();
-            fields.put("field_1", new DocumentField("field_1", Collections.singletonList("foo")));
-            fields.put("field_2", new DocumentField("field_2", Collections.singletonList("foo")));
+                Map<String, DocumentField> fields = new HashMap<>();
+                fields.put("field_1", new DocumentField("field_1", Collections.singletonList("foo")));
+                fields.put("field_2", new DocumentField("field_2", Collections.singletonList("foo")));
 
-            SearchHit hit = new SearchHit(123, String.valueOf(map.hashCode()));
-            hit.addDocumentFields(fields, Collections.emptyMap());
-            hit.sourceRef(BytesReference.bytes(XContentFactory.jsonBuilder().map(_source)));
+                SearchHit hit = new SearchHit(123, String.valueOf(map.hashCode()));
+                hit.addDocumentFields(fields, Collections.emptyMap());
+                hit.sourceRef(BytesReference.bytes(jsonBuilder.map(_source)), jsonBuilder.contentType());
 
-            list.add(hit);
+                list.add(hit);
+            }
+            SearchHits hits = new SearchHits(list.toArray(SearchHits.EMPTY), new TotalHits(source.size(), TotalHits.Relation.EQUAL_TO), 1);
+            when(response.getHits()).thenReturn(hits.asUnpooled());
+            hits.decRef();
+
+            return response;
         }
-        SearchHits hits = new SearchHits(list.toArray(SearchHits.EMPTY), new TotalHits(source.size(), TotalHits.Relation.EQUAL_TO), 1);
-        when(response.getHits()).thenReturn(hits.asUnpooled());
-        hits.decRef();
-
-        return response;
     }
 
     private Client getBasicMockedClient() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/MockClientBuilder.java
@@ -33,6 +33,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -131,7 +132,7 @@ public class MockClientBuilder {
         SearchHit hits[] = new SearchHit[docs.size()];
         for (int i = 0; i < docs.size(); i++) {
             SearchHit hit = new SearchHit(10);
-            hit.sourceRef(docs.get(i));
+            hit.sourceRef(docs.get(i), XContentType.JSON);
             hits[i] = hit;
         }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamerTests.java
@@ -102,14 +102,16 @@ public class StateStreamerTests extends ESTestCase {
         SearchResponse searchResponse = mock(SearchResponse.class);
         SearchHit[] hits = new SearchHit[source.size()];
         int i = 0;
-        for (Map<String, Object> s : source) {
-            SearchHit hit = new SearchHit(1).sourceRef(BytesReference.bytes(XContentFactory.jsonBuilder().map(s)));
-            hits[i++] = hit;
+        try (var jsonBuilder = XContentFactory.jsonBuilder()) {
+            for (Map<String, Object> s : source) {
+                SearchHit hit = new SearchHit(1).sourceRef(BytesReference.bytes(jsonBuilder.map(s)), jsonBuilder.contentType());
+                hits[i++] = hit;
+            }
+            SearchHits searchHits = new SearchHits(hits, null, (float) 0.0);
+            when(searchResponse.getHits()).thenReturn(searchHits.asUnpooled());
+            searchHits.decRef();
+            return searchResponse;
         }
-        SearchHits searchHits = new SearchHits(hits, null, (float) 0.0);
-        when(searchResponse.getHits()).thenReturn(searchHits.asUnpooled());
-        searchHits.decRef();
-        return searchResponse;
     }
 
     private static SearchRequestBuilder prepareSearchBuilder(SearchResponse response, QueryBuilder queryBuilder) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/StateStreamerTests.java
@@ -102,16 +102,17 @@ public class StateStreamerTests extends ESTestCase {
         SearchResponse searchResponse = mock(SearchResponse.class);
         SearchHit[] hits = new SearchHit[source.size()];
         int i = 0;
-        try (var jsonBuilder = XContentFactory.jsonBuilder()) {
-            for (Map<String, Object> s : source) {
+
+        for (Map<String, Object> s : source) {
+            try (var jsonBuilder = XContentFactory.jsonBuilder()) {
                 SearchHit hit = new SearchHit(1).sourceRef(BytesReference.bytes(jsonBuilder.map(s)), jsonBuilder.contentType());
                 hits[i++] = hit;
             }
-            SearchHits searchHits = new SearchHits(hits, null, (float) 0.0);
-            when(searchResponse.getHits()).thenReturn(searchHits.asUnpooled());
-            searchHits.decRef();
-            return searchResponse;
         }
+        SearchHits searchHits = new SearchHits(hits, null, (float) 0.0);
+        when(searchResponse.getHits()).thenReturn(searchHits.asUnpooled());
+        searchHits.decRef();
+        return searchResponse;
     }
 
     private static SearchRequestBuilder prepareSearchBuilder(SearchResponse response, QueryBuilder queryBuilder) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemoverTests.java
@@ -108,7 +108,7 @@ public class AbstractExpiredJobDataRemoverTests extends ESTestCase {
             hitsArray[i] = new SearchHit(randomInt());
             XContentBuilder jsonBuilder = JsonXContent.contentBuilder();
             toXContents.get(i).toXContent(jsonBuilder, ToXContent.EMPTY_PARAMS);
-            hitsArray[i].sourceRef(BytesReference.bytes(jsonBuilder));
+            hitsArray[i].sourceRef(BytesReference.bytes(jsonBuilder), jsonBuilder.contentType());
         }
         SearchHits hits = new SearchHits(hitsArray, new TotalHits(totalHits, TotalHits.Relation.EQUAL_TO), 1.0f);
         SearchResponse searchResponse = mock(SearchResponse.class);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/test/SearchHitBuilder.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/test/SearchHitBuilder.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -35,7 +36,7 @@ public class SearchHitBuilder {
     }
 
     public SearchHitBuilder setSource(String sourceJson) {
-        hit.sourceRef(new BytesArray(sourceJson));
+        hit.sourceRef(new BytesArray(sourceJson), XContentType.JSON);
         return this;
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
@@ -318,7 +318,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
         when(samlRealm.getLogoutHandler().parseFromQueryString(anyString())).thenReturn(logoutRequest);
     }
 
-    private SearchHit tokenHit(int idx, BytesReference source) {
+    private SearchHit tokenHit(int idx, BytesReference source, XContentType contentType) {
         try {
             final Map<String, Object> sourceMap = XContentType.JSON.xContent()
                 .createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.THROW_UNSUPPORTED_OPERATION, source.streamInput())
@@ -328,7 +328,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
             @SuppressWarnings("unchecked")
             final Map<String, Object> userToken = (Map<String, Object>) accessToken.get("user_token");
             final SearchHit hit = new SearchHit(idx, "token_" + userToken.get("id"));
-            hit.sourceRef(source);
+            hit.sourceRef(source, contentType);
             return hit;
         } catch (IOException e) {
             throw ExceptionsHelper.convertToRuntime(e);
@@ -365,7 +365,7 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
         final AtomicInteger counter = new AtomicInteger();
         final SearchHit[] searchHits = indexRequests.stream()
             .filter(r -> r.id().startsWith("token"))
-            .map(r -> tokenHit(counter.incrementAndGet(), r.source()))
+            .map(r -> tokenHit(counter.incrementAndGet(), r.source(), r.getContentType()))
             .collect(Collectors.toList())
             .toArray(SearchHits.EMPTY);
         assertThat(searchHits.length, equalTo(4));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -408,7 +408,7 @@ public class ApiKeyServiceTests extends ESTestCase {
             final var searchHit = SearchHit.unpooled(docId, apiKeyId);
             try (XContentBuilder builder = JsonXContent.contentBuilder()) {
                 builder.map(buildApiKeySourceDoc("some_hash".toCharArray()));
-                searchHit.sourceRef(BytesReference.bytes(builder));
+                searchHit.sourceRef(BytesReference.bytes(builder), builder.contentType());
             }
             ActionListener.respondAndRelease(
                 listener,
@@ -845,7 +845,7 @@ public class ApiKeyServiceTests extends ESTestCase {
                     "realm": "file1"
                   }
                 }""", roleDescriptor), randomBoolean()));
-            searchHit.sourceRef(BytesReference.bytes(builder));
+            searchHit.sourceRef(BytesReference.bytes(builder), builder.contentType());
             return searchHit;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -1238,7 +1238,7 @@ public class TokenServiceTests extends ESTestCase {
                 final SearchHits hits;
                 if (storedRefreshToken.equals(refreshFilter.value())) {
                     SearchHit hit = SearchHit.unpooled(randomInt(), "token_" + userToken.getId());
-                    hit.sourceRef(docSource);
+                    hit.sourceRef(docSource, XContentType.JSON);
                     hits = SearchHits.unpooled(new SearchHit[] { hit }, null, 1);
                 } else {
                     hits = SearchHits.EMPTY_WITH_TOTAL_HITS;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
@@ -352,7 +352,7 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
             );
             try (XContentBuilder builder = JsonXContent.contentBuilder()) {
                 mapping.toXContent(builder, ToXContent.EMPTY_PARAMS);
-                searchHit.sourceRef(BytesReference.bytes(builder));
+                searchHit.sourceRef(BytesReference.bytes(builder), builder.contentType());
             }
             ActionListener.respondAndRelease(
                 listener,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -812,7 +812,7 @@ public class NativePrivilegeStoreTests extends ESTestCase {
         for (int i = 0; i < hits.length; i++) {
             final ApplicationPrivilegeDescriptor p = sourcePrivileges.get(i);
             hits[i] = new SearchHit(i, "application-privilege_" + p.getApplication() + ":" + p.getName());
-            hits[i].sourceRef(new BytesArray(Strings.toString(p)));
+            hits[i].sourceRef(new BytesArray(Strings.toString(p)), XContentType.JSON);
         }
         return hits;
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
@@ -53,6 +53,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.watcher.execution.TriggeredWatchStoreField;
 import org.elasticsearch.xpack.core.watcher.execution.Wid;
 import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
@@ -215,7 +216,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
             SearchHit hit = SearchHit.unpooled(0, "first_foo");
             hit.version(1L);
             hit.shard(new SearchShardTarget("_node_id", new ShardId(index, 0), null));
-            hit.sourceRef(source);
+            hit.sourceRef(source, XContentType.JSON);
             when(searchResponse1.getHits()).thenReturn(
                 SearchHits.unpooled(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f)
             );
@@ -237,7 +238,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
                 var hit = SearchHit.unpooled(0, "second_foo");
                 hit.version(1L);
                 hit.shard(new SearchShardTarget("_node_id", new ShardId(index, 0), null));
-                hit.sourceRef(source);
+                hit.sourceRef(source, XContentType.JSON);
                 ActionListener.respondAndRelease(
                     listener,
                     new SearchResponse(


### PR DESCRIPTION
`source` is passed as a BytesReference, but then its original content type is required to write out XContent and it needs to be inferred - which is deprecated across several functions. 

This PR adds a content type parameter whenever a source is specified or set in a SearchHit.
This preliminary work will make "chunkification" of the missing bits of SearchHit response (the `source` field, missing from https://github.com/elastic/elasticsearch/pull/104770) simpler and more efficient.