### PR TITLE
[7.17] [ci] Allow CI to be triggered by old elasticmachine-style comment (#105154)

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -11,7 +11,7 @@
       "set_commit_status": false,
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "(run\\W+elasticsearch-ci.+)|(^\\s*(buildkite\\s*)?test\\s+this(\\s+please)?)",
+      "trigger_comment_regex": "(run\\W+elasticsearch-ci.+)|(^\\s*((buildkite|@elastic(search)?machine)\\s*)?test\\s+this(\\s+please)?)",
       "cancel_intermediate_builds": true,
       "cancel_intermediate_builds_on_comment": false
     },

--- a/.buildkite/scripts/pull-request/__snapshots__/pipeline.test.ts.snap
+++ b/.buildkite/scripts/pull-request/__snapshots__/pipeline.test.ts.snap
@@ -201,3 +201,111 @@ exports[`generatePipelines should generate correct pipeline when using a trigger
   },
 ]
 `;
+
+exports[`generatePipelines should generate correct pipelines with a non-docs change and @elasticmachine 1`] = `
+[
+  {
+    "name": "bwc-snapshots",
+    "pipeline": {
+      "steps": [
+        {
+          "group": "bwc-snapshots",
+          "steps": [
+            {
+              "agents": {
+                "buildDirectory": "/dev/shm/bk",
+                "image": "family/elasticsearch-ubuntu-2004",
+                "machineType": "custom-32-98304",
+                "provider": "gcp",
+              },
+              "command": ".ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTest",
+              "env": {
+                "BWC_VERSION": "{{matrix.BWC_VERSION}}",
+              },
+              "label": "{{matrix.BWC_VERSION}} / bwc-snapshots",
+              "matrix": {
+                "setup": {
+                  "BWC_VERSION": [
+                    "7.17.14",
+                    "8.10.3",
+                    "8.11.0",
+                  ],
+                },
+              },
+              "timeout_in_minutes": 300,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    "name": "using-defaults",
+    "pipeline": {
+      "env": {
+        "CUSTOM_ENV_VAR": "value",
+      },
+      "steps": [
+        {
+          "command": "echo 'hello world'",
+          "label": "test-step",
+        },
+      ],
+    },
+  },
+]
+`;
+
+exports[`generatePipelines should generate correct pipelines with a non-docs change and @elasticsearchmachine 1`] = `
+[
+  {
+    "name": "bwc-snapshots",
+    "pipeline": {
+      "steps": [
+        {
+          "group": "bwc-snapshots",
+          "steps": [
+            {
+              "agents": {
+                "buildDirectory": "/dev/shm/bk",
+                "image": "family/elasticsearch-ubuntu-2004",
+                "machineType": "custom-32-98304",
+                "provider": "gcp",
+              },
+              "command": ".ci/scripts/run-gradle.sh -Dignore.tests.seed v{{matrix.BWC_VERSION}}#bwcTest",
+              "env": {
+                "BWC_VERSION": "{{matrix.BWC_VERSION}}",
+              },
+              "label": "{{matrix.BWC_VERSION}} / bwc-snapshots",
+              "matrix": {
+                "setup": {
+                  "BWC_VERSION": [
+                    "7.17.14",
+                    "8.10.3",
+                    "8.11.0",
+                  ],
+                },
+              },
+              "timeout_in_minutes": 300,
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    "name": "using-defaults",
+    "pipeline": {
+      "env": {
+        "CUSTOM_ENV_VAR": "value",
+      },
+      "steps": [
+        {
+          "command": "echo 'hello world'",
+          "label": "test-step",
+        },
+      ],
+    },
+  },
+]
+`;

--- a/.buildkite/scripts/pull-request/pipeline.test.ts
+++ b/.buildkite/scripts/pull-request/pipeline.test.ts
@@ -13,11 +13,11 @@ describe("generatePipelines", () => {
   });
 
   // Helper for testing pipeline generations that should be the same when using the overall ci trigger comment "buildkite test this"
-  const testWithTriggerCheck = (directory: string, changedFiles?: string[]) => {
+  const testWithTriggerCheck = (directory: string, changedFiles?: string[], comment = "buildkite test this") => {
     const pipelines = generatePipelines(directory, changedFiles);
     expect(pipelines).toMatchSnapshot();
 
-    process.env["GITHUB_PR_TRIGGER_COMMENT"] = "buildkite test this";
+    process.env["GITHUB_PR_TRIGGER_COMMENT"] = comment;
     const pipelinesWithTriggerComment = generatePipelines(directory, changedFiles);
     expect(pipelinesWithTriggerComment).toEqual(pipelines);
   };
@@ -41,5 +41,21 @@ describe("generatePipelines", () => {
 
     const pipelines = generatePipelines(`${import.meta.dir}/mocks/pipelines`, ["build.gradle"]);
     expect(pipelines).toMatchSnapshot();
+  });
+
+  test("should generate correct pipelines with a non-docs change and @elasticmachine", () => {
+    testWithTriggerCheck(
+      `${import.meta.dir}/mocks/pipelines`,
+      ["build.gradle", "docs/README.asciidoc"],
+      "@elasticmachine test this please"
+    );
+  });
+
+  test("should generate correct pipelines with a non-docs change and @elasticsearchmachine", () => {
+    testWithTriggerCheck(
+      `${import.meta.dir}/mocks/pipelines`,
+      ["build.gradle", "docs/README.asciidoc"],
+      "@elasticsearchmachine test this please"
+    );
   });
 });

--- a/.buildkite/scripts/pull-request/pipeline.ts
+++ b/.buildkite/scripts/pull-request/pipeline.ts
@@ -148,7 +148,9 @@ export const generatePipelines = (
   // However, if we're using the overall CI trigger "[buildkite] test this [please]", we should use the regular filters above
   if (
     process.env["GITHUB_PR_TRIGGER_COMMENT"] &&
-    !process.env["GITHUB_PR_TRIGGER_COMMENT"].match(/^\s*(buildkite\s*)?test\s+this(\s+please)?/i)
+    !process.env["GITHUB_PR_TRIGGER_COMMENT"].match(
+      /^\s*((@elastic(search)?machine|buildkite)\s*)?test\s+this(\s+please)?/i
+    )
   ) {
     filters = [triggerCommentCheck];
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Allow CI to be triggered by old elasticmachine-style comment (#105154)](https://github.com/elastic/elasticsearch/pull/105154)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)