### PR TITLE
Add support for fetching user profileId in Query Users

### DIFF
--- a/docs/reference/rest-api/security/query-user.asciidoc
+++ b/docs/reference/rest-api/security/query-user.asciidoc
@@ -62,6 +62,13 @@ The email of the user.
 `enabled`::
 Specifies whether the user is enabled.
 
+[[security-api-query-user-query-params]]
+==== {api-query-parms-title}
+
+`with_profile_uid`::
+(Optional, boolean) Determines whether to retrieve the <<user-profile,user profile>> `uid`,
+if exists, for the users. Defaults to `false`.
+
 ====
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=from]
@@ -212,6 +219,46 @@ A successful call returns a JSON structure for a user:
                 "intelligence": 7
             },
             "enabled": true
+        }
+    ]
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+To retrieve the user `profile_uid` as part of the response:
+
+[source,console]
+--------------------------------------------------
+GET /_security/_query/user?with_profile_uid=true
+{
+    "query": {
+        "prefix": {
+            "roles": "other"
+        }
+    }
+}
+--------------------------------------------------
+// TEST[setup:jacknich_user]
+
+[source,console-result]
+--------------------------------------------------
+{
+    "total": 1,
+    "count": 1,
+    "users": [
+        {
+            "username": "jacknich",
+            "roles": [
+                "admin",
+                "other_role1"
+            ],
+            "full_name": "Jack Nicholson",
+            "email": "jacknich@example.com",
+            "metadata": {
+                "intelligence": 7
+            },
+            "enabled": true,
+            "profile_uid": "u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0"
         }
     ]
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.query_user.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.query_user.json
@@ -28,6 +28,13 @@
     "body": {
       "description": "From, size, query, sort and search_after",
       "required": false
+    },
+    "params": {
+      "with_profile_uid": {
+        "type": "boolean",
+        "default": false,
+        "description": "flag to retrieve profile uid (if exists) associated with the user"
+      }
     }
   }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/QueryUserRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/QueryUserRequest.java
