### PR TITLE
[Connectors API] Add new field `api_key_secret_id` to Connector

### DIFF
--- a/docs/changelog/104982.yaml
+++ b/docs/changelog/104982.yaml
@@ -1,0 +1,5 @@
+pr: 104982
+summary: "[Connectors API] Add new field `api_key_secret_id` to Connector"
+area: Application
+type: enhancement
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_api_key_id.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_api_key_id.json
@@ -1,7 +1,7 @@
 {
   "connector.update_api_key_id": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-api-key-id-api-key-secret-api.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/connector-apis.html",
       "description": "Updates the API key id and/or API key secret id fields in the connector document."
     },
     "stability": "experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_api_key_id.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_api_key_id.json
@@ -1,0 +1,38 @@
+{
+  "connector.update_api_key_id": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-api-key-id-api-key-secret-api.html",
+      "description": "Updates the API key id and/or API key secret id fields in the connector document."
+    },
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": [
+        "application/json"
+      ],
+      "content_type": [
+        "application/json"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_connector/{connector_id}/_api_key_id",
+          "methods": [
+            "PUT"
+          ],
+          "parts": {
+            "connector_id": {
+              "type": "string",
+              "description": "The unique identifier of the connector to be updated."
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "An object containing the connector's API key id and/or Connector Secret document id for that API key.",
+      "required": true
+    }
+  }
+}

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/341_connector_update_api_key_id.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/341_connector_update_api_key_id.yml
@@ -86,6 +86,18 @@ setup:
           api_key_secret_id: test-api-key-secret-id
 
 ---
+"Update Connector Api Key Id - 400 status code when both values are null":
+  - do:
+      catch: "bad_request"
+      connector.update_api_key_id:
+        connector_id: test-connector
+        body:
+          api_key_id: null
+          api_key_secret_id: null
+
+  - match: { error.reason: "Validation Failed: 1: [api_key_id] and [api_key_secret_id] cannot both be [null]. Please provide a value for at least one of them.;" }
+
+---
 "Update Connector Api Key Id - 400 status code when payload is not string":
   - do:
       catch: "bad_request"
@@ -95,4 +107,4 @@ setup:
           api_key_id:
             field_1: test
             field_2: something
-          description: test-description
+          api_key_secret_id: test-api-key-secret-id

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/341_connector_update_api_key_id.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/341_connector_update_api_key_id.yml
@@ -1,0 +1,98 @@
+setup:
+  - skip:
+      version: " - 8.12.99"
+      reason: Introduced in 8.13.0
+
+  - do:
+      connector.put:
+        connector_id: test-connector
+        body:
+          index_name: search-1-test
+          name: my-connector
+          language: pl
+          is_native: false
+          service_type: super-connector
+
+---
+"Update Connector Api Key Id":
+  - do:
+      connector.update_api_key_id:
+        connector_id: test-connector
+        body:
+          api_key_id: test-api-key-id
+
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { api_key_id: test-api-key-id }
+
+---
+"Update Connector Api Key Secret Id":
+  - do:
+      connector.update_api_key_id:
+        connector_id: test-connector
+        body:
+          api_key_secret_id: test-api-key-secret-id
+
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { api_key_secret_id: test-api-key-secret-id }
+
+---
+"Update Connector Api Key Id and Api Key Secret Id":
+  - do:
+      connector.update_api_key_id:
+        connector_id: test-connector
+        body:
+          api_key_id: test-api-key-id
+          api_key_secret_id: test-api-key-secret-id
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { api_key_id: test-api-key-id }
+  - match: { api_key_secret_id: test-api-key-secret-id }
+
+---
+"Update Connector Api Key Id - 404 when connector doesn't exist":
+  - do:
+      catch: "missing"
+      connector.update_api_key_id:
+        connector_id: test-non-existent-connector
+        body:
+          api_key_id: test-api-key-id
+          api_key_secret_id: test-api-key-secret-id
+
+---
+"Update Connector Api Key Id - 400 status code when connector_id is empty":
+  - do:
+      catch: "bad_request"
+      connector.update_api_key_id:
+        connector_id: ""
+        body:
+          api_key_id: test-api-key-id
+          api_key_secret_id: test-api-key-secret-id
+
+---
+"Update Connector Api Key Id - 400 status code when payload is not string":
+  - do:
+      catch: "bad_request"
+      connector.update_api_key_id:
+        connector_id: test-connector
+        body:
+          api_key_id:
+            field_1: test
+            field_2: something
+          description: test-description

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -53,6 +53,7 @@ import org.elasticsearch.xpack.application.connector.action.RestGetConnectorActi
 import org.elasticsearch.xpack.application.connector.action.RestListConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.RestPostConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.RestPutConnectorAction;
