### PR TITLE
Avoid implicit casting in ESQL SearchStats

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
@@ -307,8 +307,8 @@ public class SearchStats {
     //
     // @see org.elasticsearch.search.query.QueryPhaseCollectorManager#shortcutTotalHitCount(IndexReader, Query)
     //
-    private static int countEntries(IndexReader indexReader, String field) {
-        int count = 0;
+    private static long countEntries(IndexReader indexReader, String field) {
+        long count = 0;
         try {
             for (LeafReaderContext context : indexReader.leaves()) {
                 LeafReader reader = context.reader();


### PR DESCRIPTION
`./gradlew precommit` fails with JDK21

```
SearchStats.java:251: warning: [lossy-conversions] implicit cast from long to int in compound assignment is possibly lossy
                            count += points.size();
                                                ^
SearchStats.java:256: warning: [lossy-conversions] implicit cast from long to int in compound assignment is possibly lossy
                            count += terms.getSumTotalTermFreq();
```

I think we should use longs instead of ints.