### PR TITLE
Security auto-config overrides default `http.host`

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -13,7 +13,10 @@ address, a hostname, or a <<network-interface-values,special value>>.
 Use this setting only if you require different configurations for the
 transport and HTTP interfaces.
 +
-Defaults to the address given by `network.host`.
+Defaults to the address given by `network.host`. However, note that
+<<configuring-stack-security,security auto-configuration>> will add
+`http.host: 0.0.0.0` to your `elasticsearch.yml` configuration file, which
+overrides this default.
 
 `http.bind_host`::
 (<<static-cluster-setting,Static>>, string)

--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -43,7 +43,9 @@ Sets the address of this node for both HTTP and transport traffic. The node
 will bind to this address and will also use it as its publish address. Accepts
 an IP address, a hostname, or a <<network-interface-values,special value>>.
 +
-Defaults to `_local_`.
+Defaults to `_local_`. However, note that <<configuring-stack-security,security
+auto-configuration>> will add `http.host: 0.0.0.0` to your `elasticsearch.yml`
+configuration file, which overrides this default for HTTP traffic.
 
 `http.port`::
 (<<static-cluster-setting,Static>>, integer)


### PR DESCRIPTION
If you start up a freshly-unpacked Elasticsearch tarball, security
auto-configuration will set `http.host: 0.0.0.0` in `elasticsearch.yml`,
overriding the documented default behaviour which is to fall back to
`network.host` which itself defaults to `localhost`. This commit adds a
note to the docs about this.