### PR TITLE
[ML] Fix handling surrogate pairs in the XLM Roberta tokenizer

### DIFF
--- a/docs/changelog/105183.yaml
+++ b/docs/changelog/105183.yaml
@@ -1,0 +1,5 @@
+pr: 105183
+summary: Fix handling surrogate pairs in the XLM Roberta tokenizer
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/105183.yaml
+++ b/docs/changelog/105183.yaml
@@ -3,4 +3,5 @@ summary: Fix handling surrogate pairs in the XLM Roberta tokenizer
 area: Machine Learning
 type: bug
 issues:
+ - 104626
  - 104981

--- a/docs/changelog/105183.yaml
+++ b/docs/changelog/105183.yaml
@@ -2,4 +2,5 @@ pr: 105183
 summary: Fix handling surrogate pairs in the XLM Roberta tokenizer
 area: Machine Learning
 type: bug
-issues: []
+issues:
+ - 104981

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/TokenizerUtils.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/TokenizerUtils.java
@@ -64,19 +64,6 @@ final class TokenizerUtils {
         return bigTokens;
     }
 
-    static int numUtf8Bytes(int c) {
-        if (c < 128) {
-            return 1;
-        }
-        if (c < 2048) {
-            return 2;
-        }
-        if (c < 65536) {
-            return 3;
-        }
-        return 4;
-    }
-
     public record CharSequenceRef(CharSequence wrapped, int offset, int len) implements CharSequence {
 
         public int getOffset() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/PrecompiledCharMapNormalizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/PrecompiledCharMapNormalizerTests.java
@@ -46,6 +46,17 @@ public class PrecompiledCharMapNormalizerTests extends ESTestCase {
         assertNormalization("​​από", parsed, "  από");
     }
 
+    public void testSurrogatePairScenario() throws IOException {
+        PrecompiledCharMapNormalizer.Config parsed = loadTestCharMap();
+        assertNormalization("🇸🇴", parsed, "🇸🇴");
+        assertNormalization("🇸🇴", parsed, "\uD83C\uDDF8\uD83C\uDDF4");
+    }
+
+    public void testEmoji() throws IOException {
+        PrecompiledCharMapNormalizer.Config parsed = loadTestCharMap();
+        assertNormalization("😀", parsed, "😀");
+    }
+
     private void assertNormalization(String input, PrecompiledCharMapNormalizer.Config config, String expected) throws IOException {
         PrecompiledCharMapNormalizer normalizer = new PrecompiledCharMapNormalizer(
             config.offsets(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/XLMRobertaTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/XLMRobertaTokenizerTests.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 public class XLMRobertaTokenizerTests extends ESTestCase {
 
@@ -37,6 +39,8 @@ public class XLMRobertaTokenizerTests extends ESTestCase {
         "▁little",
         "▁red",
         "▁car",
+        "▁😀",
+        "▁🇸🇴",
         "<mask>",
         "."
     );
@@ -57,6 +61,8 @@ public class XLMRobertaTokenizerTests extends ESTestCase {
         -11.451579093933105,
         -10.858806610107422,
         -10.214239120483398,
+        -10.230172157287598,
+        -9.451579093933105,
         0.0,
         -3.0
     );
@@ -77,6 +83,43 @@ public class XLMRobertaTokenizerTests extends ESTestCase {
             assertThat(tokenStrings(tokenization.tokens().get(0)), contains("▁Ela", "stic", "search", "▁fun"));
             assertArrayEquals(new int[] { 4, 5, 6, 8 }, tokenization.tokenIds());
             assertArrayEquals(new int[] { 0, 1, 2, 3 }, tokenization.tokenMap());
+        }
+    }
+
+    public void testSurrogatePair() throws IOException {
+        try (
+            XLMRobertaTokenizer tokenizer = XLMRobertaTokenizer.builder(
+                TEST_CASE_VOCAB,
+                TEST_CASE_SCORES,
+                new XLMRobertaTokenization(false, null, Tokenization.Truncate.NONE, -1)
+            ).build()
+        ) {
+            TokenizationResult.Tokens tokenization = tokenizer.tokenize("😀", Tokenization.Truncate.NONE, -1, 0).get(0);
+            assertThat(tokenStrings(tokenization.tokens().get(0)), contains("▁\uD83D\uDE00"));
+
+            tokenization = tokenizer.tokenize("Elasticsearch 😀", Tokenization.Truncate.NONE, -1, 0).get(0);
+            assertThat(tokenStrings(tokenization.tokens().get(0)), contains("▁Ela", "stic", "search", "▁\uD83D\uDE00"));
+
+            tokenization = tokenizer.tokenize("Elasticsearch 😀 fun", Tokenization.Truncate.NONE, -1, 0).get(0);
+            assertThat(tokenStrings(tokenization.tokens().get(0)), contains("▁Ela", "stic", "search", "▁\uD83D\uDE00", "▁fun"));
+        }
+    }
+
+    public void testMultiByteEmoji() throws IOException {
+        try (
+            XLMRobertaTokenizer tokenizer = XLMRobertaTokenizer.builder(
+                TEST_CASE_VOCAB,
+                TEST_CASE_SCORES,
+                new XLMRobertaTokenization(false, null, Tokenization.Truncate.NONE, -1)
+            ).build()
+        ) {
+            TokenizationResult.Tokens tokenization = tokenizer.tokenize("🇸🇴", Tokenization.Truncate.NONE, -1, 0).get(0);
+            assertThat(tokenStrings(tokenization.tokens().get(0)), contains("▁🇸🇴"));
+            assertThat(tokenization.tokenIds()[0], not(equalTo(3))); // not the unknown token
+
+            tokenization = tokenizer.tokenize("🏁", Tokenization.Truncate.NONE, -1, 0).get(0);
+            assertThat(tokenStrings(tokenization.tokens().get(0)), contains("▁🏁"));
+            assertThat(tokenization.tokenIds()[0], equalTo(3)); // the unknown token (not in the vocabulary)
         }
     }
 


### PR DESCRIPTION
UTF16 represents some characters (greater than 2^16) as surrogate pairs where the first character is the high surrogate and is followed by a low surrogate. The pair of UTF16 chars represent a single character, often emojis are encoded as surrogate pairs and that is the cause of #104981.

The error in #104981 is due to a miscalculation in the number of bytes required to convert a UTF16 string to UTF8 when the string contains surrogates. The fix here is to treat the pair as a single character. #104626 is the same problem in  `PrecompiledCharMapNormalizer`. 

Closes #104981
Closes #104626
