### PR TITLE
Dry up some code around ScaledFloatFieldMapper

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -13,7 +13,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -21,14 +20,13 @@ import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.FieldDataContext;
-import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.NumericDoubleValues;
-import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.index.fielddata.SourceValueFetcherSortedDoubleIndexFieldData;
+import org.elasticsearch.index.fielddata.plain.LeafDoubleFieldData;
 import org.elasticsearch.index.fielddata.plain.SortedNumericIndexFieldData;
 import org.elasticsearch.index.mapper.BlockDocValuesReader;
 import org.elasticsearch.index.mapper.BlockLoader;
@@ -383,7 +381,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                         }
                         doubleValue = nullValue;
                     } else {
-                        doubleValue = objectToDouble(value);
+                        doubleValue = NumberFieldMapper.NumberType.objectToDouble(value);
                     }
 
                     double factor = getScalingFactor();
@@ -419,7 +417,9 @@ public class ScaledFloatFieldMapper extends FieldMapper {
          * @return Scaled value
          */
         private double scale(Object input) {
-            return new BigDecimal(Double.toString(parse(input))).multiply(BigDecimal.valueOf(scalingFactor)).doubleValue();
+            return new BigDecimal(Double.toString(NumberFieldMapper.NumberType.objectToDouble(input))).multiply(
+                BigDecimal.valueOf(scalingFactor)
+            ).doubleValue();
         }
 
         /**
@@ -436,7 +436,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             b.append("ScaledFloatFieldType[").append(scalingFactor);
             if (nullValue != null) {
                 b.append(", nullValue=").append(nullValue);
-                ;
             }
             if (metricType != null) {
                 b.append(", metricType=").append(metricType);
@@ -514,7 +513,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             value = null;
         } else {
             try {
-                numericValue = parse(parser, coerce.value());
+                numericValue = parser.doubleValue(coerce.value());
             } catch (IllegalArgumentException e) {
                 if (ignoreMalformed.value()) {
                     context.addIgnoredField(mappedFieldType.name());
@@ -535,7 +534,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         if (numericValue == null) {
-            numericValue = parse(value);
+            numericValue = NumberFieldMapper.NumberType.objectToDouble(value);
         }
 
         double doubleValue = numericValue.doubleValue();
@@ -559,31 +558,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
 
     static long encode(double value, double scalingFactor) {
         return Math.round(value * scalingFactor);
-    }
-
-    static Double parse(Object value) {
-        return objectToDouble(value);
-    }
-
-    private static Double parse(XContentParser parser, boolean coerce) throws IOException {
-        return parser.doubleValue(coerce);
-    }
-
-    /**
-     * Converts an Object to a double by checking it against known types first
-     */
-    private static double objectToDouble(Object value) {
-        double doubleValue;
-
-        if (value instanceof Number) {
-            doubleValue = ((Number) value).doubleValue();
-        } else if (value instanceof BytesRef) {
-            doubleValue = Double.parseDouble(((BytesRef) value).utf8ToString());
-        } else {
-            doubleValue = Double.parseDouble(value.toString());
-        }
-
-        return doubleValue;
     }
 
     private static class ScaledFloatIndexFieldData extends IndexNumericFieldData {
@@ -644,7 +618,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
 
     }
 
-    private static class ScaledFloatLeafFieldData implements LeafNumericFieldData {
+    private static class ScaledFloatLeafFieldData extends LeafDoubleFieldData {
 
         private final LeafNumericFieldData scaledFieldData;
         private final double scalingFactorInverse;
@@ -666,11 +640,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
-        public SortedBinaryDocValues getBytesValues() {
-            return FieldData.toString(getDoubleValues());
-        }
-
-        @Override
         public long ramBytesUsed() {
             return scaledFieldData.ramBytesUsed();
         }
@@ -678,11 +647,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         @Override
         public void close() {
             scaledFieldData.close();
-        }
-
-        @Override
-        public SortedNumericDocValues getLongValues() {
-            return FieldData.castToLong(getDoubleValues());
         }
 
         @Override
@@ -720,27 +684,6 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                     }
                 };
             }
