### PR TITLE
[Profiling] Rename stacktrace_ids field

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
@@ -36,7 +36,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField SAMPLE_SIZE_FIELD = new ParseField("sample_size");
     public static final ParseField INDICES_FIELD = new ParseField("indices");
-    public static final ParseField STACKTRACE_IDS_FIELD = new ParseField("stacktrace_ids");
+    public static final ParseField STACKTRACE_IDS_FIELD = new ParseField("stacktrace_ids_field");
     public static final ParseField REQUESTED_DURATION_FIELD = new ParseField("requested_duration");
     public static final ParseField AWS_COST_FACTOR_FIELD = new ParseField("aws_cost_factor");
     public static final ParseField CUSTOM_CO2_PER_KWH = new ParseField("co2_per_kwh");
@@ -49,7 +49,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
     private QueryBuilder query;
     private int sampleSize;
     private String indices;
-    private String stackTraceIds;
+    private String stackTraceIdsField;
     private Double requestedDuration;
     private Double awsCostFactor;
     private Double customCO2PerKWH;
@@ -73,7 +73,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         Double awsCostFactor,
         QueryBuilder query,
         String indices,
-        String stackTraceIds,
+        String stackTraceIdsField,
         Double customCO2PerKWH,
         Double customDatacenterPUE,
         Double customPerCoreWattX86,
@@ -85,7 +85,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         this.awsCostFactor = awsCostFactor;
         this.query = query;
         this.indices = indices;
-        this.stackTraceIds = stackTraceIds;
+        this.stackTraceIdsField = stackTraceIdsField;
         this.customCO2PerKWH = customCO2PerKWH;
         this.customDatacenterPUE = customDatacenterPUE;
         this.customPerCoreWattX86 = customPerCoreWattX86;
@@ -138,8 +138,8 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         return indices;
     }
 
