### PR TITLE
[DOCS] Update `KEEP` command with duplicate  precedence rules

### DIFF
--- a/docs/reference/esql/processing-commands/keep.asciidoc
+++ b/docs/reference/esql/processing-commands/keep.asciidoc
@@ -105,8 +105,3 @@ include::{esql-specs}/docs.csv-spec[tag=keepWildcardLowest]
 |===
 include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-lowest-result]
 |===
-
-
-
-
-

--- a/docs/reference/esql/processing-commands/keep.asciidoc
+++ b/docs/reference/esql/processing-commands/keep.asciidoc
@@ -94,7 +94,7 @@ include::{esql-specs}/docs.csv-spec[tag=keepWildcardPrecedence]
 include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-precedence-result]
 |===
 
-A simple wildcard expression `*` has the lowest priority.
+A simple wildcard expression `*` has the lowest precedence.
 Output order is determined by the other arguments:
 
 [source,esql]

--- a/docs/reference/esql/processing-commands/keep.asciidoc
+++ b/docs/reference/esql/processing-commands/keep.asciidoc
@@ -20,11 +20,13 @@ The `KEEP` processing command enables you to specify what columns are returned
 and the order in which they are returned.
 
 Precedence rules are applied when a field name matches multiple expressions.
-Fields are added in the order they appear. If one field matches multiple expressions, the following precedence rules apply (from higher to lower):
+Fields are added in the order they appear. If one field matches multiple expressions, the following precedence rules apply (from highest to lowest priority):
 
 1. Complete field name (no wildcards)
 2. Partial wildcard expressions (for example: `fieldNam*`)
 3. Wildcard only (`*`)
+
+If a field matches two expressions with the same precedence, the right-most expression wins.
 
 Refer to the examples for illustrations of these precedence rules.
 
@@ -48,6 +50,10 @@ columns with a name that matches a pattern:
 ----
 include::{esql-specs}/docs.csv-spec[tag=keepWildcard]
 ----
+[%header.monospaced.styled,format=dsv,separator=|]
+|===
+include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-result]
+|===
 
 The asterisk wildcard (`*`) by itself translates to all columns that do not
 match the other arguments.
@@ -59,19 +65,12 @@ that starts with `h`, followed by all other columns:
 ----
 include::{esql-specs}/docs.csv-spec[tag=keepDoubleWildcard]
 ----
-
-The following examples show how precedence rules work when a field name matches multiple expressions.
-
-Full name duplicates, last one wins:
-
-[source,esql]
-----
-include::{esql-specs}/docs.csv-spec[tag=keepMultipleMatch]
-----
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
-include::{esql-specs}/docs.csv-spec[tag=keep-multiple-match-result]
+include::{esql-specs}/docs.csv-spec[tag=keep-double-wildcard-result]
 |===
+
+The following examples show how precedence rules work when a field name matches multiple expressions.   
 
 Complete field name has precedence over wildcard expressions:
 
@@ -95,8 +94,6 @@ include::{esql-specs}/docs.csv-spec[tag=keepWildcardPrecedence]
 include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-precedence-result]
 |===
 
-// row foo = 1, bar = 2 | keep *, foo   ->  bar, foo
-
 A simple wildcard expression `*` has the lowest priority.
 Output order is determined by the other arguments:
 
@@ -107,24 +104,6 @@ include::{esql-specs}/docs.csv-spec[tag=keepWildcardLowest]
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
 include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-lowest-result]
-|===
-
-[source,esql]
-----
-include::{esql-specs}/docs.csv-spec[tag=keepWildcardLowest2]
-----
-[%header.monospaced.styled,format=dsv,separator=|]
-|===
-include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-lowest-result2]
-|===
-
-[source,esql]
-----
-include::{esql-specs}/docs.csv-spec[tag=keepWildcardLowest3]
-----
-[%header.monospaced.styled,format=dsv,separator=|]
-|===
-include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-lowest-result3]
 |===
 
 

--- a/docs/reference/esql/processing-commands/keep.asciidoc
+++ b/docs/reference/esql/processing-commands/keep.asciidoc
@@ -97,7 +97,8 @@ include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-precedence-result]
 
 // row foo = 1, bar = 2 | keep *, foo   ->  bar, foo
 
-A simple wildcard expression `*` has the lowest priority:
+A simple wildcard expression `*` has the lowest priority.
+Output order is determined by the other arguments:
 
 [source,esql]
 ----

