### PR TITLE
Do not enable APM agent 'instrument', it's not required for manual tracing.

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -213,10 +213,9 @@ public abstract class RunTask extends DefaultTestClustersTask {
                 // if metrics were not enabled explicitly for gradlew run we should disable them
                 else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) { // metrics
                     node.setting("telemetry.metrics.enabled", "false");
-                } else if ((node.getSettingKeys().contains("telemetry.tracing.enabled")
-                    || node.getSettingKeys().contains("tracing.apm.enabled")) == false) { // tracing
-                        node.setting("telemetry.tracing.enable", "false");
-                    }
+                } else if (node.getSettingKeys().contains("telemetry.tracing.enabled") == false) { // tracing
+                    node.setting("telemetry.tracing.enable", "false");
+                }
 
             }
         }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -213,9 +213,10 @@ public abstract class RunTask extends DefaultTestClustersTask {
                 // if metrics were not enabled explicitly for gradlew run we should disable them
                 else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) { // metrics
                     node.setting("telemetry.metrics.enabled", "false");
-                } else if (node.getSettingKeys().contains("telemetry.tracing.enabled") == false) { // tracing
-                    node.setting("telemetry.tracing.enable", "false");
-                }
+                } else if (node.getSettingKeys().contains("telemetry.tracing.enabled") == false
+                    && node.getSettingKeys().contains("tracing.apm.enabled") == false) { // tracing
+                        node.setting("telemetry.tracing.enable", "false");
+                    }
 
             }
         }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/RunTask.java
