### PR TITLE
Fixing HistoryActionConditionTests by keeping a reference to watcher history

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryActionConditionTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryActionConditionTests.java
@@ -116,45 +116,42 @@ public class HistoryActionConditionTests extends AbstractWatcherIntegrationTestC
         assertWatchWithMinimumActionsCount(id, ExecutionState.EXECUTED, 1);
 
         // only one action should have failed via condition
+        AtomicReference<SearchHit> searchHitReference = new AtomicReference<>();
         assertBusy(() -> {
             // Watcher history is now written asynchronously, so we check this in an assertBusy
             ensureGreen(HistoryStoreField.DATA_STREAM);
             final SearchResponse response = searchHistory(SearchSourceBuilder.searchSource().query(termQuery("watch_id", id)));
             try {
                 assertThat(response.getHits().getTotalHits().value, is(oneOf(1L, 2L)));
-            } finally {
+                searchHitReference.set(response.getHits().getAt(0).asUnpooled());
+            } catch (Exception | AssertionError e) {
                 response.decRef();
             }
         });
 
-        final SearchResponse response = searchHistory(SearchSourceBuilder.searchSource().query(termQuery("watch_id", id)));
-        try {
-            final SearchHit hit = response.getHits().getAt(0);
-            final List<Object> actions = getActionsFromHit(hit.getSourceAsMap());
+        final SearchHit hit = searchHitReference.get();
+        final List<Object> actions = getActionsFromHit(hit.getSourceAsMap());
 
-            for (int i = 0; i < actionConditionsWithFailure.size(); ++i) {
-                final Map<String, Object> action = (Map<String, Object>) actions.get(i);
-                final Map<String, Object> condition = (Map<String, Object>) action.get("condition");
-                final Map<String, Object> logging = (Map<String, Object>) action.get("logging");
+        for (int i = 0; i < actionConditionsWithFailure.size(); ++i) {
+            final Map<String, Object> action = (Map<String, Object>) actions.get(i);
+            final Map<String, Object> condition = (Map<String, Object>) action.get("condition");
+            final Map<String, Object> logging = (Map<String, Object>) action.get("logging");
 
-                assertThat(action.get("id"), is("action" + i));
+            assertThat(action.get("id"), is("action" + i));
 
-                if (i == failedIndex) {
-                    assertThat(action.get("status"), is("condition_failed"));
-                    assertThat(action.get("reason"), is("condition failed. skipping: [expected] failed hard"));
-                    assertThat(condition, nullValue());
-                    assertThat(logging, nullValue());
-                } else {
-                    assertThat(condition.get("type"), is(actionConditionsWithFailure.get(i).type()));
+            if (i == failedIndex) {
+                assertThat(action.get("status"), is("condition_failed"));
+                assertThat(action.get("reason"), is("condition failed. skipping: [expected] failed hard"));
+                assertThat(condition, nullValue());
+                assertThat(logging, nullValue());
+            } else {
+                assertThat(condition.get("type"), is(actionConditionsWithFailure.get(i).type()));
 
-                    assertThat(action.get("status"), is("success"));
-                    assertThat(condition.get("met"), is(true));
-                    assertThat(action.get("reason"), nullValue());
-                    assertThat(logging.get("logged_text"), is(Integer.toString(i)));
-                }
+                assertThat(action.get("status"), is("success"));
+                assertThat(condition.get("met"), is(true));
+                assertThat(action.get("reason"), nullValue());
+                assertThat(logging.get("logged_text"), is(Integer.toString(i)));
             }
-        } finally {
-            response.decRef();
         }
     }
 

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryActionConditionTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryActionConditionTests.java
@@ -124,7 +124,7 @@ public class HistoryActionConditionTests extends AbstractWatcherIntegrationTestC
             try {
                 assertThat(response.getHits().getTotalHits().value, is(oneOf(1L, 2L)));
                 searchHitReference.set(response.getHits().getAt(0).asUnpooled());
-            } catch (Exception | AssertionError e) {
+            } finally {
                 response.decRef();
             }
         });


### PR DESCRIPTION
This changes HistoryActionConditionTests.testActionConditionWithHardFailures() to hold onto a reference to its watcher history results (like the other tests in this class do) rather than re-fetching them.
Closes #105140