### PR TITLE
Change the rest client configuration in the LazyRolloverDataStreamIT

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecyclePermissionsRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecyclePermissionsRestIT.java
@@ -58,7 +58,7 @@ public class DataStreamLifecyclePermissionsRestIT extends ESRestTestCase {
 
     @Override
     protected Settings restClientSettings() {
-        // If this test is running in a test frameowrk that handles its own authorization, we don't want to overwrite it.
+        // If this test is running in a test framework that handles its own authorization, we don't want to overwrite it.
         if (super.restClientSettings().keySet().contains(ThreadContext.PREFIX + ".Authorization")) {
             return super.restClientSettings();
         } else {


### PR DESCRIPTION
This PR fixes the simple user client configuration to be able to demonstrate in the test the effect of the privileges in the lazy rollover.

We fixed by using a dedicated client that is initialised in every test instead of using the default clients the test suite provides.