### PR TITLE
Add classpath based SPI for jna native provider

### DIFF
--- a/libs/native/jna/src/main/resources/META-INF/services/org.elasticsearch.nativeaccess.lib.NativeLibraryProvider
+++ b/libs/native/jna/src/main/resources/META-INF/services/org.elasticsearch.nativeaccess.lib.NativeLibraryProvider
@@ -1,0 +1,1 @@
+org.elasticsearch.nativeaccess.jna.JnaNativeLibraryProvider


### PR DESCRIPTION
Native lib provider is normally run modular, but since tests run on the classpath it also needs to work with old style SPI.