### PR TITLE
[Connector API] Support filtering by name, index name in list action

### DIFF
--- a/docs/changelog/105131.yaml
+++ b/docs/changelog/105131.yaml
@@ -1,0 +1,5 @@
+pr: 105131
+summary: "[Connector API] Support filtering by name, index name in list action"
+area: Application
+type: enhancement
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
@@ -36,7 +36,7 @@
         "type": "string",
         "description": "connector index name(s) to fetch connector documents for"
       },
-      "name": {
+      "connector_name": {
         "type": "string",
         "description": "connector name(s) to fetch connector documents for"
       }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
@@ -31,6 +31,14 @@
         "type": "int",
         "default": 100,
         "description": "specifies a max number of results to get (default: 100)"
+      },
+      "index_name": {
+        "type": "string",
+        "description": "connector index name(s) to fetch connector documents for"
+      },
+      "name": {
+        "type": "string",
+        "description": "connector name(s) to fetch connector documents for"
       }
     }
   }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/310_connector_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/310_connector_list.yml
@@ -137,14 +137,14 @@ setup:
 "List Connector - filter by connector names":
   - do:
       connector.list:
-        name: my-connector-1
+        connector_name: my-connector-1
 
   - match: { count: 1 }
   - match: { results.0.name: "my-connector-1" }
 
   - do:
       connector.list:
-        name: my-connector-1,my-connector-2
+        connector_name: my-connector-1,my-connector-2
 
   - match: { count: 2 }
   - match: { results.0.name: "my-connector-1" }
@@ -155,7 +155,7 @@ setup:
 "List Connector - filter by index name and name":
   - do:
       connector.list:
-        name: my-connector-1,my-connector-2
+        connector_name: my-connector-1,my-connector-2
         index_name: search-2-test
 
   - match: { count: 1 }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/310_connector_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/310_connector_list.yml
@@ -9,7 +9,7 @@ setup:
         connector_id: connector-a
         body:
           index_name: search-1-test
-          name: my-connector
+          name: my-connector-1
           language: pl
           is_native: false
           service_type: super-connector
@@ -18,7 +18,7 @@ setup:
         connector_id: connector-c
         body:
           index_name: search-3-test
-          name: my-connector
+          name: my-connector-3
           language: nl
           is_native: false
           service_type: super-connector
@@ -27,7 +27,7 @@ setup:
         connector_id: connector-b
         body:
           index_name: search-2-test
-          name: my-connector
+          name: my-connector-2
           language: en
           is_native: true
           service_type: super-connector
@@ -105,4 +105,62 @@ setup:
       connector.list: { }
 
   - match: { count: 0 }
