### PR TITLE
Fix a few downsample api issues

### DIFF
--- a/docs/changelog/105228.yaml
+++ b/docs/changelog/105228.yaml
@@ -1,0 +1,6 @@
+pr: 105228
+summary: Downsampling better handle if source index isn't allocated and fix bug in
+  retrieving last processed tsid
+area: Downsampling
+type: bug
+issues: []

--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DataStreamLifecycleDownsampleDisruptionIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.downsample.DownsampleConfig;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
@@ -56,7 +57,6 @@ public class DataStreamLifecycleDownsampleDisruptionIT extends ESIntegTestCase {
         return settings.build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99520")
     @TestLogging(value = "org.elasticsearch.datastreams.lifecycle:TRACE", reason = "debugging")
     public void testDataStreamLifecycleDownsampleRollingRestart() throws Exception {
         final InternalTestCluster cluster = internalCluster();
@@ -133,12 +133,13 @@ public class DataStreamLifecycleDownsampleDisruptionIT extends ESIntegTestCase {
         );
         ensureStableCluster(cluster.numDataAndMasterNodes());
 
-        final String targetIndex = "downsample-5m-" + sourceIndex;
+        // if the source index has already been downsampled and moved into the data stream just use its name directly
+        final String targetIndex = sourceIndex.startsWith("downsample-5m-") ? sourceIndex : "downsample-5m-" + sourceIndex;
         assertBusy(() -> {
             try {
                 GetSettingsResponse getSettingsResponse = client().admin()
                     .indices()
-                    .getSettings(new GetSettingsRequest().indices(targetIndex))
+                    .getSettings(new GetSettingsRequest().indices(targetIndex).indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN))
                     .actionGet();
                 Settings indexSettings = getSettingsResponse.getIndexToSettings().get(targetIndex);
                 assertThat(indexSettings, is(notNullValue()));

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutor.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutor.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.downsample;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -26,6 +27,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotFoundException;
@@ -68,13 +70,19 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
         final SearchRequest searchRequest = new SearchRequest(params.downsampleIndex());
         searchRequest.source().sort(TimeSeriesIdFieldMapper.NAME, SortOrder.DESC).size(1);
         searchRequest.preference("_shards:" + params.shardId().id());
-        client.search(
-            searchRequest,
-            ActionListener.wrap(
-                searchResponse -> delegate(task, params, searchResponse.getHits().getHits()),
-                e -> delegate(task, params, new SearchHit[] {})
-            )
-        );
+        client.search(searchRequest, ActionListener.wrap(searchResponse -> {
+            delegate(task, params, extractTsId(searchResponse.getHits().getHits()));
+        }, e -> delegate(task, params, null)));
+    }
+
+    private static BytesRef extractTsId(SearchHit[] lastDownsampleTsidHits) {
+        if (lastDownsampleTsidHits.length == 0) {
+            return null;
+        } else {
+            var searchHit = Arrays.stream(lastDownsampleTsidHits).findFirst().get();
+            var field = searchHit.field("_tsid");
+            return field != null ? field.getValue() : null;
+        }
     }
 
     @Override
@@ -154,15 +162,11 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
         return ThreadPool.Names.SAME;
     }
 
-    private void delegate(
-        final AllocatedPersistentTask task,
-        final DownsampleShardTaskParams params,
-        final SearchHit[] lastDownsampledTsidHits
-    ) {
+    private void delegate(final AllocatedPersistentTask task, final DownsampleShardTaskParams params, final BytesRef lastDownsampleTsid) {
         DownsampleShardTask downsampleShardTask = (DownsampleShardTask) task;
         client.execute(
             DelegatingAction.INSTANCE,
-            new DelegatingAction.Request(downsampleShardTask, lastDownsampledTsidHits, params),
+            new DelegatingAction.Request(downsampleShardTask, lastDownsampleTsid, params),
             ActionListener.wrap(empty -> {}, e -> {
                 LOGGER.error("error while delegating", e);
                 markAsFailed(downsampleShardTask, e);
@@ -175,7 +179,7 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
         IndicesService indicesService,
         DownsampleShardTask task,
         DownsampleShardTaskParams params,
-        SearchHit[] lastDownsampleTsidHits
+        BytesRef lastDownsampledTsid
     ) {
         client.threadPool().executor(Downsample.DOWNSAMPLE_TASK_THREAD_POOL_NAME).execute(new AbstractRunnable() {
             @Override
@@ -185,17 +189,15 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
 
             @Override
             protected void doRun() throws Exception {
-                final var initialState = lastDownsampleTsidHits.length == 0
-                    ? new DownsampleShardPersistentTaskState(DownsampleShardIndexerStatus.INITIALIZED, null)
-                    : new DownsampleShardPersistentTaskState(
-                        DownsampleShardIndexerStatus.STARTED,
-                        Arrays.stream(lastDownsampleTsidHits).findFirst().get().field("_tsid").getValue()
-                    );
+                final var initialState = new DownsampleShardPersistentTaskState(
+                    DownsampleShardIndexerStatus.INITIALIZED,
+                    lastDownsampledTsid
+                );
                 try {
                     final var downsampleShardIndexer = new DownsampleShardIndexer(
                         task,
                         client,
-                        indicesService.indexService(params.shardId().getIndex()),
+                        indicesService.indexServiceSafe(params.shardId().getIndex()),
                         params.shardId(),
                         params.downsampleIndex(),
                         params.downsampleConfig(),
@@ -215,6 +217,9 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
                         );
                         markAsFailed(task, e);
                     }
+                } catch (IndexNotFoundException e) {
+                    LOGGER.error("Downsampling task [" + task.getPersistentTaskId() + " failing because source index not assigned");
+                    markAsFailed(task, e);
                 } catch (final Exception e) {
                     LOGGER.error("Downsampling task [" + task.getPersistentTaskId() + " non-retriable failure [" + e.getMessage() + "]");
                     markAsFailed(task, e);
@@ -247,12 +252,12 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
         public static class Request extends ActionRequest implements IndicesRequest {
 
             private final DownsampleShardTask task;
-            private final SearchHit[] lastDownsampleTsidHits;
+            private final BytesRef lastDownsampleTsid;
             private final DownsampleShardTaskParams params;
 
-            public Request(DownsampleShardTask task, SearchHit[] lastDownsampleTsidHits, DownsampleShardTaskParams params) {
+            public Request(DownsampleShardTask task, BytesRef lastDownsampleTsid, DownsampleShardTaskParams params) {
                 this.task = task;
-                this.lastDownsampleTsidHits = lastDownsampleTsidHits;
+                this.lastDownsampleTsid = lastDownsampleTsid;
                 this.params = params;
             }
 
@@ -291,7 +296,7 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
 
             @Override
             protected void doExecute(Task t, Request request, ActionListener<ActionResponse.Empty> listener) {
-                realNodeOperation(client, indicesService, request.task, request.params, request.lastDownsampleTsidHits);
+                realNodeOperation(client, indicesService, request.task, request.params, request.lastDownsampleTsid);
                 listener.onResponse(ActionResponse.Empty.INSTANCE);
             }
         }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -184,6 +184,7 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
         ActionListener<AcknowledgedResponse> listener
     ) {
         String sourceIndexName = request.getSourceIndex();
+        downsamplingInterval = request.getDownsampleConfig().getInterval().toString();
 
         final IndicesAccessControl indicesAccessControl = threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
         if (indicesAccessControl != null) {
@@ -234,6 +235,7 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
             return;
         }
 
+        final TaskId parentTask = new TaskId(clusterService.localNode().getId(), task.getId());
         // Shortcircuit if target index has been downsampled:
         final String downsampleIndexName = request.getTargetIndex();
         IndexMetadata downsampleIndex = state.getMetadata().index(downsampleIndexName);
@@ -245,6 +247,20 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
                 return;
             } else if (downsampleStatus == DownsampleTaskStatus.SUCCESS) {
                 listener.onResponse(AcknowledgedResponse.TRUE);
+                return;
+            }
+            // In case the write block has been set on the target index means that the shard level downsampling itself was successful,
+            // but the previous invocation failed later performing settings update, refresh or force merge.
+            // The write block is used a signal to resume from the refresh part of the downsample api invocation.
+            if (downsampleIndex.getSettings().get(IndexMetadata.SETTING_BLOCKS_WRITE) != null) {
+                var refreshRequest = new RefreshRequest(downsampleIndexName);
+                refreshRequest.setParentTask(parentTask);
+                client.admin()
+                    .indices()
+                    .refresh(
+                        refreshRequest,
+                        new RefreshDownsampleIndexActionListener(listener, parentTask, downsampleIndexName, request.getWaitTimeout())
+                    );
                 return;
             }
         }
@@ -266,7 +282,6 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
         // At any point if there is an issue, delete the downsample index
 
         // 1. Extract source index mappings
-        final TaskId parentTask = new TaskId(clusterService.localNode().getId(), task.getId());
         final GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(sourceIndexName);
         getMappingsRequest.setParentTask(parentTask);
         client.admin().indices().getMappings(getMappingsRequest, ActionListener.wrap(getMappingsResponse -> {
@@ -285,7 +300,6 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
 
             // Validate downsampling interval
             validateDownsamplingInterval(mapperService, request.getDownsampleConfig());
-            downsamplingInterval = request.getDownsampleConfig().getInterval().toString();
 
             final List<String> dimensionFields = new ArrayList<>();
             final List<String> metricFields = new ArrayList<>();


### PR DESCRIPTION
Backporting #105228 to 8.12 branch.

Improve downsampling by making the following changes:

- Avoid NPE and assert tripping when fetching the last processed tsid.
- If the write block has been set, then there is no reason to start the downsample persistent tasks, since shard level downsampling has completed. Not doing so also causes ILM/DSL to get stuck on downsampling. In this case shard level downsampling should be skipped.
- Sometimes the source index may not be allocated yet on the node performing shard level downsampling operation. This causes a NPE, with this PR, this now fails a shard level downsample with a less disturbing error.

Additionally unmute
DataStreamLifecycleDownsampleDisruptionIT#testDataStreamLifecycleDownsampleRollingRestart()