### PR TITLE
[8.12] Update build tools changelog schema for new Core/Infra/Metrics label (#105016)

### DIFF
--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -59,6 +59,7 @@
             "Infra/Scripting",
             "Infra/Settings",
             "Infra/Transport API",
+            "Infra/Metrics",
             "Ingest",
             "Ingest Node",
             "Java High Level REST Client",


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Update build tools changelog schema for new Core/Infra/Metrics label (#105016)