### PR TITLE
Add basic JavaDocs for retrievers

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/retriever/KnnRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/KnnRetrieverBuilder.java
@@ -24,6 +24,10 @@ import java.util.List;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
+/**
+ * A knn retriever is used to represent a knn search
+ * with some elements to specify parameters for that knn search.
+ */
 public final class KnnRetrieverBuilder extends RetrieverBuilder<KnnRetrieverBuilder> {
 
     public static final String NAME = "knn";
@@ -106,7 +110,7 @@ public final class KnnRetrieverBuilder extends RetrieverBuilder<KnnRetrieverBuil
     }
 
     @Override
-    public void doExtractToSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
+    public void extractToSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
         KnnSearchBuilder knnSearchBuilder = new KnnSearchBuilder(field, queryVector, queryVectorBuilder, k, numCands, similarity);
         if (preFilterQueryBuilders != null) {
             knnSearchBuilder.addFilterQueries(preFilterQueryBuilders);

--- a/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/RetrieversFeatures.java
@@ -13,6 +13,10 @@ import org.elasticsearch.features.NodeFeature;
 
 import java.util.Set;
 
+/**
+ * Each retriever is given its own {@link NodeFeature} so new
+ * retrievers can be added individually with additional functionality.
+ */
 public class RetrieversFeatures implements FeatureSpecification {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/retriever/StandardRetrieverBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/retriever/StandardRetrieverBuilder.java
@@ -26,6 +26,10 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * A standard retriever is used to represent anything that is a query along
+ * with some elements to specify parameters for that query.
+ */
 public final class StandardRetrieverBuilder extends RetrieverBuilder<StandardRetrieverBuilder> {
 
     public static final String NAME = "standard";
@@ -44,37 +48,37 @@ public final class StandardRetrieverBuilder extends RetrieverBuilder<StandardRet
     );
 
     static {
-        PARSER.declareObject(StandardRetrieverBuilder::queryBuilder, (p, c) -> {
+        PARSER.declareObject((r, v) -> r.queryBuilder = v, (p, c) -> {
             QueryBuilder queryBuilder = AbstractQueryBuilder.parseTopLevelQuery(p, c::trackQueryUsage);
             c.trackSectionUsage(NAME + ":" + QUERY_FIELD.getPreferredName());
             return queryBuilder;
         }, QUERY_FIELD);
 
-        PARSER.declareField(StandardRetrieverBuilder::searchAfterBuilder, (p, c) -> {
+        PARSER.declareField((r, v) -> r.searchAfterBuilder = v, (p, c) -> {
             SearchAfterBuilder searchAfterBuilder = SearchAfterBuilder.fromXContent(p);
             c.trackSectionUsage(NAME + ":" + SEARCH_AFTER_FIELD.getPreferredName());
             return searchAfterBuilder;
         }, SEARCH_AFTER_FIELD, ObjectParser.ValueType.OBJECT_ARRAY);
 
-        PARSER.declareField(StandardRetrieverBuilder::terminateAfter, (p, c) -> {
+        PARSER.declareField((r, v) -> r.terminateAfter = v, (p, c) -> {
             int terminateAfter = p.intValue();
             c.trackSectionUsage(NAME + ":" + TERMINATE_AFTER_FIELD.getPreferredName());
             return terminateAfter;
         }, TERMINATE_AFTER_FIELD, ObjectParser.ValueType.INT);
 
-        PARSER.declareField(StandardRetrieverBuilder::sortBuilders, (p, c) -> {
+        PARSER.declareField((r, v) -> r.sortBuilders = v, (p, c) -> {
             List<SortBuilder<?>> sortBuilders = SortBuilder.fromXContent(p);
             c.trackSectionUsage(NAME + ":" + SORT_FIELD.getPreferredName());
             return sortBuilders;
         }, SORT_FIELD, ObjectParser.ValueType.OBJECT_ARRAY);
 
-        PARSER.declareField(StandardRetrieverBuilder::minScore, (p, c) -> {
+        PARSER.declareField((r, v) -> r.minScore = v, (p, c) -> {
             float minScore = p.floatValue();
             c.trackSectionUsage(NAME + ":" + MIN_SCORE_FIELD.getPreferredName());
             return minScore;
         }, MIN_SCORE_FIELD, ObjectParser.ValueType.FLOAT);
 
-        PARSER.declareField(StandardRetrieverBuilder::collapseBuilder, (p, c) -> {
+        PARSER.declareField((r, v) -> r.collapseBuilder = v, (p, c) -> {
             CollapseBuilder collapseBuilder = CollapseBuilder.fromXContent(p);
             if (collapseBuilder.getField() != null) {
                 c.trackSectionUsage(COLLAPSE_FIELD.getPreferredName());
@@ -99,62 +103,9 @@ public final class StandardRetrieverBuilder extends RetrieverBuilder<StandardRet
     private Float minScore;
     private CollapseBuilder collapseBuilder;
 
-    public QueryBuilder queryBuilder() {
-        return queryBuilder;
-    }
-
-    public StandardRetrieverBuilder queryBuilder(QueryBuilder queryBuilder) {
-        this.queryBuilder = queryBuilder;
-        return this;
-    }
-
-    public SearchAfterBuilder searchAfterBuilder() {
-        return searchAfterBuilder;
-    }
-
-    public StandardRetrieverBuilder searchAfterBuilder(SearchAfterBuilder searchAfterBuilder) {
-        this.searchAfterBuilder = searchAfterBuilder;
-        return this;
-    }
-
-    public int terminateAfter() {
-        return terminateAfter;
-    }
-
-    public StandardRetrieverBuilder terminateAfter(int terminateAfter) {
-        this.terminateAfter = terminateAfter;
-        return this;
-    }
-
-    public List<SortBuilder<?>> sortBuilders() {
-        return sortBuilders;
-    }
-
-    public StandardRetrieverBuilder sortBuilders(List<SortBuilder<?>> sortBuilders) {
-        this.sortBuilders = sortBuilders;
-        return this;
-    }
-
-    public Float minScore() {
-        return minScore;
-    }
-
-    public StandardRetrieverBuilder minScore(Float minScore) {
-        this.minScore = minScore;
-        return this;
-    }
-
-    public CollapseBuilder collapseBuilder() {
-        return collapseBuilder;
-    }
-
-    public StandardRetrieverBuilder collapseBuilder(CollapseBuilder collapseBuilder) {
-        this.collapseBuilder = collapseBuilder;
-        return this;
-    }
-
-    public void doExtractToSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
-        if (preFilterQueryBuilders().isEmpty() == false) {
+    @Override
+    public void extractToSearchSourceBuilder(SearchSourceBuilder searchSourceBuilder) {
+        if (preFilterQueryBuilders.isEmpty() == false) {
             BoolQueryBuilder boolQueryBuilder = new BoolQueryBuilder();
 
             for (QueryBuilder preFilterQueryBuilder : preFilterQueryBuilders) {

--- a/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFFeatureSpecification.java
+++ b/x-pack/plugin/rank-rrf/src/main/java/org/elasticsearch/xpack/rank/rrf/RRFFeatureSpecification.java
@@ -12,6 +12,9 @@ import org.elasticsearch.features.NodeFeature;
 
 import java.util.Set;
 
+/**
+ * A set of features specifically for the rrf plugin.
+ */
 public class RRFFeatureSpecification implements FeatureSpecification {
 
     @Override


### PR DESCRIPTION
This change adds some basic JavaDocs for several retrievers classes. This also removes some unnecessary getters/setters from the retriever builders to continue to reduce the code footprint for this change.