### PR TITLE
Mute testCannotFollowLeaderInUpgradedCluster, 8.12 edition

### DIFF
--- a/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade-multi-cluster/src/test/java/org/elasticsearch/upgrades/CcrRollingUpgradeIT.java
@@ -206,6 +206,7 @@ public class CcrRollingUpgradeIT extends AbstractMultiClusterUpgradeTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104620")
     public void testCannotFollowLeaderInUpgradedCluster() throws Exception {
         if (upgradeState != UpgradeState.ALL) {
             return;


### PR DESCRIPTION
Backport of #105332
Relates to https://github.com/elastic/elasticsearch/issues/104620 and https://github.com/elastic/elasticsearch/issues/105295