### PR TITLE
Reducing the memory usage of the new IndexRequestBuilder

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
@@ -136,9 +136,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
      * Sets the document to index in bytes form.
      */
     public IndexRequestBuilder setSource(byte[] source, XContentType xContentType) {
-        this.sourceBytesReference = new BytesArray(source, 0, source.length);
-        this.sourceContentType = xContentType;
-        return this;
+        return setSource(source, 0, source.length, xContentType);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequestBuilder.java
@@ -107,7 +107,7 @@ public class IndexRequestBuilder extends ReplicationRequestBuilder<IndexRequest,
             builder.map(source);
             return setSource(builder);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new ElasticsearchGenerationException("Failed to generate", e);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/index/IndexRequestBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexRequestBuilderTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.action.index;
 
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -82,21 +81,5 @@ public class IndexRequestBuilderTests extends ESTestCase {
         doc.close();
         indexRequestBuilder.setSource(doc);
         assertEquals(EXPECTED_SOURCE, XContentHelper.convertToJson(indexRequestBuilder.request().source(), true));
-    }
-
-    public void testValidation() {
-        IndexRequestBuilder indexRequestBuilder = new IndexRequestBuilder(this.testClient);
-        Map<String, String> source = new HashMap<>();
-        source.put("SomeKey", "SomeValue");
-        indexRequestBuilder.setSource(source);
-        assertNotNull(indexRequestBuilder.request());
-        indexRequestBuilder.setSource("SomeKey", "SomeValue");
-        expectThrows(IllegalStateException.class, indexRequestBuilder::request);
-
-        indexRequestBuilder = new IndexRequestBuilder(this.testClient);
-        indexRequestBuilder.setTimeout(randomTimeValue());
-        assertNotNull(indexRequestBuilder.request());
-        indexRequestBuilder.setTimeout(TimeValue.timeValueSeconds(randomIntBetween(1, 30)));
-        expectThrows(IllegalStateException.class, indexRequestBuilder::request);
     }
 }


### PR DESCRIPTION
The new IndexRequestBuilder caused an OutOfMemoryError at https://gradle-enterprise.elastic.co/s/kciaostem2bii/tests/task/:modules:aggregations:internalClusterTest/details/org.elasticsearch.aggregations.bucket.TimeSeriesTsidHashCardinalityIT/testTimeSeriesNumberOfBuckets?expanded-stacktrace=WyIwIl0&top-execution=1. It looks like the reason is that it holds onto XContentBuilders rather than converting them to BytesReferences (which the old IndexRequestBuilder did). This apparently uses a _lot_ more memory. IndexRequestBuilder is now converting all input sources into BytesReferences.