### PR TITLE
[8.12] Avoid implicit casting in ESQL SearchStats (#104947)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
@@ -232,8 +232,8 @@ public class SearchStats {
     //
     // @see org.elasticsearch.search.query.QueryPhaseCollectorManager#shortcutTotalHitCount(IndexReader, Query)
     //
-    private static int countEntries(IndexReader indexReader, String field) {
-        int count = 0;
+    private static long countEntries(IndexReader indexReader, String field) {
+        long count = 0;
         try {
             for (LeafReaderContext context : indexReader.leaves()) {
                 LeafReader reader = context.reader();


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Avoid implicit casting in ESQL SearchStats (#104947)