### PR TITLE
Cleanup references to old `tracing.apm.*` legacy settings in favor of the `telemetry.*` settings

### DIFF
--- a/TRACING.md
+++ b/TRACING.md
@@ -23,18 +23,18 @@ You must supply configuration and credentials for the APM server (see below).
 In your `elasticsearch.yml` add the following configuration:
 
 ```
-tracing.apm.enabled: true
+telemetry.tracing.enabled: true
 telemetry.agent.server_url: https://<your-apm-server>:443
 ```
 
-When using a secret token to authenticate with the APM server, you must add it to the Elasticsearch keystore under `tracing.apm.secret_token`. For example, execute:
+When using a secret token to authenticate with the APM server, you must add it to the Elasticsearch keystore under `telemetry.secret_token`. For example, execute:
 
-    bin/elasticsearch-keystore add tracing.apm.secret_token
+    bin/elasticsearch-keystore add telemetry.secret_token
 
-then enter the token when prompted. If you are using API keys, change the keystore key name to `tracing.apm.api_key`.
+then enter the token when prompted. If you are using API keys, change the keystore key name to `telemetry.api_key`.
 
-All APM settings live under `tracing.apm`. All settings related to the Java agent
-go under `telemetry.agent`. Anything you set under there will be propagated to
+All APM settings live under `telemetry`. Tracing related settings go under `telemetry.tracing` and settings
+related to the Java agent go under `telemetry.agent`. Anything you set under there will be propagated to
 the agent.
 
 For agent settings that can be changed dynamically, you can use the cluster

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -201,10 +201,10 @@ public abstract class RunTask extends DefaultTestClustersTask {
                     try {
                         mockServer.start();
                         node.setting("telemetry.metrics.enabled", "true");
-                        node.setting("tracing.apm.enabled", "true");
-                        node.setting("tracing.apm.agent.transaction_sample_rate", "0.10");
-                        node.setting("tracing.apm.agent.metrics_interval", "10s");
-                        node.setting("tracing.apm.agent.server_url", "http://127.0.0.1:" + mockServer.getPort());
+                        node.setting("telemetry.tracing.enabled", "true");
+                        node.setting("telemetry.agent.transaction_sample_rate", "0.10");
+                        node.setting("telemetry.agent.metrics_interval", "10s");
+                        node.setting("telemetry.agent.server_url", "http://127.0.0.1:" + mockServer.getPort());
                     } catch (IOException e) {
                         logger.warn("Unable to start APM server", e);
                     }
@@ -213,9 +213,10 @@ public abstract class RunTask extends DefaultTestClustersTask {
                 // if metrics were not enabled explicitly for gradlew run we should disable them
                 else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) { // metrics
                     node.setting("telemetry.metrics.enabled", "false");
-                } else if (node.getSettingKeys().contains("tracing.apm.enabled") == false) { // tracing
-                    node.setting("tracing.apm.enable", "false");
-                }
+                } else if (node.getSettingKeys().contains("telemetry.tracing.enabled") == false
+                    && node.getSettingKeys().contains("tracing.apm.enabled") == false) { // tracing
+                        node.setting("telemetry.tracing.enable", "false");
+                    }
 
             }
         }

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/APMJvmOptionsTests.java
@@ -108,7 +108,6 @@ public class APMJvmOptionsTests extends ESTestCase {
 
     public void testExtractSettings() throws UserException {
         Function<String, Settings.Builder> buildSettings = (prefix) -> Settings.builder()
-            .put("tracing.apm.enabled", true)
             .put(prefix + "server_url", "https://myurl:443")
             .put(prefix + "service_node_name", "instance-0000000001");
 
@@ -158,7 +157,6 @@ public class APMJvmOptionsTests extends ESTestCase {
             IllegalStateException.class,
             () -> APMJvmOptions.extractApmSettings(
                 Settings.builder()
-                    .put("tracing.apm.enabled", true)
                     .put("tracing.apm.agent.server_url", "https://myurl:443")
                     .put("telemetry.agent.server_url", "https://myurl-2:443")
                     .build()

--- a/modules/apm/METERING.md
+++ b/modules/apm/METERING.md
@@ -106,7 +106,7 @@ rootProject {
         afterEvaluate {
             testClusters.matching { it.name == "runTask" }.configureEach {
                 setting 'xpack.security.audit.enabled', 'true'
-                keystore 'tracing.apm.secret_token', 'TODO-REPLACE'
+                keystore 'telemetry.secret_token', 'TODO-REPLACE'
                 setting 'telemetry.metrics.enabled', 'true'
                 setting 'telemetry.agent.server_url', 'https://TODO-REPLACE-URL.apm.eastus2.staging.azure.foundit.no:443'
             }

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/APM.java
@@ -33,7 +33,7 @@ import java.util.List;
  * programmatically attach the agent, the Security Manager permissions required for this
  * make this approach difficult to the point of impossibility.
  * <p>
- * All settings are found under the <code>tracing.apm.</code> prefix. Any setting under
+ * All settings are found under the <code>telemetry.</code> prefix. Any setting under
  * the <code>telemetry.agent.</code> prefix will be forwarded on to the APM Java agent
  * by setting appropriate system properties. Some settings can only be set once, and must be
  * set when the agent starts. We therefore also create and configure a config file in

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -113,7 +113,7 @@ public class APMAgentSettings {
 
         // Core:
         // forbid 'enabled', must remain enabled to dynamically enable tracing / metrics
-        // forbid 'recording' / 'instrument', controlled by 'telemetry.metrics.enabled' / 'tracing.apm.enabled'
+        // forbid 'recording' / 'instrument', controlled by 'telemetry.metrics.enabled' / 'telemetry.tracing.enabled'
         "service_name",
         "service_node_name",
         // forbid 'service_version', forced by APMJvmOptions
@@ -200,8 +200,8 @@ public class APMAgentSettings {
         "profiling_inferred_spans_lib_directory",
 
         // Reporter:
-        // forbid secret_token: use tracing.apm.secret_token instead
-        // forbid api_key: use tracing.apm.api_key instead
+        // forbid secret_token: use telemetry.secret_token instead
+        // forbid api_key: use telemetry.api_key instead
         "server_url",
         "server_urls",
         "disable_send",

--- a/qa/apm/docker-compose.yml
+++ b/qa/apm/docker-compose.yml
@@ -56,13 +56,13 @@ services:
       - xpack.security.authc.token.enabled=true
       - xpack.security.enabled=true
       # APM specific settings. We don't configure `secret_key` because Kibana is configured with a blank key
-      - tracing.apm.enabled=true
-      - tracing.apm.agent.server_url=http://apmserver:8200
+      - telemetry.tracing.enabled=true
+      - telemetry.agent.server_url=http://apmserver:8200
       # Send traces to APM server aggressively
-      - tracing.apm.agent.metrics_interval=1s
+      - telemetry.agent.metrics_interval=1s
       # Record everything
-      - tracing.apm.agent.transaction_sample_rate=1
-      - tracing.apm.agent.log_level=debug
+      - telemetry.agent.transaction_sample_rate=1
+      - telemetry.agent.log_level=debug
     healthcheck:
       interval: 20s
       retries: 10

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -974,7 +974,7 @@ class NodeConstruction {
             repositoryService
         );
 
-        final TimeValue metricsInterval = settings.getAsTime("tracing.apm.agent.metrics_interval", TimeValue.timeValueSeconds(10));
+        final TimeValue metricsInterval = settings.getAsTime("telemetry.agent.metrics_interval", TimeValue.timeValueSeconds(10));
         final NodeMetrics nodeMetrics = new NodeMetrics(telemetryProvider.getMeterRegistry(), nodeService, metricsInterval);
 
         final SearchService searchService = serviceProvider.newSearchService(

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/MetricsApmIT.java
@@ -46,8 +46,8 @@ public class MetricsApmIT extends ESRestTestCase {
         .module("test-apm-integration")
         .module("apm")
         .setting("telemetry.metrics.enabled", "true")
-        .setting("tracing.apm.agent.metrics_interval", "1s")
-        .setting("tracing.apm.agent.server_url", "http://127.0.0.1:" + mockApmServer.getPort())
+        .setting("telemetry.agent.metrics_interval", "1s")
+        .setting("telemetry.agent.server_url", "http://127.0.0.1:" + mockApmServer.getPort())
         .build();
 
     @Override

--- a/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/TracesApmIT.java
+++ b/test/external-modules/apm-integration/src/javaRestTest/java/org/elasticsearch/test/apmintegration/TracesApmIT.java
@@ -51,9 +51,9 @@ public class TracesApmIT extends ESRestTestCase {
         .module("test-apm-integration")
         .module("apm")
         .setting("telemetry.metrics.enabled", "false")
-        .setting("tracing.apm.enabled", "true")
-        .setting("tracing.apm.agent.metrics_interval", "1s")
-        .setting("tracing.apm.agent.server_url", "http://127.0.0.1:" + mockApmServer.getPort())
+        .setting("telemetry.tracing.enabled", "true")
+        .setting("telemetry.agent.metrics_interval", "1s")
+        .setting("telemetry.agent.server_url", "http://127.0.0.1:" + mockApmServer.getPort())
         .build();
 
     @Override


### PR DESCRIPTION
Update docs, tooling, ... to use new telemetry.* settings for APM where applicable.