### PR TITLE
[Test] Fix issue with invalid format of operational LDAP attributes

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/support/LdapTestCase.java
@@ -95,6 +95,9 @@ public abstract class LdapTestCase extends ESTestCase {
         ldapServers = new InMemoryDirectoryServer[numberOfLdapServers];
         for (int i = 0; i < numberOfLdapServers; i++) {
             InMemoryDirectoryServerConfig serverConfig = new InMemoryDirectoryServerConfig("o=sevenSeas");
+            // Avoid generating operational attributes (like createTimestamp or modifyTimestamp) whose format is dependent
+            // on the locale and can cause invalid format failures since it violates the default schema.
+            serverConfig.setGenerateOperationalAttributes(false);
             debugLogging.configure(serverConfig);
             List<InMemoryListenerConfig> listeners = new ArrayList<>(2);
             listeners.add(InMemoryListenerConfig.createLDAPConfig("ldap", null, 0, null));


### PR DESCRIPTION
This PR disables generating operational LDAP server attributes (like createTimestamp and modifyTimestamp).
The format of these attributes is dependent on the locale and can violate the default schema format. 
We don't depend on these attributes in any of our AD/LDAP tests.

Resolves #105310
