### PR TITLE
Increase assertBusy to 30 seconds to make sure the disk health data is received

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/health/UpdateHealthInfoCacheIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/UpdateHealthInfoCacheIT.java
@@ -24,6 +24,7 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -77,7 +78,7 @@ public class UpdateHealthInfoCacheIT extends ESIntegTestCase {
         DiscoveryNode newHealthNode = waitAndGetHealthNode(internalCluster);
         assertThat(newHealthNode, notNullValue());
         logger.info("Previous health node {}, new health node {}.", healthNodeToBeShutDown, newHealthNode);
-        assertBusy(() -> assertResultsCanBeFetched(internalCluster, newHealthNode, List.of(nodeIds), null));
+        assertBusy(() -> assertResultsCanBeFetched(internalCluster, newHealthNode, List.of(nodeIds), null), 30, TimeUnit.SECONDS);
     }
 
     @TestLogging(value = "org.elasticsearch.health.node:DEBUG", reason = "https://github.com/elastic/elasticsearch/issues/97213")
@@ -93,7 +94,7 @@ public class UpdateHealthInfoCacheIT extends ESIntegTestCase {
         ensureStableCluster(nodeIds.length);
         DiscoveryNode newHealthNode = waitAndGetHealthNode(internalCluster);
         assertThat(newHealthNode, notNullValue());
-        assertBusy(() -> assertResultsCanBeFetched(internalCluster, newHealthNode, List.of(nodeIds), null));
+        assertBusy(() -> assertResultsCanBeFetched(internalCluster, newHealthNode, List.of(nodeIds), null), 30, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
The local health monitor runs every 10 seconds on every node and the assertBusy statements we use to check the results are received also have a 10 seconds timeout. This increases the timeout of the assertBusy statements to 30 seconds to make sure the results from each node are received.

Fixes #97213