### PR TITLE
Add feature versioning to retrievers

### DIFF
--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/MustachePlugin.java
@@ -67,7 +67,7 @@ public class MustachePlugin extends Plugin implements ScriptPlugin, ActionPlugin
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
         return Arrays.asList(
-            new RestSearchTemplateAction(namedWriteableRegistry),
+            new RestSearchTemplateAction(namedWriteableRegistry, clusterSupportsFeature),
             new RestMultiSearchTemplateAction(settings),
             new RestRenderSearchTemplateAction()
         );

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/RestSearchTemplateAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -23,6 +24,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -35,9 +37,11 @@ public class RestSearchTemplateAction extends BaseRestHandler {
     private static final Set<String> RESPONSE_PARAMS = Set.of(TYPED_KEYS_PARAM, RestSearchAction.TOTAL_HITS_AS_INT_PARAM);
 
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final Predicate<NodeFeature> clusterSupportsFeature;
 
-    public RestSearchTemplateAction(NamedWriteableRegistry namedWriteableRegistry) {
+    public RestSearchTemplateAction(NamedWriteableRegistry namedWriteableRegistry, Predicate<NodeFeature> clusterSupportsFeature) {
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     @Override
@@ -70,6 +74,7 @@ public class RestSearchTemplateAction extends BaseRestHandler {
             request,
             null,
             namedWriteableRegistry,
+            clusterSupportsFeature,
             size -> searchRequest.source().size(size)
         );
 

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/TransportSearchTemplateAction.java
@@ -13,10 +13,13 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.script.Script;
@@ -55,9 +58,10 @@ public class TransportSearchTemplateAction extends HandledTransportAction<Search
         ActionFilters actionFilters,
         ScriptService scriptService,
         NamedXContentRegistry xContentRegistry,
-        Predicate<NodeFeature> clusterSupportsFeature,
         NodeClient client,
-        UsageService usageService
+        UsageService usageService,
+        ClusterService clusterService,
+        FeatureService featureService
     ) {
         super(
             MustachePlugin.SEARCH_TEMPLATE_ACTION.name(),
@@ -68,7 +72,10 @@ public class TransportSearchTemplateAction extends HandledTransportAction<Search
         );
         this.scriptService = scriptService;
         this.xContentRegistry = xContentRegistry;
-        this.clusterSupportsFeature = clusterSupportsFeature;
+        this.clusterSupportsFeature = f -> {
+            ClusterState state = clusterService.state();
+            return state.clusterRecovered() && featureService.clusterHasFeature(state, f);
+        };
         this.client = client;
         this.searchUsageHolder = usageService.getSearchUsageHolder();
     }

--- a/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestSearchTemplateActionTests.java
+++ b/modules/lang-mustache/src/test/java/org/elasticsearch/script/mustache/RestSearchTemplateActionTests.java
@@ -28,7 +28,7 @@ public final class RestSearchTemplateActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        controller().registerHandler(new RestSearchTemplateAction(mock(NamedWriteableRegistry.class)));
+        controller().registerHandler(new RestSearchTemplateAction(mock(NamedWriteableRegistry.class), nf -> false));
         verifyingClient.setExecuteVerifier((actionType, request) -> mock(SearchTemplateResponse.class));
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> mock(SearchTemplateResponse.class));
     }

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalPlugin.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RankEvalPlugin.java
@@ -53,7 +53,7 @@ public class RankEvalPlugin extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        return Collections.singletonList(new RestRankEvalAction());
+        return Collections.singletonList(new RestRankEvalAction(clusterSupportsFeature));
     }
 
     @Override

