### PR TITLE
Rule query cleanup

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -129,6 +129,7 @@ public class TransportVersions {
     public static final TransportVersion RESOLVE_CLUSTER_ENDPOINT_ADDED = def(8_589_00_0);
     public static final TransportVersion FIELD_CAPS_FIELD_HAS_VALUE = def(8_590_00_0);
     public static final TransportVersion ML_INFERENCE_REQUEST_INPUT_TYPE_CLASS_CLUSTER_ADDED = def(8_591_00_0);
+    public static final TransportVersion SEARCH_QUERY_RULES_IDS_REMOVED = def(8_592_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/AppliedQueryRules.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/AppliedQueryRules.java
@@ -10,20 +10,20 @@ package org.elasticsearch.xpack.application.rules;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item;
+import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.PinnedDocument;
 
 public class AppliedQueryRules {
-    private final List<Item> pinnedDocs;
+    private final List<PinnedDocument> pinnedDocs;
 
     public AppliedQueryRules() {
         this(new ArrayList<>(0));
     }
 
-    public AppliedQueryRules(List<Item> pinnedDocs) {
+    public AppliedQueryRules(List<PinnedDocument> pinnedDocs) {
         this.pinnedDocs = pinnedDocs;
     }
 
-    public List<Item> pinnedDocs() {
+    public List<PinnedDocument> pinnedDocs() {
         return pinnedDocs;
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/AppliedQueryRules.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/AppliedQueryRules.java
@@ -13,21 +13,14 @@ import java.util.List;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item;
 
 public class AppliedQueryRules {
-
-    private final List<String> pinnedIds;
     private final List<Item> pinnedDocs;
 
     public AppliedQueryRules() {
-        this(new ArrayList<>(0), new ArrayList<>(0));
+        this(new ArrayList<>(0));
     }
 
-    public AppliedQueryRules(List<String> pinnedIds, List<Item> pinnedDocs) {
-        this.pinnedIds = pinnedIds;
+    public AppliedQueryRules(List<Item> pinnedDocs) {
         this.pinnedDocs = pinnedDocs;
-    }
-
-    public List<String> pinnedIds() {
-        return pinnedIds;
     }
 
     public List<Item> pinnedDocs() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -302,7 +302,8 @@ public class QueryRule implements Writeable, ToXContentObject {
 
         if (isRuleMatch != null && isRuleMatch) {
             if (actions.containsKey(IDS_FIELD.getPreferredName())) {
-                matchingPinnedIds.addAll((List<String>) actions.get(IDS_FIELD.getPreferredName()));
+                List<String> ids = (List<String>) actions.get(IDS_FIELD.getPreferredName());
+                matchingPinnedDocs.addAll(ids.stream().map(id -> new PinnedQueryBuilder.Item(null, id)).toList());
             } else if (actions.containsKey(DOCS_FIELD.getPreferredName())) {
                 List<Map<String, String>> docsToPin = (List<Map<String, String>>) actions.get(DOCS_FIELD.getPreferredName());
                 List<PinnedQueryBuilder.Item> items = docsToPin.stream()
@@ -317,10 +318,8 @@ public class QueryRule implements Writeable, ToXContentObject {
             }
         }
 
-        List<String> pinnedIds = appliedRules.pinnedIds();
         List<PinnedQueryBuilder.Item> pinnedDocs = appliedRules.pinnedDocs();
-        pinnedIds.addAll(matchingPinnedIds);
         pinnedDocs.addAll(matchingPinnedDocs);
-        return new AppliedQueryRules(pinnedIds, pinnedDocs);
+        return new AppliedQueryRules(pinnedDocs);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.ALWAYS;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.DOCS_FIELD;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.IDS_FIELD;
-import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item.INDEX_FIELD;
+import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.PinnedDocument.INDEX_FIELD;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.MAX_NUM_PINNED_HITS;
 
 /**
@@ -283,7 +283,7 @@ public class QueryRule implements Writeable, ToXContentObject {
         }
 
         List<String> matchingPinnedIds = new ArrayList<>();
-        List<PinnedQueryBuilder.Item> matchingPinnedDocs = new ArrayList<>();
+        List<PinnedQueryBuilder.PinnedDocument> matchingPinnedDocs = new ArrayList<>();
         Boolean isRuleMatch = null;
 
         // All specified criteria in a rule must match for the rule to be applied
@@ -303,14 +303,14 @@ public class QueryRule implements Writeable, ToXContentObject {
         if (isRuleMatch != null && isRuleMatch) {
             if (actions.containsKey(IDS_FIELD.getPreferredName())) {
                 List<String> ids = (List<String>) actions.get(IDS_FIELD.getPreferredName());
-                matchingPinnedDocs.addAll(ids.stream().map(id -> new PinnedQueryBuilder.Item(null, id)).toList());
+                matchingPinnedDocs.addAll(ids.stream().map(id -> new PinnedQueryBuilder.PinnedDocument(null, id)).toList());
             } else if (actions.containsKey(DOCS_FIELD.getPreferredName())) {
                 List<Map<String, String>> docsToPin = (List<Map<String, String>>) actions.get(DOCS_FIELD.getPreferredName());
-                List<PinnedQueryBuilder.Item> items = docsToPin.stream()
+                List<PinnedQueryBuilder.PinnedDocument> items = docsToPin.stream()
                     .map(
-                        map -> new PinnedQueryBuilder.Item(
+                        map -> new PinnedQueryBuilder.PinnedDocument(
                             map.get(INDEX_FIELD.getPreferredName()),
-                            map.get(PinnedQueryBuilder.Item.ID_FIELD.getPreferredName())
+                            map.get(PinnedQueryBuilder.PinnedDocument.ID_FIELD.getPreferredName())
                         )
                     )
                     .toList();
@@ -318,7 +318,7 @@ public class QueryRule implements Writeable, ToXContentObject {
             }
         }
 
-        List<PinnedQueryBuilder.Item> pinnedDocs = appliedRules.pinnedDocs();
+        List<PinnedQueryBuilder.PinnedDocument> pinnedDocs = appliedRules.pinnedDocs();
         pinnedDocs.addAll(matchingPinnedDocs);
         return new AppliedQueryRules(pinnedDocs);
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRule.java
@@ -35,8 +35,8 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.ALWAYS;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.DOCS_FIELD;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.IDS_FIELD;
-import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.PinnedDocument.INDEX_FIELD;
 import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.MAX_NUM_PINNED_HITS;
+import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.PinnedDocument.INDEX_FIELD;
 
 /**
  * A query rule consists of:

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.PREFIX;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.SUFFIX;
-import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item;
+import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.PinnedDocument;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryRuleTests extends ESTestCase {
@@ -175,7 +175,7 @@ public class QueryRuleTests extends ESTestCase {
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic"));
-        assertEquals(List.of(new Item(null, "id1"), new Item(null, "id2")), appliedQueryRules.pinnedDocs());
+        assertEquals(List.of(new PinnedDocument(null, "id1"), new PinnedDocument(null, "id2")), appliedQueryRules.pinnedDocs());
 
         appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic1"));
@@ -191,7 +191,7 @@ public class QueryRuleTests extends ESTestCase {
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic - you know, for search"));
-        assertEquals(List.of(new Item(null, "id1"), new Item(null, "id2")), appliedQueryRules.pinnedDocs());
+        assertEquals(List.of(new PinnedDocument(null, "id1"), new PinnedDocument(null, "id2")), appliedQueryRules.pinnedDocs());
 
         appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic"));

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/QueryRuleTests.java
@@ -31,6 +31,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXC
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.EXACT;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.PREFIX;
 import static org.elasticsearch.xpack.application.rules.QueryRuleCriteriaType.SUFFIX;
+import static org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class QueryRuleTests extends ESTestCase {
@@ -174,11 +175,11 @@ public class QueryRuleTests extends ESTestCase {
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic"));
-        assertEquals(List.of("id1", "id2"), appliedQueryRules.pinnedIds());
+        assertEquals(List.of(new Item(null, "id1"), new Item(null, "id2")), appliedQueryRules.pinnedDocs());
 
         appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic1"));
-        assertEquals(Collections.emptyList(), appliedQueryRules.pinnedIds());
+        assertEquals(Collections.emptyList(), appliedQueryRules.pinnedDocs());
     }
 
     public void testApplyRuleWithMultipleCriteria() {
@@ -190,11 +191,11 @@ public class QueryRuleTests extends ESTestCase {
         );
         AppliedQueryRules appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic - you know, for search"));
-        assertEquals(List.of("id1", "id2"), appliedQueryRules.pinnedIds());
+        assertEquals(List.of(new Item(null, "id1"), new Item(null, "id2")), appliedQueryRules.pinnedDocs());
 
         appliedQueryRules = new AppliedQueryRules();
         rule.applyRule(appliedQueryRules, Map.of("query", "elastic"));
-        assertEquals(Collections.emptyList(), appliedQueryRules.pinnedIds());
+        assertEquals(Collections.emptyList(), appliedQueryRules.pinnedDocs());
     }
 
     private void assertXContent(QueryRule queryRule, boolean humanReadable) throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/RuleQueryBuilderTests.java
@@ -7,8 +7,13 @@
 
 package org.elasticsearch.xpack.application.rules;
 
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.DisjunctionMaxQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetRequest;
@@ -180,5 +185,36 @@ public class RuleQueryBuilderTests extends AbstractQueryTestCase<RuleQueryBuilde
         final Map<String, String> objects = new HashMap<>();
         objects.put(RuleQueryBuilder.MATCH_CRITERIA_FIELD.getPreferredName(), null);
         return objects;
+    }
+
+    @Override
+    public void testToQuery() throws IOException {
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+            Document document = new Document();
+            document.add(new StringField("foo", "bar", org.apache.lucene.document.Field.Store.NO));
+            iw.addDocument(document);
+            try (IndexReader reader = iw.getReader()) {
+                SearchExecutionContext context = createSearchExecutionContext(newSearcher(reader));
+                RuleQueryBuilder queryBuilder = createTestQueryBuilder();
+                IllegalStateException e = expectThrows(IllegalStateException.class, () -> queryBuilder.toQuery(context));
+                assertEquals("rule_query should have been rewritten to another query type", e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public void testMustRewrite() {
+        SearchExecutionContext context = createSearchExecutionContext();
+        RuleQueryBuilder builder = createTestQueryBuilder();
+        IllegalStateException e = expectThrows(IllegalStateException.class, () -> builder.toQuery(context));
+        assertEquals("rule_query should have been rewritten to another query type", e.getMessage());
+    }
+
+    @Override
+    public void testCacheability() throws IOException {
+        RuleQueryBuilder queryBuilder = createTestQueryBuilder();
+        SearchExecutionContext context = createSearchExecutionContext();
+        queryBuilder.rewrite(new SearchExecutionContext(context));
+        assertTrue("query should be cacheable: " + queryBuilder, context.isCacheable());
     }
 }

--- a/x-pack/plugin/search-business-rules/src/internalClusterTest/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderIT.java
+++ b/x-pack/plugin/search-business-rules/src/internalClusterTest/java/org/elasticsearch/xpack/searchbusinessrules/PinnedQueryBuilderIT.java
@@ -19,7 +19,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.Item;
+import org.elasticsearch.xpack.searchbusinessrules.PinnedQueryBuilder.PinnedDocument;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -90,11 +90,11 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
             int numPromotions = randomIntBetween(0, totalDocs);
 
             LinkedHashSet<String> idPins = new LinkedHashSet<>();
-            LinkedHashSet<Item> docPins = new LinkedHashSet<>();
+            LinkedHashSet<PinnedDocument> docPins = new LinkedHashSet<>();
             for (int j = 0; j < numPromotions; j++) {
                 String id = Integer.toString(randomIntBetween(0, totalDocs));
                 idPins.add(id);
-                docPins.add(new Item("test", id));
+                docPins.add(new PinnedDocument("test", id));
             }
             QueryBuilder organicQuery = null;
             if (i % 5 == 0) {
@@ -105,7 +105,12 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
             }
 
             assertPinnedPromotions(new PinnedQueryBuilder(organicQuery, idPins.toArray(new String[0])), idPins, i, numRelevantDocs);
-            assertPinnedPromotions(new PinnedQueryBuilder(organicQuery, docPins.toArray(new Item[0])), idPins, i, numRelevantDocs);
+            assertPinnedPromotions(
+                new PinnedQueryBuilder(organicQuery, docPins.toArray(new PinnedDocument[0])),
+                idPins,
+                i,
+                numRelevantDocs
+            );
         }
 
     }
@@ -184,7 +189,7 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
 
         QueryBuilder organicQuery = QueryBuilders.queryStringQuery("foo");
         assertExhaustiveScoring(new PinnedQueryBuilder(organicQuery, "2"));
-        assertExhaustiveScoring(new PinnedQueryBuilder(organicQuery, new Item("test", "2")));
+        assertExhaustiveScoring(new PinnedQueryBuilder(organicQuery, new PinnedDocument("test", "2")));
     }
 
     private void assertExhaustiveScoring(PinnedQueryBuilder pqb) {
@@ -218,7 +223,7 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
 
         QueryBuilder organicQuery = QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR);
         assertExplain(new PinnedQueryBuilder(organicQuery, "2"));
-        assertExplain(new PinnedQueryBuilder(organicQuery, new Item("test", "2")));
+        assertExplain(new PinnedQueryBuilder(organicQuery, new PinnedDocument("test", "2")));
     }
 
     private void assertExplain(PinnedQueryBuilder pqb) {
@@ -259,7 +264,7 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
 
         QueryBuilder organicQuery = QueryBuilders.matchQuery("field1", "the quick brown").operator(Operator.OR);
         assertHighlight(new PinnedQueryBuilder(organicQuery, "2"));
-        assertHighlight(new PinnedQueryBuilder(organicQuery, new Item("test", "2")));
+        assertHighlight(new PinnedQueryBuilder(organicQuery, new PinnedDocument("test", "2")));
     }
 
     private void assertHighlight(PinnedQueryBuilder pqb) {
@@ -320,9 +325,9 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
 
         PinnedQueryBuilder pqb = new PinnedQueryBuilder(
             QueryBuilders.queryStringQuery("foo"),
-            new Item("test2", "a"),
-            new Item("test1", "a"),
-            new Item("test1", "b")
+            new PinnedDocument("test2", "a"),
+            new PinnedDocument("test1", "a"),
+            new PinnedDocument("test1", "b")
         );
 
         assertResponse(prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH), searchResponse -> {
@@ -360,9 +365,9 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
 
         PinnedQueryBuilder pqb = new PinnedQueryBuilder(
             QueryBuilders.queryStringQuery("document"),
-            new Item("test", "b"),
-            new Item("test-alias", "a"),
-            new Item("test", "a")
+            new PinnedDocument("test", "b"),
+            new PinnedDocument("test-alias", "a"),
+            new PinnedDocument("test", "a")
         );
 
         assertResponse(prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH), searchResponse -> {
@@ -416,11 +421,11 @@ public class PinnedQueryBuilderIT extends ESIntegTestCase {
 
         PinnedQueryBuilder pqb = new PinnedQueryBuilder(
             QueryBuilders.queryStringQuery("document"),
-            new Item("test1", "b"),
-            new Item(null, "a"),
-            new Item("test1", "c"),
-            new Item("test1", "a"),
-            new Item("test-alias", "a")
+            new PinnedDocument("test1", "b"),
+            new PinnedDocument(null, "a"),
+            new PinnedDocument("test1", "c"),
+            new PinnedDocument("test1", "a"),
+            new PinnedDocument("test-alias", "a")
         );
 
         assertResponse(prepareSearch().setQuery(pqb).setTrackTotalHits(true).setSearchType(DFS_QUERY_THEN_FETCH), searchResponse -> {


### PR DESCRIPTION
Refactoring to clean up query rules: 

- Simplify logic by only using pinned documents now that the index is optional, instead of IDs OR documents
- Renamed `PinnedQueryBuilder.Item` to something more meaningful external to the pinned builder. 