### PR TITLE
[ES|QL] Return null and warning for invalid chrono values provided to date_extract

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -1062,6 +1062,34 @@ FROM sample_data
 // end::docsDateExtractBusinessHours-result[]
 ;
 
+dateExtractConst#[skip:-8.12.99, reason:return null for invalid chrono field is supported in 8.13]
+from employees
+| where gender == "M"
+| EVAL year = DATE_EXTRACT("M", birth_date)
+| sort emp_no
+| keep birth_date, year
+| limit 1
+;
+warning:Line 3:15: evaluation of [DATE_EXTRACT(\"M\", birth_date)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:15: java.lang.IllegalArgumentException: No enum constant java.time.temporal.ChronoField.M
+birth_date:date           | year:long
+1953-09-02T00:00:00.000Z  | null
+;
+
+dateExtractField
+from employees
+| where gender == "M"
+| EVAL year = DATE_EXTRACT(gender, birth_date)
+| sort emp_no
+| keep birth_date, year
+| limit 1
+;
+warning:Line 3:15: evaluation of [DATE_EXTRACT(gender, birth_date)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 3:15: java.lang.IllegalArgumentException: No enum constant java.time.temporal.ChronoField.M
+birth_date:date           | year:long
+1953-09-02T00:00:00.000Z  | null
+;
+
 docsDateFormat
 // tag::docsDateFormat[]
 FROM employees

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtract.java
@@ -15,7 +15,6 @@ import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
-import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.TypeResolutions;
 import org.elasticsearch.xpack.ql.expression.function.scalar.ConfigurationFunction;
@@ -63,11 +62,7 @@ public class DateExtract extends ConfigurationFunction implements EvaluatorMappe
         var fieldEvaluator = toEvaluator.apply(children().get(1));
         if (children().get(0).foldable()) {
             ChronoField chrono = chronoField();
-            if (chrono == null) {
-                BytesRef field = (BytesRef) children().get(0).fold();
-                throw new InvalidArgumentException("invalid date field for [{}]: {}", sourceText(), field.utf8ToString());
-            }
-            return new DateExtractConstantEvaluator.Factory(source(), fieldEvaluator, chrono, configuration().zoneId());
+            if (chrono != null) return new DateExtractConstantEvaluator.Factory(source(), fieldEvaluator, chrono, configuration().zoneId());
         }
         var chronoEvaluator = toEvaluator.apply(children().get(0));
         return new DateExtractEvaluator.Factory(source(), fieldEvaluator, chronoEvaluator, configuration().zoneId());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateExtractTests.java
@@ -11,11 +11,9 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.AbstractScalarFunctionTestCase;
-import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.tree.Source;
@@ -68,7 +66,6 @@ public class DateExtractTests extends AbstractScalarFunctionTestCase {
                         .withWarning(
                             "Line -1:-1: java.lang.IllegalArgumentException: No enum constant java.time.temporal.ChronoField.NOT A UNIT"
                         )
-                        .withFoldingException(InvalidArgumentException.class, "invalid date field for []: not a unit")
                 )
             )
         );
@@ -91,23 +88,6 @@ public class DateExtractTests extends AbstractScalarFunctionTestCase {
                 is(date.getLong(value))
             );
         }
-    }
-
-    public void testInvalidChrono() {
-        String chrono = randomAlphaOfLength(10);
-        DriverContext driverContext = driverContext();
-        InvalidArgumentException e = expectThrows(
-            InvalidArgumentException.class,
-            () -> evaluator(
-                new DateExtract(
-                    Source.EMPTY,
-                    new Literal(Source.EMPTY, new BytesRef(chrono), DataTypes.KEYWORD),
-                    field("str", DataTypes.DATETIME),
-                    null
-                )
-            ).get(driverContext)
-        );
-        assertThat(e.getMessage(), equalTo("invalid date field for []: " + chrono));
     }
 
     @Override


### PR DESCRIPTION
Resolve: #100038 

DATE_EXTRACT takes both a literal value and an index field as the date_part input, however the behaviors are inconsistent when an invalid chrono value is provided as a literal value or an index field. This is to make DATE_EXTRACT return null with warnings if an invalid chrono value is provided, regardless whether it is a literal value or an index field.
