### PR TITLE
Assign index.downsample.interval setting when downsample index gets created

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1276,8 +1276,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         INDEX_DOWNSAMPLE_INTERVAL_KEY,
         "",
         Property.IndexScope,
-        Property.InternalIndex,
-        Property.PrivateIndex
+        Property.InternalIndex
     );
 
     // LIFECYCLE_NAME is here an as optimization, see LifecycleSettings.LIFECYCLE_NAME and


### PR DESCRIPTION
This avoids keeping downsamplingInterval field around. Additionally, the downsample interval is known when downsample interval is invoked and doesn't change.