### PR TITLE
Fixing a minor typo in bulk api docs

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -246,7 +246,7 @@ on.
 
 `list_executed_pipelines`::
 (Optional, Boolean) If `true`, the response will include the ingest pipelines that
-were executed for each `index` or ``create`.
+were executed for each `index` or `create`.
 Defaults to `false`.
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=pipeline]


### PR DESCRIPTION
This removes the extra `` ` `` in our docs about the `list_executed_pipelines` field at https://www.elastic.co/guide/en/elasticsearch/reference/8.12/docs-bulk.html#docs-bulk-api-query-params. 