### PR TITLE
Refactor getAliases, add more yaml tests

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -463,13 +463,13 @@ dynamic templates with nesting:
         refresh: true
         body:
           - '{ "create": { "dynamic_templates": { "data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:08.138Z","data": "10", "resource.attributes.dim": "A", "resource.attributes.another.dim": "C", "attributes.more.dim": "E" }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z","data": "10", "resource.attributes.dim1": "A", "resource.attributes.another.dim1": "1", "attributes.dim2": "C", "attributes.another.dim2": "10" }'
           - '{ "create": { "dynamic_templates": { "data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:09.138Z","data": "20", "resource.attributes.dim": "A", "resource.attributes.another.dim": "C", "attributes.more.dim": "E" }'
+          - '{ "@timestamp": "2023-09-01T13:03:09.138Z","data": "20", "resource.attributes.dim1": "A", "resource.attributes.another.dim1": "1", "attributes.dim2": "C", "attributes.another.dim2": "10" }'
           - '{ "create": { "dynamic_templates": { "data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:10.138Z","data": "30", "resource.attributes.dim": "B", "resource.attributes.another.dim": "D", "attributes.more.dim": "F" }'
+          - '{ "@timestamp": "2023-09-01T13:03:10.138Z","data": "30", "resource.attributes.dim1": "B", "resource.attributes.another.dim1": "2", "attributes.dim2": "D", "attributes.another.dim2": "20" }'
           - '{ "create": { "dynamic_templates": { "data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:10.238Z","data": "40", "resource.attributes.dim": "B", "resource.attributes.another.dim": "D", "attributes.more.dim": "F" }'
+          - '{ "@timestamp": "2023-09-01T13:03:10.238Z","data": "40", "resource.attributes.dim1": "B", "resource.attributes.another.dim1": "2", "attributes.dim2": "D", "attributes.another.dim2": "20" }'
 
   - do:
       search:
@@ -488,14 +488,14 @@ dynamic templates with nesting:
             filterA:
               filter:
                 term:
-                  dim: A
+                  dim1: A
               aggs:
                 tsids:
                   terms:
                     field: _tsid
 
   - length: { aggregations.filterA.tsids.buckets: 1 }
-  - match: { aggregations.filterA.tsids.buckets.0.key: "LEjiJ4ATCXWlzeFvhGQ9lYlnP-nRIGKYihfZ18WoJ94t9a8OpbsCdwZALomb" }
+  - match: { aggregations.filterA.tsids.buckets.0.key: "MK0AtuFZowY4QPzoYEAZNK7zJhYuIGKYiosO9O4X2dfFtp-JEbk39FSSMEq_vwX7uw" }
   - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
 
   - do:
@@ -507,14 +507,14 @@ dynamic templates with nesting:
             filterA:
               filter:
                 term:
-                  another.dim: C
+                  dim2: C
               aggs:
                 tsids:
                   terms:
                     field: _tsid
 
   - length: { aggregations.filterA.tsids.buckets: 1 }
-  - match: { aggregations.filterA.tsids.buckets.0.key: "LEjiJ4ATCXWlzeFvhGQ9lYlnP-nRIGKYihfZ18WoJ94t9a8OpbsCdwZALomb" }
+  - match: { aggregations.filterA.tsids.buckets.0.key: "MK0AtuFZowY4QPzoYEAZNK7zJhYuIGKYiosO9O4X2dfFtp-JEbk39FSSMEq_vwX7uw" }
   - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
 
   - do:
@@ -526,14 +526,33 @@ dynamic templates with nesting:
             filterA:
               filter:
                 term:
-                  more.dim: E
+                  another.dim1: 1
               aggs:
                 tsids:
                   terms:
                     field: _tsid
 
   - length: { aggregations.filterA.tsids.buckets: 1 }
-  - match: { aggregations.filterA.tsids.buckets.0.key: "LEjiJ4ATCXWlzeFvhGQ9lYlnP-nRIGKYihfZ18WoJ94t9a8OpbsCdwZALomb" }
+  - match: { aggregations.filterA.tsids.buckets.0.key: "MK0AtuFZowY4QPzoYEAZNK7zJhYuIGKYiosO9O4X2dfFtp-JEbk39FSSMEq_vwX7uw" }
+  - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
+
+  - do:
+      search:
+        index: k9s
+        body:
+          size: 0
+          aggs:
+            filterA:
+              filter:
+                term:
+                  another.dim2: 10
+              aggs:
+                tsids:
+                  terms:
+                    field: _tsid
+
+  - length: { aggregations.filterA.tsids.buckets: 1 }
+  - match: { aggregations.filterA.tsids.buckets.0.key: "MK0AtuFZowY4QPzoYEAZNK7zJhYuIGKYiosO9O4X2dfFtp-JEbk39FSSMEq_vwX7uw" }
   - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
 
 ---

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -230,13 +230,13 @@ dynamic templates:
         refresh: true
         body:
           - '{ "create": { "dynamic_templates": { "data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:08.138Z","data": "10", "attributes.dim": "A", "attributes.another.dim": "C" }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": "10", "attributes.dim1": "A", "attributes.dim2": "1", "attributes.another.dim1": "C", "attributes.another.dim2": "10" }'
           - '{ "create": { "dynamic_templates": { "data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:09.138Z","data": "20", "attributes.dim": "A", "attributes.another.dim": "C" }'
