### PR TITLE
Reduce InternalBinaryRange and InternalRandomSampler in a streaming fashion

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/InternalRandomSampler.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/InternalRandomSampler.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
+import org.elasticsearch.search.aggregations.AggregatorsReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
@@ -20,8 +21,6 @@ import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class InternalRandomSampler extends InternalSingleBucketAggregation implements Sampler {
@@ -79,22 +78,21 @@ public class InternalRandomSampler extends InternalSingleBucketAggregation imple
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
         return new AggregatorReducer() {
             long docCount = 0L;
-            final List<InternalAggregations> subAggregationsList = new ArrayList<>(size);
+            final AggregatorsReducer subAggregatorReducer = new AggregatorsReducer(reduceContext, size);
 
             @Override
             public void accept(InternalAggregation aggregation) {
                 docCount += ((InternalSingleBucketAggregation) aggregation).getDocCount();
-                subAggregationsList.add(((InternalSingleBucketAggregation) aggregation).getAggregations());
+                subAggregatorReducer.accept(((InternalSingleBucketAggregation) aggregation).getAggregations());
             }
 
             @Override
             public InternalAggregation get() {
-                InternalAggregations aggs = InternalAggregations.reduce(subAggregationsList, reduceContext);
+                InternalAggregations aggs = subAggregatorReducer.get();
                 if (reduceContext.isFinalReduce() && aggs != null) {
                     SamplingContext context = buildContext();
                     aggs = InternalAggregations.from(aggs.asList().stream().map(agg -> agg.finalizeSampling(context)).toList());
                 }
-
                 return newAggregation(getName(), docCount, aggs);
             }
         };


### PR DESCRIPTION
Similarly to https://github.com/elastic/elasticsearch/pull/105323 and https://github.com/elastic/elasticsearch/pull/105348, InternalBinaryRange and InternalRandomSampler can be wasteful and can be reduced in a streaming fashion.  

relates https://github.com/elastic/elasticsearch/pull/105207