### PR TITLE
Map old version ids directly to its release version, don't return a range

### DIFF
--- a/server/src/main/java/org/elasticsearch/ReleaseVersions.java
+++ b/server/src/main/java/org/elasticsearch/ReleaseVersions.java
@@ -105,14 +105,15 @@ public class ReleaseVersions {
                     // the next version is just a guess - might be a newer revision, might be a newer minor or major...
                     lowerBound = nextVersion(lastItem(lowerRange.getValue())).toString();
                 } else {
-                    // a really old version we don't otherwise know about
-                    // assume it's an old version id
+                    // a really old version we don't have a record for
+                    // assume it's an old version id - we can just return it directly
                     // this will no longer be the case with ES 10 (which won't know about ES v8.x where we introduced separated versions)
+                    // maybe keep the release mapping around in the csv file?
                     // SEP for now
                     @UpdateForV9
                     // @UpdateForV10
                     Version oldVersion = Version.fromId(id);
-                    lowerBound = oldVersion.toString();
+                    return oldVersion.toString();
                 }
 
                 var upperRange = versions.higherEntry(id);

--- a/server/src/test/java/org/elasticsearch/ReleaseVersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/ReleaseVersionsTests.java
@@ -29,7 +29,7 @@ public class ReleaseVersionsTests extends ESTestCase {
         IntFunction<String> versions = ReleaseVersions.generateVersionsLookup(ReleaseVersionsTests.class);
 
         assertThat(versions.apply(17), equalTo("8.1.2-8.2.0"));
-        assertThat(versions.apply(9), equalTo("0.0.0-8.0.0"));
+        assertThat(versions.apply(9), equalTo("0.0.0"));
         assertThat(versions.apply(24), equalTo("8.2.2-snapshot[24]"));
     }
 }


### PR DESCRIPTION
When we try to generate a string from a really old version, we don't need to return a range, because we know the exact version that is from - so do that