### PR TITLE
[Transform] Add code comments for MIN_FREQUENCY and MAX_FREQUENCY constants

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PutTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PutTransformAction.java
@@ -31,7 +31,20 @@ public class PutTransformAction extends ActionType<AcknowledgedResponse> {
     public static final PutTransformAction INSTANCE = new PutTransformAction();
     public static final String NAME = "cluster:admin/transform/put";
 
+    /**
+     * Minimum transform frequency used for validation.
+     *
+     * Note: Depending on the environment (on-prem or serverless) the minimum frequency used by scheduler can be higher than this constant.
+     * The actual value used by scheduler is specified by the {@code TransformExtension.getMinFrequency} method.
+     *
+     * Example:
+     * If the user configures transform with frequency=3s but the TransformExtension.getMinFrequency method returns 5s, the validation will
+     * pass but the scheduler will silently use 5s instead of 3s.
+     */
     private static final TimeValue MIN_FREQUENCY = TimeValue.timeValueSeconds(1);
+    /**
+     * Maximum transform frequency used for validation.
+     */
     private static final TimeValue MAX_FREQUENCY = TimeValue.timeValueHours(1);
 
     private PutTransformAction() {


### PR DESCRIPTION
This PR adds code comments that explain the relationship between `MIN_FREQUENCY` used for validation and `TransformExtension.getMinFrequency` used by scheduler.