### PR TITLE
Replace generic HashSet / HashMap with more efficient EnumSet / EnumMap

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportService.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/DockerSupportService.java
@@ -25,8 +25,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -75,7 +75,7 @@ public abstract class DockerSupportService implements BuildService<DockerSupport
             Version version = null;
             boolean isVersionHighEnough = false;
             boolean isComposeAvailable = false;
-            Set<Architecture> supportedArchitectures = new HashSet<>();
+            Set<Architecture> supportedArchitectures = EnumSet.noneOf(Architecture.class);
 
             // Check if the Docker binary exists
             final Optional<String> dockerBinary = getDockerPath();

--- a/build-tools/src/main/java/org/elasticsearch/gradle/OS.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/OS.java
@@ -7,10 +7,10 @@
  */
 package org.elasticsearch.gradle;
 
-import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public enum OS {
@@ -58,8 +58,7 @@ public enum OS {
         }
 
         public T supply() {
-            HashSet<OS> missingOS = new HashSet<>(Arrays.asList(OS.values()));
-            missingOS.removeAll(conditions.keySet());
+            Set<OS> missingOS = EnumSet.complementOf(EnumSet.copyOf(conditions.keySet()));
             if (missingOS.isEmpty() == false) {
                 throw new IllegalArgumentException("No condition specified for " + missingOS);
             }

--- a/build-tools/src/main/java/org/elasticsearch/gradle/OS.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/OS.java
@@ -7,8 +7,8 @@
  */
 package org.elasticsearch.gradle;
 
+import java.util.EnumMap;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -34,7 +34,7 @@ public enum OS {
 
     public static class Conditional<T> {
 
-        private final Map<OS, Supplier<T>> conditions = new HashMap<>();
+        private final Map<OS, Supplier<T>> conditions = new EnumMap<>(OS.class);
 
         public Conditional<T> onWindows(Supplier<T> supplier) {
             conditions.put(WINDOWS, supplier);

--- a/build-tools/src/main/java/org/elasticsearch/gradle/OS.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/OS.java
@@ -58,7 +58,8 @@ public enum OS {
         }
 
         public T supply() {
-            Set<OS> missingOS = EnumSet.complementOf(EnumSet.copyOf(conditions.keySet()));
+            Set<OS> missingOS = EnumSet.allOf(OS.class);
+            missingOS.removeAll(conditions.keySet());
             if (missingOS.isEmpty() == false) {
                 throw new IllegalArgumentException("No condition specified for " + missingOS);
             }

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/NamedXContentRegistry.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/NamedXContentRegistry.java
@@ -12,6 +12,7 @@ import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.RestApiVersion;
 
 import java.io.IOException;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,7 +96,7 @@ public class NamedXContentRegistry {
             return emptyMap();
         }
 
-        Map<RestApiVersion, Map<Class<?>, Map<String, Entry>>> newRegistry = new HashMap<>();
+        Map<RestApiVersion, Map<Class<?>, Map<String, Entry>>> newRegistry = new EnumMap<>(RestApiVersion.class);
         for (Entry entry : entries) {
             for (String name : entry.name.getAllNamesIncludedDeprecated()) {
                 if (RestApiVersion.minimumSupported().matches(entry.restApiCompatibility)) {

--- a/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriPartOfSpeechStopFilterFactory.java
+++ b/plugins/analysis-nori/src/main/java/org/elasticsearch/plugin/analysis/nori/NoriPartOfSpeechStopFilterFactory.java
@@ -17,7 +17,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.analysis.AbstractTokenFilterFactory;
 import org.elasticsearch.index.analysis.Analysis;
 
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
@@ -36,7 +36,7 @@ public class NoriPartOfSpeechStopFilterFactory extends AbstractTokenFilterFactor
     }
 
     static Set<POS.Tag> resolvePOSList(List<String> tagList) {
-        Set<POS.Tag> stopTags = new HashSet<>();
+        Set<POS.Tag> stopTags = EnumSet.noneOf(POS.Tag.class);
         for (String tag : tagList) {
             stopTags.add(POS.resolveTag(tag));
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -20,7 +20,7 @@ import org.elasticsearch.tasks.TaskId;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -64,7 +64,7 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
         public static Feature[] fromRequest(RestRequest request) {
             if (request.hasParam("features")) {
                 String[] featureNames = request.param("features").split(",");
-                Set<Feature> features = new HashSet<>();
+                Set<Feature> features = EnumSet.noneOf(Feature.class);
                 List<String> invalidFeatures = new ArrayList<>();
                 for (int k = 0; k < featureNames.length; k++) {
                     try {

--- a/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthPeriodicLogger.java
@@ -33,8 +33,8 @@ import org.elasticsearch.telemetry.metric.MeterRegistry;
 
 import java.io.Closeable;
 import java.time.Clock;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -198,7 +198,7 @@ public class HealthPeriodicLogger implements ClusterStateListener, Closeable, Sc
         this.clock = Clock.systemUTC();
         this.pollInterval = POLL_INTERVAL_SETTING.get(settings);
         this.enabled = ENABLED_SETTING.get(settings);
-        this.outputModes = new HashSet<>(OUTPUT_MODE_SETTING.get(settings));
+        this.outputModes = EnumSet.copyOf(OUTPUT_MODE_SETTING.get(settings));
         this.meterRegistry = meterRegistry;
         this.metricWriter = metricWriter == null ? LongGaugeMetric::set : metricWriter;
         this.logWriter = logWriter == null ? logger::info : logWriter;
@@ -388,7 +388,7 @@ public class HealthPeriodicLogger implements ClusterStateListener, Closeable, Sc
     }
 
     private void updateOutputModes(List<OutputMode> newMode) {
-        this.outputModes = new HashSet<>(newMode);
+        this.outputModes = EnumSet.copyOf(newMode);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -145,9 +145,9 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
         private final Set<String> blockedIndices;
         private final List<DiscoveryNode> dataNodes = new ArrayList<>();
         // In this context a master node, is a master node that cannot contain data.
-        private final Map<HealthStatus, List<DiscoveryNode>> masterNodes = new HashMap<>();
+        private final Map<HealthStatus, List<DiscoveryNode>> masterNodes = new EnumMap<>(HealthStatus.class);
         // In this context "other" nodes are nodes that cannot contain data and are not masters.
-        private final Map<HealthStatus, List<DiscoveryNode>> otherNodes = new HashMap<>();
+        private final Map<HealthStatus, List<DiscoveryNode>> otherNodes = new EnumMap<>(HealthStatus.class);
         private final Set<DiscoveryNodeRole> affectedRoles = new HashSet<>();
         private final Set<String> indicesAtRisk;
         private final HealthStatus healthStatus;
@@ -402,7 +402,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             Map<String, DiskHealthInfo> diskHealthInfoMap,
             ClusterState clusterState
         ) {
-            Map<HealthStatus, Integer> counts = new HashMap<>();
+            Map<HealthStatus, Integer> counts = new EnumMap<>(HealthStatus.class);
             for (HealthStatus healthStatus : HealthStatus.values()) {
                 counts.put(healthStatus, 0);
             }

--- a/server/src/main/java/org/elasticsearch/http/CorsHandler.java
+++ b/server/src/main/java/org/elasticsearch/http/CorsHandler.java
@@ -39,6 +39,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -340,7 +341,7 @@ public class CorsHandler {
             private final boolean anyOrigin;
             private boolean allowCredentials = false;
             long maxAge;
-            private final Set<RestRequest.Method> requestMethods = new HashSet<>();
+            private final Set<RestRequest.Method> requestMethods = EnumSet.noneOf(RestRequest.Method.class);
             private final Set<String> requestHeaders = new HashSet<>();
             private final Set<String> accessControlExposeHeaders = new HashSet<>();
 

--- a/server/src/main/java/org/elasticsearch/rest/MethodHandlers.java
+++ b/server/src/main/java/org/elasticsearch/rest/MethodHandlers.java
@@ -12,7 +12,7 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.http.HttpRouteStats;
 import org.elasticsearch.http.HttpRouteStatsTracker;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,12 +28,7 @@ final class MethodHandlers {
 
     MethodHandlers(String path) {
         this.path = path;
-
-        // by setting the loadFactor to 1, these maps are resized only when they *must* be, and the vast majority of these
-        // maps contain only 1 or 2 entries anyway, so most of these maps are never resized at all and waste only 1 or 0
-        // array references, while those few that contain 3 or 4 elements will have been resized just once and will still
-        // waste only 1 or 0 array references
-        this.methodHandlers = new HashMap<>(2, 1);
+        this.methodHandlers = new EnumMap<>(RestRequest.Method.class);
     }
 
     public String getPath() {
@@ -45,10 +40,7 @@ final class MethodHandlers {
      * does not allow replacing the handler for an already existing method.
      */
     MethodHandlers addMethod(RestRequest.Method method, RestApiVersion version, RestHandler handler) {
-        RestHandler existing = methodHandlers
-            // same sizing notes as 'methodHandlers' above, except that having a size here that's more than 1 is vanishingly
-            // rare, so an initialCapacity of 1 with a loadFactor of 1 is perfect
-            .computeIfAbsent(method, k -> new HashMap<>(1, 1))
+        RestHandler existing = methodHandlers.computeIfAbsent(method, k -> new EnumMap<>(RestApiVersion.class))
             .putIfAbsent(version, handler);
         if (existing != null) {
             throw new IllegalArgumentException("Cannot replace existing handler for [" + path + "] for method: " + method);

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -51,7 +51,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -734,7 +734,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
      * Get the valid set of HTTP methods for a REST request.
      */
     private Set<RestRequest.Method> getValidHandlerMethodSet(String rawPath) {
-        Set<RestRequest.Method> validMethods = new HashSet<>();
+        Set<RestRequest.Method> validMethods = EnumSet.noneOf(RestRequest.Method.class);
         Iterator<MethodHandlers> allHandlers = getAllHandlers(null, rawPath);
         while (allHandlers.hasNext()) {
             final MethodHandlers methodHandlers = allHandlers.next();

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
@@ -17,6 +17,7 @@ import org.elasticsearch.test.cluster.util.Version;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -33,7 +34,7 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
     private final Map<String, String> environment = new HashMap<>();
     private final Set<String> modules = new HashSet<>();
     private final Set<String> plugins = new HashSet<>();
-    private final Set<FeatureFlag> features = new HashSet<>();
+    private final Set<FeatureFlag> features = EnumSet.noneOf(FeatureFlag.class);
     private final List<SettingsProvider> keystoreProviders = new ArrayList<>();
     private final Map<String, String> keystoreSettings = new HashMap<>();
     private final Map<String, Resource> keystoreFiles = new HashMap<>();

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/OS.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/OS.java
@@ -8,10 +8,10 @@
 
 package org.elasticsearch.test.cluster.util;
 
-import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -60,8 +60,7 @@ public enum OS {
         }
 
         T supply() {
-            HashSet<OS> missingOS = new HashSet<>(Arrays.asList(OS.values()));
-            missingOS.removeAll(conditions.keySet());
+            Set<OS> missingOS = EnumSet.complementOf(EnumSet.copyOf(conditions.keySet()));
             if (missingOS.isEmpty() == false) {
                 throw new IllegalArgumentException("No condition specified for " + missingOS);
             }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/OS.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/OS.java
@@ -60,7 +60,8 @@ public enum OS {
         }
 
         T supply() {
-            Set<OS> missingOS = EnumSet.complementOf(EnumSet.copyOf(conditions.keySet()));
+            Set<OS> missingOS = EnumSet.allOf(OS.class);
+            missingOS.removeAll(conditions.keySet());
             if (missingOS.isEmpty() == false) {
                 throw new IllegalArgumentException("No condition specified for " + missingOS);
             }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/OS.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/OS.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.test.cluster.util;
 
+import java.util.EnumMap;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -36,7 +36,7 @@ public enum OS {
 
     public static class Conditional<T> {
 
-        private final Map<OS, Supplier<? extends T>> conditions = new HashMap<>();
+        private final Map<OS, Supplier<? extends T>> conditions = new EnumMap<>(OS.class);
 
         public Conditional<T> onWindows(Supplier<? extends T> supplier) {
             conditions.put(WINDOWS, supplier);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchUsageTransportAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchUsageTransportAction.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.application.EnterpriseSearchFeatureSetUsage;
 
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.IntSummaryStatistics;
 import java.util.List;
@@ -224,7 +225,7 @@ public class EnterpriseSearchUsageTransportAction extends XPackUsageFeatureTrans
         List<QueryRulesetListItem> results = response.queryPage().results();
         IntSummaryStatistics ruleStats = results.stream().mapToInt(QueryRulesetListItem::ruleTotalCount).summaryStatistics();
 
-        Map<QueryRuleCriteriaType, Integer> criteriaTypeCountMap = new HashMap<>();
+        Map<QueryRuleCriteriaType, Integer> criteriaTypeCountMap = new EnumMap<>(QueryRuleCriteriaType.class);
         results.stream()
             .flatMap(result -> result.criteriaTypeToCountMap().entrySet().stream())
             .forEach(entry -> criteriaTypeCountMap.merge(entry.getKey(), entry.getValue(), Integer::sum));

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
@@ -43,7 +43,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -340,7 +340,7 @@ public class QueryRulesIndexService {
         @SuppressWarnings("unchecked")
         final List<LinkedHashMap<?, ?>> rules = ((List<LinkedHashMap<?, ?>>) sourceMap.get(QueryRuleset.RULES_FIELD.getPreferredName()));
         final int numRules = rules.size();
-        final Map<QueryRuleCriteriaType, Integer> queryRuleCriteriaTypeToCountMap = new HashMap<>();
+        final Map<QueryRuleCriteriaType, Integer> queryRuleCriteriaTypeToCountMap = new EnumMap<>(QueryRuleCriteriaType.class);
         for (LinkedHashMap<?, ?> rule : rules) {
             @SuppressWarnings("unchecked")
             List<LinkedHashMap<?, ?>> criteriaList = ((List<LinkedHashMap<?, ?>>) rule.get(QueryRule.CRITERIA_FIELD.getPreferredName()));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearningUsageTransportAction.java
@@ -57,6 +57,7 @@ import org.elasticsearch.xpack.ml.job.JobManagerHolder;
 
 import java.time.Instant;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -273,18 +274,18 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         StatsAccumulator allJobsModelSizeStats = new StatsAccumulator();
         ForecastStats allJobsForecastStats = new ForecastStats();
 
-        Map<JobState, Counter> jobCountByState = new HashMap<>();
-        Map<JobState, StatsAccumulator> detectorStatsByState = new HashMap<>();
-        Map<JobState, StatsAccumulator> modelSizeStatsByState = new HashMap<>();
-        Map<JobState, ForecastStats> forecastStatsByState = new HashMap<>();
-        Map<JobState, Map<String, Long>> createdByByState = new HashMap<>();
+        Map<JobState, Counter> jobCountByState = new EnumMap<>(JobState.class);
+        Map<JobState, StatsAccumulator> detectorStatsByState = new EnumMap<>(JobState.class);
+        Map<JobState, StatsAccumulator> modelSizeStatsByState = new EnumMap<>(JobState.class);
+        Map<JobState, ForecastStats> forecastStatsByState = new EnumMap<>(JobState.class);
+        Map<JobState, Map<String, Long>> createdByByState = new EnumMap<>(JobState.class);
 
         List<GetJobsStatsAction.Response.JobStats> jobsStats = response.getResponse().results();
         Map<String, Job> jobMap = jobs.stream().collect(Collectors.toMap(Job::getId, item -> item));
         Map<String, Long> allJobsCreatedBy = jobs.stream()
             .map(MachineLearningUsageTransportAction::jobCreatedBy)
             .collect(Collectors.groupingBy(item -> item, Collectors.counting()));
-        ;
+
         for (GetJobsStatsAction.Response.JobStats jobStats : jobsStats) {
             Job job = jobMap.get(jobStats.getJobId());
             if (job == null) {
@@ -354,7 +355,7 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
     }
 
     private static void addDatafeedsUsage(GetDatafeedsStatsAction.Response response, Map<String, Object> datafeedsUsage) {
-        Map<DatafeedState, Counter> datafeedCountByState = new HashMap<>();
+        Map<DatafeedState, Counter> datafeedCountByState = new EnumMap<>(DatafeedState.class);
 
         List<GetDatafeedsStatsAction.Response.DatafeedStats> datafeedsStats = response.getResponse().results();
         for (GetDatafeedsStatsAction.Response.DatafeedStats datafeedStats : datafeedsStats) {
@@ -380,7 +381,7 @@ public class MachineLearningUsageTransportAction extends XPackUsageFeatureTransp
         GetDataFrameAnalyticsStatsAction.Response response,
         Map<String, Object> dataframeAnalyticsUsage
     ) {
-        Map<DataFrameAnalyticsState, Counter> dataFrameAnalyticsStateCounterMap = new HashMap<>();
+        Map<DataFrameAnalyticsState, Counter> dataFrameAnalyticsStateCounterMap = new EnumMap<>(DataFrameAnalyticsState.class);
 
         StatsAccumulator memoryUsagePeakBytesStats = new StatsAccumulator();
         for (GetDataFrameAnalyticsStatsAction.Response.Stats stats : response.getResponse().results()) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
@@ -46,7 +46,7 @@ import org.elasticsearch.xpack.transform.transforms.TransformNodes;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
 
 public class TransportUpgradeTransformsAction extends TransportMasterNodeAction<Request, Response> {
@@ -223,7 +223,7 @@ public class TransportUpgradeTransformsAction extends TransportMasterNodeAction<
                 return;
             }
 
-            Map<UpdateResult.Status, Long> updatesByStatus = new HashMap<>();
+            Map<UpdateResult.Status, Long> updatesByStatus = new EnumMap<>(UpdateResult.Status.class);
             updatesByStatus.put(UpdateResult.Status.NONE, totalAndIds.v1() - totalAndIds.v2().size());
 
             Deque<String> ids = new ArrayDeque<>(totalAndIds.v2());

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/WeekTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/WeekTimes.java
@@ -158,7 +158,7 @@ public class WeekTimes implements Times {
 
     public static class Builder {
 
-        private final Set<DayOfWeek> days = new HashSet<>();
+        private final Set<DayOfWeek> days = EnumSet.noneOf(DayOfWeek.class);
         private final Set<DayTimes> times = new HashSet<>();
 
         private Builder() {}

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/trigger/schedule/support/YearTimes.java
@@ -206,7 +206,7 @@ public final class YearTimes implements Times {
 
     public static class Builder {
 
-        private final Set<Month> months = new HashSet<>();
+        private final Set<Month> months = EnumSet.noneOf(Month.class);
         private final Set<Integer> days = new HashSet<>();
         private final Set<DayTimes> times = new HashSet<>();
 


### PR DESCRIPTION
`EnumSet` / `EnumMap` are faster and more memory efficient alternatives to generic `HashSet` / `HashMap` with enumerable keys.