### PR TITLE
[8.12] [DOCS][ESQL] Document locale rest parameter (#104985)

### DIFF
--- a/docs/reference/esql/esql-query-api.asciidoc
+++ b/docs/reference/esql/esql-query-api.asciidoc
@@ -61,6 +61,10 @@ precedence.
 `false`. The API only supports this parameter for CBOR, JSON, SMILE, and YAML
 responses. See <<esql-rest-columnar>>.
 
+`locale`::
+(Optional, string) Returns results (especially dates) formatted per the conventions of the locale.
+For syntax, refer to <<esql-locale-param>>.
+
 `params`::
 (Optional, array) Values for parameters in the `query`. For syntax, refer to
 <<esql-rest-params>>.

--- a/docs/reference/esql/esql-rest.asciidoc
+++ b/docs/reference/esql/esql-rest.asciidoc
@@ -205,6 +205,33 @@ Which returns:
 ----
 
 [discrete]
+[[esql-locale-param]]
+==== Returning localized results
+
+Use the `locale` parameter in the request body to return results (especially dates) formatted per the conventions of the locale.
+If `locale` is not specified, defaults to `en-US` (English).
+Refer to https://www.oracle.com/java/technologies/javase/jdk17-suported-locales.html[JDK Supported Locales].
+
+Syntax: the `locale` parameter accepts language tags in the (case-insensitive) format `xy` and `xy-XY`.
+
+For example, to return a month name in French:
+
+[source,console]
+----
+POST /_query
+{
+  "locale": "fr-FR",
+  "query": """
+          ROW birth_date_string = "2023-01-15T00:00:00.000Z" 
+          | EVAL birth_date = date_parse(birth_date_string)
+          | EVAL month_of_birth = DATE_FORMAT("MMMM",birth_date)
+          | LIMIT 5
+   """
+}
+----
+// TEST[setup:library]
+
+[discrete]
 [[esql-rest-params]]
 ==== Passing parameters to a query
 


### PR DESCRIPTION
Backports the following commits to 8.12:
 - [DOCS][ESQL] Document locale rest parameter (#104985)