### PR TITLE
[Transform] Do not log warning when triggering an `ABORTING` transform

### DIFF
--- a/docs/changelog/105234.yaml
+++ b/docs/changelog/105234.yaml
@@ -1,0 +1,6 @@
+pr: 105234
+summary: Do not log warning when triggering an `ABORTING` transform
+area: Transform
+type: bug
+issues:
+ - 105233

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -444,11 +444,12 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
                 return;
             }
 
-            // ignore trigger if indexer is running or completely stopped
+            // ignore trigger if indexer is running, stopping, stopped or aborting
             IndexerState indexerState = getIndexer().getState();
             if (IndexerState.INDEXING.equals(indexerState)
                 || IndexerState.STOPPING.equals(indexerState)
-                || IndexerState.STOPPED.equals(indexerState)) {
+                || IndexerState.STOPPED.equals(indexerState)
+                || IndexerState.ABORTING.equals(indexerState)) {
                 logger.debug("[{}] indexer for transform has state [{}]. Ignoring trigger.", getTransformId(), indexerState);
                 return;
             }
@@ -575,7 +576,12 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
     }
 
     void initializeIndexer(ClientTransformIndexerBuilder indexerBuilder) {
-        indexer.set(indexerBuilder.build(getThreadPool(), context));
+        initializeIndexer(indexerBuilder.build(getThreadPool(), context));
+    }
+
+    /** Visible for testing. */
+    void initializeIndexer(ClientTransformIndexer indexer) {
+        this.indexer.set(indexer);
     }
 
     ThreadPool getThreadPool() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -51,6 +51,7 @@ import org.elasticsearch.xpack.transform.persistence.InMemoryTransformConfigMana
 import org.elasticsearch.xpack.transform.transforms.scheduling.TransformScheduler;
 import org.junit.After;
 import org.junit.Before;
+import org.mockito.verification.VerificationMode;
 
 import java.time.Clock;
 import java.util.Collections;