-        }
-
-        @Override
-        public FormattedDocValues getFormattedValues(DocValueFormat format) {
-            SortedNumericDoubleValues values = getDoubleValues();
-            return new FormattedDocValues() {
-                @Override
-                public boolean advanceExact(int docId) throws IOException {
-                    return values.advanceExact(docId);
-                }
-
-                @Override
-                public int docValueCount() throws IOException {
-                    return values.docValueCount();
-                }
-
-                @Override
-                public Object nextValue() throws IOException {
-                    return format.format(values.nextValue());
-                }
-            };
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/DoubleScriptFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/DoubleScriptFieldData.java
@@ -43,7 +43,7 @@ public final class DoubleScriptFieldData extends IndexNumericFieldData {
 
     private final String fieldName;
     DoubleFieldScript.LeafFactory leafFactory;
-    protected final ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory;
+    private final ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory;
 
     private DoubleScriptFieldData(
         String fieldName,
@@ -97,7 +97,6 @@ public final class DoubleScriptFieldData extends IndexNumericFieldData {
             DoubleScriptDocValues doubleScriptDocValues,
             ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory
         ) {
-            super(0);
             this.doubleScriptDocValues = doubleScriptDocValues;
             this.toScriptFieldFactory = toScriptFieldFactory;
         }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafDoubleFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/LeafDoubleFieldData.java
@@ -14,8 +14,6 @@ import org.elasticsearch.index.fielddata.FormattedDocValues;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
-import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
-import org.elasticsearch.script.field.ToScriptFieldFactory;
 import org.elasticsearch.search.DocValueFormat;
 
 import java.io.IOException;
@@ -25,15 +23,9 @@ import java.io.IOException;
  */
 public abstract class LeafDoubleFieldData implements LeafNumericFieldData {
 
-    private final long ramBytesUsed;
-
-    protected LeafDoubleFieldData(long ramBytesUsed) {
-        this.ramBytesUsed = ramBytesUsed;
-    }
-
     @Override
     public long ramBytesUsed() {
-        return ramBytesUsed;
+        return 0;
     }
 
     @Override
@@ -46,21 +38,6 @@ public abstract class LeafDoubleFieldData implements LeafNumericFieldData {
         return FieldData.castToLong(getDoubleValues());
     }
 
-    public static LeafNumericFieldData empty(final int maxDoc, ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory) {
-        return new LeafDoubleFieldData(0) {
-
-            @Override
-            public SortedNumericDoubleValues getDoubleValues() {
-                return FieldData.emptySortedNumericDoubles();
-            }
-
-            @Override
-            public DocValuesScriptFieldFactory getScriptFieldFactory(String name) {
-                return toScriptFieldFactory.getScriptFieldFactory(getDoubleValues(), name);
-            }
-        };
-    }
-
     @Override
     public FormattedDocValues getFormattedValues(DocValueFormat format) {
         SortedNumericDoubleValues values = getDoubleValues();
@@ -71,7 +48,7 @@ public abstract class LeafDoubleFieldData implements LeafNumericFieldData {
             }
 
             @Override
-            public int docValueCount() throws IOException {
+            public int docValueCount() {
                 return values.docValueCount();
             }
 

--- a/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedDoublesIndexFieldData.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/plain/SortedDoublesIndexFieldData.java
@@ -132,14 +132,13 @@ public class SortedDoublesIndexFieldData extends IndexNumericFieldData {
     static final class SortedNumericHalfFloatFieldData extends LeafDoubleFieldData {
         final LeafReader reader;
         final String field;
-        protected final ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory;
+        private final ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory;
 
         SortedNumericHalfFloatFieldData(
             LeafReader reader,
             String field,
             ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory
         ) {
-            super(0L);
             this.reader = reader;
             this.field = field;
             this.toScriptFieldFactory = toScriptFieldFactory;
@@ -230,10 +229,9 @@ public class SortedDoublesIndexFieldData extends IndexNumericFieldData {
     static final class SortedNumericFloatFieldData extends LeafDoubleFieldData {
         final LeafReader reader;
         final String field;
-        protected final ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory;
+        private final ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory;
 
         SortedNumericFloatFieldData(LeafReader reader, String field, ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory) {
-            super(0L);
             this.reader = reader;
             this.field = field;
             this.toScriptFieldFactory = toScriptFieldFactory;
@@ -331,7 +329,6 @@ public class SortedDoublesIndexFieldData extends IndexNumericFieldData {
             String field,
             ToScriptFieldFactory<SortedNumericDoubleValues> toScriptFieldFactory
         ) {
-            super(0L);
             this.reader = reader;
             this.field = field;
             this.toScriptFieldFactory = toScriptFieldFactory;


### PR DESCRIPTION
Just some random "dry-ups" found while researching other things.

We can dry up logic around LeafDoubleFieldData quite a bit. The RamBytesUsed value passed to the constructor is always `0` and we can reuse this class in one more spot. Also the object -> double path is the same code we have in the `NumberFieldMapper`.