--- a/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedRequest.java
+++ b/modules/rank-eval/src/main/java/org/elasticsearch/index/rankeval/RatedRequest.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.rankeval.RatedDocument.DocumentKey;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -31,6 +32,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Definition of a particular query in the ranking evaluation request.<br>
@@ -246,7 +248,7 @@ public class RatedRequest implements Writeable, ToXContentObject {
     private static final ParseField TEMPLATE_ID_FIELD = new ParseField("template_id");
 
     @SuppressWarnings("unchecked")
-    private static final ConstructingObjectParser<RatedRequest, Void> PARSER = new ConstructingObjectParser<>(
+    private static final ConstructingObjectParser<RatedRequest, Predicate<NodeFeature>> PARSER = new ConstructingObjectParser<>(
         "request",
         a -> new RatedRequest(
             (String) a[0],
@@ -262,7 +264,7 @@ public class RatedRequest implements Writeable, ToXContentObject {
         PARSER.declareObjectArray(ConstructingObjectParser.constructorArg(), (p, c) -> RatedDocument.fromXContent(p), RATINGS_FIELD);
         PARSER.declareObject(
             ConstructingObjectParser.optionalConstructorArg(),
-            (p, c) -> new SearchSourceBuilder().parseXContent(p, false),
+            (p, c) -> new SearchSourceBuilder().parseXContent(p, false, c),
             REQUEST_FIELD
         );
         PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> p.map(), PARAMS_FIELD);
@@ -273,8 +275,8 @@ public class RatedRequest implements Writeable, ToXContentObject {
     /**
      * parse from rest representation
      */
-    public static RatedRequest fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
+    public static RatedRequest fromXContent(XContentParser parser, Predicate<NodeFeature> clusterSupportsFeature) {
+        return PARSER.apply(parser, clusterSupportsFeature);
     }
 
     @Override

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalSpecTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RankEvalSpecTests.java
@@ -119,7 +119,7 @@ public class RankEvalSpecTests extends ESTestCase {
         RankEvalSpec testItem = createTestItem();
         XContentBuilder shuffled = shuffleXContent(testItem.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(shuffled))) {
-            RankEvalSpec parsedItem = RankEvalSpec.parse(parser);
+            RankEvalSpec parsedItem = RankEvalSpec.parse(parser, nf -> false);
             assertNotSame(testItem, parsedItem);
             assertEquals(testItem, parsedItem);
             assertEquals(testItem.hashCode(), parsedItem.hashCode());
@@ -132,7 +132,7 @@ public class RankEvalSpecTests extends ESTestCase {
         BytesReference originalBytes = toShuffledXContent(testItem, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
         BytesReference withRandomFields = insertRandomFields(xContentType, originalBytes, null, random());
         try (XContentParser parser = createParser(xContentType.xContent(), withRandomFields)) {
-            Exception exception = expectThrows(Exception.class, () -> RankEvalSpec.parse(parser));
+            Exception exception = expectThrows(Exception.class, () -> RankEvalSpec.parse(parser, nf -> false));
             assertThat(exception.getMessage(), containsString("[rank_eval] failed to parse field"));
         }
     }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedRequestsTests.java
@@ -118,7 +118,7 @@ public class RatedRequestsTests extends ESTestCase {
         try (XContentParser itemParser = createParser(shuffled)) {
             itemParser.nextToken();
 
-            RatedRequest parsedItem = RatedRequest.fromXContent(itemParser);
+            RatedRequest parsedItem = RatedRequest.fromXContent(itemParser, nf -> false);
             assertNotSame(testItem, parsedItem);
             assertEquals(testItem, parsedItem);
             assertEquals(testItem.hashCode(), parsedItem.hashCode());
@@ -133,7 +133,7 @@ public class RatedRequestsTests extends ESTestCase {
         BytesReference originalBytes = toShuffledXContent(testItem, xContentType, ToXContent.EMPTY_PARAMS, randomBoolean());
         BytesReference withRandomFields = insertRandomFields(xContentType, originalBytes, null, random());
         try (XContentParser parser = createParser(xContentType.xContent(), withRandomFields)) {
-            Throwable exception = expectThrows(XContentParseException.class, () -> RatedRequest.fromXContent(parser));
+            Throwable exception = expectThrows(XContentParseException.class, () -> RatedRequest.fromXContent(parser, nf -> false));
             if (exception.getCause() != null) {
                 assertThat(exception.getMessage(), containsString("[request] failed to parse field"));
                 exception = exception.getCause();
@@ -368,7 +368,7 @@ public class RatedRequestsTests extends ESTestCase {
               ]
             }""";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, querySpecString)) {
-            RatedRequest specification = RatedRequest.fromXContent(parser);
+            RatedRequest specification = RatedRequest.fromXContent(parser, nf -> false);
             assertEquals("my_qa_query", specification.getId());
             assertNotNull(specification.getEvaluationRequest());
             List<RatedDocument> ratedDocs = specification.getRatedDocs();

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
@@ -84,7 +84,8 @@ public final class TransportRankEvalActionTests extends ESTestCase {
             client,
             transportService,
             mock(ScriptService.class),
-            NamedXContentRegistry.EMPTY
+            NamedXContentRegistry.EMPTY,
+            nf -> false
         );
         action.doExecute(null, rankEvalRequest, null);
     }

--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/TransportRankEvalActionTests.java
@@ -16,8 +16,10 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESTestCase;
@@ -85,7 +87,8 @@ public final class TransportRankEvalActionTests extends ESTestCase {
             transportService,
             mock(ScriptService.class),
             NamedXContentRegistry.EMPTY,
-            nf -> false
+            mock(ClusterService.class),
+            mock(FeatureService.class)
         );
         action.doExecute(null, rankEvalRequest, null);
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/ReindexPlugin.java
@@ -76,9 +76,9 @@ public class ReindexPlugin extends Plugin implements ActionPlugin {
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
         return Arrays.asList(
-            new RestReindexAction(namedWriteableRegistry),
-            new RestUpdateByQueryAction(namedWriteableRegistry),
-            new RestDeleteByQueryAction(namedWriteableRegistry),
+            new RestReindexAction(namedWriteableRegistry, clusterSupportsFeature),
+            new RestUpdateByQueryAction(namedWriteableRegistry, clusterSupportsFeature),
+            new RestDeleteByQueryAction(namedWriteableRegistry, clusterSupportsFeature),
             new RestRethrottleAction(nodesInCluster)
         );
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RestDeleteByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RestDeleteByQueryAction.java
@@ -11,6 +11,7 @@ package org.elasticsearch.reindex;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.reindex.DeleteByQueryAction;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.rest.RestRequest;
@@ -23,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
@@ -30,10 +32,12 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestDeleteByQueryAction extends AbstractBulkByQueryRestHandler<DeleteByQueryRequest, DeleteByQueryAction> {
 
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final Predicate<NodeFeature> clusterSupportsFeature;
 
-    public RestDeleteByQueryAction(NamedWriteableRegistry namedWriteableRegistry) {
+    public RestDeleteByQueryAction(NamedWriteableRegistry namedWriteableRegistry, Predicate<NodeFeature> clusterSupportsFeature) {
         super(DeleteByQueryAction.INSTANCE);
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     @Override
@@ -70,7 +74,7 @@ public class RestDeleteByQueryAction extends AbstractBulkByQueryRestHandler<Dele
         consumers.put("conflicts", o -> internal.setConflicts((String) o));
         consumers.put("max_docs", s -> setMaxDocsValidateIdentical(internal, ((Number) s).intValue()));
 
-        parseInternalRequest(internal, request, namedWriteableRegistry, consumers);
+        parseInternalRequest(internal, request, namedWriteableRegistry, clusterSupportsFeature, consumers);
 
         return internal;
     }

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RestReindexAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RestReindexAction.java
@@ -11,6 +11,7 @@ package org.elasticsearch.reindex;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.reindex.ReindexAction;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.rest.RestRequest;
@@ -22,6 +23,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.core.TimeValue.parseTimeValue;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -33,10 +35,12 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestReindexAction extends AbstractBaseReindexRestHandler<ReindexRequest, ReindexAction> implements RestRequestFilter {
 
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final Predicate<NodeFeature> clusterSupportsFeature;
 
-    public RestReindexAction(NamedWriteableRegistry namedWriteableRegistry) {
+    public RestReindexAction(NamedWriteableRegistry namedWriteableRegistry, Predicate<NodeFeature> clusterSupportsFeature) {
         super(ReindexAction.INSTANCE);
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     @Override
@@ -64,7 +68,7 @@ public class RestReindexAction extends AbstractBaseReindexRestHandler<ReindexReq
 
         ReindexRequest internal;
         try (XContentParser parser = request.contentParser()) {
-            internal = ReindexRequest.fromXContent(parser);
+            internal = ReindexRequest.fromXContent(parser, clusterSupportsFeature);
         }
 
         if (request.hasParam("scroll")) {

--- a/modules/reindex/src/main/java/org/elasticsearch/reindex/RestUpdateByQueryAction.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/reindex/RestUpdateByQueryAction.java
@@ -11,6 +11,7 @@ package org.elasticsearch.reindex;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.reindex.UpdateByQueryAction;
 import org.elasticsearch.index.reindex.UpdateByQueryRequest;
 import org.elasticsearch.rest.RestRequest;
@@ -24,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
@@ -31,10 +33,12 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<UpdateByQueryRequest, UpdateByQueryAction> {
 
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final Predicate<NodeFeature> clusterSupportsFeature;
 
-    public RestUpdateByQueryAction(NamedWriteableRegistry namedWriteableRegistry) {
+    public RestUpdateByQueryAction(NamedWriteableRegistry namedWriteableRegistry, Predicate<NodeFeature> clusterSupportsFeature) {
         super(UpdateByQueryAction.INSTANCE);
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     @Override
@@ -74,7 +78,7 @@ public class RestUpdateByQueryAction extends AbstractBulkByQueryRestHandler<Upda
         consumers.put("script", o -> internal.setScript(Script.parse(o)));
         consumers.put("max_docs", s -> setMaxDocsValidateIdentical(internal, ((Number) s).intValue()));
 
-        parseInternalRequest(internal, request, namedWriteableRegistry, consumers);
+        parseInternalRequest(internal, request, namedWriteableRegistry, clusterSupportsFeature, consumers);
 
         internal.setPipeline(request.param("pipeline"));
         return internal;

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestDeleteByQueryActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestDeleteByQueryActionTests.java
@@ -31,7 +31,7 @@ public final class RestDeleteByQueryActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        controller().registerHandler(new RestDeleteByQueryAction(mock(NamedWriteableRegistry.class)));
+        controller().registerHandler(new RestDeleteByQueryAction(mock(NamedWriteableRegistry.class), nf -> false));
         verifyingClient.setExecuteVerifier((actionType, request) -> mock(BulkByScrollResponse.class));
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> mock(BulkByScrollResponse.class));
     }

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestReindexActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestReindexActionTests.java
@@ -32,7 +32,7 @@ public class RestReindexActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        action = new RestReindexAction(mock(NamedWriteableRegistry.class));
+        action = new RestReindexAction(mock(NamedWriteableRegistry.class), nf -> false);
         controller().registerHandler(action);
     }
 

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RestUpdateByQueryActionTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RestUpdateByQueryActionTests.java
@@ -31,7 +31,7 @@ public final class RestUpdateByQueryActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        controller().registerHandler(new RestUpdateByQueryAction(mock(NamedWriteableRegistry.class)));
+        controller().registerHandler(new RestUpdateByQueryAction(mock(NamedWriteableRegistry.class), nf -> false));
         verifyingClient.setExecuteVerifier((actionType, request) -> mock(BulkByScrollResponse.class));
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> mock(BulkByScrollResponse.class));
     }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/10_standard_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/10_standard_retriever.yml
@@ -6,6 +6,9 @@ setup:
       indices.create:
         index: animals
         body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               type:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/20_knn_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/20_knn_retriever.yml
@@ -6,6 +6,9 @@ setup:
       indices.create:
         index: index1
         body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               name:

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/terms/StringTermsIT.java
@@ -1265,12 +1265,15 @@ public class StringTermsIT extends AbstractTermsTestCase {
         String source = builder.toString();
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, source)) {
-            assertNoFailuresAndResponse(prepareSearch("idx").setSource(new SearchSourceBuilder().parseXContent(parser, true)), response -> {
-                LongTerms terms = response.getAggregations().get("terms");
-                assertThat(terms, notNullValue());
-                assertThat(terms.getName(), equalTo("terms"));
-                assertThat(terms.getBuckets().size(), equalTo(1));
-            });
+            assertNoFailuresAndResponse(
+                prepareSearch("idx").setSource(new SearchSourceBuilder().parseXContent(parser, true, nf -> false)),
+                response -> {
+                    LongTerms terms = response.getAggregations().get("terms");
+                    assertThat(terms, notNullValue());
+                    assertThat(terms.getName(), equalTo("terms"));
+                    assertThat(terms.getBuckets().size(), equalTo(1));
+                }
+            );
         }
 
         String invalidValueType = source.replaceAll("\"value_type\":\"n.*\"", "\"value_type\":\"foobar\"");
@@ -1278,7 +1281,7 @@ public class StringTermsIT extends AbstractTermsTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, invalidValueType)) {
             XContentParseException ex = expectThrows(
                 XContentParseException.class,
-                () -> prepareSearch("idx").setSource(new SearchSourceBuilder().parseXContent(parser, true)).get()
+                () -> prepareSearch("idx").setSource(new SearchSourceBuilder().parseXContent(parser, true, nf -> false)).get()
             );
             assertThat(ex.getCause(), instanceOf(IllegalArgumentException.class));
             assertThat(ex.getCause().getMessage(), containsString("Unknown value type [foobar]"));

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -412,7 +412,8 @@ module org.elasticsearch.server {
             org.elasticsearch.cluster.service.TransportFeatures,
             org.elasticsearch.cluster.metadata.MetadataFeatures,
             org.elasticsearch.rest.RestFeatures,
-            org.elasticsearch.indices.IndicesFeatures;
+            org.elasticsearch.indices.IndicesFeatures,
+            org.elasticsearch.search.retriever.RetrieversFeatures;
 
     uses org.elasticsearch.plugins.internal.SettingsExtension;
     uses RestExtension;

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -933,12 +933,14 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestBulkAction(settings));
         registerHandler.accept(new RestUpdateAction());
 
-        registerHandler.accept(new RestSearchAction(restController.getSearchUsageHolder(), namedWriteableRegistry));
+        registerHandler.accept(new RestSearchAction(restController.getSearchUsageHolder(), namedWriteableRegistry, clusterSupportsFeature));
         registerHandler.accept(new RestSearchScrollAction());
         registerHandler.accept(new RestClearScrollAction());
         registerHandler.accept(new RestOpenPointInTimeAction());
         registerHandler.accept(new RestClosePointInTimeAction());
-        registerHandler.accept(new RestMultiSearchAction(settings, restController.getSearchUsageHolder(), namedWriteableRegistry));
+        registerHandler.accept(
+            new RestMultiSearchAction(settings, restController.getSearchUsageHolder(), namedWriteableRegistry, clusterSupportsFeature)
+        );
         registerHandler.accept(new RestKnnSearchAction());
 
         registerHandler.accept(new RestValidateQueryAction());

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestSearchAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -47,6 +48,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import java.util.function.IntConsumer;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.core.TimeValue.parseTimeValue;
@@ -70,10 +72,16 @@ public class RestSearchAction extends BaseRestHandler {
 
     private final SearchUsageHolder searchUsageHolder;
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final Predicate<NodeFeature> clusterSupportsFeature;
 
-    public RestSearchAction(SearchUsageHolder searchUsageHolder, NamedWriteableRegistry namedWriteableRegistry) {
+    public RestSearchAction(
+        SearchUsageHolder searchUsageHolder,
+        NamedWriteableRegistry namedWriteableRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature
+    ) {
         this.searchUsageHolder = searchUsageHolder;
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     @Override
@@ -116,7 +124,15 @@ public class RestSearchAction extends BaseRestHandler {
          */
         IntConsumer setSize = size -> searchRequest.source().size(size);
         request.withContentOrSourceParamParserOrNull(
-            parser -> parseSearchRequest(searchRequest, request, parser, namedWriteableRegistry, setSize, searchUsageHolder)
+            parser -> parseSearchRequest(
+                searchRequest,
+                request,
+                parser,
+                namedWriteableRegistry,
+                clusterSupportsFeature,
+                setSize,
+                searchUsageHolder
+            )
         );
 
         return channel -> {
@@ -133,6 +149,7 @@ public class RestSearchAction extends BaseRestHandler {
      * @param requestContentParser body of the request to read. This method does not attempt to read the body from the {@code request}
      *        parameter
      * @param namedWriteableRegistry the registry of named writeables
+     * @param clusterSupportsFeature used to check if certain features are available in this cluster
      * @param setSize how the size url parameter is handled. {@code udpate_by_query} and regular search differ here.
      */
     public static void parseSearchRequest(
@@ -140,9 +157,10 @@ public class RestSearchAction extends BaseRestHandler {
         RestRequest request,
         XContentParser requestContentParser,
         NamedWriteableRegistry namedWriteableRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature,
         IntConsumer setSize
     ) throws IOException {
-        parseSearchRequest(searchRequest, request, requestContentParser, namedWriteableRegistry, setSize, null);
+        parseSearchRequest(searchRequest, request, requestContentParser, namedWriteableRegistry, clusterSupportsFeature, setSize, null);
     }
 
     /**
@@ -153,6 +171,7 @@ public class RestSearchAction extends BaseRestHandler {
      * @param requestContentParser body of the request to read. This method does not attempt to read the body from the {@code request}
      *        parameter, will be null when there is no request body to parse
      * @param namedWriteableRegistry the registry of named writeables
+      @param clusterSupportsFeature used to check if certain features are available in this cluster
      * @param setSize how the size url parameter is handled. {@code udpate_by_query} and regular search differ here.
      * @param searchUsageHolder the holder of search usage stats
      */
@@ -161,6 +180,7 @@ public class RestSearchAction extends BaseRestHandler {
         RestRequest request,
         @Nullable XContentParser requestContentParser,
         NamedWriteableRegistry namedWriteableRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature,
         IntConsumer setSize,
         @Nullable SearchUsageHolder searchUsageHolder
     ) throws IOException {
@@ -175,9 +195,9 @@ public class RestSearchAction extends BaseRestHandler {
         searchRequest.indices(Strings.splitStringByCommaToArray(request.param("index")));
         if (requestContentParser != null) {
             if (searchUsageHolder == null) {
-                searchRequest.source().parseXContent(requestContentParser, true);
+                searchRequest.source().parseXContent(requestContentParser, true, clusterSupportsFeature);
             } else {
-                searchRequest.source().parseXContent(requestContentParser, true, searchUsageHolder);
+                searchRequest.source().parseXContent(requestContentParser, true, searchUsageHolder, clusterSupportsFeature);
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -21,6 +21,7 @@ import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryRewriteContext;
@@ -65,6 +66,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 
@@ -1234,10 +1236,15 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
      * @param parser The xContent parser.
      * @param checkTrailingTokens If true throws a parsing exception when extra tokens are found after the main object.
      * @param searchUsageHolder holder for the search usage statistics
+     * @param clusterSupportsFeature used to check if certain features are available on this cluster
      */
-    public SearchSourceBuilder parseXContent(XContentParser parser, boolean checkTrailingTokens, SearchUsageHolder searchUsageHolder)
-        throws IOException {
-        return parseXContent(parser, checkTrailingTokens, searchUsageHolder::updateUsage);
+    public SearchSourceBuilder parseXContent(
+        XContentParser parser,
+        boolean checkTrailingTokens,
+        SearchUsageHolder searchUsageHolder,
+        Predicate<NodeFeature> clusterSupportsFeature
+    ) throws IOException {
+        return parseXContent(parser, checkTrailingTokens, searchUsageHolder::updateUsage, clusterSupportsFeature);
     }
 
     /**
@@ -1247,13 +1254,22 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
      *
      * @param parser The xContent parser.
      * @param checkTrailingTokens If true throws a parsing exception when extra tokens are found after the main object.
+     * @param clusterSupportsFeature used to check if certain features are available on this cluster
      */
-    public SearchSourceBuilder parseXContent(XContentParser parser, boolean checkTrailingTokens) throws IOException {
-        return parseXContent(parser, checkTrailingTokens, s -> {});
+    public SearchSourceBuilder parseXContent(
+        XContentParser parser,
+        boolean checkTrailingTokens,
+        Predicate<NodeFeature> clusterSupportsFeature
+    ) throws IOException {
+        return parseXContent(parser, checkTrailingTokens, s -> {}, clusterSupportsFeature);
     }
 
-    private SearchSourceBuilder parseXContent(XContentParser parser, boolean checkTrailingTokens, Consumer<SearchUsage> searchUsageConsumer)
-        throws IOException {
+    private SearchSourceBuilder parseXContent(
+        XContentParser parser,
+        boolean checkTrailingTokens,
+        Consumer<SearchUsage> searchUsageConsumer,
+        Predicate<NodeFeature> clusterSupportsFeature
+    ) throws IOException {
         XContentParser.Token token = parser.currentToken();
         String currentFieldName = null;
         if (token != XContentParser.Token.START_OBJECT && (token = parser.nextToken()) != XContentParser.Token.START_OBJECT) {
@@ -1337,7 +1353,8 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                         new RetrieverParserContext(
                             searchUsage::trackSectionUsage,
                             searchUsage::trackQueryUsage,
-                            searchUsage::trackRescorerUsage
+                            searchUsage::trackRescorerUsage,
+                            clusterSupportsFeature
                         )
                     );
                 } else if (QUERY_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1348,6 +1348,9 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (RETRIEVER.match(currentFieldName, parser.getDeprecationHandler())) {
+                    if (clusterSupportsFeature.test(RetrieverBuilder.NODE_FEATURE) == false) {
+                        throw new ParsingException(parser.getTokenLocation(), "Unknown key for a START_OBJECT in [retriever].");
+                    }
                     retrieverBuilder = RetrieverBuilder.parseTopLevelRetrieverBuilder(
                         parser,
                         new RetrieverParserContext(

--- a/server/src/main/java/org/elasticsearch/search/retriever/KnnRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/KnnRetrieverBuilder.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.retriever;
 
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.vectors.KnnSearchBuilder;
@@ -76,7 +77,7 @@ public final class KnnRetrieverBuilder extends RetrieverBuilder<KnnRetrieverBuil
 
     public static KnnRetrieverBuilder fromXContent(XContentParser parser, RetrieverParserContext context) throws IOException {
         if (context.clusterSupportsFeature(NODE_FEATURE) == false) {
-            throw new IllegalArgumentException("[" + NAME + "] retriever is not a supported feature");
+            throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + NAME + "]");
         }
         return PARSER.apply(parser, context);
     }

--- a/server/src/main/java/org/elasticsearch/search/retriever/KnnRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/KnnRetrieverBuilder.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.retriever;
 
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.vectors.KnnSearchBuilder;
 import org.elasticsearch.search.vectors.QueryVectorBuilder;
@@ -25,6 +26,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 public final class KnnRetrieverBuilder extends RetrieverBuilder<KnnRetrieverBuilder> {
 
     public static final String NAME = "knn";
+    public static final NodeFeature NODE_FEATURE = new NodeFeature(NAME + "_retriever");
 
     public static final ParseField FIELD_FIELD = new ParseField("field");
     public static final ParseField K_FIELD = new ParseField("k");
@@ -73,6 +75,9 @@ public final class KnnRetrieverBuilder extends RetrieverBuilder<KnnRetrieverBuil
     }
 
     public static KnnRetrieverBuilder fromXContent(XContentParser parser, RetrieverParserContext context) throws IOException {
+        if (context.clusterSupportsFeature(NODE_FEATURE) == false) {
+            throw new IllegalArgumentException("[" + NAME + "] retriever is not a supported feature");
+        }
         return PARSER.apply(parser, context);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverBuilder.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.retriever;
 
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.xcontent.SuggestingErrorOnUnknown;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -27,6 +28,8 @@ import java.util.Locale;
 import java.util.Objects;
 
 public abstract class RetrieverBuilder<RB extends RetrieverBuilder<RB>> {
+
+    public static final NodeFeature NODE_FEATURE = new NodeFeature("retrievers");
 
     public static final ParseField PRE_FILTER_FIELD = new ParseField("filter");
 

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieverParserContext.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieverParserContext.java
@@ -8,13 +8,18 @@
 
 package org.elasticsearch.search.retriever;
 
+import org.elasticsearch.features.NodeFeature;
+
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public class RetrieverParserContext {
 
     protected Consumer<String> trackSectionUsage;
     protected Consumer<String> trackQueryUsage;
     protected Consumer<String> trackRescorerUsage;
+
+    protected Predicate<NodeFeature> clusterSupportsFeature;
 
     public RetrieverParserContext() {
 
@@ -23,10 +28,13 @@ public class RetrieverParserContext {
     public RetrieverParserContext(
         Consumer<String> trackSectionUsage,
         Consumer<String> trackQueryUsage,
-        Consumer<String> trackRescorerUsage
+        Consumer<String> trackRescorerUsage,
+        Predicate<NodeFeature> clusterSupportsFeature
     ) {
         this.trackSectionUsage = trackSectionUsage;
         this.trackQueryUsage = trackQueryUsage;
+        this.trackRescorerUsage = trackRescorerUsage;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     public void trackSectionUsage(String section) {
@@ -45,5 +53,9 @@ public class RetrieverParserContext {
         if (trackRescorerUsage != null) {
             trackRescorerUsage.accept(name);
         }
+    }
+
+    public boolean clusterSupportsFeature(NodeFeature nodeFeature) {
+        return clusterSupportsFeature != null && clusterSupportsFeature.test(nodeFeature);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
@@ -17,6 +17,6 @@ public class RetrieversFeatures implements FeatureSpecification {
 
     @Override
     public Set<NodeFeature> getFeatures() {
-        return Set.of(StandardRetrieverBuilder.NODE_FEATURE, KnnRetrieverBuilder.NODE_FEATURE);
+        return Set.of(RetrieverBuilder.NODE_FEATURE, StandardRetrieverBuilder.NODE_FEATURE, KnnRetrieverBuilder.NODE_FEATURE);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.retriever;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class RetrieversFeatures implements FeatureSpecification {
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(StandardRetrieverBuilder.NODE_FEATURE, KnnRetrieverBuilder.NODE_FEATURE);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/retriever/StandardRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/StandardRetrieverBuilder.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.retriever;
 
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -86,7 +87,7 @@ public final class StandardRetrieverBuilder extends RetrieverBuilder<StandardRet
 
     public static StandardRetrieverBuilder fromXContent(XContentParser parser, RetrieverParserContext context) throws IOException {
         if (context.clusterSupportsFeature(NODE_FEATURE) == false) {
-            throw new IllegalArgumentException("[" + NAME + "] retriever is not a supported feature");
+            throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + NAME + "]");
         }
         return PARSER.apply(parser, context);
     }

--- a/server/src/main/java/org/elasticsearch/search/retriever/StandardRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/StandardRetrieverBuilder.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.retriever;
 
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -27,6 +28,7 @@ import java.util.List;
 public final class StandardRetrieverBuilder extends RetrieverBuilder<StandardRetrieverBuilder> {
 
     public static final String NAME = "standard";
+    public static final NodeFeature NODE_FEATURE = new NodeFeature(NAME + "_retriever");
 
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField SEARCH_AFTER_FIELD = new ParseField("search_after");
@@ -83,6 +85,9 @@ public final class StandardRetrieverBuilder extends RetrieverBuilder<StandardRet
     }
 
     public static StandardRetrieverBuilder fromXContent(XContentParser parser, RetrieverParserContext context) throws IOException {
+        if (context.clusterSupportsFeature(NODE_FEATURE) == false) {
+            throw new IllegalArgumentException("[" + NAME + "] retriever is not a supported feature");
+        }
         return PARSER.apply(parser, context);
     }
 

--- a/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -12,3 +12,4 @@ org.elasticsearch.cluster.service.TransportFeatures
 org.elasticsearch.cluster.metadata.MetadataFeatures
 org.elasticsearch.rest.RestFeatures
 org.elasticsearch.indices.IndicesFeatures
+org.elasticsearch.search.retriever.RetrieversFeatures

--- a/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -97,7 +97,7 @@ public class MultiSearchRequestTests extends ESTestCase {
         ).build();
         IllegalArgumentException ex = expectThrows(
             IllegalArgumentException.class,
-            () -> RestMultiSearchAction.parseRequest(restRequest, null, true, new UsageService().getSearchUsageHolder())
+            () -> RestMultiSearchAction.parseRequest(restRequest, null, true, new UsageService().getSearchUsageHolder(), nf -> false)
         );
         assertEquals("key [unknown_key] is not supported in the metadata section", ex.getMessage());
     }
@@ -111,7 +111,13 @@ public class MultiSearchRequestTests extends ESTestCase {
             new BytesArray(requestContent),
             XContentType.JSON
         ).build();
-        MultiSearchRequest request = RestMultiSearchAction.parseRequest(restRequest, null, true, new UsageService().getSearchUsageHolder());
+        MultiSearchRequest request = RestMultiSearchAction.parseRequest(
+            restRequest,
+            null,
+            true,
+            new UsageService().getSearchUsageHolder(),
+            nf -> false
+        );
         assertThat(request.requests().size(), equalTo(1));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
         assertThat(
@@ -129,7 +135,13 @@ public class MultiSearchRequestTests extends ESTestCase {
             new BytesArray(requestContent),
             XContentType.JSON
         ).withParams(Collections.singletonMap("ignore_unavailable", "true")).build();
-        MultiSearchRequest request = RestMultiSearchAction.parseRequest(restRequest, null, true, new UsageService().getSearchUsageHolder());
+        MultiSearchRequest request = RestMultiSearchAction.parseRequest(
+            restRequest,
+            null,
+            true,
+            new UsageService().getSearchUsageHolder(),
+            nf -> false
+        );
         assertThat(request.requests().size(), equalTo(1));
         assertThat(request.requests().get(0).indices()[0], equalTo("test"));
         assertThat(
@@ -238,7 +250,7 @@ public class MultiSearchRequestTests extends ESTestCase {
         ).build();
         IllegalArgumentException expectThrows = expectThrows(
             IllegalArgumentException.class,
-            () -> RestMultiSearchAction.parseRequest(restRequest, null, true, new UsageService().getSearchUsageHolder())
+            () -> RestMultiSearchAction.parseRequest(restRequest, null, true, new UsageService().getSearchUsageHolder(), nf -> false)
         );
         assertEquals("The msearch request must be terminated by a newline [\n]", expectThrows.getMessage());
 
@@ -251,7 +263,8 @@ public class MultiSearchRequestTests extends ESTestCase {
             restRequestWithNewLine,
             null,
             true,
-            new UsageService().getSearchUsageHolder()
+            new UsageService().getSearchUsageHolder(),
+            nf -> false
         );
         assertEquals(3, msearchRequest.requests().size());
     }
@@ -268,7 +281,9 @@ public class MultiSearchRequestTests extends ESTestCase {
 
         MultiSearchRequest request = new MultiSearchRequest();
         RestMultiSearchAction.parseMultiLineRequest(restRequest, SearchRequest.DEFAULT_INDICES_OPTIONS, true, (searchRequest, parser) -> {
-            searchRequest.source(new SearchSourceBuilder().parseXContent(parser, false, new UsageService().getSearchUsageHolder()));
+            searchRequest.source(
+                new SearchSourceBuilder().parseXContent(parser, false, new UsageService().getSearchUsageHolder(), nf -> false)
+            );
             request.add(searchRequest);
         });
         return request;
@@ -318,7 +333,8 @@ public class MultiSearchRequestTests extends ESTestCase {
                 SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(
                     p,
                     false,
-                    new UsageService().getSearchUsageHolder()
+                    new UsageService().getSearchUsageHolder(),
+                    nf -> false
                 );
                 if (searchSourceBuilder.equals(new SearchSourceBuilder()) == false) {
                     r.source(searchSourceBuilder);

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -115,7 +115,7 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
 
     @Override
     protected ReindexRequest doParseInstance(XContentParser parser) throws IOException {
-        return ReindexRequest.fromXContent(parser);
+        return ReindexRequest.fromXContent(parser, nf -> false);
     }
 
     @Override
@@ -349,7 +349,7 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
             request = BytesReference.bytes(b);
         }
         try (XContentParser p = createParser(JsonXContent.jsonXContent, request)) {
-            ReindexRequest r = ReindexRequest.fromXContent(p);
+            ReindexRequest r = ReindexRequest.fromXContent(p, nf -> false);
             assertEquals("localhost", r.getRemoteInfo().getHost());
             assertArrayEquals(new String[] { "source" }, r.getSearchRequest().indices());
         }
@@ -403,7 +403,7 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
             request = BytesReference.bytes(b);
         }
         try (XContentParser p = createParser(JsonXContent.jsonXContent, request)) {
-            return ReindexRequest.fromXContent(p);
+            return ReindexRequest.fromXContent(p, nf -> false);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestMultiSearchActionTests.java
@@ -34,7 +34,12 @@ public final class RestMultiSearchActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        action = new RestMultiSearchAction(Settings.EMPTY, new UsageService().getSearchUsageHolder(), mock(NamedWriteableRegistry.class));
+        action = new RestMultiSearchAction(
+            Settings.EMPTY,
+            new UsageService().getSearchUsageHolder(),
+            mock(NamedWriteableRegistry.class),
+            nf -> false
+        );
         controller().registerHandler(action);
         verifyingClient.setExecuteVerifier((actionType, request) -> mock(MultiSearchResponse.class));
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> mock(MultiSearchResponse.class));

--- a/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/search/RestSearchActionTests.java
@@ -37,7 +37,7 @@ public final class RestSearchActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        action = new RestSearchAction(new UsageService().getSearchUsageHolder(), mock(NamedWriteableRegistry.class));
+        action = new RestSearchAction(new UsageService().getSearchUsageHolder(), mock(NamedWriteableRegistry.class), nf -> false);
         controller().registerHandler(action);
         verifyingClient.setExecuteVerifier((actionType, request) -> mock(SearchResponse.class));
         verifyingClient.setExecuteLocallyVerifier((actionType, request) -> mock(SearchResponse.class));

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -93,13 +93,16 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{}}")) {
             XContentParseException exc = expectThrows(
                 XContentParseException.class,
-                () -> new SearchSourceBuilder().parseXContent(parser, true)
+                () -> new SearchSourceBuilder().parseXContent(parser, true, nf -> false)
             );
             assertThat(exc.getMessage(), containsString("Unexpected close marker"));
         }
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{}{}")) {
-            ParsingException exc = expectThrows(ParsingException.class, () -> new SearchSourceBuilder().parseXContent(parser, true));
+            ParsingException exc = expectThrows(
+                ParsingException.class,
+                () -> new SearchSourceBuilder().parseXContent(parser, true, nf -> false)
+            );
             assertThat(exc.getDetailedMessage(), containsString("found after the main object"));
         }
     }
@@ -109,7 +112,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
             parser.nextToken(); // sometimes we move it on the START_OBJECT to
                                 // test the embedded case
         }
-        SearchSourceBuilder newBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+        SearchSourceBuilder newBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
         assertNull(parser.nextToken());
         assertEquals(testBuilder, newBuilder);
         assertEquals(testBuilder.hashCode(), newBuilder.hashCode());
@@ -150,7 +153,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                 { "_source": { "includes": "include", "excludes": "*.field2"}}
                 """;
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 assertArrayEquals(new String[] { "*.field2" }, searchSourceBuilder.fetchSource().excludes());
                 assertArrayEquals(new String[] { "include" }, searchSourceBuilder.fetchSource().includes());
             }
@@ -158,7 +161,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         {
             String restContent = " { \"_source\": false}";
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 assertArrayEquals(new String[] {}, searchSourceBuilder.fetchSource().excludes());
                 assertArrayEquals(new String[] {}, searchSourceBuilder.fetchSource().includes());
                 assertFalse(searchSourceBuilder.fetchSource().fetchSource());
@@ -180,7 +183,10 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                }
              } }""".indent(1);
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-            ParsingException e = expectThrows(ParsingException.class, () -> new SearchSourceBuilder().parseXContent(parser, true));
+            ParsingException e = expectThrows(
+                ParsingException.class,
+                () -> new SearchSourceBuilder().parseXContent(parser, true, nf -> false)
+            );
             assertEquals("[multi_match] malformed query, expected [END_OBJECT] but found [FIELD_NAME]", e.getMessage());
         }
     }
@@ -226,7 +232,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
               }
             }""";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
             assertThat(searchSourceBuilder.query(), instanceOf(BoolQueryBuilder.class));
             assertThat(searchSourceBuilder.rescores().get(0), instanceOf(QueryRescorerBuilder.class));
             assertThat(
@@ -252,7 +258,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         {
             String restContent = " { \"sort\": \"foo\"}";
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 searchSourceBuilder = rewrite(searchSourceBuilder);
                 assertEquals(1, searchSourceBuilder.sorts().size());
                 assertEquals(new FieldSortBuilder("foo"), searchSourceBuilder.sorts().get(0));
@@ -269,7 +275,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                         "_score"
                     ]}""";
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 searchSourceBuilder = rewrite(searchSourceBuilder);
                 assertEquals(5, searchSourceBuilder.sorts().size());
                 assertEquals(new FieldSortBuilder("post_date"), searchSourceBuilder.sorts().get(0));
@@ -294,7 +300,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                 }
                 """;
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 searchSourceBuilder = rewrite(searchSourceBuilder);
                 assertEquals(1, searchSourceBuilder.aggregations().count());
             }
@@ -311,7 +317,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                 }
                 """;
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 searchSourceBuilder = rewrite(searchSourceBuilder);
                 assertEquals(1, searchSourceBuilder.aggregations().count());
             }
@@ -339,7 +345,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                 }
                 """;
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 searchSourceBuilder = rewrite(searchSourceBuilder);
                 assertEquals(1, searchSourceBuilder.rescores().size());
                 assertEquals(
@@ -366,7 +372,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                 }
                 """;
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 searchSourceBuilder = rewrite(searchSourceBuilder);
                 assertEquals(1, searchSourceBuilder.rescores().size());
                 assertEquals(
@@ -383,7 +389,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
             { "query": { "match_all": {}}, "timeout": "%s"}
             """, timeout);
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, query)) {
-            final SearchSourceBuilder builder = new SearchSourceBuilder().parseXContent(parser, true);
+            final SearchSourceBuilder builder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
             assertThat(builder.timeout(), equalTo(TimeValue.parseTimeValue(timeout, null, "timeout")));
         }
     }
@@ -396,7 +402,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, query)) {
             final IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> new SearchSourceBuilder().parseXContent(parser, true)
+                () -> new SearchSourceBuilder().parseXContent(parser, true, nf -> false)
             );
             assertThat(e, hasToString(containsString("unit is missing or unrecognized")));
         }
