### PR TITLE
[Profiling] Always allow for CO2 and cost defaults

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
@@ -77,6 +77,8 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
         assertEquals(39, stackTrace.fileIds.size());
         assertEquals(39, stackTrace.frameIds.size());
         assertEquals(39, stackTrace.typeIds.size());
+        assertTrue(stackTrace.annualCO2Tons > 0.0d);
+        assertTrue(stackTrace.annualCostsUSD > 0.0d);
 
         assertNotNull(response.getStackFrames());
         StackFrame stackFrame = response.getStackFrames().get("fhsEKXDuxJ-jIJrZpdRuSAAAAAAAAFtj");
@@ -141,6 +143,8 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
         assertEquals(39, stackTrace.fileIds.size());
         assertEquals(39, stackTrace.frameIds.size());
         assertEquals(39, stackTrace.typeIds.size());
+        assertTrue(stackTrace.annualCO2Tons > 0.0d);
+        assertTrue(stackTrace.annualCostsUSD > 0.0d);
 
         assertNotNull(response.getStackFrames());
         StackFrame stackFrame = response.getStackFrames().get("fhsEKXDuxJ-jIJrZpdRuSAAAAAAAAFtj");


### PR DESCRIPTION
There are two possibilities to retrieve flamegraph data:

* Via the native UI
* Via the APM integration

Depending on the scenario, different request parameters are set. While we have improved the CO2 and cost calculation for the native UI, the host id, which is required for an improved CO2 and cost calculation, is not yet available for the APM integration.

So far we've not performed this calculation at all for the APM integration because there were no associated host data for stacktraces. Consequently, we've returned zero values in all cases. With this commit we associate "dummy" host data so the CO2 and cost calculation falls back to default values. Once a host id is available for that case as well, we will instead use the improved calculations.