### PR TITLE
Run heap attack tests with two nodes

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.test.ListMatcher;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.local.distribution.DistributionType;
@@ -59,14 +60,24 @@ import static org.hamcrest.Matchers.hasSize;
 public class HeapAttackIT extends ESRestTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
-        .distribution(DistributionType.DEFAULT)
-        .module("test-esql-heap-attack")
-        .setting("xpack.security.enabled", "false")
-        .setting("xpack.license.self_generated.type", "trial")
-        .build();
+    public static ElasticsearchCluster cluster = buildCluster();
 
     static volatile boolean SUITE_ABORTED = false;
+
+    static ElasticsearchCluster buildCluster() {
+        var spec = ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .nodes(2)
+            .module("test-esql-heap-attack")
+            .setting("xpack.security.enabled", "false")
+            .setting("xpack.license.self_generated.type", "trial");
+        String javaVersion = JvmInfo.jvmInfo().version();
+        if (javaVersion.equals("20") || javaVersion.equals("21")) {
+            // see https://github.com/elastic/elasticsearch/issues/99592
+            spec.jvmArg("-XX:+UnlockDiagnosticVMOptions -XX:+G1UsePreventiveGC");
+        }
+        return spec.build();
+    }
 
     @Override
     protected String getTestRestCluster() {
@@ -526,27 +537,34 @@ public class HeapAttackIT extends ESRestTestCase {
     private void bulk(String name, String bulk) throws IOException {
         Request request = new Request("POST", "/" + name + "/_bulk");
         request.addParameter("filter_path", "errors");
-        request.setJsonEntity(bulk.toString());
+        request.setJsonEntity(bulk);
+        request.setOptions(
+            RequestOptions.DEFAULT.toBuilder()
+                .setRequestConfig(RequestConfig.custom().setSocketTimeout(Math.toIntExact(TimeValue.timeValueMinutes(5).millis())).build())
+        );
         Response response = client().performRequest(request);
         assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8), equalTo("{\"errors\":false}"));
     }
 
     private void initIndex(String name, String bulk) throws IOException {
+        if (indexExists(name) == false) {
+            // not strictly required, but this can help isolate failure from bulk indexing.
+            createIndex(name);
+        }
         if (hasText(bulk)) {
             bulk(name, bulk);
         }
-
-        Request request = new Request("POST", "/" + name + "/_refresh");
-        Response response = client().performRequest(request);
-        assertWriteResponse(response);
-
-        request = new Request("POST", "/" + name + "/_forcemerge");
+        Request request = new Request("POST", "/" + name + "/_forcemerge");
         request.addParameter("max_num_segments", "1");
-        response = client().performRequest(request);
+        RequestOptions.Builder requestOptions = RequestOptions.DEFAULT.toBuilder()
+            .setRequestConfig(RequestConfig.custom().setSocketTimeout(Math.toIntExact(TimeValue.timeValueMinutes(5).millis())).build());
+        request.setOptions(requestOptions);
+        Response response = client().performRequest(request);
         assertWriteResponse(response);
 
         request = new Request("POST", "/" + name + "/_refresh");
         response = client().performRequest(request);
+        request.setOptions(requestOptions);
         assertWriteResponse(response);
     }
 

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/HeapAttackPlugin.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/HeapAttackPlugin.java
@@ -23,13 +23,13 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -54,15 +54,13 @@ public class HeapAttackPlugin extends Plugin implements ActionPlugin {
     // so that tests in other packages can see it too.
     static final Setting<Boolean> IGNORE_DESERIALIZATION_ERRORS_SETTING = Setting.boolSetting(
         "transport.ignore_deserialization_errors",
-        false,
+        true,
         Setting.Property.NodeScope
     );
 
     @Override
     public List<Setting<?>> getSettings() {
-        var settings = new ArrayList<>(super.getSettings());
-        settings.add(IGNORE_DESERIALIZATION_ERRORS_SETTING);
-        return settings;
+        return CollectionUtils.appendToCopy(super.getSettings(), IGNORE_DESERIALIZATION_ERRORS_SETTING);
     }
 
     @Override

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/HeapAttackPlugin.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/HeapAttackPlugin.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.features.NodeFeature;
@@ -28,6 +29,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -46,5 +48,27 @@ public class HeapAttackPlugin extends Plugin implements ActionPlugin {
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
         return List.of(new RestTriggerOutOfMemoryAction());
+    }
+
+    // Deliberately unregistered, only used in unit tests. Copied to AbstractSimpleTransportTestCase#IGNORE_DESERIALIZATION_ERRORS_SETTING
+    // so that tests in other packages can see it too.
+    static final Setting<Boolean> IGNORE_DESERIALIZATION_ERRORS_SETTING = Setting.boolSetting(
+        "transport.ignore_deserialization_errors",
+        false,
+        Setting.Property.NodeScope
+    );
+
+    @Override
+    public List<Setting<?>> getSettings() {
+        var settings = new ArrayList<>(super.getSettings());
+        settings.add(IGNORE_DESERIALIZATION_ERRORS_SETTING);
+        return settings;
+    }
+
+    @Override
+    public Settings additionalSettings() {
+        Settings.Builder settings = Settings.builder().put(super.additionalSettings());
+        settings.put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true);
+        return settings.build();
     }
 }

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/HeapAttackPlugin.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/HeapAttackPlugin.java
@@ -65,8 +65,6 @@ public class HeapAttackPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public Settings additionalSettings() {
-        Settings.Builder settings = Settings.builder().put(super.additionalSettings());
-        settings.put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true);
-        return settings.build();
+        return Settings.builder().put(super.additionalSettings()).put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true).build();
     }
 }


### PR DESCRIPTION
We should run heap-attack tests on multiple nodes to ensure that we avoid causing OOM during the serialization/deserialization of exchange responses. I've merged the required changes and run thousands of iterations of these tests without seeing any failures.