+import org.elasticsearch.xpack.application.connector.action.RestUpdateConnectorApiKeyIdAction;
 import org.elasticsearch.xpack.application.connector.action.RestUpdateConnectorConfigurationAction;
 import org.elasticsearch.xpack.application.connector.action.RestUpdateConnectorErrorAction;
 import org.elasticsearch.xpack.application.connector.action.RestUpdateConnectorFilteringAction;
@@ -68,6 +69,7 @@ import org.elasticsearch.xpack.application.connector.action.TransportGetConnecto
 import org.elasticsearch.xpack.application.connector.action.TransportListConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.TransportPostConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.TransportPutConnectorAction;
+import org.elasticsearch.xpack.application.connector.action.TransportUpdateConnectorApiKeyIdAction;
 import org.elasticsearch.xpack.application.connector.action.TransportUpdateConnectorConfigurationAction;
 import org.elasticsearch.xpack.application.connector.action.TransportUpdateConnectorErrorAction;
 import org.elasticsearch.xpack.application.connector.action.TransportUpdateConnectorFilteringAction;
@@ -78,6 +80,7 @@ import org.elasticsearch.xpack.application.connector.action.TransportUpdateConne
 import org.elasticsearch.xpack.application.connector.action.TransportUpdateConnectorPipelineAction;
 import org.elasticsearch.xpack.application.connector.action.TransportUpdateConnectorSchedulingAction;
 import org.elasticsearch.xpack.application.connector.action.TransportUpdateConnectorServiceTypeAction;
+import org.elasticsearch.xpack.application.connector.action.UpdateConnectorApiKeyIdAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorConfigurationAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorErrorAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorFilteringAction;
@@ -244,6 +247,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
                     new ActionHandler<>(ListConnectorAction.INSTANCE, TransportListConnectorAction.class),
                     new ActionHandler<>(PostConnectorAction.INSTANCE, TransportPostConnectorAction.class),
                     new ActionHandler<>(PutConnectorAction.INSTANCE, TransportPutConnectorAction.class),
+                    new ActionHandler<>(UpdateConnectorApiKeyIdAction.INSTANCE, TransportUpdateConnectorApiKeyIdAction.class),
                     new ActionHandler<>(UpdateConnectorConfigurationAction.INSTANCE, TransportUpdateConnectorConfigurationAction.class),
                     new ActionHandler<>(UpdateConnectorErrorAction.INSTANCE, TransportUpdateConnectorErrorAction.class),
                     new ActionHandler<>(UpdateConnectorFilteringAction.INSTANCE, TransportUpdateConnectorFilteringAction.class),
@@ -334,6 +338,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
                     new RestListConnectorAction(),
                     new RestPostConnectorAction(),
                     new RestPutConnectorAction(),
+                    new RestUpdateConnectorApiKeyIdAction(),
                     new RestUpdateConnectorConfigurationAction(),
                     new RestUpdateConnectorErrorAction(),
                     new RestUpdateConnectorFilteringAction(),

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -42,6 +42,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  * <ul>
  *     <li>A doc _id of the connector document.</li>
  *     <li>API key for authenticating with Elasticsearch, ensuring secure access.</li>
+ *     <li>Connector Secret ID for API key, allowing Connectors to access the API key.</li>
  *     <li>A configuration mapping which holds specific settings and parameters for the connector's operation.</li>
  *     <li>A {@link ConnectorCustomSchedule} object that defines custom scheduling.</li>
  *     <li>A description providing an overview or purpose of the connector.</li>