+
+
+---
+"List Connector - filter by index names":
+  - do:
+      connector.list:
+        index_name: search-1-test
+
+  - match: { count: 1 }
+  - match: { results.0.index_name: "search-1-test" }
+
+  - do:
+      connector.list:
+        index_name: search-1-test,search-2-test
+
+  - match: { count: 2 }
+  - match: { results.0.index_name: "search-1-test" }
+  - match: { results.1.index_name: "search-2-test" }
+
+
+---
+"List Connector - filter by index names, illegal name":
+  - do:
+      catch: "bad_request"
+      connector.list:
+        index_name: ~.!$$#index-name$$$
+
+
+---
+"List Connector - filter by connector names":
+  - do:
+      connector.list:
+        name: my-connector-1
+
+  - match: { count: 1 }
+  - match: { results.0.name: "my-connector-1" }
+
+  - do:
+      connector.list:
+        name: my-connector-1,my-connector-2
+
+  - match: { count: 2 }
+  - match: { results.0.name: "my-connector-1" }
+  - match: { results.1.name: "my-connector-2" }
+
+
+---
+"List Connector - filter by index name and name":
+  - do:
+      connector.list:
+        name: my-connector-1,my-connector-2
+        index_name: search-2-test
+
+  - match: { count: 1 }
+  - match: { results.0.index_name: "search-2-test" }
+  - match: { results.0.name: "my-connector-2" }
+
+
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -283,20 +283,20 @@ public class ConnectorIndexService {
      * @param from From index to start the search from.
      * @param size The maximum number of {@link Connector}s to return.
      * @param indexNames A list of index names to filter the connectors.
-     * @param names A list of connector names to further filter the search results.
+     * @param connectorNames A list of connector names to further filter the search results.
      * @param listener The action listener to invoke on response/failure.
      */
     public void listConnectors(
         int from,
         int size,
         List<String> indexNames,
-        List<String> names,
+        List<String> connectorNames,
         ActionListener<ConnectorIndexService.ConnectorResult> listener
     ) {
         try {
             final SearchSourceBuilder source = new SearchSourceBuilder().from(from)
                 .size(size)
-                .query(buildListQuery(indexNames, names))
+                .query(buildListQuery(indexNames, connectorNames))
                 .fetchSource(true)
                 .sort(Connector.INDEX_NAME_FIELD.getPreferredName(), SortOrder.ASC);
             final SearchRequest req = new SearchRequest(CONNECTOR_INDEX_NAME).source(source);
@@ -325,17 +325,17 @@ public class ConnectorIndexService {
     }
 
     /**
-     * Constructs a query for filtering connectors based on index and/or connector names.
+     * Constructs a query for filtering instances of {@link Connector} based on index and/or connector names.
      * Returns a {@link MatchAllQueryBuilder} if both parameters are empty or null,
      * otherwise constructs a boolean query to filter by the provided lists.
      *
      * @param indexNames List of index names to filter by, or null/empty for no index name filtering.
-     * @param names List of connector names to filter by, or null/empty for no name filtering.
+     * @param connectorNames List of connector names to filter by, or null/empty for no name filtering.
      * @return A {@link QueryBuilder} tailored to the specified filters.
      */
-    private QueryBuilder buildListQuery(List<String> indexNames, List<String> names) {
+    private QueryBuilder buildListQuery(List<String> indexNames, List<String> connectorNames) {
         boolean filterByIndexNames = indexNames != null && indexNames.isEmpty() == false;
-        boolean filterByConnectorNames = indexNames != null && names.isEmpty() == false;
+        boolean filterByConnectorNames = indexNames != null && connectorNames.isEmpty() == false;
         boolean usesFilter = filterByIndexNames || filterByConnectorNames;
 
         BoolQueryBuilder boolFilterQueryBuilder = new BoolQueryBuilder();
@@ -345,7 +345,7 @@ public class ConnectorIndexService {
                 boolFilterQueryBuilder.must().add(new TermsQueryBuilder(Connector.INDEX_NAME_FIELD.getPreferredName(), indexNames));
             }
             if (filterByConnectorNames) {
-                boolFilterQueryBuilder.must().add(new TermsQueryBuilder(Connector.NAME_FIELD.getPreferredName(), names));
+                boolFilterQueryBuilder.must().add(new TermsQueryBuilder(Connector.NAME_FIELD.getPreferredName(), connectorNames));
             }
         }
         return usesFilter ? boolFilterQueryBuilder : new MatchAllQueryBuilder();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
@@ -43,7 +43,7 @@ public class ListConnectorAction {
 
         private final PageParams pageParams;
         private final List<String> indexNames;
-        private final List<String> names;
+        private final List<String> connectorNames;
 
         private static final ParseField PAGE_PARAMS_FIELD = new ParseField("pageParams");
         private static final ParseField INDEX_NAMES_FIELD = new ParseField("index_names");
@@ -53,13 +53,13 @@ public class ListConnectorAction {
             super(in);
             this.pageParams = new PageParams(in);
             this.indexNames = in.readOptionalStringCollectionAsList();
-            this.names = in.readOptionalStringCollectionAsList();
+            this.connectorNames = in.readOptionalStringCollectionAsList();
         }
 
-        public Request(PageParams pageParams, List<String> indexNames, List<String> names) {
+        public Request(PageParams pageParams, List<String> indexNames, List<String> connectorNames) {
             this.pageParams = pageParams;
             this.indexNames = indexNames;
-            this.names = names;
+            this.connectorNames = connectorNames;
         }
 
         public PageParams getPageParams() {
@@ -70,8 +70,8 @@ public class ListConnectorAction {
             return indexNames;
         }
 
-        public List<String> getNames() {
-            return names;
+        public List<String> getConnectorNames() {
+            return connectorNames;
         }
 
         @Override
@@ -96,7 +96,7 @@ public class ListConnectorAction {
             super.writeTo(out);
             pageParams.writeTo(out);
             out.writeOptionalStringCollection(indexNames);
-            out.writeOptionalStringCollection(names);
+            out.writeOptionalStringCollection(connectorNames);
         }
 
         @Override
@@ -106,12 +106,12 @@ public class ListConnectorAction {
             ListConnectorAction.Request request = (ListConnectorAction.Request) o;
             return Objects.equals(pageParams, request.pageParams)
                 && Objects.equals(indexNames, request.indexNames)
-                && Objects.equals(names, request.names);
+                && Objects.equals(connectorNames, request.connectorNames);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(pageParams, indexNames, names);
+            return Objects.hash(pageParams, indexNames, connectorNames);
         }
 
         @SuppressWarnings("unchecked")
@@ -136,7 +136,7 @@ public class ListConnectorAction {
             {
                 builder.field(PAGE_PARAMS_FIELD.getPreferredName(), pageParams);
                 builder.field(INDEX_NAMES_FIELD.getPreferredName(), indexNames);
-                builder.field(NAMES_FIELD.getPreferredName(), names);
+                builder.field(NAMES_FIELD.getPreferredName(), connectorNames);
             }
             builder.endObject();
             return builder;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
@@ -11,8 +11,10 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -26,7 +28,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class ListConnectorAction {
 
@@ -38,54 +42,88 @@ public class ListConnectorAction {
     public static class Request extends ActionRequest implements ToXContentObject {
 
         private final PageParams pageParams;
+        private final List<String> indexNames;
+        private final List<String> names;
 
         private static final ParseField PAGE_PARAMS_FIELD = new ParseField("pageParams");
+        private static final ParseField INDEX_NAMES_FIELD = new ParseField("index_names");
+        private static final ParseField NAMES_FIELD = new ParseField("names");
 
         public Request(StreamInput in) throws IOException {
             super(in);
             this.pageParams = new PageParams(in);
+            this.indexNames = in.readOptionalStringCollectionAsList();
+            this.names = in.readOptionalStringCollectionAsList();
         }
 
-        public Request(PageParams pageParams) {
+        public Request(PageParams pageParams, List<String> indexNames, List<String> names) {
             this.pageParams = pageParams;
+            this.indexNames = indexNames;
+            this.names = names;
         }
 
         public PageParams getPageParams() {
             return pageParams;
         }
 
+        public List<String> getIndexNames() {
+            return indexNames;
+        }
+
+        public List<String> getNames() {
+            return names;
+        }
+
         @Override
         public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
             // Pagination validation is done as part of PageParams constructor
-            return null;
+
+            if (indexNames != null && indexNames.isEmpty() == false) {
+                for (String indexName : indexNames) {
+                    try {
+                        MetadataCreateIndexService.validateIndexOrAliasName(indexName, InvalidIndexNameException::new);
+                    } catch (InvalidIndexNameException e) {
+                        validationException = addValidationError(e.toString(), validationException);
+                    }
+                }
+            }
+            return validationException;
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             pageParams.writeTo(out);
+            out.writeOptionalStringCollection(indexNames);
+            out.writeOptionalStringCollection(names);
         }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
-            ListConnectorAction.Request that = (ListConnectorAction.Request) o;
-            return Objects.equals(pageParams, that.pageParams);
+            ListConnectorAction.Request request = (ListConnectorAction.Request) o;
+            return Objects.equals(pageParams, request.pageParams)
+                && Objects.equals(indexNames, request.indexNames)
+                && Objects.equals(names, request.names);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(pageParams);
+            return Objects.hash(pageParams, indexNames, names);
         }
 
+        @SuppressWarnings("unchecked")
         private static final ConstructingObjectParser<ListConnectorAction.Request, String> PARSER = new ConstructingObjectParser<>(
             "list_connector_request",
-            p -> new ListConnectorAction.Request((PageParams) p[0])
+            p -> new ListConnectorAction.Request((PageParams) p[0], (List<String>) p[1], (List<String>) p[2])
         );
 
         static {
             PARSER.declareObject(constructorArg(), (p, c) -> PageParams.fromXContent(p), PAGE_PARAMS_FIELD);
+            PARSER.declareStringArray(optionalConstructorArg(), INDEX_NAMES_FIELD);
+            PARSER.declareStringArray(optionalConstructorArg(), NAMES_FIELD);
         }
 
         public static ListConnectorAction.Request parse(XContentParser parser) {
@@ -95,7 +133,11 @@ public class ListConnectorAction {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(PAGE_PARAMS_FIELD.getPreferredName(), pageParams);
+            {
+                builder.field(PAGE_PARAMS_FIELD.getPreferredName(), pageParams);
+                builder.field(INDEX_NAMES_FIELD.getPreferredName(), indexNames);
+                builder.field(NAMES_FIELD.getPreferredName(), names);
+            }
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestListConnectorAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
+import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
 import java.io.IOException;
@@ -38,7 +39,10 @@ public class RestListConnectorAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         int from = restRequest.paramAsInt("from", PageParams.DEFAULT_FROM);
         int size = restRequest.paramAsInt("size", PageParams.DEFAULT_SIZE);
-        ListConnectorAction.Request request = new ListConnectorAction.Request(new PageParams(from, size));
+        List<String> indexNames = List.of(restRequest.paramAsStringArray(Connector.INDEX_NAME_FIELD.getPreferredName(), new String[0]));
+        List<String> names = List.of(restRequest.paramAsStringArray(Connector.NAME_FIELD.getPreferredName(), new String[0]));
+
+        ListConnectorAction.Request request = new ListConnectorAction.Request(new PageParams(from, size), indexNames, names);
 
         return channel -> client.execute(ListConnectorAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestListConnectorAction.java
@@ -40,9 +40,9 @@ public class RestListConnectorAction extends BaseRestHandler {
         int from = restRequest.paramAsInt("from", PageParams.DEFAULT_FROM);
         int size = restRequest.paramAsInt("size", PageParams.DEFAULT_SIZE);
         List<String> indexNames = List.of(restRequest.paramAsStringArray(Connector.INDEX_NAME_FIELD.getPreferredName(), new String[0]));
-        List<String> names = List.of(restRequest.paramAsStringArray(Connector.NAME_FIELD.getPreferredName(), new String[0]));
+        List<String> connectorNames = List.of(restRequest.paramAsStringArray("connector_name", new String[0]));
 
-        ListConnectorAction.Request request = new ListConnectorAction.Request(new PageParams(from, size), indexNames, names);
+        ListConnectorAction.Request request = new ListConnectorAction.Request(new PageParams(from, size), indexNames, connectorNames);
 
         return channel -> client.execute(ListConnectorAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportListConnectorAction.java
@@ -42,9 +42,12 @@ public class TransportListConnectorAction extends HandledTransportAction<ListCon
     @Override
     protected void doExecute(Task task, ListConnectorAction.Request request, ActionListener<ListConnectorAction.Response> listener) {
         final PageParams pageParams = request.getPageParams();
+
         connectorIndexService.listConnectors(
             pageParams.getFrom(),
             pageParams.getSize(),
+            request.getIndexNames(),
+            request.getNames(),
             listener.map(r -> new ListConnectorAction.Response(r.connectors(), r.totalResults()))
         );
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportListConnectorAction.java
@@ -47,7 +47,7 @@ public class TransportListConnectorAction extends HandledTransportAction<ListCon
             pageParams.getFrom(),
             pageParams.getSize(),
             request.getIndexNames(),
-            request.getNames(),
+            request.getConnectorNames(),
             listener.map(r -> new ListConnectorAction.Response(r.connectors(), r.totalResults()))
         );
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -534,11 +534,12 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         return resp.get();
     }
 
-    private ConnectorIndexService.ConnectorResult awaitListConnector(int from, int size) throws Exception {
+    private ConnectorIndexService.ConnectorResult awaitListConnector(int from, int size, List<String> indexNames, List<String> names)
+        throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<ConnectorIndexService.ConnectorResult> resp = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
-        connectorIndexService.listConnectors(from, size, new ActionListener<>() {
+        connectorIndexService.listConnectors(from, size, indexNames, names, new ActionListener<>() {
             @Override
             public void onResponse(ConnectorIndexService.ConnectorResult result) {
                 resp.set(result);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionRequestBWCSerializingTests.java
@@ -45,6 +45,6 @@ public class ListConnectorActionRequestBWCSerializingTests extends AbstractBWCSe
 
     @Override
     protected ListConnectorAction.Request mutateInstanceForVersion(ListConnectorAction.Request instance, TransportVersion version) {
-        return new ListConnectorAction.Request(instance.getPageParams(), instance.getIndexNames(), instance.getNames());
+        return new ListConnectorAction.Request(instance.getPageParams(), instance.getIndexNames(), instance.getConnectorNames());
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionRequestBWCSerializingTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 
 import java.io.IOException;
+import java.util.List;
 
 public class ListConnectorActionRequestBWCSerializingTests extends AbstractBWCSerializationTestCase<ListConnectorAction.Request> {
     @Override
@@ -25,7 +26,11 @@ public class ListConnectorActionRequestBWCSerializingTests extends AbstractBWCSe
     @Override
     protected ListConnectorAction.Request createTestInstance() {
         PageParams pageParams = SearchApplicationTestUtils.randomPageParams();
-        return new ListConnectorAction.Request(pageParams);
+        return new ListConnectorAction.Request(
+            pageParams,
+            List.of(generateRandomStringArray(10, 10, false)),
+            List.of(generateRandomStringArray(10, 10, false))
+        );
     }
 
     @Override
@@ -40,6 +45,6 @@ public class ListConnectorActionRequestBWCSerializingTests extends AbstractBWCSe
 
     @Override
     protected ListConnectorAction.Request mutateInstanceForVersion(ListConnectorAction.Request instance, TransportVersion version) {
-        return new ListConnectorAction.Request(instance.getPageParams());
+        return new ListConnectorAction.Request(instance.getPageParams(), instance.getIndexNames(), instance.getNames());
     }
 }


### PR DESCRIPTION
# Changes

Add optional url parameters `index_name` and `names` that supports filtering results from list connectors endpoint by connector name(s) and/or index_name(s).

Added e2e test scenarios in yaml tests. 