### PR TITLE
Refactor ApiKeyFieldNameTranslators to expose query builder translator

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SimpleQueryStringBuilder.java
@@ -280,14 +280,14 @@ public final class SimpleQueryStringBuilder extends AbstractQueryBuilder<SimpleQ
         return this;
     }
 
-    /** For testing and serialisation only. */
-    SimpleQueryStringBuilder flags(int flags) {
+    /** For testing, builder instance copy, and serialisation only. */
+    public SimpleQueryStringBuilder flags(int flags) {
         this.flags = flags;
         return this;
     }
 
-    /** For testing only: Return the flags set for this query. */
-    int flags() {
+    /** For testing and instance copy only: Return the flags set for this query. */
+    public int flags() {
         return this.flags;
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/QueryApiKeyRequest.java
@@ -7,11 +7,9 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.TransportAction;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -60,24 +58,6 @@ public final class QueryApiKeyRequest extends ActionRequest {
         this.fieldSortBuilders = fieldSortBuilders;
         this.searchAfterBuilder = searchAfterBuilder;
         this.withLimitedBy = withLimitedBy;
-    }
-
-    public QueryApiKeyRequest(StreamInput in) throws IOException {
-        super(in);
-        this.queryBuilder = in.readOptionalNamedWriteable(QueryBuilder.class);
-        this.from = in.readOptionalVInt();
-        this.size = in.readOptionalVInt();
-        if (in.readBoolean()) {
-            this.fieldSortBuilders = in.readCollectionAsList(FieldSortBuilder::new);
-        } else {
-            this.fieldSortBuilders = null;
-        }
-        this.searchAfterBuilder = in.readOptionalWriteable(SearchAfterBuilder::new);
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_8_5_0)) {
-            this.withLimitedBy = in.readBoolean();
-        } else {
-            this.withLimitedBy = false;
-        }
     }
 
     public QueryBuilder getQueryBuilder() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilder.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilder.java
@@ -10,33 +10,20 @@ package org.elasticsearch.xpack.security.support;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.ExistsQueryBuilder;
-import org.elasticsearch.index.query.IdsQueryBuilder;
-import org.elasticsearch.index.query.MatchAllQueryBuilder;
-import org.elasticsearch.index.query.MatchNoneQueryBuilder;
-import org.elasticsearch.index.query.MatchQueryBuilder;
-import org.elasticsearch.index.query.PrefixQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.QueryRewriteContext;
-import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
-import org.elasticsearch.index.query.SimpleQueryStringBuilder;
-import org.elasticsearch.index.query.TermQueryBuilder;
-import org.elasticsearch.index.query.TermsQueryBuilder;
-import org.elasticsearch.index.query.WildcardQueryBuilder;
-import org.elasticsearch.index.search.QueryParserHelper;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
 import org.elasticsearch.xpack.security.authc.ApiKeyService;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.security.action.apikey.TransportQueryApiKeyAction.API_KEY_TYPE_RUNTIME_MAPPING_FIELD;
+import static org.elasticsearch.xpack.security.support.ApiKeyFieldNameTranslators.translateQueryBuilderFields;
 
 public class ApiKeyBoolQueryBuilder extends BoolQueryBuilder {
 
@@ -82,7 +69,7 @@ public class ApiKeyBoolQueryBuilder extends BoolQueryBuilder {
     ) {
         final ApiKeyBoolQueryBuilder finalQuery = new ApiKeyBoolQueryBuilder();
         if (queryBuilder != null) {
-            QueryBuilder processedQuery = doProcess(queryBuilder, fieldNameVisitor);
+            QueryBuilder processedQuery = translateQueryBuilderFields(queryBuilder, fieldNameVisitor);
             finalQuery.must(processedQuery);
         }
         finalQuery.filter(QueryBuilders.termQuery("doc_type", "api_key"));
@@ -106,136 +93,6 @@ public class ApiKeyBoolQueryBuilder extends BoolQueryBuilder {
             }
         }
         return finalQuery;
-    }
-
-    private static QueryBuilder doProcess(QueryBuilder qb, Consumer<String> fieldNameVisitor) {
-        if (qb instanceof final BoolQueryBuilder query) {
-            final BoolQueryBuilder newQuery = QueryBuilders.boolQuery()
-                .minimumShouldMatch(query.minimumShouldMatch())
-                .adjustPureNegative(query.adjustPureNegative())
-                .boost(query.boost());
-            query.must().stream().map(q -> ApiKeyBoolQueryBuilder.doProcess(q, fieldNameVisitor)).forEach(newQuery::must);
-            query.should().stream().map(q -> ApiKeyBoolQueryBuilder.doProcess(q, fieldNameVisitor)).forEach(newQuery::should);
-            query.mustNot().stream().map(q -> ApiKeyBoolQueryBuilder.doProcess(q, fieldNameVisitor)).forEach(newQuery::mustNot);
-            query.filter().stream().map(q -> ApiKeyBoolQueryBuilder.doProcess(q, fieldNameVisitor)).forEach(newQuery::filter);
-            return newQuery;
-        } else if (qb instanceof MatchAllQueryBuilder) {
-            return qb;
-        } else if (qb instanceof IdsQueryBuilder) {
-            return qb;
-        } else if (qb instanceof final TermQueryBuilder query) {
-            final String translatedFieldName = ApiKeyFieldNameTranslators.translate(query.fieldName());
-            fieldNameVisitor.accept(translatedFieldName);
-            return QueryBuilders.termQuery(translatedFieldName, query.value())
-                .caseInsensitive(query.caseInsensitive())
-                .boost(query.boost());
-        } else if (qb instanceof final ExistsQueryBuilder query) {
-            final String translatedFieldName = ApiKeyFieldNameTranslators.translate(query.fieldName());
-            fieldNameVisitor.accept(translatedFieldName);
-            return QueryBuilders.existsQuery(translatedFieldName).boost(query.boost());
-        } else if (qb instanceof final TermsQueryBuilder query) {
-            if (query.termsLookup() != null) {
-                throw new IllegalArgumentException("terms query with terms lookup is not supported for API Key query");
-            }
-            final String translatedFieldName = ApiKeyFieldNameTranslators.translate(query.fieldName());
-            fieldNameVisitor.accept(translatedFieldName);
-            return QueryBuilders.termsQuery(translatedFieldName, query.getValues()).boost(query.boost());
-        } else if (qb instanceof final PrefixQueryBuilder query) {
-            final String translatedFieldName = ApiKeyFieldNameTranslators.translate(query.fieldName());
-            fieldNameVisitor.accept(translatedFieldName);
-            return QueryBuilders.prefixQuery(translatedFieldName, query.value())
-                .caseInsensitive(query.caseInsensitive())
-                .rewrite(query.rewrite())
-                .boost(query.boost());
-        } else if (qb instanceof final WildcardQueryBuilder query) {
-            final String translatedFieldName = ApiKeyFieldNameTranslators.translate(query.fieldName());
-            fieldNameVisitor.accept(translatedFieldName);
-            return QueryBuilders.wildcardQuery(translatedFieldName, query.value())
-                .caseInsensitive(query.caseInsensitive())
-                .rewrite(query.rewrite())
-                .boost(query.boost());
-        } else if (qb instanceof final MatchQueryBuilder query) {
-            final String translatedFieldName = ApiKeyFieldNameTranslators.translate(query.fieldName());
-            fieldNameVisitor.accept(translatedFieldName);
-            final MatchQueryBuilder matchQueryBuilder = QueryBuilders.matchQuery(translatedFieldName, query.value());
-            if (query.operator() != null) {
-                matchQueryBuilder.operator(query.operator());
-            }
-            if (query.analyzer() != null) {
-                matchQueryBuilder.analyzer(query.analyzer());
-            }
-            if (query.fuzziness() != null) {
-                matchQueryBuilder.fuzziness(query.fuzziness());
-            }
-            if (query.minimumShouldMatch() != null) {
-                matchQueryBuilder.minimumShouldMatch(query.minimumShouldMatch());
-            }
-            if (query.fuzzyRewrite() != null) {
-                matchQueryBuilder.fuzzyRewrite(query.fuzzyRewrite());
-            }
-            if (query.zeroTermsQuery() != null) {
-                matchQueryBuilder.zeroTermsQuery(query.zeroTermsQuery());
-            }
-            matchQueryBuilder.prefixLength(query.prefixLength())
-                .maxExpansions(query.maxExpansions())
-                .fuzzyTranspositions(query.fuzzyTranspositions())
-                .lenient(query.lenient())
-                .autoGenerateSynonymsPhraseQuery(query.autoGenerateSynonymsPhraseQuery())
-                .boost(query.boost());
-            return matchQueryBuilder;
-        } else if (qb instanceof final RangeQueryBuilder query) {
-            if (query.relation() != null) {
-                throw new IllegalArgumentException("range query with relation is not supported for API Key query");
-            }
-            final String translatedFieldName = ApiKeyFieldNameTranslators.translate(query.fieldName());
-            fieldNameVisitor.accept(translatedFieldName);
-            final RangeQueryBuilder newQuery = QueryBuilders.rangeQuery(translatedFieldName);
-            if (query.format() != null) {
-                newQuery.format(query.format());
-            }
-            if (query.timeZone() != null) {
-                newQuery.timeZone(query.timeZone());
-            }
-            if (query.from() != null) {
-                newQuery.from(query.from()).includeLower(query.includeLower());
-            }
-            if (query.to() != null) {
-                newQuery.to(query.to()).includeUpper(query.includeUpper());
-            }
-            return newQuery.boost(query.boost());
-        } else if (qb instanceof final SimpleQueryStringBuilder simpleQueryStringBuilder) {
-            if (simpleQueryStringBuilder.fields().isEmpty()) {
-                simpleQueryStringBuilder.field("*");
-            }
-            // override lenient if querying all the fields, because, due to different field mappings,
-            // the query parsing will almost certainly fail otherwise
-            if (QueryParserHelper.hasAllFieldsWildcard(simpleQueryStringBuilder.fields().keySet())) {
-                simpleQueryStringBuilder.lenient(true);
-            }
-            Map<String, Float> requestedFields = new HashMap<>(simpleQueryStringBuilder.fields());
-            simpleQueryStringBuilder.fields().clear();
-            for (Map.Entry<String, Float> requestedFieldNameOrPattern : requestedFields.entrySet()) {
-                for (String translatedField : ApiKeyFieldNameTranslators.translatePattern(requestedFieldNameOrPattern.getKey())) {
-                    simpleQueryStringBuilder.fields()
-                        .compute(
-                            translatedField,
-                            (k, v) -> (v == null) ? requestedFieldNameOrPattern.getValue() : v * requestedFieldNameOrPattern.getValue()
-                        );
-                    fieldNameVisitor.accept(translatedField);
-                }
-            }
-            if (simpleQueryStringBuilder.fields().isEmpty()) {
-                // A SimpleQueryStringBuilder with empty fields() will eventually produce a SimpleQueryString query
-                // that accesses all the fields, including disallowed ones.
-                // Instead, the behavior we're after is that a query that accesses only disallowed fields should
-                // not match any docs.
-                return new MatchNoneQueryBuilder();
-            } else {
-                return simpleQueryStringBuilder;
-            }
-        } else {
-            throw new IllegalArgumentException("Query type [" + qb.getName() + "] is not supported for API Key query");
-        }
     }
 
     @Override

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportQueryApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/apikey/TransportQueryApiKeyActionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.search.sort.NestedSortBuilder;
 import org.elasticsearch.search.sort.SortMode;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.security.support.ApiKeyFieldNameTranslators;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +43,7 @@ public class TransportQueryApiKeyActionTests extends ESTestCase {
 
         List<String> sortFields = new ArrayList<>();
         final SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource();
-        TransportQueryApiKeyAction.translateFieldSortBuilders(originals, searchSourceBuilder, sortFields::add);
+        ApiKeyFieldNameTranslators.translateFieldSortBuilders(originals, searchSourceBuilder, sortFields::add);
 
         IntStream.range(0, originals.size()).forEach(i -> {
             final FieldSortBuilder original = originals.get(i);
@@ -95,7 +96,7 @@ public class TransportQueryApiKeyActionTests extends ESTestCase {
         fieldSortBuilder.setNestedSort(new NestedSortBuilder("name"));
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> TransportQueryApiKeyAction.translateFieldSortBuilders(
+            () -> ApiKeyFieldNameTranslators.translateFieldSortBuilders(
                 List.of(fieldSortBuilder),
                 SearchSourceBuilder.searchSource(),
                 ignored -> {}


### PR DESCRIPTION
This exposes a public method that deep-copies a `QueryBuilder`,
to be used for querying API Keys from the .security index,
while also translating the query-level field names to index-level ones. 

Relates https://github.com/elastic/elasticsearch/pull/104895