### PR TITLE
[8.12] [ML] Fixing inference shutdown bug

### DIFF
--- a/docs/changelog/105213.yaml
+++ b/docs/changelog/105213.yaml
@@ -1,0 +1,5 @@
+pr: 105213
+summary: Inference service should reject tasks during shutdown
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestExecutorService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/HttpRequestExecutorService.java
@@ -133,6 +133,7 @@ class HttpRequestExecutorService implements ExecutorService {
             if (task.shouldShutdown() || running.get() == false) {
                 running.set(false);
                 logger.debug(() -> format("Http executor service [%s] exiting", serviceName));
+                rejectTask(task);
             } else {
                 executeTask(task);
             }


### PR DESCRIPTION
This is a manual backport of this PR: https://github.com/elastic/elasticsearch/pull/105213

Issue: https://github.com/elastic/elasticsearch/issues/105212