### PR TITLE
[8.12] Field-caps should read fields from up-to-dated shards (#105153)

### DIFF
--- a/docs/changelog/105153.yaml
+++ b/docs/changelog/105153.yaml
@@ -1,0 +1,6 @@
+pr: 105153
+summary: Field-caps should read fields from up-to-dated shards
+area: "Search"
+type: bug
+issues:
+ - 104809


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Field-caps should read fields from up-to-dated shards (#105153)