### PR TITLE
[8.12] Fix exception handling on DateFormatters.forPattern() with wrong date pattern (#105048)

### DIFF
--- a/docs/changelog/105048.yaml
+++ b/docs/changelog/105048.yaml
@@ -1,0 +1,6 @@
+pr: 105048
+summary: "ES|QL: Fix exception handling on `date_parse` with wrong date pattern"
+area: ES|QL
+type: bug
+issues:
+ - 104124

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -2125,7 +2125,8 @@ public class DateFormatters {
                     input,
                     new DateTimeFormatterBuilder().appendPattern(input).toFormatter(Locale.ROOT).withResolverStyle(ResolverStyle.STRICT)
                 );
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | ClassCastException e) {
+                // ClassCastException catches this bug https://bugs.openjdk.org/browse/JDK-8193877
                 throw new IllegalArgumentException("Invalid format: [" + input + "]: " + e.getMessage(), e);
             }
         }

--- a/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateFormattersTests.java
@@ -1371,4 +1371,12 @@ public class DateFormattersTests extends ESTestCase {
         long millisJoda = DateFormatter.forPattern("yyyy-MM-dd HH:mm:ss").parseMillis("2018-02-18 17:47:17");
         assertThat(millisJava, is(millisJoda));
     }
+
+    // see https://bugs.openjdk.org/browse/JDK-8193877
+    public void testNoClassCastException() {
+        String input = "DpNKOGqhjZ";
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> DateFormatter.forPattern(input));
+        assertThat(e.getCause(), instanceOf(ClassCastException.class));
+        assertThat(e.getMessage(), containsString(input));
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateParseTests.java
@@ -64,9 +64,8 @@ public class DateParseTests extends AbstractScalarFunctionTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104124")
     public void testInvalidPattern() {
-        String pattern = randomAlphaOfLength(10);
+        String pattern = "invalid";
         DriverContext driverContext = driverContext();
         InvalidArgumentException e = expectThrows(
             InvalidArgumentException.class,


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Fix exception handling on DateFormatters.forPattern() with wrong date pattern (#105048)