### PR TITLE
[ML] Switch OpenAI and Cohere configuration to use model_id field instead of model

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequest.java
@@ -37,7 +37,7 @@ public class CohereEmbeddingsRequest implements Request {
     private final CohereEmbeddingsTaskSettings taskSettings;
     private final String model;
     private final CohereEmbeddingType embeddingType;
-    private final String modelId;
+    private final String inferenceEntityId;
 
     public CohereEmbeddingsRequest(CohereAccount account, List<String> input, CohereEmbeddingsModel embeddingsModel) {
         Objects.requireNonNull(embeddingsModel);
@@ -48,7 +48,7 @@ public class CohereEmbeddingsRequest implements Request {
         taskSettings = embeddingsModel.getTaskSettings();
         model = embeddingsModel.getServiceSettings().getCommonSettings().getModelId();
         embeddingType = embeddingsModel.getServiceSettings().getEmbeddingType();
-        modelId = embeddingsModel.getInferenceEntityId();
+        inferenceEntityId = embeddingsModel.getInferenceEntityId();
     }
 
     @Override
@@ -69,7 +69,7 @@ public class CohereEmbeddingsRequest implements Request {
 
     @Override
     public String getInferenceEntityId() {
-        return modelId;
+        return inferenceEntityId;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequest.java
@@ -46,7 +46,7 @@ public class CohereEmbeddingsRequest implements Request {
         this.input = Objects.requireNonNull(input);
         uri = buildUri(this.account.url(), "Cohere", CohereEmbeddingsRequest::buildDefaultUri);
         taskSettings = embeddingsModel.getTaskSettings();
-        model = embeddingsModel.getServiceSettings().getCommonSettings().getModel();
+        model = embeddingsModel.getServiceSettings().getCommonSettings().getModelId();
         embeddingType = embeddingsModel.getServiceSettings().getEmbeddingType();
         modelId = embeddingsModel.getInferenceEntityId();
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequestEntity.java
@@ -47,7 +47,7 @@ public record CohereEmbeddingsRequestEntity(
         builder.startObject();
         builder.field(TEXTS_FIELD, input);
         if (model != null) {
-            builder.field(CohereServiceSettings.MODEL, model);
+            builder.field(CohereServiceSettings.OLD_MODEL_ID_FIELD, model);
         }
 
         if (taskSettings.getInputType() != null) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/openai/OpenAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/openai/OpenAiEmbeddingsRequest.java
@@ -54,7 +54,11 @@ public class OpenAiEmbeddingsRequest implements Request {
 
         ByteArrayEntity byteEntity = new ByteArrayEntity(
             Strings.toString(
-                new OpenAiEmbeddingsRequestEntity(truncationResult.input(), model.getTaskSettings().model(), model.getTaskSettings().user())
+                new OpenAiEmbeddingsRequestEntity(
+                    truncationResult.input(),
+                    model.getTaskSettings().modelId(),
+                    model.getTaskSettings().user()
+                )
             ).getBytes(StandardCharsets.UTF_8)
         );
         httpPost.setEntity(byteEntity);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
@@ -180,7 +180,7 @@ public class CohereService extends SenderService {
                 SimilarityMeasure.DOT_PRODUCT,
                 embeddingSize,
                 model.getServiceSettings().getCommonSettings().getMaxInputTokens(),
-                model.getServiceSettings().getCommonSettings().getModel()
+                model.getServiceSettings().getCommonSettings().getModelId()
             ),
             model.getServiceSettings().getEmbeddingType()
         );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
@@ -54,7 +54,7 @@ public class CohereService extends SenderService {
 
     @Override
     public CohereModel parseRequestConfig(
-        String modelId,
+        String inferenceEntityId,
         TaskType taskType,
         Map<String, Object> config,
         Set<String> platformArchitectures
@@ -63,7 +63,7 @@ public class CohereService extends SenderService {
         Map<String, Object> taskSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.TASK_SETTINGS);
 
         CohereModel model = createModel(
-            modelId,
+            inferenceEntityId,
             taskType,
             serviceSettingsMap,
             taskSettingsMap,
@@ -80,18 +80,18 @@ public class CohereService extends SenderService {
     }
 
     private static CohereModel createModelWithoutLoggingDeprecations(
-        String modelId,
+        String inferenceEntityId,
         TaskType taskType,
         Map<String, Object> serviceSettings,
         Map<String, Object> taskSettings,
         @Nullable Map<String, Object> secretSettings,
         String failureMessage
     ) {
-        return createModel(modelId, taskType, serviceSettings, taskSettings, secretSettings, failureMessage, false);
+        return createModel(inferenceEntityId, taskType, serviceSettings, taskSettings, secretSettings, failureMessage, false);
     }
 
     private static CohereModel createModel(
-        String modelId,
+        String inferenceEntityId,
         TaskType taskType,
         Map<String, Object> serviceSettings,
         Map<String, Object> taskSettings,
@@ -101,7 +101,7 @@ public class CohereService extends SenderService {
     ) {
         return switch (taskType) {
             case TEXT_EMBEDDING -> new CohereEmbeddingsModel(
-                modelId,
+                inferenceEntityId,
                 taskType,
                 NAME,
                 serviceSettings,
@@ -115,7 +115,7 @@ public class CohereService extends SenderService {
 
     @Override
     public CohereModel parsePersistedConfigWithSecrets(
-        String modelId,
+        String inferenceEntityId,
         TaskType taskType,
         Map<String, Object> config,
         Map<String, Object> secrets
@@ -125,27 +125,27 @@ public class CohereService extends SenderService {
         Map<String, Object> secretSettingsMap = removeFromMapOrThrowIfNull(secrets, ModelSecrets.SECRET_SETTINGS);
 
         return createModelWithoutLoggingDeprecations(
-            modelId,
+            inferenceEntityId,
             taskType,
             serviceSettingsMap,
             taskSettingsMap,
             secretSettingsMap,
-            parsePersistedConfigErrorMsg(modelId, NAME)
+            parsePersistedConfigErrorMsg(inferenceEntityId, NAME)
         );
     }
 
     @Override
-    public CohereModel parsePersistedConfig(String modelId, TaskType taskType, Map<String, Object> config) {
+    public CohereModel parsePersistedConfig(String inferenceEntityId, TaskType taskType, Map<String, Object> config) {
         Map<String, Object> serviceSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.SERVICE_SETTINGS);
         Map<String, Object> taskSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.TASK_SETTINGS);
 
         return createModelWithoutLoggingDeprecations(
-            modelId,
+            inferenceEntityId,
             taskType,
             serviceSettingsMap,
             taskSettingsMap,
             null,
-            parsePersistedConfigErrorMsg(modelId, NAME)
+            parsePersistedConfigErrorMsg(inferenceEntityId, NAME)
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
@@ -39,7 +39,7 @@ public class CohereServiceSettings implements ServiceSettings {
 
     private static final Logger logger = LogManager.getLogger(CohereServiceSettings.class);
     public static final String NAME = "cohere_service_settings";
-    public static final String MODEL = "model";
+    public static final String OLD_MODEL_ID_FIELD = "model";
     public static final String MODEL_ID = "model_id";
 
     public static CohereServiceSettings fromMap(Map<String, Object> map, boolean logDeprecations) {
@@ -51,11 +51,11 @@ public class CohereServiceSettings implements ServiceSettings {
         Integer dims = removeAsType(map, DIMENSIONS, Integer.class);
         Integer maxInputTokens = removeAsType(map, MAX_INPUT_TOKENS, Integer.class);
         URI uri = convertToUri(url, URL, ModelConfigurations.SERVICE_SETTINGS, validationException);
-        String model = extractOptionalString(map, MODEL, ModelConfigurations.SERVICE_SETTINGS, validationException);
+        String oldModelId = extractOptionalString(map, OLD_MODEL_ID_FIELD, ModelConfigurations.SERVICE_SETTINGS, validationException);
 
         String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
 
-        if (logDeprecations && model != null) {
+        if (logDeprecations && oldModelId != null) {
             logger.info("The cohere [service_settings.model] field is deprecated. Please use [service_settings.model_id] instead.");
         }
 
@@ -63,7 +63,7 @@ public class CohereServiceSettings implements ServiceSettings {
             throw validationException;
         }
 
-        return new CohereServiceSettings(uri, similarity, dims, maxInputTokens, getModelId(model, modelId));
+        return new CohereServiceSettings(uri, similarity, dims, maxInputTokens, getModelId(oldModelId, modelId));
     }
 
     private static String getModelId(@Nullable String model, @Nullable String modelId) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
@@ -42,7 +42,7 @@ public class CohereServiceSettings implements ServiceSettings {
     public static final String MODEL = "model";
     public static final String MODEL_ID = "model_id";
 
-    public static CohereServiceSettings fromMap(Map<String, Object> map) {
+    public static CohereServiceSettings fromMap(Map<String, Object> map, boolean logDeprecations) {
         ValidationException validationException = new ValidationException();
 
         String url = extractOptionalString(map, URL, ModelConfigurations.SERVICE_SETTINGS, validationException);
@@ -55,7 +55,7 @@ public class CohereServiceSettings implements ServiceSettings {
 
         String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
 
-        if (model != null) {
+        if (logDeprecations && model != null) {
             logger.info("The cohere service_settings.model field is deprecated. Please use model_id instead.");
         }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
@@ -56,7 +56,7 @@ public class CohereServiceSettings implements ServiceSettings {
         String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
 
         if (logDeprecations && model != null) {
-            logger.info("The cohere service_settings.model field is deprecated. Please use model_id instead.");
+            logger.info("The cohere [service_settings.model] field is deprecated. Please use [service_settings.model_id] instead.");
         }
 
         if (validationException.validationErrors().isEmpty() == false) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.inference.services.cohere;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
@@ -34,8 +36,11 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractSim
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeAsType;
 
 public class CohereServiceSettings implements ServiceSettings {
+
+    private static final Logger logger = LogManager.getLogger(CohereServiceSettings.class);
     public static final String NAME = "cohere_service_settings";
     public static final String MODEL = "model";
+    public static final String MODEL_ID = "model_id";
 
     public static CohereServiceSettings fromMap(Map<String, Object> map) {
         ValidationException validationException = new ValidationException();
@@ -48,31 +53,41 @@ public class CohereServiceSettings implements ServiceSettings {
         URI uri = convertToUri(url, URL, ModelConfigurations.SERVICE_SETTINGS, validationException);
         String model = extractOptionalString(map, MODEL, ModelConfigurations.SERVICE_SETTINGS, validationException);
 
+        String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
+
+        if (model != null) {
+            logger.info("The cohere service_settings.model field is deprecated. Please use model_id instead.");
+        }
+
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
 
-        return new CohereServiceSettings(uri, similarity, dims, maxInputTokens, model);
+        return new CohereServiceSettings(uri, similarity, dims, maxInputTokens, getModelId(model, modelId));
+    }
+
+    private static String getModelId(@Nullable String model, @Nullable String modelId) {
+        return modelId != null ? modelId : model;
     }
 
     private final URI uri;
     private final SimilarityMeasure similarity;
     private final Integer dimensions;
     private final Integer maxInputTokens;
-    private final String model;
+    private final String modelId;
 
     public CohereServiceSettings(
         @Nullable URI uri,
         @Nullable SimilarityMeasure similarity,
         @Nullable Integer dimensions,
         @Nullable Integer maxInputTokens,
-        @Nullable String model
+        @Nullable String modelId
     ) {
         this.uri = uri;
         this.similarity = similarity;
         this.dimensions = dimensions;
         this.maxInputTokens = maxInputTokens;
-        this.model = model;
+        this.modelId = modelId;
     }
 
     public CohereServiceSettings(
@@ -80,9 +95,9 @@ public class CohereServiceSettings implements ServiceSettings {
         @Nullable SimilarityMeasure similarity,
         @Nullable Integer dimensions,
         @Nullable Integer maxInputTokens,
-        @Nullable String model
+        @Nullable String modelId
     ) {
-        this(createOptionalUri(url), similarity, dimensions, maxInputTokens, model);
+        this(createOptionalUri(url), similarity, dimensions, maxInputTokens, modelId);
     }
 
     public CohereServiceSettings(StreamInput in) throws IOException {
@@ -90,7 +105,7 @@ public class CohereServiceSettings implements ServiceSettings {
         similarity = in.readOptionalEnum(SimilarityMeasure.class);
         dimensions = in.readOptionalVInt();
         maxInputTokens = in.readOptionalVInt();
-        model = in.readOptionalString();
+        modelId = in.readOptionalString();
     }
 
     public URI getUri() {
@@ -109,8 +124,8 @@ public class CohereServiceSettings implements ServiceSettings {
         return maxInputTokens;
     }
 
-    public String getModel() {
-        return model;
+    public String getModelId() {
+        return modelId;
     }
 
     @Override
@@ -141,8 +156,8 @@ public class CohereServiceSettings implements ServiceSettings {
         if (maxInputTokens != null) {
             builder.field(MAX_INPUT_TOKENS, maxInputTokens);
         }
-        if (model != null) {
-            builder.field(MODEL, model);
+        if (modelId != null) {
+            builder.field(MODEL_ID, modelId);
         }
 
         return builder;
@@ -160,7 +175,7 @@ public class CohereServiceSettings implements ServiceSettings {
         out.writeOptionalEnum(similarity);
         out.writeOptionalVInt(dimensions);
         out.writeOptionalVInt(maxInputTokens);
-        out.writeOptionalString(model);
+        out.writeOptionalString(modelId);
     }
 
     @Override
@@ -172,11 +187,11 @@ public class CohereServiceSettings implements ServiceSettings {
             && Objects.equals(similarity, that.similarity)
             && Objects.equals(dimensions, that.dimensions)
             && Objects.equals(maxInputTokens, that.maxInputTokens)
-            && Objects.equals(model, that.model);
+            && Objects.equals(modelId, that.modelId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri, similarity, dimensions, maxInputTokens, model);
+        return Objects.hash(uri, similarity, dimensions, maxInputTokens, modelId);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsModel.java
@@ -31,13 +31,14 @@ public class CohereEmbeddingsModel extends CohereModel {
         String service,
         Map<String, Object> serviceSettings,
         Map<String, Object> taskSettings,
-        @Nullable Map<String, Object> secrets
+        @Nullable Map<String, Object> secrets,
+        boolean logDeprecations
     ) {
         this(
             modelId,
             taskType,
             service,
-            CohereEmbeddingsServiceSettings.fromMap(serviceSettings),
+            CohereEmbeddingsServiceSettings.fromMap(serviceSettings, logDeprecations),
             CohereEmbeddingsTaskSettings.fromMap(taskSettings),
             DefaultSecretSettings.fromMap(secrets)
         );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettings.java
@@ -30,9 +30,9 @@ public class CohereEmbeddingsServiceSettings implements ServiceSettings {
 
     static final String EMBEDDING_TYPE = "embedding_type";
 
-    public static CohereEmbeddingsServiceSettings fromMap(Map<String, Object> map) {
+    public static CohereEmbeddingsServiceSettings fromMap(Map<String, Object> map, boolean logDeprecations) {
         ValidationException validationException = new ValidationException();
-        var commonServiceSettings = CohereServiceSettings.fromMap(map);
+        var commonServiceSettings = CohereServiceSettings.fromMap(map, logDeprecations);
         CohereEmbeddingType embeddingTypes = extractOptionalEnum(
             map,
             EMBEDDING_TYPE,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -67,7 +67,8 @@ public class OpenAiService extends SenderService {
             serviceSettingsMap,
             taskSettingsMap,
             serviceSettingsMap,
-            TaskType.unsupportedTaskTypeErrorMsg(taskType, NAME)
+            TaskType.unsupportedTaskTypeErrorMsg(taskType, NAME),
+            true
         );
 
         throwIfNotEmptyMap(config, NAME);
@@ -77,13 +78,25 @@ public class OpenAiService extends SenderService {
         return model;
     }
 
-    private static OpenAiModel createModel(
+    private static OpenAiModel createModelWithoutLoggingDeprecations(
         String inferenceEntityId,
         TaskType taskType,
         Map<String, Object> serviceSettings,
         Map<String, Object> taskSettings,
         @Nullable Map<String, Object> secretSettings,
         String failureMessage
+    ) {
+        return createModel(inferenceEntityId, taskType, serviceSettings, taskSettings, secretSettings, failureMessage, false);
+    }
+
+    private static OpenAiModel createModel(
+        String inferenceEntityId,
+        TaskType taskType,
+        Map<String, Object> serviceSettings,
+        Map<String, Object> taskSettings,
+        @Nullable Map<String, Object> secretSettings,
+        String failureMessage,
+        boolean logDeprecations
     ) {
         return switch (taskType) {
             case TEXT_EMBEDDING -> new OpenAiEmbeddingsModel(
@@ -92,7 +105,8 @@ public class OpenAiService extends SenderService {
                 NAME,
                 serviceSettings,
                 taskSettings,
-                secretSettings
+                secretSettings,
+                logDeprecations
             );
             default -> throw new ElasticsearchStatusException(failureMessage, RestStatus.BAD_REQUEST);
         };
@@ -109,7 +123,7 @@ public class OpenAiService extends SenderService {
         Map<String, Object> taskSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.TASK_SETTINGS);
         Map<String, Object> secretSettingsMap = removeFromMapOrThrowIfNull(secrets, ModelSecrets.SECRET_SETTINGS);
 
-        return createModel(
+        return createModelWithoutLoggingDeprecations(
             inferenceEntityId,
             taskType,
             serviceSettingsMap,
@@ -124,7 +138,7 @@ public class OpenAiService extends SenderService {
         Map<String, Object> serviceSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.SERVICE_SETTINGS);
         Map<String, Object> taskSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.TASK_SETTINGS);
 
-        return createModel(
+        return createModelWithoutLoggingDeprecations(
             inferenceEntityId,
             taskType,
             serviceSettingsMap,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModel.java
@@ -36,14 +36,15 @@ public class OpenAiEmbeddingsModel extends OpenAiModel {
         String service,
         Map<String, Object> serviceSettings,
         Map<String, Object> taskSettings,
-        @Nullable Map<String, Object> secrets
+        @Nullable Map<String, Object> secrets,
+        boolean logDeprecations
     ) {
         this(
             inferenceEntityId,
             taskType,
             service,
             OpenAiServiceSettings.fromMap(serviceSettings),
-            OpenAiEmbeddingsTaskSettings.fromMap(taskSettings),
+            OpenAiEmbeddingsTaskSettings.fromMap(taskSettings, logDeprecations),
             DefaultSecretSettings.fromMap(secrets)
         );
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
@@ -17,7 +17,6 @@ import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
 import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.MODEL;
-import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.MODEL_DEPRECATION_MESSAGE;
 import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.USER;
 
@@ -46,10 +45,8 @@ public record OpenAiEmbeddingsRequestTaskSettings(@Nullable String modelId, @Nul
 
         ValidationException validationException = new ValidationException();
 
+        // I'm intentionally not logging if this is set because it would log on every request
         String model = extractOptionalString(map, MODEL, ModelConfigurations.TASK_SETTINGS, validationException);
-        if (model != null) {
-            logger.info(MODEL_DEPRECATION_MESSAGE);
-        }
 
         String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.TASK_SETTINGS, validationException);
         String user = extractOptionalString(map, USER, ModelConfigurations.TASK_SETTINGS, validationException);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
@@ -16,8 +16,8 @@ import org.elasticsearch.inference.ModelConfigurations;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
-import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.MODEL;
 import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD;
 import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.USER;
 
 /**
@@ -46,7 +46,7 @@ public record OpenAiEmbeddingsRequestTaskSettings(@Nullable String modelId, @Nul
         ValidationException validationException = new ValidationException();
 
         // I'm intentionally not logging if this is set because it would log on every request
-        String model = extractOptionalString(map, MODEL, ModelConfigurations.TASK_SETTINGS, validationException);
+        String model = extractOptionalString(map, OLD_MODEL_ID_FIELD, ModelConfigurations.TASK_SETTINGS, validationException);
 
         String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.TASK_SETTINGS, validationException);
         String user = extractOptionalString(map, USER, ModelConfigurations.TASK_SETTINGS, validationException);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
 public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user) implements TaskSettings {
 
     public static final String NAME = "openai_embeddings_task_settings";
-    public static final String MODEL = "model";
+    public static final String OLD_MODEL_ID_FIELD = "model";
     public static final String MODEL_ID = "model_id";
     public static final String USER = "user";
     private static final String MODEL_DEPRECATION_MESSAGE =
@@ -46,15 +46,15 @@ public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user
     public static OpenAiEmbeddingsTaskSettings fromMap(Map<String, Object> map, boolean logDeprecations) {
         ValidationException validationException = new ValidationException();
 
-        String model = extractOptionalString(map, MODEL, ModelConfigurations.TASK_SETTINGS, validationException);
-        if (logDeprecations && model != null) {
+        String oldModelId = extractOptionalString(map, OLD_MODEL_ID_FIELD, ModelConfigurations.TASK_SETTINGS, validationException);
+        if (logDeprecations && oldModelId != null) {
             logger.info(MODEL_DEPRECATION_MESSAGE);
         }
 
         String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.TASK_SETTINGS, validationException);
         String user = extractOptionalString(map, USER, ModelConfigurations.TASK_SETTINGS, validationException);
 
-        var modelIdToUse = getModelId(model, modelId, validationException);
+        var modelIdToUse = getModelId(oldModelId, modelId, validationException);
 
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
@@ -63,8 +63,8 @@ public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user
         return new OpenAiEmbeddingsTaskSettings(modelIdToUse, user);
     }
 
-    private static String getModelId(@Nullable String model, @Nullable String modelId, ValidationException validationException) {
-        var modelIdToUse = modelId != null ? modelId : model;
+    private static String getModelId(@Nullable String oldModelId, @Nullable String modelId, ValidationException validationException) {
+        var modelIdToUse = modelId != null ? modelId : oldModelId;
 
         if (modelIdToUse == null) {
             validationException.addValidationError(ServiceUtils.missingSettingErrorMsg(MODEL_ID, ModelConfigurations.TASK_SETTINGS));

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
@@ -35,12 +35,13 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
  */
 public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user) implements TaskSettings {
 
-    private static final Logger logger = LogManager.getLogger(OpenAiEmbeddingsTaskSettings.class);
     public static final String NAME = "openai_embeddings_task_settings";
     public static final String MODEL = "model";
     public static final String MODEL_ID = "model_id";
     public static final String USER = "user";
-    static final String MODEL_DEPRECATION_MESSAGE = "The openai task_settings.model field is deprecated. Please use model_id instead.";
+    private static final String MODEL_DEPRECATION_MESSAGE =
+        "The openai [task_settings.model] field is deprecated. Please use [task_settings.model_id] instead.";
+    private static final Logger logger = LogManager.getLogger(OpenAiEmbeddingsTaskSettings.class);
 
     public static OpenAiEmbeddingsTaskSettings fromMap(Map<String, Object> map, boolean logDeprecations) {
         ValidationException validationException = new ValidationException();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
@@ -40,13 +40,14 @@ public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user
     public static final String MODEL = "model";
     public static final String MODEL_ID = "model_id";
     public static final String USER = "user";
+    static final String MODEL_DEPRECATION_MESSAGE = "The openai task_settings.model field is deprecated. Please use model_id instead.";
 
     public static OpenAiEmbeddingsTaskSettings fromMap(Map<String, Object> map, boolean logDeprecations) {
         ValidationException validationException = new ValidationException();
 
         String model = extractOptionalString(map, MODEL, ModelConfigurations.TASK_SETTINGS, validationException);
         if (logDeprecations && model != null) {
-            logger.info("The openai task_settings.model field is deprecated. Please use model_id instead.");
+            logger.info(MODEL_DEPRECATION_MESSAGE);
         }
 
         String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.TASK_SETTINGS, validationException);
@@ -82,7 +83,7 @@ public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user
         OpenAiEmbeddingsTaskSettings originalSettings,
         OpenAiEmbeddingsRequestTaskSettings requestSettings
     ) {
-        var modelToUse = requestSettings.model() == null ? originalSettings.modelId : requestSettings.model();
+        var modelToUse = requestSettings.modelId() == null ? originalSettings.modelId : requestSettings.modelId();
         var userToUse = requestSettings.user() == null ? originalSettings.user : requestSettings.user();
 
         return new OpenAiEmbeddingsTaskSettings(modelToUse, userToUse);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettingsTests.java
@@ -73,7 +73,7 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
                     dims,
                     ServiceFields.MAX_INPUT_TOKENS,
                     maxInputTokens,
-                    CohereServiceSettings.MODEL,
+                    CohereServiceSettings.OLD_MODEL_ID_FIELD,
                     model
                 )
             ),
@@ -133,7 +133,7 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
                     dims,
                     ServiceFields.MAX_INPUT_TOKENS,
                     maxInputTokens,
-                    CohereServiceSettings.MODEL,
+                    CohereServiceSettings.OLD_MODEL_ID_FIELD,
                     "old_model",
                     CohereServiceSettings.MODEL_ID,
                     model
@@ -230,7 +230,7 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
         }
 
         if (model != null) {
-            map.put(CohereServiceSettings.MODEL, model);
+            map.put(CohereServiceSettings.OLD_MODEL_ID_FIELD, model);
         }
 
         return map;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettingsTests.java
@@ -12,9 +12,13 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.SimilarityMeasure;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -72,7 +76,70 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
                     CohereServiceSettings.MODEL,
                     model
                 )
-            )
+            ),
+            true
+        );
+
+        MatcherAssert.assertThat(
+            serviceSettings,
+            is(new CohereServiceSettings(ServiceUtils.createUri(url), SimilarityMeasure.DOT_PRODUCT, dims, maxInputTokens, model))
+        );
+    }
+
+    public void testFromMap_WhenUsingModelId() {
+        var url = "https://www.abc.com";
+        var similarity = SimilarityMeasure.DOT_PRODUCT.toString();
+        var dims = 1536;
+        var maxInputTokens = 512;
+        var model = "model";
+        var serviceSettings = CohereServiceSettings.fromMap(
+            new HashMap<>(
+                Map.of(
+                    ServiceFields.URL,
+                    url,
+                    ServiceFields.SIMILARITY,
+                    similarity,
+                    ServiceFields.DIMENSIONS,
+                    dims,
+                    ServiceFields.MAX_INPUT_TOKENS,
+                    maxInputTokens,
+                    CohereServiceSettings.MODEL_ID,
+                    model
+                )
+            ),
+            false
+        );
+
+        MatcherAssert.assertThat(
+            serviceSettings,
+            is(new CohereServiceSettings(ServiceUtils.createUri(url), SimilarityMeasure.DOT_PRODUCT, dims, maxInputTokens, model))
+        );
+    }
+
+    public void testFromMap_PrefersModelId_OverModel() {
+        var url = "https://www.abc.com";
+        var similarity = SimilarityMeasure.DOT_PRODUCT.toString();
+        var dims = 1536;
+        var maxInputTokens = 512;
+        var model = "model";
+        var serviceSettings = CohereServiceSettings.fromMap(
+            new HashMap<>(
+                Map.of(
+                    ServiceFields.URL,
+                    url,
+                    ServiceFields.SIMILARITY,
+                    similarity,
+                    ServiceFields.DIMENSIONS,
+                    dims,
+                    ServiceFields.MAX_INPUT_TOKENS,
+                    maxInputTokens,
+                    CohereServiceSettings.MODEL,
+                    "old_model",
+                    CohereServiceSettings.MODEL_ID,
+                    model
+                )
+            ),
+            false
         );
 
         MatcherAssert.assertThat(
@@ -82,14 +149,14 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
     }
 
     public void testFromMap_MissingUrl_DoesNotThrowException() {
-        var serviceSettings = CohereServiceSettings.fromMap(new HashMap<>(Map.of()));
+        var serviceSettings = CohereServiceSettings.fromMap(new HashMap<>(Map.of()), false);
         assertNull(serviceSettings.getUri());
     }
 
     public void testFromMap_EmptyUrl_ThrowsError() {
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, "")))
+            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, "")), false)
         );
 
         MatcherAssert.assertThat(
@@ -107,7 +174,7 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
         var url = "https://www.abc^.com";
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, url)))
+            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, url)), false)
         );
 
         MatcherAssert.assertThat(
@@ -120,13 +187,24 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
         var similarity = "by_size";
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.SIMILARITY, similarity)))
+            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.SIMILARITY, similarity)), false)
         );
 
         MatcherAssert.assertThat(
             thrownException.getMessage(),
             is("Validation Failed: 1: [service_settings] Unknown similarity measure [by_size];")
         );
+    }
+
+    public void testXContent_WritesModelId() throws IOException {
+        var entity = new CohereServiceSettings((String) null, null, null, null, "modelId");
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        entity.toXContent(builder, null);
+        String xContentResult = Strings.toString(builder);
+
+        assertThat(xContentResult, CoreMatchers.is("""
+            {"model_id":"modelId"}"""));
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceTests.java
@@ -111,7 +111,7 @@ public class CohereServiceTests extends ESTestCase {
 
             var embeddingsModel = (CohereEmbeddingsModel) model;
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getUri().toString(), is("url"));
-            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModel(), is("model"));
+            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModelId(), is("model"));
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getEmbeddingType(), is(CohereEmbeddingType.FLOAT));
             MatcherAssert.assertThat(
                 embeddingsModel.getTaskSettings(),
@@ -306,7 +306,7 @@ public class CohereServiceTests extends ESTestCase {
 
             var embeddingsModel = (CohereEmbeddingsModel) model;
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getUri().toString(), is("url"));
-            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModel(), is("model"));
+            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModelId(), is("model"));
             MatcherAssert.assertThat(embeddingsModel.getTaskSettings(), is(new CohereEmbeddingsTaskSettings(null, null)));
             MatcherAssert.assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -396,7 +396,7 @@ public class CohereServiceTests extends ESTestCase {
 
             var embeddingsModel = (CohereEmbeddingsModel) model;
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getUri().toString(), is("url"));
-            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModel(), is("model"));
+            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModelId(), is("model"));
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getEmbeddingType(), is(CohereEmbeddingType.INT8));
             MatcherAssert.assertThat(
                 embeddingsModel.getTaskSettings(),
@@ -463,7 +463,7 @@ public class CohereServiceTests extends ESTestCase {
 
             var embeddingsModel = (CohereEmbeddingsModel) model;
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getUri().toString(), is("url"));
-            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModel(), is("model"));
+            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModelId(), is("model"));
             MatcherAssert.assertThat(embeddingsModel.getTaskSettings(), is(new CohereEmbeddingsTaskSettings(null, null)));
             MatcherAssert.assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -524,7 +524,7 @@ public class CohereServiceTests extends ESTestCase {
 
             var embeddingsModel = (CohereEmbeddingsModel) model;
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getUri().toString(), is("url"));
-            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModel(), is("model"));
+            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModelId(), is("model"));
             MatcherAssert.assertThat(embeddingsModel.getTaskSettings(), is(new CohereEmbeddingsTaskSettings(InputType.SEARCH, null)));
             MatcherAssert.assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -548,7 +548,7 @@ public class CohereServiceTests extends ESTestCase {
 
             var embeddingsModel = (CohereEmbeddingsModel) model;
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getUri().toString(), is("url"));
-            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModel(), is("model"));
+            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModelId(), is("model"));
             MatcherAssert.assertThat(embeddingsModel.getTaskSettings(), is(new CohereEmbeddingsTaskSettings(null, CohereTruncation.NONE)));
             assertNull(embeddingsModel.getSecretSettings());
         }
@@ -596,7 +596,7 @@ public class CohereServiceTests extends ESTestCase {
 
             var embeddingsModel = (CohereEmbeddingsModel) model;
             assertNull(embeddingsModel.getServiceSettings().getCommonSettings().getUri());
-            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModel(), is("model"));
+            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModelId(), is("model"));
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getEmbeddingType(), is(CohereEmbeddingType.FLOAT));
             MatcherAssert.assertThat(embeddingsModel.getTaskSettings(), is(new CohereEmbeddingsTaskSettings(null, null)));
             assertNull(embeddingsModel.getSecretSettings());
@@ -671,7 +671,7 @@ public class CohereServiceTests extends ESTestCase {
 
             var embeddingsModel = (CohereEmbeddingsModel) model;
             MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getUri().toString(), is("url"));
-            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModel(), is("model"));
+            MatcherAssert.assertThat(embeddingsModel.getServiceSettings().getCommonSettings().getModelId(), is("model"));
             MatcherAssert.assertThat(embeddingsModel.getTaskSettings(), is(new CohereEmbeddingsTaskSettings(InputType.INGEST, null)));
             assertNull(embeddingsModel.getSecretSettings());
         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettingsTests.java
@@ -57,7 +57,7 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     dims,
                     ServiceFields.MAX_INPUT_TOKENS,
                     maxInputTokens,
-                    CohereServiceSettings.MODEL,
+                    CohereServiceSettings.OLD_MODEL_ID_FIELD,
                     model,
                     CohereEmbeddingsServiceSettings.EMBEDDING_TYPE,
                     CohereEmbeddingType.INT8.toString()
@@ -94,7 +94,7 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     dims,
                     ServiceFields.MAX_INPUT_TOKENS,
                     maxInputTokens,
-                    CohereServiceSettings.MODEL,
+                    CohereServiceSettings.OLD_MODEL_ID_FIELD,
                     model,
                     CohereEmbeddingsServiceSettings.EMBEDDING_TYPE,
                     CohereEmbeddingType.INT8.toString()
@@ -131,7 +131,7 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     dims,
                     ServiceFields.MAX_INPUT_TOKENS,
                     maxInputTokens,
-                    CohereServiceSettings.MODEL,
+                    CohereServiceSettings.OLD_MODEL_ID_FIELD,
                     "old_model",
                     CohereServiceSettings.MODEL_ID,
                     model,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettingsTests.java
@@ -62,7 +62,84 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     CohereEmbeddingsServiceSettings.EMBEDDING_TYPE,
                     CohereEmbeddingType.INT8.toString()
                 )
+            ),
+            false
+        );
+
+        MatcherAssert.assertThat(
+            serviceSettings,
+            is(
+                new CohereEmbeddingsServiceSettings(
+                    new CohereServiceSettings(ServiceUtils.createUri(url), SimilarityMeasure.DOT_PRODUCT, dims, maxInputTokens, model),
+                    CohereEmbeddingType.INT8
+                )
             )
+        );
+    }
+
+    public void testFromMap_WithModelId() {
+        var url = "https://www.abc.com";
+        var similarity = SimilarityMeasure.DOT_PRODUCT.toString();
+        var dims = 1536;
+        var maxInputTokens = 512;
+        var model = "model";
+        var serviceSettings = CohereEmbeddingsServiceSettings.fromMap(
+            new HashMap<>(
+                Map.of(
+                    ServiceFields.URL,
+                    url,
+                    ServiceFields.SIMILARITY,
+                    similarity,
+                    ServiceFields.DIMENSIONS,
+                    dims,
+                    ServiceFields.MAX_INPUT_TOKENS,
+                    maxInputTokens,
+                    CohereServiceSettings.MODEL,
+                    model,
+                    CohereEmbeddingsServiceSettings.EMBEDDING_TYPE,
+                    CohereEmbeddingType.INT8.toString()
+                )
+            ),
+            false
+        );
+
+        MatcherAssert.assertThat(
+            serviceSettings,
+            is(
+                new CohereEmbeddingsServiceSettings(
+                    new CohereServiceSettings(ServiceUtils.createUri(url), SimilarityMeasure.DOT_PRODUCT, dims, maxInputTokens, model),
+                    CohereEmbeddingType.INT8
+                )
+            )
+        );
+    }
+
+    public void testFromMap_PrefersModelId_OverModel() {
+        var url = "https://www.abc.com";
+        var similarity = SimilarityMeasure.DOT_PRODUCT.toString();
+        var dims = 1536;
+        var maxInputTokens = 512;
+        var model = "model";
+        var serviceSettings = CohereEmbeddingsServiceSettings.fromMap(
+            new HashMap<>(
+                Map.of(
+                    ServiceFields.URL,
+                    url,
+                    ServiceFields.SIMILARITY,
+                    similarity,
+                    ServiceFields.DIMENSIONS,
+                    dims,
+                    ServiceFields.MAX_INPUT_TOKENS,
+                    maxInputTokens,
+                    CohereServiceSettings.MODEL,
+                    "old_model",
+                    CohereServiceSettings.MODEL_ID,
+                    model,
+                    CohereEmbeddingsServiceSettings.EMBEDDING_TYPE,
+                    CohereEmbeddingType.INT8.toString()
+                )
+            ),
+            false
         );
 
         MatcherAssert.assertThat(
@@ -77,14 +154,14 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
     }
 
     public void testFromMap_MissingEmbeddingType_DoesNotThrowException() {
-        var serviceSettings = CohereEmbeddingsServiceSettings.fromMap(new HashMap<>(Map.of()));
+        var serviceSettings = CohereEmbeddingsServiceSettings.fromMap(new HashMap<>(Map.of()), false);
         assertNull(serviceSettings.getEmbeddingType());
     }
 
     public void testFromMap_EmptyEmbeddingType_ThrowsError() {
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereEmbeddingsServiceSettings.fromMap(new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, "")))
+            () -> CohereEmbeddingsServiceSettings.fromMap(new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, "")), true)
         );
 
         MatcherAssert.assertThat(
@@ -101,7 +178,10 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
     public void testFromMap_InvalidEmbeddingType_ThrowsError() {
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereEmbeddingsServiceSettings.fromMap(new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, "abc")))
+            () -> CohereEmbeddingsServiceSettings.fromMap(
+                new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, "abc")),
+                false
+            )
         );
 
         MatcherAssert.assertThat(
@@ -118,7 +198,8 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
         var exception = expectThrows(
             ElasticsearchStatusException.class,
             () -> CohereEmbeddingsServiceSettings.fromMap(
-                new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, List.of("abc")))
+                new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, List.of("abc"))),
+                false
             )
         );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceTests.java
