### PR TITLE
Add a gradle plugin for embedded providers

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -143,6 +143,10 @@ gradlePlugin {
       id = 'elasticsearch.mrjar'
       implementationClass = 'org.elasticsearch.gradle.internal.MrjarPlugin'
     }
+    embeddedProvider {
+      id = 'elasticsearch.embedded-providers'
+      implementationClass = 'org.elasticsearch.gradle.internal.EmbeddedProviderPlugin'
+    }
     releaseTools {
       id = 'elasticsearch.release-tools'
       implementationClass = 'org.elasticsearch.gradle.internal.release.ReleaseToolsPlugin'

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
@@ -49,11 +49,10 @@ public class EmbeddedProviderExtension {
         String implTaskName = "generate" + capitalName + "ProviderImpl";
         var generateProviderImpl = project.getTasks().register(implTaskName, Sync.class);
         generateProviderImpl.configure(t -> {
-            t.into(generatedResourcesDir, spec -> {
-                spec.into("IMPL-JARS/" + implName, childSpec -> {
-                    childSpec.from(implConfig);
-                    childSpec.from(generateProviderManifest);
-                });
+            t.into(generatedResourcesDir);
+            t.into("IMPL-JARS/" + implName, spec -> {
+                spec.from(implConfig);
+                spec.from(generateProviderManifest);
             });
         });
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal;
+
+import org.elasticsearch.gradle.transform.UnzipTransform;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.file.Directory;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.Sync;
+
+import static org.elasticsearch.gradle.internal.conventions.GUtils.capitalize;
+import static org.elasticsearch.gradle.util.GradleUtils.getJavaSourceSets;
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.DIRECTORY_TYPE;
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.JAR_TYPE;
+
+public class EmbeddedProviderExtension {
+
+    private static final Attribute<Boolean> IMPL_ATTR = Attribute.of("is.impl", Boolean.class);
+
+    private final Project project;
+
+    public EmbeddedProviderExtension(Project project) {
+        this.project = project;
+    }
+
+    void impl(String implName, Project implProject) {
+        String projectName = implProject.getName();
+        String capitalName = capitalize(projectName);
+
+        String configName = "embedded" + capitalName;
+        Configuration implConfig = project.getConfigurations().create(configName);
+        implConfig.attributes(attrs -> {
+            attrs.attribute(ARTIFACT_TYPE_ATTRIBUTE, DIRECTORY_TYPE);
+            attrs.attribute(IMPL_ATTR, true);
+        });
+
+        var deps = project.getDependencies();
+        deps.registerTransform(UnzipTransform.class,
+            transformSpec -> {
+                transformSpec.getFrom().attribute(ARTIFACT_TYPE_ATTRIBUTE, JAR_TYPE).attribute(IMPL_ATTR, true);
+                transformSpec.getTo().attribute(ARTIFACT_TYPE_ATTRIBUTE, DIRECTORY_TYPE).attribute(IMPL_ATTR, true);
+                transformSpec.parameters(parameters -> parameters.getIncludeArtifactName().set(true));
+            });
+        deps.add(configName, implProject);
+
+        String manifestTaskName = "generate" + capitalName + "ProviderManifest";
+        Directory generatedResourcesDir = project.getLayout().getBuildDirectory().dir("generated-resources").get();
+        var generateProviderManifest = project.getTasks().register(manifestTaskName, GenerateProviderManifest.class);
+        generateProviderManifest.configure(t -> {
+            t.getManifestFile().set(generatedResourcesDir.file("LISTING.TXT"));
+            t.getProviderImplClasspath().from(implConfig);
+        });
+
+        String implTaskName = "generate" + capitalName + "ProviderImpl";
+        Directory implsDir = generatedResourcesDir.dir("impls");
+        var generateProviderImpl = project.getTasks().register(implTaskName, Sync.class);
+        generateProviderImpl.configure(t -> {
+            t.setDestinationDir(implsDir.dir(projectName).getAsFile());
+            t.into("IMPL-JARS/" + implName, copySpec -> {
+                copySpec.from(implConfig);
+                copySpec.from(generateProviderManifest);
+            });
+        });
+
+        var mainSourceSet = getJavaSourceSets(project).findByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        mainSourceSet.getOutput().dir(generateProviderImpl);
+    }
+
+
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
@@ -11,8 +11,9 @@ package org.elasticsearch.gradle.internal;
 import org.elasticsearch.gradle.transform.UnzipTransform;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.attributes.Attribute;
 import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.Sync;
 
@@ -24,8 +25,6 @@ import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.JAR_TYPE;
 
 public class EmbeddedProviderExtension {
 
-    private static final Attribute<Boolean> IMPL_ATTR = Attribute.of("is.impl", Boolean.class);
-
     private final Project project;
 
     public EmbeddedProviderExtension(Project project) {
@@ -36,35 +35,25 @@ public class EmbeddedProviderExtension {
         String projectName = implProject.getName();
         String capitalName = capitalize(projectName);
 
-        String configName = "embedded" + capitalName;
-        Configuration implConfig = project.getConfigurations().create(configName);
+        Configuration implConfig = project.getConfigurations().detachedConfiguration(project.getDependencies().create(implProject));
         implConfig.attributes(attrs -> {
             attrs.attribute(ARTIFACT_TYPE_ATTRIBUTE, DIRECTORY_TYPE);
-            attrs.attribute(IMPL_ATTR, true);
+            attrs.attribute(EmbeddedProviderPlugin.IMPL_ATTR, true);
         });
 
-        var deps = project.getDependencies();
-        deps.registerTransform(UnzipTransform.class,
-            transformSpec -> {
-                transformSpec.getFrom().attribute(ARTIFACT_TYPE_ATTRIBUTE, JAR_TYPE).attribute(IMPL_ATTR, true);
-                transformSpec.getTo().attribute(ARTIFACT_TYPE_ATTRIBUTE, DIRECTORY_TYPE).attribute(IMPL_ATTR, true);
-                transformSpec.parameters(parameters -> parameters.getIncludeArtifactName().set(true));
-            });
-        deps.add(configName, implProject);
-
         String manifestTaskName = "generate" + capitalName + "ProviderManifest";
-        Directory generatedResourcesDir = project.getLayout().getBuildDirectory().dir("generated-resources").get();
+        Provider<Directory> generatedResourcesDir = project.getLayout().getBuildDirectory().dir("generated-resources");
         var generateProviderManifest = project.getTasks().register(manifestTaskName, GenerateProviderManifest.class);
         generateProviderManifest.configure(t -> {
-            t.getManifestFile().set(generatedResourcesDir.file("LISTING.TXT"));
+            t.getManifestFile().set(generatedResourcesDir.get().file("LISTING.TXT"));
             t.getProviderImplClasspath().from(implConfig);
         });
 
         String implTaskName = "generate" + capitalName + "ProviderImpl";
-        Directory implsDir = generatedResourcesDir.dir("impls");
+        Provider<Directory> implsDir = generatedResourcesDir.map(d -> d.dir("impls"));
         var generateProviderImpl = project.getTasks().register(implTaskName, Sync.class);
         generateProviderImpl.configure(t -> {
-            t.setDestinationDir(implsDir.dir(projectName).getAsFile());
+            t.setDestinationDir(implsDir.get().dir(projectName).getAsFile());
             t.into("IMPL-JARS/" + implName, copySpec -> {
                 copySpec.from(implConfig);
                 copySpec.from(generateProviderManifest);
@@ -74,6 +63,4 @@ public class EmbeddedProviderExtension {
         var mainSourceSet = getJavaSourceSets(project).findByName(SourceSet.MAIN_SOURCE_SET_NAME);
         mainSourceSet.getOutput().dir(generateProviderImpl);
     }
-
-
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
@@ -8,11 +8,9 @@
 
 package org.elasticsearch.gradle.internal;
 
-import org.elasticsearch.gradle.transform.UnzipTransform;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.Directory;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.Sync;
@@ -21,7 +19,6 @@ import static org.elasticsearch.gradle.internal.conventions.GUtils.capitalize;
 import static org.elasticsearch.gradle.util.GradleUtils.getJavaSourceSets;
 import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
 import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.DIRECTORY_TYPE;
-import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.JAR_TYPE;
 
 public class EmbeddedProviderExtension {
 
@@ -45,18 +42,18 @@ public class EmbeddedProviderExtension {
         Provider<Directory> generatedResourcesDir = project.getLayout().getBuildDirectory().dir("generated-resources");
         var generateProviderManifest = project.getTasks().register(manifestTaskName, GenerateProviderManifest.class);
         generateProviderManifest.configure(t -> {
-            t.getManifestFile().set(generatedResourcesDir.get().file("LISTING.TXT"));
+            t.getManifestFile().set(generatedResourcesDir.map(d -> d.file("LISTING.TXT")));
             t.getProviderImplClasspath().from(implConfig);
         });
 
         String implTaskName = "generate" + capitalName + "ProviderImpl";
-        Provider<Directory> implsDir = generatedResourcesDir.map(d -> d.dir("impls"));
         var generateProviderImpl = project.getTasks().register(implTaskName, Sync.class);
         generateProviderImpl.configure(t -> {
-            t.setDestinationDir(implsDir.get().dir(projectName).getAsFile());
-            t.into("IMPL-JARS/" + implName, copySpec -> {
-                copySpec.from(implConfig);
-                copySpec.from(generateProviderManifest);
+            t.into(generatedResourcesDir, spec -> {
+                spec.into("IMPL-JARS/" + implName, childSpec -> {
+                    childSpec.from(implConfig);
+                    childSpec.from(generateProviderManifest);
+                });
             });
         });
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderPlugin.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class EmbeddedProviderPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        project.getExtensions().create("embeddedProviders", EmbeddedProviderExtension.class, project);
+    }
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderPlugin.java
@@ -23,12 +23,11 @@ public class EmbeddedProviderPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
 
-        project.getDependencies().registerTransform(UnzipTransform.class,
-            transformSpec -> {
-                transformSpec.getFrom().attribute(ARTIFACT_TYPE_ATTRIBUTE, JAR_TYPE).attribute(IMPL_ATTR, true);
-                transformSpec.getTo().attribute(ARTIFACT_TYPE_ATTRIBUTE, DIRECTORY_TYPE).attribute(IMPL_ATTR, true);
-                transformSpec.parameters(parameters -> parameters.getIncludeArtifactName().set(true));
-            });
+        project.getDependencies().registerTransform(UnzipTransform.class, transformSpec -> {
+            transformSpec.getFrom().attribute(ARTIFACT_TYPE_ATTRIBUTE, JAR_TYPE).attribute(IMPL_ATTR, true);
+            transformSpec.getTo().attribute(ARTIFACT_TYPE_ATTRIBUTE, DIRECTORY_TYPE).attribute(IMPL_ATTR, true);
+            transformSpec.parameters(parameters -> parameters.getIncludeArtifactName().set(true));
+        });
 
         project.getExtensions().create("embeddedProviders", EmbeddedProviderExtension.class, project);
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderPlugin.java
@@ -8,12 +8,28 @@
 
 package org.elasticsearch.gradle.internal;
 
+import org.elasticsearch.gradle.transform.UnzipTransform;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.attributes.Attribute;
+
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.DIRECTORY_TYPE;
+import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.JAR_TYPE;
 
 public class EmbeddedProviderPlugin implements Plugin<Project> {
+    static final Attribute<Boolean> IMPL_ATTR = Attribute.of("is.impl", Boolean.class);
+
     @Override
     public void apply(Project project) {
+
+        project.getDependencies().registerTransform(UnzipTransform.class,
+            transformSpec -> {
+                transformSpec.getFrom().attribute(ARTIFACT_TYPE_ATTRIBUTE, JAR_TYPE).attribute(IMPL_ATTR, true);
+                transformSpec.getTo().attribute(ARTIFACT_TYPE_ATTRIBUTE, DIRECTORY_TYPE).attribute(IMPL_ATTR, true);
+                transformSpec.parameters(parameters -> parameters.getIncludeArtifactName().set(true));
+            });
+
         project.getExtensions().create("embeddedProviders", EmbeddedProviderExtension.class, project);
     }
 }

--- a/libs/x-content/build.gradle
+++ b/libs/x-content/build.gradle
@@ -6,43 +6,16 @@
  * Side Public License, v 1.
  */
 
-
-import org.elasticsearch.gradle.transform.UnzipTransform
-import org.elasticsearch.gradle.internal.GenerateProviderManifest
-import org.gradle.api.internal.artifacts.ArtifactAttributes
-
-import java.util.stream.Collectors
-
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
+apply plugin: 'elasticsearch.embedded-providers'
 
-def isImplAttr = Attribute.of("is.impl", Boolean)
-
-configurations {
-  providerImpl {
-    attributes.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
-    attributes.attribute(isImplAttr, true)
-  }
+embeddedProviders {
+  impl 'x-content', project(':libs:elasticsearch-x-content:impl')
 }
 
 dependencies {
-  registerTransform(
-    UnzipTransform.class, transformSpec -> {
-    transformSpec.getFrom()
-      .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.JAR_TYPE)
-      .attribute(isImplAttr, true)
-    transformSpec.getTo()
-      .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.DIRECTORY_TYPE)
-      .attribute(isImplAttr, true)
-    transformSpec.parameters(parameters -> {
-      parameters.includeArtifactName.set(true)
-    })
-
-  })
-
   api project(':libs:elasticsearch-core')
-
-  providerImpl project(':libs:elasticsearch-x-content:impl')
 
   testImplementation(project(":test:framework")) {
     exclude group: 'org.elasticsearch', module: 'elasticsearch-x-content'
@@ -66,18 +39,3 @@ tasks.named("thirdPartyAudit").configure {
 tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
 }
-
-Directory generatedResourcesDir = layout.buildDirectory.dir('generated-resources').get()
-def generateProviderManifest = tasks.register("generateProviderManifest", GenerateProviderManifest.class) {
-  manifestFile = generatedResourcesDir.file("LISTING.TXT")
-  getProviderImplClasspath().from(configurations.providerImpl)
-}
-
-def generateProviderImpl = tasks.register("generateProviderImpl", Sync) {
-  destinationDir = generatedResourcesDir.dir("impl").getAsFile()
-  into("IMPL-JARS/x-content") {
-    from(configurations.providerImpl)
-    from(generateProviderManifest)
-  }
-}
-sourceSets.main.output.dir(generateProviderImpl)


### PR DESCRIPTION
x-content embeds its jackson implementation inside its jar. This commit formalizes the setup for this embedding with a gradle plugin so that it can be reused by other libs.