### PR TITLE
[DOCS] Small fixes for the 'Installing Elasticsearch' page

### DIFF
--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -16,8 +16,8 @@ To set up Elasticsearch in {ecloud}, sign up for a {ess-trial}[free {ecloud} tri
 
 If you want to install and manage {es} yourself, you can:
 
-* Run {es} on any Linux, MacOS, or Windows machine.
-* Run {es} in a <<docker, Docker container>>. 
+* Run {es} using a <<elasticsearch-install-packages,Linux, MacOS, or Windows install package>>.
+* Run {es} in a <<elasticsearch-docker-images,Docker container>>. 
 * Set up and manage {es}, {kib}, {agent}, and the rest of the Elastic Stack on Kubernetes with {eck-ref}[{eck}].
 
 TIP: To try out Elasticsearch on your own machine, we recommend using Docker and running both Elasticsearch and Kibana. For more information, see <<run-elasticsearch-locally,Run Elasticsearch locally>>.
@@ -57,14 +57,20 @@ Elasticsearch website or from our RPM repository.
 +
 <<rpm>>
 
+TIP: For a step-by-step example of setting up the {stack} on your own premises, try out our tutorial: {stack-ref}/installing-stack-demo-self.html[Installing a self-managed Elastic Stack].
+
+[discrete]
+[[elasticsearch-docker-images]]
+=== Elasticsearch container images
+
+You can also run {es} inside a container image.
+
+[horizontal]
 `docker`::
 
-Images are available for running Elasticsearch as Docker containers. They may be
-downloaded from the Elastic Docker Registry.
+Docker container images may be downloaded from the Elastic Docker Registry.
 +
 {ref}/docker.html[Install {es} with Docker]
-
-TIP: For a step-by-step example of setting up the {stack} on your own premises, try out our tutorial: {stack-ref}/installing-stack-demo-self.html[Installing a self-managed Elastic Stack].
 
 [discrete]
 [[jvm-version]]

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -22,8 +22,6 @@ If you want to install and manage {es} yourself, you can:
 
 TIP: To try out Elasticsearch on your own machine, we recommend using Docker and running both Elasticsearch and Kibana. For more information, see <<run-elasticsearch-locally,Run Elasticsearch locally>>.
 
-TIP: For a step-by-step example of setting up the {stack} on your own premises, try out our tutorial: {stack-ref}/installing-stack-demo-self.html[Installing a self-managed Elastic Stack].
-
 [discrete]
 [[elasticsearch-install-packages]]
 === Elasticsearch install packages
@@ -65,6 +63,8 @@ Images are available for running Elasticsearch as Docker containers. They may be
 downloaded from the Elastic Docker Registry.
 +
 {ref}/docker.html[Install {es} with Docker]
+
+TIP: For a step-by-step example of setting up the {stack} on your own premises, try out our tutorial: {stack-ref}/installing-stack-demo-self.html[Installing a self-managed Elastic Stack].
 
 [discrete]
 [[jvm-version]]

--- a/docs/reference/setup/install.asciidoc
+++ b/docs/reference/setup/install.asciidoc
@@ -22,6 +22,8 @@ If you want to install and manage {es} yourself, you can:
 
 TIP: To try out Elasticsearch on your own machine, we recommend using Docker and running both Elasticsearch and Kibana. For more information, see <<run-elasticsearch-locally,Run Elasticsearch locally>>.
 
+TIP: For a step-by-step example of setting up the {stack} on your own premises, try out our tutorial: {stack-ref}/installing-stack-demo-self.html[Installing a self-managed Elastic Stack].
+
 [discrete]
 [[elasticsearch-install-packages]]
 === Elasticsearch install packages

--- a/docs/reference/setup/install/rpm.asciidoc
+++ b/docs/reference/setup/install/rpm.asciidoc
@@ -19,6 +19,8 @@ NOTE: Elasticsearch includes a bundled version of https://openjdk.java.net[OpenJ
 from the JDK maintainers (GPLv2+CE). To use your own version of Java,
 see the <<jvm-version, JVM version requirements>>
 
+TIP: For a step-by-step example of setting up the {stack} on your own premises, try out our tutorial: {stack-ref}/installing-stack-demo-self.html[Installing a self-managed Elastic Stack].
+
 [[rpm-key]]
 ==== Import the Elasticsearch GPG Key
 


### PR DESCRIPTION
This addresses a few items that Chris mentioned in a [comment](https://github.com/elastic/elasticsearch/pull/105034#pullrequestreview-1857602315) below with regard to the [Installing Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html) page, and also adds a link on that page, pointing to a new on-prem install tutorial.

Preview is [here](https://elasticsearch_105034.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/install-elasticsearch.html).

Closes: https://github.com/elastic/ingest-docs/issues/882

