### PR TITLE
Remove ignore_malformed from metric settings

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/metrics@settings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/metrics@settings.json
@@ -7,7 +7,6 @@
         },
         "codec": "best_compression",
         "mapping": {
-          "ignore_malformed": true,
           "total_fields": {
             "ignore_dynamic_beyond_limit": true
           }

--- a/x-pack/plugin/core/template-resources/src/main/resources/metrics@tsdb-settings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/metrics@tsdb-settings.json
@@ -6,7 +6,6 @@
           "name": "metrics"
         },
         "mapping": {
-          "ignore_malformed": true,
           "total_fields": {
             "ignore_dynamic_beyond_limit": true
           }

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -43,7 +43,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 6;
+    public static final int REGISTRY_VERSION = 7;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/105314.

The issue is that `ignore_malformed` isn't fully compatible with synthetic _source. See also https://github.com/elastic/elasticsearch/issues/90007.

Labling as `>non-issue` as this hasn't been released, yet, so we don't want it to appear in the changelog.