### PR TITLE
Rename QueryPhaseTimeoutException to SearchTimeoutException

### DIFF
--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -37,7 +37,7 @@ import org.elasticsearch.search.TooManyScrollContextsException;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.UnsupportedAggregationOnDownsampledIndex;
-import org.elasticsearch.search.query.QueryPhaseTimeoutException;
+import org.elasticsearch.search.query.SearchTimeoutException;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
@@ -1899,10 +1899,10 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             TransportVersions.MISSED_INDICES_UPDATE_EXCEPTION_ADDED
         ),
         QUERY_PHASE_TIMEOUT_EXCEPTION(
-            QueryPhaseTimeoutException.class,
-            QueryPhaseTimeoutException::new,
+            SearchTimeoutException.class,
+            SearchTimeoutException::new,
             176,
-            TransportVersions.QUERY_PHASE_TIMEOUT_EXCEPTION_ADDED
+            TransportVersions.SEARCH_TIMEOUT_EXCEPTION_ADDED
         );
 
         final Class<? extends ElasticsearchException> exceptionClass;

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -1898,7 +1898,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             175,
             TransportVersions.MISSED_INDICES_UPDATE_EXCEPTION_ADDED
         ),
-        QUERY_PHASE_TIMEOUT_EXCEPTION(
+        SEARCH_TIMEOUT_EXCEPTION(
             SearchTimeoutException.class,
             SearchTimeoutException::new,
             176,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -170,7 +170,7 @@ public class TransportVersions {
     public static final TransportVersion KNN_QUERY_NUMCANDS_AS_OPTIONAL_PARAM = def(8_583_00_0);
     public static final TransportVersion TRANSFORM_GET_BASIC_STATS = def(8_584_00_0);
     public static final TransportVersion NLP_DOCUMENT_CHUNKING_ADDED = def(8_585_00_0);
-    public static final TransportVersion QUERY_PHASE_TIMEOUT_EXCEPTION_ADDED = def(8_586_00_0);
+    public static final TransportVersion SEARCH_TIMEOUT_EXCEPTION_ADDED = def(8_586_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -210,7 +210,7 @@ public class QueryPhase {
             if (searcher.timeExceeded()) {
                 assert timeoutRunnable != null : "TimeExceededException thrown even though timeout wasn't set";
                 if (searchContext.request().allowPartialSearchResults() == false) {
-                    throw new QueryPhaseTimeoutException(searchContext.shardTarget(), "Time exceeded");
+                    throw new SearchTimeoutException(searchContext.shardTarget(), "Time exceeded");
                 }
                 queryResult.searchTimedOut(true);
             }

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhaseExecutionException.java
@@ -13,11 +13,12 @@ import org.elasticsearch.search.SearchException;
 import org.elasticsearch.search.SearchShardTarget;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public final class QueryPhaseExecutionException extends SearchException {
 
     public QueryPhaseExecutionException(SearchShardTarget shardTarget, String msg, Throwable cause) {
-        super(shardTarget, "Query Failed [" + msg + "]", cause);
+        super(shardTarget, "Query Failed [" + msg + "]", Objects.requireNonNull(cause, "cause cannot be null"));
     }
 
     public QueryPhaseExecutionException(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhaseExecutionException.java
@@ -14,7 +14,7 @@ import org.elasticsearch.search.SearchShardTarget;
 
 import java.io.IOException;
 
-public class QueryPhaseExecutionException extends SearchException {
+public final class QueryPhaseExecutionException extends SearchException {
 
     public QueryPhaseExecutionException(SearchShardTarget shardTarget, String msg, Throwable cause) {
         super(shardTarget, "Query Failed [" + msg + "]", cause);
@@ -22,9 +22,5 @@ public class QueryPhaseExecutionException extends SearchException {
 
     public QueryPhaseExecutionException(StreamInput in) throws IOException {
         super(in);
-    }
-
-    public QueryPhaseExecutionException(SearchShardTarget shardTarget, String msg) {
-        super(shardTarget, msg);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/query/SearchTimeoutException.java
+++ b/server/src/main/java/org/elasticsearch/search/query/SearchTimeoutException.java
@@ -10,20 +10,21 @@ package org.elasticsearch.search.query;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.SearchException;
 import org.elasticsearch.search.SearchShardTarget;
 
 import java.io.IOException;
 
 /**
- * Specific instance of QueryPhaseExecutionException that indicates that a search timeout occurred.
+ * Specific instance of {@link SearchException} that indicates that a search timeout occurred.
  * Always returns http status 504 (Gateway Timeout)
  */
-public class QueryPhaseTimeoutException extends QueryPhaseExecutionException {
-    public QueryPhaseTimeoutException(SearchShardTarget shardTarget, String msg) {
+public class SearchTimeoutException extends SearchException {
+    public SearchTimeoutException(SearchShardTarget shardTarget, String msg) {
         super(shardTarget, msg);
     }
 
-    public QueryPhaseTimeoutException(StreamInput in) throws IOException {
+    public SearchTimeoutException(StreamInput in) throws IOException {
         super(in);
     }
 

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -80,7 +80,7 @@ import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.UnsupportedAggregationOnDownsampledIndex;
 import org.elasticsearch.search.internal.ShardSearchContextId;
-import org.elasticsearch.search.query.QueryPhaseTimeoutException;
+import org.elasticsearch.search.query.SearchTimeoutException;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotException;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -828,7 +828,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         ids.put(173, TooManyScrollContextsException.class);
         ids.put(174, AggregationExecutionException.InvalidPath.class);
         ids.put(175, AutoscalingMissedIndicesUpdateException.class);
-        ids.put(176, QueryPhaseTimeoutException.class);
+        ids.put(176, SearchTimeoutException.class);
 
         Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
         for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {


### PR DESCRIPTION
The newly introduced `QueryPhaseTimeoutException` (added in ##10468) extends from `QueryPhaseExecutionException`. It can instead subclass directly `SearchException`. That allows us to enforce that `QueryPhaseExecutionException` always has a root cause provided, which in turn helps us enforce that its status code never defaults to 500.

These are no serialization changes involved in this change, as `QueryPhaseExecutionException` exposes the exact same instance members as `SearchException`.

This change does rename the transport version constant introduced in #10468, but that should be safe as the version id is left untouched. It is a cosmetic change to ensure consistency between the constant name and the now renamed exception.