### PR TITLE
Fix needless BytesArray allocation in SourceToParse

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceToParse.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceToParse.java
@@ -40,7 +40,7 @@ public class SourceToParse {
         this.id = id;
         // we always convert back to byte array, since we store it and Field only supports bytes..
         // so, we might as well do it here, and improve the performance of working with direct byte arrays
-        this.source = new BytesArray(Objects.requireNonNull(source).toBytesRef());
+        this.source = source.hasArray() ? source : new BytesArray(source.toBytesRef());
         this.xContentType = Objects.requireNonNull(xContentType);
         this.routing = routing;
         this.dynamicTemplates = Objects.requireNonNull(dynamicTemplates);


### PR DESCRIPTION
No need to copy here and allocate GB/min of additional pointers to the same `byte[]` over and over, the reference here is in most if not all relevant cases backed by an array anyway. Just adds more cycles to indexing and makes heap dumps harder to interpret at times :)
