### PR TITLE
Speedup slicing from ReleasableBytesReference some more

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -143,6 +143,14 @@ class BytesReferenceStreamInput extends StreamInput {
 
     @Override
     public int read(final byte[] b, final int bOffset, final int len) throws IOException {
+        if (slice.remaining() >= len) {
+            slice.get(b, bOffset, len);
+            return len;
+        }
+        return readFromMultipleSlices(b, bOffset, len);
+    }
+
+    private int readFromMultipleSlices(byte[] b, int bOffset, int len) throws IOException {
         final int length = bytesReference.length();
         final int offset = offset();
         if (offset >= length) {
@@ -186,6 +194,14 @@ class BytesReferenceStreamInput extends StreamInput {
         if (n <= 0L) {
             return 0L;
         }
+        if (n <= slice.remaining()) {
+            slice.position(slice.position() + (int) n);
+            return n;
+        }
+        return skipMultiple(n);
+    }
+
+    private int skipMultiple(long n) throws IOException {
         assert offset() <= bytesReference.length() : offset() + " vs " + bytesReference.length();
         // definitely >= 0 and <= Integer.MAX_VALUE so casting is ok
         final int numBytesSkipped = (int) Math.min(n, bytesReference.length() - offset());

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -144,7 +144,7 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     @Override
     public StreamInput streamInput() throws IOException {
         assert hasReferences();
-        return new BytesReferenceStreamInput(this) {
+        return new BytesReferenceStreamInput(delegate) {
             private ReleasableBytesReference retainAndSkip(int len) throws IOException {
                 if (len == 0) {
                     return ReleasableBytesReference.empty();


### PR DESCRIPTION
We can speed up the slice operation quite a bit by speeding up skip for the common case and passing the delegate as the basis for the stream (this neatly avoids a multi-morphic call to `length` on the bytes reference). Also, while we're at it, we can speed up the common-case read operation the same way.


This is a considerable speedup to the bulk indexing logic on the transport threads it seems:

Before:

<img width="2000" alt="image" src="https://github.com/elastic/elasticsearch/assets/6490959/a4e27a0b-7d31-4667-a49b-61382fe206fe">


Now:
<img width="2009" alt="image" src="https://github.com/elastic/elasticsearch/assets/6490959/cb7cddf3-cbee-4419-8127-2a61f79898b6">


Note that this is the initial parsing step with the same data in each. All the operations that do a read or slice the bytes reference are way faster now, hence the relative contribution of `indexOf` (performance unchanged here) is way up.