@@ -108,7 +108,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -256,7 +256,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertNull(embeddingsModel.getServiceSettings().uri());
             assertNull(embeddingsModel.getServiceSettings().organizationId());
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertNull(embeddingsModel.getTaskSettings().user());
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -287,7 +287,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -348,7 +348,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertNull(embeddingsModel.getServiceSettings().uri());
             assertNull(embeddingsModel.getServiceSettings().organizationId());
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertNull(embeddingsModel.getTaskSettings().user());
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -380,7 +380,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -414,7 +414,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -446,7 +446,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -480,7 +480,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -514,7 +514,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertThat(embeddingsModel.getSecretSettings().apiKey().toString(), is("secret"));
         }
@@ -536,7 +536,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertNull(embeddingsModel.getSecretSettings());
         }
@@ -579,7 +579,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertNull(embeddingsModel.getServiceSettings().uri());
             assertNull(embeddingsModel.getServiceSettings().organizationId());
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertNull(embeddingsModel.getTaskSettings().user());
             assertNull(embeddingsModel.getSecretSettings());
         }
@@ -602,7 +602,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertNull(embeddingsModel.getSecretSettings());
         }
@@ -627,7 +627,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertNull(embeddingsModel.getSecretSettings());
         }
@@ -652,7 +652,7 @@ public class OpenAiServiceTests extends ESTestCase {
             var embeddingsModel = (OpenAiEmbeddingsModel) model;
             assertThat(embeddingsModel.getServiceSettings().uri().toString(), is("url"));
             assertThat(embeddingsModel.getServiceSettings().organizationId(), is("org"));
-            assertThat(embeddingsModel.getTaskSettings().model(), is("model"));
+            assertThat(embeddingsModel.getTaskSettings().modelId(), is("model"));
             assertThat(embeddingsModel.getTaskSettings().user(), is("user"));
             assertNull(embeddingsModel.getSecretSettings());
         }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
