### PR TITLE
Fix exception handling on DateFormatters.forPattern() with wrong date pattern

### DIFF
--- a/docs/changelog/105048.yaml
+++ b/docs/changelog/105048.yaml
@@ -1,0 +1,6 @@
+pr: 105048
+summary: "ES|QL: Fix exception handling on `date_parse` with wrong date pattern"
+area: ES|QL
+type: bug
+issues:
+ - 104124

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -2125,7 +2125,8 @@ public class DateFormatters {
                     input,
                     new DateTimeFormatterBuilder().appendPattern(input).toFormatter(Locale.ROOT).withResolverStyle(ResolverStyle.STRICT)
                 );
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | ClassCastException e) {
+                // ClassCastException catches this bug https://bugs.openjdk.org/browse/JDK-8193877
                 throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -2125,18 +2125,9 @@ public class DateFormatters {
                     input,
                     new DateTimeFormatterBuilder().appendPattern(input).toFormatter(Locale.ROOT).withResolverStyle(ResolverStyle.STRICT)
                 );
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | ClassCastException e) {
+                // ClassCastException catches this bug https://bugs.openjdk.org/browse/JDK-8193877
                 throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
-            } catch (ClassCastException e) {
-                // this catches this bug https://bugs.openjdk.org/browse/JDK-8193877
-                if (e.getMessage()
-                    .startsWith(
-                        "class java.time.format.DateTimeFormatterBuilder$PadPrinterParserDecorator "
-                            + "cannot be cast to class java.time.format.DateTimeFormatterBuilder$NumberPrinterParser"
-                    )) {
-                    throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
-                }
-                throw e;
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -2125,9 +2125,18 @@ public class DateFormatters {
                     input,
                     new DateTimeFormatterBuilder().appendPattern(input).toFormatter(Locale.ROOT).withResolverStyle(ResolverStyle.STRICT)
                 );
-            } catch (IllegalArgumentException | ClassCastException e) {
-                // ClassCastException catches this bug https://bugs.openjdk.org/browse/JDK-8193877
+            } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
+            } catch (ClassCastException e) {
+                // this catches this bug https://bugs.openjdk.org/browse/JDK-8193877
+                if (e.getMessage()
+                    .startsWith(
+                        "class java.time.format.DateTimeFormatterBuilder$PadPrinterParserDecorator "
+                            + "cannot be cast to class java.time.format.DateTimeFormatterBuilder$NumberPrinterParser"
+                    )) {
+                    throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
+                }
+                throw e;
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -1376,6 +1376,7 @@ public class DateFormattersTests extends ESTestCase {
     public void testNoClassCastException() {
         String input = "DpNKOGqhjZ";
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DateFormatter.forPattern(input));
+        assertThat(e.getCause(), instanceOf(ClassCastException.class));
         assertThat(e.getMessage(), containsString(input));
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -1371,4 +1371,11 @@ public class DateFormattersTests extends ESTestCase {
         long millisJoda = DateFormatter.forPattern("yyyy-MM-dd HH:mm:ss").parseMillis("2018-02-18 17:47:17");
         assertThat(millisJava, is(millisJoda));
     }
+
+    // see https://bugs.openjdk.org/browse/JDK-8193877
+    public void testNoClassCastException() {
+        String input = "DpNKOGqhjZ";
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DateFormatter.forPattern(input));
+        assertThat(e.getMessage(), containsString(input));
+    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -122,15 +122,7 @@ public class DateParse extends ScalarFunction implements OptionalArgument, Evalu
     }
 
     private static DateFormatter toFormatter(Object format, ZoneId zone) {
-        String pattern = ((BytesRef) format).utf8ToString();
-        DateFormatter formatter;
-        try {
-            formatter = forPattern(pattern);
-        } catch (ClassCastException e) {
-            // https://github.com/elastic/elasticsearch/issues/104124#issuecomment-1921755275
-            throw new InvalidArgumentException("invalid date pattern for []: Invalid format: [" + pattern + "]", e);
-        }
-        return formatter.withZone(zone);
+        return forPattern(((BytesRef) format).utf8ToString()).withZone(zone);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParse.java
@@ -122,7 +122,15 @@ public class DateParse extends ScalarFunction implements OptionalArgument, Evalu
     }
 
     private static DateFormatter toFormatter(Object format, ZoneId zone) {
-        return forPattern(((BytesRef) format).utf8ToString()).withZone(zone);
+        String pattern = ((BytesRef) format).utf8ToString();
+        DateFormatter formatter;
+        try {
+            formatter = forPattern(pattern);
+        } catch (ClassCastException e) {
+            // https://github.com/elastic/elasticsearch/issues/104124#issuecomment-1921755275
+            throw new InvalidArgumentException("invalid date pattern for []: Invalid format: [" + pattern + "]", e);
+        }
+        return formatter.withZone(zone);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
@@ -104,7 +104,7 @@ public class DateParseTests extends AbstractScalarFunctionTestCase {
     }
 
     public void testInvalidPattern() {
-        String pattern = randomAlphaOfLength(10);
+        String pattern = "invalid";
         DriverContext driverContext = driverContext();
         InvalidArgumentException e = expectThrows(
             InvalidArgumentException.class,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
@@ -103,7 +103,6 @@ public class DateParseTests extends AbstractScalarFunctionTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104124")
     public void testInvalidPattern() {
         String pattern = randomAlphaOfLength(10);
         DriverContext driverContext = driverContext();


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/104124

Apparently there is a bug in `java.time` so that passing a wrong date pattern in some cases results in a `ClassCastException` instead of the expected `InvalidArgumentException` (see comment [here](https://github.com/elastic/elasticsearch/issues/104124#issuecomment-1921755275))

It's quite unlikely to catch this problem in a real production use case, but our randomized tests tripped over it.

The proposed solution is to also catch ClassCastException and in case wrap it in the expected InvalidArgumentException