### PR TITLE
[DOCS][ESQL] Document case insensitive equals operator

### DIFF
--- a/docs/reference/esql/functions/binary.asciidoc
+++ b/docs/reference/esql/functions/binary.asciidoc
@@ -11,7 +11,7 @@ Supported types:
 
 include::types/equals.asciidoc[]
 
-==== Case Insensitive Equals `=~`
+==== Case insensitive equality `=~`
 [.text-center]
 //image::esql/functions/signature/case_insensitive_equals.svg[Embedded,opts=inline]
 

--- a/docs/reference/esql/functions/binary.asciidoc
+++ b/docs/reference/esql/functions/binary.asciidoc
@@ -3,13 +3,24 @@
 === Binary operators
 
 [[esql-binary-operators-equality]]
-==== Equality
+==== Equality `==`
 [.text-center]
 image::esql/functions/signature/equals.svg[Embedded,opts=inline]
 
 Supported types:
 
 include::types/equals.asciidoc[]
+
+==== Case Insensitive Equals `=~`
+[.text-center]
+//image::esql/functions/signature/case_insensitive_equals.svg[Embedded,opts=inline]
+
+*lhs* `=~` *rhs*
+// placeholder pending svg
+
+Supported types:
+
+include::types/case_insensitive_equals.asciidoc[]
 
 ==== Inequality `!=`
 [.text-center]

--- a/docs/reference/esql/functions/types/case_insensitive_equals.asciidoc
+++ b/docs/reference/esql/functions/types/case_insensitive_equals.asciidoc
@@ -1,0 +1,5 @@
+[%header.monospaced.styled,format=dsv,separator=|]
+|===
+lhs | rhs | result
+integer | integer | boolean
+|===


### PR DESCRIPTION
Blocked because currently disabled. See https://github.com/elastic/elasticsearch/issues/105603.


- Closes https://github.com/elastic/elasticsearch/issues/104844
- Operator added in https://github.com/elastic/elasticsearch/pull/103656