### PR TITLE
Fix geoip index deletion race condition

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -212,7 +212,6 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92888")
     public void testUpdatedTimestamp() throws Exception {
         assumeTrue("only test with fixture to have stable results", getEndpoint() != null);
         testGeoIpDatabasesDownload();
@@ -224,7 +223,6 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
         testGeoIpDatabasesDownload();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92888")
     public void testGeoIpDatabasesDownload() throws Exception {
         putGeoIpPipeline();
         updateClusterSettings(Settings.builder().put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), true));

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
@@ -126,7 +126,7 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
     }
 
     // visible for testing
-    void updateDatabases() throws IOException {
+    synchronized void updateDatabases() throws IOException {
         var clusterState = clusterService.state();
         var geoipIndex = clusterState.getMetadata().getIndicesLookup().get(GeoIpDownloader.DATABASES_INDEX);
         if (geoipIndex != null) {
@@ -327,7 +327,7 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
         stats = stats.expiredDatabases((int) expiredDatabases);
     }
 
-    public void deleteIndex() {
+    synchronized void deleteIndex() {
         IndexAbstraction databasesAbstraction = clusterService.state().metadata().getIndicesLookup().get(DATABASES_INDEX);
         if (databasesAbstraction != null) {
             // regardless of whether DATABASES_INDEX is an alias, resolve it to a concrete index

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -366,7 +366,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
         final GeoIpDownloader geoIpDownloader = this.getCurrentTask();
         persistentTasksService.sendRemoveRequest(GEOIP_DOWNLOADER, ActionListener.runAfter(listener, () -> {
             if (geoIpDownloader != null) {
-                geoIpDownloader.deleteIndex();
+                threadPool.generic().execute(geoIpDownloader::deleteIndex);
             }
         }));
     }


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/75221, https://github.com/elastic/elasticsearch/issues/100361, and https://github.com/elastic/elasticsearch/issues/101418

Just a draft/WIP PR, thinking about how to prevent the scenario from https://github.com/elastic/elasticsearch/issues/101418#issuecomment-1924657164 from occurring.

I'm uncertain about the `threadPool` bit, especially, but also the `geoIpDownloader != null` check is interesting (without it we do get test failures, but there was no such requirement before that there'd a current task...).