### PR TITLE
Extend timeout in RepositoryAnalysisFailureIT

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
@@ -423,7 +423,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
     }
 
     private void analyseRepository(RepositoryAnalyzeAction.Request request) {
-        client().execute(RepositoryAnalyzeAction.INSTANCE, request).actionGet(30L, TimeUnit.SECONDS);
+        client().execute(RepositoryAnalyzeAction.INSTANCE, request).actionGet(5L, TimeUnit.MINUTES);
     }
 
     private static void assertPurpose(OperationPurpose purpose) {


### PR DESCRIPTION
We see occasional test failures in CI due to the analysis not completing
within this 30s timeout. It doesn't look like anything is actually
wrong, the test machine is just busy and these tests can be quite
IO-intensive. This commit gives them more time.

Closes #99422