### PR TITLE
Reduce InternalSingleBucketAggregation in a streaming fashion

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorsReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorsReducer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations;
+
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ *  Interface for reducing {@link InternalAggregations} to a single one in a streaming fashion.
+ */
+public final class AggregatorsReducer implements Releasable {
+
+    private final Map<String, AggregatorReducer> aggByName = new HashMap<>();
+    private final AggregationReduceContext context;
+    private final int size;
+
+    public AggregatorsReducer(AggregationReduceContext context, int size) {
+        this.context = context;
+        this.size = size;
+    }
+
+    /**
+     * Adds a {@link InternalAggregations} for reduction.
+     */
+    public void accept(InternalAggregations aggregations) {
+        for (InternalAggregation aggregation : aggregations) {
+            AggregatorReducer reducer = aggByName.computeIfAbsent(
+                aggregation.getName(),
+                k -> aggregation.getReducer(context.forAgg(aggregation.getName()), size)
+            );
+            reducer.accept(aggregation);
+        }
+    }
+
+    /**
+     * returns the reduced {@link InternalAggregations}.
+     */
+    public InternalAggregations get() {
+        return InternalAggregations.from(aggByName.values().stream().map(AggregatorReducer::get).toList());
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(aggByName.values());
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/InternalSingleBucketAggregation.java
@@ -9,9 +9,11 @@ package org.elasticsearch.search.aggregations.bucket;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
+import org.elasticsearch.search.aggregations.AggregatorsReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
@@ -95,18 +97,22 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
         return new AggregatorReducer() {
             long docCount = 0L;
-            final List<InternalAggregations> subAggregationsList = new ArrayList<>();
+            final AggregatorsReducer subAggregatorReducer = new AggregatorsReducer(reduceContext, size);
 
             @Override
             public void accept(InternalAggregation aggregation) {
                 docCount += ((InternalSingleBucketAggregation) aggregation).docCount;
-                subAggregationsList.add(((InternalSingleBucketAggregation) aggregation).aggregations);
+                subAggregatorReducer.accept(((InternalSingleBucketAggregation) aggregation).aggregations);
             }
 
             @Override
             public InternalAggregation get() {
-                final InternalAggregations aggs = InternalAggregations.reduce(subAggregationsList, reduceContext);
-                return newAggregation(getName(), docCount, aggs);
+                return newAggregation(getName(), docCount, subAggregatorReducer.get());
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(subAggregatorReducer);
             }
         };
     }
@@ -125,9 +131,9 @@ public abstract class InternalSingleBucketAggregation extends InternalAggregatio
         InternalAggregation reduced = this;
         if (pipelineTree.hasSubTrees()) {
             List<InternalAggregation> aggs = new ArrayList<>();
-            for (Aggregation agg : getAggregations().asList()) {
+            for (InternalAggregation agg : getAggregations().asList()) {
                 PipelineTree subTree = pipelineTree.subTree(agg.getName());
-                aggs.add(((InternalAggregation) agg).reducePipelines((InternalAggregation) agg, reduceContext, subTree));
+                aggs.add(agg.reducePipelines(agg, reduceContext, subTree));
             }
             InternalAggregations reducedSubAggs = InternalAggregations.from(aggs);
             reduced = create(reducedSubAggs);


### PR DESCRIPTION
For InternalSingleBucketAggregation we are collecting all the subaggregations in memory before reducing them which it can be wasteful. Here we introduce a AggregatorsReducer that reduces InternalAggregations in a streaming fashion. we use it to stream the reduction for the subaggregations of InternalSingleBucketAggregation.

relates https://github.com/elastic/elasticsearch/pull/105207