### PR TITLE
[Transform] Remove duplicate checkpoint audits

### DIFF
--- a/docs/changelog/105164.yaml
+++ b/docs/changelog/105164.yaml
@@ -1,0 +1,6 @@
+pr: 105164
+summary: Remove duplicate checkpoint audits
+area: Transform
+type: bug
+issues:
+ - 105106

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
@@ -119,8 +120,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     private Map<String, Object> nextChangeCollectorBucketPosition = null;
 
     private volatile Integer initialConfiguredPageSize;
-    private volatile long logEvery = 1;
-    private volatile long logCount = 0;
+    private final AtomicInteger remainingCheckpointsToSkipAuditing = new AtomicInteger(0);
     private volatile TransformCheckpoint lastCheckpoint;
     private volatile TransformCheckpoint nextCheckpoint;
 
@@ -1155,25 +1155,31 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
     /**
      * Indicates if an audit message should be written when onFinish is called for the given checkpoint
-     * We audit the first checkpoint, and then every 10 checkpoints until completedCheckpoint == 99
-     * Then we audit every 100, until completedCheckpoint == 999
+     * We audit every checkpoint for the first 10 checkpoints until completedCheckpoint = 9.
+     * Then we audit every 10 checkpoints until completedCheckpoint == 99.
+     * Then we audit every 100, until completedCheckpoint == 999.
      *
-     * Then we always audit every 1_000 checkpoints
+     * Then we always audit every 1_000 checkpoints.
      *
      * @param completedCheckpoint The checkpoint that was just completed
      * @return {@code true} if an audit message should be written
      */
     protected boolean shouldAuditOnFinish(long completedCheckpoint) {
-        if (++logCount % logEvery != 0) {
-            return false;
-        }
-        if (completedCheckpoint == 0) {
-            return true;
-        }
-        int log10Checkpoint = (int) Math.floor(Math.log10(completedCheckpoint));
-        logEvery = log10Checkpoint >= 3 ? 1_000 : (int) Math.pow(10.0, log10Checkpoint);
-        logCount = 0;
-        return true;
+        return remainingCheckpointsToSkipAuditing.getAndUpdate(count -> {
+            if (count > 0) {
+                return count - 1;
+            }
+
+            if (completedCheckpoint >= 1000) {
+                return 999;
+            } else if (completedCheckpoint >= 100) {
+                return 99;
+            } else if (completedCheckpoint >= 10) {
+                return 9;
+            } else {
+                return 0;
+            }
+        }) == 0;
     }
 
     private RunState determineRunStateAtStart() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -68,7 +68,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.mockito.Mockito.mock;
@@ -78,7 +77,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
     public void testAuditOnFinishFrequency() {
         ClientTransformIndexer indexer = createTestIndexer();
-        List<Boolean> shouldAudit = IntStream.range(0, 100_000).boxed().map(indexer::shouldAuditOnFinish).collect(Collectors.toList());
+        List<Boolean> shouldAudit = IntStream.range(0, 100_000).boxed().map(indexer::shouldAuditOnFinish).toList();
 
         // Audit every checkpoint for the first 10
         assertTrue(shouldAudit.get(0));


### PR DESCRIPTION
Transform Checkpoints have a chance to log duplicate audits or drop iterations.  The volatile counters can be read and incremented in multiple threads, potentially storing the same value back into memory.

Replacing volatile counters with a single Atomic counter, which counts down the iterations until it reaches zero, then updates the counter to the next audited checkpoint.

Closes #105106