@@ -19,21 +19,21 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
     public void testFromMap_ReturnsEmptySettings_WhenTheMapIsEmpty() {
         var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of()));
 
-        assertNull(settings.model());
+        assertNull(settings.modelId());
         assertNull(settings.user());
     }
 
     public void testFromMap_ReturnsEmptySettings_WhenTheMapDoesNotContainTheFields() {
         var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of("key", "model")));
 
-        assertNull(settings.model());
+        assertNull(settings.modelId());
         assertNull(settings.user());
     }
 
     public void testFromMap_ReturnsEmptyModel_WhenTheMapDoesNotContainThatField() {
         var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")));
 
-        assertNull(settings.model());
+        assertNull(settings.modelId());
         assertThat(settings.user(), is("user"));
     }
 
@@ -41,7 +41,16 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
         var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model")));
 
         assertNull(settings.user());
-        assertThat(settings.model(), is("model"));
+        assertThat(settings.modelId(), is("model"));
+    }
+
+    public void testFromMap_PrefersModelId_OverModel() {
+        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.MODEL_ID, "model_id"))
+        );
+
+        assertNull(settings.user());
+        assertThat(settings.modelId(), is("model_id"));
     }
 
     public static Map<String, Object> getRequestTaskSettingsMap(@Nullable String model, @Nullable String user) {
@@ -49,6 +58,24 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
 
         if (model != null) {
             map.put(OpenAiEmbeddingsTaskSettings.MODEL, model);
+        }
+
+        if (user != null) {
+            map.put(OpenAiEmbeddingsTaskSettings.USER, user);
+        }
+
+        return map;
+    }
+
+    public static Map<String, Object> getRequestTaskSettingsMap(@Nullable String model, @Nullable String modelId, @Nullable String user) {
+        var map = new HashMap<String, Object>();
+
+        if (model != null) {
+            map.put(OpenAiEmbeddingsTaskSettings.MODEL, model);
+        }
+
+        if (modelId != null) {
+            map.put(OpenAiEmbeddingsTaskSettings.MODEL_ID, model);
         }
 
         if (user != null) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
@@ -38,7 +38,9 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
     }
 
     public void testFromMap_ReturnsEmptyUser_WhenTheDoesMapNotContainThatField() {
-        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model")));
+        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model"))
+        );
 
         assertNull(settings.user());
         assertThat(settings.modelId(), is("model"));
