### PR TITLE
Really drop symlink env test on Windows

### DIFF
--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -645,7 +645,7 @@ public class NodeEnvironmentTests extends ESTestCase {
         try {
             Files.createSymbolicLink(symLinkPath, dataPath);
         } catch (FileSystemException e) {
-            if (IOUtils.WINDOWS && e.getReason().equals("A required privilege is not held by the client")) {
+            if (IOUtils.WINDOWS && "A required privilege is not held by the client".equals(e.getReason())) {
                 throw new AssumptionViolatedException("Symlinks on Windows need admin privileges", e);
             } else {
                 throw e;

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -645,8 +645,8 @@ public class NodeEnvironmentTests extends ESTestCase {
         try {
             Files.createSymbolicLink(symLinkPath, dataPath);
         } catch (FileSystemException e) {
-            if (IOUtils.WINDOWS && e.getMessage().equals("A required privilege is not held by the client")) {
-                throw new AssumptionViolatedException("Symlinks on windows needs admin privileges", e);
+            if (IOUtils.WINDOWS && e.getReason().equals("A required privilege is not held by the client")) {
+                throw new AssumptionViolatedException("Symlinks on Windows need admin privileges", e);
             } else {
                 throw e;
             }


### PR DESCRIPTION
Rectification of #102762

`FileSystemException` "message" may also contain a file name:
https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/nio/file/FileSystemException.java#L118

Check "reason" instead.