### PR TITLE
Fixing age field in ExplainLifecycleResponseTests

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponseTests.java
@@ -26,8 +26,11 @@ public class ExplainLifecycleResponseTests extends AbstractXContentSerializingTe
     @Override
     protected ExplainLifecycleResponse createTestInstance() {
         Map<String, IndexLifecycleExplainResponse> indexResponses = new HashMap<>();
+        long now = System.currentTimeMillis();
         for (int i = 0; i < randomIntBetween(0, 2); i++) {
             IndexLifecycleExplainResponse indexResponse = IndexLifecycleExplainResponseTests.randomIndexExplainResponse();
+            // Since the age is calculated from now, we make now constant so that we don't get changes in age during the run of the test:
+            indexResponse.nowSupplier = () -> now;
             indexResponses.put(indexResponse.getIndex(), indexResponse);
         }
         return new ExplainLifecycleResponse(indexResponses);


### PR DESCRIPTION
ExplainLifecycleResponseTests testConcurrentToXContent fails sometimes (very rarely) because the `age` field is slightly different between the two ExplainLifecycleResponse objects. The reason is that we calculate the `age` field based on `System.currentMilliseconds()` at the time serialization is run. This change makes it so that we use a constant value instead for the test.
Closes #104686