### PR TITLE
Adjust skip version for tsdb bwc tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/25_id_generation.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/25_id_generation.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 8.1.99,8.7.00 - 8.12.99"
-      reason: _tsid hashing introduced in 8.13
+      version: " - 8.1.99,8.7.00 - 8.9.99"
+      reason: "tsdb indexing changed in 8.2.0, synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests"
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/25_id_generation.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/25_id_generation.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: " - 8.1.99,8.7.00 - 8.9.99"
-      reason: "tsdb indexing changed in 8.2.0, synthetic source shows up in the mapping in 8.10 and on, may trigger assert failures in mixed cluster tests"
+      version: "- 8.12.99"
+      reason: _tsid hashing introduced in 8.13
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
@@ -1,7 +1,7 @@
 ---
 setup:
   - skip:
-      version: "8.7.00 - 8.12.99"
+      version: " - 8.12.99"
       reason: _tsid hashing introduced in 8.13
 
   - do:


### PR DESCRIPTION
Yaml tests executed in mixed clusters need to skip clusters that run 8.12.x or earlier versions. The yaml tests assume hashing based time series ids, but if a node in the test cluster is on 8.12.x or earlier, then it can happen pre hashing time series ids are used (depending on the version of the elected master node). 

Tsdb yaml tests that assert the _id or _tsid should be skipped if there are 8.12.x nodes in the mixed test cluster.
Rolling upgrade or full upgrade tests are better for assertion the _id or _tsid in this case, because tests are setup prior to upgrade and pre 8.12.x logic can be asserted in a more controlled way.

Closes #105129