### PR TITLE
Fix compilation of example rest handler

### DIFF
--- a/plugins/examples/rest-handler/src/main/java/org/elasticsearch/example/resthandler/ExampleRestHandlerPlugin.java
+++ b/plugins/examples/rest-handler/src/main/java/org/elasticsearch/example/resthandler/ExampleRestHandlerPlugin.java
@@ -15,12 +15,14 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
@@ -35,8 +37,8 @@ public class ExampleRestHandlerPlugin extends Plugin implements ActionPlugin {
                                              final IndexScopedSettings indexScopedSettings,
                                              final SettingsFilter settingsFilter,
                                              final IndexNameExpressionResolver indexNameExpressionResolver,
-                                             final Supplier<DiscoveryNodes> nodesInCluster) {
-
+                                             final Supplier<DiscoveryNodes> nodesInCluster,
+                                             final Predicate<NodeFeature> clusterSupportsFeature) {
         return singletonList(new ExampleCatAction());
     }
 }


### PR DESCRIPTION
The signature for getRestHandlers was updated. This commit fixes the example rest handler plugin to use the new signature.