### PR TITLE
[Profiling] Return early when no data are found

### DIFF
--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/GetStackTracesActionIT.java
@@ -176,4 +176,25 @@ public class GetStackTracesActionIT extends ProfilingTestCase {
         GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
         assertEquals(0, response.getTotalFrames());
     }
+
+    public void testGetStackTracesFromAPMIndexNotAvailable() throws Exception {
+        TermQueryBuilder query = QueryBuilders.termQuery("transaction.name", "nonExistingTransaction");
+
+        GetStackTracesRequest request = new GetStackTracesRequest(
+            null,
+            1.0d,
+            1.0d,
+            1.0d,
+            query,
+            new String[] { "non-existing-apm-index-*" },
+            "transaction.profiler_stack_trace_ids",
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        GetStackTracesResponse response = client().execute(GetStackTracesAction.INSTANCE, request).get();
+        assertEquals(0, response.getTotalFrames());
+    }
 }

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/TransportGetStackTracesAction.java
@@ -242,7 +242,11 @@ public class TransportGetStackTracesAction extends TransportAction<GetStackTrace
                     request.getIndices(),
                     responseBuilder.getSamplingRate()
                 );
-                searchGenericEventGroupedByStackTrace(submitTask, client, request, submitListener, responseBuilder);
+                if (sampleCount > 0) {
+                    searchGenericEventGroupedByStackTrace(submitTask, client, request, submitListener, responseBuilder);
+                } else {
+                    submitListener.onResponse(responseBuilder.build());
+                }
             }, submitListener::onFailure));
     }
 


### PR DESCRIPTION
With this commit we check whether any documents match when custom indices are provided and terminate early if the response is empty.