### PR TITLE
[Connectors API] Relax strict response parsing for get/list operations

### DIFF
--- a/docs/changelog/104909.yaml
+++ b/docs/changelog/104909.yaml
@@ -1,0 +1,5 @@
+pr: 104909
+summary: "[Connectors API] Relax strict response parsing for get/list operations"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -356,34 +356,38 @@ public class Connector implements NamedWriteable, ToXContentObject {
         return PARSER.parse(parser, docId);
     }
 
+    public void toInnerXContent(XContentBuilder builder, Params params) throws IOException {
+        // The "id": connectorId is included in GET and LIST responses to provide the connector's docID.
+        // Note: This ID is not written to the Elasticsearch index; it's only for API response purposes.
+        if (connectorId != null) {
+            builder.field(ID_FIELD.getPreferredName(), connectorId);
+        }
+        builder.field(API_KEY_ID_FIELD.getPreferredName(), apiKeyId);
+        builder.xContentValuesMap(CONFIGURATION_FIELD.getPreferredName(), configuration);
+        builder.xContentValuesMap(CUSTOM_SCHEDULING_FIELD.getPreferredName(), customScheduling);
+        builder.field(DESCRIPTION_FIELD.getPreferredName(), description);
+        builder.field(ERROR_FIELD.getPreferredName(), error);
+        builder.field(FEATURES_FIELD.getPreferredName(), features);
+        builder.xContentList(FILTERING_FIELD.getPreferredName(), filtering);
+        builder.field(INDEX_NAME_FIELD.getPreferredName(), indexName);
+        builder.field(IS_NATIVE_FIELD.getPreferredName(), isNative);
+        builder.field(LANGUAGE_FIELD.getPreferredName(), language);
+        builder.field(LAST_SEEN_FIELD.getPreferredName(), lastSeen);
+        syncInfo.toXContent(builder, params);
+        builder.field(NAME_FIELD.getPreferredName(), name);
+        builder.field(PIPELINE_FIELD.getPreferredName(), pipeline);
+        builder.field(SCHEDULING_FIELD.getPreferredName(), scheduling);
+        builder.field(SERVICE_TYPE_FIELD.getPreferredName(), serviceType);
+        builder.field(SYNC_CURSOR_FIELD.getPreferredName(), syncCursor);
+        builder.field(STATUS_FIELD.getPreferredName(), status.toString());
+        builder.field(SYNC_NOW_FIELD.getPreferredName(), syncNow);
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         {
-            // The "id": connectorId is included in GET and LIST responses to provide the connector's docID.
-            // Note: This ID is not written to the Elasticsearch index; it's only for API response purposes.
-            if (connectorId != null) {
-                builder.field(ID_FIELD.getPreferredName(), connectorId);
-            }
-            builder.field(API_KEY_ID_FIELD.getPreferredName(), apiKeyId);
-            builder.xContentValuesMap(CONFIGURATION_FIELD.getPreferredName(), configuration);
-            builder.xContentValuesMap(CUSTOM_SCHEDULING_FIELD.getPreferredName(), customScheduling);
-            builder.field(DESCRIPTION_FIELD.getPreferredName(), description);
-            builder.field(ERROR_FIELD.getPreferredName(), error);
-            builder.field(FEATURES_FIELD.getPreferredName(), features);
-            builder.xContentList(FILTERING_FIELD.getPreferredName(), filtering);
-            builder.field(INDEX_NAME_FIELD.getPreferredName(), indexName);
-            builder.field(IS_NATIVE_FIELD.getPreferredName(), isNative);
-            builder.field(LANGUAGE_FIELD.getPreferredName(), language);
-            builder.field(LAST_SEEN_FIELD.getPreferredName(), lastSeen);
-            syncInfo.toXContent(builder, params);
-            builder.field(NAME_FIELD.getPreferredName(), name);
-            builder.field(PIPELINE_FIELD.getPreferredName(), pipeline);
-            builder.field(SCHEDULING_FIELD.getPreferredName(), scheduling);
-            builder.field(SERVICE_TYPE_FIELD.getPreferredName(), serviceType);
-            builder.field(SYNC_CURSOR_FIELD.getPreferredName(), syncCursor);
-            builder.field(STATUS_FIELD.getPreferredName(), status.toString());
-            builder.field(SYNC_NOW_FIELD.getPreferredName(), syncNow);
+            toInnerXContent(builder, params);
         }
         builder.endObject();
         return builder;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSearchResult.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSearchResult.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents the outcome of a search query in the connectors index, encapsulating the search result.
+ * It includes a raw byte reference to the result which can be deserialized into a {@code Connector} object,
+ * and a result map for returning the data without strict deserialization.
+ */
+public class ConnectorSearchResult implements Writeable, ToXContentObject {
+
+    private final BytesReference resultBytes;
+    private final Map<String, Object> resultMap;
+    private final String id;
+
+    private ConnectorSearchResult(BytesReference resultBytes, Map<String, Object> resultMap, String id) {
+        this.resultBytes = resultBytes;
+        this.resultMap = resultMap;
+        this.id = id;
+    }
+
+    public ConnectorSearchResult(StreamInput in) throws IOException {
+        this.resultBytes = in.readBytesReference();
+        this.resultMap = in.readGenericMap();
+        this.id = in.readString();
+    }
+
+    public BytesReference getSourceRef() {
+        return resultBytes;
+    }
+
+    public Map<String, Object> getResultMap() {
+        return resultMap;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field(Connector.ID_FIELD.getPreferredName(), id);
+            builder.mapContents(resultMap);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBytesReference(resultBytes);
+        out.writeGenericMap(resultMap);
+        out.writeString(id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConnectorSearchResult that = (ConnectorSearchResult) o;
+        return Objects.equals(resultBytes, that.resultBytes) && Objects.equals(resultMap, that.resultMap) && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resultBytes, resultMap, id);
+    }
+
+    public static class Builder {
+
+        private BytesReference resultBytes;
+        private Map<String, Object> resultMap;
+        private String id;
+
+        public Builder setResultBytes(BytesReference resultBytes) {
+            this.resultBytes = resultBytes;
+            return this;
+        }
+
+        public Builder setResultMap(Map<String, Object> resultMap) {
+            this.resultMap = resultMap;
+            return this;
+        }
+
+        public Builder setId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public ConnectorSearchResult build() {
+            return new ConnectorSearchResult(resultBytes, resultMap, id);
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSearchResult.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSearchResult.java
@@ -13,32 +13,33 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 
 /**
- * Represents the outcome of a search query in the connectors index, encapsulating the search result.
- * It includes a raw byte reference to the result which can be deserialized into a {@code Connector} object,
+ * Represents the outcome of a search query in the connectors and sync job index, encapsulating the search result.
+ * It includes a raw byte reference to the result which can be deserialized into a {@link Connector} or {@link ConnectorSyncJob} object,
  * and a result map for returning the data without strict deserialization.
  */
 public class ConnectorSearchResult implements Writeable, ToXContentObject {
 
     private final BytesReference resultBytes;
     private final Map<String, Object> resultMap;
-    private final String id;
+    private final String docId;
 
     private ConnectorSearchResult(BytesReference resultBytes, Map<String, Object> resultMap, String id) {
         this.resultBytes = resultBytes;
         this.resultMap = resultMap;
-        this.id = id;
+        this.docId = id;
     }
 
     public ConnectorSearchResult(StreamInput in) throws IOException {
         this.resultBytes = in.readBytesReference();
         this.resultMap = in.readGenericMap();
-        this.id = in.readString();
+        this.docId = in.readString();
     }
 
     public BytesReference getSourceRef() {
@@ -49,15 +50,15 @@ public class ConnectorSearchResult implements Writeable, ToXContentObject {
         return resultMap;
     }
 
-    public String getId() {
-        return id;
+    public String getDocId() {
+        return docId;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         {
-            builder.field(Connector.ID_FIELD.getPreferredName(), id);
+            builder.field("id", docId);
             builder.mapContents(resultMap);
         }
         builder.endObject();
@@ -68,7 +69,7 @@ public class ConnectorSearchResult implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeBytesReference(resultBytes);
         out.writeGenericMap(resultMap);
-        out.writeString(id);
+        out.writeString(docId);
     }
 
     @Override
@@ -76,12 +77,14 @@ public class ConnectorSearchResult implements Writeable, ToXContentObject {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ConnectorSearchResult that = (ConnectorSearchResult) o;
-        return Objects.equals(resultBytes, that.resultBytes) && Objects.equals(resultMap, that.resultMap) && Objects.equals(id, that.id);
+        return Objects.equals(resultBytes, that.resultBytes)
+            && Objects.equals(resultMap, that.resultMap)
+            && Objects.equals(docId, that.docId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(resultBytes, resultMap, id);
+        return Objects.hash(resultBytes, resultMap, docId);
     }
 
     public static class Builder {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorsAPISearchResult.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorsAPISearchResult.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents the outcome of a search query in the connectors and sync job index, encapsulating the search result.
+ * It includes a raw byte reference to the result which can be deserialized into a {@link Connector} or {@link ConnectorSyncJob} object,
+ * and a result map for returning the data without strict deserialization.
+ */
+public class ConnectorsAPISearchResult implements Writeable, ToXContentObject {
+
+    private final BytesReference resultBytes;
+    private final Map<String, Object> resultMap;
+    private final String docId;
+
+    protected ConnectorsAPISearchResult(BytesReference resultBytes, Map<String, Object> resultMap, String id) {
+        this.resultBytes = resultBytes;
+        this.resultMap = resultMap;
+        this.docId = id;
+    }
+
+    public ConnectorsAPISearchResult(StreamInput in) throws IOException {
+        this.resultBytes = in.readBytesReference();
+        this.resultMap = in.readGenericMap();
+        this.docId = in.readString();
+    }
+
+    public BytesReference getSourceRef() {
+        return resultBytes;
+    }
+
+    public Map<String, Object> getResultMap() {
+        return resultMap;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        {
+            builder.field("id", docId);
+            builder.mapContents(resultMap);
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBytesReference(resultBytes);
+        out.writeGenericMap(resultMap);
+        out.writeString(docId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConnectorsAPISearchResult that = (ConnectorsAPISearchResult) o;
+        return Objects.equals(resultBytes, that.resultBytes)
+            && Objects.equals(resultMap, that.resultMap)
+            && Objects.equals(docId, that.docId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resultBytes, resultMap, docId);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/GetConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/GetConnectorAction.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -110,15 +110,15 @@ public class GetConnectorAction {
 
     public static class Response extends ActionResponse implements ToXContentObject {
 
-        private final Connector connector;
+        private final ConnectorSearchResult connector;
 
-        public Response(Connector connector) {
+        public Response(ConnectorSearchResult connector) {
             this.connector = connector;
         }
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.connector = new Connector(in);
+            this.connector = new ConnectorSearchResult(in);
         }
 
         @Override
@@ -129,10 +129,6 @@ public class GetConnectorAction {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             return connector.toXContent(builder, params);
-        }
-
-        public static GetConnectorAction.Response fromXContent(XContentParser parser, String docId) throws IOException {
-            return new GetConnectorAction.Response(Connector.fromXContent(parser, docId));
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
@@ -18,7 +18,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 
@@ -105,14 +105,14 @@ public class ListConnectorAction {
 
         public static final ParseField RESULT_FIELD = new ParseField("results");
 
-        final QueryPage<Connector> queryPage;
+        final QueryPage<ConnectorSearchResult> queryPage;
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.queryPage = new QueryPage<>(in, Connector::new);
+            this.queryPage = new QueryPage<>(in, ConnectorSearchResult::new);
         }
 
-        public Response(List<Connector> items, Long totalResults) {
+        public Response(List<ConnectorSearchResult> items, Long totalResults) {
             this.queryPage = new QueryPage<>(items, totalResults, RESULT_FIELD);
         }
 
@@ -126,7 +126,7 @@ public class ListConnectorAction {
             return queryPage.toXContent(builder, params);
         }
 
-        public QueryPage<Connector> queryPage() {
+        public QueryPage<ConnectorSearchResult> queryPage() {
             return queryPage;
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
@@ -200,7 +200,7 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
         this.createdAt = createdAt;
         this.deletedDocumentCount = deletedDocumentCount;
         this.error = error;
-        this.id = Objects.requireNonNull(id, "[id] cannot be null");
+        this.id = id;
         this.indexedDocumentCount = indexedDocumentCount;
         this.indexedDocumentVolume = indexedDocumentVolume;
         this.jobType = Objects.requireNonNullElse(jobType, ConnectorSyncJobType.FULL);
@@ -235,10 +235,10 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
     }
 
     @SuppressWarnings("unchecked")
-    private static final ConstructingObjectParser<ConnectorSyncJob, Void> PARSER = new ConstructingObjectParser<>(
+    private static final ConstructingObjectParser<ConnectorSyncJob, String> PARSER = new ConstructingObjectParser<>(
         "connector_sync_job",
         true,
-        (args) -> {
+        (args, docId) -> {
             int i = 0;
             return new Builder().setCancellationRequestedAt((Instant) args[i++])
                 .setCanceledAt((Instant) args[i++])
@@ -247,7 +247,7 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
                 .setCreatedAt((Instant) args[i++])
                 .setDeletedDocumentCount((Long) args[i++])
                 .setError((String) args[i++])
-                .setId((String) args[i++])
+                .setId(docId)
                 .setIndexedDocumentCount((Long) args[i++])
                 .setIndexedDocumentVolume((Long) args[i++])
                 .setJobType((ConnectorSyncJobType) args[i++])
@@ -295,7 +295,6 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
         );
         PARSER.declareLong(constructorArg(), DELETED_DOCUMENT_COUNT_FIELD);
         PARSER.declareStringOrNull(optionalConstructorArg(), ERROR_FIELD);
-        PARSER.declareString(constructorArg(), ID_FIELD);
         PARSER.declareLong(constructorArg(), INDEXED_DOCUMENT_COUNT_FIELD);
         PARSER.declareLong(constructorArg(), INDEXED_DOCUMENT_VOLUME_FIELD);
         PARSER.declareField(
@@ -383,16 +382,16 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
         );
     }
 
-    public static ConnectorSyncJob fromXContentBytes(BytesReference source, XContentType xContentType) {
+    public static ConnectorSyncJob fromXContentBytes(BytesReference source, String docId, XContentType xContentType) {
         try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, source, xContentType)) {
-            return ConnectorSyncJob.fromXContent(parser);
+            return ConnectorSyncJob.fromXContent(parser, docId);
         } catch (IOException e) {
             throw new ElasticsearchParseException("Failed to parse a connector sync job document.", e);
         }
     }
 
-    public static ConnectorSyncJob fromXContent(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
+    public static ConnectorSyncJob fromXContent(XContentParser parser, String docId) throws IOException {
+        return PARSER.parse(parser, docId);
     }
 
     public static Connector syncJobConnectorFromXContentBytes(BytesReference source, String connectorId, XContentType xContentType) {
@@ -479,68 +478,71 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
         return workerHostname;
     }
 
+    public void toInnerXContent(XContentBuilder builder, Params params) throws IOException {
+        if (cancelationRequestedAt != null) {
+            builder.field(CANCELATION_REQUESTED_AT_FIELD.getPreferredName(), cancelationRequestedAt);
+        }
+        if (canceledAt != null) {
+            builder.field(CANCELED_AT_FIELD.getPreferredName(), canceledAt);
+        }
+        if (completedAt != null) {
+            builder.field(COMPLETED_AT_FIELD.getPreferredName(), completedAt);
+        }
+
+        builder.startObject(CONNECTOR_FIELD.getPreferredName());
+        {
+            if (connector.getConnectorId() != null) {
+                builder.field(Connector.ID_FIELD.getPreferredName(), connector.getConnectorId());
+            }
+            if (connector.getSyncJobFiltering() != null) {
+                builder.field(Connector.FILTERING_FIELD.getPreferredName(), connector.getSyncJobFiltering());
+            }
+            if (connector.getIndexName() != null) {
+                builder.field(Connector.INDEX_NAME_FIELD.getPreferredName(), connector.getIndexName());
+            }
+            if (connector.getLanguage() != null) {
+                builder.field(Connector.LANGUAGE_FIELD.getPreferredName(), connector.getLanguage());
+            }
+            if (connector.getPipeline() != null) {
+                builder.field(Connector.PIPELINE_FIELD.getPreferredName(), connector.getPipeline());
+            }
+            if (connector.getServiceType() != null) {
+                builder.field(Connector.SERVICE_TYPE_FIELD.getPreferredName(), connector.getServiceType());
+            }
+            if (connector.getConfiguration() != null) {
+                builder.field(Connector.CONFIGURATION_FIELD.getPreferredName(), connector.getConfiguration());
+            }
+        }
+        builder.endObject();
+
+        builder.field(CREATED_AT_FIELD.getPreferredName(), createdAt);
+        builder.field(DELETED_DOCUMENT_COUNT_FIELD.getPreferredName(), deletedDocumentCount);
+        if (error != null) {
+            builder.field(ERROR_FIELD.getPreferredName(), error);
+        }
+        builder.field(INDEXED_DOCUMENT_COUNT_FIELD.getPreferredName(), indexedDocumentCount);
+        builder.field(INDEXED_DOCUMENT_VOLUME_FIELD.getPreferredName(), indexedDocumentVolume);
+        builder.field(JOB_TYPE_FIELD.getPreferredName(), jobType);
+        if (lastSeen != null) {
+            builder.field(LAST_SEEN_FIELD.getPreferredName(), lastSeen);
+        }
+        builder.field(METADATA_FIELD.getPreferredName(), metadata);
+        if (startedAt != null) {
+            builder.field(STARTED_AT_FIELD.getPreferredName(), startedAt);
+        }
+        builder.field(STATUS_FIELD.getPreferredName(), status);
+        builder.field(TOTAL_DOCUMENT_COUNT_FIELD.getPreferredName(), totalDocumentCount);
+        builder.field(TRIGGER_METHOD_FIELD.getPreferredName(), triggerMethod);
+        if (workerHostname != null) {
+            builder.field(WORKER_HOSTNAME_FIELD.getPreferredName(), workerHostname);
+        }
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         {
-            if (cancelationRequestedAt != null) {
-                builder.field(CANCELATION_REQUESTED_AT_FIELD.getPreferredName(), cancelationRequestedAt);
-            }
-            if (canceledAt != null) {
-                builder.field(CANCELED_AT_FIELD.getPreferredName(), canceledAt);
-            }
-            if (completedAt != null) {
-                builder.field(COMPLETED_AT_FIELD.getPreferredName(), completedAt);
-            }
-
-            builder.startObject(CONNECTOR_FIELD.getPreferredName());
-            {
-                if (connector.getConnectorId() != null) {
-                    builder.field(Connector.ID_FIELD.getPreferredName(), connector.getConnectorId());
-                }
-                if (connector.getSyncJobFiltering() != null) {
-                    builder.field(Connector.FILTERING_FIELD.getPreferredName(), connector.getSyncJobFiltering());
-                }
-                if (connector.getIndexName() != null) {
-                    builder.field(Connector.INDEX_NAME_FIELD.getPreferredName(), connector.getIndexName());
-                }
-                if (connector.getLanguage() != null) {
-                    builder.field(Connector.LANGUAGE_FIELD.getPreferredName(), connector.getLanguage());
-                }
-                if (connector.getPipeline() != null) {
-                    builder.field(Connector.PIPELINE_FIELD.getPreferredName(), connector.getPipeline());
-                }
-                if (connector.getServiceType() != null) {
-                    builder.field(Connector.SERVICE_TYPE_FIELD.getPreferredName(), connector.getServiceType());
-                }
-                if (connector.getConfiguration() != null) {
-                    builder.field(Connector.CONFIGURATION_FIELD.getPreferredName(), connector.getConfiguration());
-                }
-            }
-            builder.endObject();
-
-            builder.field(CREATED_AT_FIELD.getPreferredName(), createdAt);
-            builder.field(DELETED_DOCUMENT_COUNT_FIELD.getPreferredName(), deletedDocumentCount);
-            if (error != null) {
-                builder.field(ERROR_FIELD.getPreferredName(), error);
-            }
-            builder.field(ID_FIELD.getPreferredName(), id);
-            builder.field(INDEXED_DOCUMENT_COUNT_FIELD.getPreferredName(), indexedDocumentCount);
-            builder.field(INDEXED_DOCUMENT_VOLUME_FIELD.getPreferredName(), indexedDocumentVolume);
-            builder.field(JOB_TYPE_FIELD.getPreferredName(), jobType);
-            if (lastSeen != null) {
-                builder.field(LAST_SEEN_FIELD.getPreferredName(), lastSeen);
-            }
-            builder.field(METADATA_FIELD.getPreferredName(), metadata);
-            if (startedAt != null) {
-                builder.field(STARTED_AT_FIELD.getPreferredName(), startedAt);
-            }
-            builder.field(STATUS_FIELD.getPreferredName(), status);
-            builder.field(TOTAL_DOCUMENT_COUNT_FIELD.getPreferredName(), totalDocumentCount);
-            builder.field(TRIGGER_METHOD_FIELD.getPreferredName(), triggerMethod);
-            if (workerHostname != null) {
-                builder.field(WORKER_HOSTNAME_FIELD.getPreferredName(), workerHostname);
-            }
+            toInnerXContent(builder, params);
         }
         builder.endObject();
         return builder;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -40,9 +40,9 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
-import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry;
+import org.elasticsearch.xpack.application.connector.ConnectorsAPISearchResult;
 import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
 import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;
 import org.elasticsearch.xpack.application.connector.syncjob.action.UpdateConnectorSyncJobIngestionStatsAction;
@@ -193,7 +193,7 @@ public class ConnectorSyncJobIndexService {
      * @param connectorSyncJobId The id of the connector sync job object.
      * @param listener           The action listener to invoke on response/failure.
      */
-    public void getConnectorSyncJob(String connectorSyncJobId, ActionListener<ConnectorSearchResult> listener) {
+    public void getConnectorSyncJob(String connectorSyncJobId, ActionListener<ConnectorSyncJobSearchResult> listener) {
         final GetRequest getRequest = new GetRequest(CONNECTOR_SYNC_JOB_INDEX_NAME).id(connectorSyncJobId).realtime(true);
 
         try {
@@ -206,7 +206,7 @@ public class ConnectorSyncJobIndexService {
                     }
 
                     try {
-                        ConnectorSearchResult syncJobSearchResult = new ConnectorSearchResult.Builder().setId(getResponse.getId())
+                        ConnectorSyncJobSearchResult syncJobSearchResult = new ConnectorSyncJobSearchResult.Builder().setId(getResponse.getId())
                             .setResultBytes(getResponse.getSourceAsBytesRef())
                             .setResultMap(getResponse.getSourceAsMap())
                             .build();
@@ -334,7 +334,7 @@ public class ConnectorSyncJobIndexService {
     }
 
     private ConnectorSyncJobsResult mapSearchResponseToConnectorSyncJobsList(SearchResponse searchResponse) {
-        final List<ConnectorSearchResult> connectorSyncJobs = Arrays.stream(searchResponse.getHits().getHits())
+        final List<ConnectorSyncJobSearchResult> connectorSyncJobs = Arrays.stream(searchResponse.getHits().getHits())
             .map(ConnectorSyncJobIndexService::hitToConnectorSyncJob)
             .toList();
 
@@ -344,17 +344,17 @@ public class ConnectorSyncJobIndexService {
         );
     }
 
-    private static ConnectorSearchResult hitToConnectorSyncJob(SearchHit searchHit) {
+    private static ConnectorSyncJobSearchResult hitToConnectorSyncJob(SearchHit searchHit) {
         // TODO: don't return sensitive data from configuration inside connector in list endpoint
 
-        return new ConnectorSearchResult.Builder().setId(searchHit.getId())
+        return new ConnectorSyncJobSearchResult.Builder().setId(searchHit.getId())
             .setResultBytes(searchHit.getSourceRef())
             .setResultMap(searchHit.getSourceAsMap())
             .build();
 
     }
 
-    public record ConnectorSyncJobsResult(List<ConnectorSearchResult> connectorSyncJobs, long totalResults) {}
+    public record ConnectorSyncJobsResult(List<ConnectorSyncJobSearchResult> connectorSyncJobs, long totalResults) {}
 
     /**
     * Updates the ingestion stats of the {@link ConnectorSyncJob} in the underlying index.

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -42,7 +42,6 @@ import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry;
-import org.elasticsearch.xpack.application.connector.ConnectorsAPISearchResult;
 import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
 import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;
 import org.elasticsearch.xpack.application.connector.syncjob.action.UpdateConnectorSyncJobIngestionStatsAction;
@@ -206,10 +205,9 @@ public class ConnectorSyncJobIndexService {
                     }
 
                     try {
-                        ConnectorSyncJobSearchResult syncJobSearchResult = new ConnectorSyncJobSearchResult.Builder().setId(getResponse.getId())
-                            .setResultBytes(getResponse.getSourceAsBytesRef())
-                            .setResultMap(getResponse.getSourceAsMap())
-                            .build();
+                        ConnectorSyncJobSearchResult syncJobSearchResult = new ConnectorSyncJobSearchResult.Builder().setId(
+                            getResponse.getId()
+                        ).setResultBytes(getResponse.getSourceAsBytesRef()).setResultMap(getResponse.getSourceAsMap()).build();
                         l.onResponse(syncJobSearchResult);
                     } catch (Exception e) {
                         listener.onFailure(e);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
+import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry;
 import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
@@ -97,14 +98,11 @@ public class ConnectorSyncJobIndexService {
                 );
 
                 try {
-                    String syncJobId = generateId();
 
-                    final IndexRequest indexRequest = new IndexRequest(CONNECTOR_SYNC_JOB_INDEX_NAME).id(syncJobId)
-                        .opType(DocWriteRequest.OpType.INDEX)
+                    final IndexRequest indexRequest = new IndexRequest(CONNECTOR_SYNC_JOB_INDEX_NAME).opType(DocWriteRequest.OpType.INDEX)
                         .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
-                    ConnectorSyncJob syncJob = new ConnectorSyncJob.Builder().setId(syncJobId)
-                        .setJobType(jobType)
+                    ConnectorSyncJob syncJob = new ConnectorSyncJob.Builder().setJobType(jobType)
                         .setTriggerMethod(triggerMethod)
                         .setStatus(ConnectorSyncJob.DEFAULT_INITIAL_STATUS)
                         .setConnector(connector)
@@ -195,7 +193,7 @@ public class ConnectorSyncJobIndexService {
      * @param connectorSyncJobId The id of the connector sync job object.
      * @param listener           The action listener to invoke on response/failure.
      */
-    public void getConnectorSyncJob(String connectorSyncJobId, ActionListener<ConnectorSyncJob> listener) {
+    public void getConnectorSyncJob(String connectorSyncJobId, ActionListener<ConnectorSearchResult> listener) {
         final GetRequest getRequest = new GetRequest(CONNECTOR_SYNC_JOB_INDEX_NAME).id(connectorSyncJobId).realtime(true);
 
         try {
@@ -208,11 +206,11 @@ public class ConnectorSyncJobIndexService {
                     }
 
                     try {
-                        final ConnectorSyncJob syncJob = ConnectorSyncJob.fromXContentBytes(
-                            getResponse.getSourceAsBytesRef(),
-                            XContentType.JSON
-                        );
-                        l.onResponse(syncJob);
+                        ConnectorSearchResult syncJobSearchResult = new ConnectorSearchResult.Builder().setId(getResponse.getId())
+                            .setResultBytes(getResponse.getSourceAsBytesRef())
+                            .setResultMap(getResponse.getSourceAsMap())
+                            .build();
+                        l.onResponse(syncJobSearchResult);
                     } catch (Exception e) {
                         listener.onFailure(e);
                     }
@@ -336,7 +334,7 @@ public class ConnectorSyncJobIndexService {
     }
 
     private ConnectorSyncJobsResult mapSearchResponseToConnectorSyncJobsList(SearchResponse searchResponse) {
-        final List<ConnectorSyncJob> connectorSyncJobs = Arrays.stream(searchResponse.getHits().getHits())
+        final List<ConnectorSearchResult> connectorSyncJobs = Arrays.stream(searchResponse.getHits().getHits())
             .map(ConnectorSyncJobIndexService::hitToConnectorSyncJob)
             .toList();
 
@@ -346,13 +344,17 @@ public class ConnectorSyncJobIndexService {
         );
     }
 
-    private static ConnectorSyncJob hitToConnectorSyncJob(SearchHit searchHit) {
+    private static ConnectorSearchResult hitToConnectorSyncJob(SearchHit searchHit) {
         // TODO: don't return sensitive data from configuration inside connector in list endpoint
 
-        return ConnectorSyncJob.fromXContentBytes(searchHit.getSourceRef(), XContentType.JSON);
+        return new ConnectorSearchResult.Builder().setId(searchHit.getId())
+            .setResultBytes(searchHit.getSourceRef())
+            .setResultMap(searchHit.getSourceAsMap())
+            .build();
+
     }
 
-    public record ConnectorSyncJobsResult(List<ConnectorSyncJob> connectorSyncJobs, long totalResults) {}
+    public record ConnectorSyncJobsResult(List<ConnectorSearchResult> connectorSyncJobs, long totalResults) {}
 
     /**
     * Updates the ingestion stats of the {@link ConnectorSyncJob} in the underlying index.

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobSearchResult.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobSearchResult.java
@@ -5,21 +5,22 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.application.connector;
+package org.elasticsearch.xpack.application.connector.syncjob;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.xpack.application.connector.ConnectorsAPISearchResult;
 
 import java.io.IOException;
 import java.util.Map;
 
-public class ConnectorSearchResult extends ConnectorsAPISearchResult {
+public class ConnectorSyncJobSearchResult extends ConnectorsAPISearchResult {
 
-    public ConnectorSearchResult(StreamInput in) throws IOException {
+    public ConnectorSyncJobSearchResult(StreamInput in) throws IOException {
         super(in);
     }
 
-    private ConnectorSearchResult(BytesReference resultBytes, Map<String, Object> resultMap, String id) {
+    private ConnectorSyncJobSearchResult(BytesReference resultBytes, Map<String, Object> resultMap, String id) {
         super(resultBytes, resultMap, id);
     }
 
@@ -44,8 +45,8 @@ public class ConnectorSearchResult extends ConnectorsAPISearchResult {
             return this;
         }
 
-        public ConnectorSearchResult build() {
-            return new ConnectorSearchResult(resultBytes, resultMap, id);
+        public ConnectorSyncJobSearchResult build() {
+            return new ConnectorSyncJobSearchResult(resultBytes, resultMap, id);
         }
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/GetConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/GetConnectorSyncJobAction.java
@@ -19,8 +19,8 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobConstants;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobSearchResult;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -110,15 +110,15 @@ public class GetConnectorSyncJobAction {
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {
-        private final ConnectorSearchResult connectorSyncJob;
+        private final ConnectorSyncJobSearchResult connectorSyncJob;
 
-        public Response(ConnectorSearchResult connectorSyncJob) {
+        public Response(ConnectorSyncJobSearchResult connectorSyncJob) {
             this.connectorSyncJob = connectorSyncJob;
         }
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.connectorSyncJob = new ConnectorSearchResult(in);
+            this.connectorSyncJob = new ConnectorSyncJobSearchResult(in);
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/GetConnectorSyncJobAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/GetConnectorSyncJobAction.java
@@ -19,7 +19,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
+import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobConstants;
 
 import java.io.IOException;
@@ -110,15 +110,15 @@ public class GetConnectorSyncJobAction {
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {
-        private final ConnectorSyncJob connectorSyncJob;
+        private final ConnectorSearchResult connectorSyncJob;
 
-        public Response(ConnectorSyncJob connectorSyncJob) {
+        public Response(ConnectorSearchResult connectorSyncJob) {
             this.connectorSyncJob = connectorSyncJob;
         }
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.connectorSyncJob = new ConnectorSyncJob(in);
+            this.connectorSyncJob = new ConnectorSearchResult(in);
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
@@ -18,9 +18,9 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
+import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobSearchResult;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.action.util.QueryPage;
 
@@ -134,14 +134,14 @@ public class ListConnectorSyncJobsAction {
     public static class Response extends ActionResponse implements ToXContentObject {
         public static final ParseField RESULTS_FIELD = new ParseField("results");
 
-        final QueryPage<ConnectorSearchResult> queryPage;
+        final QueryPage<ConnectorSyncJobSearchResult> queryPage;
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.queryPage = new QueryPage<>(in, ConnectorSearchResult::new);
+            this.queryPage = new QueryPage<>(in, ConnectorSyncJobSearchResult::new);
         }
 
-        public Response(List<ConnectorSearchResult> items, Long totalResults) {
+        public Response(List<ConnectorSyncJobSearchResult> items, Long totalResults) {
             this.queryPage = new QueryPage<>(items, totalResults, RESULTS_FIELD);
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
 import org.elasticsearch.xpack.core.action.util.PageParams;
@@ -133,14 +134,14 @@ public class ListConnectorSyncJobsAction {
     public static class Response extends ActionResponse implements ToXContentObject {
         public static final ParseField RESULTS_FIELD = new ParseField("results");
 
-        final QueryPage<ConnectorSyncJob> queryPage;
+        final QueryPage<ConnectorSearchResult> queryPage;
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            this.queryPage = new QueryPage<>(in, ConnectorSyncJob::new);
+            this.queryPage = new QueryPage<>(in, ConnectorSearchResult::new);
         }
 
-        public Response(List<ConnectorSyncJob> items, Long totalResults) {
+        public Response(List<ConnectorSearchResult> items, Long totalResults) {
             this.queryPage = new QueryPage<>(items, totalResults, RESULTS_FIELD);
         }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.action.PostConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.PutConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorConfigurationAction;
@@ -401,7 +402,13 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
         connectorIndexService.getConnector(connectorId, new ActionListener<>() {
             @Override
-            public void onResponse(Connector connector) {
+            public void onResponse(ConnectorSearchResult connectorResult) {
+                // Serialize the sourceRef to Connector class for unit tests
+                Connector connector = Connector.fromXContentBytes(
+                    connectorResult.getSourceRef(),
+                    connectorResult.getId(),
+                    XContentType.JSON
+                );
                 resp.set(connector);
                 latch.countDown();
             }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -406,7 +406,7 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
                 // Serialize the sourceRef to Connector class for unit tests
                 Connector connector = Connector.fromXContentBytes(
                     connectorResult.getSourceRef(),
-                    connectorResult.getId(),
+                    connectorResult.getDocId(),
                     XContentType.JSON
                 );
                 resp.set(connector);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/GetConnectorActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/GetConnectorActionResponseBWCSerializingTests.java
@@ -9,15 +9,12 @@ package org.elasticsearch.xpack.application.connector.action;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
 import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
 import java.io.IOException;
 
 public class GetConnectorActionResponseBWCSerializingTests extends AbstractBWCWireSerializationTestCase<GetConnectorAction.Response> {
-
-    private ConnectorSearchResult connector;
 
     @Override
     protected Writeable.Reader<GetConnectorAction.Response> instanceReader() {
@@ -26,8 +23,7 @@ public class GetConnectorActionResponseBWCSerializingTests extends AbstractBWCWi
 
     @Override
     protected GetConnectorAction.Response createTestInstance() {
-        this.connector = ConnectorTestUtils.getRandomConnectorSearchResult();
-        return new GetConnectorAction.Response(this.connector);
+        return new GetConnectorAction.Response(ConnectorTestUtils.getRandomConnectorSearchResult());
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/GetConnectorActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/GetConnectorActionResponseBWCSerializingTests.java
@@ -9,16 +9,15 @@ package org.elasticsearch.xpack.application.connector.action;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
-import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 
 import java.io.IOException;
 
-public class GetConnectorActionResponseBWCSerializingTests extends AbstractBWCSerializationTestCase<GetConnectorAction.Response> {
+public class GetConnectorActionResponseBWCSerializingTests extends AbstractBWCWireSerializationTestCase<GetConnectorAction.Response> {
 
-    private Connector connector;
+    private ConnectorSearchResult connector;
 
     @Override
     protected Writeable.Reader<GetConnectorAction.Response> instanceReader() {
@@ -27,18 +26,13 @@ public class GetConnectorActionResponseBWCSerializingTests extends AbstractBWCSe
 
     @Override
     protected GetConnectorAction.Response createTestInstance() {
-        this.connector = ConnectorTestUtils.getRandomConnector();
+        this.connector = ConnectorTestUtils.getRandomConnectorSearchResult();
         return new GetConnectorAction.Response(this.connector);
     }
 
     @Override
     protected GetConnectorAction.Response mutateInstance(GetConnectorAction.Response instance) throws IOException {
         return randomValueOtherThan(instance, this::createTestInstance);
-    }
-
-    @Override
-    protected GetConnectorAction.Response doParseInstance(XContentParser parser) throws IOException {
-        return GetConnectorAction.Response.fromXContent(parser, connector.getConnectorId());
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionResponseBWCSerializingTests.java
@@ -22,7 +22,10 @@ public class ListConnectorActionResponseBWCSerializingTests extends AbstractBWCW
 
     @Override
     protected ListConnectorAction.Response createTestInstance() {
-        return new ListConnectorAction.Response(randomList(10, ConnectorTestUtils::getRandomConnector), randomLongBetween(0, 100));
+        return new ListConnectorAction.Response(
+            randomList(10, ConnectorTestUtils::getRandomConnectorSearchResult),
+            randomLongBetween(0, 100)
+        );
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
-import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
+import org.elasticsearch.xpack.application.connector.ConnectorsAPISearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
 import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;
@@ -724,9 +724,9 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         final AtomicReference<ConnectorSyncJob> resp = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
 
-        connectorSyncJobIndexService.getConnectorSyncJob(connectorSyncJobId, new ActionListener<ConnectorSearchResult>() {
+        connectorSyncJobIndexService.getConnectorSyncJob(connectorSyncJobId, new ActionListener<ConnectorSyncJobSearchResult>() {
             @Override
-            public void onResponse(ConnectorSearchResult searchResult) {
+            public void onResponse(ConnectorSyncJobSearchResult searchResult) {
                 // Serialize the sourceRef to ConnectorSyncJob class for unit tests
                 ConnectorSyncJob connectorSyncJob = ConnectorSyncJob.fromXContentBytes(
                     searchResult.getSourceRef(),

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
-import org.elasticsearch.xpack.application.connector.ConnectorsAPISearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
 import org.elasticsearch.xpack.application.connector.syncjob.action.PostConnectorSyncJobAction;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.application.connector.ConnectorsAPISearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
 import org.elasticsearch.xpack.application.connector.syncjob.action.CancelConnectorSyncJobAction;
 import org.elasticsearch.xpack.application.connector.syncjob.action.CheckInConnectorSyncJobAction;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
@@ -7,7 +7,11 @@
 
 package org.elasticsearch.xpack.application.connector.syncjob;
 
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
 import org.elasticsearch.xpack.application.connector.syncjob.action.CancelConnectorSyncJobAction;
 import org.elasticsearch.xpack.application.connector.syncjob.action.CheckInConnectorSyncJobAction;
@@ -19,7 +23,9 @@ import org.elasticsearch.xpack.application.connector.syncjob.action.UpdateConnec
 import org.elasticsearch.xpack.application.connector.syncjob.action.UpdateConnectorSyncJobIngestionStatsAction;
 import org.elasticsearch.xpack.application.search.SearchApplicationTestUtils;
 
+import java.io.IOException;
 import java.time.Instant;
+import java.util.Map;
 
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
 import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
@@ -62,6 +68,30 @@ public class ConnectorSyncJobTestUtils {
             .setTotalDocumentCount(randomLong())
             .setTriggerMethod(getRandomConnectorSyncJobTriggerMethod())
             .setWorkerHostname(randomAlphaOfLength(10))
+            .build();
+    }
+
+    private static BytesReference convertSyncJobToBytesReference(ConnectorSyncJob syncJob) {
+        try {
+            return XContentHelper.toXContent((builder, params) -> {
+                syncJob.toInnerXContent(builder, params);
+                return builder;
+            }, XContentType.JSON, null, false);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Map<String, Object> convertSyncJobToGenericMap(ConnectorSyncJob syncJob) {
+        return XContentHelper.convertToMap(convertSyncJobToBytesReference(syncJob), true, XContentType.JSON).v2();
+    }
+
+    public static ConnectorSearchResult getRandomSyncJobSearchResult() {
+        ConnectorSyncJob syncJob = getRandomConnectorSyncJob();
+
+        return new ConnectorSearchResult.Builder().setId(randomAlphaOfLength(10))
+            .setResultMap(convertSyncJobToGenericMap(syncJob))
+            .setResultBytes(convertSyncJobToBytesReference(syncJob))
             .build();
     }
 
@@ -146,7 +176,7 @@ public class ConnectorSyncJobTestUtils {
     }
 
     public static GetConnectorSyncJobAction.Response getRandomGetConnectorSyncJobResponse() {
-        return new GetConnectorSyncJobAction.Response(getRandomConnectorSyncJob());
+        return new GetConnectorSyncJobAction.Response(getRandomSyncJobSearchResult());
     }
 
     public static ListConnectorSyncJobsAction.Request getRandomListConnectorSyncJobsActionRequest() {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTestUtils.java
@@ -11,7 +11,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xpack.application.connector.ConnectorSearchResult;
+import org.elasticsearch.xpack.application.connector.ConnectorsAPISearchResult;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
 import org.elasticsearch.xpack.application.connector.syncjob.action.CancelConnectorSyncJobAction;
 import org.elasticsearch.xpack.application.connector.syncjob.action.CheckInConnectorSyncJobAction;
@@ -86,10 +86,10 @@ public class ConnectorSyncJobTestUtils {
         return XContentHelper.convertToMap(convertSyncJobToBytesReference(syncJob), true, XContentType.JSON).v2();
     }
 
-    public static ConnectorSearchResult getRandomSyncJobSearchResult() {
+    public static ConnectorSyncJobSearchResult getRandomSyncJobSearchResult() {
         ConnectorSyncJob syncJob = getRandomConnectorSyncJob();
 
-        return new ConnectorSearchResult.Builder().setId(randomAlphaOfLength(10))
+        return new ConnectorSyncJobSearchResult.Builder().setId(randomAlphaOfLength(10))
             .setResultMap(convertSyncJobToGenericMap(syncJob))
             .setResultBytes(convertSyncJobToBytesReference(syncJob))
             .build();

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -87,7 +87,6 @@ public class ConnectorSyncJobTests extends ESTestCase {
                 "created_at": "2023-12-01T14:18:43.07693Z",
                 "deleted_document_count": 10,
                 "error": "some-error",
-                "id": "HIC-JYwB9RqKhB7x_hIE",
                 "indexed_document_count": 10,
                 "indexed_document_volume": 10,
                 "job_type": "full",
@@ -101,7 +100,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
             }
             """);
 
-        ConnectorSyncJob syncJob = ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        ConnectorSyncJob syncJob = ConnectorSyncJob.fromXContentBytes(new BytesArray(content), "HIC-JYwB9RqKhB7x_hIE", XContentType.JSON);
 
         assertThat(syncJob.getCancelationRequestedAt(), equalTo(Instant.parse("2023-12-01T14:19:39.394194Z")));
         assertThat(syncJob.getCanceledAt(), equalTo(Instant.parse("2023-12-01T14:19:39.394194Z")));
@@ -170,7 +169,6 @@ public class ConnectorSyncJobTests extends ESTestCase {
                 },
                 "created_at": "2023-12-01T14:18:43.07693Z",
                 "deleted_document_count": 10,
-                "id": "HIC-JYwB9RqKhB7x_hIE",
                 "indexed_document_count": 10,
                 "indexed_document_volume": 10,
                 "job_type": "full",
@@ -182,7 +180,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
             }
             """);
 
-        ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        ConnectorSyncJob.fromXContentBytes(new BytesArray(content), "HIC-JYwB9RqKhB7x_hIE", XContentType.JSON);
     }
 
     public void testFromXContent_WithAllNullableFieldsSetToNull_DoesNotThrow() throws IOException {
@@ -230,7 +228,6 @@ public class ConnectorSyncJobTests extends ESTestCase {
                 "created_at": "2023-12-01T14:18:43.07693Z",
                 "deleted_document_count": 10,
                 "error": null,
-                "id": "HIC-JYwB9RqKhB7x_hIE",
                 "indexed_document_count": 10,
                 "indexed_document_volume": 10,
                 "job_type": "full",
@@ -244,7 +241,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
             }
             """);
 
-        ConnectorSyncJob.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        ConnectorSyncJob.fromXContentBytes(new BytesArray(content), "HIC-JYwB9RqKhB7x_hIE", XContentType.JSON);
     }
 
     public void testSyncJobConnectorFromXContent_WithAllFieldsSet() throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsActionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/ListConnectorSyncJobsActionResponseBWCSerializingTests.java
@@ -33,7 +33,7 @@ public class ListConnectorSyncJobsActionResponseBWCSerializingTests extends Abst
     @Override
     protected ListConnectorSyncJobsAction.Response createTestInstance() {
         return new ListConnectorSyncJobsAction.Response(
-            randomList(10, ConnectorSyncJobTestUtils::getRandomConnectorSyncJob),
+            randomList(10, ConnectorSyncJobTestUtils::getRandomSyncJobSearchResult),
             randomLongBetween(0, 100)
         );
     }


### PR DESCRIPTION
We use strict data model for both validating user input and [processing get/list responses](https://github.com/elastic/elasticsearch/blob/b07595c7774a18c1ccca51273c7830b10d069ddc/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java#L188). Our strict data model, while effective for input validation, struggles with some connector documents due to the connector protocol's loose enforcement in the past. We might have missed some edge cases when defining parsers for `Connector` and `ConnectorSyncJob` and therefore we might accidentally break things for some users when they want to list/get connectors and sync jobs using the api. Given how many cases we missed initially I think ditching strict response parsing will make the integration safer.

### Changes
- Implemented `ConnectorSearchResult` that Represents the outcome of a search query in the connectors and sync job index, encapsulating the search result. It includes a raw byte reference to the result which can be deserialized into a `Connector` or `ConnectorSyncJob` object (useful for unit tests), and a result map for returning the data without strict deserialization.
- Adapted connector and sync job index service to use the new class for get and list API endpoints
- Adapted unit tests
- Adapted handling of `id` field in `SyncJob` class as the `ConnectorSearchResult` makes sure that the `docId` is returned as `id`
- No changes in YAML tests, as there should be no user-facing changes