### PR TITLE
Reduce InternalRange and InternalFilters in a streaming fashion

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/FixedMultiBucketAggregatorsReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/FixedMultiBucketAggregatorsReducer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *  Class for reducing many fixed lists of {@link B} to a single reduced list.
+ *
+ */
+public abstract class FixedMultiBucketAggregatorsReducer<B extends MultiBucketsAggregation.Bucket> implements Releasable {
+
+    // we could use an ObjectArray here but these arrays are in normally small, so it is not worthy
+    private final MultiBucketAggregatorsReducer[] bucketsReducer;
+    private final List<B> protoList;
+
+    public FixedMultiBucketAggregatorsReducer(AggregationReduceContext reduceContext, int size, List<B> protoList) {
+        reduceContext.consumeBucketsAndMaybeBreak(protoList.size());
+        this.protoList = protoList;
+        this.bucketsReducer = new MultiBucketAggregatorsReducer[protoList.size()];
+        for (int i = 0; i < protoList.size(); ++i) {
+            bucketsReducer[i] = new MultiBucketAggregatorsReducer(reduceContext, size);
+        }
+    }
+
+    /**
+     * Adds a list of buckets for reduction. The size of the list must be the same as the sizze
+     * of the list passed on the constructor
+     */
+    public final void accept(List<B> buckets) {
+        assert buckets.size() == protoList.size();
+        int i = 0;
+        for (B bucket : buckets) {
+            bucketsReducer[i++].accept(bucket);
+        }
+    }
+
+    /**
+     * returns the reduced buckets.
+     */
+    public final List<B> get() {
+        final List<B> reduceBuckets = new ArrayList<>(protoList.size());
+        for (int i = 0; i < protoList.size(); i++) {
+            final B proto = protoList.get(i);
+            final MultiBucketAggregatorsReducer reducer = bucketsReducer[i];
+            reduceBuckets.add(createBucket(proto, reducer.getDocCount(), reducer.get()));
+        }
+        return reduceBuckets;
+    }
+
+    protected abstract B createBucket(B proto, long focCount, InternalAggregations aggregations);
+
+    @Override
+    public final void close() {
+        Releasables.close(bucketsReducer);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/FixedMultiBucketAggregatorsReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/FixedMultiBucketAggregatorsReducer.java
@@ -36,7 +36,7 @@ public abstract class FixedMultiBucketAggregatorsReducer<B extends MultiBucketsA
     }
 
     /**
-     * Adds a list of buckets for reduction. The size of the list must be the same as the sizze
+     * Adds a list of buckets for reduction. The size of the list must be the same as the size
      * of the list passed on the constructor
      */
     public final void accept(List<B> buckets) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketAggregatorsReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/MultiBucketAggregatorsReducer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket;
+
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.search.aggregations.AggregationReduceContext;
+import org.elasticsearch.search.aggregations.AggregatorsReducer;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+
+/**
+ *  Class for reducing a list of {@link MultiBucketsAggregation.Bucket} to a single
+ *  {@link InternalAggregations} and the number of documents.
+ */
+public final class MultiBucketAggregatorsReducer implements Releasable {
+
+    private final AggregatorsReducer aggregatorsReducer;
+    long count = 0;
+
+    public MultiBucketAggregatorsReducer(AggregationReduceContext context, int size) {
+        this.aggregatorsReducer = new AggregatorsReducer(context, size);
+    }
+
+    /**
+     * Adds a {@link MultiBucketsAggregation.Bucket} for reduction.
+     */
+    public void accept(MultiBucketsAggregation.Bucket bucket) {
+        count += bucket.getDocCount();
+        aggregatorsReducer.accept(bucket.getAggregations());
+    }
+
+    /**
+     * returns the reduced {@link InternalAggregations}.
+     */
+    public InternalAggregations get() {
+        return aggregatorsReducer.get();
+
+    }
+
+    /**
+     * returns the number of docs
+     */
+    public long getDocCount() {
+        return count;
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(aggregatorsReducer);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -12,11 +12,13 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.FixedMultiBucketAggregatorsReducer;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -201,34 +203,31 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
     @Override
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
         return new AggregatorReducer() {
-            List<List<InternalBucket>> bucketsList = null;
+            final FixedMultiBucketAggregatorsReducer<InternalBucket> reducer = new FixedMultiBucketAggregatorsReducer<>(
+                reduceContext,
+                size,
+                getBuckets()
+            ) {
+                @Override
+                protected InternalBucket createBucket(InternalBucket proto, long docCount, InternalAggregations aggregations) {
+                    return new InternalBucket(proto.key, docCount, aggregations, proto.keyed, proto.keyedBucket);
+                }
+            };
 
             @Override
             public void accept(InternalAggregation aggregation) {
-                InternalFilters filters = (InternalFilters) aggregation;
-                if (bucketsList == null) {
-                    bucketsList = new ArrayList<>(filters.buckets.size());
-                    for (InternalBucket bucket : filters.buckets) {
-                        List<InternalBucket> sameRangeList = new ArrayList<>(size);
-                        sameRangeList.add(bucket);
-                        bucketsList.add(sameRangeList);
-                    }
-                } else {
-                    int i = 0;
-                    for (InternalBucket bucket : filters.buckets) {
-                        bucketsList.get(i++).add(bucket);
-                    }
-                }
+                final InternalFilters filters = (InternalFilters) aggregation;
+                reducer.accept(filters.getBuckets());
             }
 
             @Override
             public InternalAggregation get() {
-                reduceContext.consumeBucketsAndMaybeBreak(bucketsList.size());
-                InternalFilters reduced = new InternalFilters(name, new ArrayList<>(bucketsList.size()), keyed, keyedBucket, getMetadata());
-                for (List<InternalBucket> sameRangeList : bucketsList) {
-                    reduced.buckets.add(reduceBucket(sameRangeList, reduceContext));
-                }
-                return reduced;
+                return new InternalFilters(name, reducer.get(), keyed, keyedBucket, getMetadata());
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(reducer);
             }
         };
     }
@@ -242,21 +241,6 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
             keyedBucket,
             getMetadata()
         );
-    }
-
-    private InternalBucket reduceBucket(List<InternalBucket> buckets, AggregationReduceContext context) {
-        assert buckets.isEmpty() == false;
-        InternalBucket reduced = null;
-        for (InternalBucket bucket : buckets) {
-            if (reduced == null) {
-                reduced = new InternalBucket(bucket.key, bucket.docCount, bucket.aggregations, bucket.keyed, keyedBucket);
-            } else {
-                reduced.docCount += bucket.docCount;
-            }
-        }
-        final List<InternalAggregations> aggregations = new BucketAggregationList<>(buckets);
-        reduced.aggregations = InternalAggregations.reduce(aggregations, context);
-        return reduced;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -10,12 +10,14 @@ package org.elasticsearch.search.aggregations.bucket.range;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.FixedMultiBucketAggregatorsReducer;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceType;
@@ -323,30 +325,34 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
     @SuppressWarnings("unchecked")
     @Override
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
-        reduceContext.consumeBucketsAndMaybeBreak(ranges.size());
-        @SuppressWarnings("rawtypes")
-        List<B>[] rangeList = new List[ranges.size()];
-        for (int i = 0; i < rangeList.length; ++i) {
-            rangeList[i] = new ArrayList<>();
-        }
         return new AggregatorReducer() {
+            final FixedMultiBucketAggregatorsReducer<B> reducer = new FixedMultiBucketAggregatorsReducer<>(
+                reduceContext,
+                size,
+                getBuckets()
+            ) {
+
+                @Override
+                protected Bucket createBucket(Bucket proto, long docCount, InternalAggregations aggregations) {
+                    return getFactory().createBucket(proto.key, proto.from, proto.to, docCount, aggregations, proto.keyed, proto.format);
+                }
+            };
+
             @Override
             public void accept(InternalAggregation aggregation) {
                 @SuppressWarnings("unchecked")
-                InternalRange<B, R> ranges = (InternalRange<B, R>) aggregation;
-                int i = 0;
-                for (B range : ranges.ranges) {
-                    rangeList[i++].add(range);
-                }
+                final InternalRange<B, R> ranges = (InternalRange<B, R>) aggregation;
+                reducer.accept(ranges.ranges);
             }
 
             @Override
             public InternalAggregation get() {
-                final List<B> reducedRanges = new ArrayList<>();
-                for (int i = 0; i < ranges.size(); ++i) {
-                    reducedRanges.add(reduceBucket(rangeList[i], reduceContext));
-                }
-                return getFactory().create(name, reducedRanges, format, keyed, getMetadata());
+                return getFactory().create(name, reducer.get(), format, keyed, getMetadata());
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(reducer);
             }
         };
     }
@@ -373,18 +379,6 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
             keyed,
             getMetadata()
         );
-    }
-
-    private B reduceBucket(List<B> buckets, AggregationReduceContext context) {
-        assert buckets.isEmpty() == false;
-        long docCount = 0;
-        for (Bucket bucket : buckets) {
-            docCount += bucket.docCount;
-        }
-        final List<InternalAggregations> aggregations = new BucketAggregationList<>(buckets);
-        final InternalAggregations aggs = InternalAggregations.reduce(aggregations, context);
-        Bucket prototype = buckets.get(0);
-        return getFactory().createBucket(prototype.key, prototype.from, prototype.to, docCount, aggs, keyed, format);
     }
 
     @Override


### PR DESCRIPTION
Similarly to https://github.com/elastic/elasticsearch/pull/105323 InternalRange and InternalFilters can be wasteful and can be reduced in a streaming fashion. In this case we introduce a MultiBucketAggregatorsReducer and a FixedMultiBucketAggregatorsReducer to do the job.

relates https://github.com/elastic/elasticsearch/pull/105207