-    public String getStackTraceIds() {
-        return stackTraceIds;
+    public String getStackTraceIdsField() {
+        return stackTraceIdsField;
     }
 
     public boolean isAdjustSampleCount() {
@@ -170,7 +170,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
                 } else if (INDICES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     this.indices = parser.text();
                 } else if (STACKTRACE_IDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
-                    this.stackTraceIds = parser.text();
+                    this.stackTraceIdsField = parser.text();
                 } else if (REQUESTED_DURATION_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     this.requestedDuration = parser.doubleValue();
                 } else if (AWS_COST_FACTOR_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
@@ -215,14 +215,14 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
         if (indices != null) {
-            if (stackTraceIds == null || stackTraceIds.isEmpty()) {
+            if (stackTraceIdsField == null || stackTraceIdsField.isEmpty()) {
                 validationException = addValidationError(
                     "[" + STACKTRACE_IDS_FIELD.getPreferredName() + "] is mandatory",
                     validationException
                 );
             }
         } else {
-            if (stackTraceIds != null) {
+            if (stackTraceIdsField != null) {
                 validationException = addValidationError(
                     "[" + STACKTRACE_IDS_FIELD.getPreferredName() + "] must not be set",
                     validationException
@@ -257,7 +257,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
                 // generating description lazily since the query could be large
                 StringBuilder sb = new StringBuilder();
                 appendField(sb, "indices", indices);
-                appendField(sb, "stacktrace_ids", stackTraceIds);
+                appendField(sb, "stacktrace_ids_field", stackTraceIdsField);
                 appendField(sb, "sample_size", sampleSize);
                 appendField(sb, "requested_duration", requestedDuration);
                 appendField(sb, "aws_cost_factor", awsCostFactor);
@@ -295,7 +295,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         return Objects.equals(query, that.query)
             && Objects.equals(sampleSize, that.sampleSize)
             && Objects.equals(indices, that.indices)
-            && Objects.equals(stackTraceIds, that.stackTraceIds);
+            && Objects.equals(stackTraceIdsField, that.stackTraceIdsField);
     }
 
     @Override
@@ -306,7 +306,7 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
         // Resampler to produce a consistent downsampling results, relying on the default hashCode implementation of `query` will
         // produce consistent results per node but not across the cluster. To avoid this, we produce the hashCode based on the
         // string representation instead, which will produce consistent results for the entire cluster and across node restarts.
-        return Objects.hash(Objects.toString(query, "null"), sampleSize, indices, stackTraceIds);
+        return Objects.hash(Objects.toString(query, "null"), sampleSize, indices, stackTraceIdsField);
     }
 
     @Override

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -266,7 +266,8 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                 new RandomSamplerAggregationBuilder("sample").setSeed(request.hashCode())
                     .setProbability(responseBuilder.getSamplingRate())
                     .subAggregation(
-                        new CountedTermsAggregationBuilder("group_by").size(MAX_TRACE_EVENTS_RESULT_SIZE).field(request.getStackTraceIds())
+                        new CountedTermsAggregationBuilder("group_by").size(MAX_TRACE_EVENTS_RESULT_SIZE)
+                            .field(request.getStackTraceIdsField())
                     )
             )
             .execute(handleEventsGroupedByStackTrace(submitTask, client, responseBuilder, submitListener, searchResponse -> {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/GetStackTracesRequestTests.java
@@ -50,7 +50,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
             assertEquals("@timestamp", ((RangeQueryBuilder) request.getQuery()).fieldName());
             // Expect the default values
             assertNull(request.getIndices());
-            assertNull(request.getStackTraceIds());
+            assertNull(request.getStackTraceIdsField());
             assertNull(request.getAwsCostFactor());
             assertNull(request.getCustomCO2PerKWH());
             assertNull(request.getCustomDatacenterPUE());
@@ -66,7 +66,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
             .startObject()
                 .field("sample_size", 2000)
                 .field("indices", "my-traces")
-                .field("stacktrace_ids", "stacktraces")
+                .field("stacktrace_ids_field", "stacktraces")
                 .startObject("query")
                     .startObject("range")
                         .startObject("@timestamp")
@@ -83,7 +83,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
 
             assertEquals(2000, request.getSampleSize());
             assertEquals("my-traces", request.getIndices());
-            assertEquals("stacktraces", request.getStackTraceIds());
+            assertEquals("stacktraces", request.getStackTraceIdsField());
             // a basic check suffices here
             assertEquals("@timestamp", ((RangeQueryBuilder) request.getQuery()).fieldName());
 
@@ -138,7 +138,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
 
             // Expect the default values
             assertNull(request.getIndices());
-            assertNull(request.getStackTraceIds());
+            assertNull(request.getStackTraceIdsField());
         }
     }
 
@@ -217,7 +217,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
         );
         List<String> validationErrors = request.validate().validationErrors();
         assertEquals(1, validationErrors.size());
-        assertEquals("[stacktrace_ids] must not be set", validationErrors.get(0));
+        assertEquals("[stacktrace_ids_field] must not be set", validationErrors.get(0));
     }
 
     public void testValidateIndicesWithoutStacktraces() {
@@ -236,7 +236,7 @@ public class GetStackTracesRequestTests extends ESTestCase {
         );
         List<String> validationErrors = request.validate().validationErrors();
         assertEquals(1, validationErrors.size());
-        assertEquals("[stacktrace_ids] is mandatory", validationErrors.get(0));
+        assertEquals("[stacktrace_ids_field] is mandatory", validationErrors.get(0));
     }
 
     public void testConsidersCustomIndicesInRelatedIndices() {


### PR DESCRIPTION
With this commit we rename the field `stacktrace_ids` to `stacktrace_ids_field` for the API calls `_profiling/stacktraces` and `_profiling/flamegraph`. The semantics of this field are to contain the name of the field to query in the indices provided by the `indices` parameter. As the old field name was misleading (should we provide the name of the field or a list of ids?) we rename it. As these APIs are meant for exclusive use by Kibana and the field has been unused so far we make this change directly without introducing any BWC layer.