@@ -61,6 +62,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -68,9 +70,12 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class TransformTaskTests extends ESTestCase {
@@ -521,6 +526,85 @@ public class TransformTaskTests extends ESTestCase {
         assertThat(checkpointingInfo.getNext().getCheckpoint(), equalTo(6L));
         assertThat(checkpointingInfo.getNext().getPosition(), sameInstance(position));
         assertThat(checkpointingInfo.getNext().getCheckpointProgress(), sameInstance(progress));
+    }
+
+    public void testInitializeIndexerWhenAlreadyInitialized() {
+        var transformTask = createTransformTask(
+            TransformConfigTests.randomTransformConfigWithoutHeaders(),
+            MockTransformAuditor.createMockAuditor()
+        );
+        transformTask.initializeIndexer(mock(ClientTransformIndexerBuilder.class));
+        IllegalStateException e = expectThrows(
+            IllegalStateException.class,
+            () -> transformTask.initializeIndexer(mock(ClientTransformIndexerBuilder.class))
+        );
+        assertThat(e.getMessage(), containsString("The object cannot be set twice!"));
+    }
+
+    public void testTriggeredIsNoOpWhenTransformIdMismatch() {
+        var transformId = randomAlphaOfLengthBetween(1, 10);
+        var transformTask = createTransformTask(
+            TransformConfigTests.randomTransformConfigWithoutHeaders(transformId),
+            MockTransformAuditor.createMockAuditor()
+        );
+        transformTask.triggered(new TransformScheduler.Event("not-" + transformId, randomNonNegativeLong(), randomNonNegativeLong()));
+    }
+
+    public void testTriggeredIsNoOpWhenIndexerIsUninitialized() {
+        var transformId = randomAlphaOfLengthBetween(1, 10);
+        var transformTask = createTransformTask(
+            TransformConfigTests.randomTransformConfigWithoutHeaders(transformId),
+            MockTransformAuditor.createMockAuditor()
+        );
+        transformTask.triggered(new TransformScheduler.Event(transformId, randomNonNegativeLong(), randomNonNegativeLong()));
+    }
+
+    public void testTriggeredIsNoOpWhenStateIsWrong() {
+        testTriggered(TransformTaskState.STOPPED, IndexerState.INDEXING, never());
+        testTriggered(TransformTaskState.STOPPED, IndexerState.STOPPING, never());
+        testTriggered(TransformTaskState.STOPPED, IndexerState.STOPPED, never());
+        testTriggered(TransformTaskState.STOPPED, IndexerState.ABORTING, never());
+        testTriggered(TransformTaskState.STOPPED, IndexerState.STARTED, never());
+        testTriggered(TransformTaskState.FAILED, IndexerState.INDEXING, never());
+        testTriggered(TransformTaskState.FAILED, IndexerState.STOPPING, never());
+        testTriggered(TransformTaskState.FAILED, IndexerState.STOPPED, never());
+        testTriggered(TransformTaskState.FAILED, IndexerState.ABORTING, never());
+        testTriggered(TransformTaskState.FAILED, IndexerState.STARTED, never());
+        testTriggered(TransformTaskState.STARTED, IndexerState.INDEXING, never());
+        testTriggered(TransformTaskState.STARTED, IndexerState.STOPPING, never());
+        testTriggered(TransformTaskState.STARTED, IndexerState.STOPPED, never());
+        testTriggered(TransformTaskState.STARTED, IndexerState.ABORTING, never());
+    }
+
+    public void testTriggeredActuallyTriggersIndexer() {
+        testTriggered(TransformTaskState.STARTED, IndexerState.STARTED, times(1));
+    }
+
+    private void testTriggered(TransformTaskState taskState, IndexerState indexerState, VerificationMode indexerVerificationMode) {
+        String transformId = randomAlphaOfLengthBetween(1, 10);
+        TransformState transformState = new TransformState(taskState, indexerState, null, 0L, "because", null, null, false, null);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        TransformAuditor auditor = mock(TransformAuditor.class);
+        TransformTask transformTask = new TransformTask(
+            42,
+            "some_type",
+            "some_action",
+            TaskId.EMPTY_TASK_ID,
+            createTransformTaskParams(transformId),
+            transformState,
+            new TransformScheduler(mock(Clock.class), threadPool, Settings.EMPTY, TimeValue.ZERO),
+            auditor,
+            threadPool,
+            Collections.emptyMap()
+        );
+
+        ClientTransformIndexer indexer = mock(ClientTransformIndexer.class);
+        when(indexer.getState()).thenReturn(indexerState);
+        transformTask.initializeIndexer(indexer);
+        transformTask.triggered(new TransformScheduler.Event(transformId, randomNonNegativeLong(), randomNonNegativeLong()));
+
+        verify(indexer, indexerVerificationMode).maybeTriggerAsyncJob(anyLong());
+        verifyNoInteractions(auditor, threadPool);
     }
 
     private static TransformTaskParams createTransformTaskParams(String transformId) {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -547,7 +547,10 @@ public class TransformTaskTests extends ESTestCase {
             TransformConfigTests.randomTransformConfigWithoutHeaders(transformId),
             MockTransformAuditor.createMockAuditor()
         );
+        var indexer = mock(ClientTransformIndexer.class);
+        transformTask.initializeIndexer(indexer);
         transformTask.triggered(new TransformScheduler.Event("not-" + transformId, randomNonNegativeLong(), randomNonNegativeLong()));
+        verifyNoInteractions(indexer);
     }
 
     public void testTriggeredIsNoOpWhenIndexerIsUninitialized() {


### PR DESCRIPTION
When transform scheduler is trying to trigger a transform which indexer is already in `ABORTING` state, the transform is not triggered but warnings are logged in an excessive number.

This PR prevents the warnings from being logged by exiting early if the indexer is in `ABORTING` state.
Additionally, this PR adds a bunch of unit tests for `initializeIndexer` and `triggered` methods.

Closes https://github.com/elastic/elasticsearch/issues/105233