### PR TITLE
[DOCS] Drop these unused references

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -46,9 +46,6 @@ ifeval::["{release-state}"!="unreleased"]
 :version_qualified: {bare_version}
 endif::[]
 
-:javadoc-license: {rest-high-level-client-javadoc}/org/elasticsearch/protocol/xpack/license
-:javadoc-watcher: {rest-high-level-client-javadoc}/org/elasticsearch/protocol/xpack/watcher
-
 ///////
 Shared attribute values are pulled from elastic/docs
 ///////


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/83423

https://github.com/elastic/elasticsearch/pull/105406 actually deletes the very last vestiges of the code, but there's still a few grep hits in the docs. This PR drops those, too. Here's an after:

```
joegallo@simulacron:~/Code/elastic/elasticsearch $ git grep javadoc-license
joegallo@simulacron:~/Code/elastic/elasticsearch $ git grep javadoc-watcher
joegallo@simulacron:~/Code/elastic/elasticsearch $ git grep rest-high-level-client-javadoc
joegallo@simulacron:~/Code/elastic/elasticsearch $
```

-----

This reference remains (which you can see in the live docs [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/java-clients.html)), but it indirectly gets the user to the [Java API Client](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html) eventually, so I think it's fine to stay:
```
joegallo@simulacron:~/Code/elastic/elasticsearch $ grep -B6 -A1 rest-high-level -- docs/reference/redirects.asciidoc
[role="exclude",id="java-clients"]
=== Java transport client and security

The Java transport client has been removed. Use the
https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high.html[Java
high-level REST client] instead. For migration steps, refer to the
https://www.elastic.co/guide/en/elasticsearch/client/java-rest/7.15/java-rest-high-level-migration.html[migration
guide].
```