### PR TITLE
[ML] Fix handling of `ml.config_version` node attribute

### DIFF
--- a/docs/changelog/105066.yaml
+++ b/docs/changelog/105066.yaml
@@ -1,0 +1,5 @@
+pr: 105066
+summary: Fix handling of `ml.config_version` node attribute
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/105066.yaml
+++ b/docs/changelog/105066.yaml
@@ -1,5 +1,5 @@
 pr: 105066
-summary: Fix handling of `ml.config_version` node attribute
+summary: Fix handling of `ml.config_version` node attribute for nodes with machine learning disabled
 area: Machine Learning
 type: bug
 issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlConfigVersion.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlConfigVersion.java
@@ -289,7 +289,7 @@ public record MlConfigVersion(int id) implements VersionId<MlConfigVersion>, ToX
                 if (mlConfigVersion.after(maxMlConfigVersion)) {
                     maxMlConfigVersion = mlConfigVersion;
                 }
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalStateException e) {
                 // This means we encountered a node that is after 8.10.0 but has the ML plugin disabled - ignore it
             }
         }


### PR DESCRIPTION
This PR fixes 2 issues related to handling `ml.config_version` node attribute:
1. It changes the type of the exception caught from `IllegalArgumentException` to `IllegalStateException`
  + adds a regression test (`MlConfigVersionTests.testGetMinMaxMlConfigVersionWhenMlConfigVersionAttrIsMissing`)
2. It **always** adds `ml.config_version` to node attributes, even if ML is disabled on a node
  + adds a regression test (`MlPluginDisabledIT.testAllNodesHaveMlConfigVersionAttribute`)