### PR TITLE
[8.12] [Connectors API] Fix bug with crawler configuration parsing and sync_now flag (#105024)

### DIFF
--- a/docs/changelog/105024.yaml
+++ b/docs/changelog/105024.yaml
@@ -1,0 +1,6 @@
+pr: 105024
+summary: "[Connectors API] Fix bug with crawler configuration parsing and `sync_now`\
+  \ flag"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
@@ -183,7 +183,6 @@ setup:
                 - field: some_field
                   value: 31
               display: numeric
-              label: Very important field
 
 ---
 "Update Connector Configuration - Unknown field type":
@@ -238,3 +237,26 @@ setup:
                 - constraint: 0
                   type: unknown_constraint
               value: 123
+
+---
+"Update Connector Configuration - Crawler configuration":
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          configuration:
+            nextSyncConfig:
+              label: nextSyncConfig
+              value:
+                max_crawl_depth: 3
+                sitemap_discovery_disabled: false
+                seed_urls:
+                  - https://elastic.co/
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { configuration.nextSyncConfig.value.max_crawl_depth: 3 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -682,8 +682,8 @@ public class Connector implements NamedWriteable, ToXContentObject {
             return this;
         }
 
-        public Builder setSyncNow(boolean syncNow) {
-            this.syncNow = syncNow;
+        public Builder setSyncNow(Boolean syncNow) {
+            this.syncNow = Objects.requireNonNullElse(syncNow, false);
             return this;
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
@@ -162,8 +162,8 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
                 .setOptions((List<ConfigurationSelectOption>) args[i++])
                 .setOrder((Integer) args[i++])
                 .setPlaceholder((String) args[i++])
-                .setRequired((boolean) args[i++])
-                .setSensitive((boolean) args[i++])
+                .setRequired((Boolean) args[i++])
+                .setSensitive((Boolean) args[i++])
                 .setTooltip((String) args[i++])
                 .setType((ConfigurationFieldType) args[i++])
                 .setUiRestrictions((List<String>) args[i++])
@@ -187,40 +187,42 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
             }
             throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
         }, DEFAULT_VALUE_FIELD, ObjectParser.ValueType.VALUE);
-        PARSER.declareObjectArray(constructorArg(), (p, c) -> ConfigurationDependency.fromXContent(p), DEPENDS_ON_FIELD);
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> ConfigurationDependency.fromXContent(p), DEPENDS_ON_FIELD);
         PARSER.declareField(
-            constructorArg(),
+            optionalConstructorArg(),
             (p, c) -> ConfigurationDisplayType.displayType(p.text()),
             DISPLAY_FIELD,
-            ObjectParser.ValueType.STRING
+            ObjectParser.ValueType.STRING_OR_NULL
         );
         PARSER.declareString(constructorArg(), LABEL_FIELD);
-        PARSER.declareObjectArray(constructorArg(), (p, c) -> ConfigurationSelectOption.fromXContent(p), OPTIONS_FIELD);
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> ConfigurationSelectOption.fromXContent(p), OPTIONS_FIELD);
         PARSER.declareInt(optionalConstructorArg(), ORDER_FIELD);
-        PARSER.declareString(optionalConstructorArg(), PLACEHOLDER_FIELD);
-        PARSER.declareBoolean(constructorArg(), REQUIRED_FIELD);
-        PARSER.declareBoolean(constructorArg(), SENSITIVE_FIELD);
+        PARSER.declareStringOrNull(optionalConstructorArg(), PLACEHOLDER_FIELD);
+        PARSER.declareBoolean(optionalConstructorArg(), REQUIRED_FIELD);
+        PARSER.declareBoolean(optionalConstructorArg(), SENSITIVE_FIELD);
         PARSER.declareStringOrNull(optionalConstructorArg(), TOOLTIP_FIELD);
         PARSER.declareField(
-            constructorArg(),
-            (p, c) -> ConfigurationFieldType.fieldType(p.text()),
+            optionalConstructorArg(),
+            (p, c) -> p.currentToken() == XContentParser.Token.VALUE_NULL ? null : ConfigurationFieldType.fieldType(p.text()),
             TYPE_FIELD,
-            ObjectParser.ValueType.STRING
+            ObjectParser.ValueType.STRING_OR_NULL
         );
-        PARSER.declareStringArray(constructorArg(), UI_RESTRICTIONS_FIELD);
-        PARSER.declareObjectArray(constructorArg(), (p, c) -> ConfigurationValidation.fromXContent(p), VALIDATIONS_FIELD);
-        PARSER.declareField(constructorArg(), (p, c) -> {
+        PARSER.declareStringArray(optionalConstructorArg(), UI_RESTRICTIONS_FIELD);
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> ConfigurationValidation.fromXContent(p), VALIDATIONS_FIELD);
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> {
             if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
                 return p.text();
             } else if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
                 return p.numberValue();
             } else if (p.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
                 return p.booleanValue();
+            } else if (p.currentToken() == XContentParser.Token.START_OBJECT) {
+                return p.map();
             } else if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
                 return null;
             }
             throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
