### PR TITLE
[PoC] Add user to logging context to be used with slowlog

### DIFF
--- a/distribution/src/config/log4j2.properties
+++ b/distribution/src/config/log4j2.properties
@@ -90,6 +90,7 @@ appender.index_search_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:f
   .cluster_name}_index_search_slowlog.json
 appender.index_search_slowlog_rolling.layout.type = ECSJsonLayout
 appender.index_search_slowlog_rolling.layout.dataset = elasticsearch.index_search_slowlog
+appender.index_search_slowlog_rolling.layout.pattern = %X{effective_user}
 
 appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs\
   .cluster_name}_index_search_slowlog-%i.json.gz

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -115,6 +115,7 @@ class Elasticsearch {
                 }
             });
             LogConfigurator.registerErrorListener();
+            LogConfigurator.registerContextDataProviders();
 
             BootstrapInfo.init();
 

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -28,6 +28,8 @@ import org.apache.logging.log4j.core.config.plugins.util.PluginManager;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfiguration;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder;
 import org.apache.logging.log4j.core.config.properties.PropertiesConfigurationFactory;
+import org.apache.logging.log4j.core.impl.ThreadContextDataInjector;
+import org.apache.logging.log4j.core.util.ContextDataProvider;
 import org.apache.logging.log4j.status.StatusConsoleListener;
 import org.apache.logging.log4j.status.StatusData;
 import org.apache.logging.log4j.status.StatusListener;
@@ -90,6 +92,15 @@ public class LogConfigurator {
     public static void registerErrorListener() {
         error.set(false);
         StatusLogger.getLogger().registerListener(ERROR_LISTENER);
+    }
+
+    /**
+     * This register any needed {@link org.apache.logging.log4j.core.util.ContextDataProvider} implementations.
+     * It must be called early during logging configuration so that the providers are picked up by the relevant
+     * {@link org.apache.logging.log4j.core.ContextDataInjector}.
+     */
+    public static void registerContextDataProviders() {
+        ThreadContextDataInjector.contextDataProviders.add(new LoggingContextProvider());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/logging/LoggingContextProvider.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LoggingContextProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.logging;
+
+import org.apache.logging.log4j.core.util.ContextDataProvider;
+import org.apache.logging.log4j.util.StringMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class LoggingContextProvider implements ContextDataProvider {
+
+    // TODO Should be thread safe for testing purposes
+    private static final List<Supplier<Map<String, String>>> loggingContextProviders = new ArrayList<>();
+
+    public static void registerLoggingContextProvider(Supplier<Map<String, String>> logginContextSupplier) {
+        loggingContextProviders.add(logginContextSupplier);
+    }
+
+    @Override
+    public Map<String, String> supplyContextData() {
+        return loggingContextProviders.stream()
+            .flatMap(supplier -> supplier.get().entrySet().stream())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public StringMap supplyStringMap() {
+        return ContextDataProvider.super.supplyStringMap();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -68,6 +68,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.HeaderWarning;
+import org.elasticsearch.common.logging.LoggingContextProvider;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -145,6 +146,7 @@ import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.HealthPlugin;
 import org.elasticsearch.plugins.InferenceRegistryPlugin;
 import org.elasticsearch.plugins.IngestPlugin;
+import org.elasticsearch.plugins.LoggingContextPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.MetadataUpgrader;
 import org.elasticsearch.plugins.NetworkPlugin;
@@ -995,6 +997,14 @@ class NodeConstruction {
             systemIndices.getExecutorSelector(),
             telemetryProvider.getTracer()
         );
+
+        final Stream<LoggingContextPlugin> loggingContextPlugins = pluginsService.filterPlugins(LoggingContextPlugin.class);
+        loggingContextPlugins.findFirst()
+            .ifPresent(
+                loggingContextPlugin -> LoggingContextProvider.registerLoggingContextProvider(
+                    loggingContextPlugin.getLoggingContextSupplier()
+                )
+            );
 
         modules.add(
             loadPersistentTasksService(

--- a/server/src/main/java/org/elasticsearch/plugins/LoggingContextPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/LoggingContextPlugin.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public interface LoggingContextPlugin {
+    Supplier<Map<String, String>> getLoggingContextSupplier();
+}


### PR DESCRIPTION
Example of how user could be added to slowlog by adding a new logging context provider plugin. The slowlog will then look like: 
```
{"@timestamp":"2024-02-06T14:18:06.406Z", "log.level": "INFO",  "elasticsearch.slowlog.id":null,"elasticsearch.slowlog.message":"[test][0]","elasticsearch.slowlog.search_type":"QUERY_THEN_FETCH","elasticsearch.slowlog.source":"{}","elasticsearch.slowlog.stats":"[]","elasticsearch.slowlog.took":"10.4ms","elasticsearch.slowlog.took_millis":10,"elasticsearch.slowlog.total_hits":"1 hits","elasticsearch.slowlog.total_shards":1 , "ecs.version": "1.2.0","service.name":"ES_ECS","event.dataset":"elasticsearch.index_search_slowlog","process.thread.name":"elasticsearch[runTask-0][search][T#1]","log.logger":"index.search.slowlog.query","elasticsearch.cluster.uuid":"QAnjel9YSAGurKndMy71Cg","elasticsearch.node.id":"_oS2USGkS2ucV2CQqFn89g","elasticsearch.node.name":"runTask-0","elasticsearch.cluster.name":"runTask","effective_user":"elastic"}
```

Thos doesn't work as expected because it adds the effective user to all logs, not only the slow log. 