@@ -213,8 +213,8 @@ public abstract class RunTask extends DefaultTestClustersTask {
                 // if metrics were not enabled explicitly for gradlew run we should disable them
                 else if (node.getSettingKeys().contains("telemetry.metrics.enabled") == false) { // metrics
                     node.setting("telemetry.metrics.enabled", "false");
-                } else if (node.getSettingKeys().contains("telemetry.tracing.enabled") == false
-                    && node.getSettingKeys().contains("tracing.apm.enabled") == false) { // tracing
+                } else if ((node.getSettingKeys().contains("telemetry.tracing.enabled")
+                    || node.getSettingKeys().contains("tracing.apm.enabled")) == false) { // tracing
                         node.setting("telemetry.tracing.enable", "false");
                     }
 

--- a/docs/changelog/105055.yaml
+++ b/docs/changelog/105055.yaml
@@ -1,0 +1,5 @@
+pr: 105055
+summary: "Do not enable APM agent 'instrument', it's not required for manual tracing"
+area: Infra/Core
+type: bug
+issues: []

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -119,7 +119,7 @@ public class APMAgentSettings {
         // Core:
         // forbid 'enabled', must remain enabled to dynamically enable tracing / metrics
         // forbid 'recording', controlled by 'telemetry.metrics.enabled' / 'telemetry.tracing.enabled'
-        "instrument",
+        // forbid 'instrument', automatic instrumentation can cause issues
         "service_name",
         "service_node_name",
         // forbid 'service_version', forced by APMJvmOptions

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettings.java
@@ -44,7 +44,6 @@ public class APMAgentSettings {
 
         clusterSettings.addSettingsUpdateConsumer(TELEMETRY_TRACING_ENABLED_SETTING, enabled -> {
             apmTracer.setEnabled(enabled);
-            this.setAgentSetting("instrument", Boolean.toString(enabled));
             // The agent records data other than spans, e.g. JVM metrics, so we toggle this setting in order to
             // minimise its impact to a running Elasticsearch.
             boolean recording = enabled || clusterSettings.get(TELEMETRY_METRICS_ENABLED_SETTING);
@@ -73,7 +72,6 @@ public class APMAgentSettings {
         boolean metrics = TELEMETRY_METRICS_ENABLED_SETTING.get(settings);
 
         this.setAgentSetting("recording", Boolean.toString(tracing || metrics));
-        this.setAgentSetting("instrument", Boolean.toString(tracing));
         // Apply values from the settings in the cluster state
         APM_AGENT_SETTINGS.getAsMap(settings).forEach(this::setAgentSetting);
     }
@@ -120,7 +118,8 @@ public class APMAgentSettings {
 
         // Core:
         // forbid 'enabled', must remain enabled to dynamically enable tracing / metrics
-        // forbid 'recording' / 'instrument', controlled by 'telemetry.metrics.enabled' / 'telemetry.tracing.enabled'
+        // forbid 'recording', controlled by 'telemetry.metrics.enabled' / 'telemetry.tracing.enabled'
+        "instrument",
         "service_name",
         "service_node_name",
         // forbid 'service_version', forced by APMJvmOptions

--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
@@ -60,13 +60,11 @@ public class APMAgentSettingsTests extends ESTestCase {
             apmAgentSettings.initAgentSystemProperties(update);
 
             verify(apmAgentSettings).setAgentSetting("recording", "true");
-            verify(apmAgentSettings).setAgentSetting("instrument", "true");
             clearInvocations(apmAgentSettings);
 
             Settings initial = Settings.builder().put(update).put(TELEMETRY_TRACING_ENABLED_SETTING.getKey(), false).build();
             triggerUpdateConsumer(initial, update);
             verify(apmAgentSettings).setAgentSetting("recording", "true");
-            verify(apmAgentSettings).setAgentSetting("instrument", "true");
             verify(apmTelemetryProvider.getTracer()).setEnabled(true);
         }
     }
@@ -76,7 +74,6 @@ public class APMAgentSettingsTests extends ESTestCase {
         apmAgentSettings.initAgentSystemProperties(settings);
 
         verify(apmAgentSettings).setAgentSetting("recording", "true");
-        verify(apmAgentSettings).setAgentSetting("instrument", "true");
     }
 
     public void testEnableMetrics() {
@@ -90,7 +87,6 @@ public class APMAgentSettingsTests extends ESTestCase {
             apmAgentSettings.initAgentSystemProperties(update);
 
             verify(apmAgentSettings).setAgentSetting("recording", "true");
-            verify(apmAgentSettings).setAgentSetting("instrument", Boolean.toString(tracingEnabled));
             clearInvocations(apmAgentSettings);
 
             Settings initial = Settings.builder().put(update).put(TELEMETRY_METRICS_ENABLED_SETTING.getKey(), false).build();
@@ -114,13 +110,11 @@ public class APMAgentSettingsTests extends ESTestCase {
             apmAgentSettings.initAgentSystemProperties(update);
 
             verify(apmAgentSettings).setAgentSetting("recording", Boolean.toString(metricsEnabled));
-            verify(apmAgentSettings).setAgentSetting("instrument", "false");
             clearInvocations(apmAgentSettings);
 
             Settings initial = Settings.builder().put(update).put(TELEMETRY_TRACING_ENABLED_SETTING.getKey(), true).build();
             triggerUpdateConsumer(initial, update);
             verify(apmAgentSettings).setAgentSetting("recording", Boolean.toString(metricsEnabled));
-            verify(apmAgentSettings).setAgentSetting("instrument", "false");
             verify(apmTelemetryProvider.getTracer()).setEnabled(false);
         }
     }
@@ -130,7 +124,6 @@ public class APMAgentSettingsTests extends ESTestCase {
         apmAgentSettings.initAgentSystemProperties(settings);
 
         verify(apmAgentSettings).setAgentSetting("recording", "false");
-        verify(apmAgentSettings).setAgentSetting("instrument", "false");
     }
 
     public void testDisableMetrics() {
@@ -144,7 +137,6 @@ public class APMAgentSettingsTests extends ESTestCase {
             apmAgentSettings.initAgentSystemProperties(update);
 
             verify(apmAgentSettings).setAgentSetting("recording", Boolean.toString(tracingEnabled));
-            verify(apmAgentSettings).setAgentSetting("instrument", Boolean.toString(tracingEnabled));
             clearInvocations(apmAgentSettings);
 
             Settings initial = Settings.builder().put(update).put(TELEMETRY_METRICS_ENABLED_SETTING.getKey(), true).build();


### PR DESCRIPTION
Do not enable APM agent 'instrument', it's not required for manual tracing.