### PR TITLE
[Profiling] add `service.name` field to event index template

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
@@ -76,6 +76,9 @@
         },
         "tags": {
           "type": "keyword"
+        },
+        "service.name": {
+          "type": "keyword"
         }
       }
     }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
@@ -44,10 +44,11 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 1: initial
     // version 2: Added 'profiling.host.machine' keyword mapping to profiling-hosts
     // version 3: Add optional component template 'profiling-ilm@custom' to all ILM-managed index templates
-    public static final int INDEX_TEMPLATE_VERSION = 3;
+    // version 4: Added 'service.name' keyword mapping to profiling-events
+    public static final int INDEX_TEMPLATE_VERSION = 4;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
-    public static final int PROFILING_EVENTS_VERSION = 1;
+    public static final int PROFILING_EVENTS_VERSION = 2;
     public static final int PROFILING_EXECUTABLES_VERSION = 1;
     public static final int PROFILING_METRICS_VERSION = 1;
     public static final int PROFILING_HOSTS_VERSION = 1;


### PR DESCRIPTION
This PR adds a new `service.name` field to the index template of the `profiling-events` data-stream. The field name was chosen in [accordance with ECS](https://www.elastic.co/guide/en/ecs/8.12/ecs-service.html#field-service-name) and also matches what the field is called in the APM indices.