@@ -46,7 +48,9 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
 
     public void testFromMap_PrefersModelId_OverModel() {
         var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.MODEL_ID, "model_id"))
+            new HashMap<>(
+                Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.MODEL_ID, "model_id")
+            )
         );
 
         assertNull(settings.user());
@@ -57,7 +61,7 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
         var map = new HashMap<String, Object>();
 
         if (model != null) {
-            map.put(OpenAiEmbeddingsTaskSettings.MODEL, model);
+            map.put(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, model);
         }
 
         if (user != null) {
@@ -71,7 +75,7 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
         var map = new HashMap<String, Object>();
 
         if (model != null) {
-            map.put(OpenAiEmbeddingsTaskSettings.MODEL, model);
+            map.put(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, model);
         }
 
         if (modelId != null) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
@@ -57,7 +57,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
 
     public void testFromMap_CreatesWithModelAndUser() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
             false
         );
 
@@ -81,7 +81,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
                 Map.of(
                     OpenAiEmbeddingsTaskSettings.MODEL_ID,
                     "model",
-                    OpenAiEmbeddingsTaskSettings.MODEL,
+                    OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD,
                     "old_model",
                     OpenAiEmbeddingsTaskSettings.USER,
                     "user"
@@ -95,7 +95,10 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
     }
 
     public void testFromMap_MissingUser_DoesNotThrowException() {
-        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model")), false);
+        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model")),
+            false
+        );
 
         MatcherAssert.assertThat(taskSettings.modelId(), is("model"));
         assertNull(taskSettings.user());