--- a/docs/reference/esql/processing-commands/keep.asciidoc
+++ b/docs/reference/esql/processing-commands/keep.asciidoc
@@ -10,6 +10,7 @@ KEEP columns
 ----
 
 *Parameters*
+
 `columns`::
 A comma-separated list of columns to keep. Supports wildcards.
 
@@ -17,6 +18,15 @@ A comma-separated list of columns to keep. Supports wildcards.
 
 The `KEEP` processing command enables you to specify what columns are returned
 and the order in which they are returned.
+
+Precedence rules are applied when a field name matches multiple expressions.
+Fields are added in the order they appear. If one field matches multiple expressions, the following precedence rules apply (from higher to lower):
+
+1. Complete field name (no wildcards)
+2. Partial wildcard expressions (for example: `fieldNam*`)
+3. Wildcard only (`*`)
+
+Refer to the examples for illustrations of these precedence rules.
 
 *Examples*
 
@@ -40,10 +50,83 @@ include::{esql-specs}/docs.csv-spec[tag=keepWildcard]
 ----
 
 The asterisk wildcard (`*`) by itself translates to all columns that do not
-match the other arguments. This query will first return all columns with a name
+match the other arguments.
+
+This query will first return all columns with a name
 that starts with `h`, followed by all other columns:
 
 [source,esql]
 ----
 include::{esql-specs}/docs.csv-spec[tag=keepDoubleWildcard]
 ----
+
+The following examples show how precedence rules work when a field name matches multiple expressions.
+
+Full name duplicates, last one wins:
+
+[source,esql]
+----
+include::{esql-specs}/docs.csv-spec[tag=keepMultipleMatch]
+----
+[%header.monospaced.styled,format=dsv,separator=|]
+|===
+include::{esql-specs}/docs.csv-spec[tag=keep-multiple-match-result]
+|===
+
+Complete field name has precedence over wildcard expressions:
+
+[source,esql]
+----
+include::{esql-specs}/docs.csv-spec[tag=keepCompleteName]
+----
+[%header.monospaced.styled,format=dsv,separator=|]
+|===
+include::{esql-specs}/docs.csv-spec[tag=keep-complete-name-result]
+|===
+
+Wildcard expressions have the same priority, but last one wins (despite being less specific):
+
+[source,esql]
+----
+include::{esql-specs}/docs.csv-spec[tag=keepWildcardPrecedence]
+----
+[%header.monospaced.styled,format=dsv,separator=|]
+|===
+include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-precedence-result]
+|===
+
+// row foo = 1, bar = 2 | keep *, foo   ->  bar, foo
+
+A simple wildcard expression `*` has the lowest priority:
+
+[source,esql]
+----
+include::{esql-specs}/docs.csv-spec[tag=keepWildcardLowest]
+----
+[%header.monospaced.styled,format=dsv,separator=|]
+|===
+include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-lowest-result]
+|===
+
+[source,esql]
+----
+include::{esql-specs}/docs.csv-spec[tag=keepWildcardLowest2]
+----
+[%header.monospaced.styled,format=dsv,separator=|]
+|===
+include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-lowest-result2]
+|===
+
+[source,esql]
+----
+include::{esql-specs}/docs.csv-spec[tag=keepWildcardLowest3]
+----
+[%header.monospaced.styled,format=dsv,separator=|]
+|===
+include::{esql-specs}/docs.csv-spec[tag=keep-wildcard-lowest-result3]
+|===
+
+
+
+
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -74,7 +74,7 @@ FROM employees
 height:double | height.float:double | height.half_float:double | height.scaled_float:double |       hire_date:date | avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long |still_hired:boolean
 ;
 
-docsKeepMultipleMatch
+docsKeepMultipleMatch#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
 // tag::keepMultipleMatch[]
 FROM employees
 | KEEP first_name, last_name, first_name
@@ -87,7 +87,7 @@ last_name:keyword | first_name:keyword
 ;
 
 docsKeepCompleteName
-// tag::keepCompleteName[]
+// tag::keepCompleteName[]#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
 FROM employees
 | KEEP first_name, last_name, first_name*
 // end::keepCompleteName[]
@@ -98,7 +98,7 @@ first_name:keyword | last_name:keyword
 // end::keep-complete-name-result[]
 ;
 
-docsKeepWildcardPrecedence
+docsKeepWildcardPrecedence#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
 // tag::keepWildcardPrecedence[]
 FROM employees
 | KEEP first_name*, last_name, first_na*
