### PR TITLE
[8.12] Fix race in HTTP response shutdown handling (#105306)

### DIFF
--- a/docs/changelog/105306.yaml
+++ b/docs/changelog/105306.yaml
@@ -1,0 +1,5 @@
+pr: 105306
+summary: Fix race in HTTP response shutdown handling
+area: Network
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Fix race in HTTP response shutdown handling (#105306)