### PR TITLE
Execute SAML authentication on the generic threadpool

### DIFF
--- a/docs/changelog/105232.yaml
+++ b/docs/changelog/105232.yaml
@@ -2,4 +2,5 @@ pr: 105232
 summary: Execute SAML authentication on the generic threadpool
 area: Authentication
 type: bug
-issues: []
+issues:
+ - 104962

--- a/docs/changelog/105232.yaml
+++ b/docs/changelog/105232.yaml
@@ -1,0 +1,5 @@
+pr: 105232
+summary: Execute SAML authentication on the generic threadpool
+area: Authentication
+type: bug
+issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -75,6 +75,7 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
 
     private void doExecuteForked(Task task, SamlAuthenticateRequest request, ActionListener<SamlAuthenticateResponse> listener) {
         assert Transports.assertNotTransportThread("SAML authentication may involve slow IO/HTTP calls");
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         final SamlToken saml = new SamlToken(request.getSaml(), request.getValidRequestIds(), request.getRealm());
         logger.trace("Attempting to authenticate SamlToken [{}]", saml);
         final ThreadContext threadContext = threadPool.getThreadContext();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.saml.SamlAuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlAuthenticateRequest;
@@ -74,7 +73,6 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
     }
 
     private void doExecuteForked(Task task, SamlAuthenticateRequest request, ActionListener<SamlAuthenticateResponse> listener) {
-        assert Transports.assertNotTransportThread("SAML authentication may involve slow IO/HTTP calls");
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         final SamlToken saml = new SamlToken(request.getSaml(), request.getValidRequestIds(), request.getRealm());
         logger.trace("Attempting to authenticate SamlToken [{}]", saml);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.action.saml.SamlAuthenticateAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlAuthenticateRequest;
@@ -57,6 +58,7 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
 
     @Override
     protected void doExecute(Task task, SamlAuthenticateRequest request, ActionListener<SamlAuthenticateResponse> listener) {
+        assert Transports.assertNotTransportThread("SAML authentication may involve slow IO/HTTP calls");
         final SamlToken saml = new SamlToken(request.getSaml(), request.getValidRequestIds(), request.getRealm());
         logger.trace("Attempting to authenticate SamlToken [{}]", saml);
         final ThreadContext threadContext = threadPool.getThreadContext();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -10,7 +10,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.Task;
@@ -49,13 +48,7 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
         TokenService tokenService,
         SecurityContext securityContext
     ) {
-        super(
-            SamlAuthenticateAction.NAME,
-            transportService,
-            actionFilters,
-            SamlAuthenticateRequest::new,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE
-        );
+        super(SamlAuthenticateAction.NAME, transportService, actionFilters, SamlAuthenticateRequest::new, threadPool.generic());
         this.threadPool = threadPool;
         this.authenticationService = authenticationService;
         this.tokenService = tokenService;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlAuthenticateAction.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.security.action.saml;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
@@ -29,6 +30,7 @@ import org.elasticsearch.xpack.security.authc.saml.SamlRealm;
 import org.elasticsearch.xpack.security.authc.saml.SamlToken;
 
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * Transport action responsible for taking saml content and turning it into a token.
@@ -39,6 +41,7 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
     private final AuthenticationService authenticationService;
     private final TokenService tokenService;
     private final SecurityContext securityContext;
+    private final Executor genericExecutor;
 
     @Inject
     public TransportSamlAuthenticateAction(
@@ -49,15 +52,28 @@ public final class TransportSamlAuthenticateAction extends HandledTransportActio
         TokenService tokenService,
         SecurityContext securityContext
     ) {
-        super(SamlAuthenticateAction.NAME, transportService, actionFilters, SamlAuthenticateRequest::new, threadPool.generic());
+        // TODO replace SAME when removing workaround for https://github.com/elastic/elasticsearch/issues/97916
+        super(
+            SamlAuthenticateAction.NAME,
+            transportService,
+            actionFilters,
+            SamlAuthenticateRequest::new,
+            threadPool.executor(ThreadPool.Names.SAME)
+        );
         this.threadPool = threadPool;
         this.authenticationService = authenticationService;
         this.tokenService = tokenService;
         this.securityContext = securityContext;
+        this.genericExecutor = threadPool.generic();
     }
 
     @Override
     protected void doExecute(Task task, SamlAuthenticateRequest request, ActionListener<SamlAuthenticateResponse> listener) {
+        // workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
+        genericExecutor.execute(ActionRunnable.wrap(listener, l -> doExecuteForked(task, request, l)));
+    }
+
+    private void doExecuteForked(Task task, SamlAuthenticateRequest request, ActionListener<SamlAuthenticateResponse> listener) {
         assert Transports.assertNotTransportThread("SAML authentication may involve slow IO/HTTP calls");
         final SamlToken saml = new SamlToken(request.getSaml(), request.getValidRequestIds(), request.getRealm());
         logger.trace("Attempting to authenticate SamlToken [{}]", saml);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlCompleteLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlCompleteLogoutAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.saml.SamlCompleteLogoutRequest;
@@ -34,7 +35,7 @@ public final class TransportSamlCompleteLogoutAction extends HandledTransportAct
 
     @Inject
     public TransportSamlCompleteLogoutAction(TransportService transportService, ActionFilters actionFilters, Realms realms) {
-        super(TYPE.name(), transportService, actionFilters, SamlCompleteLogoutRequest::new, transportService.getThreadPool().generic());
+        super(TYPE.name(), transportService, actionFilters, SamlCompleteLogoutRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
         this.realms = realms;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlCompleteLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlCompleteLogoutAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.saml.SamlCompleteLogoutRequest;
@@ -35,7 +34,7 @@ public final class TransportSamlCompleteLogoutAction extends HandledTransportAct
 
     @Inject
     public TransportSamlCompleteLogoutAction(TransportService transportService, ActionFilters actionFilters, Realms realms) {
-        super(TYPE.name(), transportService, actionFilters, SamlCompleteLogoutRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        super(TYPE.name(), transportService, actionFilters, SamlCompleteLogoutRequest::new, transportService.getThreadPool().generic());
         this.realms = realms;
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -80,7 +79,6 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
     }
 
     private void doExecuteForked(Task task, SamlInvalidateSessionRequest request, ActionListener<SamlInvalidateSessionResponse> listener) {
-        assert Transports.assertNotTransportThread("SAML invalidate session may involve slow IO/HTTP calls");
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         List<SamlRealm> realms = findSamlRealms(this.realms, request.getRealmName(), request.getAssertionConsumerServiceURL());
         if (realms.isEmpty()) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -81,6 +81,7 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
 
     private void doExecuteForked(Task task, SamlInvalidateSessionRequest request, ActionListener<SamlInvalidateSessionResponse> listener) {
         assert Transports.assertNotTransportThread("SAML invalidate session may involve slow IO/HTTP calls");
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         List<SamlRealm> realms = findSamlRealms(this.realms, request.getRealmName(), request.getAssertionConsumerServiceURL());
         if (realms.isEmpty()) {
             listener.onFailure(SamlUtils.samlException("Cannot find any matching realm for [{}]", request));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
@@ -61,7 +60,7 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
             transportService,
             actionFilters,
             SamlInvalidateSessionRequest::new,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE
+            transportService.getThreadPool().generic()
         );
         this.tokenService = tokenService;
         this.realms = realms;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -10,11 +10,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xcontent.ToXContent;
@@ -34,6 +36,7 @@ import org.opensaml.saml.saml2.core.LogoutResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.xpack.security.authc.saml.SamlRealm.findSamlRealms;
@@ -48,6 +51,7 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
     private static final Logger LOGGER = LogManager.getLogger(TransportSamlInvalidateSessionAction.class);
     private final TokenService tokenService;
     private final Realms realms;
+    private final Executor genericExecutor;
 
     @Inject
     public TransportSamlInvalidateSessionAction(
@@ -56,19 +60,26 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
         TokenService tokenService,
         Realms realms
     ) {
+        // TODO replace SAME when removing workaround for https://github.com/elastic/elasticsearch/issues/97916
         super(
             SamlInvalidateSessionAction.NAME,
             transportService,
             actionFilters,
             SamlInvalidateSessionRequest::new,
-            transportService.getThreadPool().generic()
+            transportService.getThreadPool().executor(ThreadPool.Names.SAME)
         );
         this.tokenService = tokenService;
         this.realms = realms;
+        this.genericExecutor = transportService.getThreadPool().generic();
     }
 
     @Override
     protected void doExecute(Task task, SamlInvalidateSessionRequest request, ActionListener<SamlInvalidateSessionResponse> listener) {
+        // workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
+        genericExecutor.execute(ActionRunnable.wrap(listener, l -> doExecuteForked(task, request, l)));
+    }
+
+    private void doExecuteForked(Task task, SamlInvalidateSessionRequest request, ActionListener<SamlInvalidateSessionResponse> listener) {
         assert Transports.assertNotTransportThread("SAML invalidate session may involve slow IO/HTTP calls");
         List<SamlRealm> realms = findSamlRealms(this.realms, request.getRealmName(), request.getAssertionConsumerServiceURL());
         if (realms.isEmpty()) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -68,6 +69,7 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
 
     @Override
     protected void doExecute(Task task, SamlInvalidateSessionRequest request, ActionListener<SamlInvalidateSessionResponse> listener) {
+        assert Transports.assertNotTransportThread("SAML invalidate session may involve slow IO/HTTP calls");
         List<SamlRealm> realms = findSamlRealms(this.realms, request.getRealmName(), request.getAssertionConsumerServiceURL());
         if (realms.isEmpty()) {
             listener.onFailure(SamlUtils.samlException("Cannot find any matching realm for [{}]", request));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -72,6 +72,7 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
 
     private void doExecuteForked(Task task, SamlLogoutRequest request, ActionListener<SamlLogoutResponse> listener) {
         assert Transports.assertNotTransportThread("SAML logout may involve slow IO/HTTP calls");
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         invalidateRefreshToken(request.getRefreshToken(), ActionListener.wrap(ignore -> {
             try {
                 final String token = request.getToken();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutRequest;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutResponse;
@@ -71,7 +70,6 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
     }
 
     private void doExecuteForked(Task task, SamlLogoutRequest request, ActionListener<SamlLogoutResponse> listener) {
-        assert Transports.assertNotTransportThread("SAML logout may involve slow IO/HTTP calls");
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         invalidateRefreshToken(request.getRefreshToken(), ActionListener.wrap(ignore -> {
             try {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -8,11 +8,13 @@ package org.elasticsearch.xpack.security.action.saml;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutAction;
@@ -31,6 +33,7 @@ import org.elasticsearch.xpack.security.authc.saml.SamlUtils;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 /**
  * Transport action responsible for generating a SAML {@code &lt;LogoutRequest&gt;} as a redirect binding URL.
@@ -39,6 +42,7 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
 
     private final Realms realms;
     private final TokenService tokenService;
+    private final Executor genericExecutor;
 
     @Inject
     public TransportSamlLogoutAction(
@@ -47,13 +51,26 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
         Realms realms,
         TokenService tokenService
     ) {
-        super(SamlLogoutAction.NAME, transportService, actionFilters, SamlLogoutRequest::new, transportService.getThreadPool().generic());
+        // TODO replace SAME when removing workaround for https://github.com/elastic/elasticsearch/issues/97916
+        super(
+            SamlLogoutAction.NAME,
+            transportService,
+            actionFilters,
+            SamlLogoutRequest::new,
+            transportService.getThreadPool().executor(ThreadPool.Names.SAME)
+        );
         this.realms = realms;
         this.tokenService = tokenService;
+        this.genericExecutor = transportService.getThreadPool().generic();
     }
 
     @Override
     protected void doExecute(Task task, SamlLogoutRequest request, ActionListener<SamlLogoutResponse> listener) {
+        // workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
+        genericExecutor.execute(ActionRunnable.wrap(listener, l -> doExecuteForked(task, request, l)));
+    }
+
+    private void doExecuteForked(Task task, SamlLogoutRequest request, ActionListener<SamlLogoutResponse> listener) {
         assert Transports.assertNotTransportThread("SAML logout may involve slow IO/HTTP calls");
         invalidateRefreshToken(request.getRefreshToken(), ActionListener.wrap(ignore -> {
             try {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutRequest;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutResponse;
@@ -53,6 +54,7 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
 
     @Override
     protected void doExecute(Task task, SamlLogoutRequest request, ActionListener<SamlLogoutResponse> listener) {
+        assert Transports.assertNotTransportThread("SAML logout may involve slow IO/HTTP calls");
         invalidateRefreshToken(request.getRefreshToken(), ActionListener.wrap(ignore -> {
             try {
                 final String token = request.getToken();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutAction.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.saml.SamlLogoutAction;
@@ -47,7 +46,7 @@ public final class TransportSamlLogoutAction extends HandledTransportAction<Saml
         Realms realms,
         TokenService tokenService
     ) {
-        super(SamlLogoutAction.NAME, transportService, actionFilters, SamlLogoutRequest::new, EsExecutors.DIRECT_EXECUTOR_SERVICE);
+        super(SamlLogoutAction.NAME, transportService, actionFilters, SamlLogoutRequest::new, transportService.getThreadPool().generic());
         this.realms = realms;
         this.tokenService = tokenService;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationRequest;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationResponse;
@@ -69,7 +68,6 @@ public final class TransportSamlPrepareAuthenticationAction extends HandledTrans
         SamlPrepareAuthenticationRequest request,
         ActionListener<SamlPrepareAuthenticationResponse> listener
     ) {
-        assert Transports.assertNotTransportThread("SAML prepare authentication may involve slow IO/HTTP calls");
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         List<SamlRealm> realms = findSamlRealms(this.realms, request.getRealmName(), request.getAssertionConsumerServiceURL());
         if (realms.isEmpty()) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
@@ -70,6 +70,7 @@ public final class TransportSamlPrepareAuthenticationAction extends HandledTrans
         ActionListener<SamlPrepareAuthenticationResponse> listener
     ) {
         assert Transports.assertNotTransportThread("SAML prepare authentication may involve slow IO/HTTP calls");
+        assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         List<SamlRealm> realms = findSamlRealms(this.realms, request.getRealmName(), request.getAssertionConsumerServiceURL());
         if (realms.isEmpty()) {
             listener.onFailure(SamlUtils.samlException("Cannot find any matching realm for [{}]", request));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationAction;
@@ -43,7 +42,7 @@ public final class TransportSamlPrepareAuthenticationAction extends HandledTrans
             transportService,
             actionFilters,
             SamlPrepareAuthenticationRequest::new,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE
+            transportService.getThreadPool().generic()
         );
         this.realms = realms;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlPrepareAuthenticationAction.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationAction;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationRequest;
 import org.elasticsearch.xpack.core.security.action.saml.SamlPrepareAuthenticationResponse;
@@ -53,6 +54,7 @@ public final class TransportSamlPrepareAuthenticationAction extends HandledTrans
         SamlPrepareAuthenticationRequest request,
         ActionListener<SamlPrepareAuthenticationResponse> listener
     ) {
+        assert Transports.assertNotTransportThread("SAML prepare authentication may involve slow IO/HTTP calls");
         List<SamlRealm> realms = findSamlRealms(this.realms, request.getRealmName(), request.getAssertionConsumerServiceURL());
         if (realms.isEmpty()) {
             listener.onFailure(SamlUtils.samlException("Cannot find any matching realm for [{}]", request));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlRealm.java
@@ -110,6 +110,7 @@ import javax.net.ssl.X509KeyManager;
 
 import static org.elasticsearch.common.Strings.collectionToCommaDelimitedString;
 import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.transport.Transports.assertNotTransportThread;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.CLOCK_SKEW;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.DN_ATTRIBUTE;
 import static org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings.ENCRYPTION_KEY_ALIAS;
@@ -746,6 +747,7 @@ public final class SamlRealm extends Realm implements Releasable {
 
         @Override
         protected byte[] fetchMetadata() throws ResolverException {
+            assert assertNotTransportThread("fetching SAML metadata from a URL");
             try {
                 return AccessController.doPrivileged(
                     (PrivilegedExceptionAction<byte[]>) () -> PrivilegedHTTPMetadataResolver.super.fetchMetadata()
@@ -767,7 +769,13 @@ public final class SamlRealm extends Realm implements Releasable {
 
         final String entityId = require(config, IDP_ENTITY_ID);
         final Path path = config.env().configFile().resolve(metadataPath);
-        final FilesystemMetadataResolver resolver = new FilesystemMetadataResolver(path.toFile());
+        final FilesystemMetadataResolver resolver = new FilesystemMetadataResolver(path.toFile()) {
+            @Override
+            protected byte[] fetchMetadata() throws ResolverException {
+                assert assertNotTransportThread("fetching SAML metadata from a file");
+                return super.fetchMetadata();
+            }
+        };
 
         for (var httpSetting : List.of(IDP_METADATA_HTTP_REFRESH, IDP_METADATA_HTTP_MIN_REFRESH, IDP_METADATA_HTTP_FAIL_ON_ERROR)) {
             if (config.hasSetting(httpSetting)) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionActionTests.java
@@ -55,9 +55,9 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.DeprecationHandler;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -94,7 +94,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -147,8 +146,9 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
             .put(getFullSettingKey(realmId, RealmSettings.ORDER_SETTING), 0)
             .build();
 
+        final TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final ThreadContext threadContext = new ThreadContext(settings);
-        final ThreadPool threadPool = mock(ThreadPool.class);
+        final ThreadPool threadPool = transportService.getThreadPool();
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         AuthenticationTestHelper.builder()
             .user(new User("kibana"))
@@ -290,15 +290,6 @@ public class TransportSamlInvalidateSessionActionTests extends SamlTestCase {
             clusterService
         );
 
-        final TransportService transportService = new TransportService(
-            Settings.EMPTY,
-            mock(Transport.class),
-            threadPool,
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-            x -> null,
-            null,
-            Collections.emptySet()
-        );
         final Realms realms = mock(Realms.class);
         action = new TransportSamlInvalidateSessionAction(transportService, mock(ActionFilters.class), tokenService, realms);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/saml/TransportSamlLogoutActionTests.java
@@ -37,8 +37,8 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackSettings;
@@ -69,7 +69,6 @@ import org.opensaml.saml.saml2.core.NameID;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -116,8 +115,9 @@ public class TransportSamlLogoutActionTests extends SamlTestCase {
             .put(getFullSettingKey(realmIdentifier, RealmSettings.ORDER_SETTING), 0)
             .build();
 
+        final TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
         final ThreadContext threadContext = new ThreadContext(settings);
-        final ThreadPool threadPool = mock(ThreadPool.class);
+        final ThreadPool threadPool = transportService.getThreadPool();
         when(threadPool.getThreadContext()).thenReturn(threadContext);
         AuthenticationTestHelper.builder()
             .user(new User("kibana"))
@@ -219,15 +219,6 @@ public class TransportSamlLogoutActionTests extends SamlTestCase {
             clusterService
         );
 
-        final TransportService transportService = new TransportService(
-            Settings.EMPTY,
-            mock(Transport.class),
-            threadPool,
-            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
-            x -> null,
-            null,
-            Collections.emptySet()
-        );
         final Realms realms = mock(Realms.class);
         action = new TransportSamlLogoutAction(transportService, mock(ActionFilters.class), realms, tokenService);
 

--- a/x-pack/qa/saml-idp-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticationIT.java
+++ b/x-pack/qa/saml-idp-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticationIT.java
@@ -82,6 +82,7 @@ import javax.net.ssl.X509ExtendedTrustManager;
 import static java.util.Map.entry;
 import static org.elasticsearch.common.xcontent.XContentHelper.convertToMap;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
@@ -251,19 +252,23 @@ public class SamlAuthenticationIT extends ESRestTestCase {
      * </ol>
      */
     public void testLoginUserWithSamlRoleMapping() throws Exception {
-        // this realm name comes from the config in build.gradle
         final Tuple<String, String> authTokens = loginViaSaml("shibboleth");
         verifyElasticsearchAccessTokenForRoleMapping(authTokens.v1());
-        final String accessToken = verifyElasticsearchRefreshToken(authTokens.v2());
+        final Tuple<String, String> newAuthTokens = verifyElasticsearchRefreshToken(authTokens.v2());
+        final String accessToken = newAuthTokens.v1();
         verifyElasticsearchAccessTokenForRoleMapping(accessToken);
+        logoutSaml(newAuthTokens);
+        verifyElasticsearchAccessTokenInvalidated(accessToken);
     }
 
     public void testLoginUserWithAuthorizingRealm() throws Exception {
-        // this realm name comes from the config in build.gradle
         final Tuple<String, String> authTokens = loginViaSaml("shibboleth_native");
         verifyElasticsearchAccessTokenForAuthorizingRealms(authTokens.v1());
-        final String accessToken = verifyElasticsearchRefreshToken(authTokens.v2());
+        final Tuple<String, String> newAuthTokens = verifyElasticsearchRefreshToken(authTokens.v2());
+        final String accessToken = newAuthTokens.v1();
         verifyElasticsearchAccessTokenForAuthorizingRealms(accessToken);
+        logoutSaml(newAuthTokens);
+        verifyElasticsearchAccessTokenInvalidated(accessToken);
     }
 
     public void testLoginWithWrongRealmFails() throws Exception {
@@ -340,6 +345,11 @@ public class SamlAuthenticationIT extends ESRestTestCase {
         assertThat(metadata.get("is_native"), equalTo(true));
     }
 
+    private void verifyElasticsearchAccessTokenInvalidated(String accessToken) {
+        var e = expectThrows(ResponseException.class, () -> callAuthenticateApiUsingAccessToken(accessToken));
+        assertThat(e.getMessage(), containsString("The access token expired"));
+    }
+
     private Map<String, Object> callAuthenticateApiUsingAccessToken(String accessToken) throws IOException {
         Request request = new Request("GET", "/_security/_authenticate");
         RequestOptions.Builder options = request.getOptions().toBuilder();
@@ -348,7 +358,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
         return entityAsMap(client().performRequest(request));
     }
 
-    private String verifyElasticsearchRefreshToken(String refreshToken) throws IOException {
+    private Tuple<String, String> verifyElasticsearchRefreshToken(String refreshToken) throws IOException {
         final Map<String, ?> body = Map.of("grant_type", "refresh_token", "refresh_token", refreshToken);
         final Response response = client().performRequest(buildRequest("POST", "/_security/oauth2/token", body, kibanaAuth()));
         assertOK(response);
@@ -361,7 +371,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
         final Object accessToken = result.get("access_token");
         assertThat(accessToken, notNullValue());
         assertThat(accessToken, instanceOf(String.class));
-        return (String) accessToken;
+        return Tuple.tuple((String) accessToken, (String) newRefreshToken);
     }
 
     /**
@@ -460,6 +470,13 @@ public class SamlAuthenticationIT extends ESRestTestCase {
             }
             return Map.of();
         }
+    }
+
+    private Map<String, Object> logoutSaml(final Tuple<String, String> authTokens) throws IOException {
+        final Map<String, Object> body = Map.of("token", authTokens.v1(), "refresh_token", authTokens.v2());
+        final Response response = client().performRequest(buildRequest("POST", "/_security/saml/logout", body, kibanaAuth()));
+        assertHttpOk(response.getStatusLine());
+        return parseResponseAsMap(response.getEntity());
     }
 
     /**


### PR DESCRIPTION
This PR changes SAML transport actions to use `GENERIC` executor 
in order to avoid executing potentially slow and blocking IO/HTTP 
operations on the `transport_worker` threads.

Fixes https://github.com/elastic/elasticsearch/issues/104962