-        }, VALUE_FIELD, ObjectParser.ValueType.VALUE);
+        }, VALUE_FIELD, ObjectParser.ValueType.VALUE_OBJECT_ARRAY);
     }
 
     @Override
@@ -231,10 +233,16 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
                 builder.field(CATEGORY_FIELD.getPreferredName(), category);
             }
             builder.field(DEFAULT_VALUE_FIELD.getPreferredName(), defaultValue);
-            builder.xContentList(DEPENDS_ON_FIELD.getPreferredName(), dependsOn);
-            builder.field(DISPLAY_FIELD.getPreferredName(), display.toString());
+            if (dependsOn != null) {
+                builder.xContentList(DEPENDS_ON_FIELD.getPreferredName(), dependsOn);
+            }
+            if (display != null) {
+                builder.field(DISPLAY_FIELD.getPreferredName(), display.toString());
+            }
             builder.field(LABEL_FIELD.getPreferredName(), label);
-            builder.xContentList(OPTIONS_FIELD.getPreferredName(), options);
+            if (options != null) {
+                builder.xContentList(OPTIONS_FIELD.getPreferredName(), options);
+            }
             if (order != null) {
                 builder.field(ORDER_FIELD.getPreferredName(), order);
             }
@@ -243,10 +251,18 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
             }
             builder.field(REQUIRED_FIELD.getPreferredName(), required);
             builder.field(SENSITIVE_FIELD.getPreferredName(), sensitive);
-            builder.field(TOOLTIP_FIELD.getPreferredName(), tooltip);
-            builder.field(TYPE_FIELD.getPreferredName(), type.toString());
-            builder.stringListField(UI_RESTRICTIONS_FIELD.getPreferredName(), uiRestrictions);
-            builder.xContentList(VALIDATIONS_FIELD.getPreferredName(), validations);
+            if (tooltip != null) {
+                builder.field(TOOLTIP_FIELD.getPreferredName(), tooltip);
+            }
+            if (type != null) {
+                builder.field(TYPE_FIELD.getPreferredName(), type.toString());
+            }
+            if (uiRestrictions != null) {
+                builder.stringListField(UI_RESTRICTIONS_FIELD.getPreferredName(), uiRestrictions);
+            }
+            if (validations != null) {
+                builder.xContentList(VALIDATIONS_FIELD.getPreferredName(), validations);
+            }
             builder.field(VALUE_FIELD.getPreferredName(), value);
         }
         builder.endObject();
@@ -385,13 +401,13 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
             return this;
         }
 
-        public Builder setRequired(boolean required) {
-            this.required = required;
+        public Builder setRequired(Boolean required) {
+            this.required = Objects.requireNonNullElse(required, false);
             return this;
         }
 
-        public Builder setSensitive(boolean sensitive) {
-            this.sensitive = sensitive;
+        public Builder setSensitive(Boolean sensitive) {
+            this.sensitive = Objects.requireNonNullElse(sensitive, false);
             return this;
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJob.java
@@ -312,7 +312,7 @@ public class ConnectorSyncJob implements Writeable, ToXContentObject {
             STATUS_FIELD,
             ObjectParser.ValueType.STRING
         );
-        PARSER.declareLong(constructorArg(), TOTAL_DOCUMENT_COUNT_FIELD);
+        PARSER.declareLongOrNull(constructorArg(), 0L, TOTAL_DOCUMENT_COUNT_FIELD);
         PARSER.declareField(
             constructorArg(),
             (p, c) -> ConnectorSyncJobTriggerMethod.fromString(p.text()),

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorConfigurationTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorConfigurationTests.java
@@ -85,6 +85,46 @@ public class ConnectorConfigurationTests extends ESTestCase {
         assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
     }
 
+    public void testToXContentCrawlerConfig_WithNullValue() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "label": "nextSyncConfig",
+               "value": null
+            }
+            """);
+
+        ConnectorConfiguration configuration = ConnectorConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        ConnectorConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = ConnectorConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToXContentCrawlerConfig_WithCrawlerConfigurationOverrides() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "label": "nextSyncConfig",
+               "value": {
+                   "max_crawl_depth": 3,
+                   "sitemap_discovery_disabled": false,
+                   "seed_urls": ["https://elastic.co/"]
+               }
+            }
+            """);
+
+        ConnectorConfiguration configuration = ConnectorConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        ConnectorConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = ConnectorConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
     public void testToXContentWithMultipleConstraintTypes() throws IOException {
         String content = XContentHelper.stripWhitespace("""
             {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTests.java
@@ -238,7 +238,7 @@ public class ConnectorSyncJobTests extends ESTestCase {
                 "metadata": {},
                 "started_at": null,
                 "status": "canceling",
-                "total_document_count": 0,
+                "total_document_count": null,
                 "trigger_method": "scheduled",
                 "worker_hostname": null
             }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [Connectors API] Fix bug with crawler configuration parsing and sync_now flag (#105024)