### PR TITLE
Handling the case in ActionErrorIntegrationTests where watch history index is being created when read

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/ActionErrorIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/ActionErrorIntegrationTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.watcher.actions;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -52,12 +53,20 @@ public class ActionErrorIntegrationTests extends AbstractWatcherIntegrationTestC
 
         // there should be a single history record with a failure status for the action:
         assertBusy(() -> {
-            long count = watchRecordCount(
-                QueryBuilders.boolQuery()
-                    .must(termsQuery("result.actions.id", "_action"))
-                    .must(termsQuery("result.actions.status", "failure"))
-            );
-            assertThat(count, is(1L));
+            try {
+                long count = watchRecordCount(
+                    QueryBuilders.boolQuery()
+                        .must(termsQuery("result.actions.id", "_action"))
+                        .must(termsQuery("result.actions.status", "failure"))
+                );
+                assertThat(count, is(1L));
+            } catch (ElasticsearchException e) {
+                /*
+                 * Since the history is written asynchronously, it is possible that we try to query it after the history index is
+                 * created, but before the shards are allocated, which throws an exception.
+                 */
+                throw new AssertionError(e);
+            }
         });
 
         // now we'll trigger the watch again and make sure that it's not throttled and instead
@@ -71,12 +80,20 @@ public class ActionErrorIntegrationTests extends AbstractWatcherIntegrationTestC
 
         // there should be a single history record with a failure status for the action:
         assertBusy(() -> {
-            long count = watchRecordCount(
-                QueryBuilders.boolQuery()
-                    .must(termsQuery("result.actions.id", "_action"))
-                    .must(termsQuery("result.actions.status", "failure"))
-            );
-            assertThat(count, is(2L));
+            try {
+                long count = watchRecordCount(
+                    QueryBuilders.boolQuery()
+                        .must(termsQuery("result.actions.id", "_action"))
+                        .must(termsQuery("result.actions.status", "failure"))
+                );
+                assertThat(count, is(2L));
+            } catch (ElasticsearchException e) {
+                /*
+                 * Since the history is written asynchronously, it is possible that we try to query it after the history index is
+                 * created, but before the shards are allocated, which throws an exception.
+                 */
+                throw new AssertionError(e);
+            }
         });
 
         // now lets confirm that the ack status of the action is awaits_successful_execution


### PR DESCRIPTION
I can't reproduce this one, but it looks it's possible that we try to read the watcher history index before its shards have been allocated. We're reading the index in an assertBusy, but assertBusy doesn't catch ElasticsearchException. I'm now catching that ElasticsearchException and rethrowing it as an AssertionError so that it's compatible with assertBusy.
Closes #104382