### PR TITLE
Cross-cluster painless execute API fails security checks always happen locally

### DIFF
--- a/docs/changelog/105215.yaml
+++ b/docs/changelog/105215.yaml
@@ -1,0 +1,5 @@
+pr: 105215
+summary: Cross-cluster painless execute API fails on secured clusters in some scenarios
+area: Search
+type: bug
+issues: []

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.RemoteClusterActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -102,6 +103,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -121,7 +123,7 @@ public class PainlessExecuteAction {
 
     private PainlessExecuteAction() {/* no instances */}
 
-    public static class Request extends SingleShardRequest<Request> implements ToXContentObject {
+    public static class Request extends SingleShardRequest<Request> implements ToXContentObject, IndicesRequest.Replaceable {
 
         private static final ParseField SCRIPT_FIELD = new ParseField("script");
         private static final ParseField CONTEXT_FIELD = new ParseField("context");
@@ -156,6 +158,19 @@ public class PainlessExecuteAction {
                 throw new UnsupportedOperationException("unsupported script context name [" + name + "]");
             }
             return scriptContext;
+        }
+
+        @Override
+        public IndicesRequest indices(String... indices) {
+            assert indices != null && indices.length == 1
+                : "PainlessExecuteAction only supports a single index but indices method got " + Arrays.toString(indices);
+            index(indices[0]);
+            return this;
+        }
+
+        @Override
+        public boolean allowsRemoteIndices() {
+            return true;
         }
 
         static class ContextSetup implements Writeable, ToXContentObject {


### PR DESCRIPTION
When cross-cluster painless execute API runs against a secured cluster and a remote index is
intended to be searched, the user must have permission to access it on the local cluster 
(or at least have permission to search that index pattern).
Since it is a cross-cluster remote request, the security check should be happening on the remote
cluster, not the local one.

Fixes [#105084](https://github.com/elastic/elasticsearch/issues/105084)