### PR TITLE
MockLogAppender takes string logger names for capturing

### DIFF
--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3RetryingInputStream.java
@@ -252,7 +252,7 @@ class S3RetryingInputStream extends InputStream {
                 action,
                 blobStore.bucket(),
                 blobKey,
-                purpose,
+                purpose.getKey(),
                 attempt - initialAttempt
             );
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -241,8 +241,17 @@ public class MockLogAppender extends AbstractAppender {
     }
 
     public Releasable capturing(Class<?>... classes) {
-        start();
         final var loggers = Arrays.stream(classes).map(LogManager::getLogger).toArray(Logger[]::new);
+        return appendToLoggers(loggers);
+    }
+
+    public Releasable capturing(String... names) {
+        final var loggers = Arrays.stream(names).map(LogManager::getLogger).toArray(Logger[]::new);
+        return appendToLoggers(loggers);
+    }
+
+    private Releasable appendToLoggers(Logger[] loggers) {
+        start();
         for (final var logger : loggers) {
             Loggers.addAppender(logger, this);
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -241,16 +241,14 @@ public class MockLogAppender extends AbstractAppender {
     }
 
     public Releasable capturing(Class<?>... classes) {
-        final var loggers = Arrays.stream(classes).map(LogManager::getLogger).toArray(Logger[]::new);
-        return appendToLoggers(loggers);
+        return appendToLoggers(Arrays.stream(classes).map(LogManager::getLogger).toList());
     }
 
     public Releasable capturing(String... names) {
-        final var loggers = Arrays.stream(names).map(LogManager::getLogger).toArray(Logger[]::new);
-        return appendToLoggers(loggers);
+        return appendToLoggers(Arrays.stream(names).map(LogManager::getLogger).toList());
     }
 
-    private Releasable appendToLoggers(Logger[] loggers) {
+    private Releasable appendToLoggers(List<Logger> loggers) {
         start();
         for (final var logger : loggers) {
             Loggers.addAppender(logger, this);


### PR DESCRIPTION
For classes that are not publically accessible, we can use the cannoical names for capturing.
