### PR TITLE
ESQL: More tests for `STATS BY blah, blah` syntax

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -583,6 +583,33 @@ M
 null
 ;
 
+aggsWithoutStatsTwo
+FROM employees | STATS BY gender, still_hired | SORT gender, still_hired;
+
+gender:keyword | still_hired:boolean
+F              | false
+F              | true
+M              | false
+M              | true
+null           | false
+null           | true
+;
+
+aggsWithoutStatsFormula
+FROM employees | EVAL birth_decade = ROUND(DATE_EXTRACT("YEAR", birth_date), -1) | STATS BY gender, birth_decade | SORT gender, birth_decade;
+
+gender:keyword | birth_decade:long
+F              | 1950
+F              | 1960
+F              | null
+M              | 1950
+M              | 1960
+M              | 1970
+M              | null
+null           | 1950
+null           | 1960
+;
+
 countFieldNoGrouping
 from employees | where emp_no < 10050 | stats c = count(salary);
 


### PR DESCRIPTION
In ESQL you can write a grouping `STATS` command without any any functions - just `STATS BY foo, bar, baz` and we'll calculate all the combinations of group keys without running any functions. We only have a single example of that in our tests though! This adds two more that are slightly more complex. Just out of paranoia.
