### PR TITLE
[Connector API] Support updating configuration values only

### DIFF
--- a/docs/changelog/105249.yaml
+++ b/docs/changelog/105249.yaml
@@ -1,0 +1,5 @@
+pr: 105249
+summary: "[Connector API] Support updating configuration values only"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
@@ -350,3 +350,46 @@ setup:
             field_not_present_in_config: 42
 
   - match: { error.reason: "Unknown [configuration] fields in the request payload: [field_not_present_in_config]. Remove them from request or register their schema first." }
+
+
+---
+"Update Connector Configuration - 'configuration' and 'values' are both non-null":
+  - do:
+      catch: "bad_request"
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          configuration:
+            yet_another_field:
+              default_value: null
+              depends_on:
+                - field: some_field
+                  value: 31
+              display: numeric
+              label: Another important field
+              options: [ ]
+              order: 4
+              required: true
+              sensitive: false
+              tooltip: Wow, this tooltip is useful.
+              type: str
+              ui_restrictions: [ ]
+              validations:
+                - constraint: 0
+                  type: greater_than
+              value: 42
+          values:
+            yet_another_field: 42
+
+  - match: { error.reason: "Validation Failed: 1: [configuration] and [values] cannot both be provided in the same request.;" }
+
+
+---
+"Update Connector Configuration - 'configuration' and 'values' are null":
+  - do:
+      catch: "bad_request"
+      connector.update_configuration:
+        connector_id: test-connector
+        body: {}
+
+  - match: { error.reason: "Validation Failed: 1: [configuration] and [values] cannot both be null.;" }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
@@ -13,8 +13,6 @@ setup:
           is_native: false
           service_type: super-connector
 
----
-"Update Connector Configuration":
   - do:
       connector.update_configuration:
         connector_id: test-connector
@@ -38,9 +36,27 @@ setup:
                 - constraint: 0
                   type: greater_than
               value: 123
+            yet_another_field:
+              default_value: null
+              depends_on:
+                - field: some_field
+                  value: 31
+              display: numeric
+              label: Another important field
+              options: [ ]
+              order: 4
+              required: true
+              sensitive: false
+              tooltip: Wow, this tooltip is useful.
+              type: str
+              ui_restrictions: [ ]
+              validations:
+                - constraint: 0
+                  type: greater_than
+              value: "peace & love"
 
-
-  - match: { result: updated }
+---
+"Update Connector Configuration":
 
   - do:
       connector.get:
@@ -50,6 +66,7 @@ setup:
   - match: { configuration.some_field.sensitive: false }
   - match: { configuration.some_field.display: numeric }
   - match: { status: configured }
+  - match: { configuration.yet_another_field.value: "peace & love" }
 
 
   - do:
@@ -262,3 +279,74 @@ setup:
         connector_id: test-connector
 
   - match: { configuration.nextSyncConfig.value.max_crawl_depth: 3 }
+
+
+---
+"Update Connector Configuration - Clear configuration":
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          configuration: {}
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { configuration: {} }
+
+
+---
+"Update Connector Configuration - Values Only":
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          values:
+            some_field: 42
+            yet_another_field: 456
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { configuration.some_field.value: 42 }
+  - match: { configuration.some_field.label: Very important field }
+  - match: { configuration.yet_another_field.value: 456 }
+  - match: { configuration.yet_another_field.label: Another important field }
+
+
+---
+"Update Connector Configuration - Partial Values Update":
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          values:
+            yet_another_field: 42
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { configuration.some_field.value: 123 }
+  - match: { configuration.yet_another_field.value: 42 }
+
+
+---
+"Update Connector Configuration - Update unknown field value":
+  - do:
+      catch: "bad_request"
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          values:
+            field_not_present_in_config: 42
+
+  - match: { error.reason: "Unknown [configuration] fields in the request payload: [field_not_present_in_config]. Remove them from request or register their schema first." }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
@@ -222,9 +222,9 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
     }
 
     /**
-     * Parses a configuration value from a parser context, supporting the connector protocol's value types.
+     * Parses a configuration value from a parser context, supporting the {@link Connector} protocol's value types.
      * This method can parse strings, numbers, booleans, objects, and null values, matching the types commonly
-     * supported in connector configurations.
+     * supported in {@link ConnectorConfiguration}.
      *
      * @param p the {@link org.elasticsearch.xcontent.XContentParser} instance from which to parse the configuration value.
      */

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
@@ -226,7 +226,7 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
      * This method can parse strings, numbers, booleans, objects, and null values, matching the types commonly
      * supported in connector configurations.
      *
