### PR TITLE
Fix KeywordFieldMapperTests testDimensionExtraLongKeyword

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -390,7 +390,6 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         assertThat(e.getCause().getMessage(), containsString("Dimension field [field] cannot be a multi-valued field"));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/105276")
     public void testDimensionExtraLongKeyword() throws IOException {
         DocumentMapper mapper = createTimeSeriesModeDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
@@ -400,7 +399,9 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         Exception e = expectThrows(
             DocumentParsingException.class,
             () -> mapper.parse(
-                source(b -> b.field("field", randomAlphaOfLengthBetween(IndexWriter.MAX_TERM_LENGTH, IndexWriter.MAX_TERM_LENGTH + 100)))
+                source(
+                    b -> b.field("field", randomAlphaOfLengthBetween(IndexWriter.MAX_TERM_LENGTH + 1, IndexWriter.MAX_TERM_LENGTH + 100))
+                )
             )
         );
         assertThat(


### PR DESCRIPTION
To throw exception keyword length should be greater than `MAX_TERM_LENGTH`.
The random string was of length from `MAX_TERM_LENGTH` to `MAX_TERM_LENGTH+100`,
changed to be from `MAX_TERM_LENGTH+1` and `MAX_TERM_LENGTH+100`
closes #105276 
