### PR TITLE
Reuse APMMeterService of APMTelemetryProvider

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
@@ -64,14 +64,15 @@ public class APM extends Plugin implements NetworkPlugin, TelemetryPlugin {
     @Override
     public Collection<?> createComponents(PluginServices services) {
         final APMTracer apmTracer = telemetryProvider.get().getTracer();
+        final APMMeterService apmMeter = telemetryProvider.get().getMeterService();
 
         apmTracer.setClusterName(services.clusterService().getClusterName().value());
         apmTracer.setNodeName(services.clusterService().getNodeName());
 
         final APMAgentSettings apmAgentSettings = new APMAgentSettings();
         apmAgentSettings.syncAgentSystemProperties(settings);
-        final APMMeterService apmMeter = new APMMeterService(settings);
-        apmAgentSettings.addClusterSettingsListeners(services.clusterService(), telemetryProvider.get(), apmMeter);
+
+        apmAgentSettings.addClusterSettingsListeners(services.clusterService(), telemetryProvider.get());
         logger.info("Sending apm metrics is {}", APMAgentSettings.TELEMETRY_METRICS_ENABLED_SETTING.get(settings) ? "enabled" : "disabled");
         logger.info("Sending apm tracing is {}", APMAgentSettings.TELEMETRY_TRACING_ENABLED_SETTING.get(settings) ? "enabled" : "disabled");
 

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -37,13 +37,10 @@ public class APMAgentSettings {
 
     private static final Logger LOGGER = LogManager.getLogger(APMAgentSettings.class);
 
-    public void addClusterSettingsListeners(
-        ClusterService clusterService,
-        APMTelemetryProvider apmTelemetryProvider,
-        APMMeterService apmMeterService
-    ) {
+    public void addClusterSettingsListeners(ClusterService clusterService, APMTelemetryProvider apmTelemetryProvider) {
         final ClusterSettings clusterSettings = clusterService.getClusterSettings();
         final APMTracer apmTracer = apmTelemetryProvider.getTracer();
+        final APMMeterService apmMeterService = apmTelemetryProvider.getMeterService();
 
         clusterSettings.addSettingsUpdateConsumer(TELEMETRY_TRACING_ENABLED_SETTING, enabled -> {
             apmTracer.setEnabled(enabled);

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMMeterService.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMMeterService.java
@@ -49,7 +49,7 @@ public class APMMeterService extends AbstractLifecycleComponent {
     }
 
     /**
-     * @see APMAgentSettings#addClusterSettingsListeners(ClusterService, APMTelemetryProvider, APMMeterService)
+     * @see APMAgentSettings#addClusterSettingsListeners(ClusterService, APMTelemetryProvider)
      */
     void setEnabled(boolean enabled) {
         this.enabled = enabled;

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMTelemetryProvider.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMTelemetryProvider.java
@@ -14,12 +14,10 @@ import org.elasticsearch.telemetry.apm.APMMeterRegistry;
 import org.elasticsearch.telemetry.apm.internal.tracing.APMTracer;
 
 public class APMTelemetryProvider implements TelemetryProvider {
-    private final Settings settings;
     private final APMTracer apmTracer;
     private final APMMeterService apmMeterService;
 
     public APMTelemetryProvider(Settings settings) {
-        this.settings = settings;
         apmTracer = new APMTracer(settings);
         apmMeterService = new APMMeterService(settings);
     }
@@ -27,6 +25,10 @@ public class APMTelemetryProvider implements TelemetryProvider {
     @Override
     public APMTracer getTracer() {
         return apmTracer;
+    }
+
+    public APMMeterService getMeterService() {
+        return apmMeterService;
     }
 
     @Override


### PR DESCRIPTION
Having two instances of APMMeterService is problematic, each one would be using it's own APMMeterRegistry.
With that `registerLock` won't work as expected when enabling / disabling metrics (see APMMeterRegistry#setProvider).


