### PR TITLE
ESQL: Document `_source` requirements

### DIFF
--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -82,8 +82,6 @@ all.
 
 experimental:[] {esql}'s support for <<synthetic-source,synthetic `_source`>>
 is currently experimental.
-
-
 [discrete]
 [[esql-limitations-full-text-search]]
 === Full-text search is not supported

--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -74,7 +74,7 @@ values, with the exception of nested fields. Nested fields are not returned at
 all.
 
 [discrete]
-[[esql-limitations-full-text-search]]
+[[esql-_source-availability]]
 === _source availability
 
 {esql} is not supported with configurations where the

--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -77,7 +77,7 @@ all.
 [[esql-_source-availability]]
 === _source availability
 
-{esql} is not supported with configurations where the
+{esql} does not support configurations where the
 <<mapping-source-field,_source field>> is <<disable-source-field,disabled>>.
 
 experimental:[] {esql}'s support for <<synthetic-source,synthetic `_source`>>

--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -75,6 +75,17 @@ all.
 
 [discrete]
 [[esql-limitations-full-text-search]]
+=== _source availability
+
+{esql} is not supported with configurations where the
+<<mapping-source-field,_source field>> is <<disable-source-field,disabled>>.
+
+experimental:[] {esql}'s support for <<synthetic-source,synthetic `_source`>>
+is currently experimental.
+
+
+[discrete]
+[[esql-limitations-full-text-search]]
 === Full-text search is not supported
 
 Because of <<esql-limitations-text-fields,the way {esql} treats `text` values>>,

--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -82,6 +82,7 @@ all.
 
 experimental:[] {esql}'s support for <<synthetic-source,synthetic `_source`>>
 is currently experimental.
+
 [discrete]
 [[esql-limitations-full-text-search]]
 === Full-text search is not supported


### PR DESCRIPTION
This documents the requirements for _source availability:
- not supported with disabled _source;
- experimental support for synthetic.
