### PR TITLE
Simplify `ChunkedToXContentHelper#singleChunk`

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentBuilder.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentBuilder.java
@@ -976,7 +976,7 @@ public final class XContentBuilder implements Closeable, Flushable {
         return map(map);
     }
 
-    private XContentBuilder value(ToXContent value, ToXContent.Params params) throws IOException {
+    public XContentBuilder value(ToXContent value, ToXContent.Params params) throws IOException {
         if (value == null) {
             return nullValue();
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
@@ -88,10 +88,10 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(
             singleChunk(
-                (builder, p) -> builder.startObject(),
-                (builder, p) -> builder.field("stats", stats),
-                (builder, p) -> builder.field("cluster_balance_stats", clusterBalanceStats),
-                (builder, p) -> builder.startObject("routing_table")
+                (builder, p) -> builder.startObject()
+                    .field("stats", stats)
+                    .field("cluster_balance_stats", clusterBalanceStats)
+                    .startObject("routing_table")
             ),
             Iterators.flatMap(
                 routingTable.entrySet().iterator(),
@@ -172,14 +172,9 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
         @Override
         public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
             return Iterators.concat(
-                singleChunk((builder, p) -> builder.startObject(), (builder, p) -> builder.startArray("current")),
+                singleChunk((builder, p) -> builder.startObject().startArray("current")),
                 current().iterator(),
-                singleChunk(
-                    (builder, p) -> builder.endArray(),
-                    (builder, p) -> builder.field("desired"),
-                    desired,
-                    (builder, p) -> builder.endObject()
-                )
+                singleChunk((builder, p) -> builder.endArray().field("desired").value(desired, p).endObject())
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -329,7 +329,9 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
 
             ifPresent(getIndices()).toXContentChunked(outerParams),
 
-            singleChunk(ifPresent(getOs()), ifPresent(getProcess()), ifPresent(getJvm())),
+            singleChunk(
+                (builder, p) -> builder.value(ifPresent(getOs()), p).value(ifPresent(getProcess()), p).value(ifPresent(getJvm()), p)
+            ),
 
             ifPresent(getThreadPool()).toXContentChunked(outerParams),
             singleChunk(ifPresent(getFs())),

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -304,7 +304,7 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
 
         return Iterators.concat(
 
-            Iterators.single((builder, params) -> {
+            singleChunk((builder, params) -> {
                 builder.field("name", getNode().getName());
                 builder.field("transport_address", getNode().getAddress().toString());
                 builder.field("host", getNode().getHostName());
@@ -343,8 +343,7 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
             ifPresent(getIngestStats()).toXContentChunked(outerParams),
             singleChunk(ifPresent(getAdaptiveSelectionStats())),
             ifPresent(getScriptCacheStats()).toXContentChunked(outerParams),
-            singleChunk(ifPresent(getIndexingPressureStats())),
-            singleChunk(ifPresent(getRepositoriesStats()))
+            singleChunk((builder, p) -> builder.value(ifPresent(getIndexingPressureStats()), p).value(ifPresent(getRepositoriesStats()), p))
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -163,8 +163,8 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
             return builder;
         }),
             singleChunk(
-                (builder, p) -> builder.endObject(), // end "nodes"
-                (builder, p) -> builder.startObject("shard_sizes")
+                (builder, p) -> builder.endObject() // end "nodes"
+                    .startObject("shard_sizes")
             ),
 
             Iterators.map(
@@ -172,8 +172,8 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
                 c -> (builder, p) -> builder.humanReadableField(c.getKey() + "_bytes", c.getKey(), ByteSizeValue.ofBytes(c.getValue()))
             ),
             singleChunk(
-                (builder, p) -> builder.endObject(), // end "shard_sizes"
-                (builder, p) -> builder.startObject("shard_data_set_sizes")
+                (builder, p) -> builder.endObject() // end "shard_sizes"
+                    .startObject("shard_data_set_sizes")
             ),
             Iterators.map(
                 shardDataSetSizes.entrySet().iterator(),
@@ -184,13 +184,13 @@ public class ClusterInfo implements ChunkedToXContent, Writeable {
                 )
             ),
             singleChunk(
-                (builder, p) -> builder.endObject(), // end "shard_data_set_sizes"
-                (builder, p) -> builder.startObject("shard_paths")
+                (builder, p) -> builder.endObject() // end "shard_data_set_sizes"
+                    .startObject("shard_paths")
             ),
             Iterators.map(dataPath.entrySet().iterator(), c -> (builder, p) -> builder.field(c.getKey().toString(), c.getValue())),
             singleChunk(
-                (builder, p) -> builder.endObject(), // end "shard_paths"
-                (builder, p) -> builder.startArray("reserved_sizes")
+                (builder, p) -> builder.endObject() // end "shard_paths"
+                    .startArray("reserved_sizes")
             ),
             Iterators.map(reservedSpace.entrySet().iterator(), c -> (builder, p) -> {
                 builder.startObject();

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
@@ -115,17 +115,13 @@ public enum ChunkedToXContentHelper {
     }
 
     /**
-     * Creates an Iterator of a single ToXContent object that serializes all the given 'contents' ToXContent objects into a single chunk.
+     * Creates an Iterator of a single ToXContent object that serializes the given object as a single chunk. Just wraps {@link
+     * Iterators#single}, but still useful because it avoids any type ambiguity.
      *
-     * @param contents ToXContent objects supporting toXContent() calls.
-     * @return Iterator of a single ToXContent object serializing all the ToXContent "contents".
+     * @param item Item to wrap
+     * @return Singleton iterator for the given item.
      */
-    public static Iterator<ToXContent> singleChunk(ToXContent... contents) {
-        return Iterators.single((builder, params) -> {
-            for (ToXContent content : contents) {
-                content.toXContent(builder, params);
-            }
-            return builder;
-        });
+    public static Iterator<ToXContent> singleChunk(ToXContent item) {
+        return Iterators.single(item);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -491,8 +491,8 @@ public class NodeStatsTests extends ESTestCase {
     }
 
     private static int expectedChunks(NodeStats nodeStats, NodeStatsLevel level) {
-        // expectedChunks = number of static chunks (8 at the moment, see NodeStats#toXContentChunked) + number of variable chunks
-        return 8 + expectedChunks(nodeStats.getHttp()) //
+        return 7 // number of static chunks, see NodeStats#toXContentChunked
+            + expectedChunks(nodeStats.getHttp()) //
             + expectedChunks(nodeStats.getIndices(), level) //
             + expectedChunks(nodeStats.getTransport()) //
             + expectedChunks(nodeStats.getIngestStats()) //


### PR DESCRIPTION
There's no need for this helper to take more than one argument. Almost
all the usages only passed in a single argument, and the few cases that
supplied more than one can be rewritten as a single argument to save
allocating all those extra lambdas.