### PR TITLE
Remove unnecessary String concatenation, part 1

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeRequest.java
@@ -178,7 +178,7 @@ public class ForceMergeRequest extends BroadcastRequest<ForceMergeRequest> {
         ActionRequestValidationException validationError = super.validate();
         if (onlyExpungeDeletes && maxNumSegments != Defaults.MAX_NUM_SEGMENTS) {
             validationError = addValidationError(
-                "cannot set only_expunge_deletes and max_num_segments at the same time, those two " + "parameters are mutually exclusive",
+                "cannot set only_expunge_deletes and max_num_segments at the same time, those two parameters are mutually exclusive",
                 validationError
             );
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -174,7 +174,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                     message = "Lazy rollover can be used only without any conditions."
                         + " Please remove the conditions from the request body or the query parameter 'lazy'.";
                 } else if (rolloverRequest.getConditions().hasConditions() == false) {
-                    message = "Lazy rollover can be applied only on a data stream." + " Please remove the query parameter 'lazy'.";
+                    message = "Lazy rollover can be applied only on a data stream. Please remove the query parameter 'lazy'.";
                 } else {
                     message = "Lazy rollover can be applied only on a data stream with no conditions."
                         + " Please remove the query parameter 'lazy'.";

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -396,7 +396,7 @@ public final class BulkRequestParser {
                     } else if ("update".equals(action)) {
                         if (version != Versions.MATCH_ANY || versionType != VersionType.INTERNAL) {
                             throw new IllegalArgumentException(
-                                "Update requests do not support versioning. " + "Please use `if_seq_no` and `if_primary_term` instead"
+                                "Update requests do not support versioning. Please use `if_seq_no` and `if_primary_term` instead"
                             );
                         }
                         if (requireDataStream) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -477,7 +477,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
         if (minCompatibleShardNode() != null) {
             if (isCcsMinimizeRoundtrips()) {
                 validationException = addValidationError(
-                    "[ccs_minimize_roundtrips] cannot be [true] when setting a minimum compatible " + "shard version",
+                    "[ccs_minimize_roundtrips] cannot be [true] when setting a minimum compatible shard version",
                     validationException
                 );
             }

--- a/server/src/main/java/org/elasticsearch/action/support/ListenerTimeouts.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ListenerTimeouts.java
@@ -40,7 +40,7 @@ public class ListenerTimeouts {
         String listenerName
     ) {
         return wrapWithTimeout(threadPool, timeout, executor, listener, (ignore) -> {
-            String timeoutMessage = "[" + listenerName + "]" + " timed out after [" + timeout + "]";
+            String timeoutMessage = "[" + listenerName + "] timed out after [" + timeout + "]";
             listener.onFailure(new ElasticsearchTimeoutException(timeoutMessage));
         });
     }

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsRequest.java
@@ -565,14 +565,14 @@ public final class TermVectorsRequest extends SingleShardRequest<TermVectorsRequ
                 } else if (ID.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (termVectorsRequest.doc != null) {
                         throw new ElasticsearchParseException(
-                            "failed to parse term vectors request. " + "either [id] or [doc] can be specified, but not both!"
+                            "failed to parse term vectors request. either [id] or [doc] can be specified, but not both!"
                         );
                     }
                     termVectorsRequest.id = parser.text();
                 } else if (DOC.match(currentFieldName, parser.getDeprecationHandler())) {
                     if (termVectorsRequest.id != null) {
                         throw new ElasticsearchParseException(
-                            "failed to parse term vectors request. " + "either [id] or [doc] can be specified, but not both!"
+                            "failed to parse term vectors request. either [id] or [doc] can be specified, but not both!"
                         );
                     }
                     termVectorsRequest.doc(jsonBuilder().copyCurrentStructure(parser));

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -233,7 +233,7 @@ final class BootstrapChecks {
                 } else {
                     message = String.format(
                         Locale.ROOT,
-                        "initial heap size [%d] not equal to maximum heap size [%d]; " + "this can cause resize pauses",
+                        "initial heap size [%d] not equal to maximum heap size [%d]; this can cause resize pauses",
                         getInitialHeapSize(),
                         getMaxHeapSize()
                     );

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -471,9 +471,7 @@ class Elasticsearch {
             es.node.prepareForClose();
             IOUtils.close(es.node, es.spawner);
             if (es.node.awaitClose(10, TimeUnit.SECONDS) == false) {
-                throw new IllegalStateException(
-                    "Node didn't stop within 10 seconds. " + "Any outstanding requests or tasks might get killed."
-                );
+                throw new IllegalStateException("Node didn't stop within 10 seconds. Any outstanding requests or tasks might get killed.");
             }
         } catch (IOException ex) {
             throw new ElasticsearchException("Failure occurred while shutting down node", ex);

--- a/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/SystemCallFilter.java
@@ -313,7 +313,7 @@ final class SystemCallFilter {
                 if (errno == EINVAL) {
                     // friendly error, this will be the typical case for an old kernel
                     throw new UnsupportedOperationException(
-                        "seccomp unavailable: requires kernel 3.5+ with" + " CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER compiled in"
+                        "seccomp unavailable: requires kernel 3.5+ with CONFIG_SECCOMP and CONFIG_SECCOMP_FILTER compiled in"
                     );
                 } else {
                     throw new UnsupportedOperationException("prctl(PR_GET_NO_NEW_PRIVS): " + JNACLibrary.strerror(errno));

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -134,7 +134,7 @@ public class ShardStateAction {
                     } else {
                         logger.warn(
                             () -> format(
-                                "unexpected failure while sending request [%s]" + " to [%s] for shard entry [%s]",
+                                "unexpected failure while sending request [%s] to [%s] for shard entry [%s]",
                                 actionName,
                                 masterNode,
                                 request

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ElasticsearchNodeCommand.java
@@ -54,7 +54,7 @@ import java.util.Objects;
 public abstract class ElasticsearchNodeCommand extends EnvironmentAwareCommand {
     private static final Logger logger = LogManager.getLogger(ElasticsearchNodeCommand.class);
     protected static final String DELIMITER = "------------------------------------------------------------------------\n";
-    static final String STOP_WARNING_MSG = DELIMITER + "\n" + "    WARNING: Elasticsearch MUST be stopped before running this tool." + "\n";
+    static final String STOP_WARNING_MSG = DELIMITER + "\n    WARNING: Elasticsearch MUST be stopped before running this tool.\n";
     protected static final String FAILED_TO_OBTAIN_NODE_LOCK_MSG = "failed to lock node's directory, is Elasticsearch still running?";
     protected static final String ABORTED_BY_USER_MSG = "aborted by user";
     static final String NO_NODE_FOLDER_FOUND_MSG = "no node folder is found in data folder(s), node has not been started yet?";

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2865,14 +2865,14 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             factor = targetNumberOfShards / sourceNumberOfShards;
             if (factor * sourceNumberOfShards != targetNumberOfShards || factor <= 1) {
                 throw new IllegalArgumentException(
-                    "the number of source shards [" + sourceNumberOfShards + "] must be a " + "factor of [" + targetNumberOfShards + "]"
+                    "the number of source shards [" + sourceNumberOfShards + "] must be a factor of [" + targetNumberOfShards + "]"
                 );
             }
         } else if (sourceNumberOfShards > targetNumberOfShards) { // shrink
             factor = sourceNumberOfShards / targetNumberOfShards;
             if (factor * targetNumberOfShards != sourceNumberOfShards || factor <= 1) {
                 throw new IllegalArgumentException(
-                    "the number of source shards [" + sourceNumberOfShards + "] must be a " + "multiple of [" + targetNumberOfShards + "]"
+                    "the number of source shards [" + sourceNumberOfShards + "] must be a multiple of [" + targetNumberOfShards + "]"
                 );
             }
         } else {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolver.java
@@ -516,7 +516,7 @@ public class IndexNameExpressionResolver {
 
     private static IllegalArgumentException aliasesNotSupportedException(String expression) {
         return new IllegalArgumentException(
-            "The provided expression [" + expression + "] matches an " + "alias, specify the corresponding concrete indices instead."
+            "The provided expression [" + expression + "] matches an alias, specify the corresponding concrete indices instead."
         );
     }
 
@@ -537,7 +537,7 @@ public class IndexNameExpressionResolver {
         Index[] indices = concreteIndices(state, request.indicesOptions(), indexExpression);
         if (indices.length != 1) {
             throw new IllegalArgumentException(
-                "unable to return a single index as the index and options" + " provided got resolved to multiple indices"
+                "unable to return a single index as the index and options provided got resolved to multiple indices"
             );
         }
         return indices[0];
@@ -1459,7 +1459,7 @@ public class IndexNameExpressionResolver {
                                 inPlaceHolderSb.append(c);
                             } else {
                                 throw new ElasticsearchParseException(
-                                    "invalid dynamic name expression [{}]." + " invalid character in placeholder at position [{}]",
+                                    "invalid dynamic name expression [{}]. invalid character in placeholder at position [{}]",
                                     new String(text, from, length),
                                     i
                                 );
@@ -1486,7 +1486,7 @@ public class IndexNameExpressionResolver {
                                 } else {
                                     if (inPlaceHolderString.lastIndexOf(RIGHT_BOUND) != inPlaceHolderString.length() - 1) {
                                         throw new ElasticsearchParseException(
-                                            "invalid dynamic name expression [{}]. missing closing `}`" + " for date math format",
+                                            "invalid dynamic name expression [{}]. missing closing `}` for date math format",
                                             inPlaceHolderString
                                         );
                                     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -102,7 +102,7 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
                         required = nodeBooleanValue(fieldNode);
                     } catch (IllegalArgumentException ex) {
                         throw new IllegalArgumentException(
-                            "Failed to create mapping for type [" + this.type() + "]. " + "Illegal value in field [_routing.required].",
+                            "Failed to create mapping for type [" + this.type() + "]. Illegal value in field [_routing.required].",
                             ex
                         );
                     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -846,7 +846,7 @@ public class MetadataCreateIndexService {
         final Map<String, Object> mappings = MapperService.parseMapping(xContentRegistry, request.mappings());
         if (mappings.isEmpty() == false) {
             throw new IllegalArgumentException(
-                "mappings are not allowed when creating an index from a source index, " + "all mappings are copied from the source index"
+                "mappings are not allowed when creating an index from a source index, all mappings are copied from the source index"
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -1102,7 +1102,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             @Override
             public void remove() {
                 throw new UnsupportedOperationException(
-                    "remove is not supported in unassigned iterator," + " use removeAndIgnore or initialize"
+                    "remove is not supported in unassigned iterator, use removeAndIgnore or initialize"
                 );
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -734,7 +734,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
                 + "]";
 
         assert b == false || this.primary == other.primary
-            : "ShardRouting is a relocation target but primary flag is different." + " This [" + this + "], target [" + other + "]";
+            : "ShardRouting is a relocation target but primary flag is different. This [" + this + "], target [" + other + "]";
 
         return b;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -252,7 +252,7 @@ public class DiskThresholdMonitor {
                     // will log about this node when the reroute completes
                 } else {
                     logger.debug(
-                        "high disk watermark exceeded on {} but an automatic reroute has occurred " + "in the last [{}], skipping reroute",
+                        "high disk watermark exceeded on {} but an automatic reroute has occurred in the last [{}], skipping reroute",
                         node,
                         diskThresholdSettings.getRerouteInterval()
                     );

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocationCommands.java
@@ -145,7 +145,7 @@ public class AllocationCommands implements ToXContentFragment {
                 // move to the end object one
                 if (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                     throw new ElasticsearchParseException(
-                        "allocation command is malformed, done parsing a command," + " but didn't get END_OBJECT, got [{}] instead",
+                        "allocation command is malformed, done parsing a command, but didn't get END_OBJECT, got [{}] instead",
                         token
                     );
                 }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDecider.java
@@ -162,7 +162,7 @@ public class DiskThresholdDecider extends AllocationDecider {
     private static final Decision YES_UNALLOCATED_PRIMARY_BETWEEN_WATERMARKS = Decision.single(
         Decision.Type.YES,
         NAME,
-        "the node " + "is above the low watermark, but less than the high watermark, and this primary shard has never been allocated before"
+        "the node is above the low watermark, but less than the high watermark, and this primary shard has never been allocated before"
     );
 
     private static final Decision YES_DISK_WATERMARKS_IGNORED = Decision.single(

--- a/server/src/main/java/org/elasticsearch/common/geo/BoundingBox.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/BoundingBox.java
@@ -162,7 +162,7 @@ public abstract class BoundingBox<T extends SpatialPoint> implements ToXContentF
                     || Double.isNaN(left) == false
                     || Double.isNaN(right) == false) {
                     throw new ElasticsearchParseException(
-                        "failed to parse bounding box. Conflicting definition found " + "using well-known text and explicit corners."
+                        "failed to parse bounding box. Conflicting definition found using well-known text and explicit corners."
                     );
                 }
                 return createWithEnvelope();

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -83,7 +83,7 @@ public final class GeoPoint implements SpatialPoint, ToXContentFragment {
     public GeoPoint resetFromCoordinates(String value, final boolean ignoreZValue) {
         String[] vals = value.split(",");
         if (vals.length > 3) {
-            throw new ElasticsearchParseException("failed to parse [{}], expected 2 or 3 coordinates " + "but found: [{}]", vals.length);
+            throw new ElasticsearchParseException("failed to parse [{}], expected 2 or 3 coordinates but found: [{}]", vals.length);
         }
         final double lat;
         final double lon;
@@ -111,9 +111,7 @@ public final class GeoPoint implements SpatialPoint, ToXContentFragment {
             throw new ElasticsearchParseException("Invalid WKT format", e);
         }
         if (geometry.type() != ShapeType.POINT) {
-            throw new ElasticsearchParseException(
-                "[geo_point] supports only POINT among WKT primitives, " + "but found " + geometry.type()
-            );
+            throw new ElasticsearchParseException("[geo_point] supports only POINT among WKT primitives, but found " + geometry.type());
         }
         Point point = (Point) geometry;
         return reset(point.getY(), point.getX());
@@ -250,7 +248,7 @@ public final class GeoPoint implements SpatialPoint, ToXContentFragment {
     public static double assertZValue(final boolean ignoreZValue, double zValue) {
         if (ignoreZValue == false) {
             throw new ElasticsearchParseException(
-                "Exception parsing coordinates: found Z value [{}] but [ignore_z_value] " + "parameter is [{}]",
+                "Exception parsing coordinates: found Z value [{}] but [ignore_z_value] parameter is [{}]",
                 zValue,
                 ignoreZValue
             );

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPolygonDecomposer.java
@@ -783,7 +783,7 @@ class GeoPolygonDecomposer {
 
         @Override
         public String toString() {
-            return "Edge[Component=" + component + "; start=" + coordinate + " " + "; intersection=" + intersect + "]";
+            return "Edge[Component=" + component + "; start=" + coordinate + "; intersection=" + intersect + "]";
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/Errors.java
@@ -132,7 +132,7 @@ public final class Errors {
 
     public Errors converterReturnedNull(String stringValue, Object source, TypeLiteral<?> type, MatcherAndConverter matchingConverter) {
         return addMessage(
-            "Received null converting '%s' (bound at %s) to %s%n" + " using %s.",
+            "Received null converting '%s' (bound at %s) to %s%n using %s.",
             stringValue,
             convert(source),
             type,
@@ -148,7 +148,7 @@ public final class Errors {
         Object converted
     ) {
         return addMessage(
-            "Type mismatch converting '%s' (bound at %s) to %s%n" + " using %s.%n" + " Converter returned %s.",
+            "Type mismatch converting '%s' (bound at %s) to %s%n using %s.%n Converter returned %s.",
             stringValue,
             convert(source),
             type,
@@ -166,7 +166,7 @@ public final class Errors {
     ) {
         return errorInUserCode(
             cause,
-            "Error converting '%s' (bound at %s) to %s%n" + " using %s.%n" + " Reason: %s",
+            "Error converting '%s' (bound at %s) to %s%n using %s.%n Reason: %s",
             stringValue,
             convert(source),
             type,
@@ -216,7 +216,7 @@ public final class Errors {
     }
 
     public Errors missingRuntimeRetention(Object source) {
-        return addMessage("Please annotate with @Retention(RUNTIME).%n" + " Bound at %s.", convert(source));
+        return addMessage("Please annotate with @Retention(RUNTIME).%n Bound at %s.", convert(source));
     }
 
     public Errors missingScopeAnnotation() {
@@ -224,7 +224,7 @@ public final class Errors {
     }
 
     public Errors optionalConstructor(Constructor constructor) {
-        return addMessage("%s is annotated @Inject(optional=true), " + "but constructors cannot be optional.", constructor);
+        return addMessage("%s is annotated @Inject(optional=true), but constructors cannot be optional.", constructor);
     }
 
     public Errors cannotBindToGuiceType(String simpleName) {
@@ -237,7 +237,7 @@ public final class Errors {
 
     public Errors scopeAnnotationOnAbstractType(Class<? extends Annotation> scopeAnnotation, Class<?> type, Object source) {
         return addMessage(
-            "%s is annotated with %s, but scope annotations are not supported " + "for abstract types.%n Bound at %s.",
+            "%s is annotated with %s, but scope annotations are not supported for abstract types.%n Bound at %s.",
             type,
             scopeAnnotation,
             convert(source)
@@ -246,7 +246,7 @@ public final class Errors {
 
     public Errors misplacedBindingAnnotation(Member member, Annotation bindingAnnotation) {
         return addMessage(
-            "%s is annotated with %s, but binding annotations should be applied " + "to its parameters instead.",
+            "%s is annotated with %s, but binding annotations should be applied to its parameters instead.",
             member,
             bindingAnnotation
         );
@@ -278,13 +278,13 @@ public final class Errors {
 
     public Errors cannotInjectInnerClass(Class<?> type) {
         return addMessage(
-            "Injecting into inner classes is not supported.  " + "Please use a 'static' class (top-level or nested) instead of %s.",
+            "Injecting into inner classes is not supported. Please use a 'static' class (top-level or nested) instead of %s.",
             type
         );
     }
 
     public Errors duplicateBindingAnnotations(Member member, Class<? extends Annotation> a, Class<? extends Annotation> b) {
-        return addMessage("%s has more than one annotation annotated with @BindingAnnotation: " + "%s and %s", member, a, b);
+        return addMessage("%s has more than one annotation annotated with @BindingAnnotation: %s and %s", member, a, b);
     }
 
     public Errors duplicateScopeAnnotations(Class<? extends Annotation> a, Class<? extends Annotation> b) {
@@ -316,11 +316,11 @@ public final class Errors {
     }
 
     public Errors errorInUserInjector(MembersInjector<?> listener, TypeLiteral<?> type, RuntimeException cause) {
-        return errorInUserCode(cause, "Error injecting %s using %s.%n" + " Reason: %s", type, listener, cause);
+        return errorInUserCode(cause, "Error injecting %s using %s.%n Reason: %s", type, listener, cause);
     }
 
     public Errors errorNotifyingInjectionListener(InjectionListener<?> listener, TypeLiteral<?> type, RuntimeException cause) {
-        return errorInUserCode(cause, "Error notifying InjectionListener %s of %s.%n" + " Reason: %s", listener, type, cause);
+        return errorInUserCode(cause, "Error notifying InjectionListener %s of %s.%n Reason: %s", listener, type, cause);
     }
 
     public static Collection<Message> getMessagesFromThrowable(Throwable throwable) {

--- a/server/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/internal/MoreTypes.java
@@ -158,7 +158,7 @@ public class MoreTypes {
 
         } else {
             throw new IllegalArgumentException(
-                "Expected a Class, ParameterizedType, or " + "GenericArrayType, but <" + type + "> is of type " + type.getClass().getName()
+                "Expected a Class, ParameterizedType, or GenericArrayType, but <" + type + "> is of type " + type.getClass().getName()
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/common/inject/spi/Elements.java
+++ b/server/src/main/java/org/elasticsearch/common/inject/spi/Elements.java
@@ -194,7 +194,7 @@ public final class Elements {
 
         @Override
         public void expose(Key<?> key) {
-            addError("Cannot expose %s on a standard binder. " + "Exposed bindings are only applicable to private binders.", key);
+            addError("Cannot expose %s on a standard binder. Exposed bindings are only applicable to private binders.", key);
 
         }
 

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/XMoreLikeThis.java
@@ -586,7 +586,7 @@ public final class XMoreLikeThis {
      */
     private void addTermFrequencies(Reader r, Map<String, Int> termFreqMap, String fieldName) throws IOException {
         if (analyzer == null) {
-            throw new UnsupportedOperationException("To use MoreLikeThis without " + "term vectors, you must provide an Analyzer");
+            throw new UnsupportedOperationException("To use MoreLikeThis without term vectors, you must provide an Analyzer");
         }
         try (TokenStream ts = analyzer.tokenStream(fieldName, r)) {
             int tokenCount = 0;

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreQuery.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/ScriptScoreQuery.java
@@ -186,7 +186,7 @@ public class ScriptScoreQuery extends Query {
 
     @Override
     public String toString(String field) {
-        return "script_score (" + subQuery.toString(field) + ", script: " + "{" + script.toString() + "}";
+        return "script_score (" + subQuery.toString(field) + ", script: {" + script.toString() + "}";
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/scheduler/SchedulerEngine.java
+++ b/server/src/main/java/org/elasticsearch/common/scheduler/SchedulerEngine.java
@@ -82,7 +82,7 @@ public class SchedulerEngine {
 
         @Override
         public String toString() {
-            return "Event[jobName=" + jobName + "," + "triggeredTime=" + triggeredTime + "," + "scheduledTime=" + scheduledTime + "]";
+            return "Event[jobName=" + jobName + ", triggeredTime=" + triggeredTime + ", scheduledTime=" + scheduledTime + "]";
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -106,8 +106,7 @@ public class KeyStoreWrapper implements SecureSettings {
     public static final Setting<SecureString> SEED_SETTING = SecureSetting.secureString("keystore.seed", null);
 
     /** Characters that may be used in the bootstrap seed setting added to all keystores. */
-    private static final char[] SEED_CHARS = ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789" + "~!@#$%^&*-_=+?")
-        .toCharArray();
+    private static final char[] SEED_CHARS = ("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789~!@#$%^&*-_=+?").toCharArray();
 
     /** The name of the keystore file to read and write. */
     public static final String KEYSTORE_FILENAME = "elasticsearch.keystore";

--- a/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
@@ -184,9 +184,7 @@ public abstract class SecureSetting<T> extends Setting<T> {
         @Override
         public SecureString get(Settings settings) {
             if (ALLOW_INSECURE_SETTINGS == false && exists(settings)) {
-                throw new IllegalArgumentException(
-                    "Setting [" + name + "] is insecure, " + "but property [allow_insecure_settings] is not set"
-                );
+                throw new IllegalArgumentException("Setting [" + name + "] is insecure, but property [allow_insecure_settings] is not set");
             }
             return super.get(settings);
         }

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1000,14 +1000,14 @@ public class Setting<T> implements ToXContentObject {
         @Override
         public T get(Settings settings) {
             throw new UnsupportedOperationException(
-                "affix settings can't return values" + " use #getConcreteSetting to obtain a concrete setting"
+                "affix settings can't return values use #getConcreteSetting to obtain a concrete setting"
             );
         }
 
         @Override
         public String innerGetRaw(final Settings settings) {
             throw new UnsupportedOperationException(
-                "affix settings can't return values" + " use #getConcreteSetting to obtain a concrete setting"
+                "affix settings can't return values use #getConcreteSetting to obtain a concrete setting"
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateUtils.java
@@ -193,12 +193,12 @@ public class DateUtils {
     public static long toLong(Instant instant) {
         if (instant.isBefore(Instant.EPOCH)) {
             throw new IllegalArgumentException(
-                "date[" + instant + "] is before the epoch in 1970 and cannot be " + "stored in nanosecond resolution"
+                "date[" + instant + "] is before the epoch in 1970 and cannot be stored in nanosecond resolution"
             );
         }
         if (instant.isAfter(MAX_NANOSECOND_INSTANT)) {
             throw new IllegalArgumentException(
-                "date[" + instant + "] is after 2262-04-11T23:47:16.854775807 and cannot be " + "stored in nanosecond resolution"
+                "date[" + instant + "] is after 2262-04-11T23:47:16.854775807 and cannot be stored in nanosecond resolution"
             );
         }
         return instant.getEpochSecond() * 1_000_000_000 + instant.getNano();
@@ -258,7 +258,7 @@ public class DateUtils {
     public static long toNanoSeconds(long milliSecondsSinceEpoch) {
         if (milliSecondsSinceEpoch < 0) {
             throw new IllegalArgumentException(
-                "milliSeconds [" + milliSecondsSinceEpoch + "] are before the epoch in 1970 and cannot " + "be converted to nanoseconds"
+                "milliSeconds [" + milliSecondsSinceEpoch + "] are before the epoch in 1970 and cannot be converted to nanoseconds"
             );
         } else if (milliSecondsSinceEpoch > MAX_NANOSECOND_IN_MILLIS) {
             throw new IllegalArgumentException(
@@ -281,7 +281,7 @@ public class DateUtils {
     public static long toMilliSeconds(long nanoSecondsSinceEpoch) {
         if (nanoSecondsSinceEpoch < 0) {
             throw new IllegalArgumentException(
-                "nanoseconds are [" + nanoSecondsSinceEpoch + "] are before the epoch in 1970 and cannot " + "be converted to milliseconds"
+                "nanoseconds are [" + nanoSecondsSinceEpoch + "] are before the epoch in 1970 and cannot be converted to milliseconds"
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
+++ b/server/src/main/java/org/elasticsearch/common/util/SetBackedScalingCuckooFilter.java
@@ -266,7 +266,7 @@ public class SetBackedScalingCuckooFilter implements Writeable {
     void convert() {
         if (isSetMode == false) {
             throw new IllegalStateException(
-                "Cannot convert SetBackedScalingCuckooFilter to approximate " + "when it has already been converted."
+                "Cannot convert SetBackedScalingCuckooFilter to approximate when it has already been converted."
             );
         }
         long oldSize = getSizeInBytes();

--- a/server/src/main/java/org/elasticsearch/discovery/SeedHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/SeedHostsResolver.java
@@ -150,7 +150,7 @@ public class SeedHostsResolver extends AbstractLifecycleComponent implements Con
         final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory(settings, "[unicast_configured_hosts_resolver]");
         executorService.set(
             EsExecutors.newScaling(
-                nodeName + "/" + "unicast_configured_hosts_resolver",
+                nodeName + "/unicast_configured_hosts_resolver",
                 0,
                 concurrentConnects,
                 60,

--- a/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PrimaryShardAllocator.java
@@ -331,7 +331,7 @@ public abstract class PrimaryShardAllocator extends BaseGatewayShardAllocator {
                 } else {
                     logger.trace(
                         () -> format(
-                            "[%s] on node [%s] has allocation id [%s] but the store can not be " + "opened, treating as no allocation id",
+                            "[%s] on node [%s] has allocation id [%s] but the store can not be opened, treating as no allocation id",
                             shard,
                             nodeShardState.getNode(),
                             finalAllocationId

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -114,7 +114,7 @@ public final class IndexSettings {
         return switch (s) {
             case "false", "true", "checksum" -> s;
             default -> throw new IllegalArgumentException(
-                "unknown value for [index.shard.check_on_startup] must be one of " + "[true, false, checksum] but was: " + s
+                "unknown value for [index.shard.check_on_startup] must be one of [true, false, checksum] but was: " + s
             );
         };
     }, Property.IndexScope);

--- a/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSortConfig.java
@@ -111,7 +111,7 @@ public final class IndexSortConfig {
 
     private static String validateMissingValue(String missing) {
         if ("_last".equals(missing) == false && "_first".equals(missing) == false) {
-            throw new IllegalArgumentException("Illegal missing value:[" + missing + "], " + "must be one of [_last, _first]");
+            throw new IllegalArgumentException("Illegal missing value:[" + missing + "], must be one of [_last, _first]");
         }
         return missing;
     }
@@ -128,7 +128,7 @@ public final class IndexSortConfig {
         MultiValueMode mode = MultiValueMode.fromString(value);
         if (mode != MultiValueMode.MAX && mode != MultiValueMode.MIN) {
             throw new IllegalArgumentException(
-                "Illegal index sort mode:[" + mode + "], " + "must be one of [" + MultiValueMode.MAX + ", " + MultiValueMode.MIN + "]"
+                "Illegal index sort mode:[" + mode + "], must be one of [" + MultiValueMode.MAX + ", " + MultiValueMode.MIN + "]"
             );
         }
         return mode;

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -287,7 +287,7 @@ public final class MergePolicyConfig {
         this.mergesEnabled = indexSettings.getSettings().getAsBoolean(INDEX_MERGE_ENABLED, true);
         if (mergesEnabled == false) {
             logger.warn(
-                "[{}] is set to false, this should only be used in tests and can cause serious problems in production" + " environments",
+                "[{}] is set to false, this should only be used in tests and can cause serious problems in production environments",
                 INDEX_MERGE_ENABLED
             );
         }
@@ -373,7 +373,7 @@ public final class MergePolicyConfig {
                 newMaxMergeAtOnce = 2;
             }
             logger.debug(
-                "changing max_merge_at_once from [{}] to [{}] because segments_per_tier [{}] has to be higher or " + "equal to it",
+                "changing max_merge_at_once from [{}] to [{}] because segments_per_tier [{}] has to be higher or equal to it",
                 maxMergeAtOnce,
                 newMaxMergeAtOnce,
                 segmentsPerTier

--- a/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -297,7 +297,7 @@ public class Analysis {
                 String[] values = CSVUtil.parse(line);
                 if (dup.add(values[0]) == false) {
                     throw new IllegalArgumentException(
-                        "Found duplicate term [" + values[0] + "] in user dictionary " + "at line [" + lineNum + "]"
+                        "Found duplicate term [" + values[0] + "] in user dictionary at line [" + lineNum + "]"
                     );
                 }
             }

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalysisRegistry.java
@@ -476,7 +476,7 @@ public final class AnalysisRegistry implements Closeable {
                         factory = (T) new CustomAnalyzerProvider(settings, name, currentSettings);
                     } else {
                         throw new IllegalArgumentException(
-                            component + " [" + name + "] " + "must specify either an analyzer type, or a tokenizer"
+                            component + " [" + name + "] must specify either an analyzer type, or a tokenizer"
                         );
                     }
                 } else if (typeName.equals("custom")) {

--- a/server/src/main/java/org/elasticsearch/index/analysis/AnalyzerComponents.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/AnalyzerComponents.java
@@ -54,7 +54,7 @@ public final class AnalyzerComponents {
         TokenizerFactory tokenizer = tokenizers.get(tokenizerName);
         if (tokenizer == null) {
             throw new IllegalArgumentException(
-                "Custom Analyzer [" + name + "] failed to find tokenizer under name " + "[" + tokenizerName + "]"
+                "Custom Analyzer [" + name + "] failed to find tokenizer under name [" + tokenizerName + "]"
             );
         }
 
@@ -64,7 +64,7 @@ public final class AnalyzerComponents {
             CharFilterFactory charFilter = charFilters.get(charFilterName);
             if (charFilter == null) {
                 throw new IllegalArgumentException(
-                    "Custom Analyzer [" + name + "] failed to find char_filter under name " + "[" + charFilterName + "]"
+                    "Custom Analyzer [" + name + "] failed to find char_filter under name [" + charFilterName + "]"
                 );
             }
             charFiltersList.add(charFilter);
@@ -76,7 +76,7 @@ public final class AnalyzerComponents {
             TokenFilterFactory tokenFilter = tokenFilters.get(tokenFilterName);
             if (tokenFilter == null) {
                 throw new IllegalArgumentException(
-                    "Custom Analyzer [" + name + "] failed to find filter under name " + "[" + tokenFilterName + "]"
+                    "Custom Analyzer [" + name + "] failed to find filter under name [" + tokenFilterName + "]"
                 );
             }
             tokenFilter = tokenFilter.getChainAwareTokenFilterFactory(

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -90,7 +90,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
     protected void throwIfEmpty() {
         if (size() == 0) {
             throw new IllegalStateException(
-                "A document doesn't have a value for a field! " + "Use doc[<field>].size()==0 to check if a document is missing a field!"
+                "A document doesn't have a value for a field! Use doc[<field>].size()==0 to check if a document is missing a field!"
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/AbstractPointGeometryFieldMapper.java
@@ -110,7 +110,7 @@ public abstract class AbstractPointGeometryFieldMapper<T> extends AbstractGeomet
                     if (token == XContentParser.Token.VALUE_NUMBER) {
                         if (ignoreZValue == false) {
                             throw new ElasticsearchParseException(
-                                "Exception parsing coordinates: found Z value [{}] but [ignore_z_value] " + "parameter is [{}]",
+                                "Exception parsing coordinates: found Z value [{}] but [ignore_z_value] parameter is [{}]",
                                 parser.doubleValue(),
                                 ignoreZValue
                             );

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointScriptFieldType.java
@@ -143,7 +143,7 @@ public final class GeoPointScriptFieldType extends AbstractScriptFieldType<GeoPo
             originGeoPoint = GeoUtils.parseFromString((String) origin);
         } else {
             throw new IllegalArgumentException(
-                "Illegal type [" + origin.getClass() + "] for [origin]! " + "Must be of type [geo_point] or [string] for geo_point fields!"
+                "Illegal type [" + origin.getClass() + "] for [origin]! Must be of type [geo_point] or [string] for geo_point fields!"
             );
         }
         double pivotDouble = DistanceUnit.DEFAULT.parse(pivot, DistanceUnit.DEFAULT);

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -329,9 +329,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             SearchExecutionContext context,
             @Nullable MultiTermQuery.RewriteMethod rewriteMethod
         ) {
-            throw new UnsupportedOperationException(
-                "[fuzzy] queries are not currently supported on keyed " + "[" + CONTENT_TYPE + "] fields."
-            );
+            throw new UnsupportedOperationException("[fuzzy] queries are not currently supported on keyed [" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
@@ -343,9 +341,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             MultiTermQuery.RewriteMethod method,
             SearchExecutionContext context
         ) {
-            throw new UnsupportedOperationException(
-                "[regexp] queries are not currently supported on keyed " + "[" + CONTENT_TYPE + "] fields."
-            );
+            throw new UnsupportedOperationException("[regexp] queries are not currently supported on keyed [" + CONTENT_TYPE + "] fields.");
         }
 
         @Override
@@ -356,7 +352,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             SearchExecutionContext context
         ) {
             throw new UnsupportedOperationException(
-                "[wildcard] queries are not currently supported on keyed " + "[" + CONTENT_TYPE + "] fields."
+                "[wildcard] queries are not currently supported on keyed [" + CONTENT_TYPE + "] fields."
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/ReindexRequest.java
@@ -499,7 +499,7 @@ public class ReindexRequest extends AbstractBulkIndexByScrollRequest<ReindexRequ
     static void setMaxDocsValidateIdentical(AbstractBulkByScrollRequest<?> request, int maxDocs) {
         if (request.getMaxDocs() != AbstractBulkByScrollRequest.MAX_DOCS_ALL_MATCHES && request.getMaxDocs() != maxDocs) {
             throw new IllegalArgumentException(
-                "[max_docs] set to two different values [" + request.getMaxDocs() + "]" + " and [" + maxDocs + "]"
+                "[max_docs] set to two different values [" + request.getMaxDocs() + "] and [" + maxDocs + "]"
             );
         } else {
             request.setMaxDocs(maxDocs);

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProviders.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityProviders.java
@@ -103,7 +103,7 @@ final class SimilarityProviders {
             if (replacement != null) {
                 if (indexCreatedVersion.onOrAfter(IndexVersions.V_7_0_0)) {
                     throw new IllegalArgumentException(
-                        "Basic model [" + basicModel + "] isn't supported anymore, " + "please use another model."
+                        "Basic model [" + basicModel + "] isn't supported anymore, please use another model."
                     );
                 } else {
                     deprecationLogger.warn(

--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -142,7 +142,7 @@ public class IndexShardSnapshotStatus {
             ensureNotAborted();
             assert false : "Should not try to move stage [" + stage.get() + "] to [STARTED]";
             throw new IllegalStateException(
-                "Unable to move the shard snapshot status to [STARTED]: " + "expecting [INIT] but got [" + stage.get() + "]"
+                "Unable to move the shard snapshot status to [STARTED]: expecting [INIT] but got [" + stage.get() + "]"
             );
         }
         return asCopy();
@@ -178,7 +178,7 @@ public class IndexShardSnapshotStatus {
         } else {
             assert false : "Should not try to move stage [" + stage.get() + "] to [DONE]";
             throw new IllegalStateException(
-                "Unable to move the shard snapshot status to [DONE]: " + "expecting [FINALIZE] but got [" + stage.get() + "]"
+                "Unable to move the shard snapshot status to [DONE]: expecting [FINALIZE] but got [" + stage.get() + "]"
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1168,7 +1168,7 @@ public class IndicesService extends AbstractLifecycleComponent
                 }
             } catch (Exception e) {
                 logger.warn(
-                    () -> format("[%s] failed to load state file from a stale deleted index, " + "folders will be left on disk", index),
+                    () -> format("[%s] failed to load state file from a stale deleted index, folders will be left on disk", index),
                     e
                 );
                 return null;

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -601,7 +601,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
                     public void onTimeout(TimeValue timeout) {
                         // note that we do not use a timeout (see comment above)
                         listener.onFailure(
-                            new ElasticsearchTimeoutException("timed out waiting for mapping updates " + "(timeout [" + timeout + "])")
+                            new ElasticsearchTimeoutException("timed out waiting for mapping updates (timeout [" + timeout + "])")
                         );
                     }
                 });

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -601,7 +601,7 @@ public class RecoverySourceHandler {
         if (logger.isTraceEnabled()) {
             for (StoreFileMetadata md : shardRecoveryPlan.getFilesPresentInTarget()) {
                 logger.trace(
-                    "recovery [phase1]: not recovering [{}], exist in local store and has checksum [{}]," + " size [{}]",
+                    "recovery [phase1]: not recovering [{}], exist in local store and has checksum [{}], size [{}]",
                     md.name(),
                     md.checksum(),
                     md.length()

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -363,7 +363,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
     private void ensureRefCount() {
         if (refCount() <= 0) {
             throw new ElasticsearchException(
-                "RecoveryStatus is used but it's refcount is 0. Probably a mismatch between incRef/decRef " + "calls"
+                "RecoveryStatus is used but it's refcount is 0. Probably a mismatch between incRef/decRef calls"
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
+++ b/server/src/main/java/org/elasticsearch/lucene/search/uhighlight/BoundedBreakIteratorScanner.java
@@ -83,7 +83,7 @@ public class BoundedBreakIteratorScanner extends BreakIterator {
     @Override
     public int preceding(int offset) {
         if (offset < lastPrecedingOffset) {
-            throw new IllegalArgumentException("offset < lastPrecedingOffset: " + "usage doesn't look like UnifiedHighlighter");
+            throw new IllegalArgumentException("offset < lastPrecedingOffset: usage doesn't look like UnifiedHighlighter");
         }
         if (offset > windowStart && offset < windowEnd) {
             innerStart = innerEnd;

--- a/server/src/main/java/org/elasticsearch/monitor/StatusInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/StatusInfo.java
@@ -50,6 +50,6 @@ public record StatusInfo(Status status, String info) implements Writeable {
 
     @Override
     public String toString() {
-        return "status[" + status + "]" + ", info[" + info + "]";
+        return "status[" + status + "], info[" + info + "]";
     }
 }

--- a/server/src/main/java/org/elasticsearch/plugins/spi/SPIClassIterator.java
+++ b/server/src/main/java/org/elasticsearch/plugins/spi/SPIClassIterator.java
@@ -163,7 +163,7 @@ public final class SPIClassIterator<S> implements Iterator<Class<? extends S>> {
             throw new ServiceConfigurationError(
                 String.format(
                     Locale.ROOT,
-                    "An SPI class of type %s with classname %s does not exist, " + "please fix the file '%s%1$s' in your classpath.",
+                    "An SPI class of type %s with classname %s does not exist, please fix the file '%s%1$s' in your classpath.",
                     clazz.getName(),
                     c,
                     META_INF_SERVICES

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2236,7 +2236,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 genToLoad = latestKnownRepoGen.accumulateAndGet(generation, Math::max);
                 if (genToLoad > generation) {
                     logger.info(
-                        "Determined repository generation [{}] from repository contents but correct generation must be at " + "least [{}]",
+                        "Determined repository generation [{}] from repository contents but correct generation must be at least [{}]",
                         generation,
                         genToLoad
                     );

--- a/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/fs/FsRepository.java
@@ -95,7 +95,7 @@ public class FsRepository extends BlobStoreRepository {
         if (locationFile == null) {
             if (environment.repoFiles().length > 0) {
                 logger.warn(
-                    "The specified location [{}] doesn't start with any " + "repository paths specified by the path.repo setting: [{}] ",
+                    "The specified location [{}] doesn't start with any repository paths specified by the path.repo setting: [{}] ",
                     location,
                     environment.repoFiles()
                 );

--- a/server/src/main/java/org/elasticsearch/script/AbstractSortScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractSortScript.java
@@ -28,14 +28,14 @@ abstract class AbstractSortScript extends DocBasedScript implements ScorerAware 
         deprecationLogger.warn(
             DeprecationCategory.SCRIPTING,
             "sort-script_doc",
-            "Accessing variable [doc] via [params.doc] from within an sort-script " + "is deprecated in favor of directly accessing [doc]."
+            "Accessing variable [doc] via [params.doc] from within an sort-script is deprecated in favor of directly accessing [doc]."
         );
         return value;
     }, "_doc", value -> {
         deprecationLogger.warn(
             DeprecationCategory.SCRIPTING,
             "sort-script__doc",
-            "Accessing variable [doc] via [params._doc] from within an sort-script " + "is deprecated in favor of directly accessing [doc]."
+            "Accessing variable [doc] via [params._doc] from within an sort-script is deprecated in favor of directly accessing [doc]."
         );
         return value;
     }, "_source", value -> ((Supplier<Source>) value).get().source());

--- a/server/src/main/java/org/elasticsearch/script/FieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/FieldScript.java
@@ -34,7 +34,7 @@ public abstract class FieldScript extends DocBasedScript {
         deprecationLogger.warn(
             DeprecationCategory.SCRIPTING,
             "field-script_doc",
-            "Accessing variable [doc] via [params.doc] from within an field-script " + "is deprecated in favor of directly accessing [doc]."
+            "Accessing variable [doc] via [params.doc] from within an field-script is deprecated in favor of directly accessing [doc]."
         );
         return value;
     }, "_doc", value -> {

--- a/server/src/main/java/org/elasticsearch/script/ScoreScript.java
+++ b/server/src/main/java/org/elasticsearch/script/ScoreScript.java
@@ -57,7 +57,7 @@ public abstract class ScoreScript extends DocBasedScript {
         deprecationLogger.warn(
             DeprecationCategory.SCRIPTING,
             "score-script_doc",
-            "Accessing variable [doc] via [params.doc] from within an score-script " + "is deprecated in favor of directly accessing [doc]."
+            "Accessing variable [doc] via [params.doc] from within an score-script is deprecated in favor of directly accessing [doc]."
         );
         return value;
     }, "_doc", value -> {

--- a/server/src/main/java/org/elasticsearch/script/Script.java
+++ b/server/src/main/java/org/elasticsearch/script/Script.java
@@ -243,7 +243,7 @@ public final class Script implements ToXContentObject, Writeable {
                     options = null;
                 } else {
                     throw new IllegalArgumentException(
-                        "field [" + OPTIONS_PARSE_FIELD.getPreferredName() + "] " + "cannot be specified using a stored script"
+                        "field [" + OPTIONS_PARSE_FIELD.getPreferredName() + "] cannot be specified using a stored script"
                     );
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorFactory.java
@@ -130,7 +130,7 @@ public final class DateHistogramAggregatorFactory extends ValuesSourceAggregator
         if (getSamplingContext().map(SamplingContext::isSampled).orElse(false)) {
             if (minDocCount > 1) {
                 throw new ElasticsearchStatusException(
-                    "aggregation [{}] is within a sampling context; " + "min_doc_count, provided [{}], cannot be greater than 1",
+                    "aggregation [{}] is within a sampling context; min_doc_count, provided [{}], cannot be greater than 1",
                     RestStatus.BAD_REQUEST,
                     name(),
                     minDocCount

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateIntervalWrapper.java
@@ -163,7 +163,7 @@ public class DateIntervalWrapper implements ToXContentFragment, Writeable {
             throw new IllegalArgumentException("[interval] must not be null: [date_histogram]");
         }
         if (DateHistogramAggregationBuilder.DATE_FIELD_UNITS.get(interval.toString()) == null) {
-            throw new IllegalArgumentException("The supplied interval [" + interval + "] could not be parsed " + "as a calendar interval.");
+            throw new IllegalArgumentException("The supplied interval [" + interval + "] could not be parsed as a calendar interval.");
         }
         setIntervalType(IntervalTypeEnum.CALENDAR);
         this.dateHistogramInterval = interval;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramAggregatorFactory.java
@@ -92,7 +92,7 @@ public final class HistogramAggregatorFactory extends ValuesSourceAggregatorFact
         if (getSamplingContext().map(SamplingContext::isSampled).orElse(false)) {
             if (minDocCount > 1) {
                 throw new ElasticsearchStatusException(
-                    "aggregation [{}] is within a sampling context; " + "min_doc_count, provided [{}], cannot be greater than 1",
+                    "aggregation [{}] is within a sampling context; min_doc_count, provided [{}], cannot be greater than 1",
                     RestStatus.BAD_REQUEST,
                     name(),
                     minDocCount

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/GeoDistanceAggregationBuilder.java
@@ -163,7 +163,7 @@ public class GeoDistanceAggregationBuilder extends ValuesSourceAggregationBuilde
             if (Double.isNaN(lat) || Double.isNaN(lon)) {
                 throw new ParsingException(
                     parser.getTokenLocation(),
-                    "malformed [" + currentFieldName + "] geo point object. either [lat] or [lon] (or both) are " + "missing"
+                    "malformed [" + currentFieldName + "] geo point object. either [lat] or [lon] (or both) are missing"
                 );
             }
             return new GeoPoint(lat, lon);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java
@@ -140,7 +140,7 @@ public class RareTermsAggregationBuilder extends ValuesSourceAggregationBuilder<
         // TODO review: what size cap should we put on this?
         if (maxDocCount > MAX_MAX_DOC_COUNT) {
             throw new IllegalArgumentException(
-                "[" + MAX_DOC_COUNT_FIELD_NAME.getPreferredName() + "] must be smaller" + "than " + MAX_MAX_DOC_COUNT + "in [" + name + "]"
+                "[" + MAX_DOC_COUNT_FIELD_NAME.getPreferredName() + "] must be smaller than " + MAX_MAX_DOC_COUNT + "in [" + name + "]"
             );
         }
         this.maxDocCount = (int) maxDocCount;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantTextAggregatorFactory.java
@@ -90,7 +90,7 @@ public class SignificantTextAggregatorFactory extends AggregatorFactory {
         if (fieldType != null) {
             if (supportsAgg(fieldType) == false) {
                 throw new IllegalArgumentException(
-                    "Field [" + fieldType.name() + "] has no analyzer, but SignificantText " + "requires an analyzed field"
+                    "Field [" + fieldType.name() + "] has no analyzer, but SignificantText requires an analyzed field"
                 );
             }
             String indexedFieldName = fieldType.name();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/ScriptHeuristic.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/heuristic/ScriptHeuristic.java
@@ -111,7 +111,7 @@ public class ScriptHeuristic extends SignificanceHeuristic {
     @Override
     public double getScore(long subsetFreq, long subsetSize, long supersetFreq, long supersetSize) {
         throw new UnsupportedOperationException(
-            "This scoring heuristic must have 'rewrite' called on it to provide a version ready " + "for use"
+            "This scoring heuristic must have 'rewrite' called on it to provide a version ready for use"
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractPercentilesAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractPercentilesAggregationBuilder.java
@@ -183,7 +183,7 @@ public abstract class AbstractPercentilesAggregationBuilder<T extends AbstractPe
             percentilesConfig = new PercentilesConfig.Hdr(numberOfSignificantValueDigits);
         } else {
             throw new IllegalArgumentException(
-                "Cannot set [numberOfSignificantValueDigits] because the method " + "has already been configured for TDigest"
+                "Cannot set [numberOfSignificantValueDigits] because the method has already been configured for TDigest"
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -675,9 +675,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
 
     public SearchSourceBuilder trackTotalHitsUpTo(int trackTotalHitsUpTo) {
         if (trackTotalHitsUpTo < TRACK_TOTAL_HITS_DISABLED) {
-            throw new IllegalArgumentException(
-                "[track_total_hits] parameter must be positive or equals to -1, " + "got " + trackTotalHitsUpTo
-            );
+            throw new IllegalArgumentException("[track_total_hits] parameter must be positive or equals to -1, got " + trackTotalHitsUpTo);
         }
         this.trackTotalHitsUpTo = trackTotalHitsUpTo;
         return this;

--- a/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/collapse/CollapseBuilder.java
@@ -210,7 +210,7 @@ public class CollapseBuilder implements Writeable, ToXContentObject {
         }
         if (fieldType.isIndexed() == false && (innerHits != null && innerHits.isEmpty() == false)) {
             throw new IllegalArgumentException(
-                "cannot expand `inner_hits` for collapse field `" + field + "`, " + "only indexed field can retrieve `inner_hits`"
+                "cannot expand `inner_hits` for collapse field `" + field + "`, only indexed field can retrieve `inner_hits`"
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/FieldSortBuilder.java
@@ -136,7 +136,7 @@ public final class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
         if (in.getTransportVersion().before(TransportVersions.V_8_0_0)) {
             if (in.readOptionalNamedWriteable(QueryBuilder.class) != null || in.readOptionalString() != null) {
                 throw new IOException(
-                    "the [sort] options [nested_path] and [nested_filter] are removed in 8.x, " + "please use [nested] instead"
+                    "the [sort] options [nested_path] and [nested_filter] are removed in 8.x, please use [nested] instead"
                 );
             }
         }
@@ -272,7 +272,7 @@ public final class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
 
             default:
                 throw new IllegalArgumentException(
-                    "invalid value for [numeric_type], " + "must be [long, double, date, date_nanos], got " + lowerCase
+                    "invalid value for [numeric_type], must be [long, double, date, date_nanos], got " + lowerCase
                 );
         }
         this.numericType = lowerCase;
@@ -330,7 +330,7 @@ public final class FieldSortBuilder extends SortBuilder<FieldSortBuilder> {
             case "date" -> NumericType.DATE;
             case "date_nanos" -> NumericType.DATE_NANOSECONDS;
             default -> throw new IllegalArgumentException(
-                "invalid value for [numeric_type], " + "must be [long, double, date, date_nanos], got " + value
+                "invalid value for [numeric_type], must be [long, double, date, date_nanos], got " + value
             );
         };
     }

--- a/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/GeoDistanceSortBuilder.java
@@ -163,7 +163,7 @@ public class GeoDistanceSortBuilder extends SortBuilder<GeoDistanceSortBuilder> 
         if (in.getTransportVersion().before(TransportVersions.V_8_0_0)) {
             if (in.readOptionalNamedWriteable(QueryBuilder.class) != null || in.readOptionalString() != null) {
                 throw new IOException(
-                    "the [sort] options [nested_path] and [nested_filter] are removed in 8.x, " + "please use [nested] instead"
+                    "the [sort] options [nested_path] and [nested_filter] are removed in 8.x, please use [nested] instead"
                 );
             }
 

--- a/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/ScriptSortBuilder.java
@@ -113,7 +113,7 @@ public class ScriptSortBuilder extends SortBuilder<ScriptSortBuilder> {
         if (in.getTransportVersion().before(TransportVersions.V_8_0_0)) {
             if (in.readOptionalNamedWriteable(QueryBuilder.class) != null || in.readOptionalString() != null) {
                 throw new IOException(
-                    "the [sort] options [nested_path] and [nested_filter] are removed in 8.x, " + "please use [nested] instead"
+                    "the [sort] options [nested_path] and [nested_filter] are removed in 8.x, please use [nested] instead"
                 );
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/sort/SortBuilder.java
@@ -110,7 +110,7 @@ public abstract class SortBuilder<T extends SortBuilder<T>>
                     sortFields.add(fieldOrScoreSort(fieldName));
                 } else {
                     throw new IllegalArgumentException(
-                        "malformed sort format, " + "within the sort array, an object, or an actual string are allowed"
+                        "malformed sort format, within the sort array, an object, or an actual string are allowed"
                     );
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchBuilder.java
@@ -194,7 +194,7 @@ public class KnnSearchBuilder implements Writeable, ToXContentFragment, Rewritea
         }
         if (numCandidates < k) {
             throw new IllegalArgumentException(
-                "[" + NUM_CANDS_FIELD.getPreferredName() + "] cannot be less than " + "[" + K_FIELD.getPreferredName() + "]"
+                "[" + NUM_CANDS_FIELD.getPreferredName() + "] cannot be less than [" + K_FIELD.getPreferredName() + "]"
             );
         }
         if (numCandidates > NUM_CANDS_LIMIT) {

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnSearchRequestParser.java
@@ -249,7 +249,7 @@ public class KnnSearchRequestParser {
             }
             if (numCands < k) {
                 throw new IllegalArgumentException(
-                    "[" + NUM_CANDS_FIELD.getPreferredName() + "] cannot be less than " + "[" + K_FIELD.getPreferredName() + "]"
+                    "[" + NUM_CANDS_FIELD.getPreferredName() + "] cannot be less than [" + K_FIELD.getPreferredName() + "]"
                 );
             }
             if (numCands > NUM_CANDS_LIMIT) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -3166,7 +3166,7 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
 
             if (changedCount > 0) {
                 logger.trace(
-                    "changed cluster state triggered by [{}] snapshot state updates and resulted in starting " + "[{}] shard snapshots",
+                    "changed cluster state triggered by [{}] snapshot state updates and resulted in starting [{}] shard snapshots",
                     changedCount,
                     startedCount
                 );

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterAware.java
@@ -92,7 +92,7 @@ public abstract class RemoteClusterAware {
                     if (indexName.equals("*") == false) {
                         throw new IllegalArgumentException(
                             Strings.format(
-                                "To exclude a cluster you must specify the '*' wildcard for " + "the index expression, but found: [%s]",
+                                "To exclude a cluster you must specify the '*' wildcard for the index expression, but found: [%s]",
                                 indexName
                             )
                         );


### PR DESCRIPTION
Reformatting the code put parts of previously split String literals on the same line leaving redundant concatenation behind:

```
"Node didn't stop within 10 seconds. " + "Any outstanding requests or tasks might get killed."
```

To keep the PR size manageable this is just a part of the changes.