### PR TITLE
Mute more tests that tend to leak searchhits

### DIFF
--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -110,6 +110,8 @@ public class RatedRequestsTests extends ESTestCase {
     }
 
     public void testXContentRoundtrip() throws IOException {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/104570", Constants.WINDOWS);
+
         RatedRequest testItem = createTestItem(randomBoolean());
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         XContentBuilder shuffled = shuffleXContent(testItem.toXContent(builder, ToXContent.EMPTY_PARAMS));
@@ -302,6 +304,8 @@ public class RatedRequestsTests extends ESTestCase {
      * matter for parsing xContent
      */
     public void testParseFromXContent() throws IOException {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/104570", Constants.WINDOWS);
+
         String querySpecString = """
             {
               "id": "my_qa_query",


### PR DESCRIPTION
Extend #104853 and mute more tests leaking SearchHits