### PR TITLE
Fix bug in rule_query that resulted in errors when performing text_ex…

### DIFF
--- a/docs/changelog/105311.yaml
+++ b/docs/changelog/105311.yaml
@@ -1,5 +1,5 @@
 pr: 105311
-summary: Fix bug in `rule_query` that resulted in errors when performing text_ex…
+summary: Fix bug in `rule_query` that resulted in errors when performing text_expansion queries
 area: Application
 type: bug
 issues: []

--- a/docs/changelog/105311.yaml
+++ b/docs/changelog/105311.yaml
@@ -1,0 +1,5 @@
+pr: 105311
+summary: Fix bug in `rule_query` that resulted in errors when performing text_ex…
+area: Application
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -172,6 +172,7 @@ public class TransportVersions {
     public static final TransportVersion NLP_DOCUMENT_CHUNKING_ADDED = def(8_585_00_0);
     public static final TransportVersion SEARCH_TIMEOUT_EXCEPTION_ADDED = def(8_586_00_0);
     public static final TransportVersion ML_TEXT_EMBEDDING_INFERENCE_SERVICE_ADDED = def(8_587_00_0);
+    public static final TransportVersion SEARCH_QUERY_RULES_ID_REMOVED = def(8_588_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/AppliedQueryRules.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/AppliedQueryRules.java
@@ -13,21 +13,14 @@ import java.util.List;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item;
 
 public class AppliedQueryRules {
-
-    private final List<String> pinnedIds;
     private final List<Item> pinnedDocs;
 
     public AppliedQueryRules() {
-        this(new ArrayList<>(0), new ArrayList<>(0));
+        this(new ArrayList<>(0));
     }
 
-    public AppliedQueryRules(List<String> pinnedIds, List<Item> pinnedDocs) {
-        this.pinnedIds = pinnedIds;
+    public AppliedQueryRules(List<Item> pinnedDocs) {
         this.pinnedDocs = pinnedDocs;
-    }
-
-    public List<String> pinnedIds() {
-        return pinnedIds;
     }
 
     public List<Item> pinnedDocs() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -282,7 +282,6 @@ public class QueryRule implements Writeable, ToXContentObject {
             throw new UnsupportedOperationException("Only pinned query rules are supported");
         }
 
-        List<String> matchingPinnedIds = new ArrayList<>();
         List<PinnedQueryBuilder.Item> matchingPinnedDocs = new ArrayList<>();
         Boolean isRuleMatch = null;
 
@@ -302,7 +301,8 @@ public class QueryRule implements Writeable, ToXContentObject {
 
         if (isRuleMatch != null && isRuleMatch) {
             if (actions.containsKey(IDS_FIELD.getPreferredName())) {
-                matchingPinnedIds.addAll((List<String>) actions.get(IDS_FIELD.getPreferredName()));
+                List<String> ids = (List<String>) actions.get(IDS_FIELD.getPreferredName());
+                matchingPinnedDocs.addAll(ids.stream().map(id -> new PinnedQueryBuilder.Item(null, id)).toList());
             } else if (actions.containsKey(DOCS_FIELD.getPreferredName())) {
                 List<Map<String, String>> docsToPin = (List<Map<String, String>>) actions.get(DOCS_FIELD.getPreferredName());
                 List<PinnedQueryBuilder.Item> items = docsToPin.stream()
@@ -317,10 +317,8 @@ public class QueryRule implements Writeable, ToXContentObject {
             }
         }
 
-        List<String> pinnedIds = appliedRules.pinnedIds();
         List<PinnedQueryBuilder.Item> pinnedDocs = appliedRules.pinnedDocs();
-        pinnedIds.addAll(matchingPinnedIds);
         pinnedDocs.addAll(matchingPinnedDocs);
-        return new AppliedQueryRules(pinnedIds, pinnedDocs);
+        return new AppliedQueryRules(pinnedDocs);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilder.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder;
 import org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -82,6 +83,9 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
         organicQuery = in.readNamedWriteable(QueryBuilder.class);
         matchCriteria = in.readGenericMap();
         rulesetId = in.readString();
+        if (in.getTransportVersion().before(TransportVersions.SEARCH_QUERY_RULES_ID_REMOVED)) {
+            in.readOptionalStringCollectionAsList();
+        }
         pinnedDocs = in.readOptionalCollectionAsList(Item::new);
         pinnedDocsSupplier = null;
     }
@@ -127,6 +131,11 @@ public class RuleQueryBuilder extends AbstractQueryBuilder<RuleQueryBuilder> {
         out.writeNamedWriteable(organicQuery);
         out.writeGenericMap(matchCriteria);
         out.writeString(rulesetId);
+
+        if (out.getTransportVersion().before(TransportVersions.SEARCH_QUERY_RULES_ID_REMOVED)) {
+            out.writeOptionalStringCollection(Collections.emptyList());
+        }
+
         out.writeOptionalCollection(pinnedDocs);
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
@@ -31,6 +31,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.PREFIX;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.SUFFIX;
+import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryRuleTests extends ESTestCase {
@@ -174,11 +175,11 @@ public class QueryRuleTests extends ESTestCase {
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic"));
-        assertEquals(List.of("id1", "id2"), appliedQueryRules.pinnedIds());
+        assertEquals(List.of(new Item(null, "id1"), new Item(null, "id2")), appliedQueryRules.pinnedDocs());
 
         appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic1"));
-        assertEquals(Collections.emptyList(), appliedQueryRules.pinnedIds());
+        assertEquals(Collections.emptyList(), appliedQueryRules.pinnedDocs());
     }
 
     public void testApplyRuleWithMultipleCriteria() {
@@ -190,11 +191,11 @@ public class QueryRuleTests extends ESTestCase {
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic - you know, for search"));
-        assertEquals(List.of("id1", "id2"), appliedQueryRules.pinnedIds());
+        assertEquals(List.of(new Item(null, "id1"), new Item(null, "id2")), appliedQueryRules.pinnedDocs());
 
         appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic"));
-        assertEquals(Collections.emptyList(), appliedQueryRules.pinnedIds());
+        assertEquals(Collections.emptyList(), appliedQueryRules.pinnedDocs());
     }
 
     private void assertXContent(QueryRule queryRule, boolean humanReadable) throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
@@ -7,8 +7,13 @@
 
 package org.elasticsearch.xpack.application.rules;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
@@ -181,4 +186,39 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
         objects.put(RuleQueryBuilder.MATCH_CRITERIA_FIELD.getPreferredName(), null);
         return objects;
     }
+
+    /**
+     * Overridden to ensure that {@link SearchExecutionContext} has a non-null {@link IndexReader}; this query should always be rewritten
+     */
+    @Override
+    public void testToQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            Document document = new Document();
+            document.add(new StringField("foo", "bar", org.apache.lucene.document.Field.Store.NO));
+            iw.addDocument(document);
+            try (IndexReader reader = iw.getReader()) {
+                SearchExecutionContext context = createSearchExecutionContext(newSearcher(reader));
+                RuleQueryBuilder queryBuilder = createTestQueryBuilder();
+                IllegalStateException e = expectThrows(IllegalStateException.class, () -> queryBuilder.toQuery(context));
+                assertEquals("rule_query should have been rewritten to another query type", e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public void testMustRewrite() {
+        SearchExecutionContext context = createSearchExecutionContext();
+        RuleQueryBuilder builder = createTestQueryBuilder();
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> builder.toQuery(context));
+        assertEquals("rule_query should have been rewritten to another query type", e.getMessage());
+    }
+
+    @Override
+    public void testCacheability() throws IOException {
+        RuleQueryBuilder queryBuilder = createTestQueryBuilder();
+        SearchExecutionContext context = createSearchExecutionContext();
+        queryBuilder.rewrite(new SearchExecutionContext(context));
+        assertTrue("query should be cacheable: " + queryBuilder, context.isCacheable());
+    }
+
 }


### PR DESCRIPTION
Query rules has a bug where a `rule_query` with an underlying organic `text_expansion` query will fail with the reason `"failed to create query: text_expansion should have been rewritten to another query type"`. 

The reason for this is that the `text_expansion` query will throw this as it expects to be rewritten as a boolean query of weighted tokens. However, when we change it to a pinned query during the rewrite phase, it never gets re-written again when the pinned query tries to generate a query. 

I also did some cleanup in this PR to simplify pinned documents - previously we allowed a list of String ids or Item documents specifying an index and an id. Since we now support documents with a null index that behave the same as a String id we can simplify the logic to determine what needs to be pinned. 

Here's an example script to test the functionality. It requires an index pipeline set up using ELSER on a field called `text`. 

```
// Index some sample data
POST /search-example/_doc/1?pipeline=search-example@ml-inference
{
  "text": "What is the weather in Jamaica?"
}
POST /search-example/_doc/2?pipeline=search-example@ml-inference
{
  "text": "Why is the sky blue?"
}
// Here we create a hidden document, with a different field. 
// This will not be returned by search results but will be returned by query rules 
POST /search-example/_doc/hidden
{
  "name": "Rule query pinned doc"
}

// Ruleset - since we did some cleanup, we'll specify two rules: one that specifies IDs and one that specifies docs.
PUT /_query_rules/rules
{
  "ruleset_id": "rules",
  "rules": [
    {
      "rule_id": "pin_hidden_id",
      "type": "pinned",
      "criteria": [
        {
          "type": "exact",
          "metadata": "foo",
          "values": [
            "bar"
          ]
        }
      ],
      "actions": {
        "ids": [
          "hidden"
        ]
      }
    },
    {
      "rule_id": "pin_hidden_doc",
      "type": "pinned",
      "criteria": [
        {
          "type": "exact",
          "metadata": "foo",
          "values": [
            "baz"
          ]
        }
      ],
      "actions": {
        "docs": [
          {
            "_index": "search-example",
            "_id": "hidden"
          }
        ]
      }
    }
  ]
}

// Simple search examples verifying the rule query works with ID matches, docs matches, and no matches
POST search-example/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "blue",
          "default_field": "text"
        }
      },
      "ruleset_id": "rules",
      "match_criteria": {
        "foo": "bar"
      }
    }
  }, "_source": [ "text", "name" ]
}

POST search-example/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "blue",
          "default_field": "text"
        }
      },
      "ruleset_id": "rules",
      "match_criteria": {
        "foo": "baz"
      }
    }
  }, "_source": [ "text", "name" ]
}

POST search-example/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "query_string": {
          "query": "blue",
          "default_field": "text"
        }
      },
      "ruleset_id": "rules",
      "match_criteria": {
        "foo": "nomatch"
      }
    }
  }, "_source": [ "text", "name" ]
}

// Example showing a rule query with a text_expansion query, this previously threw an error and now works 
POST search-example/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "text_expansion": {
          "ml.inference.text_expanded.predicted_value": {
            "model_id": ".elser_model_2",
            "model_text": "Why is the sky blue?",
            "boost": 1
          }
        }
      },
      "ruleset_id": "rules",
      "match_criteria": {
        "foo": "bar"
      }
    }
  }, "_source": [ "text", "name" ]
}
```