@@ -103,7 +106,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
 
     public void testOverrideWith_KeepsOriginalValuesWithOverridesAreNull() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
             false
         );
 
@@ -113,12 +116,12 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
 
     public void testOverrideWith_UsesOverriddenSettings() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
             false
         );
 
         var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model2", OpenAiEmbeddingsTaskSettings.USER, "user2"))
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model2", OpenAiEmbeddingsTaskSettings.USER, "user2"))
         );
 
         var overriddenTaskSettings = OpenAiEmbeddingsTaskSettings.of(taskSettings, requestTaskSettings);
@@ -127,7 +130,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
 
     public void testOverrideWith_UsesOverriddenSettings_UsesModel2_FromModelIdField() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
             false
         );
 
@@ -136,7 +139,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
                 Map.of(
                     OpenAiEmbeddingsTaskSettings.MODEL_ID,
                     "model2",
-                    OpenAiEmbeddingsTaskSettings.MODEL,
+                    OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD,
                     "model3",
                     OpenAiEmbeddingsTaskSettings.USER,
                     "user2"
@@ -150,12 +153,12 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
 
     public void testOverrideWith_UsesOnlyNonNullModelSetting() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
             false
         );
 
         var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model2"))
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model2"))
         );
 
         var overriddenTaskSettings = OpenAiEmbeddingsTaskSettings.of(taskSettings, requestTaskSettings);
