### PR TITLE
Apply publish plugin to es-opensaml-security-api project

### DIFF
--- a/x-pack/libs/es-opensaml-security-api/build.gradle
+++ b/x-pack/libs/es-opensaml-security-api/build.gradle
@@ -7,6 +7,7 @@
  */
 
 apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {


### PR DESCRIPTION
This library is used by a couple of x-pack plugins, including the security plugin, which is commonly used in third party plugins. For third party plugin authors to successfully build plugins depending on those modules this library needs to be available in maven central.