### PR TITLE
Safely public RecoveryFilesDetails in RecoveryState#Index

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -865,7 +865,9 @@ public class RecoveryState implements ToXContentFragment, Writeable {
 
         public Index(StreamInput in) throws IOException {
             super(in);
-            fileDetails = new RecoveryFilesDetails(in);
+            synchronized (this) {
+                fileDetails = new RecoveryFilesDetails(in);
+            }
             sourceThrottlingInNanos = in.readLong();
             targetThrottleTimeInNanos = in.readLong();
         }


### PR DESCRIPTION
`fileDetails` is accessed via `synchronized` lock on the Index object, but is published without one and it's not immutable, so it can be seen in incomplete state outside of the thread where it was constructed. 

Fixes #87568