@@ -189,7 +192,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
     }
 
     public static Map<String, Object> getTaskSettingsMap(String model, @Nullable String user) {
-        var map = new HashMap<String, Object>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, model));
+        var map = new HashMap<String, Object>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, model));
 
         if (user != null) {
             map.put(OpenAiEmbeddingsTaskSettings.USER, user);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
@@ -125,6 +125,29 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
         MatcherAssert.assertThat(overriddenTaskSettings, is(new OpenAiEmbeddingsTaskSettings("model2", "user2")));
     }
 
+    public void testOverrideWith_UsesOverriddenSettings_UsesModel2_FromModelIdField() {
+        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
+            false
+        );
+
+        var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
+            new HashMap<>(
+                Map.of(
+                    OpenAiEmbeddingsTaskSettings.MODEL_ID,
+                    "model2",
+                    OpenAiEmbeddingsTaskSettings.MODEL,
+                    "model3",
+                    OpenAiEmbeddingsTaskSettings.USER,
+                    "user2"
+                )
+            )
+        );
+
+        var overriddenTaskSettings = OpenAiEmbeddingsTaskSettings.of(taskSettings, requestTaskSettings);
+        MatcherAssert.assertThat(overriddenTaskSettings, is(new OpenAiEmbeddingsTaskSettings("model2", "user2")));
+    }
+
     public void testOverrideWith_UsesOnlyNonNullModelSetting() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
             new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),


