### PR TITLE
[8.12] [Docs] Fix a doc bug for Flush API's force parameter (#105112)

### DIFF
--- a/docs/reference/indices/flush.asciidoc
+++ b/docs/reference/indices/flush.asciidoc
@@ -81,7 +81,7 @@ Defaults to `open`.
 If `true`,
 the request forces a flush
 even if there are no changes to commit to the index.
-Defaults to `true`.
+Defaults to `false`.
 
 You can use this parameter
 to increment the generation number of the transaction log.


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Docs] Fix a doc bug for Flush API's force parameter (#105112)