-     * @param p the XContentParser instance from which to parse the configuration value.
+     * @param p the {@link org.elasticsearch.xcontent.XContentParser} instance from which to parse the configuration value.
      */
     public static Object parseConfigurationValue(XContentParser p) throws IOException {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
@@ -150,7 +150,7 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<ConnectorConfiguration, Void> PARSER = new ConstructingObjectParser<>(
-        "connector_configuration_dependency",
+        "connector_configuration",
         true,
         args -> {
             int i = 0;
@@ -209,20 +209,40 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
         );
         PARSER.declareStringArray(optionalConstructorArg(), UI_RESTRICTIONS_FIELD);
         PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> ConfigurationValidation.fromXContent(p), VALIDATIONS_FIELD);
-        PARSER.declareField(optionalConstructorArg(), (p, c) -> {
-            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
-                return p.text();
-            } else if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
-                return p.numberValue();
-            } else if (p.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
-                return p.booleanValue();
-            } else if (p.currentToken() == XContentParser.Token.START_OBJECT) {
-                return p.map();
-            } else if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
-                return null;
-            }
-            throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
-        }, VALUE_FIELD, ObjectParser.ValueType.VALUE_OBJECT_ARRAY);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            (p, c) -> parseConfigurationValue(p),
+            VALUE_FIELD,
+            ObjectParser.ValueType.VALUE_OBJECT_ARRAY
+        );
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    /**
+     * Parses a configuration value from a parser context, supporting the connector protocol's value types.
+     * This method can parse strings, numbers, booleans, objects, and null values, matching the types commonly
+     * supported in connector configurations.
+     *
+     * @param p the XContentParser instance from which to parse the configuration value.
+     */
+    public static Object parseConfigurationValue(XContentParser p) throws IOException {
+
+        if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
+            return p.text();
+        } else if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+            return p.numberValue();
+        } else if (p.currentToken() == XContentParser.Token.VALUE_BOOLEAN) {
+            return p.booleanValue();
+        } else if (p.currentToken() == XContentParser.Token.START_OBJECT) {
+            // Crawler expects the value to be an object
+            return p.map();
+        } else if (p.currentToken() == XContentParser.Token.VALUE_NULL) {
+            return null;
+        }
+        throw new XContentParseException("Unsupported token [" + p.currentToken() + "]");
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -386,7 +386,7 @@ public class ConnectorIndexService {
      * Updates the {@link ConnectorConfiguration} property of a {@link Connector}.
      * This method supports full configuration replacement or individual configuration value updates.
      * If a full configuration is provided, it overwrites all existing configurations in non-additive way.
-     * If only configuration values are provided, existing configuration object is updated with new values
+     * If only configuration values are provided, the existing {@link ConnectorConfiguration} is updated with new values
      * provided in the request.
      *
      * @param request   Request for updating connector configuration property.

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -63,7 +63,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ClientHelper.CONNECTORS_ORIGIN;
@@ -382,51 +384,114 @@ public class ConnectorIndexService {
 
     /**
      * Updates the {@link ConnectorConfiguration} property of a {@link Connector}.
-     * The update process is non-additive; it completely replaces all existing configuration fields with the new configuration mapping,
-     * thereby deleting any old configurations.
+     * This method supports full configuration replacement or individual configuration value updates.
+     * If a full configuration is provided, it overwrites all existing configurations in non-additive way.
+     * If only configuration values are provided, existing configuration object is updated with new values
+     * provided in the request.
      *
      * @param request   Request for updating connector configuration property.
      * @param listener  Listener to respond to a successful response or an error.
      */
     public void updateConnectorConfiguration(UpdateConnectorConfigurationAction.Request request, ActionListener<UpdateResponse> listener) {
         try {
+            Map<String, ConnectorConfiguration> fullConfiguration = request.getConfiguration();
+            Map<String, Object> configurationValues = request.getConfigurationValues();
             String connectorId = request.getConnectorId();
 
-            String updateConfigurationScript = String.format(
-                Locale.ROOT,
-                """
-                    ctx._source.%s = params.%s;
-                    ctx._source.%s = params.%s;
-                    """,
-                Connector.CONFIGURATION_FIELD.getPreferredName(),
-                Connector.CONFIGURATION_FIELD.getPreferredName(),
-                Connector.STATUS_FIELD.getPreferredName(),
-                Connector.STATUS_FIELD.getPreferredName()
-            );
-            Script script = new Script(
-                ScriptType.INLINE,
-                "painless",
-                updateConfigurationScript,
-                Map.of(
-                    Connector.CONFIGURATION_FIELD.getPreferredName(),
-                    request.getConfiguration(),
-                    Connector.STATUS_FIELD.getPreferredName(),
-                    ConnectorStatus.CONFIGURED.toString()
-                )
-            );
-            final UpdateRequest updateRequest = new UpdateRequest(CONNECTOR_INDEX_NAME, connectorId).script(script)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+            getConnector(connectorId, listener.delegateFailure((l, connector) -> {
 
-            clientWithOrigin.update(
-                updateRequest,
-                new DelegatingIndexNotFoundActionListener<>(connectorId, listener, (l, updateResponse) -> {
-                    if (updateResponse.getResult() == UpdateResponse.Result.NOT_FOUND) {
-                        l.onFailure(new ResourceNotFoundException(connectorNotFoundErrorMsg(connectorId)));
+                UpdateRequest updateRequest = new UpdateRequest(CONNECTOR_INDEX_NAME, connectorId).setRefreshPolicy(
+                    WriteRequest.RefreshPolicy.IMMEDIATE
+                );
+
+                // Completely override [configuration] field with script
+                if (fullConfiguration != null) {
+                    String updateConfigurationScript = String.format(
+                        Locale.ROOT,
+                        """
+                            ctx._source.%s = params.%s;
+                            ctx._source.%s = params.%s;
+                            """,
+                        Connector.CONFIGURATION_FIELD.getPreferredName(),
+                        Connector.CONFIGURATION_FIELD.getPreferredName(),
+                        Connector.STATUS_FIELD.getPreferredName(),
+                        Connector.STATUS_FIELD.getPreferredName()
+                    );
+                    Script script = new Script(
+                        ScriptType.INLINE,
+                        "painless",
+                        updateConfigurationScript,
+                        Map.of(
+                            Connector.CONFIGURATION_FIELD.getPreferredName(),
+                            request.getConfiguration(),
+                            Connector.STATUS_FIELD.getPreferredName(),
+                            ConnectorStatus.CONFIGURED.toString()
+                        )
+                    );
+                    updateRequest = updateRequest.script(script);
+
+                }
+                // Only update configuration values for (key, value) pairs provided
+                else if (configurationValues != null) {
+
+                    Set<String> existingKeys = getConnectorConfigurationFromSearchResult(connector).keySet();
+                    Set<String> newConfigurationKeys = configurationValues.keySet();
+
+                    // Fail request it could result in updating values for unknown configuration keys
+                    if (existingKeys.containsAll(newConfigurationKeys) == false) {
+
+                        Set<String> unknownConfigKeys = newConfigurationKeys.stream()
+                            .filter(key -> existingKeys.contains(key) == false)
+                            .collect(Collectors.toSet());
+
+                        l.onFailure(
+                            new ElasticsearchStatusException(
+                                "Unknown [configuration] fields in the request payload: ["
+                                    + String.join(", ", unknownConfigKeys)
+                                    + "]. Remove them from request or register their schema first.",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
                         return;
                     }
-                    l.onResponse(updateResponse);
-                })
-            );
+
+                    Map<String, Object> configurationValuesUpdatePayload = configurationValues.entrySet()
+                        .stream()
+                        .collect(
+                            Collectors.toMap(
+                                Map.Entry::getKey,
+                                entry -> Map.of(ConnectorConfiguration.VALUE_FIELD.getPreferredName(), entry.getValue())
+                            )
+                        );
+
+                    updateRequest = updateRequest.doc(
+                        new IndexRequest(CONNECTOR_INDEX_NAME).opType(DocWriteRequest.OpType.INDEX)
+                            .id(connectorId)
+                            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                            .source(
+                                Map.of(
+                                    Connector.CONFIGURATION_FIELD.getPreferredName(),
+                                    configurationValuesUpdatePayload,
+                                    Connector.STATUS_FIELD.getPreferredName(),
+                                    ConnectorStatus.CONFIGURED.toString()
+                                )
+                            )
+                    );
+                } else {
+                    l.onFailure(
+                        new ElasticsearchStatusException("[configuration] and [values] cannot both be null.", RestStatus.BAD_REQUEST)
+                    );
+                    return;
+                }
+
+                clientWithOrigin.update(updateRequest, new DelegatingIndexNotFoundActionListener<>(connectorId, l, (ll, updateResponse) -> {
+                    if (updateResponse.getResult() == UpdateResponse.Result.NOT_FOUND) {
+                        ll.onFailure(new ResourceNotFoundException(connectorNotFoundErrorMsg(connectorId)));
+                        return;
+                    }
+                    ll.onResponse(updateResponse);
+                }));
+            }));
         } catch (Exception e) {
             listener.onFailure(e);
         }
@@ -849,6 +914,11 @@ public class ConnectorIndexService {
 
     private ConnectorStatus getConnectorStatusFromSearchResult(ConnectorSearchResult searchResult) {
         return ConnectorStatus.connectorStatus((String) searchResult.getResultMap().get(Connector.STATUS_FIELD.getPreferredName()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getConnectorConfigurationFromSearchResult(ConnectorSearchResult searchResult) {
+        return (Map<String, Object>) searchResult.getResultMap().get(Connector.CONFIGURATION_FIELD.getPreferredName());
     }
 
     private static ConnectorIndexService.ConnectorResult mapSearchResponseToConnectorList(SearchResponse response) {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -240,8 +240,16 @@ public final class ConnectorTestUtils {
 
     public static Map<String, ConnectorConfiguration> getRandomConnectorConfiguration() {
         Map<String, ConnectorConfiguration> configMap = new HashMap<>();
-        for (int i = 0; i < 3; i++) {
+        for (int i = 0; i < 5; i++) {
             configMap.put(randomAlphaOfLength(10), getRandomConnectorConfigurationField());
+        }
+        return configMap;
+    }
+
+    public static Map<String, Object> getRandomConnectorConfigurationValues() {
+        Map<String, Object> configMap = new HashMap<>();
+        for (int i = 0; i < 5; i++) {
+            configMap.put(randomAlphaOfLength(10), randomFrom(randomAlphaOfLengthBetween(3, 10), randomInt(), randomBoolean()));
         }
         return configMap;
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorConfigurationActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorConfigurationActionRequestBWCSerializingTests.java
@@ -28,7 +28,11 @@ public class UpdateConnectorConfigurationActionRequestBWCSerializingTests extend
     @Override
     protected UpdateConnectorConfigurationAction.Request createTestInstance() {
         this.connectorId = randomUUID();
-        return new UpdateConnectorConfigurationAction.Request(connectorId, ConnectorTestUtils.getRandomConnectorConfiguration());
+        return new UpdateConnectorConfigurationAction.Request(
+            connectorId,
+            ConnectorTestUtils.getRandomConnectorConfiguration(),
+            ConnectorTestUtils.getRandomConnectorConfigurationValues()
+        );
     }
 
     @Override


### PR DESCRIPTION
### Changes

- Support updating connector configuration values directly with:
```
PUT _connector/{id}/_configuration
{
   "values": {"key1": "value", "key2": 42}
}
```
- Connector full configuration schema has to be registered first, you can pass `{"configuration": {... full config obj..}}` as request payload to do it
- passing `configuration` in request payload overrides config fully
- passing `values` uses default ES additive update of an object

#### Validations
- `values` and `configuration` cannot both be present and both be null
- `values` keys have to be subset of existing configuration schema. If we have connector with configuration with fields: `field_a` , `field_b`, `field_c`, then the `values` cannot contain mapping to unknown key, e.g. `field_d` but can contain subset, e.g. only update value for fields: `field_a` , `field_b`. If this is violated we throw informative error message and a 400 status code e.g.:
  - `"Unknown [configuration] fields in the request payload: [xd]. Remove them from request or register their schema first."`


### Testing
- Added unit tests - but need to skip given that we still didn't figure out how to register connector index template mappings for unit tests, mappings are inferred for nested object and this makes tests to fail
- Comprehensive e2e tests
- Tested manually