### PR TITLE
Remove abstract method InternalMultiBucketAggregation#reduceBucket

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
@@ -209,8 +209,7 @@ public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<Inte
         return new InternalAdjacencyMatrix(name, buckets.stream().map(b -> b.finalizeSampling(samplingContext)).toList(), getMetadata());
     }
 
-    @Override
-    protected InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
+    private InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         InternalBucket reduced = null;
         for (InternalBucket bucket : buckets) {

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -407,8 +407,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
         return reducedBuckets;
     }
 
-    @Override
-    protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
+    private Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long docCount = 0;
         for (Bucket bucket : buckets) {

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
@@ -254,8 +254,7 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
         return new InternalBucket(prototype.key, prototype.docCount, aggregations, prototype.keyed);
     }
 
-    @Override
-    protected InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
+    private InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
         InternalTimeSeries.InternalBucket reduced = null;
         for (InternalTimeSeries.InternalBucket bucket : buckets) {
             if (reduced == null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/DelayedBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/DelayedBucket.java
@@ -35,9 +35,6 @@ public final class DelayedBucket<B extends InternalMultiBucketAggregation.Intern
 
     /**
      * Build a delayed bucket.
-     * <p>
-     * We take a {@link BiFunction} to match the signature of
-     * {@link InternalMultiBucketAggregation#reduceBucket}.
      */
     public DelayedBucket(
         BiFunction<List<B>, AggregationReduceContext, B> reduce,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -72,12 +72,6 @@ public abstract class InternalMultiBucketAggregation<
      */
     public abstract B createBucket(InternalAggregations aggregations, B prototype);
 
-    /**
-     * Reduce a list of same-keyed buckets (from multiple shards) to a single bucket. This
-     * requires all buckets to have the same key.
-     */
-    protected abstract B reduceBucket(List<B> buckets, AggregationReduceContext context);
-
     /** Helps to lazily construct the aggregation list for reduction */
     protected static class BucketAggregationList<B extends Bucket> extends AbstractList<InternalAggregations> {
         private final List<B> buckets;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -290,8 +290,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         );
     }
 
-    @Override
-    protected InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
+    private InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long docCount = 0;
         for (InternalBucket bucket : buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -244,8 +244,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
         );
     }
 
-    @Override
-    protected InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
+    private InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         InternalBucket reduced = null;
         for (InternalBucket bucket : buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
@@ -142,8 +142,7 @@ public abstract class InternalGeoGrid<B extends InternalGeoGridBucket> extends I
         );
     }
 
-    @Override
-    protected InternalGeoGridBucket reduceBucket(List<InternalGeoGridBucket> buckets, AggregationReduceContext context) {
+    private InternalGeoGridBucket reduceBucket(List<InternalGeoGridBucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long docCount = 0;
         for (InternalGeoGridBucket bucket : buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -391,8 +391,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
      * Reduce a list of same-keyed buckets (from multiple shards) to a single bucket. This
      * requires all buckets to have the same key.
      */
-    @Override
-    protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
+    private Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long docCount = 0;
         for (Bucket bucket : buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -347,8 +347,7 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
         return reducedBuckets;
     }
 
-    @Override
-    protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
+    private Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long docCount = 0;
         for (Bucket bucket : buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
@@ -306,8 +306,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
         return ((Bucket) bucket).centroid;
     }
 
-    @Override
-    protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
+    private Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
         long docCount = 0;
         double min = Double.POSITIVE_INFINITY;
         double max = Double.NEGATIVE_INFINITY;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
@@ -342,8 +342,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
         );
     }
 
-    @Override
-    protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
+    private Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long docCount = 0;
         for (InternalIpPrefix.Bucket bucket : buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -307,8 +307,7 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
         );
     }
 
-    @Override
-    protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
+    private Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         final List<InternalAggregations> aggregations = new BucketAggregationList<>(buckets);
         final InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -375,8 +375,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
         );
     }
 
-    @Override
-    protected B reduceBucket(List<B> buckets, AggregationReduceContext context) {
+    private B reduceBucket(List<B> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long docCount = 0;
         for (Bucket bucket : buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -86,8 +86,7 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
 
     protected abstract B createBucket(long docCount, InternalAggregations aggs, long docCountError, B prototype);
 
-    @Override
-    public B reduceBucket(List<B> buckets, AggregationReduceContext context) {
+    private B reduceBucket(List<B> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long docCount = 0;
         // For the per term doc count error we add up the errors from the

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedRareTerms.java
@@ -133,6 +133,17 @@ public abstract class InternalMappedRareTerms<A extends InternalRareTerms<A, B>,
         };
     }
 
+    private B reduceBucket(List<B> buckets, AggregationReduceContext context) {
+        assert buckets.isEmpty() == false;
+        long docCount = 0;
+        for (B bucket : buckets) {
+            docCount += bucket.docCount;
+        }
+        final List<InternalAggregations> aggregations = new BucketAggregationList<>(buckets);
+        final InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
+        return createBucket(docCount, aggs, buckets.get(0));
+    }
+
     @Override
     public A finalizeSampling(SamplingContext samplingContext) {
         return createWithFilter(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalRareTerms.java
@@ -11,7 +11,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.SetBackedScalingCuckooFilter;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
@@ -139,18 +138,6 @@ public abstract class InternalRareTerms<A extends InternalRareTerms<A, B>, B ext
     public abstract List<B> getBuckets();
 
     abstract B createBucket(long docCount, InternalAggregations aggs, B prototype);
-
-    @Override
-    protected B reduceBucket(List<B> buckets, AggregationReduceContext context) {
-        assert buckets.isEmpty() == false;
-        long docCount = 0;
-        for (B bucket : buckets) {
-            docCount += bucket.docCount;
-        }
-        final List<InternalAggregations> aggregations = new BucketAggregationList<>(buckets);
-        final InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
-        return createBucket(docCount, aggs, buckets.get(0));
-    }
 
     protected abstract A createWithFilter(String name, List<B> buckets, SetBackedScalingCuckooFilter filter);
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -285,8 +285,7 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
         );
     }
 
-    @Override
-    protected B reduceBucket(List<B> buckets, AggregationReduceContext context) {
+    private B reduceBucket(List<B> buckets, AggregationReduceContext context) {
         assert buckets.isEmpty() == false;
         long subsetDf = 0;
         long supersetDf = 0;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -297,11 +297,6 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
     }
 
     @Override
-    protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
-        throw new UnsupportedOperationException("For optimization purposes, typical bucket path is not supported");
-    }
-
-    @Override
     public List<Bucket> getBuckets() {
         return buckets;
     }


### PR DESCRIPTION
This method is only used on the actual implementation of the abstract classes and it can be made private.