### PR TITLE
[Transform] Do not log deduction-related warnings for transforms with disabled mapping deduction

### DIFF
--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -306,6 +306,6 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
             );
         }, listener::onFailure);
 
-        function.deduceMappings(parentTaskClient, filteredHeaders, source, deduceMappingsListener);
+        function.deduceMappings(parentTaskClient, filteredHeaders, transformId, source, deduceMappingsListener);
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportValidateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportValidateTransformAction.java
@@ -130,7 +130,7 @@ public class TransportValidateTransformAction extends HandledTransportAction<Req
             if (request.isDeferValidation()) {
                 deduceMappingsListener.onResponse(emptyMap());
             } else {
-                function.deduceMappings(client, config.getHeaders(), config.getSource(), deduceMappingsListener);
+                function.deduceMappings(client, config.getHeaders(), config.getId(), config.getSource(), deduceMappingsListener);
             }
         }, listener::onFailure);
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
@@ -118,12 +118,14 @@ public interface Function {
      *
      * @param client a client instance for querying the source mappings
      * @param headers headers to be used to query only for what the caller is allowed to
+     * @param transformId transform id
      * @param sourceConfig the source configuration
      * @param listener listener to take the deduced mapping
      */
     void deduceMappings(
         Client client,
         Map<String, String> headers,
+        String transformId,
         SourceConfig sourceConfig,
         ActionListener<Map<String, String>> listener
     );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/latest/Latest.java
@@ -116,6 +116,7 @@ public class Latest extends AbstractCompositeAggFunction {
     public void deduceMappings(
         Client client,
         Map<String, String> headers,
+        String transformId,
         SourceConfig sourceConfig,
         ActionListener<Map<String, String>> listener
     ) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/pivot/Pivot.java
@@ -89,18 +89,11 @@ public class Pivot extends AbstractCompositeAggFunction {
     public void deduceMappings(
         Client client,
         Map<String, String> headers,
+        String transformId,
         SourceConfig sourceConfig,
         final ActionListener<Map<String, String>> listener
     ) {
-        SchemaUtil.deduceMappings(
-            client,
-            headers,
-            config,
-            sourceConfig.getIndex(),
-            sourceConfig.getQueryConfig().getQuery(),
-            sourceConfig.getRuntimeMappings(),
-            listener
-        );
+        SchemaUtil.deduceMappings(client, headers, transformId, settings, config, sourceConfig, listener);
     }
 
     /**

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
@@ -28,6 +27,8 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
+import org.elasticsearch.xpack.core.transform.transforms.SourceConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.AggregationConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfig;
 import org.elasticsearch.xpack.core.transform.transforms.pivot.GroupConfigTests;
@@ -151,10 +152,10 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
             listener -> SchemaUtil.deduceMappings(
                 client,
                 emptyMap(),
+                "my-transform",
+                new SettingsConfig(),
                 pivotConfig,
-                new String[] { "source-index" },
-                QueryBuilders.matchAllQuery(),
-                emptyMap(),
+                new SourceConfig(new String[] { "source-index" }),
                 listener
             ),
             mappings -> {
@@ -231,10 +232,10 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
             listener -> SchemaUtil.deduceMappings(
                 client,
                 emptyMap(),
+                "my-transform",
+                new SettingsConfig(),
                 pivotConfig,
-                new String[] { "source-index" },
-                QueryBuilders.matchAllQuery(),
-                emptyMap(),
+                new SourceConfig(new String[] { "source-index" }),
                 listener
             ),
             mappings -> {


### PR DESCRIPTION
Currently, when the mapping type for transform's group-by field is missing in the source index, `keyword` is assumed and a warning is logged.
Logging a warning can be confusing for user who's set `deduce_mappings = false` in their transform config.
This PR sets logging level based on the value of `deduce_mappings` setting:
- `WARN` when `deduce_mappings` is set to `true`
- `INFO` otherwise

Additionally, this PR:
- cleans up the interface of `SchemaUtil.deduceMappings` method by making it accept `SourceConfig` rather than `index`, `query` and `runtime_mappings` separately
- adds `transformId` to log messages to help debugging

Marking `>non-issue` as this PR is essentially code refactoring + change in logging level of 2 log messages.

Relates https://github.com/elastic/elasticsearch/issues/103115