### PR TITLE
Eagerly initialize `ReleaseVersions`

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -17,6 +17,7 @@ import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ReleaseVersions;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.filesystem.FileSystemNatives;
@@ -185,6 +186,8 @@ class Elasticsearch {
         IfConfig.logIfNecessary();
 
         ensureInitialized(
+            // ReleaseVersions does nontrivial static initialization which should always succeed but load it now (before SM) to be sure
+            ReleaseVersions.class,
             // ReferenceDocs class does nontrivial static initialization which should always succeed but load it now (before SM) to be sure
             ReferenceDocs.class,
             // The following classes use MethodHandles.lookup during initialization, load them now (before SM) to be sure they succeed


### PR DESCRIPTION
`ReleaseVersions` does some nontrivial initialization. It shouldn't
fail, but if it does then it should do so early in startup rather than
waiting until the class is first used, which may be in a context in
which failure is undesirable. This commit adds it to the list of classes
that are initialized even before the security manager is installed.

Relates #103627