@@ -110,7 +110,7 @@ last_name:keyword | first_name:keyword
 // end::keep-wildcard-precedence-result[]
 ;
 
-docsKeepWildcardLowest
+docsKeepWildcardLowest#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
 // tag::keepWildcardLowest[]
 FROM employees
 | KEEP *, first_name
@@ -122,7 +122,7 @@ avg_worked_seconds:long|birth_date:date|emp_no:integer|gender:keyword|height:dou
 // end::keep-wildcard-lowest-result[]
 ;
 
-docskeepWildcardLowest2
+docskeepWildcardLowest2#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
 // tag::keepWildcardLowest2[]
 FROM employees
 | KEEP first_name, *
@@ -134,7 +134,7 @@ first_name:keyword |avg_worked_seconds:long|birth_date:date|emp_no:integer|gende
 // end::keep-wildcard-lowest-result2[]
 ;
 
-docskeepWildcardLowest3
+docskeepWildcardLowest3#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
 // tag::keepWildcardLowest3[]
 FROM employees
 | KEEP last_name*, first_name, *

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -86,8 +86,8 @@ last_name:keyword | first_name:keyword
 // end::keep-multiple-match-result[]
 ;
 
-docsKeepCompleteName
-// tag::keepCompleteName[]#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
+docsKeepCompleteName#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
+// tag::keepCompleteName[]
 FROM employees
 | KEEP first_name, last_name, first_name*
 // end::keepCompleteName[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -61,7 +61,9 @@ FROM employees
 // end::keepWildcard[]
 | LIMIT 0;
 
+// tag::keep-wildcard-result[]
 height:double | height.float:double | height.half_float:double | height.scaled_float:double | hire_date:date
+// end::keep-wildcard-result[]
 ;
 
 docsKeepDoubleWildcard
@@ -71,19 +73,9 @@ FROM employees
 // end::keepDoubleWildcard[]
 | LIMIT 0;
 
+// tag::keep-double-wildcard-result[]
 height:double | height.float:double | height.half_float:double | height.scaled_float:double |       hire_date:date | avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long |still_hired:boolean
-;
-
-docsKeepMultipleMatch#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
-// tag::keepMultipleMatch[]
-FROM employees
-| KEEP first_name, last_name, first_name
-// end::keepMultipleMatch[]
-| LIMIT 0;
-
-// tag::keep-multiple-match-result[]
-last_name:keyword | first_name:keyword
-// end::keep-multiple-match-result[]
+// end::keep-double-wildcard-result[]
 ;
 
 docsKeepCompleteName#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
@@ -120,30 +112,6 @@ FROM employees
 // tag::keep-wildcard-lowest-result[]
 avg_worked_seconds:long|birth_date:date|emp_no:integer|gender:keyword|height:double|height.float:double|height.half_float:double|height.scaled_float:double|hire_date:date|is_rehired:boolean|job_positions:keyword|languages:integer|languages.byte:integer|languages.long:long|languages.short:integer|last_name:keyword|salary:integer|salary_change:double|salary_change.int:integer|salary_change.keyword:keyword|salary_change.long:long|still_hired:boolean|first_name:keyword
 // end::keep-wildcard-lowest-result[]
-;
-
-docskeepWildcardLowest2#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
-// tag::keepWildcardLowest2[]
-FROM employees
-| KEEP first_name, *
-// end::keepWildcardLowest2[]
-| LIMIT 0;
-
-// tag::keep-wildcard-lowest-result2[]
-first_name:keyword |avg_worked_seconds:long|birth_date:date|emp_no:integer|gender:keyword|height:double|height.float:double|height.half_float:double|height.scaled_float:double|hire_date:date|is_rehired:boolean|job_positions:keyword|languages:integer|languages.byte:integer|languages.long:long|languages.short:integer|last_name:keyword|salary:integer|salary_change:double|salary_change.int:integer|salary_change.keyword:keyword|salary_change.long:long|still_hired:boolean
-// end::keep-wildcard-lowest-result2[]
-;
-
-docskeepWildcardLowest3#[skip:-8.12.99, reason:duplicate precedence rules added in 8.13]
-// tag::keepWildcardLowest3[]
-FROM employees
-| KEEP last_name*, first_name, *
-// end::keepWildcardLowest3[]
-| LIMIT 0;
-
-// tag::keep-wildcard-lowest-result3[]
-last_name:keyword | first_name:keyword | avg_worked_seconds:long | birth_date:date | emp_no:integer | gender:keyword | height:double | height.float:double | height.half_float:double | height.scaled_float:double | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | salary:integer | salary_change:double | salary_change.int:integer | salary_change.keyword:keyword | salary_change.long:long | still_hired:boolean
-// end::keep-wildcard-lowest-result3[]
 ;
 
 docsRename

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/docs.csv-spec
@@ -74,6 +74,78 @@ FROM employees
 height:double | height.float:double | height.half_float:double | height.scaled_float:double |       hire_date:date | avg_worked_seconds:long | birth_date:date | emp_no:integer | first_name:keyword | gender:keyword | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | last_name:keyword | salary:integer | salary_change:double | salary_change.int:integer |salary_change.keyword:keyword |salary_change.long:long |still_hired:boolean
 ;
 
