### PR TITLE
[8.12] Increase timeout for ensureGreen in testDownsampleIndexWithRollingRestart (#105277)

### DIFF
--- a/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleClusterDisruptionIT.java
+++ b/x-pack/plugin/downsample/src/internalClusterTest/java/org/elasticsearch/xpack/downsample/DownsampleClusterDisruptionIT.java
@@ -109,7 +109,7 @@ public class DownsampleClusterDisruptionIT extends ESIntegTestCase {
                     .getNodes()[0].getName();
                 logger.info("Candidate node [" + candidateNode + "]");
                 disruption.accept(candidateNode);
-                ensureGreen(sourceIndex);
+                ensureGreen(TimeValue.timeValueSeconds(60), sourceIndex);
                 ensureStableCluster(cluster.numDataAndMasterNodes(), clientNode);
 
             } catch (Exception e) {
@@ -208,7 +208,6 @@ public class DownsampleClusterDisruptionIT extends ESIntegTestCase {
         assertTargetIndex(cluster, sourceIndex, targetIndex, indexedDocs);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/100653")
     public void testDownsampleIndexWithRollingRestart() throws Exception {
         final InternalTestCluster cluster = internalCluster();
         final List<String> masterNodes = cluster.startMasterOnlyNodes(1);

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -955,11 +955,11 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
                 .indices()
                 .forceMerge(request, ActionListener.wrap(mergeIndexResp -> actionListener.onResponse(AcknowledgedResponse.TRUE), t -> {
                     /*
-                     * At this point downsampel index has been created
-                     * successfully even force merge fails.
-                     * So, we should not fail the downsample operation
+                     * At this point downsample index has been created
+                     * successfully even if force merge failed.
+                     * So, we should not fail the downsample operation.
                      */
-                    logger.error("Failed to force-merge " + "downsample index [" + downsampleIndexName + "]", t);
+                    logger.error("Failed to force-merge downsample index [" + downsampleIndexName + "]", t);
                     actionListener.onResponse(AcknowledgedResponse.TRUE);
                 }));
         }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Increase timeout for ensureGreen in testDownsampleIndexWithRollingRestart (#105277)