### PR TITLE
Extract interface from ModelRegistry so it can be used from server

### DIFF
--- a/server/src/main/java/org/elasticsearch/inference/InferenceServiceRegistry.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceServiceRegistry.java
@@ -13,49 +13,41 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
-public class InferenceServiceRegistry implements Closeable {
+public interface InferenceServiceRegistry extends Closeable {
+    void init(Client client);
 
-    private final Map<String, InferenceService> services;
-    private final List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>();
+    Map<String, InferenceService> getServices();
 
-    public InferenceServiceRegistry(
-        List<InferenceServiceExtension> inferenceServicePlugins,
-        InferenceServiceExtension.InferenceServiceFactoryContext factoryContext
-    ) {
-        // TODO check names are unique
-        services = inferenceServicePlugins.stream()
-            .flatMap(r -> r.getInferenceServiceFactories().stream())
-            .map(factory -> factory.create(factoryContext))
-            .collect(Collectors.toMap(InferenceService::name, Function.identity()));
-    }
+    Optional<InferenceService> getService(String serviceName);
 
-    public void init(Client client) {
-        services.values().forEach(s -> s.init(client));
-    }
+    List<NamedWriteableRegistry.Entry> getNamedWriteables();
 
-    public Map<String, InferenceService> getServices() {
-        return services;
-    }
+    class NoopInferenceServiceRegistry implements InferenceServiceRegistry {
+        public NoopInferenceServiceRegistry() {}
 
-    public Optional<InferenceService> getService(String serviceName) {
-        return Optional.ofNullable(services.get(serviceName));
-    }
+        @Override
+        public void init(Client client) {}
 
-    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
-        return namedWriteables;
-    }
-
-    @Override
-    public void close() throws IOException {
-        for (var service : services.values()) {
-            service.close();
+        @Override
+        public Map<String, InferenceService> getServices() {
+            return Map.of();
         }
+
+        @Override
+        public Optional<InferenceService> getService(String serviceName) {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+            return List.of();
+        }
+
+        @Override
+        public void close() throws IOException {}
     }
 }

--- a/server/src/main/java/org/elasticsearch/inference/InferenceServiceRegistryImpl.java
+++ b/server/src/main/java/org/elasticsearch/inference/InferenceServiceRegistryImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class InferenceServiceRegistryImpl implements InferenceServiceRegistry {
+
+    private final Map<String, InferenceService> services;
+    private final List<NamedWriteableRegistry.Entry> namedWriteables = new ArrayList<>();
+
+    public InferenceServiceRegistryImpl(
+        List<InferenceServiceExtension> inferenceServicePlugins,
+        InferenceServiceExtension.InferenceServiceFactoryContext factoryContext
+    ) {
+        // TODO check names are unique
+        services = inferenceServicePlugins.stream()
+            .flatMap(r -> r.getInferenceServiceFactories().stream())
+            .map(factory -> factory.create(factoryContext))
+            .collect(Collectors.toMap(InferenceService::name, Function.identity()));
+    }
+
+    @Override
+    public void init(Client client) {
+        services.values().forEach(s -> s.init(client));
+    }
+
+    @Override
+    public Map<String, InferenceService> getServices() {
+        return services;
+    }
+
+    @Override
+    public Optional<InferenceService> getService(String serviceName) {
+        return Optional.ofNullable(services.get(serviceName));
+    }
+
+    @Override
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return namedWriteables;
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (var service : services.values()) {
+            service.close();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/inference/ModelRegistry.java
+++ b/server/src/main/java/org/elasticsearch/inference/ModelRegistry.java
@@ -60,4 +60,40 @@ public interface ModelRegistry {
         Map<String, Object> settings,
         Map<String, Object> secrets
     ) {}
+
+    class NoopModelRegistry implements ModelRegistry {
+        @Override
+        public void getModel(String modelId, ActionListener<UnparsedModel> listener) {
+            fail(listener);
+        }
+
+        @Override
+        public void getModelsByTaskType(TaskType taskType, ActionListener<List<UnparsedModel>> listener) {
+            listener.onResponse(List.of());
+        }
+
+        @Override
+        public void getAllModels(ActionListener<List<UnparsedModel>> listener) {
+            listener.onResponse(List.of());
+        }
+
+        @Override
+        public void storeModel(Model model, ActionListener<Boolean> listener) {
+            fail(listener);
+        }
+
+        @Override
+        public void deleteModel(String modelId, ActionListener<Boolean> listener) {
+            fail(listener);
+        }
+
+        @Override
+        public void getModelWithSecrets(String inferenceEntityId, ActionListener<UnparsedModel> listener) {
+            fail(listener);
+        }
+
+        private static void fail(ActionListener<?> listener) {
+            listener.onFailure(new IllegalArgumentException("No model registry configured"));
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/inference/ModelRegistry.java
+++ b/server/src/main/java/org/elasticsearch/inference/ModelRegistry.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.inference;
+
+import org.elasticsearch.action.ActionListener;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ModelRegistry {
+
+    /**
+     * Get a model.
+     * Secret settings are not included
+     * @param inferenceEntityId Model to get
+     * @param listener Model listener
+     */
+    void getModel(String inferenceEntityId, ActionListener<UnparsedModel> listener);
+
+    /**
+     * Get a model with its secret settings
+     * @param inferenceEntityId Model to get
+     * @param listener Model listener
+     */
+    void getModelWithSecrets(String inferenceEntityId, ActionListener<UnparsedModel> listener);
+
+    /**
+     * Get all models of a particular task type.
+     * Secret settings are not included
+     * @param taskType The task type
+     * @param listener Models listener
+     */
+    void getModelsByTaskType(TaskType taskType, ActionListener<List<UnparsedModel>> listener);
+
+    /**
+     * Get all models.
+     * Secret settings are not included
+     * @param listener Models listener
+     */
+    void getAllModels(ActionListener<List<UnparsedModel>> listener);
+
+    void storeModel(Model model, ActionListener<Boolean> listener);
+
+    void deleteModel(String modelId, ActionListener<Boolean> listener);
+
+    /**
+     * Semi parsed model where inference entity id, task type and service
+     * are known but the settings are not parsed.
+     */
+    record UnparsedModel(
+        String inferenceEntityId,
+        TaskType taskType,
+        String service,
+        Map<String, Object> settings,
+        Map<String, Object> secrets
+    ) {}
+}

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -143,6 +143,7 @@ import org.elasticsearch.plugins.ClusterCoordinationPlugin;
 import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.HealthPlugin;
+import org.elasticsearch.plugins.InferenceRegistryPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.MetadataUpgrader;
@@ -1090,24 +1091,20 @@ class NodeConstruction {
         }
 
         // Register noop versions of inference services if Inference plugin is not available
-        if (isPluginComponentDefined(pluginComponents, InferenceServiceRegistry.class) == false) {
-            logger.warn("Inference service is not available");
-            modules.bindToInstance(InferenceServiceRegistry.class, new InferenceServiceRegistry.NoopInferenceServiceRegistry());
-        }
-        if (isPluginComponentDefined(pluginComponents, ModelRegistry.class) == false) {
-            logger.warn("Model registry is not available");
-            modules.bindToInstance(ModelRegistry.class, new ModelRegistry.NoopModelRegistry());
-        }
+        Optional<InferenceRegistryPlugin> inferenceRegistryPlugin = getSinglePlugin(InferenceRegistryPlugin.class);
+        modules.bindToInstance(
+            InferenceServiceRegistry.class,
+            inferenceRegistryPlugin.map(InferenceRegistryPlugin::getInferenceServiceRegistry)
+                .orElse(new InferenceServiceRegistry.NoopInferenceServiceRegistry())
+        );
+        modules.bindToInstance(
+            ModelRegistry.class,
+            inferenceRegistryPlugin.map(InferenceRegistryPlugin::getModelRegistry).orElse(new ModelRegistry.NoopModelRegistry())
+        );
 
         injector = modules.createInjector();
 
         postInjection(clusterModule, actionModule, clusterService, transportService, featureService);
-    }
-
-    private static boolean isPluginComponentDefined(Collection<?> pluginComponents, Class<?> clazz) {
-        return pluginComponents.stream()
-            .map(p -> p instanceof PluginComponentBinding ? ((PluginComponentBinding) p).impl() : p)
-            .anyMatch(p -> clazz.isAssignableFrom(clazz));
     }
 
     private ClusterService createClusterService(SettingsModule settingsModule, ThreadPool threadPool, TaskManager taskManager) {

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1090,16 +1090,24 @@ class NodeConstruction {
         }
 
         // Register noop versions of inference services if Inference plugin is not available
-        if (pluginComponents.stream().noneMatch(p -> p instanceof InferenceServiceRegistry)) {
+        if (isPluginComponentDefined(pluginComponents, InferenceServiceRegistry.class) == false) {
+            logger.warn("Inference service is not available");
             modules.bindToInstance(InferenceServiceRegistry.class, new InferenceServiceRegistry.NoopInferenceServiceRegistry());
         }
-        if (pluginComponents.stream().noneMatch(p -> p instanceof ModelRegistry)) {
+        if (isPluginComponentDefined(pluginComponents, ModelRegistry.class) == false) {
+            logger.warn("Model registry is not available");
             modules.bindToInstance(ModelRegistry.class, new ModelRegistry.NoopModelRegistry());
         }
 
         injector = modules.createInjector();
 
         postInjection(clusterModule, actionModule, clusterService, transportService, featureService);
+    }
+
+    private static boolean isPluginComponentDefined(Collection<?> pluginComponents, Class<?> clazz) {
+        return pluginComponents.stream()
+            .map(p -> p instanceof PluginComponentBinding ? ((PluginComponentBinding) p).impl() : p)
+            .anyMatch(p -> clazz.isAssignableFrom(clazz));
     }
 
     private ClusterService createClusterService(SettingsModule settingsModule, ThreadPool threadPool, TaskManager taskManager) {

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -123,6 +123,8 @@ import org.elasticsearch.indices.recovery.SnapshotFilesProvider;
 import org.elasticsearch.indices.recovery.plan.PeerOnlyRecoveryPlannerService;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
 import org.elasticsearch.indices.recovery.plan.ShardSnapshotsService;
+import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.ModelRegistry;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.monitor.MonitorService;
 import org.elasticsearch.monitor.fs.FsHealthService;
@@ -1085,6 +1087,14 @@ class NodeConstruction {
                 ReadinessService.class,
                 serviceProvider.newReadinessService(pluginsService, clusterService, environment)
             );
+        }
+
+        // Register noop versions of inference services if Inference plugin is not available
+        if (pluginComponents.stream().noneMatch(p -> p instanceof InferenceServiceRegistry)) {
+            modules.bindToInstance(InferenceServiceRegistry.class, new InferenceServiceRegistry.NoopInferenceServiceRegistry());
+        }
+        if (pluginComponents.stream().noneMatch(p -> p instanceof ModelRegistry)) {
+            modules.bindToInstance(ModelRegistry.class, new ModelRegistry.NoopModelRegistry());
         }
 
         injector = modules.createInjector();

--- a/server/src/main/java/org/elasticsearch/plugins/InferenceRegistryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/InferenceRegistryPlugin.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.ModelRegistry;
+
+/**
+ * Plugins that provide inference services should implement this interface.
+ * There should be a single one in the classpath, as we currently support a single instance for ModelRegistry / InfereceServiceRegistry.
+ */
+public interface InferenceRegistryPlugin {
+    InferenceServiceRegistry getInferenceServiceRegistry();
+
+    ModelRegistry getModelRegistry();
+}

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryImplIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/integration/ModelRegistryImplIT.java
@@ -25,7 +25,7 @@ import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.InferencePlugin;
-import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.elasticsearch.xpack.inference.registry.ModelRegistryImpl;
 import org.elasticsearch.xpack.inference.services.elser.ElserMlNodeModel;
 import org.elasticsearch.xpack.inference.services.elser.ElserMlNodeService;
 import org.elasticsearch.xpack.inference.services.elser.ElserMlNodeServiceSettingsTests;
@@ -54,13 +54,13 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 
-public class ModelRegistryIT extends ESSingleNodeTestCase {
+public class ModelRegistryImplIT extends ESSingleNodeTestCase {
 
-    private ModelRegistry modelRegistry;
+    private ModelRegistryImpl ModelRegistryImpl;
 
     @Before
     public void createComponents() {
-        modelRegistry = new ModelRegistry(client());
+        ModelRegistryImpl = new ModelRegistryImpl(client());
     }
 
     @Override
@@ -74,7 +74,7 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
         AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 
-        blockingCall(listener -> modelRegistry.storeModel(model, listener), storeModelHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.storeModel(model, listener), storeModelHolder, exceptionHolder);
 
         assertThat(storeModelHolder.get(), is(true));
         assertThat(exceptionHolder.get(), is(nullValue()));
@@ -86,7 +86,7 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
         AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 
-        blockingCall(listener -> modelRegistry.storeModel(model, listener), storeModelHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.storeModel(model, listener), storeModelHolder, exceptionHolder);
 
         assertNull(storeModelHolder.get());
         assertNotNull(exceptionHolder.get());
@@ -105,12 +105,12 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
         AtomicReference<Boolean> putModelHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 
-        blockingCall(listener -> modelRegistry.storeModel(model, listener), putModelHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.storeModel(model, listener), putModelHolder, exceptionHolder);
         assertThat(putModelHolder.get(), is(true));
 
         // now get the model
-        AtomicReference<ModelRegistry.UnparsedModel> modelHolder = new AtomicReference<>();
-        blockingCall(listener -> modelRegistry.getModelWithSecrets(inferenceEntityId, listener), modelHolder, exceptionHolder);
+        AtomicReference<ModelRegistryImpl.UnparsedModel> modelHolder = new AtomicReference<>();
+        blockingCall(listener -> ModelRegistryImpl.getModelWithSecrets(inferenceEntityId, listener), modelHolder, exceptionHolder);
         assertThat(exceptionHolder.get(), is(nullValue()));
         assertThat(modelHolder.get(), not(nullValue()));
 
@@ -132,13 +132,13 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
         AtomicReference<Boolean> putModelHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 
-        blockingCall(listener -> modelRegistry.storeModel(model, listener), putModelHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.storeModel(model, listener), putModelHolder, exceptionHolder);
         assertThat(putModelHolder.get(), is(true));
         assertThat(exceptionHolder.get(), is(nullValue()));
 
         putModelHolder.set(false);
         // an model with the same id exists
-        blockingCall(listener -> modelRegistry.storeModel(model, listener), putModelHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.storeModel(model, listener), putModelHolder, exceptionHolder);
         assertThat(putModelHolder.get(), is(false));
         assertThat(exceptionHolder.get(), not(nullValue()));
         assertThat(
@@ -153,20 +153,20 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
             Model model = buildElserModelConfig(id, TaskType.SPARSE_EMBEDDING);
             AtomicReference<Boolean> putModelHolder = new AtomicReference<>();
             AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
-            blockingCall(listener -> modelRegistry.storeModel(model, listener), putModelHolder, exceptionHolder);
+            blockingCall(listener -> ModelRegistryImpl.storeModel(model, listener), putModelHolder, exceptionHolder);
             assertThat(putModelHolder.get(), is(true));
         }
 
         AtomicReference<Boolean> deleteResponseHolder = new AtomicReference<>();
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
-        blockingCall(listener -> modelRegistry.deleteModel("model1", listener), deleteResponseHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.deleteModel("model1", listener), deleteResponseHolder, exceptionHolder);
         assertThat(exceptionHolder.get(), is(nullValue()));
         assertTrue(deleteResponseHolder.get());
 
         // get should fail
         deleteResponseHolder.set(false);
-        AtomicReference<ModelRegistry.UnparsedModel> modelHolder = new AtomicReference<>();
-        blockingCall(listener -> modelRegistry.getModelWithSecrets("model1", listener), modelHolder, exceptionHolder);
+        AtomicReference<ModelRegistryImpl.UnparsedModel> modelHolder = new AtomicReference<>();
+        blockingCall(listener -> ModelRegistryImpl.getModelWithSecrets("model1", listener), modelHolder, exceptionHolder);
 
         assertThat(exceptionHolder.get(), not(nullValue()));
         assertFalse(deleteResponseHolder.get());
@@ -186,13 +186,13 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
             AtomicReference<Boolean> putModelHolder = new AtomicReference<>();
             AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 
-            blockingCall(listener -> modelRegistry.storeModel(model, listener), putModelHolder, exceptionHolder);
+            blockingCall(listener -> ModelRegistryImpl.storeModel(model, listener), putModelHolder, exceptionHolder);
             assertThat(putModelHolder.get(), is(true));
         }
 
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
-        AtomicReference<List<ModelRegistry.UnparsedModel>> modelHolder = new AtomicReference<>();
-        blockingCall(listener -> modelRegistry.getModelsByTaskType(TaskType.SPARSE_EMBEDDING, listener), modelHolder, exceptionHolder);
+        AtomicReference<List<ModelRegistryImpl.UnparsedModel>> modelHolder = new AtomicReference<>();
+        blockingCall(listener -> ModelRegistryImpl.getModelsByTaskType(TaskType.SPARSE_EMBEDDING, listener), modelHolder, exceptionHolder);
         assertThat(modelHolder.get(), hasSize(3));
         var sparseIds = sparseAndTextEmbeddingModels.stream()
             .filter(m -> m.getConfigurations().getTaskType() == TaskType.SPARSE_EMBEDDING)
@@ -203,7 +203,7 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
             assertThat(m.secrets().keySet(), empty());
         });
 
-        blockingCall(listener -> modelRegistry.getModelsByTaskType(TaskType.TEXT_EMBEDDING, listener), modelHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.getModelsByTaskType(TaskType.TEXT_EMBEDDING, listener), modelHolder, exceptionHolder);
         assertThat(modelHolder.get(), hasSize(2));
         var denseIds = sparseAndTextEmbeddingModels.stream()
             .filter(m -> m.getConfigurations().getTaskType() == TaskType.TEXT_EMBEDDING)
@@ -227,13 +227,13 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
             var model = createModel(randomAlphaOfLength(5), randomFrom(TaskType.values()), service);
             createdModels.add(model);
 
-            blockingCall(listener -> modelRegistry.storeModel(model, listener), putModelHolder, exceptionHolder);
+            blockingCall(listener -> ModelRegistryImpl.storeModel(model, listener), putModelHolder, exceptionHolder);
             assertThat(putModelHolder.get(), is(true));
             assertNull(exceptionHolder.get());
         }
 
-        AtomicReference<List<ModelRegistry.UnparsedModel>> modelHolder = new AtomicReference<>();
-        blockingCall(listener -> modelRegistry.getAllModels(listener), modelHolder, exceptionHolder);
+        AtomicReference<List<ModelRegistryImpl.UnparsedModel>> modelHolder = new AtomicReference<>();
+        blockingCall(listener -> ModelRegistryImpl.getAllModels(listener), modelHolder, exceptionHolder);
         assertThat(modelHolder.get(), hasSize(modelCount));
         var getAllModels = modelHolder.get();
 
@@ -257,18 +257,18 @@ public class ModelRegistryIT extends ESSingleNodeTestCase {
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
 
         var modelWithSecrets = createModelWithSecrets(inferenceEntityId, randomFrom(TaskType.values()), service, secret);
-        blockingCall(listener -> modelRegistry.storeModel(modelWithSecrets, listener), putModelHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.storeModel(modelWithSecrets, listener), putModelHolder, exceptionHolder);
         assertThat(putModelHolder.get(), is(true));
         assertNull(exceptionHolder.get());
 
-        AtomicReference<ModelRegistry.UnparsedModel> modelHolder = new AtomicReference<>();
-        blockingCall(listener -> modelRegistry.getModelWithSecrets(inferenceEntityId, listener), modelHolder, exceptionHolder);
+        AtomicReference<ModelRegistryImpl.UnparsedModel> modelHolder = new AtomicReference<>();
+        blockingCall(listener -> ModelRegistryImpl.getModelWithSecrets(inferenceEntityId, listener), modelHolder, exceptionHolder);
         assertThat(modelHolder.get().secrets().keySet(), hasSize(1));
         var secretSettings = (Map<String, Object>) modelHolder.get().secrets().get("secret_settings");
         assertThat(secretSettings.get("secret"), equalTo(secret));
 
         // get model without secrets
-        blockingCall(listener -> modelRegistry.getModel(inferenceEntityId, listener), modelHolder, exceptionHolder);
+        blockingCall(listener -> ModelRegistryImpl.getModel(inferenceEntityId, listener), modelHolder, exceptionHolder);
         assertThat(modelHolder.get().secrets().keySet(), empty());
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -28,6 +28,7 @@ import org.elasticsearch.inference.ModelRegistry;
 import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.InferenceRegistryPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestController;
@@ -70,7 +71,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class InferencePlugin extends Plugin implements ActionPlugin, ExtensiblePlugin, SystemIndexPlugin {
+public class InferencePlugin extends Plugin implements ActionPlugin, ExtensiblePlugin, SystemIndexPlugin, InferenceRegistryPlugin {
 
     public static final String NAME = "inference";
     public static final String UTILITY_THREAD_POOL_NAME = "inference_utility";
@@ -79,6 +80,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
     private final SetOnce<ServiceComponents> serviceComponents = new SetOnce<>();
 
     private final SetOnce<InferenceServiceRegistry> inferenceServiceRegistry = new SetOnce<>();
+    private final SetOnce<ModelRegistry> modelRegistry = new SetOnce<>();
 
     private List<InferenceServiceExtension> inferenceServiceExtensions;
 
@@ -130,7 +132,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
         );
         httpFactory.set(httpRequestSenderFactory);
 
-        ModelRegistry modelRegistry = new ModelRegistryImpl(services.client());
+        ModelRegistry modelReg = new ModelRegistryImpl(services.client());
 
         if (inferenceServiceExtensions == null) {
             inferenceServiceExtensions = new ArrayList<>();
@@ -139,14 +141,13 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
         inferenceServices.add(this::getInferenceServiceFactories);
 
         var factoryContext = new InferenceServiceExtension.InferenceServiceFactoryContext(services.client());
-        var registry = new InferenceServiceRegistryImpl(inferenceServices, factoryContext);
-        registry.init(services.client());
-        inferenceServiceRegistry.set(registry);
+        var inferenceRegistry = new InferenceServiceRegistryImpl(inferenceServices, factoryContext);
+        inferenceRegistry.init(services.client());
+        inferenceServiceRegistry.set(inferenceRegistry);
+        modelRegistry.set(modelReg);
 
-        return List.of(
-            new PluginComponentBinding<>(ModelRegistry.class, modelRegistry),
-            new PluginComponentBinding<>(InferenceServiceRegistry.class, registry)
-        );
+        // Don't return components as they will be registered using InferenceRegistryPlugin methods to retrieve them
+        return List.of();
     }
 
     @Override
@@ -240,5 +241,15 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
         var throttlerToClose = serviceComponentsRef != null ? serviceComponentsRef.throttlerManager() : null;
 
         IOUtils.closeWhileHandlingException(inferenceServiceRegistry.get(), throttlerToClose);
+    }
+
+    @Override
+    public InferenceServiceRegistry getInferenceServiceRegistry() {
+        return inferenceServiceRegistry.get();
+    }
+
+    @Override
+    public ModelRegistry getModelRegistry() {
+        return modelRegistry.get();
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -23,6 +23,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.InferenceServiceRegistryImpl;
 import org.elasticsearch.inference.ModelRegistry;
 import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.ActionPlugin;
@@ -138,7 +139,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
         inferenceServices.add(this::getInferenceServiceFactories);
 
         var factoryContext = new InferenceServiceExtension.InferenceServiceFactoryContext(services.client());
-        var registry = new InferenceServiceRegistry(inferenceServices, factoryContext);
+        var registry = new InferenceServiceRegistryImpl(inferenceServices, factoryContext);
         registry.init(services.client());
         inferenceServiceRegistry.set(registry);
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -143,13 +143,15 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
         registry.init(services.client());
         inferenceServiceRegistry.set(registry);
 
-        return List.of(new PluginComponentBinding<>(ModelRegistry.class, modelRegistry), registry);
+        return List.of(
+            new PluginComponentBinding<>(ModelRegistry.class, modelRegistry),
+            new PluginComponentBinding<>(InferenceServiceRegistry.class, registry)
+        );
     }
 
     @Override
     public void loadExtensions(ExtensionLoader loader) {
         inferenceServiceExtensions = loader.loadExtensions(InferenceServiceExtension.class);
-        loader.loadExtensions(ModelRegistry.class);
     }
 
     public List<InferenceServiceExtension.Factory> getInferenceServiceFactories() {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -25,7 +25,6 @@ import org.elasticsearch.inference.InferenceServiceExtension;
 import org.elasticsearch.inference.InferenceServiceRegistry;
 import org.elasticsearch.inference.InferenceServiceRegistryImpl;
 import org.elasticsearch.inference.ModelRegistry;
-import org.elasticsearch.node.PluginComponentBinding;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.InferenceRegistryPlugin;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportDeleteInferenceModelAction.java
@@ -23,12 +23,12 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.inference.InferenceServiceRegistry;
+import org.elasticsearch.inference.ModelRegistry;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.inference.action.DeleteInferenceModelAction;
-import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 
 public class TransportDeleteInferenceModelAction extends AcknowledgedTransportMasterNodeAction<DeleteInferenceModelAction.Request> {
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportGetInferenceModelAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.inference.InferenceServiceRegistry;
 import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.ModelRegistry;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
@@ -24,7 +25,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
 import org.elasticsearch.xpack.inference.InferencePlugin;
-import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportInferenceAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportInferenceAction.java
@@ -16,11 +16,11 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.InferenceServiceRegistry;
 import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.ModelRegistry;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.inference.action.InferenceAction;
-import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 
 public class TransportInferenceAction extends HandledTransportAction<InferenceAction.Request, InferenceAction.Response> {
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/TransportPutInferenceModelAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.inference.InferenceService;
 import org.elasticsearch.inference.InferenceServiceRegistry;
 import org.elasticsearch.inference.Model;
 import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.ModelRegistry;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
@@ -42,7 +43,6 @@ import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.core.ml.utils.MlPlatformArchitecturesUtil;
 import org.elasticsearch.xpack.inference.InferencePlugin;
-import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 
 import java.io.IOException;
 import java.util.Map;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryImplTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryImplTests.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ModelRegistryTests extends ESTestCase {
+public class ModelRegistryImplTests extends ESTestCase {
 
     private static final TimeValue TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
 
@@ -65,9 +65,9 @@ public class ModelRegistryTests extends ESTestCase {
         var client = mockClient();
         mockClientExecuteSearch(client, mockSearchResponse(SearchHits.EMPTY));
 
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
 
-        var listener = new PlainActionFuture<ModelRegistry.UnparsedModel>();
+        var listener = new PlainActionFuture<ModelRegistryImpl.UnparsedModel>();
         registry.getModelWithSecrets("1", listener);
 
         ResourceNotFoundException exception = expectThrows(ResourceNotFoundException.class, () -> listener.actionGet(TIMEOUT));
@@ -79,9 +79,9 @@ public class ModelRegistryTests extends ESTestCase {
         var unknownIndexHit = SearchHit.createFromMap(Map.of("_index", "unknown_index"));
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { unknownIndexHit }));
 
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
 
-        var listener = new PlainActionFuture<ModelRegistry.UnparsedModel>();
+        var listener = new PlainActionFuture<ModelRegistryImpl.UnparsedModel>();
         registry.getModelWithSecrets("1", listener);
 
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> listener.actionGet(TIMEOUT));
@@ -96,9 +96,9 @@ public class ModelRegistryTests extends ESTestCase {
         var inferenceSecretsHit = SearchHit.createFromMap(Map.of("_index", ".secrets-inference"));
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceSecretsHit }));
 
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
 
-        var listener = new PlainActionFuture<ModelRegistry.UnparsedModel>();
+        var listener = new PlainActionFuture<ModelRegistryImpl.UnparsedModel>();
         registry.getModelWithSecrets("1", listener);
 
         IllegalStateException exception = expectThrows(IllegalStateException.class, () -> listener.actionGet(TIMEOUT));
@@ -113,9 +113,9 @@ public class ModelRegistryTests extends ESTestCase {
         var inferenceHit = SearchHit.createFromMap(Map.of("_index", ".inference"));
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceHit }));
 
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
 
-        var listener = new PlainActionFuture<ModelRegistry.UnparsedModel>();
+        var listener = new PlainActionFuture<ModelRegistryImpl.UnparsedModel>();
         registry.getModelWithSecrets("1", listener);
 
         IllegalStateException exception = expectThrows(IllegalStateException.class, () -> listener.actionGet(TIMEOUT));
@@ -147,9 +147,9 @@ public class ModelRegistryTests extends ESTestCase {
 
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceHit, inferenceSecretsHit }));
 
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
 
-        var listener = new PlainActionFuture<ModelRegistry.UnparsedModel>();
+        var listener = new PlainActionFuture<ModelRegistryImpl.UnparsedModel>();
         registry.getModelWithSecrets("1", listener);
 
         var modelConfig = listener.actionGet(TIMEOUT);
@@ -176,9 +176,9 @@ public class ModelRegistryTests extends ESTestCase {
 
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceHit }));
 
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
 
-        var listener = new PlainActionFuture<ModelRegistry.UnparsedModel>();
+        var listener = new PlainActionFuture<ModelRegistryImpl.UnparsedModel>();
         registry.getModel("1", listener);
 
         registry.getModel("1", listener);
@@ -201,7 +201,7 @@ public class ModelRegistryTests extends ESTestCase {
         mockClientExecuteBulk(client, bulkResponse);
 
         var model = TestModel.createRandomInstance();
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
         var listener = new PlainActionFuture<Boolean>();
 
         registry.storeModel(model, listener);
@@ -218,7 +218,7 @@ public class ModelRegistryTests extends ESTestCase {
         mockClientExecuteBulk(client, bulkResponse);
 
         var model = TestModel.createRandomInstance();
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
         var listener = new PlainActionFuture<Boolean>();
 
         registry.storeModel(model, listener);
@@ -249,7 +249,7 @@ public class ModelRegistryTests extends ESTestCase {
         mockClientExecuteBulk(client, bulkResponse);
 
         var model = TestModel.createRandomInstance();
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
         var listener = new PlainActionFuture<Boolean>();
 
         registry.storeModel(model, listener);
@@ -275,7 +275,7 @@ public class ModelRegistryTests extends ESTestCase {
         mockClientExecuteBulk(client, bulkResponse);
 
         var model = TestModel.createRandomInstance();
-        var registry = new ModelRegistry(client);
+        var registry = new ModelRegistryImpl(client);
         var listener = new PlainActionFuture<Boolean>();
 
         registry.storeModel(model, listener);


### PR DESCRIPTION
As part of https://github.com/elastic/elasticsearch/pull/103697, there is the need to access `ModelRegistry` and `InferenceServiceRegistry` from `server` code so:
- Inference can be done without using actions
- Model config can be retrieved so it can be added to the inference results

Extracted a `ModelRegistry` and `InferenceServiceRegistry` interface to server and create the implementation class in Inference plugin, so it can be provided from it.

Also, create no-op implementations for these interfaces so they can be polyfilled in case the `InferencePlugin` is not present (like in our tests)