### PR TITLE
Fix file path when looking for docker exclusions file

### DIFF
--- a/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/util/Util.java
+++ b/build-conventions/src/main/java/org/elasticsearch/gradle/internal/conventions/util/Util.java
@@ -119,29 +119,29 @@ public class Util {
         return project.getExtensions().getByType(JavaPluginExtension.class).getSourceSets();
     }
 
-        public static File locateElasticsearchWorkspace(Gradle gradle) {
-            if(gradle.getRootProject().getName().startsWith("build-tools")) {
-                File buildToolsParent = gradle.getRootProject().getRootDir().getParentFile();
-                if(versionFileExists(buildToolsParent)) {
-                    return buildToolsParent;
-                }
+    public static File locateElasticsearchWorkspace(Gradle gradle) {
+        if (gradle.getRootProject().getName().startsWith("build-tools")) {
+            File buildToolsParent = gradle.getRootProject().getRootDir().getParentFile();
+            if (versionFileExists(buildToolsParent)) {
                 return buildToolsParent;
             }
-            if (gradle.getParent() == null) {
-                // See if any of these included builds is the Elasticsearch gradle
-                for (IncludedBuild includedBuild : gradle.getIncludedBuilds()) {
-                    if (versionFileExists(includedBuild.getProjectDir())) {
-                        return includedBuild.getProjectDir();
-                    }
-                }
-
-                // Otherwise assume this gradle is the root elasticsearch workspace
-                return gradle.getRootProject().getRootDir();
-            } else {
-                // We're an included build, so keep looking
-                return locateElasticsearchWorkspace(gradle.getParent());
-            }
+            return buildToolsParent;
         }
+        if (gradle.getParent() == null) {
+            // See if any of these included builds is the Elasticsearch gradle
+            for (IncludedBuild includedBuild : gradle.getIncludedBuilds()) {
+                if (versionFileExists(includedBuild.getProjectDir())) {
+                    return includedBuild.getProjectDir();
+                }
+            }
+
+            // Otherwise assume this gradle is the root elasticsearch workspace
+            return gradle.getRootProject().getRootDir();
+        } else {
+            // We're an included build, so keep looking
+            return locateElasticsearchWorkspace(gradle.getParent());
+        }
+    }
 
     private static boolean versionFileExists(File rootDir) {
         return new File(rootDir, "build-tools-internal/version.properties").exists();

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -144,6 +144,7 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
             // don't track these as inputs since they contain absolute paths and break cache relocatability
             File gradleUserHome = project.getGradle().getGradleUserHomeDir();
             nonInputProperties.systemProperty("gradle.user.home", gradleUserHome);
+            nonInputProperties.systemProperty("workspace.dir", Util.locateElasticsearchWorkspace(project.getGradle()));
             // we use 'temp' relative to CWD since this is per JVM and tests are forbidden from writing to CWD
             nonInputProperties.systemProperty("java.io.tmpdir", test.getWorkingDir().toPath().resolve("temp"));
 

--- a/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
+++ b/test/fixtures/testcontainer-utils/src/main/java/org/elasticsearch/test/fixtures/testcontainers/DockerEnvironmentAwareTestContainer.java
@@ -115,7 +115,7 @@ public abstract class DockerEnvironmentAwareTestContainer extends GenericContain
     }
 
     private static List<String> getLinuxExclusionList() {
-        File exclusionsFile = new File(DOCKER_ON_LINUX_EXCLUSIONS_FILE);
+        File exclusionsFile = new File(System.getProperty("workspace.dir"), DOCKER_ON_LINUX_EXCLUSIONS_FILE);
         if (exclusionsFile.exists()) {
             try {
                 return Files.readAllLines(exclusionsFile.toPath())


### PR DESCRIPTION
We are looking for the docker exclusions file via a relative path. This is unpredicable as the working directory of the test runner is likely not going to be the project workspace directory. This PR adds a new system property for the current workspace directory that can be used within tests to lookup files relative to that path.

Closes #105252