### PR TITLE
Lower G1 minimum full GC interval

### DIFF
--- a/docs/changelog/105259.yaml
+++ b/docs/changelog/105259.yaml
@@ -1,0 +1,5 @@
+pr: 105259
+summary: Lower G1 minimum full GC interval
+area: Infra/Circuit Breakers
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -520,7 +520,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                 createYoungGcCountSupplier(),
                 System::currentTimeMillis,
                 500,
-                5000,
+                2000,
                 lockTimeout,
                 fullGCLockTimeout
             );


### PR DESCRIPTION
We sometimes see a need to do full GC twice within the current 5s interval. While we should work to improve our allocation pattern for that, it also seems too conservative to not allow more full GCs, as long as we also get some real work done. Hence lowering it to 2s here, which would fix the current problematic cases.
