### PR TITLE
Do not record s3 http request time when it is not available

### DIFF
--- a/docs/changelog/105103.yaml
+++ b/docs/changelog/105103.yaml
@@ -1,0 +1,5 @@
+pr: 105103
+summary: Do not record s3 http request time when it is not available
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
+++ b/modules/repository-s3/src/main/java/org/elasticsearch/repositories/s3/S3BlobStore.java
@@ -230,20 +230,6 @@ class S3BlobStore implements BlobStore {
         }
     }
 
-    private static long getTotalTimeInMicros(List<TimingInfo> requestTimesIncludingRetries) {
-        // Here we calculate the timing in Microseconds for the sum of the individual subMeasurements with the goal of deriving the TTFB
-        // (time to first byte). We calculate the time in micros for later use with an APM style counter (exposed as a long), rather than
-        // using the default double exposed by getTimeTakenMillisIfKnown().
-        long totalTimeInMicros = 0;
-        for (TimingInfo timingInfo : requestTimesIncludingRetries) {
-            var endTimeInNanos = timingInfo.getEndTimeNanoIfKnown();
-            if (endTimeInNanos != null) {
-                totalTimeInMicros += TimeUnit.NANOSECONDS.toMicros(endTimeInNanos - timingInfo.getStartTimeNano());
-            }
-        }
-        return totalTimeInMicros;
-    }
-
     private static long getCountForMetric(TimingInfo info, AWSRequestMetrics.Field field) {
         var count = info.getCounter(field.name());
         if (count == null) {
@@ -256,6 +242,20 @@ class S3BlobStore implements BlobStore {
         } else {
             return count.longValue();
         }
+    }
+
+    private static long getTotalTimeInMicros(List<TimingInfo> requestTimesIncludingRetries) {
+        // Here we calculate the timing in Microseconds for the sum of the individual subMeasurements with the goal of deriving the TTFB
+        // (time to first byte). We calculate the time in micros for later use with an APM style counter (exposed as a long), rather than
+        // using the default double exposed by getTimeTakenMillisIfKnown().
+        long totalTimeInMicros = 0;
+        for (TimingInfo timingInfo : requestTimesIncludingRetries) {
+            var endTimeInNanos = timingInfo.getEndTimeNanoIfKnown();
+            if (endTimeInNanos != null) {
+                totalTimeInMicros += TimeUnit.NANOSECONDS.toMicros(endTimeInNanos - timingInfo.getStartTimeNano());
+            }
+        }
+        return totalTimeInMicros;
     }
 
     @Override


### PR DESCRIPTION
The metrics of HTTP request time can be unavailable (null) when the request fails on the client side. This PR makes sure we do not attempt to record it when it happens to avoid NPE.