@@ -452,7 +458,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
             String restContent = """
                 { "indices_boost": {"foo": 1.0, "bar": 2.0}}""";
             try (XContentParser parser = createParserWithCompatibilityFor(JsonXContent.jsonXContent, restContent, RestApiVersion.V_7)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 assertEquals(2, searchSourceBuilder.indexBoosts().size());
                 assertEquals(new SearchSourceBuilder.IndexBoost("foo", 1.0f), searchSourceBuilder.indexBoosts().get(0));
                 assertEquals(new SearchSourceBuilder.IndexBoost("bar", 2.0f), searchSourceBuilder.indexBoosts().get(1));
@@ -466,7 +472,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
                   "indices_boost": [ { "foo": 1 }, { "bar": 2 }, { "baz": 3 } ]
                 }""";
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
-                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+                SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
                 assertEquals(3, searchSourceBuilder.indexBoosts().size());
                 assertEquals(new SearchSourceBuilder.IndexBoost("foo", 1.0f), searchSourceBuilder.indexBoosts().get(0));
                 assertEquals(new SearchSourceBuilder.IndexBoost("bar", 2.0f), searchSourceBuilder.indexBoosts().get(1));
@@ -534,14 +540,14 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
             IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> new SearchSourceBuilder().parseXContent(parser, true)
+                () -> new SearchSourceBuilder().parseXContent(parser, true, nf -> false)
             );
             assertThat(ex.getMessage(), containsString(Integer.toString(boundedRandomSize)));
         }
 
         restContent = "{\"size\" : -1}";
         try (XContentParser parser = createParserWithCompatibilityFor(JsonXContent.jsonXContent, restContent, RestApiVersion.V_7)) {
-            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().parseXContent(parser, true, nf -> false);
             assertEquals(-1, searchSourceBuilder.size());
         }
         assertCriticalWarnings(
@@ -562,7 +568,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
             IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> new SearchSourceBuilder().parseXContent(parser, true)
+                () -> new SearchSourceBuilder().parseXContent(parser, true, nf -> false)
             );
             assertThat(ex.getMessage(), containsString("terminateAfter must be > 0"));
         }
@@ -580,7 +586,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
             IllegalArgumentException ex = expectThrows(
                 IllegalArgumentException.class,
-                () -> new SearchSourceBuilder().parseXContent(parser, true)
+                () -> new SearchSourceBuilder().parseXContent(parser, true, nf -> false)
             );
             assertEquals("[track_total_hits] parameter must be positive or equals to -1, got " + randomNegativeValue, ex.getMessage());
         }
@@ -709,7 +715,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
     private void assertSectionNotTracked(SearchUsageHolder searchUsageHolder, String request) throws IOException {
         long totalSearch = searchUsageHolder.getSearchUsageStats().getTotalSearchCount();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, request)) {
-            new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder);
+            new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder, nf -> false);
             assertEquals(totalSearch + 1, searchUsageHolder.getSearchUsageStats().getTotalSearchCount());
             assertEquals(0, searchUsageHolder.getSearchUsageStats().getSectionsUsage().size());
         }
@@ -718,7 +724,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
     private void assertParseFailureNotTracked(SearchUsageHolder searchUsageHolder, String request) throws IOException {
         long totalSearch = searchUsageHolder.getSearchUsageStats().getTotalSearchCount();
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, request)) {
-            expectThrows(Exception.class, () -> new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder));
+            expectThrows(Exception.class, () -> new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder, nf -> false));
             assertEquals(totalSearch, searchUsageHolder.getSearchUsageStats().getTotalSearchCount());
             assertEquals(0, searchUsageHolder.getSearchUsageStats().getSectionsUsage().size());
         }
@@ -789,7 +795,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         assertEquals(0, searchUsageHolder.getSearchUsageStats().getTotalSearchCount());
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(searchSourceBuilder))) {
-            new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder);
+            new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder, nf -> false);
         }
 
         SearchUsageStats searchUsageStats = searchUsageHolder.getSearchUsageStats();
@@ -842,7 +848,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         assertEquals(0, searchUsageHolder.getSearchUsageStats().getTotalSearchCount());
 
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(searchSourceBuilder))) {
-            new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder);
+            new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder, nf -> false);
         }
 
         SearchUsageStats searchUsageStats = searchUsageHolder.getSearchUsageStats();
@@ -865,7 +871,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         int iters = randomIntBetween(10, 100);
         for (int i = 0; i < iters; i++) {
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, Strings.toString(searchSourceBuilder))) {
-                new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder);
+                new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder, nf -> false);
             }
         }
 
@@ -969,7 +975,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, restContent)) {
             ParsingException e = expectThrows(
                 ParsingException.class,
-                () -> new SearchSourceBuilder().parseXContent(parser, true, new UsageService().getSearchUsageHolder())
+                () -> new SearchSourceBuilder().parseXContent(parser, true, new UsageService().getSearchUsageHolder(), nf -> false)
             );
             assertEquals(expectedErrorMessage, e.getMessage());
         }

--- a/server/src/test/java/org/elasticsearch/search/retriever/RetrieverBuilderVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/RetrieverBuilderVersionTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.retriever;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Tests retrievers validate on their own {@link NodeFeature} */
+public class RetrieverBuilderVersionTests extends ESTestCase {
+
+    public void testRetrieverVersions() throws IOException {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"retriever\":{\"standard\":{}}}")) {
+            SearchSourceBuilder ssb = new SearchSourceBuilder();
+            IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> ssb.parseXContent(parser, true, nf -> false));
+            assertEquals("[standard] retriever is not a supported feature", iae.getMessage());
+            ssb.parseXContent(parser, false, nf -> nf == StandardRetrieverBuilder.NODE_FEATURE);
+        }
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"retriever\":{\"knn\":{}}}")) {
+            SearchSourceBuilder ssb = new SearchSourceBuilder();
+            IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> ssb.parseXContent(parser, true, nf -> false));
+            assertEquals("[knn] retriever is not a supported feature", iae.getMessage());
+            ssb.parseXContent(parser, false, nf -> nf == KnnRetrieverBuilder.NODE_FEATURE);
+        }
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        return new NamedXContentRegistry(new SearchModule(Settings.EMPTY, List.of()).getNamedXContents());
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/retriever/RetrieverBuilderVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/retriever/RetrieverBuilderVersionTests.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class RetrieverBuilderVersionTests extends ESTestCase {
 
     public void testRetrieverVersions() throws IOException {
-        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"retriever\":{\"standard\":{}}}")) {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"retriever\":{\"blah\":{}}}")) {
             SearchSourceBuilder ssb = new SearchSourceBuilder();
             IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> ssb.parseXContent(parser, true, nf -> false));
             assertEquals("[standard] retriever is not a supported feature", iae.getMessage());

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearch.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearch.java
@@ -57,7 +57,7 @@ public final class AsyncSearch extends Plugin implements ActionPlugin {
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
         return Arrays.asList(
-            new RestSubmitAsyncSearchAction(restController.getSearchUsageHolder(), namedWriteableRegistry),
+            new RestSubmitAsyncSearchAction(restController.getSearchUsageHolder(), namedWriteableRegistry, clusterSupportsFeature),
             new RestGetAsyncSearchAction(),
             new RestGetAsyncStatusAction(),
             new RestDeleteAsyncSearchAction()

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchAction.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.search;
 
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
@@ -25,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.IntConsumer;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.rest.action.search.RestSearchAction.parseSearchRequest;
@@ -36,10 +38,16 @@ public final class RestSubmitAsyncSearchAction extends BaseRestHandler {
 
     private final SearchUsageHolder searchUsageHolder;
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final Predicate<NodeFeature> clusterSupportsFeature;
 
-    public RestSubmitAsyncSearchAction(SearchUsageHolder searchUsageHolder, NamedWriteableRegistry namedWriteableRegistry) {
+    public RestSubmitAsyncSearchAction(
+        SearchUsageHolder searchUsageHolder,
+        NamedWriteableRegistry namedWriteableRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature
+    ) {
         this.searchUsageHolder = searchUsageHolder;
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     @Override
@@ -61,7 +69,15 @@ public final class RestSubmitAsyncSearchAction extends BaseRestHandler {
         // them as supported. We rely on SubmitAsyncSearchRequest#validate to fail in case they are set.
         // Note that ccs_minimize_roundtrips is also set this way, which is a supported option.
         request.withContentOrSourceParamParserOrNull(
-            parser -> parseSearchRequest(submit.getSearchRequest(), request, parser, namedWriteableRegistry, setSize, searchUsageHolder)
+            parser -> parseSearchRequest(
+                submit.getSearchRequest(),
+                request,
+                parser,
+                namedWriteableRegistry,
+                clusterSupportsFeature,
+                setSize,
+                searchUsageHolder
+            )
         );
 
         if (request.hasParam("wait_for_completion_timeout")) {

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
@@ -35,7 +35,11 @@ public class RestSubmitAsyncSearchActionTests extends RestActionTestCase {
 
     @Before
     public void setUpAction() {
-        action = new RestSubmitAsyncSearchAction(new UsageService().getSearchUsageHolder(), mock(NamedWriteableRegistry.class));
+        action = new RestSubmitAsyncSearchAction(
+            new UsageService().getSearchUsageHolder(),
+            mock(NamedWriteableRegistry.class),
+            nf -> false
+        );
         controller().registerHandler(action);
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportQuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportQuerySearchApplicationAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.script.ScriptService;
@@ -28,6 +29,8 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.search.SearchApplicationTemplateService;
+
+import java.util.function.Predicate;
 
 public class TransportQuerySearchApplicationAction extends HandledTransportAction<SearchApplicationSearchRequest, SearchResponse> {
 
@@ -46,7 +49,8 @@ public class TransportQuerySearchApplicationAction extends HandledTransportActio
         NamedWriteableRegistry namedWriteableRegistry,
         BigArrays bigArrays,
         ScriptService scriptService,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature
     ) {
         super(
             QuerySearchApplicationAction.NAME,
@@ -56,7 +60,7 @@ public class TransportQuerySearchApplicationAction extends HandledTransportActio
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.client = client;
-        this.templateService = new SearchApplicationTemplateService(scriptService, xContentRegistry);
+        this.templateService = new SearchApplicationTemplateService(scriptService, xContentRegistry, clusterSupportsFeature);
         this.systemIndexService = new SearchApplicationIndexService(client, clusterService, namedWriteableRegistry, bigArrays);
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportQuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportQuerySearchApplicationAction.java
@@ -14,11 +14,13 @@ import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -50,7 +52,7 @@ public class TransportQuerySearchApplicationAction extends HandledTransportActio
         BigArrays bigArrays,
         ScriptService scriptService,
         NamedXContentRegistry xContentRegistry,
-        Predicate<NodeFeature> clusterSupportsFeature
+        FeatureService featureService
     ) {
         super(
             QuerySearchApplicationAction.NAME,
@@ -60,6 +62,10 @@ public class TransportQuerySearchApplicationAction extends HandledTransportActio
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.client = client;
+        Predicate<NodeFeature> clusterSupportsFeature = f -> {
+            ClusterState state = clusterService.state();
+            return state.clusterRecovered() && featureService.clusterHasFeature(state, f);
+        };
         this.templateService = new SearchApplicationTemplateService(scriptService, xContentRegistry, clusterSupportsFeature);
         this.systemIndexService = new SearchApplicationIndexService(client, clusterService, namedWriteableRegistry, bigArrays);
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportRenderSearchApplicationQueryAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportRenderSearchApplicationQueryAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.script.ScriptService;
@@ -27,6 +28,7 @@ import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.search.SearchApplicationTemplateService;
 
 import java.util.Map;
+import java.util.function.Predicate;
 
 public class TransportRenderSearchApplicationQueryAction extends HandledTransportAction<
     SearchApplicationSearchRequest,
@@ -47,7 +49,8 @@ public class TransportRenderSearchApplicationQueryAction extends HandledTranspor
         NamedWriteableRegistry namedWriteableRegistry,
         BigArrays bigArrays,
         ScriptService scriptService,
-        NamedXContentRegistry xContentRegistry
+        NamedXContentRegistry xContentRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature
     ) {
         super(
             RenderSearchApplicationQueryAction.NAME,
@@ -57,7 +60,7 @@ public class TransportRenderSearchApplicationQueryAction extends HandledTranspor
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
         this.systemIndexService = new SearchApplicationIndexService(client, clusterService, namedWriteableRegistry, bigArrays);
-        this.templateService = new SearchApplicationTemplateService(scriptService, xContentRegistry);
+        this.templateService = new SearchApplicationTemplateService(scriptService, xContentRegistry, clusterSupportsFeature);
     }
 
     @Override

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -368,8 +368,8 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     ) {
         return List.of(
             new RestGetGlobalCheckpointsAction(),
-            new RestFleetSearchAction(restController.getSearchUsageHolder(), namedWriteableRegistry),
-            new RestFleetMultiSearchAction(settings, restController.getSearchUsageHolder(), namedWriteableRegistry),
+            new RestFleetSearchAction(restController.getSearchUsageHolder(), namedWriteableRegistry, clusterSupportsFeature),
+            new RestFleetMultiSearchAction(settings, restController.getSearchUsageHolder(), namedWriteableRegistry, clusterSupportsFeature),
             new RestGetSecretsAction(),
             new RestPostSecretsAction(),
             new RestDeleteSecretsAction()

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetMultiSearchAction.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/rest/RestFleetMultiSearchAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -30,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeStringArrayValue;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeTimeValue;
@@ -42,15 +44,18 @@ public class RestFleetMultiSearchAction extends BaseRestHandler {
     private final boolean allowExplicitIndex;
     private final SearchUsageHolder searchUsageHolder;
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final Predicate<NodeFeature> clusterSupportsFeature;
 
     public RestFleetMultiSearchAction(
         Settings settings,
         SearchUsageHolder searchUsageHolder,
-        NamedWriteableRegistry namedWriteableRegistry
+        NamedWriteableRegistry namedWriteableRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature
     ) {
         this.allowExplicitIndex = MULTI_ALLOW_EXPLICIT_INDEX.get(settings);
         this.searchUsageHolder = searchUsageHolder;
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     @Override
@@ -75,6 +80,7 @@ public class RestFleetMultiSearchAction extends BaseRestHandler {
             namedWriteableRegistry,
             allowExplicitIndex,
             searchUsageHolder,
+            clusterSupportsFeature,
             (key, value, searchRequest) -> {
                 if ("wait_for_checkpoints".equals(key)) {
                     String[] stringWaitForCheckpoints = nodeStringArrayValue(value);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   javaRestTestImplementation project(path: xpackModule('slm'))
   javaRestTestImplementation project(path: xpackModule('monitoring'))
   javaRestTestImplementation project(path: xpackModule('transform'))
+  javaRestTestImplementation project(path: xpackModule('rank-rrf'))
 }
 
 // location for keys and certificates

--- a/x-pack/plugin/rank-rrf/src/main/java/module-info.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/module-info.java
@@ -13,4 +13,6 @@ module org.elasticsearch.rank.rrf {
     requires org.elasticsearch.xcore;
 
     exports org.elasticsearch.xpack.rank.rrf;
+
+    provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.rank.rrf.RRFFeatureSpecification;
 }

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFFeatureSpecification.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFFeatureSpecification.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.rank.rrf;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class RRFFeatureSpecification implements FeatureSpecification {
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(RRFRetrieverBuilder.NODE_FEATURE);
+    }
+}

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.rank.rrf;
 
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -50,7 +51,7 @@ public final class RRFRetrieverBuilder extends RetrieverBuilder<RRFRetrieverBuil
 
     public static RRFRetrieverBuilder fromXContent(XContentParser parser, RetrieverParserContext context) throws IOException {
         if (context.clusterSupportsFeature(NODE_FEATURE) == false) {
-            throw new IllegalArgumentException("[" + RRFRankPlugin.NAME + "] retriever is not a supported feature");
+            throw new ParsingException(parser.getTokenLocation(), "unknown retriever [" + RRFRankPlugin.NAME + "]");
         }
         if (RRFRankPlugin.RANK_RRF_FEATURE.check(XPackPlugin.getSharedLicenseState()) == false) {
             throw LicenseUtils.newComplianceException("Reciprocal Rank Fusion (RRF)");

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilder.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.rank.rrf;
 
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.license.LicenseUtils;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.retriever.RetrieverBuilder;
@@ -21,6 +22,8 @@ import java.util.Collections;
 import java.util.List;
 
 public final class RRFRetrieverBuilder extends RetrieverBuilder<RRFRetrieverBuilder> {
+
+    public static final NodeFeature NODE_FEATURE = new NodeFeature(RRFRankPlugin.NAME + "_retriever");
 
     public static final ParseField RETRIEVERS_FIELD = new ParseField("retrievers");
     public static final ParseField WINDOW_SIZE_FIELD = new ParseField("window_size");
@@ -46,6 +49,9 @@ public final class RRFRetrieverBuilder extends RetrieverBuilder<RRFRetrieverBuil
     }
 
     public static RRFRetrieverBuilder fromXContent(XContentParser parser, RetrieverParserContext context) throws IOException {
+        if (context.clusterSupportsFeature(NODE_FEATURE) == false) {
+            throw new IllegalArgumentException("[" + RRFRankPlugin.NAME + "] retriever is not a supported feature");
+        }
         if (RRFRankPlugin.RANK_RRF_FEATURE.check(XPackPlugin.getSharedLicenseState()) == false) {
             throw LicenseUtils.newComplianceException("Reciprocal Rank Fusion (RRF)");
         }

--- a/x-pack/plugin/rank-rrf/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/x-pack/plugin/rank-rrf/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -1,0 +1,8 @@
+#
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License
+# 2.0; you may not use this file except in compliance with the Elastic License
+# 2.0.
+#
+
+org.elasticsearch.xpack.rank.rrf.RRFFeatureSpecification

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.rank.rrf;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.features.NodeFeature;
+import org.elasticsearch.search.SearchModule;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.retriever.RetrieverBuilder;
+import org.elasticsearch.search.retriever.RetrieverParserContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RRFRetrieverBuilderTests extends ESTestCase {
+
+    /** Tests the rrf retriever validates on its own {@link NodeFeature} */
+    public void testRetrieverVersions() throws IOException {
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"retriever\":{\"rrf\":{}}}")) {
+            SearchSourceBuilder ssb = new SearchSourceBuilder();
+            IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> ssb.parseXContent(parser, true, nf -> false));
+            assertEquals("[rrf] retriever is not a supported feature", iae.getMessage());
+            ssb.parseXContent(parser, false, nf -> nf == RRFRetrieverBuilder.NODE_FEATURE);
+        }
+    }
+
+    @Override
+    protected NamedXContentRegistry xContentRegistry() {
+        List<NamedXContentRegistry.Entry> entries = new SearchModule(Settings.EMPTY, List.of()).getNamedXContents();
+        entries.add(
+            new NamedXContentRegistry.Entry(
+                RetrieverBuilder.class,
+                new ParseField(RRFRankPlugin.NAME),
+                (p, c) -> RRFRetrieverBuilder.fromXContent(p, (RetrieverParserContext) c)
+            )
+        );
+        return new NamedXContentRegistry(entries);
+    }
+}

--- a/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
+++ b/x-pack/plugin/rank-rrf/src/test/java/org/elasticsearch/xpack/rank/rrf/RRFRetrieverBuilderTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.rank.rrf;
 
+import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.search.SearchModule;
@@ -28,9 +29,11 @@ public class RRFRetrieverBuilderTests extends ESTestCase {
     public void testRetrieverVersions() throws IOException {
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, "{\"retriever\":{\"rrf\":{}}}")) {
             SearchSourceBuilder ssb = new SearchSourceBuilder();
-            IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> ssb.parseXContent(parser, true, nf -> false));
-            assertEquals("[rrf] retriever is not a supported feature", iae.getMessage());
-            ssb.parseXContent(parser, false, nf -> nf == RRFRetrieverBuilder.NODE_FEATURE);
+            ParsingException iae = expectThrows(
+                ParsingException.class,
+                () -> ssb.parseXContent(parser, true, nf -> nf == RetrieverBuilder.NODE_FEATURE)
+            );
+            assertEquals("unknown retriever [rrf]", iae.getMessage());
         }
     }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -99,7 +99,7 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
         return Arrays.asList(
-            new RestRollupSearchAction(namedWriteableRegistry),
+            new RestRollupSearchAction(namedWriteableRegistry, clusterSupportsFeature),
             new RestPutRollupJobAction(),
             new RestStartRollupJobAction(),
             new RestStopRollupJobAction(),

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/rest/RestRollupSearchAction.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.rollup.rest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
@@ -18,6 +19,7 @@ import org.elasticsearch.xpack.core.rollup.action.RollupSearchAction;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -27,9 +29,11 @@ public class RestRollupSearchAction extends BaseRestHandler {
     private static final Set<String> RESPONSE_PARAMS = Set.of(RestSearchAction.TYPED_KEYS_PARAM, RestSearchAction.TOTAL_HITS_AS_INT_PARAM);
 
     private final NamedWriteableRegistry namedWriteableRegistry;
+    private final Predicate<NodeFeature> clusterSupportsFeature;
 
-    public RestRollupSearchAction(NamedWriteableRegistry namedWriteableRegistry) {
+    public RestRollupSearchAction(NamedWriteableRegistry namedWriteableRegistry, Predicate<NodeFeature> clusterSupportsFeature) {
         this.namedWriteableRegistry = namedWriteableRegistry;
+        this.clusterSupportsFeature = clusterSupportsFeature;
     }
 
     @Override
@@ -51,6 +55,7 @@ public class RestRollupSearchAction extends BaseRestHandler {
                 restRequest,
                 parser,
                 namedWriteableRegistry,
+                clusterSupportsFeature,
                 size -> searchRequest.source().size(size)
             )
         );

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/SearchInputFactory.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/SearchInputFactory.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.watcher.input.search;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
@@ -16,6 +17,7 @@ import org.elasticsearch.xpack.watcher.input.InputFactory;
 import org.elasticsearch.xpack.watcher.support.search.WatcherSearchTemplateService;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 
 public class SearchInputFactory extends InputFactory<SearchInput, SearchInput.Result, ExecutableSearchInput> {
 
@@ -23,10 +25,16 @@ public class SearchInputFactory extends InputFactory<SearchInput, SearchInput.Re
     private final TimeValue defaultTimeout;
     private final WatcherSearchTemplateService searchTemplateService;
 
-    public SearchInputFactory(Settings settings, Client client, NamedXContentRegistry xContentRegistry, ScriptService scriptService) {
+    public SearchInputFactory(
+        Settings settings,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature,
+        ScriptService scriptService
+    ) {
         this.client = client;
         this.defaultTimeout = settings.getAsTime("xpack.watcher.input.search.default_timeout", TimeValue.timeValueMinutes(1));
-        this.searchTemplateService = new WatcherSearchTemplateService(scriptService, xContentRegistry);
+        this.searchTemplateService = new WatcherSearchTemplateService(scriptService, xContentRegistry, clusterSupportsFeature);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/SearchTransformFactory.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transform/search/SearchTransformFactory.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParser;
@@ -17,6 +18,7 @@ import org.elasticsearch.xpack.core.watcher.transform.TransformFactory;
 import org.elasticsearch.xpack.watcher.support.search.WatcherSearchTemplateService;
 
 import java.io.IOException;
+import java.util.function.Predicate;
 
 public class SearchTransformFactory extends TransformFactory<SearchTransform, SearchTransform.Result, ExecutableSearchTransform> {
 
@@ -24,11 +26,17 @@ public class SearchTransformFactory extends TransformFactory<SearchTransform, Se
     private final TimeValue defaultTimeout;
     private final WatcherSearchTemplateService searchTemplateService;
 
-    public SearchTransformFactory(Settings settings, Client client, NamedXContentRegistry xContentRegistry, ScriptService scriptService) {
+    public SearchTransformFactory(
+        Settings settings,
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        Predicate<NodeFeature> clusterSupportsFeature,
+        ScriptService scriptService
+    ) {
         super(LogManager.getLogger(ExecutableSearchTransform.class));
         this.client = client;
         this.defaultTimeout = settings.getAsTime("xpack.watcher.transform.search.default_timeout", TimeValue.timeValueMinutes(1));
-        this.searchTemplateService = new WatcherSearchTemplateService(scriptService, xContentRegistry);
+        this.searchTemplateService = new WatcherSearchTemplateService(scriptService, xContentRegistry, clusterSupportsFeature);
     }
 
     @Override

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/SearchInputTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/SearchInputTests.java
@@ -174,7 +174,7 @@ public class SearchInputTests extends ESTestCase {
         XContentParser parser = createParser(builder);
         parser.nextToken();
 
-        SearchInputFactory factory = new SearchInputFactory(Settings.EMPTY, client, xContentRegistry(), scriptService);
+        SearchInputFactory factory = new SearchInputFactory(Settings.EMPTY, client, xContentRegistry(), nf -> false, scriptService);
 
         SearchInput searchInput = factory.parseInput("_id", parser);
         assertEquals(SearchInput.TYPE, searchInput.type());
@@ -211,7 +211,7 @@ public class SearchInputTests extends ESTestCase {
 
             parser.nextToken(); // advance past the first starting object
 
-            SearchInputFactory factory = new SearchInputFactory(Settings.EMPTY, client, xContentRegistry(), scriptService);
+            SearchInputFactory factory = new SearchInputFactory(Settings.EMPTY, client, xContentRegistry(), nf -> false, scriptService);
             SearchInput input = factory.parseInput("my-watch", parser);
             assertThat(input.getRequest(), is(not(nullValue())));
             assertThat(input.getRequest().getSearchSource(), is(BytesArray.EMPTY));
@@ -228,6 +228,6 @@ public class SearchInputTests extends ESTestCase {
 
     private WatcherSearchTemplateService watcherSearchTemplateService() {
         SearchModule module = new SearchModule(Settings.EMPTY, Collections.emptyList());
-        return new WatcherSearchTemplateService(scriptService, new NamedXContentRegistry(module.getNamedXContents()));
+        return new WatcherSearchTemplateService(scriptService, new NamedXContentRegistry(module.getNamedXContents()), nf -> false);
     }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/SearchTransformTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/integration/SearchTransformTests.java
@@ -71,7 +71,13 @@ public class SearchTransformTests extends ESTestCase {
         ScriptService scriptService = new ScriptService(Settings.EMPTY, engines, ScriptModule.CORE_CONTEXTS, () -> 1L);
 
         Client client = mock(Client.class);
-        SearchTransformFactory transformFactory = new SearchTransformFactory(Settings.EMPTY, client, xContentRegistry(), scriptService);
+        SearchTransformFactory transformFactory = new SearchTransformFactory(
+            Settings.EMPTY,
+            client,
+            xContentRegistry(),
+            nf -> false,
+            scriptService
+        );
         ExecutableSearchTransform executable = transformFactory.parseExecutable("_id", parser);
 
         assertThat(executable, notNullValue());

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchTests.java
@@ -340,7 +340,11 @@ public class WatchTests extends ESTestCase {
         ActionRegistry actionRegistry = registry(Collections.emptyList(), conditionRegistry, transformRegistry);
         WatchParser watchParser = new WatchParser(triggerService, actionRegistry, inputRegistry, null, Clock.systemUTC());
 
-        WatcherSearchTemplateService searchTemplateService = new WatcherSearchTemplateService(scriptService, xContentRegistry());
+        WatcherSearchTemplateService searchTemplateService = new WatcherSearchTemplateService(
+            scriptService,
+            xContentRegistry(),
+            nf -> false
+        );
 
         XContentBuilder builder = jsonBuilder();
         builder.startObject();
@@ -533,7 +537,7 @@ public class WatchTests extends ESTestCase {
     private InputRegistry registry(String inputType) {
         return switch (inputType) {
             case SearchInput.TYPE -> new InputRegistry(
-                Map.of(SearchInput.TYPE, new SearchInputFactory(settings, client, xContentRegistry(), scriptService))
+                Map.of(SearchInput.TYPE, new SearchInputFactory(settings, client, xContentRegistry(), nf -> false, scriptService))
             );
             default -> new InputRegistry(Map.of(SimpleInput.TYPE, new SimpleInputFactory()));
         };
@@ -592,7 +596,7 @@ public class WatchTests extends ESTestCase {
                 ScriptTransform.TYPE,
                 new ScriptTransformFactory(scriptService),
                 SearchTransform.TYPE,
-                new SearchTransformFactory(settings, client, xContentRegistry(), scriptService)
+                new SearchTransformFactory(settings, client, xContentRegistry(), nf -> false, scriptService)
             )
         );
     }


### PR DESCRIPTION
This change adds feature version checking for each individual retriever builder. An error will be thrown for each retriever that is not currently supported across the entire cluster.