### PR TITLE
[Connector API] Support filtering connectors by service type and a query

### DIFF
--- a/docs/changelog/105178.yaml
+++ b/docs/changelog/105178.yaml
@@ -1,0 +1,5 @@
+pr: 105178
+summary: "[Connector API] Support filtering connectors by service type and a query"
+area: Application
+type: enhancement
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
@@ -30,15 +30,23 @@
       "size": {
         "type": "int",
         "default": 100,
-        "description": "specifies a max number of results to get (default: 100)"
+        "description": "Specifies a max number of results to get (default: 100)"
       },
       "index_name": {
-        "type": "string",
-        "description": "connector index name(s) to fetch connector documents for"
+        "type": "list",
+        "description": "A comma-separated list of connector index names to fetch connector documents for"
       },
       "connector_name": {
+        "type": "list",
+        "description": "A comma-separated list of connector name(s) to fetch connector documents for"
+      },
+      "service_type": {
         "type": "string",
-        "description": "connector name(s) to fetch connector documents for"
+        "description": "Connector service type to fetch connector documents for"
+      },
+      "query": {
+        "type": "string",
+        "description": "A search string for querying connectors, filtering results by matching against connector names, descriptions, and index names"
       }
     }
   }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.list.json
@@ -38,11 +38,11 @@
       },
       "connector_name": {
         "type": "list",
-        "description": "A comma-separated list of connector name(s) to fetch connector documents for"
+        "description": "A comma-separated list of connector names to fetch connector documents for"
       },
       "service_type": {
-        "type": "string",
-        "description": "Connector service type to fetch connector documents for"
+        "type": "list",
+        "description": "A comma-separated list of connector service types to fetch connector documents for"
       },
       "query": {
         "type": "string",

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/310_connector_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/310_connector_list.yml
@@ -30,7 +30,7 @@ setup:
           name: my-connector-2
           language: en
           is_native: true
-          service_type: super-connector
+          service_type: extra-connector
 
 ---
 "List Connectors":
@@ -161,6 +161,53 @@ setup:
   - match: { count: 1 }
   - match: { results.0.index_name: "search-2-test" }
   - match: { results.0.name: "my-connector-2" }
+
+
+---
+"List Connector - filter by service type":
+  - do:
+      connector.list:
+        service_type: super-connector
+
+  - match: { count: 2 }
+  - match: { results.0.id: "connector-a" }
+  - match: { results.1.id: "connector-c" }
+
+  - do:
+      connector.list:
+        service_type: extra-connector
+
+  - match: { count: 1 }
+  - match: { results.0.id: "connector-b" }
+
+---
+"List Connector - filter by search query":
+  - do:
+      connector.list:
+        query: my-connector-1
+
+  - match: { count: 1 }
+  - match: { results.0.id: "connector-a" }
+
+  - do:
+      connector.list:
+        query: my-connector
+
+  - match: { count: 3 }
+
+
+  - do:
+      connector.list:
+        query: search-3-test
+
+  - match: { count: 1 }
+
+  - do:
+      connector.list:
+        query: search-
+
+  - match: { count: 3 }
+
 
 
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/310_connector_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/310_connector_list.yml
@@ -181,6 +181,14 @@ setup:
   - match: { results.0.id: "connector-b" }
 
 ---
+"List Connector - filter by multiple service types":
+  - do:
+      connector.list:
+        service_type: super-connector,extra-connector
+
+  - match: { count: 3 }
+
+---
 "List Connector - filter by search query":
   - do:
       connector.list:

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.IdsQueryBuilder;
@@ -32,6 +33,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
+import org.elasticsearch.index.query.WildcardQueryBuilder;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
@@ -278,25 +280,29 @@ public class ConnectorIndexService {
     }
 
     /**
-     * List the {@link Connector} in ascending order of their index names.
+     * Lists {@link Connector}s in ascending order of index names, filtered by specified criteria.
      *
-     * @param from From index to start the search from.
-     * @param size The maximum number of {@link Connector}s to return.
-     * @param indexNames A list of index names to filter the connectors.
-     * @param connectorNames A list of connector names to further filter the search results.
-     * @param listener The action listener to invoke on response/failure.
+     * @param from Starting index for the search.
+     * @param size Maximum number of {@link Connector}s to retrieve.
+     * @param indexNames Filter connectors by these index names, if provided.
+     * @param connectorNames Further filter connectors by these names, if provided.
+     * @param serviceType Filter connectors by service type, if provided.
+     * @param searchQuery Apply a wildcard search on index name, connector name, and description, if provided.
+     * @param listener Invoked with search results or upon failure.
      */
     public void listConnectors(
         int from,
         int size,
         List<String> indexNames,
         List<String> connectorNames,
+        String serviceType,
+        String searchQuery,
         ActionListener<ConnectorIndexService.ConnectorResult> listener
     ) {
         try {
             final SearchSourceBuilder source = new SearchSourceBuilder().from(from)
                 .size(size)
-                .query(buildListQuery(indexNames, connectorNames))
+                .query(buildListQuery(indexNames, connectorNames, serviceType, searchQuery))
                 .fetchSource(true)
                 .sort(Connector.INDEX_NAME_FIELD.getPreferredName(), SortOrder.ASC);
             final SearchRequest req = new SearchRequest(CONNECTOR_INDEX_NAME).source(source);
@@ -325,18 +331,21 @@ public class ConnectorIndexService {
     }
 
     /**
-     * Constructs a query for filtering instances of {@link Connector} based on index and/or connector names.
-     * Returns a {@link MatchAllQueryBuilder} if both parameters are empty or null,
-     * otherwise constructs a boolean query to filter by the provided lists.
+     * Builds a query to filter {@link Connector} instances by index names, connector names, service type, and/or search query.
+     * Returns a {@link MatchAllQueryBuilder} if no filters are applied, otherwise constructs a boolean query with the specified filters.
      *
-     * @param indexNames List of index names to filter by, or null/empty for no index name filtering.
-     * @param connectorNames List of connector names to filter by, or null/empty for no name filtering.
-     * @return A {@link QueryBuilder} tailored to the specified filters.
+     * @param indexNames List of index names for filtering, or null/empty to skip.
+     * @param connectorNames List of connector names for filtering, or null/empty to skip.
+     * @param serviceType Service type for filtering, or null/empty to skip.
+     * @param searchQuery Search query for wildcard filtering on index name, connector name, and description, or null/empty to skip.
+     * @return A {@link QueryBuilder} customized based on provided filters.
      */
-    private QueryBuilder buildListQuery(List<String> indexNames, List<String> connectorNames) {
+    private QueryBuilder buildListQuery(List<String> indexNames, List<String> connectorNames, String serviceType, String searchQuery) {
         boolean filterByIndexNames = indexNames != null && indexNames.isEmpty() == false;
         boolean filterByConnectorNames = indexNames != null && connectorNames.isEmpty() == false;
-        boolean usesFilter = filterByIndexNames || filterByConnectorNames;
+        boolean filterByServiceType = Strings.isNullOrEmpty(serviceType) == false;
+        boolean filterBySearchQuery = Strings.isNullOrEmpty(searchQuery) == false;
+        boolean usesFilter = filterByIndexNames || filterByConnectorNames || filterByServiceType || filterBySearchQuery;
 
         BoolQueryBuilder boolFilterQueryBuilder = new BoolQueryBuilder();
 
@@ -346,6 +355,20 @@ public class ConnectorIndexService {
             }
             if (filterByConnectorNames) {
                 boolFilterQueryBuilder.must().add(new TermsQueryBuilder(Connector.NAME_FIELD.getPreferredName(), connectorNames));
+            }
+            if (filterByServiceType) {
+                boolFilterQueryBuilder.must().add(new TermQueryBuilder(Connector.SERVICE_TYPE_FIELD.getPreferredName(), serviceType));
+            }
+            if (filterBySearchQuery) {
+                String wildcardQueryValue = '*' + searchQuery + '*';
+                boolFilterQueryBuilder.must()
+                    .add(
+                        new BoolQueryBuilder().should(
+                            new WildcardQueryBuilder(Connector.INDEX_NAME_FIELD.getPreferredName(), wildcardQueryValue)
+                        )
+                            .should(new WildcardQueryBuilder(Connector.NAME_FIELD.getPreferredName(), wildcardQueryValue))
+                            .should(new WildcardQueryBuilder(Connector.DESCRIPTION_FIELD.getPreferredName(), wildcardQueryValue))
+                    );
             }
         }
         return usesFilter ? boolFilterQueryBuilder : new MatchAllQueryBuilder();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/ListConnectorAction.java
@@ -45,7 +45,7 @@ public class ListConnectorAction {
         private final PageParams pageParams;
         private final List<String> indexNames;
         private final List<String> connectorNames;
-        private final String connectorServiceType;
+        private final List<String> connectorServiceTypes;
         private final String connectorSearchQuery;
 
         private static final ParseField PAGE_PARAMS_FIELD = new ParseField("pageParams");
@@ -58,7 +58,7 @@ public class ListConnectorAction {
             this.pageParams = new PageParams(in);
             this.indexNames = in.readOptionalStringCollectionAsList();
             this.connectorNames = in.readOptionalStringCollectionAsList();
-            this.connectorServiceType = in.readOptionalString();
+            this.connectorServiceTypes = in.readOptionalStringCollectionAsList();
             this.connectorSearchQuery = in.readOptionalString();
         }
 
@@ -66,13 +66,13 @@ public class ListConnectorAction {
             PageParams pageParams,
             List<String> indexNames,
             List<String> connectorNames,
-            String serviceType,
+            List<String> serviceTypes,
             String connectorSearchQuery
         ) {
             this.pageParams = pageParams;
             this.indexNames = indexNames;
             this.connectorNames = connectorNames;
-            this.connectorServiceType = serviceType;
+            this.connectorServiceTypes = serviceTypes;
             this.connectorSearchQuery = connectorSearchQuery;
         }
 
@@ -88,8 +88,8 @@ public class ListConnectorAction {
             return connectorNames;
         }
 
-        public String getConnectorServiceType() {
-            return connectorServiceType;
+        public List<String> getConnectorServiceTypes() {
+            return connectorServiceTypes;
         }
 
         public String getConnectorSearchQuery() {
@@ -119,7 +119,7 @@ public class ListConnectorAction {
             pageParams.writeTo(out);
             out.writeOptionalStringCollection(indexNames);
             out.writeOptionalStringCollection(connectorNames);
-            out.writeOptionalString(connectorServiceType);
+            out.writeOptionalStringCollection(connectorServiceTypes);
             out.writeOptionalString(connectorSearchQuery);
         }
 
@@ -131,26 +131,32 @@ public class ListConnectorAction {
             return Objects.equals(pageParams, request.pageParams)
                 && Objects.equals(indexNames, request.indexNames)
                 && Objects.equals(connectorNames, request.connectorNames)
-                && Objects.equals(connectorServiceType, request.connectorServiceType)
+                && Objects.equals(connectorServiceTypes, request.connectorServiceTypes)
                 && Objects.equals(connectorSearchQuery, request.connectorSearchQuery);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(pageParams, indexNames, connectorNames, connectorServiceType, connectorSearchQuery);
+            return Objects.hash(pageParams, indexNames, connectorNames, connectorServiceTypes, connectorSearchQuery);
         }
 
         @SuppressWarnings("unchecked")
         private static final ConstructingObjectParser<ListConnectorAction.Request, String> PARSER = new ConstructingObjectParser<>(
             "list_connector_request",
-            p -> new ListConnectorAction.Request((PageParams) p[0], (List<String>) p[1], (List<String>) p[2], (String) p[3], (String) p[4])
+            p -> new ListConnectorAction.Request(
+                (PageParams) p[0],
+                (List<String>) p[1],
+                (List<String>) p[2],
+                (List<String>) p[3],
+                (String) p[4]
+            )
         );
 
         static {
             PARSER.declareObject(constructorArg(), (p, c) -> PageParams.fromXContent(p), PAGE_PARAMS_FIELD);
             PARSER.declareStringArray(optionalConstructorArg(), INDEX_NAMES_FIELD);
             PARSER.declareStringArray(optionalConstructorArg(), NAMES_FIELD);
-            PARSER.declareString(optionalConstructorArg(), Connector.SERVICE_TYPE_FIELD);
+            PARSER.declareStringArray(optionalConstructorArg(), Connector.SERVICE_TYPE_FIELD);
             PARSER.declareString(optionalConstructorArg(), SEARCH_QUERY_FIELD);
         }
 
@@ -165,7 +171,7 @@ public class ListConnectorAction {
                 builder.field(PAGE_PARAMS_FIELD.getPreferredName(), pageParams);
                 builder.field(INDEX_NAMES_FIELD.getPreferredName(), indexNames);
                 builder.field(NAMES_FIELD.getPreferredName(), connectorNames);
-                builder.field(Connector.SERVICE_TYPE_FIELD.getPreferredName(), connectorServiceType);
+                builder.field(Connector.SERVICE_TYPE_FIELD.getPreferredName(), connectorServiceTypes);
                 builder.field(SEARCH_QUERY_FIELD.getPreferredName(), connectorSearchQuery);
             }
             builder.endObject();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestListConnectorAction.java
@@ -41,8 +41,16 @@ public class RestListConnectorAction extends BaseRestHandler {
         int size = restRequest.paramAsInt("size", PageParams.DEFAULT_SIZE);
         List<String> indexNames = List.of(restRequest.paramAsStringArray(Connector.INDEX_NAME_FIELD.getPreferredName(), new String[0]));
         List<String> connectorNames = List.of(restRequest.paramAsStringArray("connector_name", new String[0]));
+        String serviceType = restRequest.param("service_type");
+        String searchQuery = restRequest.param("query");
 
-        ListConnectorAction.Request request = new ListConnectorAction.Request(new PageParams(from, size), indexNames, connectorNames);
+        ListConnectorAction.Request request = new ListConnectorAction.Request(
+            new PageParams(from, size),
+            indexNames,
+            connectorNames,
+            serviceType,
+            searchQuery
+        );
 
         return channel -> client.execute(ListConnectorAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/RestListConnectorAction.java
@@ -41,14 +41,14 @@ public class RestListConnectorAction extends BaseRestHandler {
         int size = restRequest.paramAsInt("size", PageParams.DEFAULT_SIZE);
         List<String> indexNames = List.of(restRequest.paramAsStringArray(Connector.INDEX_NAME_FIELD.getPreferredName(), new String[0]));
         List<String> connectorNames = List.of(restRequest.paramAsStringArray("connector_name", new String[0]));
-        String serviceType = restRequest.param("service_type");
+        List<String> serviceTypes = List.of(restRequest.paramAsStringArray("service_type", new String[0]));
         String searchQuery = restRequest.param("query");
 
         ListConnectorAction.Request request = new ListConnectorAction.Request(
             new PageParams(from, size),
             indexNames,
             connectorNames,
-            serviceType,
+            serviceTypes,
             searchQuery
         );
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportListConnectorAction.java
@@ -48,6 +48,8 @@ public class TransportListConnectorAction extends HandledTransportAction<ListCon
             pageParams.getSize(),
             request.getIndexNames(),
             request.getConnectorNames(),
+            request.getConnectorServiceType(),
+            request.getConnectorSearchQuery(),
             listener.map(r -> new ListConnectorAction.Response(r.connectors(), r.totalResults()))
         );
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportListConnectorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportListConnectorAction.java
@@ -48,7 +48,7 @@ public class TransportListConnectorAction extends HandledTransportAction<ListCon
             pageParams.getSize(),
             request.getIndexNames(),
             request.getConnectorNames(),
-            request.getConnectorServiceType(),
+            request.getConnectorServiceTypes(),
             request.getConnectorSearchQuery(),
             listener.map(r -> new ListConnectorAction.Response(r.connectors(), r.totalResults()))
         );

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -539,13 +539,13 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         int size,
         List<String> indexNames,
         List<String> names,
-        String serviceType,
+        List<String> serviceTypes,
         String searchQuery
     ) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<ConnectorIndexService.ConnectorResult> resp = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
-        connectorIndexService.listConnectors(from, size, indexNames, names, serviceType, searchQuery, new ActionListener<>() {
+        connectorIndexService.listConnectors(from, size, indexNames, names, serviceTypes, searchQuery, new ActionListener<>() {
             @Override
             public void onResponse(ConnectorIndexService.ConnectorResult result) {
                 resp.set(result);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -534,12 +534,18 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         return resp.get();
     }
 
-    private ConnectorIndexService.ConnectorResult awaitListConnector(int from, int size, List<String> indexNames, List<String> names)
-        throws Exception {
+    private ConnectorIndexService.ConnectorResult awaitListConnector(
+        int from,
+        int size,
+        List<String> indexNames,
+        List<String> names,
+        String serviceType,
+        String searchQuery
+    ) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<ConnectorIndexService.ConnectorResult> resp = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
-        connectorIndexService.listConnectors(from, size, indexNames, names, new ActionListener<>() {
+        connectorIndexService.listConnectors(from, size, indexNames, names, serviceType, searchQuery, new ActionListener<>() {
             @Override
             public void onResponse(ConnectorIndexService.ConnectorResult result) {
                 resp.set(result);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionRequestBWCSerializingTests.java
@@ -30,7 +30,7 @@ public class ListConnectorActionRequestBWCSerializingTests extends AbstractBWCSe
             pageParams,
             List.of(generateRandomStringArray(10, 10, false)),
             List.of(generateRandomStringArray(10, 10, false)),
-            randomAlphaOfLengthBetween(3, 10),
+            List.of(generateRandomStringArray(10, 10, false)),
             randomAlphaOfLengthBetween(3, 10)
         );
     }
@@ -51,7 +51,7 @@ public class ListConnectorActionRequestBWCSerializingTests extends AbstractBWCSe
             instance.getPageParams(),
             instance.getIndexNames(),
             instance.getConnectorNames(),
-            instance.getConnectorServiceType(),
+            instance.getConnectorServiceTypes(),
             instance.getConnectorSearchQuery()
         );
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/ListConnectorActionRequestBWCSerializingTests.java
@@ -29,7 +29,9 @@ public class ListConnectorActionRequestBWCSerializingTests extends AbstractBWCSe
         return new ListConnectorAction.Request(
             pageParams,
             List.of(generateRandomStringArray(10, 10, false)),
-            List.of(generateRandomStringArray(10, 10, false))
+            List.of(generateRandomStringArray(10, 10, false)),
+            randomAlphaOfLengthBetween(3, 10),
+            randomAlphaOfLengthBetween(3, 10)
         );
     }
 
@@ -45,6 +47,12 @@ public class ListConnectorActionRequestBWCSerializingTests extends AbstractBWCSe
 
     @Override
     protected ListConnectorAction.Request mutateInstanceForVersion(ListConnectorAction.Request instance, TransportVersion version) {
-        return new ListConnectorAction.Request(instance.getPageParams(), instance.getIndexNames(), instance.getConnectorNames());
+        return new ListConnectorAction.Request(
+            instance.getPageParams(),
+            instance.getIndexNames(),
+            instance.getConnectorNames(),
+            instance.getConnectorServiceType(),
+            instance.getConnectorSearchQuery()
+        );
     }
 }


### PR DESCRIPTION
### Changes

- Support filtering connectors by `service_type` in list endpoint
- Support filtering connectors by a wildcard query across `name`, `index_name` and `description` field