+          - '{ "@timestamp": "2023-09-01T13:03:09.138Z", "data": "20", "attributes.dim1": "A", "attributes.dim2": "1", "attributes.another.dim1": "C", "attributes.another.dim2": "10" }'
           - '{ "create": { "dynamic_templates": { "data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:10.138Z","data": "30", "attributes.dim": "B", "attributes.another.dim": "D" }'
+          - '{ "@timestamp": "2023-09-01T13:03:10.138Z", "data": "30", "attributes.dim1": "B", "attributes.dim2": "2", "attributes.another.dim1": "D", "attributes.another.dim2": "20" }'
           - '{ "create": { "dynamic_templates": { "data": "counter_metric" } } }'
-          - '{ "@timestamp": "2023-09-01T13:03:10.238Z","data": "40", "attributes.dim": "B", "attributes.another.dim": "D" }'
+          - '{ "@timestamp": "2023-09-01T13:03:10.238Z", "data": "40", "attributes.dim1": "B", "attributes.dim2": "2", "attributes.another.dim1": "D", "attributes.another.dim2": "20" }'
 
   - do:
       search:
@@ -255,14 +255,14 @@ dynamic templates:
             filterA:
               filter:
                 term:
-                  dim: A
+                  dim1: A
               aggs:
                 tsids:
                   terms:
                     field: _tsid
 
   - length: { aggregations.filterA.tsids.buckets: 1 }
-  - match: { aggregations.filterA.tsids.buckets.0.key: "KPLatIF-tbSjI8l9LcbTur4gYpiKF9nXxRUMHnJBiqqP58deEIun8H8" }
+  - match: { aggregations.filterA.tsids.buckets.0.key: "MD2HE8yse1ZklY-p0-bRcC8gYpiK8yYWLhfZ18WLDvTuBX1YJX1Ll7UMNJqYNES5Eg" }
   - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
 
   - do:
@@ -274,14 +274,52 @@ dynamic templates:
             filterA:
               filter:
                 term:
-                  another.dim: C
+                  dim2: 1
               aggs:
                 tsids:
                   terms:
                     field: _tsid
 
   - length: { aggregations.filterA.tsids.buckets: 1 }
