### PR TITLE
Reuse ChannelSet in other projections with the same input

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -524,6 +524,7 @@ public class LocalExecutionPlanner {
                 channelSet = new Layout.ChannelSet(new HashSet<>(), input.type());
                 channelSet.nameIds().add(ne.id());
                 layout.append(channelSet);
+                inputChannelToOutputIds.put(input.channel(), channelSet);
             } else {
                 channelSet.nameIds().add(ne.id());
             }


### PR DESCRIPTION
It seems `inputChannelToOutputIds` was meant to enable `ChannelSet` reuse, but the `put()` call got lost?