### PR TITLE
Use Pattern.quote() instead of manual escaping of regex special symbols

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/SerializableTokenListCategory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/SerializableTokenListCategory.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -36,8 +37,6 @@ public class SerializableTokenListCategory implements Writeable {
      * <code>CTokenListReverseSearchCreator</code></a> in the C++ code.
      */
     public static final int KEY_BUDGET = 10000;
-
-    private static final String REGEX_NEEDS_ESCAPE_PATTERN = "([\\\\|()\\[\\]{}^$.+*?])";
 
     final BytesRef[] baseTokens;
     final int[] baseTokenWeights;
@@ -168,7 +167,7 @@ public class SerializableTokenListCategory implements Writeable {
         }
         return Arrays.stream(keyTokenIndexes)
             .filter(index -> index >= orderedCommonTokenBeginIndex && index < orderedCommonTokenEndIndex)
-            .mapToObj(index -> baseTokens[index].utf8ToString().replaceAll(REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1"))
+            .mapToObj(index -> Pattern.quote(baseTokens[index].utf8ToString()))
             .collect(Collectors.joining(".+?", ".*?", ".*?"));
     }
 

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinder.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
@@ -36,7 +37,6 @@ import static org.elasticsearch.core.Strings.format;
 public class DelimitedTextStructureFinder implements TextStructureFinder {
 
     static final int MAX_EXCLUDE_LINES_PATTERN_LENGTH = 1000;
-    static final String REGEX_NEEDS_ESCAPE_PATTERN = "([\\\\|()\\[\\]{}^$.+*?])";
     private static final int MAX_LEVENSHTEIN_COMPARISONS = 100;
     private static final int LONG_FIELD_THRESHOLD = 100;
     private static final int LOW_CARDINALITY_MAX_SIZE = 5;
@@ -142,9 +142,9 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
             .setColumnNames(columnNamesList);
 
         String quote = String.valueOf(quoteChar);
-        String quotePattern = quote.replaceAll(REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1");
+        String quotePattern = Pattern.quote(quote);
         String optQuotePattern = quotePattern + "?";
-        String delimiterPattern = (delimiter == '\t') ? "\\t" : String.valueOf(delimiter).replaceAll(REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1");
+        String delimiterPattern = (delimiter == '\t') ? "\\t" : Pattern.quote(String.valueOf(delimiter));
         if (isHeaderInText) {
             structureBuilder.setExcludeLinesPattern(makeExcludeLinesPattern(header, quote, optQuotePattern, delimiterPattern));
         }
@@ -908,10 +908,7 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
             }
         }
 
-        return values.stream()
-            .map(value -> value.replaceAll(REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1"))
-            .sorted()
-            .collect(Collectors.joining("|", "(?:", ")"));
+        return values.stream().map(Pattern::quote).sorted().collect(Collectors.joining("|", "(?:", ")"));
     }
 
     /**
@@ -946,10 +943,9 @@ public class DelimitedTextStructureFinder implements TextStructureFinder {
         String twoQuotes = quote + quote;
         StringBuilder excludeLinesPattern = new StringBuilder("^");
         boolean isFirst = true;
-        int maxLengthOfFields = MAX_EXCLUDE_LINES_PATTERN_LENGTH - delimiterPattern.length() - 2; // 2 is length of ".*"
+        int maxLengthOfFields = MAX_EXCLUDE_LINES_PATTERN_LENGTH - delimiterPattern.length() - ".*".length();
         for (String column : header) {
-            String columnPattern = optQuotePattern + column.replace(quote, twoQuotes).replaceAll(REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1")
-                + optQuotePattern;
+            String columnPattern = optQuotePattern + Pattern.quote(column.replace(quote, twoQuotes)) + optQuotePattern;
             if (isFirst) {
                 // Always append the pattern for the first column, even if it exceeds the limit
                 excludeLinesPattern.append(columnPattern);

--- a/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderTests.java
+++ b/x-pack/plugin/text-structure/src/test/java/org/elasticsearch/xpack/textstructure/structurefinder/DelimitedTextStructureFinderTests.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -1285,12 +1286,11 @@ public class DelimitedTextStructureFinderTests extends TextStructureTestCase {
 
         String[] header = generateRandomStringArray(1000, randomIntBetween(5, 50), false, false);
         String quote = randomFrom("\"", "'");
-        String quotePattern = quote.replaceAll(DelimitedTextStructureFinder.REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1");
-        String optQuotePattern = quotePattern + "?";
         char delimiter = randomFrom(',', ';', '\t', '|');
-        String delimiterPattern = (delimiter == '\t')
-            ? "\\t"
-            : String.valueOf(delimiter).replaceAll(DelimitedTextStructureFinder.REGEX_NEEDS_ESCAPE_PATTERN, "\\\\$1");
+
+        String quotePattern = Pattern.quote(quote);
+        String optQuotePattern = quotePattern + "?";
+        String delimiterPattern = (delimiter == '\t') ? "\\t" : Pattern.quote(String.valueOf(delimiter));
 
         String excludeLinesPattern = DelimitedTextStructureFinder.makeExcludeLinesPattern(header, quote, optQuotePattern, delimiterPattern);
 


### PR DESCRIPTION
`Pattern.quote()` is an efficient and reliable way to force literal matching for regexp even when the pattern text contains special characters.

Some code was still using manual escaping like this:
```
text.replaceAll("([\\\\|()\\[\\]{}^$.+*?])", "\\\\$1")
```
which is inefficient and fragile. For instance, `#` could be treated as an end-of-line comment in a pattern.

In this PR I replaced such manual escaping with `Pattern.quote()` calls.