### PR DESCRIPTION
This PR updates inference API for the OpenAI and Cohere 3rd party integrations to prefer the `model_id` field over `model` when specifying the name of the model (e.g. `embed-english-v3.0` or `text-embedding-ada-002`).

The `model` field is still permitted but will generate a deprecation warning in the logs when it is used when configuring one of these 3rd party integrations.

This PR also changes how the field is persisted. So if `model` is passed in the PUT call when creating a service, it will be persisted in elasticsearch as `model_id`. This could be problematic during an upgrade scenario but the service configurations are not updated when being read (except once when the configuration is being setup) so we shouldn't be changing `model` to `model_id` in the elasticsearch document when performing inference. This change should only happen when the initial service configuration is being stored. This could be problematic if we support editing in the future. In that scenario I think we should prevent edits during upgrades. We can check that all the nodes are on the same transport version and fail in the edit transport handler if they are different (we already do this in the PUT call when creating a service).

This PR does not address the fact that OpenAI stores the model id in the `task_settings` which allows users to override it in a request (in Cohere we store it in `service_settings`). We can address that in a follow up PR.

Another option would be when we read the inference entity, we check for deprecations, and then persist the migrated version. This would be complicated though because we allow inference requests during an upgrade. I suppose we could check that all the nodes are on the same transport version and only then do the migration. We may need to do something like that when move the `model_id` field from the `task_settings` within OpenAI.