### PR TITLE
Add gradle task to update the min CCS transport version

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/AbstractVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/AbstractVersionsTask.java
@@ -8,10 +8,16 @@
 
 package org.elasticsearch.gradle.internal.release;
 
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+
 import org.gradle.api.DefaultTask;
 import org.gradle.initialization.layout.BuildLayout;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 public abstract class AbstractVersionsTask extends DefaultTask {
 
@@ -19,6 +25,7 @@ public abstract class AbstractVersionsTask extends DefaultTask {
     static final String INDEX_VERSION_TYPE = "IndexVersion";
 
     static final String SERVER_MODULE_PATH = "server/src/main/java/";
+    static final String VERSION_FILE_PATH = SERVER_MODULE_PATH + "org/elasticsearch/Version.java";
     static final String TRANSPORT_VERSION_FILE_PATH = SERVER_MODULE_PATH + "org/elasticsearch/TransportVersions.java";
     static final String INDEX_VERSION_FILE_PATH = SERVER_MODULE_PATH + "org/elasticsearch/index/IndexVersions.java";
 
@@ -32,4 +39,10 @@ public abstract class AbstractVersionsTask extends DefaultTask {
         rootDir = layout.getRootDirectory().toPath();
     }
 
+    static void writeOutNewContents(Path file, CompilationUnit unit) throws IOException {
+        if (unit.containsData(LexicalPreservingPrinter.NODE_TEXT_DATA) == false) {
+            throw new IllegalArgumentException("CompilationUnit has no lexical information for output");
+        }
+        Files.writeString(file, LexicalPreservingPrinter.print(unit), StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/ReleaseToolsPlugin.java
@@ -49,6 +49,7 @@ public class ReleaseToolsPlugin implements Plugin<Project> {
 
         project.getTasks()
             .register("updateVersions", UpdateVersionsTask.class, t -> project.getTasks().named("spotlessApply").get().mustRunAfter(t));
+        project.getTasks().register("setMinCcsVersion", SetMinCCSVersionTask.class);
 
         project.getTasks().register("extractCurrentVersions", ExtractCurrentVersionsTask.class);
         project.getTasks().register("tagVersions", TagVersionsTask.class);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/SetMinCCSVersionTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/SetMinCCSVersionTask.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.release;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.expr.IntegerLiteralExpr;
+import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinter;
+
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.initialization.layout.BuildLayout;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import javax.inject.Inject;
+
+public class SetMinCCSVersionTask extends AbstractVersionsTask {
+
+    private static final String MINIMUM_CCS_VERSION_FIELD = "MINIMUM_CCS_VERSION";
+
+    private int versionToSet = -1;
+
+    @Inject
+    public SetMinCCSVersionTask(BuildLayout layout) {
+        super(layout);
+    }
+
+    @Option(option = "min-ccs-version", description = "The version id to set as the minimum CCS version")
+    public void minCcsVersion(String versionId) {
+        versionToSet = Integer.parseInt(versionId);
+    }
+
+    @TaskAction
+    public void executeTask() throws IOException {
+        if (versionToSet == -1) {
+            throw new IllegalArgumentException("Version not specified");
+        }
+
+        Path tvJava = rootDir.resolve(TRANSPORT_VERSION_FILE_PATH);
+        CompilationUnit file = LexicalPreservingPrinter.setup(StaticJavaParser.parse(tvJava));
+
+        setMinCcsVersionField(file, versionToSet);
+
+        writeOutNewContents(tvJava, file);
+    }
+
+    static void setMinCcsVersionField(CompilationUnit file, int version) {
+        ClassOrInterfaceDeclaration tvs = file.getClassByName("TransportVersions").get();
+
+        FieldDeclaration minCcsField = tvs.getFieldByName(MINIMUM_CCS_VERSION_FIELD)
+            .orElseThrow(() -> new IllegalArgumentException("Could not find " + MINIMUM_CCS_VERSION_FIELD + " constant"));
+
+        if (minCcsField.getVariable(0).getInitializer().get().isNameExpr() == false) {
+            throw new IllegalArgumentException(MINIMUM_CCS_VERSION_FIELD + " initializer is not a single field, cannot update");
+        }
+
+        var versionField = tvs.findFirst(FieldDeclaration.class, f -> {
+            var ints = f.findAll(IntegerLiteralExpr.class);
+            return ints.size() == 1 && ints.get(0).asNumber().intValue() == version;
+        }).orElseThrow(() -> new IllegalArgumentException("Could not find constant for version id " + version));
+
+        minCcsField.getVariable(0).setInitializer(versionField.getVariable(0).getNameAsExpression());
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/release/UpdateVersionsTask.java
@@ -23,7 +23,6 @@ import com.github.javaparser.printer.lexicalpreservation.LexicalPreservingPrinte
 import com.google.common.annotations.VisibleForTesting;
 
 import org.elasticsearch.gradle.Version;
-import org.gradle.api.DefaultTask;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.TaskAction;
@@ -32,9 +31,7 @@ import org.gradle.initialization.layout.BuildLayout;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
@@ -62,7 +59,7 @@ import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.space
 import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.string;
 import static com.github.javaparser.printer.concretesyntaxmodel.CsmElement.token;
 
-public class UpdateVersionsTask extends DefaultTask {
+public class UpdateVersionsTask extends AbstractVersionsTask {
 
     static {
         replaceDefaultJavaParserClassCsm();
@@ -127,12 +124,7 @@ public class UpdateVersionsTask extends DefaultTask {
 
     private static final Logger LOGGER = Logging.getLogger(UpdateVersionsTask.class);
 
-    static final String SERVER_MODULE_PATH = "server/src/main/java/";
-    static final String VERSION_FILE_PATH = SERVER_MODULE_PATH + "org/elasticsearch/Version.java";
-
     static final Pattern VERSION_FIELD = Pattern.compile("V_(\\d+)_(\\d+)_(\\d+)(?:_(\\w+))?");
-
-    final Path rootDir;
 
     @Nullable
     private Version addVersion;
@@ -142,7 +134,7 @@ public class UpdateVersionsTask extends DefaultTask {
 
     @Inject
     public UpdateVersionsTask(BuildLayout layout) {
-        rootDir = layout.getRootDirectory().toPath();
+        super(layout);
     }
 
     @Option(option = "add-version", description = "Specifies the version to add")
@@ -286,12 +278,5 @@ public class UpdateVersionsTask extends DefaultTask {
         declaration.get().remove();
 
         return Optional.of(versionJava);
-    }
-
-    static void writeOutNewContents(Path file, CompilationUnit unit) throws IOException {
-        if (unit.containsData(LexicalPreservingPrinter.NODE_TEXT_DATA) == false) {
-            throw new IllegalArgumentException("CompilationUnit has no lexical information for output");
-        }
-        Files.writeString(file, LexicalPreservingPrinter.print(unit), StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
     }
 }

--- a/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/SetMinCCSVersionTaskTests.java
+++ b/build-tools-internal/src/test/java/org/elasticsearch/gradle/internal/release/SetMinCCSVersionTaskTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.release;
+
+import com.github.javaparser.StaticJavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasToString;
+
+public class SetMinCCSVersionTaskTests {
+
+    @Test
+    public void setCcsVersion() {
+        final String transportVersionsJava = """
+            public class TransportVersions {
+                public static final TransportVersion V_1 = 10;
+                public static final TransportVersion V_2 = 20;
+                public static final TransportVersion V_3 = 30;
+                public static final TransportVersion V_4 = 40;
+
+                public static final TransportVersion MINIMUM_CCS_VERSION = V_3;
+            }""";
+        final String updatedTransportVersionsJava = """
+            public class TransportVersions {
+
+                public static final TransportVersion V_1 = 10;
+
+                public static final TransportVersion V_2 = 20;
+
+                public static final TransportVersion V_3 = 30;
+
+                public static final TransportVersion V_4 = 40;
+
+                public static final TransportVersion MINIMUM_CCS_VERSION = V_4;
+            }
+            """;
+
+        CompilationUnit unit = StaticJavaParser.parse(transportVersionsJava);
+
+        SetMinCCSVersionTask.setMinCcsVersionField(unit, 40);
+
+        assertThat(unit, hasToString(updatedTransportVersionsJava));
+    }
+}


### PR DESCRIPTION
Called like `./gradlew setMinCcsVersion --min-ccs-version=8624000`. This should be called on `main` when a new minor release is finalized, to set the min ccs version to the transport version used by that release.