+docsKeepMultipleMatch
+// tag::keepMultipleMatch[]
+FROM employees
+| KEEP first_name, last_name, first_name
+// end::keepMultipleMatch[]
+| LIMIT 0;
+
+// tag::keep-multiple-match-result[]
+last_name:keyword | first_name:keyword
+// end::keep-multiple-match-result[]
+;
+
+docsKeepCompleteName
+// tag::keepCompleteName[]
+FROM employees
+| KEEP first_name, last_name, first_name*
+// end::keepCompleteName[]
+| LIMIT 0;
+
+// tag::keep-complete-name-result[]
+first_name:keyword | last_name:keyword
+// end::keep-complete-name-result[]
+;
+
+docsKeepWildcardPrecedence
+// tag::keepWildcardPrecedence[]
+FROM employees
+| KEEP first_name*, last_name, first_na*
+// end::keepWildcardPrecedence[]
+| LIMIT 0;
+
+// tag::keep-wildcard-precedence-result[]
+last_name:keyword | first_name:keyword
+// end::keep-wildcard-precedence-result[]
+;
+
+docsKeepWildcardLowest
+// tag::keepWildcardLowest[]
+FROM employees
+| KEEP *, first_name
+// end::keepWildcardLowest[]
+| LIMIT 0;
+
+// tag::keep-wildcard-lowest-result[]
+avg_worked_seconds:long|birth_date:date|emp_no:integer|gender:keyword|height:double|height.float:double|height.half_float:double|height.scaled_float:double|hire_date:date|is_rehired:boolean|job_positions:keyword|languages:integer|languages.byte:integer|languages.long:long|languages.short:integer|last_name:keyword|salary:integer|salary_change:double|salary_change.int:integer|salary_change.keyword:keyword|salary_change.long:long|still_hired:boolean|first_name:keyword
+// end::keep-wildcard-lowest-result[]
+;
+
+docskeepWildcardLowest2
+// tag::keepWildcardLowest2[]
+FROM employees
+| KEEP first_name, *
+// end::keepWildcardLowest2[]
+| LIMIT 0;
+
+// tag::keep-wildcard-lowest-result2[]
+first_name:keyword |avg_worked_seconds:long|birth_date:date|emp_no:integer|gender:keyword|height:double|height.float:double|height.half_float:double|height.scaled_float:double|hire_date:date|is_rehired:boolean|job_positions:keyword|languages:integer|languages.byte:integer|languages.long:long|languages.short:integer|last_name:keyword|salary:integer|salary_change:double|salary_change.int:integer|salary_change.keyword:keyword|salary_change.long:long|still_hired:boolean
+// end::keep-wildcard-lowest-result2[]
+;
+
+docskeepWildcardLowest3
+// tag::keepWildcardLowest3[]
+FROM employees
+| KEEP last_name*, first_name, *
+// end::keepWildcardLowest3[]
+| LIMIT 0;
+
+// tag::keep-wildcard-lowest-result3[]
+last_name:keyword | first_name:keyword | avg_worked_seconds:long | birth_date:date | emp_no:integer | gender:keyword | height:double | height.float:double | height.half_float:double | height.scaled_float:double | hire_date:date | is_rehired:boolean | job_positions:keyword | languages:integer | languages.byte:integer | languages.long:long | languages.short:integer | salary:integer | salary_change:double | salary_change.int:integer | salary_change.keyword:keyword | salary_change.long:long | still_hired:boolean
+// end::keep-wildcard-lowest-result3[]
+;
+
 docsRename
 // tag::rename[]
 FROM employees


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/103385

Docs per https://github.com/elastic/elasticsearch/pull/103316, showing how we don't return duplicate column names via precedence rules.