### PR TITLE
Update versions to skip after backport to 8.12

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/220_drop_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/220_drop_processor.yml
@@ -99,8 +99,8 @@ teardown:
 ---
 "Test Drop Processor with Upsert (_bulk)":
   - skip:
-      version: ' - 8.12.99'
-      reason: 'https://github.com/elastic/elasticsearch/issues/36746 fixed in 8.13.0'
+      version: ' - 8.12.0'
+      reason: 'https://github.com/elastic/elasticsearch/issues/36746 fixed in 8.12.1'
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"
@@ -140,8 +140,8 @@ teardown:
 ---
 "Test Drop Processor with Upsert (_update)":
   - skip:
-      version: ' - 8.12.99'
-      reason: 'https://github.com/elastic/elasticsearch/issues/36746 fixed in 8.13.0'
+      version: ' - 8.12.0'
+      reason: 'https://github.com/elastic/elasticsearch/issues/36746 fixed in 8.12.1'
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/60_fail.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/60_fail.yml
@@ -77,8 +77,8 @@ teardown:
 ---
 "Test Fail Processor with Upsert (bulk)":
   - skip:
-      version: ' - 8.12.99'
-      reason: 'https://github.com/elastic/elasticsearch/issues/36746 fixed in 8.13.0'
+      version: ' - 8.12.0'
+      reason: 'https://github.com/elastic/elasticsearch/issues/36746 fixed in 8.12.1'
   - do:
       ingest.put_pipeline:
         id: "my_pipeline"


### PR DESCRIPTION
Update the version checks from https://github.com/elastic/elasticsearch/pull/104585 now that it has been back ported to 8.12 via https://github.com/elastic/elasticsearch/pull/104884.

I don't think we run these exact `yamlRestTest` files against mixed mode clusters (maybe we should, though!), but I didn't want to forget to do this now that the backport has happened.