### PR TITLE
Expose forbidden apis fail on missing classes option

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/CheckForbiddenApisTask.java
@@ -98,6 +98,7 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
     private File resourcesDir;
 
     private boolean ignoreFailures = false;
+    private boolean ignoreMissingClasses = false;
 
     @Input
     @Optional
@@ -250,6 +251,15 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
         this.ignoreFailures = ignoreFailures;
     }
 
+    @Input
+    public boolean getIgnoreMissingClasses() {
+        return ignoreMissingClasses;
+    }
+
+    public void setIgnoreMissingClasses(boolean ignoreMissingClasses) {
+        this.ignoreMissingClasses = ignoreMissingClasses;
+    }
+
     /**
      * The default compiler target version used to expand references to bundled JDK signatures.
      * E.g., if you use "jdk-deprecated", it will expand to this version.
@@ -378,6 +388,7 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
             parameters.getSignatures().set(getSignatures());
             parameters.getTargetCompatibility().set(getTargetCompatibility());
             parameters.getIgnoreFailures().set(getIgnoreFailures());
+            parameters.getIgnoreMissingClasses().set(getIgnoreMissingClasses());
             parameters.getSuccessMarker().set(getSuccessMarker());
             parameters.getSignaturesFiles().from(getSignaturesFiles());
         });
@@ -514,7 +525,9 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
         @NotNull
         private Checker createChecker(URLClassLoader urlLoader) {
             final EnumSet<Checker.Option> options = EnumSet.noneOf(Checker.Option.class);
-            options.add(FAIL_ON_MISSING_CLASSES);
+            if (getParameters().getIgnoreMissingClasses().get() == false) {
+                options.add(FAIL_ON_MISSING_CLASSES);
+            }
             if (getParameters().getIgnoreFailures().get() == false) {
                 options.add(FAIL_ON_VIOLATION);
             }
@@ -572,6 +585,8 @@ public abstract class CheckForbiddenApisTask extends DefaultTask implements Patt
         Property<String> getTargetCompatibility();
 
         Property<Boolean> getIgnoreFailures();
+
+        Property<Boolean> getIgnoreMissingClasses();
 
         ListProperty<String> getSignatures();
 


### PR DESCRIPTION
The forbidden apis task always fails when classes are missing. Sometimes we may want to not fail, for example when it is not possible to get to the classes in question, as is the case with preview features. This commit adds an ignoreMissingClasses option to the forbidden apis task and extends the worker to conditionally use the forbidden apis option to fail on missing classes.