### PR TITLE
Fix server cli to always pass through exit code

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ErrorPumpThread.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ErrorPumpThread.java
@@ -51,7 +51,7 @@ class ErrorPumpThread extends Thread {
     /**
      * Waits until the server ready marker has been received.
      *
-     * @return a bootstrap exeption message if a bootstrap error occurred, or null otherwise
+     * {@code true} if successful, {@code false} if a startup error occurred
      * @throws IOException if there was a problem reading from stderr of the process
      */
     boolean waitUntilReady() throws IOException {

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ErrorPumpThread.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ErrorPumpThread.java
@@ -54,12 +54,12 @@ class ErrorPumpThread extends Thread {
      * @return a bootstrap exeption message if a bootstrap error occurred, or null otherwise
      * @throws IOException if there was a problem reading from stderr of the process
      */
-    String waitUntilReady() throws IOException {
+    boolean waitUntilReady() throws IOException {
         nonInterruptibleVoid(readyOrDead::await);
         if (ioFailure != null) {
             throw ioFailure;
         }
-        return null;
+        return ready;
     }
 
     /**

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcessBuilder.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcessBuilder.java
@@ -158,11 +158,11 @@ public class ServerProcessBuilder {
             errorPump.start();
             sendArgs(serverArgs, jvmProcess.getOutputStream());
 
-            String errorMsg = errorPump.waitUntilReady();
-            if (errorMsg != null) {
+            boolean serverOk = errorPump.waitUntilReady();
+            if (serverOk == false) {
                 // something bad happened, wait for the process to exit then rethrow
                 int exitCode = jvmProcess.waitFor();
-                throw new UserException(exitCode, errorMsg);
+                throw new UserException(exitCode, "Elasticsearch died while starting up");
             }
             success = true;
         } catch (InterruptedException e) {

--- a/docs/changelog/104943.yaml
+++ b/docs/changelog/104943.yaml
@@ -1,0 +1,5 @@
+pr: 104943
+summary: Fix server cli to always pass through exit code
+area: Infra/CLI
+type: bug
+issues: []


### PR DESCRIPTION
In certain circumstances if Elasticsearch encounters an error while starting up, the server cli may exit with no error. This commit fixes the cli to always check and wait on the Elasticsearch process and exit with the same exit code.

relates #104055