### PR TITLE
[Transform] Allow transforms to use PIT with remote clusters again

### DIFF
--- a/docs/changelog/105192.yaml
+++ b/docs/changelog/105192.yaml
@@ -1,0 +1,6 @@
+pr: 105192
+summary: Allow transforms to use PIT with remote clusters again
+area: Transform
+type: bug
+issues:
+ - 104518

--- a/docs/changelog/105192.yaml
+++ b/docs/changelog/105192.yaml
@@ -1,6 +1,6 @@
 pr: 105192
 summary: Allow transforms to use PIT with remote clusters again
 area: Transform
-type: bug
+type: enhancement
 issues:
  - 104518

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -449,8 +449,7 @@ class ClientTransformIndexer extends TransformIndexer {
         ActionListener<Tuple<String, SearchRequest>> listener
     ) {
         SearchRequest searchRequest = namedSearchRequest.v2();
-        // We explicitly disable PIT in the presence of remote clusters in the source due to huge PIT handles causing performance problems.
-        if (disablePit || searchRequest.indices().length == 0 || transformConfig.getSource().requiresRemoteCluster()) {
+        if (disablePit || searchRequest.indices().length == 0) {
             listener.onResponse(namedSearchRequest);
             return;
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -293,72 +293,14 @@ public class ClientTransformIndexerTests extends ESTestCase {
     }
 
     public void testDisablePit() throws InterruptedException {
-        // TransformConfigTests.randomTransformConfig never produces remote indices in the source, hence we are safe here. */
-        TransformConfig config = TransformConfigTests.randomTransformConfig();
-        boolean pitEnabled = config.getSettings().getUsePit() == null || config.getSettings().getUsePit();
-
-        try (var threadPool = createThreadPool()) {
-            final var client = new PitMockClient(threadPool, true);
-            MockClientTransformIndexer indexer = new MockClientTransformIndexer(
-                mock(ThreadPool.class),
-                new TransformServices(
-                    mock(IndexBasedTransformConfigManager.class),
-                    mock(TransformCheckpointService.class),
-                    mock(TransformAuditor.class),
-                    new TransformScheduler(Clock.systemUTC(), mock(ThreadPool.class), Settings.EMPTY, TimeValue.ZERO)
-                ),
-                mock(CheckpointProvider.class),
-                new AtomicReference<>(IndexerState.STOPPED),
-                null,
-                new ParentTaskAssigningClient(client, new TaskId("dummy-node:123456")),
-                mock(TransformIndexerStats.class),
-                config,
-                null,
-                new TransformCheckpoint(
-                    "transform",
-                    Instant.now().toEpochMilli(),
-                    0L,
-                    Collections.emptyMap(),
-                    Instant.now().toEpochMilli()
-                ),
-                new TransformCheckpoint(
-                    "transform",
-                    Instant.now().toEpochMilli(),
-                    2L,
-                    Collections.emptyMap(),
-                    Instant.now().toEpochMilli()
-                ),
-                new SeqNoPrimaryTermAndIndex(1, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME),
-                mock(TransformContext.class),
-                false
-            );
-
-            this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                if (pitEnabled) {
-                    assertEquals("the_pit_id+", response.pointInTimeId());
-                } else {
-                    assertNull(response.pointInTimeId());
-                }
-            });
-
-            // reverse the setting
-            indexer.applyNewSettings(new SettingsConfig.Builder().setUsePit(pitEnabled == false).build());
-
-            this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                if (pitEnabled) {
-                    assertNull(response.pointInTimeId());
-                } else {
-                    assertEquals("the_pit_id+", response.pointInTimeId());
-                }
-            });
+        TransformConfig.Builder configBuilder = new TransformConfig.Builder(TransformConfigTests.randomTransformConfig());
+        if (randomBoolean()) {
+            // TransformConfigTests.randomTransformConfig never produces remote indices in the source.
+            // We need to explicitly set the remote index here for coverage.
+            configBuilder.setSource(new SourceConfig("remote-cluster:remote-index"));
         }
-    }
+        TransformConfig config = configBuilder.build();
 
-    public void testDisablePitWhenThereIsRemoteIndexInSource() throws InterruptedException {
-        TransformConfig config = new TransformConfig.Builder(TransformConfigTests.randomTransformConfig())
-            // Remote index is configured within source
-            .setSource(new SourceConfig("remote-cluster:remote-index"))
-            .build();
         boolean pitEnabled = config.getSettings().getUsePit() == null || config.getSettings().getUsePit();
 
         try (var threadPool = createThreadPool()) {
@@ -397,20 +339,24 @@ public class ClientTransformIndexerTests extends ESTestCase {
                 false
             );
 
-            // Because remote index is configured within source, we expect PIT *not* being used regardless the transform settings
-            this.<SearchResponse>assertAsync(
-                listener -> indexer.doNextSearch(0, listener),
-                response -> assertNull(response.pointInTimeId())
-            );
+            this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
+                if (pitEnabled) {
+                    assertEquals("the_pit_id+", response.pointInTimeId());
+                } else {
+                    assertNull(response.pointInTimeId());
+                }
+            });
 
             // reverse the setting
             indexer.applyNewSettings(new SettingsConfig.Builder().setUsePit(pitEnabled == false).build());
 
-            // Because remote index is configured within source, we expect PIT *not* being used regardless the transform settings
-            this.<SearchResponse>assertAsync(
-                listener -> indexer.doNextSearch(0, listener),
-                response -> assertNull(response.pointInTimeId())
-            );
+            this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
+                if (pitEnabled) {
+                    assertNull(response.pointInTimeId());
+                } else {
+                    assertEquals("the_pit_id+", response.pointInTimeId());
+                }
+            });
         }
     }
 


### PR DESCRIPTION
There used to be problems with transforms using PIT together with remote source indices.
The mitigation was https://github.com/elastic/elasticsearch/pull/99803.
Then the underlying issue got fixed so the mitigation can be reverted.
This PR does exactly this.

Closes https://github.com/elastic/elasticsearch/issues/104518