### PR TITLE
Efficiently encode multi-valued dimensions

### DIFF
--- a/docs/changelog/105271.yaml
+++ b/docs/changelog/105271.yaml
@@ -1,0 +1,5 @@
+pr: 105271
+summary: Efficiently encode multi-valued dimensions
+area: TSDB
+type: enhancement
+issues: []

--- a/docs/changelog/105271.yaml
+++ b/docs/changelog/105271.yaml
@@ -1,5 +1,0 @@
-pr: 105271
-summary: Efficiently encode multi-valued dimensions
-area: TSDB
-type: enhancement
-issues: []

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.codec.postings.ES812PostingsFormat;
 import org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormat;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.IpFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
@@ -123,6 +124,9 @@ public final class PerFieldMapperCodec extends Lucene99Codec {
                 return true;
             }
             if (mappingLookup.getMapper(field) instanceof TimeSeriesIdFieldMapper) {
+                return true;
+            }
+            if (mappingLookup.getMapper(field) instanceof IpFieldMapper) {
                 return true;
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
@@ -207,11 +207,10 @@ public class ES87TSDBDocValuesEncoder {
                     // first candidate cycle detected
                     cycleLength = i;
                 } else if (cycleLength == 1 || i % cycleLength != 0) {
-                    // this isn't a cycle if the first two values are the same,
-                    // because ordinals are a sorted set, it might be a run, though
+                    // if the first two values are the same this isn't a cycle, it might be a run, though
                     // this also isn't a cycle if the index of the next occurrence of the first value
                     // isn't a multiple of the candidate cycle length
-                    // we can stop looking for cycles
+                    // we can stop looking for cycles now
                     cycleLength = -1;
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
@@ -229,7 +229,7 @@ public class ES87TSDBDocValuesEncoder {
         }
         if (numRuns == 1 && bitsPerOrd < 63) {
             long value = in[0];
-            // set first bit to 0 (0 trailing bits) to indicate the block has a single run
+            // unset first bit (0 trailing ones) to indicate the block has a single run
             out.writeVLong(value << 1);
         } else if (numRuns == 2 && bitsPerOrd < 62) {
             // set 1 trailing bit to indicate the block has two runs

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
@@ -262,12 +262,12 @@ public class ES87TSDBDocValuesEncoder {
 
         long v1 = in.readVLong();
         int encoding = Long.numberOfTrailingZeros(~v1);
+        v1 >>>= encoding + 1;
         if (encoding == 0) {
             // single run
-            Arrays.fill(out, v1 >>> 1);
+            Arrays.fill(out, v1);
         } else if (encoding == 1) {
             // two runs
-            v1 = v1 >>> 2;
             int runLen = in.readVInt();
             long v2 = v1 + in.readZLong();
             Arrays.fill(out, 0, runLen, v1);
@@ -277,7 +277,7 @@ public class ES87TSDBDocValuesEncoder {
             forUtil.decode(bitsPerOrd, in, out);
         } else if (encoding == 3) {
             // cycle encoding
-            int cycleLength = (int) v1 >>> 4;
+            int cycleLength = (int) v1;
             for (int i = 0; i < cycleLength; i++) {
                 out[i] = in.readVLong();
             }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
@@ -229,10 +229,9 @@ public class ES87TSDBDocValuesEncoder {
         if (numRuns > 2 && cycleLength > 1 && cycleLength < in.length >> 1) {
             // check if the data cycles through the same values
             cyclic = true;
-            outer:
-            for (int i = 0; i < cycleLength; i++) {
+            outer: for (int i = 0; i < cycleLength; i++) {
                 long v = in[i];
-                for (int j = i + cycleLength; j < in.length; j+= cycleLength) {
+                for (int j = i + cycleLength; j < in.length; j += cycleLength) {
                     if (v != in[j]) {
                         cyclic = false;
                         break outer;

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoderTests.java
@@ -291,7 +291,7 @@ public class ES87TSDBDocValuesEncoderTests extends LuceneTestCase {
     public void testEncodeOrdinalsAlmostCycle() throws IOException {
         long[] arr = new long[blockSize];
         Arrays.setAll(arr, i -> i % 3);
-        arr[arr.length -1] = 4;
+        arr[arr.length - 1] = 4;
         doTestOrdinals(arr, 49);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoderTests.java
@@ -260,12 +260,53 @@ public class ES87TSDBDocValuesEncoderTests extends LuceneTestCase {
         doTestOrdinals(arr, 113);
     }
 
+    public void testEncodeOrdinalsBitPack3Bits() throws IOException {
+        long[] arr = new long[blockSize];
+        Arrays.fill(arr, 4);
+        for (int i = 0; i < 4; i++) {
+            arr[i] = i;
+        }
+        doTestOrdinals(arr, 49);
+    }
+
+    public void testEncodeOrdinalsCycle() throws IOException {
+        long[] arr = new long[blockSize];
+        Arrays.setAll(arr, i -> i % 3);
+        doTestOrdinals(arr, 4);
+    }
+
+    public void testEncodeOrdinalsLongCycle() throws IOException {
+        long[] arr = new long[blockSize];
+        Arrays.setAll(arr, i -> i % 63);
+        doTestOrdinals(arr, 65);
+    }
+
+    public void testEncodeOrdinalsCycleTooLong() throws IOException {
+        long[] arr = new long[blockSize];
+        Arrays.setAll(arr, i -> i % 64);
+        // the cycle is too long and the vales are bit-packed
+        doTestOrdinals(arr, 97);
+    }
+
+    public void testEncodeOrdinalsAlmostCycle() throws IOException {
+        long[] arr = new long[blockSize];
+        Arrays.setAll(arr, i -> i % 3);
+        arr[arr.length -1] = 4;
+        doTestOrdinals(arr, 49);
+    }
+
+    public void testEncodeOrdinalsDifferentCycles() throws IOException {
+        long[] arr = new long[blockSize];
+        Arrays.setAll(arr, i -> i > 64 ? i % 4 : i % 3);
+        doTestOrdinals(arr, 33);
+    }
+
     private void doTestOrdinals(long[] arr, long expectedNumBytes) throws IOException {
         long maxOrd = 0;
         for (long ord : arr) {
             maxOrd = Math.max(maxOrd, ord);
         }
-        final int bitsPerOrd = PackedInts.bitsRequired(maxOrd - 1);
+        final int bitsPerOrd = PackedInts.bitsRequired(maxOrd);
         final long[] expected = arr.clone();
         try (Directory dir = newDirectory()) {
             try (IndexOutput out = dir.createOutput("tests.bin", IOContext.DEFAULT)) {

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoderTests.java
@@ -269,7 +269,13 @@ public class ES87TSDBDocValuesEncoderTests extends LuceneTestCase {
         doTestOrdinals(arr, 49);
     }
 
-    public void testEncodeOrdinalsCycle() throws IOException {
+    public void testEncodeOrdinalsCycle2() throws IOException {
+        long[] arr = new long[blockSize];
+        Arrays.setAll(arr, i -> i % 2);
+        doTestOrdinals(arr, 3);
+    }
+
+    public void testEncodeOrdinalsCycle3() throws IOException {
         long[] arr = new long[blockSize];
         Arrays.setAll(arr, i -> i % 3);
         doTestOrdinals(arr, 4);
@@ -277,13 +283,13 @@ public class ES87TSDBDocValuesEncoderTests extends LuceneTestCase {
 
     public void testEncodeOrdinalsLongCycle() throws IOException {
         long[] arr = new long[blockSize];
-        Arrays.setAll(arr, i -> i % 63);
-        doTestOrdinals(arr, 65);
+        Arrays.setAll(arr, i -> i % 32);
+        doTestOrdinals(arr, 34);
     }
 
     public void testEncodeOrdinalsCycleTooLong() throws IOException {
         long[] arr = new long[blockSize];
-        Arrays.setAll(arr, i -> i % 64);
+        Arrays.setAll(arr, i -> i % 33);
         // the cycle is too long and the vales are bit-packed
         doTestOrdinals(arr, 97);
     }


### PR DESCRIPTION
Detects and efficiently encodes cyclic ordinals, as proposed by @jpountz. This is beneficial for encoding dimensions that are multivalued, such as host.ip.

A follow-up on #99747 