### PR TITLE
ESQL: Fix out of range filter floats

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -335,9 +335,8 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
             "long",
             // TODO: https://github.com/elastic/elasticsearch/issues/102935
             // "unsigned_long",
-            // TODO: https://github.com/elastic/elasticsearch/issues/100130
-            // "half_float",
-            // "float",
+            "half_float",
+            "float",
             "double",
             "scaled_float"
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -177,9 +177,6 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 var type = EsqlDataTypes.widenSmallNumericTypes(t.getDataType());
                 // due to a bug also copy the field since the Attribute hierarchy extracts the data type
                 // directly even if the data type is passed explicitly
-                if (type != t.getDataType()) {
-                    t = new EsField(t.getName(), type, t.getProperties(), t.isAggregatable(), t.isAlias());
-                }
 
                 // primitive branch
                 if (EsqlDataTypes.isPrimitive(type)) {
@@ -187,7 +184,8 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                     if (t instanceof UnsupportedEsField uef) {
                         attribute = new UnsupportedAttribute(source, name, uef);
                     } else {
-                        attribute = new FieldAttribute(source, null, name, t);
+                        // The contained EsField retains its original data type, but the FieldAttribute's type is the widened one.
+                        attribute = new FieldAttribute(source, null, name, t).withDataType(type);
                     }
                     list.add(attribute);
                 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlTranslatorHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlTranslatorHandler.java
@@ -164,12 +164,13 @@ public final class EsqlTranslatorHandler extends QlTranslatorHandler {
             }
 
             DataType valueType = bc.right().dataType();
-            DataType attributeDataType = bc.left().dataType();
+            // The EsField contains the original field data type, the containing FieldAttribute's type might be widened.
+            DataType fieldDataType = ((FieldAttribute) bc.left()).field().getDataType();
             if (valueType == UNSIGNED_LONG && value instanceof Long ul) {
                 value = unsignedLongAsNumber(ul);
             }
             Number num = (Number) value;
-            if (isInRange(attributeDataType, valueType, num)) {
+            if (isInRange(fieldDataType, valueType, num)) {
                 return null;
             }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -76,10 +76,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     private static final String PARAM_FORMATTING = "%1$s";
 
-    /**
-     * Estimated size of a keyword field in bytes.
-     */
-    private static final int KEYWORD_EST = EstimatesRowSize.estimateSize(DataTypes.KEYWORD);
+    private static final double HALF_FLOAT_MAX = 65504;
 
     private EsqlParser parser;
     private Analyzer analyzer;
@@ -429,13 +426,20 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
         String largerThanLong = String.valueOf(randomDoubleBetween(longUpperBoundExclusive, Double.MAX_VALUE, true));
         String smallerThanLong = String.valueOf(randomDoubleBetween(-Double.MAX_VALUE, longLowerBoundExclusive, true));
 
+        String largerThanHalfFloat = String.valueOf(randomDoubleBetween(HALF_FLOAT_MAX, Double.MAX_VALUE, false));
+        String smallerThanHalfFloat = String.valueOf(randomDoubleBetween(-Double.MAX_VALUE, -HALF_FLOAT_MAX, true));
+
+        String largerThanFloat = String.valueOf(randomDoubleBetween(Float.MAX_VALUE, Double.MAX_VALUE, false));
+        String smallerThanFloat = String.valueOf(randomDoubleBetween(-Double.MAX_VALUE, -Float.MAX_VALUE, true));
+
         List<OutOfRangeTestCase> cases = List.of(
             new OutOfRangeTestCase("byte", smallerThanInteger, largerThanInteger),
             new OutOfRangeTestCase("short", smallerThanInteger, largerThanInteger),
             new OutOfRangeTestCase("integer", smallerThanInteger, largerThanInteger),
             new OutOfRangeTestCase("long", smallerThanLong, largerThanLong),
             // TODO: add unsigned_long https://github.com/elastic/elasticsearch/issues/102935
-            // TODO: add half_float, float https://github.com/elastic/elasticsearch/issues/100130
+            new OutOfRangeTestCase("half_float", smallerThanHalfFloat, largerThanHalfFloat),
+            new OutOfRangeTestCase("float", smallerThanFloat, largerThanFloat),
             new OutOfRangeTestCase("double", "-1.0/0.0", "1.0/0.0"),
             new OutOfRangeTestCase("scaled_float", "-1.0/0.0", "1.0/0.0")
         );

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/FieldAttribute.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/FieldAttribute.java
@@ -132,7 +132,7 @@ public class FieldAttribute extends TypedAttribute {
         boolean synthetic
     ) {
         FieldAttribute qualifiedParent = parent != null ? (FieldAttribute) parent.withQualifier(qualifier) : null;
-        return new FieldAttribute(source, qualifiedParent, name, field, qualifier, nullability, id, synthetic);
+        return new FieldAttribute(source, qualifiedParent, name, type, field, qualifier, nullability, id, synthetic);
     }
 
     @Override


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/100130

When analyzing a mapping, field data types are [widened](https://github.com/elastic/elasticsearch/blob/125c1c86af1529edbb02f272792586a878735055/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java#L207) in ESQL, e.g. `half_float -> double` and `byte -> integer`.
More specifically, we map fields to a `FieldAttribute`, which wraps an `EsField` object, and both have the new, widened type.

Instead, use the widened data type only in the `FieldAttribute`, but retain the original type in the contained `EsField`; use this to trivialize comparisons like `WHERE some_float < 1E300` (which currently lead to errors) when pushing down filters.