@@ -38,12 +38,14 @@ public final class QueryUserRequest extends ActionRequest {
     @Nullable
     private final SearchAfterBuilder searchAfterBuilder;
 
+    private final boolean withProfileUid;
+
     public QueryUserRequest() {
         this(null);
     }
 
     public QueryUserRequest(QueryBuilder queryBuilder) {
-        this(queryBuilder, null, null, null, null);
+        this(queryBuilder, null, null, null, null, false);
     }
 
     public QueryUserRequest(
@@ -51,13 +53,15 @@ public final class QueryUserRequest extends ActionRequest {
         @Nullable Integer from,
         @Nullable Integer size,
         @Nullable List<FieldSortBuilder> fieldSortBuilders,
-        @Nullable SearchAfterBuilder searchAfterBuilder
+        @Nullable SearchAfterBuilder searchAfterBuilder,
+        boolean withProfileUid
     ) {
         this.queryBuilder = queryBuilder;
         this.from = from;
         this.size = size;
         this.fieldSortBuilders = fieldSortBuilders;
         this.searchAfterBuilder = searchAfterBuilder;
+        this.withProfileUid = withProfileUid;
     }
 
     public QueryBuilder getQueryBuilder() {
@@ -95,5 +99,9 @@ public final class QueryUserRequest extends ActionRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         TransportAction.localOnly();
+    }
+
+    public boolean isWithProfileUid() {
+        return withProfileUid;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/QueryUserResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/QueryUserResponse.java
@@ -68,7 +68,7 @@ public final class QueryUserResponse extends ActionResponse implements ToXConten
         TransportAction.localOnly();
     }
 
-    public record Item(User user, @Nullable Object[] sortValues) implements ToXContentObject {
+    public record Item(User user, @Nullable Object[] sortValues, @Nullable String profileUid) implements ToXContentObject {
 
         @Override
         public Object[] sortValues() {
@@ -81,6 +81,9 @@ public final class QueryUserResponse extends ActionResponse implements ToXConten
             user.innerToXContent(builder);
             if (sortValues != null && sortValues.length > 0) {
                 builder.array("_sort", sortValues);
+            }
+            if (profileUid != null) {
+                builder.field("profile_uid", profileUid);
             }
             builder.endObject();
             return builder;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/user/QueryUserRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/user/QueryUserRequestTests.java
@@ -18,7 +18,8 @@ public class QueryUserRequestTests extends ESTestCase {
             randomIntBetween(0, Integer.MAX_VALUE),
             randomIntBetween(0, Integer.MAX_VALUE),
             null,
-            null
+            null,
+            false
         );
         assertThat(request1.validate(), nullValue());
 
@@ -27,7 +28,8 @@ public class QueryUserRequestTests extends ESTestCase {
             randomIntBetween(Integer.MIN_VALUE, -1),
             randomIntBetween(0, Integer.MAX_VALUE),
             null,
-            null
+            null,
+            false
         );
         assertThat(request2.validate().getMessage(), containsString("[from] parameter cannot be negative"));
 
@@ -36,7 +38,8 @@ public class QueryUserRequestTests extends ESTestCase {
             randomIntBetween(0, Integer.MAX_VALUE),
             randomIntBetween(Integer.MIN_VALUE, -1),
             null,
-            null
+            null,
+            false
         );
         assertThat(request3.validate().getMessage(), containsString("[size] parameter cannot be negative"));
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportQueryUserAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportQueryUserAction.java
@@ -7,11 +7,14 @@
 
 package org.elasticsearch.xpack.security.action.user;
 
+import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.tasks.Task;
@@ -19,24 +22,47 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.ActionTypes;
 import org.elasticsearch.xpack.core.security.action.user.QueryUserRequest;
 import org.elasticsearch.xpack.core.security.action.user.QueryUserResponse;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.Subject;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.security.authc.Realms;
 import org.elasticsearch.xpack.security.authc.esnative.NativeUsersStore;
+import org.elasticsearch.xpack.security.profile.ProfileService;
 import org.elasticsearch.xpack.security.support.UserBoolQueryBuilder;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_ALIAS;
 import static org.elasticsearch.xpack.security.support.UserBoolQueryBuilder.USER_FIELD_NAME_TRANSLATOR;
 
 public final class TransportQueryUserAction extends TransportAction<QueryUserRequest, QueryUserResponse> {
     private final NativeUsersStore usersStore;
+    private final ProfileService profileService;
+    private final Authentication.RealmRef nativeRealmRef;
     private static final Set<String> FIELD_NAMES_WITH_SORT_SUPPORT = Set.of("username", "roles", "enabled");
 
     @Inject
-    public TransportQueryUserAction(TransportService transportService, ActionFilters actionFilters, NativeUsersStore usersStore) {
+    public TransportQueryUserAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        NativeUsersStore usersStore,
+        ProfileService profileService,
+        Realms realms
+    ) {
         super(ActionTypes.QUERY_USER_ACTION.name(), actionFilters, transportService.getTaskManager());
         this.usersStore = usersStore;
+        this.profileService = profileService;
+        this.nativeRealmRef = realms.getRealmRefs()
+            .values()
+            .stream()
+            .filter(realmRef -> NativeRealmSettings.TYPE.equals(realmRef.getType()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("native realm realm ref not found"));
     }
 
     @Override
@@ -64,7 +90,56 @@ public final class TransportQueryUserAction extends TransportAction<QueryUserReq
         }
 
         final SearchRequest searchRequest = new SearchRequest(new String[] { SECURITY_MAIN_ALIAS }, searchSourceBuilder);
-        usersStore.queryUsers(searchRequest, listener);
+
+        usersStore.queryUsers(searchRequest, ActionListener.wrap(queryUserResults -> {
+            if (request.isWithProfileUid()) {
+                resolveProfileUids(queryUserResults, listener);
+            } else {
+                List<QueryUserResponse.Item> queryUserResponseResults = queryUserResults.userQueryResult()
+                    .stream()
+                    .map(queryUserResult -> new QueryUserResponse.Item(queryUserResult.user(), queryUserResult.sortValues(), null))
+                    .toList();
+                listener.onResponse(new QueryUserResponse(queryUserResults.total(), queryUserResponseResults));
+            }
+        }, listener::onFailure));
+    }
+
+    private void resolveProfileUids(NativeUsersStore.QueryUserResults queryUserResults, ActionListener<QueryUserResponse> listener) {
+        final List<Subject> subjects = queryUserResults.userQueryResult()
+            .stream()
+            .map(item -> new Subject(item.user(), nativeRealmRef))
+            .toList();
+
+        profileService.searchProfilesForSubjects(subjects, ActionListener.wrap(resultsAndErrors -> {
+            if (resultsAndErrors == null || resultsAndErrors.errors().isEmpty()) {
+                final Map<String, String> profileUidLookup = resultsAndErrors == null
+                    ? Map.of()
+                    : resultsAndErrors.results()
+                        .stream()
+                        .filter(t -> Objects.nonNull(t.v2()))
+                        .map(t -> new Tuple<>(t.v1().getUser().principal(), t.v2().uid()))
+                        .collect(Collectors.toUnmodifiableMap(Tuple::v1, Tuple::v2));
+
+                List<QueryUserResponse.Item> queryUserResponseResults = queryUserResults.userQueryResult()
+                    .stream()
+                    .map(
+                        userResult -> new QueryUserResponse.Item(
+                            userResult.user(),
+                            userResult.sortValues(),
+                            profileUidLookup.getOrDefault(userResult.user().principal(), null)
+                        )
+                    )
+                    .toList();
+                listener.onResponse(new QueryUserResponse(queryUserResults.total(), queryUserResponseResults));
+            } else {
+                final ElasticsearchStatusException exception = new ElasticsearchStatusException(
+                    "failed to retrieve profile for users. please retry without fetching profile uid (with_profile_uid=false)",
+                    RestStatus.INTERNAL_SERVER_ERROR
+                );
+                resultsAndErrors.errors().values().forEach(exception::addSuppressed);
+                listener.onFailure(exception);
+            }
+        }, listener::onFailure));
     }
 
     // package private for testing

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestQueryUserAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/user/RestQueryUserAction.java
@@ -89,6 +89,7 @@ public final class RestQueryUserAction extends SecurityBaseRestHandler {
 
     @Override
     protected RestChannelConsumer innerPrepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        final boolean withProfileUid = request.paramAsBoolean("with_profile_uid", false);
         final QueryUserRequest queryUserRequest;
         if (request.hasContentOrSourceParam()) {
             final Payload payload = PARSER.parse(request.contentOrSourceParamParser(), null);
@@ -97,10 +98,11 @@ public final class RestQueryUserAction extends SecurityBaseRestHandler {
                 payload.from,
                 payload.size,
                 payload.fieldSortBuilders,
-                payload.searchAfterBuilder
+                payload.searchAfterBuilder,
+                withProfileUid
             );
         } else {
-            queryUserRequest = new QueryUserRequest(null, null, null, null, null);
+            queryUserRequest = new QueryUserRequest(null, null, null, null, null, withProfileUid);
         }
         return channel -> client.execute(ActionTypes.QUERY_USER_ACTION, queryUserRequest, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportQueryUserActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportQueryUserActionTests.java
@@ -7,18 +7,62 @@
 
 package org.elasticsearch.xpack.security.action.user;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.NestedSortBuilder;
 import org.elasticsearch.search.sort.SortMode;
 import org.elasticsearch.search.sort.SortOrder;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.Transport;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.action.profile.Profile;
+import org.elasticsearch.xpack.core.security.action.user.QueryUserRequest;
+import org.elasticsearch.xpack.core.security.action.user.QueryUserResponse;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.authc.Subject;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.authc.Realms;
+import org.elasticsearch.xpack.security.authc.esnative.NativeUsersStore;
+import org.elasticsearch.xpack.security.profile.ProfileService;
+import org.mockito.ArgumentMatchers;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TransportQueryUserActionTests extends ESTestCase {
     private static final String[] allowedIndexFieldNames = new String[] { "username", "roles", "enabled" };
@@ -66,6 +110,213 @@ public class TransportQueryUserActionTests extends ESTestCase {
             () -> TransportQueryUserAction.translateFieldSortBuilders(originals, searchSourceBuilder)
         );
         assertThat(e.getMessage(), equalTo(String.format(Locale.ROOT, "sorting is not supported for field [%s] in User query", fieldName)));
+    }
+
+    public void testQueryUsers() {
+        final List<User> storeUsers = randomFrom(
+            Collections.singletonList(new User("joe")),
+            Arrays.asList(new User("jane"), new User("fred")),
+            randomUsers()
+        );
+        final boolean profileIndexExists = randomBoolean();
+        NativeUsersStore usersStore = mock(NativeUsersStore.class);
+
+        TransportService transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            mock(ThreadPool.class),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+
+        TransportQueryUserAction action = new TransportQueryUserAction(
+            transportService,
+            mock(ActionFilters.class),
+            usersStore,
+            mockProfileService(false, profileIndexExists),
+            mockRealms()
+        );
+        boolean withProfileUid = randomBoolean();
+        QueryUserRequest request = new QueryUserRequest(null, null, null, null, null, withProfileUid);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            @SuppressWarnings("unchecked")
+            ActionListener<NativeUsersStore.QueryUserResults> listener = (ActionListener<NativeUsersStore.QueryUserResults>) args[1];
+
+            listener.onResponse(
+                new NativeUsersStore.QueryUserResults(
+                    storeUsers.stream().map(user -> new NativeUsersStore.QueryUserResult(user, null)).toList(),
+                    storeUsers.size()
+                )
+            );
+            return null;
+        }).when(usersStore).queryUsers(ArgumentMatchers.any(SearchRequest.class), anyActionListener());
+
+        final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+        final AtomicReference<QueryUserResponse> responseRef = new AtomicReference<>();
+        action.doExecute(mock(Task.class), request, new ActionListener<>() {
+            @Override
+            public void onResponse(QueryUserResponse response) {
+                responseRef.set(response);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throwableRef.set(e);
+            }
+        });
+
+        assertThat(throwableRef.get(), is(nullValue()));
+        assertThat(responseRef.get(), is(notNullValue()));
+        assertEquals(responseRef.get().getItems().length, storeUsers.size());
+
+        if (profileIndexExists && withProfileUid) {
+            assertEquals(
+                storeUsers.stream().map(user -> "u_profile_" + user.principal()),
+                Arrays.stream(responseRef.get().getItems()).map(QueryUserResponse.Item::profileUid)
+            );
+        } else {
+            for (QueryUserResponse.Item item : responseRef.get().getItems()) {
+                assertThat(item.profileUid(), nullValue());
+            }
+        }
+    }
+
+    public void testQueryUsersWithProfileUidException() {
+        final List<User> storeUsers = randomFrom(
+            Collections.singletonList(new User("joe")),
+            Arrays.asList(new User("jane"), new User("fred")),
+            randomUsers()
+        );
+        NativeUsersStore usersStore = mock(NativeUsersStore.class);
+
+        TransportService transportService = new TransportService(
+            Settings.EMPTY,
+            mock(Transport.class),
+            mock(ThreadPool.class),
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            x -> null,
+            null,
+            Collections.emptySet()
+        );
+
+        TransportQueryUserAction action = new TransportQueryUserAction(
+            transportService,
+            mock(ActionFilters.class),
+            usersStore,
+            mockProfileService(true, true),
+            mockRealms()
+        );
+
+        QueryUserRequest request = new QueryUserRequest(null, null, null, null, null, true);
+
+        doAnswer(invocation -> {
+            Object[] args = invocation.getArguments();
+            @SuppressWarnings("unchecked")
+            ActionListener<NativeUsersStore.QueryUserResults> listener = (ActionListener<NativeUsersStore.QueryUserResults>) args[1];
+
+            listener.onResponse(
+                new NativeUsersStore.QueryUserResults(
+                    storeUsers.stream().map(user -> new NativeUsersStore.QueryUserResult(user, null)).toList(),
+                    storeUsers.size()
+                )
+            );
+            return null;
+        }).when(usersStore).queryUsers(ArgumentMatchers.any(SearchRequest.class), anyActionListener());
+
+        final PlainActionFuture<QueryUserResponse> future = new PlainActionFuture<>();
+        action.doExecute(mock(Task.class), request, future);
+
+        final ElasticsearchStatusException e = expectThrows(ElasticsearchStatusException.class, future::actionGet);
+
+        assertThat(e.status(), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
+        assertThat(e.getSuppressed().length, greaterThan(0));
+        Arrays.stream(e.getSuppressed()).forEach(suppressed -> {
+            assertThat(suppressed, instanceOf(ElasticsearchException.class));
+            assertThat(suppressed.getMessage(), equalTo("something is not right"));
+        });
+    }
+
+    private List<User> randomUsers() {
+        int size = scaledRandomIntBetween(3, 16);
+        List<User> users = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            users.add(new User("user_" + i, randomAlphaOfLengthBetween(4, 12)));
+        }
+        return users;
+    }
+
+    private Profile profileFromSubject(Subject subject) {
+        final User user = subject.getUser();
+        final Authentication.RealmRef realmRef = subject.getRealm();
+        return new Profile(
+            "u_profile_" + user.principal(),
+            randomBoolean(),
+            randomNonNegativeLong(),
+            new Profile.ProfileUser(
+                user.principal(),
+                Arrays.asList(user.roles()),
+                realmRef.getName(),
+                realmRef.getDomain() == null ? null : realmRef.getDomain().name(),
+                user.email(),
+                user.fullName()
+            ),
+            Map.of(),
+            Map.of(),
+            new Profile.VersionControl(randomNonNegativeLong(), randomNonNegativeLong())
+        );
+    }
+
+    private ProfileService mockProfileService(boolean throwException, boolean profileIndexExists) {
+        final ProfileService profileService = mock(ProfileService.class);
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            final var listener = (ActionListener<ProfileService.SubjectSearchResultsAndErrors<Profile>>) invocation.getArguments()[1];
+            if (false == profileIndexExists) {
+                listener.onResponse(null);
+                return null;
+            }
+            @SuppressWarnings("unchecked")
+            final List<Subject> subjects = (List<Subject>) invocation.getArguments()[0];
+            List<Tuple<Subject, Profile>> results = subjects.stream()
+                .map(subject -> new Tuple<>(subject, profileFromSubject(subject)))
+                .toList();
+
+            final Map<Subject, Exception> errors = new HashMap<>();
+            if (throwException) {
+                assertThat("random exception requires non-empty results", results, not(empty()));
+                final int exceptionSize = randomIntBetween(1, results.size());
+                errors.putAll(
+                    results.subList(0, exceptionSize)
+                        .stream()
+                        .collect(Collectors.toUnmodifiableMap(Tuple::v1, t -> new ElasticsearchException("something is not right")))
+                );
+                results = results.subList(exceptionSize - 1, results.size());
+            }
+
+            listener.onResponse(new ProfileService.SubjectSearchResultsAndErrors<>(results, errors));
+            return null;
+        }).when(profileService).searchProfilesForSubjects(anyList(), anyActionListener());
+        return profileService;
+    }
+
+    private Realms mockRealms() {
+        final Realms realms = mock(Realms.class);
+        when(realms.getRealmRefs()).thenReturn(
+            Map.of(
+                new RealmConfig.RealmIdentifier(NativeRealmSettings.TYPE, NativeRealmSettings.DEFAULT_NAME),
+                new Authentication.RealmRef(
+                    NativeRealmSettings.DEFAULT_NAME,
+                    NativeRealmSettings.TYPE,
+                    randomAlphaOfLengthBetween(3, 8),
+                    null
+                )
+            )
+        );
+        return realms;
     }
 
     private FieldSortBuilder randomFieldSortBuilderWithName(String name) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportQueryUserActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/TransportQueryUserActionTests.java
@@ -175,8 +175,8 @@ public class TransportQueryUserActionTests extends ESTestCase {
 
         if (profileIndexExists && withProfileUid) {
             assertEquals(
-                storeUsers.stream().map(user -> "u_profile_" + user.principal()),
-                Arrays.stream(responseRef.get().getItems()).map(QueryUserResponse.Item::profileUid)
+                storeUsers.stream().map(user -> "u_profile_" + user.principal()).toList(),
+                Arrays.stream(responseRef.get().getItems()).map(QueryUserResponse.Item::profileUid).toList()
             );
         } else {
             for (QueryUserResponse.Item item : responseRef.get().getItems()) {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/users/40_query.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/users/40_query.yml
@@ -64,6 +64,17 @@ teardown:
   - match: { "created": true }
 
   - do:
+      security.activate_user_profile:
+        body: >
+          {
+            "grant_type": "password",
+            "username": "test_user_1",
+            "password" : "x-pack-test-password"
+          }
+  - is_true: uid
+  - set: { uid: profile_uid_1 }
+
+  - do:
       headers:
         Authorization: "Basic dXNlcnNfYWRtaW46eC1wYWNrLXRlc3QtcGFzc3dvcmQ=" # users_admin
       security.put_user:
@@ -120,6 +131,8 @@ teardown:
             "from": 1,
             "size": 1
           }
+        with_profile_uid: true
   - match: { total: 2 }
   - match: { count: 1 }
   - match: { users.0.username: "test_user_1" }
+  - match: { users.0.profile_uid: "$profile_uid_1" }


### PR DESCRIPTION
This PR adds a `with_profile_uid` query parameter to the query user api to match the [get users api](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-user.html#security-api-get-user-query-params).

It determines whether to retrieve the user profile id if it exists for the users.

**Example Request**
```json
GET /_security/_query/user?with_profile_uid=true
{
    "query": {
        "prefix": {
            "roles": "other"
        }
    }
}
```
**Example Response**
```json
{
    "total": 1,
    "count": 1,
    "users": [
        {
            "username": "jacknich",
            "roles": [
                "admin",
                "other_role1"
            ],
            "full_name": "Jack Nicholson",
            "email": "jacknich@example.com",
            "metadata": {
                "intelligence": 7
            },
            "enabled": true,
            "profile_uid": "u_79HkWkwmnBH5gqFKwoxggWPjEBOur1zLPXQPEl1VBW0_0"
        }
    ]
}
```