### PR TITLE
Test fix: handling engine closed when refreshing FieldInfos

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -4013,6 +4013,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             if (enableFieldHasValue) {
                 try (Engine.Searcher hasValueSearcher = getEngine().acquireSearcher("field_has_value")) {
                     setFieldInfos(FieldInfos.getMergedFieldInfos(hasValueSearcher.getIndexReader()));
+                } catch (AlreadyClosedException ignore) {
+                    // engine is closed - no updated FieldInfos is fine
                 }
             }
         }


### PR DESCRIPTION
Relates to: https://github.com/elastic/elasticsearch/pull/103651
closes #105330 
