### PR TITLE
Fix for SearchServiceTests#testWaitOnRefreshFailsIfCheckpointNotIndexed

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -1767,7 +1767,9 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         final IndexService indexService = indicesService.indexServiceSafe(resolveIndex("index"));
         final IndexShard indexShard = indexService.getShard(0);
         SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true);
-        searchRequest.setWaitForCheckpointsTimeout(TimeValue.timeValueMillis(randomIntBetween(10, 100)));
+        // Increased timeout to avoid cancelling the search task prior to its completion,
+        // as we expect to raise an Exception. Timeout itself is tested on the following `testWaitOnRefreshTimeout` test.
+        searchRequest.setWaitForCheckpointsTimeout(TimeValue.timeValueMillis(randomIntBetween(200, 300)));
         searchRequest.setWaitForCheckpoints(Collections.singletonMap("index", new long[] { 1 }));
 
         final DocWriteResponse response = prepareIndex("index").setSource("id", "1").get();


### PR DESCRIPTION
There are very sparse random failures of this test (1 / 1000 runs) where we get a `TimeoutException` raised, instead of the expected `IllegalArugmentException`. Almost all of such instances have very low timeout limits in the region of [10-20] ms, with one outlier only at 96ms. 

Given that the timeout itself is covered in a different test (`SearchServiceTests#testWaitOnRefreshTimeout`), in this PR we simply increase the possible timeout values of the refresh tread to isolate the change under testing and make sure to verify whether we fail for the right reasons. Brief analysis on the test failures can also be found on this [comment](https://github.com/elastic/elasticsearch/issues/102754#issuecomment-1936406934). 

Closes https://github.com/elastic/elasticsearch/issues/102754.