### PR TITLE
Do not set apm agent instrument setting

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -214,7 +214,7 @@ public abstract class RunTask extends DefaultTestClustersTask {
                 else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) { // metrics
                     node.setting("telemetry.metrics.enabled", "false");
                 } else if (node.getSettingKeys().contains("telemetry.tracing.enabled") == false
-                    && node.getSettingKeys().contains("tracing.apm.enabled") == false) { // tracing
+                    && node.getSettingKeys().contains("telemetry.tracing.enable") == false) { // tracing
                         node.setting("telemetry.tracing.enable", "false");
                     }
 

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -213,10 +213,9 @@ public abstract class RunTask extends DefaultTestClustersTask {
                 // if metrics were not enabled explicitly for gradlew run we should disable them
                 else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) { // metrics
                     node.setting("telemetry.metrics.enabled", "false");
-                } else if (node.getSettingKeys().contains("telemetry.tracing.enabled") == false
-                    && node.getSettingKeys().contains("telemetry.tracing.enable") == false) { // tracing
-                        node.setting("telemetry.tracing.enable", "false");
-                    }
+                } else if (node.getSettingKeys().contains("telemetry.tracing.enabled") == false) { // tracing
+                    node.setting("telemetry.tracing.enable", "false");
+                }
 
             }
         }

--- a/docs/changelog/105050.yaml
+++ b/docs/changelog/105050.yaml
@@ -1,0 +1,5 @@
+pr: 105050
+summary: Do not set apm agent instrument setting
+area: Infra/Metrics
+type: bug
+issues: []

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -44,7 +44,6 @@ public class APMAgentSettings {
 
         clusterSettings.addSettingsUpdateConsumer(TELEMETRY_TRACING_ENABLED_SETTING, enabled -> {
             apmTracer.setEnabled(enabled);
-            this.setAgentSetting("instrument", Boolean.toString(enabled));
             // The agent records data other than spans, e.g. JVM metrics, so we toggle this setting in order to
             // minimise its impact to a running Elasticsearch.
             boolean recording = enabled || clusterSettings.get(TELEMETRY_METRICS_ENABLED_SETTING);
@@ -73,7 +72,6 @@ public class APMAgentSettings {
         boolean metrics = TELEMETRY_METRICS_ENABLED_SETTING.get(settings);
 
         this.setAgentSetting("recording", Boolean.toString(tracing || metrics));
-        this.setAgentSetting("instrument", Boolean.toString(tracing));
         // Apply values from the settings in the cluster state
         APM_AGENT_SETTINGS.getAsMap(settings).forEach(this::setAgentSetting);
     }

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
@@ -60,13 +60,11 @@ public class APMAgentSettingsTests extends ESTestCase {
             apmAgentSettings.initAgentSystemProperties(update);
 
             verify(apmAgentSettings).setAgentSetting("recording", "true");
-            verify(apmAgentSettings).setAgentSetting("instrument", "true");
             clearInvocations(apmAgentSettings);
 
             Settings initial = Settings.builder().put(update).put(TELEMETRY_TRACING_ENABLED_SETTING.getKey(), false).build();
             triggerUpdateConsumer(initial, update);
             verify(apmAgentSettings).setAgentSetting("recording", "true");
-            verify(apmAgentSettings).setAgentSetting("instrument", "true");
             verify(apmTelemetryProvider.getTracer()).setEnabled(true);
         }
     }
@@ -76,7 +74,6 @@ public class APMAgentSettingsTests extends ESTestCase {
         apmAgentSettings.initAgentSystemProperties(settings);
 
         verify(apmAgentSettings).setAgentSetting("recording", "true");
-        verify(apmAgentSettings).setAgentSetting("instrument", "true");
     }
 
     public void testEnableMetrics() {
@@ -90,7 +87,6 @@ public class APMAgentSettingsTests extends ESTestCase {
             apmAgentSettings.initAgentSystemProperties(update);
 
             verify(apmAgentSettings).setAgentSetting("recording", "true");
-            verify(apmAgentSettings).setAgentSetting("instrument", Boolean.toString(tracingEnabled));
             clearInvocations(apmAgentSettings);
 
             Settings initial = Settings.builder().put(update).put(TELEMETRY_METRICS_ENABLED_SETTING.getKey(), false).build();
@@ -114,13 +110,11 @@ public class APMAgentSettingsTests extends ESTestCase {
             apmAgentSettings.initAgentSystemProperties(update);
 
             verify(apmAgentSettings).setAgentSetting("recording", Boolean.toString(metricsEnabled));
-            verify(apmAgentSettings).setAgentSetting("instrument", "false");
             clearInvocations(apmAgentSettings);
 
             Settings initial = Settings.builder().put(update).put(TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true).build();
             triggerUpdateConsumer(initial, update);
             verify(apmAgentSettings).setAgentSetting("recording", Boolean.toString(metricsEnabled));
-            verify(apmAgentSettings).setAgentSetting("instrument", "false");
             verify(apmTelemetryProvider.getTracer()).setEnabled(false);
         }
     }
@@ -130,7 +124,6 @@ public class APMAgentSettingsTests extends ESTestCase {
         apmAgentSettings.initAgentSystemProperties(settings);
 
         verify(apmAgentSettings).setAgentSetting("recording", "false");
-        verify(apmAgentSettings).setAgentSetting("instrument", "false");
     }
 
     public void testDisableMetrics() {
@@ -144,7 +137,6 @@ public class APMAgentSettingsTests extends ESTestCase {
             apmAgentSettings.initAgentSystemProperties(update);
 
             verify(apmAgentSettings).setAgentSetting("recording", Boolean.toString(tracingEnabled));
-            verify(apmAgentSettings).setAgentSetting("instrument", Boolean.toString(tracingEnabled));
             clearInvocations(apmAgentSettings);
 
             Settings initial = Settings.builder().put(update).put(TELEMETRY_METRICS_ENABLED_SETTING.getKey(), true).build();


### PR DESCRIPTION
we should not be setting apm agent instrument setting as ES is not using auto instrumentation
this commit removes the possibility to set this and relies on a static settings in ApmJavaOptions

this commit also migrates deprecated setting in RunTask

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
