### PR TITLE
[ML] Take advantage of TransportVersion.toReleaseVersion()

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/CategorizeTextAggregationBuilder.java
@@ -123,7 +123,7 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
                 "["
                     + NAME
                     + "] aggregation cannot be used in a cluster where some nodes have version ["
-                    + ALGORITHM_CHANGED_VERSION
+                    + ALGORITHM_CHANGED_VERSION.toReleaseVersion()
                     + "] or higher and others have a version before this",
                 RestStatus.BAD_REQUEST
             );
@@ -280,7 +280,7 @@ public class CategorizeTextAggregationBuilder extends AbstractAggregationBuilder
                 "["
                     + NAME
                     + "] aggregation cannot be used in a cluster where some nodes have version ["
-                    + ALGORITHM_CHANGED_VERSION
+                    + ALGORITHM_CHANGED_VERSION.toReleaseVersion()
                     + "] or higher and others have a version before this",
                 RestStatus.BAD_REQUEST
             );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -114,7 +114,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
                     "["
                         + CategorizeTextAggregationBuilder.NAME
                         + "] aggregation cannot be used in a cluster where some nodes have version ["
-                        + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION
+                        + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION.toReleaseVersion()
                         + "] or higher and others have a version before this",
                     RestStatus.BAD_REQUEST
                 );
@@ -133,7 +133,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
                     "["
                         + CategorizeTextAggregationBuilder.NAME
                         + "] aggregation cannot be used in a cluster where some nodes have version ["
-                        + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION
+                        + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION.toReleaseVersion()
                         + "] or higher and others have a version before this",
                     RestStatus.BAD_REQUEST
                 );
@@ -246,7 +246,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
                 "["
                     + CategorizeTextAggregationBuilder.NAME
                     + "] aggregation cannot be used in a cluster where some nodes have version ["
-                    + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION
+                    + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION.toReleaseVersion()
                     + "] or higher and others have a version before this",
                 RestStatus.BAD_REQUEST
             );
@@ -265,7 +265,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
                 "["
                     + CategorizeTextAggregationBuilder.NAME
                     + "] aggregation cannot be used in a cluster where some nodes have version ["
-                    + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION
+                    + CategorizeTextAggregationBuilder.ALGORITHM_CHANGED_VERSION.toReleaseVersion()
                     + "] or higher and others have a version before this",
                 RestStatus.BAD_REQUEST
             );


### PR DESCRIPTION
This new method can be used to make the error reporting friendlier when we include transport versions in error messages.