### PR TITLE
Generate all provider impls on IDE gradle import

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -102,11 +102,11 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
     description = 'Configures the appropriate JVM for Gradle'
 
     doLast {
-      /*modifyXml('.idea/gradle.xml') { xml ->
+      modifyXml('.idea/gradle.xml') { xml ->
         def gradleSettings = xml.component.find { it.'@name' == 'GradleSettings' }.option[0].GradleProjectSettings
         // Remove configured JVM option to force IntelliJ to use the project JDK for Gradle
         gradleSettings.option.findAll { it.'@name' == 'gradleJvm' }.each { it.parent().remove(it) }
-      }*/
+      }
     }
   }
 
@@ -130,7 +130,6 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
       ':server:generateModulesList',
       ':server:generatePluginsList',
       ':generateProviderImpls'].collect { elasticsearchProject.right()?.task(it) ?: it })
-    // generate all embedded providers
   }
 
   idea {

--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -7,6 +7,7 @@
  */
 
 import org.elasticsearch.gradle.util.Pair
+import org.elasticsearch.gradle.util.GradleUtils
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.jetbrains.gradle.ext.JUnit
 
@@ -101,12 +102,22 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
     description = 'Configures the appropriate JVM for Gradle'
 
     doLast {
-      modifyXml('.idea/gradle.xml') { xml ->
+      /*modifyXml('.idea/gradle.xml') { xml ->
         def gradleSettings = xml.component.find { it.'@name' == 'GradleSettings' }.option[0].GradleProjectSettings
         // Remove configured JVM option to force IntelliJ to use the project JDK for Gradle
         gradleSettings.option.findAll { it.'@name' == 'gradleJvm' }.each { it.parent().remove(it) }
-      }
+      }*/
     }
+  }
+
+  // aggregate task so dependency artifacts below can can use one task name
+  tasks.register("generateProviderImpls").configure {
+    group = 'ide'
+    description = 'Builds all embedded provider impls'
+
+    dependsOn subprojects
+      .collect { GradleUtils.findByName(it.tasks, 'generateProviderImpls') }
+      .findAll { it != null }
   }
 
   tasks.register('buildDependencyArtifacts') {
@@ -114,11 +125,12 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
     description = 'Builds artifacts needed as dependency for IDE modules'
     dependsOn([':client:rest-high-level:shadowJar',
       ':plugins:repository-hdfs:hadoop-client-api:shadowJar',
-      ':libs:elasticsearch-x-content:generateImplProviderImpl',
       ':x-pack:plugin:esql:compute:ann:jar',
       ':x-pack:plugin:esql:compute:gen:jar',
       ':server:generateModulesList',
-      ':server:generatePluginsList'].collect { elasticsearchProject.right()?.task(it) ?: it })
+      ':server:generatePluginsList',
+      ':generateProviderImpls'].collect { elasticsearchProject.right()?.task(it) ?: it })
+    // generate all embedded providers
   }
 
   idea {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
@@ -59,9 +59,7 @@ public class EmbeddedProviderExtension {
                 spec.from(generateProviderManifest);
             });
         });
-        metaTask.configure(t -> {
-            t.dependsOn(generateProviderImpl);
-        });
+        metaTask.configure(t -> { t.dependsOn(generateProviderImpl); });
 
         var mainSourceSet = getJavaSourceSets(project).findByName(SourceSet.MAIN_SOURCE_SET_NAME);
         mainSourceSet.getOutput().dir(generateProviderImpl);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderExtension.java
@@ -9,11 +9,13 @@
 package org.elasticsearch.gradle.internal;
 
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.Directory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.Sync;
+import org.gradle.api.tasks.TaskProvider;
 
 import static org.elasticsearch.gradle.internal.conventions.GUtils.capitalize;
 import static org.elasticsearch.gradle.util.GradleUtils.getJavaSourceSets;
@@ -23,9 +25,11 @@ import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.DIRECTORY_TYP
 public class EmbeddedProviderExtension {
 
     private final Project project;
+    private final TaskProvider<Task> metaTask;
 
-    public EmbeddedProviderExtension(Project project) {
+    public EmbeddedProviderExtension(Project project, TaskProvider<Task> metaTask) {
         this.project = project;
+        this.metaTask = metaTask;
     }
 
     void impl(String implName, Project implProject) {
@@ -54,6 +58,9 @@ public class EmbeddedProviderExtension {
                 spec.from(implConfig);
                 spec.from(generateProviderManifest);
             });
+        });
+        metaTask.configure(t -> {
+            t.dependsOn(generateProviderImpl);
         });
 
         var mainSourceSet = getJavaSourceSets(project).findByName(SourceSet.MAIN_SOURCE_SET_NAME);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/EmbeddedProviderPlugin.java
@@ -11,7 +11,9 @@ package org.elasticsearch.gradle.internal;
 import org.elasticsearch.gradle.transform.UnzipTransform;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.tasks.TaskProvider;
 
 import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE;
 import static org.gradle.api.artifacts.type.ArtifactTypeDefinition.DIRECTORY_TYPE;
@@ -29,6 +31,7 @@ public class EmbeddedProviderPlugin implements Plugin<Project> {
             transformSpec.parameters(parameters -> parameters.getIncludeArtifactName().set(true));
         });
 
-        project.getExtensions().create("embeddedProviders", EmbeddedProviderExtension.class, project);
+        TaskProvider<Task> metaTask = project.getTasks().register("generateProviderImpls");
+        project.getExtensions().create("embeddedProviders", EmbeddedProviderExtension.class, project, metaTask);
     }
 }


### PR DESCRIPTION
This commit adjusts the IntelliJ setup to generate the provider implementations from all projects using embedded providers.