### PR TITLE
Adjust enrich policy not found error message

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
@@ -148,7 +148,7 @@ public abstract class RestEnrichTestCase extends ESRestTestCase {
         );
         assertThat(
             EntityUtils.toString(re.getResponse().getEntity()),
-            containsString("enrich policy [countris] doesn't exist, did you mean [countries]?")
+            containsString("cannot find enrich policy [countris], did you mean [countries]?")
         );
     }
 
@@ -161,7 +161,7 @@ public abstract class RestEnrichTestCase extends ESRestTestCase {
         );
         assertThat(
             EntityUtils.toString(re.getResponse().getEntity()),
-            containsString("enrich policy [countris] doesn't exist, did you mean [countries]?")
+            containsString("cannot find enrich policy [countris], did you mean [countries]?")
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolver.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolver.java
@@ -228,8 +228,8 @@ public class EnrichPolicyResolver {
 
     private String missingPolicyError(String policyName, Collection<String> targetClusters, List<String> missingClusters) {
         // local cluster only
+        String reason = "cannot find enrich policy [" + policyName + "]";
         if (targetClusters.size() == 1 && Iterables.get(missingClusters, 0).isEmpty()) {
-            String reason = "enrich policy [" + policyName + "] doesn't exist";
             // accessing the policy names directly after we have checked the permission.
             List<String> potentialMatches = StringUtils.findSimilar(policyName, availablePolicies().keySet());
             if (potentialMatches.isEmpty() == false) {
@@ -239,7 +239,7 @@ public class EnrichPolicyResolver {
             return reason;
         }
         String detailed = missingClusters.stream().sorted().map(c -> c.isEmpty() ? "_local" : c).collect(Collectors.joining(", "));
-        return "enrich policy [" + policyName + "] doesn't exist on clusters [" + detailed + "]";
+        return reason + " on clusters [" + detailed + "]";
     }
 
     private void lookupPolicies(

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/enrich/EnrichPolicyResolverTests.java
@@ -369,7 +369,7 @@ public class EnrichPolicyResolverTests extends ESTestCase {
         for (Enrich.Mode mode : Enrich.Mode.values()) {
             var resolution = localCluster.resolvePolicies(Set.of(""), List.of(new EnrichPolicyResolver.UnresolvedPolicy("authoz", mode)));
             assertNull(resolution.getResolvedPolicy("authoz", mode));
-            assertThat(resolution.getError("authoz", mode), equalTo("enrich policy [authoz] doesn't exist, did you mean [author]?"));
+            assertThat(resolution.getError("authoz", mode), equalTo("cannot find enrich policy [authoz], did you mean [author]?"));
         }
     }
 
@@ -381,7 +381,7 @@ public class EnrichPolicyResolverTests extends ESTestCase {
                 List.of(new EnrichPolicyResolver.UnresolvedPolicy("addrezz", mode))
             );
             assertNull(resolution.getResolvedPolicy("addrezz", mode));
-            assertThat(resolution.getError("addrezz", mode), equalTo("enrich policy [addrezz] doesn't exist on clusters [cluster_a]"));
+            assertThat(resolution.getError("addrezz", mode), equalTo("cannot find enrich policy [addrezz] on clusters [cluster_a]"));
         }
         {
             var mode = Enrich.Mode.ANY;
@@ -392,7 +392,7 @@ public class EnrichPolicyResolverTests extends ESTestCase {
             assertNull(resolution.getResolvedPolicy("addrezz", mode));
             assertThat(
                 resolution.getError("addrezz", mode),
-                equalTo("enrich policy [addrezz] doesn't exist on clusters [_local, cluster_a]")
+                equalTo("cannot find enrich policy [addrezz] on clusters [_local, cluster_a]")
             );
         }
     }


### PR DESCRIPTION
This change relaxes the error message for the scenario in which users lack permission to access an enrich policy, even though it cannot happen at present. However, this could occur when we implement more fine-grained access control for enrich policies in the future.

See https://github.com/elastic/elasticsearch/pull/104840#discussion_r1470535630