### PR TITLE
Minor refactors to knn search & mapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/vectors/ESDiversifyingChildrenByteKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ESDiversifyingChildrenByteKnnVectorQuery.java
@@ -8,16 +8,17 @@
 
 package org.elasticsearch.search.vectors;
 
-import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
 import org.elasticsearch.search.profile.query.QueryProfiler;
 
-public class ProfilingKnnFloatVectorQuery extends KnnFloatVectorQuery implements ProfilingQuery {
+public class ESDiversifyingChildrenByteKnnVectorQuery extends DiversifyingChildrenByteKnnVectorQuery implements ProfilingQuery {
     private long vectorOpsCount;
 
-    public ProfilingKnnFloatVectorQuery(String field, float[] target, int k, Query filter) {
-        super(field, target, k, filter);
+    public ESDiversifyingChildrenByteKnnVectorQuery(String field, byte[] query, Query childFilter, int k, BitSetProducer parentsFilter) {
+        super(field, query, childFilter, k, parentsFilter);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/ESDiversifyingChildrenFloatKnnVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ESDiversifyingChildrenFloatKnnVectorQuery.java
@@ -8,16 +8,17 @@
 
 package org.elasticsearch.search.vectors;
 
-import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
 import org.elasticsearch.search.profile.query.QueryProfiler;
 
-public class ProfilingKnnByteVectorQuery extends KnnByteVectorQuery implements ProfilingQuery {
+public class ESDiversifyingChildrenFloatKnnVectorQuery extends DiversifyingChildrenFloatKnnVectorQuery implements ProfilingQuery {
     private long vectorOpsCount;
 
-    public ProfilingKnnByteVectorQuery(String field, byte[] target, int k, Query filter) {
-        super(field, target, k, filter);
+    public ESDiversifyingChildrenFloatKnnVectorQuery(String field, float[] query, Query childFilter, int k, BitSetProducer parentsFilter) {
+        super(field, query, childFilter, k, parentsFilter);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/ESKnnByteVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ESKnnByteVectorQuery.java
@@ -8,23 +8,16 @@
 
 package org.elasticsearch.search.vectors;
 
+import org.apache.lucene.search.KnnByteVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.join.BitSetProducer;
-import org.apache.lucene.search.join.DiversifyingChildrenFloatKnnVectorQuery;
 import org.elasticsearch.search.profile.query.QueryProfiler;
 
-public class ProfilingDiversifyingChildrenFloatKnnVectorQuery extends DiversifyingChildrenFloatKnnVectorQuery implements ProfilingQuery {
+public class ESKnnByteVectorQuery extends KnnByteVectorQuery implements ProfilingQuery {
     private long vectorOpsCount;
 
-    public ProfilingDiversifyingChildrenFloatKnnVectorQuery(
-        String field,
-        float[] query,
-        Query childFilter,
-        int k,
-        BitSetProducer parentsFilter
-    ) {
-        super(field, query, childFilter, k, parentsFilter);
+    public ESKnnByteVectorQuery(String field, byte[] target, int k, Query filter) {
+        super(field, target, k, filter);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/vectors/ESKnnFloatVectorQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/ESKnnFloatVectorQuery.java
@@ -8,23 +8,16 @@
 
 package org.elasticsearch.search.vectors;
 
+import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.join.BitSetProducer;
-import org.apache.lucene.search.join.DiversifyingChildrenByteKnnVectorQuery;
 import org.elasticsearch.search.profile.query.QueryProfiler;
 
-public class ProfilingDiversifyingChildrenByteKnnVectorQuery extends DiversifyingChildrenByteKnnVectorQuery implements ProfilingQuery {
+public class ESKnnFloatVectorQuery extends KnnFloatVectorQuery implements ProfilingQuery {
     private long vectorOpsCount;
 
-    public ProfilingDiversifyingChildrenByteKnnVectorQuery(
-        String field,
-        byte[] query,
-        Query childFilter,
-        int k,
-        BitSetProducer parentsFilter
-    ) {
-        super(field, query, childFilter, k, parentsFilter);
+    public ESKnnFloatVectorQuery(String field, float[] target, int k, Query filter) {
+        super(field, target, k, filter);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/AbstractKnnVectorQueryBuilderTestCase.java
@@ -99,13 +99,13 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
             Query knnQuery = ((VectorSimilarityQuery) query).getInnerKnnQuery();
             assertThat(((VectorSimilarityQuery) query).getSimilarity(), equalTo(queryBuilder.getVectorSimilarity()));
             switch (elementType()) {
-                case FLOAT -> assertTrue(knnQuery instanceof ProfilingKnnFloatVectorQuery);
-                case BYTE -> assertTrue(knnQuery instanceof ProfilingKnnByteVectorQuery);
+                case FLOAT -> assertTrue(knnQuery instanceof ESKnnFloatVectorQuery);
+                case BYTE -> assertTrue(knnQuery instanceof ESKnnByteVectorQuery);
             }
         } else {
             switch (elementType()) {
-                case FLOAT -> assertTrue(query instanceof ProfilingKnnFloatVectorQuery);
-                case BYTE -> assertTrue(query instanceof ProfilingKnnByteVectorQuery);
+                case FLOAT -> assertTrue(query instanceof ESKnnFloatVectorQuery);
+                case BYTE -> assertTrue(query instanceof ESKnnByteVectorQuery);
             }
         }
 
@@ -117,13 +117,13 @@ abstract class AbstractKnnVectorQueryBuilderTestCase extends AbstractQueryTestCa
         Query filterQuery = booleanQuery.clauses().isEmpty() ? null : booleanQuery;
         // The field should always be resolved to the concrete field
         Query knnVectorQueryBuilt = switch (elementType()) {
-            case BYTE -> new ProfilingKnnByteVectorQuery(
+            case BYTE -> new ESKnnByteVectorQuery(
                 VECTOR_FIELD,
                 getByteQueryVector(queryBuilder.queryVector()),
                 queryBuilder.numCands(),
                 filterQuery
             );
-            case FLOAT -> new ProfilingKnnFloatVectorQuery(VECTOR_FIELD, queryBuilder.queryVector(), queryBuilder.numCands(), filterQuery);
+            case FLOAT -> new ESKnnFloatVectorQuery(VECTOR_FIELD, queryBuilder.queryVector(), queryBuilder.numCands(), filterQuery);
         };
         if (query instanceof VectorSimilarityQuery vectorSimilarityQuery) {
             query = vectorSimilarityQuery.getInnerKnnQuery();


### PR DESCRIPTION
While completing other work, these refactors become evident.

We should better name these knnQueries to indicate that they are ES queries and aren't ONLY for profiling (if the need arises).

Additionally, for easier extensibility, I adjusted the format & element_type validates.