### PR TITLE
Harden index mapping parameter check in enrich runner

### DIFF
--- a/docs/changelog/105096.yaml
+++ b/docs/changelog/105096.yaml
@@ -1,0 +1,5 @@
+pr: 105096
+summary: Harden index mapping parameter check in enrich runner
+area: Ingest Node
+type: bug
+issues: []

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -248,13 +248,21 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
 
     public void testEnrichSpecialTypes() throws IOException {
         final String mapping = """
-              "properties": {
-               "keyword_field": { "type": "keyword" },
-               "content_embedding": { "type": "sparse_vector" },
-               "arbitrary_sparse_vector": { "type": "sparse_vector" }
-              }
+
             """;
-        createIndex("source-enrich-vector", Settings.EMPTY, mapping);
+        var createIndexRequest = new Request("PUT", "source-enrich-vector");
+        createIndexRequest.setJsonEntity("""
+            {
+                "mappings": {
+                    "properties": {
+                    "keyword_field": { "type": "keyword" },
+                    "content_embedding": { "type": "sparse_vector" },
+                    "arbitrary_sparse_vector": { "type": "sparse_vector" }
+                  }
+                }
+            }
+            """);
+        assertOK(adminClient().performRequest(createIndexRequest));
         var indexRequest = new Request("PUT", "/source-enrich-vector/_doc/1");
         indexRequest.setJsonEntity("""
             {
@@ -263,7 +271,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
              "keyword_field": 1214
             }
             """);
-        assertOK(client().performRequest(indexRequest));
+        assertOK(adminClient().performRequest(indexRequest));
 
         var putEnrich = new Request("PUT", "/_enrich/policy/vector_policy");
         putEnrich.setJsonEntity("""
@@ -275,13 +283,13 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
                  }
                 }
             """);
-        assertOK(client().performRequest(putEnrich));
+        assertOK(adminClient().performRequest(putEnrich));
         try {
             var executeEnrich = new Request("PUT", "/_enrich/policy/vector_policy/_execute");
-            assertOK(client().performRequest(executeEnrich));
+            assertOK(adminClient().performRequest(executeEnrich));
         } finally {
             var deleteEnrich = new Request("DELETE", "/_enrich/policy/vector_policy");
-            assertOK(client().performRequest(deleteEnrich));
+            assertOK(adminClient().performRequest(deleteEnrich));
         }
     }
 

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -246,6 +246,45 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         assertOK(client().performRequest(getRequest));
     }
 
+    public void testEnrichSpecialTypes() throws IOException {
+        final String mapping = """
+              "properties": {
+               "keyword_field": { "type": "keyword" },
+               "content_embedding": { "type": "sparse_vector" },
+               "arbitrary_sparse_vector": { "type": "sparse_vector" }
+              }
+            """;
+        createIndex("source-enrich-vector", Settings.EMPTY, mapping);
+        var indexRequest = new Request("PUT", "/source-enrich-vector/_doc/1");
+        indexRequest.setJsonEntity("""
+            {
+             "arbitrary_sparse_vector": { "arbitrary_value": 7 },
+             "content_embedding": { "arbitrary_value": 9},
+             "keyword_field": 1214
+            }
+            """);
+        assertOK(client().performRequest(indexRequest));
+
+        var putEnrich = new Request("PUT", "/_enrich/policy/vector_policy");
+        putEnrich.setJsonEntity("""
+                {
+                 "match": {
+                  "indices": "source-enrich-vector",
+                  "match_field": "keyword_field",
+                  "enrich_fields": ["content_embedding", "arbitrary_sparse_vector"]
+                 }
+                }
+            """);
+        assertOK(client().performRequest(putEnrich));
+        try {
+            var executeEnrich = new Request("PUT", "/_enrich/policy/vector_policy/_execute");
+            assertOK(client().performRequest(executeEnrich));
+        } finally {
+            var deleteEnrich = new Request("DELETE", "/_enrich/policy/vector_policy");
+            assertOK(client().performRequest(deleteEnrich));
+        }
+    }
+
     public static String generatePolicySource(String index) throws IOException {
         return generatePolicySource(index, "host", "match");
     }


### PR DESCRIPTION
There is a case where the mapper parser throws a MapperParsingException instead of not consuming the `index:false` parameter. We missed that case in the previous fix (see #98038). This PR hardens that check by returning false when hitting a MapperParsingException.

Relates #98038