### PR TITLE
Fix Releasables.close performance issues

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
@@ -30,10 +30,8 @@ public enum Releasables {
 
     /** Release the provided {@link Releasable}. */
     public static void close(@Nullable Releasable releasable) {
-        try {
-            IOUtils.close(releasable);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
+        if (releasable != null) {
+            releasable.close();
         }
     }
 
@@ -192,10 +190,7 @@ public enum Releasables {
 
         @Override
         public void close() {
-            final var acquired = getAndSet(null);
-            if (acquired != null) {
-                acquired.close();
-            }
+            Releasables.close(getAndSet(null));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/TransportValidateQueryAction.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.QueryShardException;
@@ -202,8 +201,7 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
             request.nowInMillis(),
             request.filteringAliases()
         );
-        SearchContext searchContext = searchService.createSearchContext(shardSearchLocalRequest, SearchService.NO_TIMEOUT);
-        try {
+        try (SearchContext searchContext = searchService.createSearchContext(shardSearchLocalRequest, SearchService.NO_TIMEOUT)) {
             ParsedQuery parsedQuery = searchContext.getSearchExecutionContext().toQuery(request.query());
             searchContext.parsedQuery(parsedQuery);
             searchContext.preProcess();
@@ -215,8 +213,6 @@ public class TransportValidateQueryAction extends TransportBroadcastAction<
         } catch (AssertionError e) {
             valid = false;
             error = e.getMessage();
-        } finally {
-            Releasables.close(searchContext);
         }
 
         return new ShardValidateQueryResponse(request.shardId(), valid, explanation, error);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -176,7 +176,7 @@ public class JoinHelper {
         }
 
         logger.debug("releasing [{}] connections on successful cluster state application", releasables.size());
-        releasables.forEach(Releasables::close);
+        Releasables.close(releasables);
     }
 
     private void registerConnection(DiscoveryNode destination, Releasable connectionReference) {

--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -25,7 +25,6 @@ import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -573,8 +572,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * @throws IOException if adding the operation to the translog resulted in an I/O exception
      */
     public Location add(final Operation operation) throws IOException {
-        final ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(bigArrays);
-        try {
+        try (ReleasableBytesStreamOutput out = new ReleasableBytesStreamOutput(bigArrays)) {
             writeOperationWithSize(out, operation);
             final BytesReference bytes = out.bytes();
             try (ReleasableLock ignored = readLock.acquire()) {
@@ -604,8 +602,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         } catch (final Exception ex) {
             closeOnTragicEvent(ex);
             throw new TranslogException(shardId, "Failed to write operation [" + operation + "]", ex);
-        } finally {
-            Releasables.close(out);
         }
     }
 


### PR DESCRIPTION
It's less code and it actually inlines (avoiding virtual calls in most cases) to just do the null check here instead of delegating to IOUtils and then catching the impossible IOException.
Also, no need to use `Releaseables` in 2 spots where try-with-resources works as well and needs less code.

Noticed this when I saw that we had a lot of strange CPU overhead in this call in some hot loops like translog writes.