### PR TITLE
Fix`HierarchyCircuitBreakerServiceTests#testG1OverLimitStrategyThrottling` assertions

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -628,14 +628,17 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         })).toList();
 
         threads.forEach(Thread::start);
-        safeAwait(barrier);
 
         int iterationCount = randomIntBetween(1, 5);
+        int lastIterationTriggerCount = leaderTriggerCount.get();
+
+        safeAwait(barrier);
         for (int i = 0; i < iterationCount; ++i) {
             memoryUsage.set(randomLongBetween(0, 100));
             safeAwait(countDown.get());
             assertThat(leaderTriggerCount.get(), lessThanOrEqualTo(i + 1));
-            assertThat(leaderTriggerCount.get(), greaterThanOrEqualTo(i / 2 + 1));
+            assertThat(leaderTriggerCount.get(), greaterThanOrEqualTo(lastIterationTriggerCount));
+            lastIterationTriggerCount = leaderTriggerCount.get();
             time.addAndGet(randomLongBetween(interval, interval * 2));
             countDown.set(new CountDownLatch(randomIntBetween(1, 20)));
         }


### PR DESCRIPTION
As is, the second assertion may not always be met - hence the test failure in https://github.com/elastic/elasticsearch/issues/104811

Extremely rare, as it requires particular thread scheduling, but possible; if there is no `strategy.overLimit()` invocation by the worker threads for two consecutive loop iterations of the main test thread, the number of triggered GCs (simulated) can be less than what asserted.
This can happen if we have a large-ish number of threads, and consecutive small-ish number for the CountDown latch (e.g. 1). That way the main test thread can be freed (twice) from its wait on the `CountDownLatch` by separate test threads that already executed `strategy.overLimit()` (with no trigger - they all used the time set during the previous iteration), but have not yet counted down.

Then, the test thread gets to loop twice (not stopping at the `CountDownLatch`), and one of the iteration goes "void" (no worker thread executes `strategy.overLimit()` for that iteration).

Therefore we can guarantee only that the number of triggered GCs (simulated) is only greater or equal to the previous number), not that is always progressing. I have changed the assertion this way.

An alternative that may work is to generate `CountDownLatch` counts to be > `#threads / 2`; this way we should not have 2 consecutive iterations with no invocation of `strategy.overLimit()`. Given that this test is to measure throttling, I thought it was better to just touch the assertion.

Closes https://github.com/elastic/elasticsearch/issues/104811