@@ -71,6 +72,8 @@ public class Connector implements NamedWriteable, ToXContentObject {
     private final String connectorId;
     @Nullable
     private final String apiKeyId;
+    @Nullable
+    private final String apiKeySecretId;
     private final Map<String, ConnectorConfiguration> configuration;
     private final Map<String, ConnectorCustomSchedule> customScheduling;
     @Nullable
@@ -108,6 +111,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
      *
      * @param connectorId        Unique identifier for the connector. Used when building get/list response. Equals to doc _id.
      * @param apiKeyId           API key ID used for authentication/authorization against ES.
+     * @param apiKeySecretId     Connector Secret document ID for API key.
      * @param configuration      Configuration settings for the connector.
      * @param customScheduling   Custom scheduling settings for the connector.
      * @param description        Description of the connector.
@@ -131,6 +135,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
     private Connector(
         String connectorId,
         String apiKeyId,
+        String apiKeySecretId,
         Map<String, ConnectorConfiguration> configuration,
         Map<String, ConnectorCustomSchedule> customScheduling,
         String description,
@@ -153,6 +158,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
     ) {
         this.connectorId = connectorId;
         this.apiKeyId = apiKeyId;
+        this.apiKeySecretId = apiKeySecretId;
         this.configuration = configuration;
         this.customScheduling = customScheduling;
         this.description = description;
@@ -177,6 +183,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
     public Connector(StreamInput in) throws IOException {
         this.connectorId = in.readOptionalString();
         this.apiKeyId = in.readOptionalString();
+        this.apiKeySecretId = in.readOptionalString();
         this.configuration = in.readMap(ConnectorConfiguration::new);
         this.customScheduling = in.readMap(ConnectorCustomSchedule::new);
         this.description = in.readOptionalString();
@@ -199,7 +206,8 @@ public class Connector implements NamedWriteable, ToXContentObject {
     }
 
     public static final ParseField ID_FIELD = new ParseField("id");
-    static final ParseField API_KEY_ID_FIELD = new ParseField("api_key_id");
+    public static final ParseField API_KEY_ID_FIELD = new ParseField("api_key_id");
+    public static final ParseField API_KEY_SECRET_ID_FIELD = new ParseField("api_key_secret_id");
     public static final ParseField CONFIGURATION_FIELD = new ParseField("configuration");
     static final ParseField CUSTOM_SCHEDULING_FIELD = new ParseField("custom_scheduling");
     public static final ParseField DESCRIPTION_FIELD = new ParseField("description");
@@ -226,6 +234,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
             int i = 0;
             return new Builder().setConnectorId(docId)
                 .setApiKeyId((String) args[i++])
+                .setApiKeySecretId((String) args[i++])
                 .setConfiguration((Map<String, ConnectorConfiguration>) args[i++])
                 .setCustomScheduling((Map<String, ConnectorCustomSchedule>) args[i++])
                 .setDescription((String) args[i++])
@@ -262,6 +271,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
 
     static {
         PARSER.declareStringOrNull(optionalConstructorArg(), API_KEY_ID_FIELD);
+        PARSER.declareStringOrNull(optionalConstructorArg(), API_KEY_SECRET_ID_FIELD);
         PARSER.declareObject(
             optionalConstructorArg(),
             (p, c) -> p.map(HashMap::new, ConnectorConfiguration::fromXContent),
@@ -363,6 +373,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
             builder.field(ID_FIELD.getPreferredName(), connectorId);
         }
         builder.field(API_KEY_ID_FIELD.getPreferredName(), apiKeyId);
+        builder.field(API_KEY_SECRET_ID_FIELD.getPreferredName(), apiKeySecretId);
         builder.xContentValuesMap(CONFIGURATION_FIELD.getPreferredName(), configuration);
         builder.xContentValuesMap(CUSTOM_SCHEDULING_FIELD.getPreferredName(), customScheduling);
         builder.field(DESCRIPTION_FIELD.getPreferredName(), description);
@@ -397,6 +408,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(connectorId);
         out.writeOptionalString(apiKeyId);
+        out.writeOptionalString(apiKeySecretId);
         out.writeMap(configuration, StreamOutput::writeWriteable);
         out.writeMap(customScheduling, StreamOutput::writeWriteable);
         out.writeOptionalString(description);
@@ -424,6 +436,10 @@ public class Connector implements NamedWriteable, ToXContentObject {
 
     public String getApiKeyId() {
         return apiKeyId;
+    }
+
+    public String getApiKeySecretId() {
+        return apiKeySecretId;
     }
 
     public Map<String, ConnectorConfiguration> getConfiguration() {
@@ -511,6 +527,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
             && syncNow == connector.syncNow
             && Objects.equals(connectorId, connector.connectorId)
             && Objects.equals(apiKeyId, connector.apiKeyId)
+            && Objects.equals(apiKeySecretId, connector.apiKeySecretId)
             && Objects.equals(configuration, connector.configuration)
             && Objects.equals(customScheduling, connector.customScheduling)
             && Objects.equals(description, connector.description)
@@ -535,6 +552,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
         return Objects.hash(
             connectorId,
             apiKeyId,
+            apiKeySecretId,
             configuration,
             customScheduling,
             description,
@@ -566,6 +584,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
 
         private String connectorId;
         private String apiKeyId;
+        private String apiKeySecretId;
         private Map<String, ConnectorConfiguration> configuration = Collections.emptyMap();
         private Map<String, ConnectorCustomSchedule> customScheduling = Collections.emptyMap();
         private String description;
@@ -593,6 +612,11 @@ public class Connector implements NamedWriteable, ToXContentObject {
 
         public Builder setApiKeyId(String apiKeyId) {
             this.apiKeyId = apiKeyId;
+            return this;
+        }
+
+        public Builder setApiKeySecretId(String apiKeySecretId) {
+            this.apiKeySecretId = apiKeySecretId;
             return this;
         }
 
@@ -695,6 +719,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
             return new Connector(
                 connectorId,
                 apiKeyId,
+                apiKeySecretId,
                 configuration,
                 customScheduling,
                 description,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.application.connector.action.PostConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.PutConnectorAction;
+import org.elasticsearch.xpack.application.connector.action.UpdateConnectorApiKeyIdAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorConfigurationAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorErrorAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorFilteringAction;
@@ -616,6 +617,33 @@ public class ConnectorIndexService {
                     })
                 );
             }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    public void updateConnectorApiKeyIdOrApiKeySecretId(
+        UpdateConnectorApiKeyIdAction.Request request,
+        ActionListener<UpdateResponse> listener
+    ) {
+        try {
+            String connectorId = request.getConnectorId();
+            final UpdateRequest updateRequest = new UpdateRequest(CONNECTOR_INDEX_NAME, connectorId).doc(
+                new IndexRequest(CONNECTOR_INDEX_NAME).opType(DocWriteRequest.OpType.INDEX)
+                    .id(connectorId)
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                    .source(request.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS))
+            );
+            clientWithOrigin.update(
+                updateRequest,
+                new DelegatingIndexNotFoundActionListener<>(connectorId, listener, (l, updateResponse) -> {
+                    if (updateResponse.getResult() == UpdateResponse.Result.NOT_FOUND) {
+                        l.onFailure(new ResourceNotFoundException(connectorId));
+                        return;
+                    }
+                    l.onResponse(updateResponse);
+                })
+            );
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestUpdateConnectorApiKeyIdAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestUpdateConnectorApiKeyIdAction.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.action;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.application.EnterpriseSearch;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.PUT;
+
+@ServerlessScope(Scope.PUBLIC)
+public class RestUpdateConnectorApiKeyIdAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "connector_update_api_key_id_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(PUT, "/" + EnterpriseSearch.CONNECTOR_API_ENDPOINT + "/{connector_id}/_api_key_id"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        UpdateConnectorApiKeyIdAction.Request request = UpdateConnectorApiKeyIdAction.Request.fromXContentBytes(
+            restRequest.param("connector_id"),
+            restRequest.content(),
+            restRequest.getXContentType()
+        );
+        return channel -> client.execute(
+            UpdateConnectorApiKeyIdAction.INSTANCE,
+            request,
+            new RestToXContentListener<>(channel, ConnectorUpdateActionResponse::status)
+        );
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportUpdateConnectorApiKeyIdAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportUpdateConnectorApiKeyIdAction.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
+
+public class TransportUpdateConnectorApiKeyIdAction extends HandledTransportAction<
+    UpdateConnectorApiKeyIdAction.Request,
+    ConnectorUpdateActionResponse> {
+
+    protected final ConnectorIndexService connectorIndexService;
+
+    @Inject
+    public TransportUpdateConnectorApiKeyIdAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ActionFilters actionFilters,
+        Client client
+    ) {
+        super(
+            UpdateConnectorApiKeyIdAction.NAME,
+            transportService,
+            actionFilters,
+            UpdateConnectorApiKeyIdAction.Request::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+        this.connectorIndexService = new ConnectorIndexService(client);
+    }
+
+    @Override
+    protected void doExecute(
+        Task task,
+        UpdateConnectorApiKeyIdAction.Request request,
+        ActionListener<ConnectorUpdateActionResponse> listener
+    ) {
+        connectorIndexService.updateConnectorApiKeyIdOrApiKeySecretId(
+            request,
+            listener.map(r -> new ConnectorUpdateActionResponse(r.getResult()))
+        );
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdAction.java
@@ -84,12 +84,11 @@ public class UpdateConnectorApiKeyIdAction {
             return validationException;
         }
 
-        private static final ConstructingObjectParser<Request, String> PARSER =
-            new ConstructingObjectParser<>(
-                "connector_update_api_key_id_request",
-                false,
-                ((args, connectorId) -> new UpdateConnectorApiKeyIdAction.Request(connectorId, (String) args[0], (String) args[1]))
-            );
+        private static final ConstructingObjectParser<Request, String> PARSER = new ConstructingObjectParser<>(
+            "connector_update_api_key_id_request",
+            false,
+            ((args, connectorId) -> new UpdateConnectorApiKeyIdAction.Request(connectorId, (String) args[0], (String) args[1]))
+        );
 
         static {
             PARSER.declareStringOrNull(optionalConstructorArg(), Connector.API_KEY_ID_FIELD);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdAction.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.action;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.*;
+import org.elasticsearch.xpack.application.connector.Connector;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class UpdateConnectorApiKeyIdAction {
+
+    public static final String NAME = "cluster:admin/xpack/connector/update_api_key_id";
+    public static final ActionType<ConnectorUpdateActionResponse> INSTANCE = new ActionType<>(NAME);
+
+    private UpdateConnectorApiKeyIdAction() {/* no instances */}
+
+    public static class Request extends ActionRequest implements ToXContentObject {
+
+        private final String connectorId;
+
+        @Nullable
+        private final String apiKeyId;
+
+        @Nullable
+        private final String apiKeySecretId;
+
+        public Request(String connectorId, String apiKeyId, String apiKeySecretId) {
+            this.connectorId = connectorId;
+            this.apiKeyId = apiKeyId;
+            this.apiKeySecretId = apiKeySecretId;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.connectorId = in.readString();
+            this.apiKeyId = in.readOptionalString();
+            this.apiKeySecretId = in.readOptionalString();
+        }
+
+        public String getConnectorId() {
+            return connectorId;
+        }
+
+        public String getApiKeyId() {
+            return apiKeyId;
+        }
+
+        public String getApiKeySecretId() {
+            return apiKeySecretId;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
+
+            if (Strings.isNullOrEmpty(connectorId)) {
+                validationException = addValidationError("[connector_id] cannot be [null] or [\"\"].", validationException);
+            }
+
+            return validationException;
+        }
+
+        private static final ConstructingObjectParser<UpdateConnectorApiKeyIdAction.Request, String> PARSER =
+            new ConstructingObjectParser<>(
+                "connector_update_api_key_id_request",
+                false,
+                ((args, connectorId) -> new UpdateConnectorApiKeyIdAction.Request(connectorId, (String) args[0], (String) args[1]))
+            );
+
+        static {
+            PARSER.declareStringOrNull(optionalConstructorArg(), Connector.API_KEY_ID_FIELD);
+            PARSER.declareStringOrNull(optionalConstructorArg(), Connector.API_KEY_SECRET_ID_FIELD);
+        }
+
+        public static UpdateConnectorApiKeyIdAction.Request fromXContentBytes(
+            String connectorId,
+            BytesReference source,
+            XContentType xContentType
+        ) {
+            try (XContentParser parser = XContentHelper.createParser(XContentParserConfiguration.EMPTY, source, xContentType)) {
+                return UpdateConnectorApiKeyIdAction.Request.fromXContent(parser, connectorId);
+            } catch (IOException e) {
+                throw new ElasticsearchParseException("Failed to parse: " + source.utf8ToString(), e);
+            }
+        }
+
+        public static UpdateConnectorApiKeyIdAction.Request fromXContent(XContentParser parser, String connectorId) throws IOException {
+            return PARSER.parse(parser, connectorId);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            {
+                if (apiKeyId != null) {
+                    builder.field(Connector.API_KEY_ID_FIELD.getPreferredName(), apiKeyId);
+                }
+                if (apiKeySecretId != null) {
+                    builder.field(Connector.API_KEY_SECRET_ID_FIELD.getPreferredName(), apiKeySecretId);
+                }
+            }
+            builder.endObject();
+            return builder;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(connectorId);
+            out.writeOptionalString(apiKeyId);
+            out.writeOptionalString(apiKeySecretId);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return Objects.equals(connectorId, request.connectorId)
+                && Objects.equals(apiKeyId, request.apiKeyId)
+                && Objects.equals(apiKeySecretId, request.apiKeySecretId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(connectorId, apiKeyId, apiKeySecretId);
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdAction.java
@@ -80,6 +80,12 @@ public class UpdateConnectorApiKeyIdAction {
             if (Strings.isNullOrEmpty(connectorId)) {
                 validationException = addValidationError("[connector_id] cannot be [null] or [\"\"].", validationException);
             }
+            if (apiKeyId == null && apiKeySecretId == null) {
+                validationException = addValidationError(
+                    "[api_key_id] and [api_key_secret_id] cannot both be [null]. Please provide a value for at least one of them.",
+                    validationException
+                );
+            }
 
             return validationException;
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdAction.java
@@ -17,7 +17,12 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.xcontent.*;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.Connector;
 
 import java.io.IOException;
@@ -79,7 +84,7 @@ public class UpdateConnectorApiKeyIdAction {
             return validationException;
         }
 
-        private static final ConstructingObjectParser<UpdateConnectorApiKeyIdAction.Request, String> PARSER =
+        private static final ConstructingObjectParser<Request, String> PARSER =
             new ConstructingObjectParser<>(
                 "connector_update_api_key_id_request",
                 false,

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -247,6 +247,7 @@ public final class ConnectorTestUtils {
     public static Connector getRandomConnector() {
 
         return new Connector.Builder().setApiKeyId(randomFrom(new String[] { null, randomAlphaOfLength(10) }))
+            .setApiKeySecretId(randomFrom(new String[] { null, randomAlphaOfLength(10) }))
             .setConfiguration(getRandomConnectorConfiguration())
             .setCustomScheduling(Map.of(randomAlphaOfLengthBetween(5, 10), getRandomConnectorCustomSchedule()))
             .setDescription(randomFrom(new String[] { null, randomAlphaOfLength(10) }))

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTests.java
@@ -50,7 +50,8 @@ public class ConnectorTests extends ESTestCase {
         String connectorId = "test-connector";
         String content = XContentHelper.stripWhitespace("""
             {
-               "api_key_id":"test",
+               "api_key_id":"test-aki",
+               "api_key_secret_id":"test-aksi",
                "custom_scheduling":{
                   "schedule-key":{
                      "configuration_overrides":{
@@ -246,6 +247,7 @@ public class ConnectorTests extends ESTestCase {
         String content = XContentHelper.stripWhitespace("""
             {
                "api_key_id": null,
+               "api_key_secret_id": null,
                "custom_scheduling":{},
                "configuration":{},
                "description": null,
@@ -297,6 +299,71 @@ public class ConnectorTests extends ESTestCase {
             parsed = Connector.fromXContent(parser, connectorId);
         }
         assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToXContent_withOptionalFieldsMissing() throws IOException {
+        // This test is to ensure the doc can serialize without fields that have been added since 8.12.
+        // This is to avoid breaking serverless, which has a regular BC built
+        // that can be broken if we haven't made migrations yet.
+        String connectorId = "test-connector";
+
+        // Missing from doc:
+        // api_key_secret_id
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "api_key_id": null,
+               "custom_scheduling":{},
+               "configuration":{},
+               "description": null,
+               "features": null,
+               "filtering":[],
+               "index_name": "search-test",
+               "is_native": false,
+               "language": null,
+               "last_access_control_sync_error": null,
+               "last_access_control_sync_scheduled_at": null,
+               "last_access_control_sync_status": null,
+               "last_incremental_sync_scheduled_at": null,
+               "last_seen": null,
+               "last_sync_error": null,
+               "last_sync_scheduled_at": null,
+               "last_sync_status": null,
+               "last_synced": null,
+               "name": null,
+               "pipeline":{
+                  "extract_binary_content":true,
+                  "name":"ent-search-generic-ingestion",
+                  "reduce_whitespace":true,
+                  "run_ml_inference":false
+               },
+               "scheduling":{
+                  "access_control":{
+                     "enabled":false,
+                     "interval":"0 0 0 * * ?"
+                  },
+                  "full":{
+                     "enabled":false,
+                     "interval":"0 0 0 * * ?"
+                  },
+                  "incremental":{
+                     "enabled":false,
+                     "interval":"0 0 0 * * ?"
+                  }
+               },
+               "service_type": null,
+               "status": "needs_configuration",
+               "sync_now":false
+            }""");
+
+        Connector connector = Connector.fromXContentBytes(new BytesArray(content), connectorId, XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(connector, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        Connector parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = Connector.fromXContent(parser, connectorId);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+        assertThat(parsed.getApiKeySecretId(), equalTo(null));
     }
 
     private void assertTransportSerialization(Connector testInstance) throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorApiKeyIdActionRequestBWCSerializingTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.action;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
+
+import java.io.IOException;
+
+public class UpdateConnectorApiKeyIdActionRequestBWCSerializingTests extends AbstractBWCSerializationTestCase<
+    UpdateConnectorApiKeyIdAction.Request> {
+
+    private String connectorId;
+
+    @Override
+    protected Writeable.Reader<UpdateConnectorApiKeyIdAction.Request> instanceReader() {
+        return UpdateConnectorApiKeyIdAction.Request::new;
+    }
+
+    @Override
+    protected UpdateConnectorApiKeyIdAction.Request createTestInstance() {
+        this.connectorId = randomUUID();
+        return new UpdateConnectorApiKeyIdAction.Request(connectorId, randomAlphaOfLengthBetween(5, 15), randomAlphaOfLengthBetween(5, 15));
+    }
+
+    @Override
+    protected UpdateConnectorApiKeyIdAction.Request mutateInstance(UpdateConnectorApiKeyIdAction.Request instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+
+    @Override
+    protected UpdateConnectorApiKeyIdAction.Request doParseInstance(XContentParser parser) throws IOException {
+        return UpdateConnectorApiKeyIdAction.Request.fromXContent(parser, this.connectorId);
+    }
+
+    @Override
+    protected UpdateConnectorApiKeyIdAction.Request mutateInstanceForVersion(
+        UpdateConnectorApiKeyIdAction.Request instance,
+        TransportVersion version
+    ) {
+        return instance;
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -128,6 +128,7 @@ public class Constants {
         "cluster:admin/xpack/connector/list",
         "cluster:admin/xpack/connector/post",
         "cluster:admin/xpack/connector/put",
+        "cluster:admin/xpack/connector/update_api_key_id",
         "cluster:admin/xpack/connector/update_configuration",
         "cluster:admin/xpack/connector/update_error",
         "cluster:admin/xpack/connector/update_filtering",


### PR DESCRIPTION
- Add `api_key_secret_id` field
- Add PUT endpoint for updating `api_key_id` and/or `api_key_secret_id`
- Add unit tests, yaml tests, BWC tests
- Add toXContent test to ensure adding new field doesn't break serverless

You can test these changes by going to Dev tools and running the following:
```
PUT /_connector/<connector_id>/_api_key_id
{
  "api_key_id": "foo",
  "api_key_secret_id": "bar"
}

```