### PR TITLE
Move `MlConfigVersion.getMinMlConfigVersion` call under try-catch block

### DIFF
--- a/docs/changelog/105391.yaml
+++ b/docs/changelog/105391.yaml
@@ -1,0 +1,5 @@
+pr: 105391
+summary: Move `MlConfigVersion.getMinMlConfigVersion` call under try-catch block
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/105391.yaml
+++ b/docs/changelog/105391.yaml
@@ -1,5 +1,5 @@
 pr: 105391
-summary: Move `MlConfigVersion.getMinMlConfigVersion` call under try-catch block
+summary: Catch all the potential exceptions in the ingest processor code
 area: Machine Learning
 type: bug
 issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -381,8 +381,8 @@ public class InferenceProcessor extends AbstractProcessor {
 
         @Override
         public void accept(ClusterState state) {
-            minNodeVersion = MlConfigVersion.getMinMlConfigVersion(state.nodes());
             try {
+                minNodeVersion = MlConfigVersion.getMinMlConfigVersion(state.nodes());
                 currentInferenceProcessors = InferenceProcessorInfoExtractor.countInferenceProcessors(state);
             } catch (Exception ex) {
                 // We cannot throw any exception here. It might break other pipelines.


### PR DESCRIPTION
This PR moves the `MlConfigVersion.getMinMlConfigVersion` call made by the `InferenceProcessor.Factory.accept method into the try-catch block so that the potential exception thrown by this call cannot break other processors/pipelines.