### PR TITLE
[8.12] Apply publish plugin to es-opensaml-security-api project (#104933)

### DIFF
--- a/x-pack/libs/es-opensaml-security-api/build.gradle
+++ b/x-pack/libs/es-opensaml-security-api/build.gradle
@@ -7,6 +7,7 @@
  */
 
 apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.publish'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Apply publish plugin to es-opensaml-security-api project (#104933)