### PR TITLE
Fix unnecessary allocations in ChildMemoryCircuitBreaker

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/ChildMemoryCircuitBreaker.java
@@ -198,7 +198,9 @@ public class ChildMemoryCircuitBreaker implements CircuitBreaker {
     @Override
     public void addWithoutBreaking(long bytes) {
         long u = used.addAndGet(bytes);
-        logger.trace(() -> format("[%s] Adjusted breaker by [%s] bytes, now [%s]", this.name, bytes, u));
+        if (logger.isTraceEnabled()) {
+            logger.trace("[{}] Adjusted breaker by [{}] bytes, now [{}]", this.name, bytes, u);
+        }
         assert u >= 0 : "Used bytes: [" + u + "] must be >= 0";
     }
 


### PR DESCRIPTION
This line allocates GB/min for the capturing lambda during hot indexing according to async-profiler. No need for that.
