### PR TITLE
Mute RatedRequestsTests.testSuggestionsNotAllowed

### DIFF
--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -266,6 +266,8 @@ public class RatedRequestsTests extends ESTestCase {
     }
 
     public void testSuggestionsNotAllowed() {
+        assumeFalse("https://github.com/elastic/elasticsearch/issues/104570", Constants.WINDOWS);
+
         List<RatedDocument> ratedDocs = Arrays.asList(new RatedDocument("index1", "id1", 1));
         SearchSourceBuilder query = new SearchSourceBuilder();
         query.suggest(new SuggestBuilder().addSuggestion("id", SuggestBuilders.completionSuggestion("fieldname")));


### PR DESCRIPTION
Related to #104570

Similar mutes to https://github.com/elastic/elasticsearch/pull/104853, https://github.com/elastic/elasticsearch/pull/104922