-  - match: { aggregations.filterA.tsids.buckets.0.key: "KPLatIF-tbSjI8l9LcbTur4gYpiKF9nXxRUMHnJBiqqP58deEIun8H8" }
+  - match: { aggregations.filterA.tsids.buckets.0.key: "MD2HE8yse1ZklY-p0-bRcC8gYpiK8yYWLhfZ18WLDvTuBX1YJX1Ll7UMNJqYNES5Eg" }
+  - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
+
+  - do:
+      search:
+        index: k9s
+        body:
+          size: 0
+          aggs:
+            filterA:
+              filter:
+                term:
+                  another.dim1: C
+              aggs:
+                tsids:
+                  terms:
+                    field: _tsid
+
+  - length: { aggregations.filterA.tsids.buckets: 1 }
+  - match: { aggregations.filterA.tsids.buckets.0.key: "MD2HE8yse1ZklY-p0-bRcC8gYpiK8yYWLhfZ18WLDvTuBX1YJX1Ll7UMNJqYNES5Eg" }
+  - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
+
+  - do:
+      search:
+        index: k9s
+        body:
+          size: 0
+          aggs:
+            filterA:
+              filter:
+                term:
+                  another.dim2: 10
+              aggs:
+                tsids:
+                  terms:
+                    field: _tsid
+
+  - length: { aggregations.filterA.tsids.buckets: 1 }
+  - match: { aggregations.filterA.tsids.buckets.0.key: "MD2HE8yse1ZklY-p0-bRcC8gYpiK8yYWLhfZ18WLDvTuBX1YJX1Ll7UMNJqYNES5Eg" }
   - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
 
 ---

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -112,15 +112,7 @@ public class RootObjectMapper extends ObjectMapper {
         @Override
         public RootObjectMapper build(MapperBuilderContext context) {
             Map<String, Mapper> mappers = buildMappers(context);
-
-            Map<String, Mapper> aliasMappers = new HashMap<>();
-            Map<String, ObjectMapper.Builder> objectIntermediates = new HashMap<>(1);
-            getAliasMappers(mappers, aliasMappers, objectIntermediates, context, 0);
-            for (var entry : objectIntermediates.entrySet()) {
-                aliasMappers.put(entry.getKey(), entry.getValue().build(context));
-            }
-            mappers.putAll(aliasMappers);
-
+            mappers.putAll(getAliasMappers(mappers, context));
             return new RootObjectMapper(
                 name,
                 enabled,
@@ -133,6 +125,16 @@ public class RootObjectMapper extends ObjectMapper {
                 dateDetection,
                 numericDetection
             );
+        }
+
+        Map<String, Mapper> getAliasMappers(Map<String, Mapper> mappers, MapperBuilderContext context) {
+            Map<String, Mapper> aliasMappers = new HashMap<>();
+            Map<String, ObjectMapper.Builder> objectIntermediates = new HashMap<>(1);
+            getAliasMappers(mappers, aliasMappers, objectIntermediates, context, 0);
+            for (var entry : objectIntermediates.entrySet()) {
+                aliasMappers.put(entry.getKey(), entry.getValue().build(context));
+            }
+            return aliasMappers;
         }
 
         void getAliasMappers(

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -393,9 +393,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
 
     public void testAliasMappersCreatesAlias() throws Exception {
         var context = MapperBuilderContext.root(false, false);
-        Map<String, Mapper> aliases = new HashMap<>();
-        var objectIntermediates = new HashMap<String, ObjectMapper.Builder>(1);
-        new RootObjectMapper.Builder("root", Explicit.EXPLICIT_FALSE).getAliasMappers(
+        Map<String, Mapper> aliases = new RootObjectMapper.Builder("root", Explicit.EXPLICIT_FALSE).getAliasMappers(
             Map.of(
                 "labels",
                 new PassThroughObjectMapper(
@@ -407,10 +405,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
                     Explicit.EXPLICIT_FALSE
                 )
             ),
-            aliases,
-            objectIntermediates,
-            context,
-            0
+            context
         );
         assertEquals(1, aliases.size());
         assertThat(aliases.get("host"), instanceOf(FieldAliasMapper.class));
@@ -418,9 +413,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
 
     public void testAliasMappersCreatesAliasNested() throws Exception {
         var context = MapperBuilderContext.root(false, false);
-        Map<String, Mapper> aliases = new HashMap<>();
-        var objectIntermediates = new HashMap<String, ObjectMapper.Builder>(1);
-        new RootObjectMapper.Builder("root", Explicit.EXPLICIT_FALSE).getAliasMappers(
+        Map<String, Mapper> aliases = new RootObjectMapper.Builder("root", Explicit.EXPLICIT_FALSE).getAliasMappers(
             Map.of(
                 "outer",
                 new ObjectMapper(
@@ -442,10 +435,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
                     )
                 )
             ),
-            aliases,
-            objectIntermediates,
-            context,
-            0
+            context
         );
         assertEquals(1, aliases.size());
         assertThat(aliases.get("host"), instanceOf(FieldAliasMapper.class));
@@ -477,9 +467,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
 
     public void testAliasMappersCreatesNoAliasForRegularObject() throws Exception {
         var context = MapperBuilderContext.root(false, false);
-        Map<String, Mapper> aliases = new HashMap<>();
-        var objectIntermediates = new HashMap<String, ObjectMapper.Builder>(1);
-        new RootObjectMapper.Builder("root", Explicit.EXPLICIT_FALSE).getAliasMappers(
+        Map<String, Mapper> aliases = new RootObjectMapper.Builder("root", Explicit.EXPLICIT_FALSE).getAliasMappers(
             Map.of(
                 "labels",
                 new ObjectMapper(
@@ -491,19 +479,14 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
                     Map.of("host", new KeywordFieldMapper.Builder("host", IndexVersion.current()).build(context))
                 )
             ),
-            aliases,
-            objectIntermediates,
-            context,
-            0
+            context
         );
         assertTrue(aliases.isEmpty());
     }
 
     public void testAliasMappersConflictingField() throws Exception {
         var context = MapperBuilderContext.root(false, false);
-        Map<String, Mapper> aliases = new HashMap<>();
-        var objectIntermediates = new HashMap<String, ObjectMapper.Builder>(1);
-        new RootObjectMapper.Builder("root", Explicit.EXPLICIT_FALSE).getAliasMappers(
+        Map<String, Mapper> aliases = new RootObjectMapper.Builder("root", Explicit.EXPLICIT_FALSE).getAliasMappers(
             Map.of(
                 "labels",
                 new PassThroughObjectMapper(
@@ -517,10 +500,7 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
                 "host",
                 new KeywordFieldMapper.Builder("host", IndexVersion.current()).build(context)
             ),
-            aliases,
-            objectIntermediates,
-            context,
-            0
+            context
         );
         assertTrue(aliases.isEmpty());
     }


### PR DESCRIPTION
Simplify top-level calls to getAliases, encapsulating how the object and alias mappers get built.

Also, add yaml coverage for the case where aliases are nested within the same object.

Related to #103567