### PR TITLE
ES|QL: Adding tests for =~ operator

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ignore-case.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ignore-case.csv-spec
@@ -49,9 +49,7 @@ emp_no:integer | first_name:keyword | a:boolean | b:boolean | c:boolean | d:bool
 ;
 
 
-//waiting for final decisions on supporting generic expressions on the right
-//https://github.com/elastic/elasticsearch/issues/103599
-constantsAndFolding-Ignore
+constantsAndFolding#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 row name = "foobar" | where "FoObAr" =~ name;
 
 name:keyword
@@ -80,9 +78,7 @@ emp_no:integer | first_name:keyword
 ;
 
 
-//waiting for final decisions on supporting generic expressions on the right
-//https://github.com/elastic/elasticsearch/issues/103599
-fieldRight-Ignore
+fieldRight#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees | where "Guoxiang" =~ first_name | keep emp_no, first_name;
 
 emp_no:integer  | first_name:keyword
@@ -106,9 +102,7 @@ emp_no:integer  | first_name:keyword
 ;
 
 
-//waiting for final decisions on supporting generic expressions on the right
-//https://github.com/elastic/elasticsearch/issues/103599
-expressionsLeftRight-Ignore
+expressionsLeftRight#[skip:-8.12.99, reason:case insensitive operators implemented in v 8.13]
 from employees | where substring(first_name, 1, 2) =~ substring(last_name, -2) | keep emp_no, first_name, last_name | sort emp_no;
 
 emp_no:integer  | first_name:keyword    | last_name:keyword

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/InsensitiveBinaryComparison.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/evaluator/predicate/operator/comparison/InsensitiveBinaryComparison.java
@@ -7,15 +7,25 @@
 package org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison;
 
 import org.elasticsearch.xpack.ql.expression.Expression;
-import org.elasticsearch.xpack.ql.expression.function.scalar.BinaryScalarFunction;
+import org.elasticsearch.xpack.ql.expression.predicate.BinaryOperator;
+import org.elasticsearch.xpack.ql.expression.predicate.PredicateBiFunction;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 
-public abstract class InsensitiveBinaryComparison extends BinaryScalarFunction {
+public abstract class InsensitiveBinaryComparison extends BinaryOperator<
+    Object,
+    Object,
+    Boolean,
+    PredicateBiFunction<Object, Object, Boolean>> {
 
-    protected InsensitiveBinaryComparison(Source source, Expression left, Expression right) {
-        super(source, left, right);
+    protected InsensitiveBinaryComparison(
+        Source source,
+        Expression left,
+        Expression right,
+        PredicateBiFunction<Object, Object, Boolean> f
+    ) {
+        super(source, left, right, f);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/AbstractBinaryOperatorTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/AbstractBinaryOperatorTestCase.java
@@ -124,7 +124,7 @@ public abstract class AbstractBinaryOperatorTestCase extends AbstractFunctionTes
             }
             Literal lhs = randomLiteral(lhsType);
             for (DataType rhsType : EsqlDataTypes.types()) {
-                if (isRepresentable(rhsType) == false) {
+                if (isRepresentable(rhsType) == false || supportsTypes(lhsType, rhsType) == false) {
                     continue;
                 }
                 Literal rhs = randomLiteral(rhsType);

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/AbstractInsensitiveBinaryComparisonTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/AbstractInsensitiveBinaryComparisonTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.predicate.operator.comparison;
+
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.AbstractBinaryOperatorTestCase;
+import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
+import org.elasticsearch.xpack.ql.expression.predicate.BinaryOperator;
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.isSpatial;
+import static org.hamcrest.Matchers.equalTo;
+
+public abstract class AbstractInsensitiveBinaryComparisonTestCase extends AbstractBinaryOperatorTestCase {
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    protected final Matcher<Object> resultMatcher(List<Object> data, DataType dataType) {
+        Comparable lhs = (Comparable) data.get(0);
+        Comparable rhs = (Comparable) data.get(1);
+        if (lhs instanceof Double || rhs instanceof Double) {
+            return (Matcher<Object>) (Matcher<?>) resultMatcher(((Number) lhs).doubleValue(), ((Number) rhs).doubleValue());
+        }
+        if (lhs instanceof Long || rhs instanceof Long) {
+            return (Matcher<Object>) (Matcher<?>) resultMatcher(((Number) lhs).longValue(), ((Number) rhs).longValue());
+        }
+        if (lhs instanceof Integer || rhs instanceof Integer) {
+            return (Matcher<Object>) (Matcher<?>) resultMatcher(((Number) lhs).intValue(), ((Number) rhs).intValue());
+        }
+        return (Matcher<Object>) (Matcher<?>) resultMatcher(lhs, rhs);
+    }
+
+    @Override
+    protected Matcher<Object> resultsMatcher(List<TestCaseSupplier.TypedData> typedData) {
+        Number lhs = (Number) typedData.get(0).data();
+        Number rhs = (Number) typedData.get(1).data();
+        if (typedData.stream().anyMatch(t -> t.type().equals(DataTypes.DOUBLE))) {
+            return equalTo(resultMatcher(lhs.doubleValue(), rhs.doubleValue()));
+        }
+        if (typedData.stream().anyMatch(t -> t.type().equals(DataTypes.UNSIGNED_LONG))) {
+            // TODO: Is this correct behavior for unsigned long?
+            return resultMatcher(lhs.longValue(), rhs.longValue());
+        }
+        if (typedData.stream().anyMatch(t -> t.type().equals(DataTypes.LONG))) {
+            return resultMatcher(lhs.longValue(), rhs.longValue());
+        }
+        if (typedData.stream().anyMatch(t -> t.type().equals(DataTypes.INTEGER))) {
+            return resultMatcher(lhs.intValue(), rhs.intValue());
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    protected abstract <T extends Comparable<T>> Matcher<Object> resultMatcher(T lhs, T rhs);
+
+    protected abstract boolean isEquality();
+
+    @Override
+    protected final boolean supportsType(DataType type) {
+        // Boolean and Spatial types do not support inequality operators
+        if (type == DataTypes.BOOLEAN || isSpatial(type)) {
+            return isEquality();
+        }
+        return EsqlDataTypes.isRepresentable(type);
+    }
+
+    @Override
+    protected boolean supportsTypes(DataType lhsType, DataType rhsType) {
+        return super.supportsTypes(lhsType, rhsType) && (lhsType == rhsType || lhsType.isNumeric() && rhsType.isNumeric());
+    }
+
+    @Override
+    protected void validateType(BinaryOperator<?, ?, ?, ?> op, DataType lhsType, DataType rhsType) {
+        assertTrue(op.typeResolved().resolved());
+        assertThat(op.dataType(), equalTo(DataTypes.BOOLEAN));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InsensitiveEqualsTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InsensitiveEqualsTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.predicate.operator.comparison;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.InsensitiveBinaryComparison;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.InsensitiveEquals;
+import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class InsensitiveEqualsTests extends AbstractInsensitiveBinaryComparisonTestCase {
+    public InsensitiveEqualsTests(@Name("TestCase") Supplier<TestCaseSupplier.TestCase> testCaseSupplier) {
+        this.testCase = testCaseSupplier.get();
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() {
+        return parameterSuppliersFromTypedData(List.of(new TestCaseSupplier("String =~ String", () -> {
+            BytesRef rhs = BytesRefs.toBytesRef(randomAlphaOfLength(5));
+            BytesRef lhs = BytesRefs.toBytesRef(randomAlphaOfLength(5));
+            return new TestCaseSupplier.TestCase(
+                List.of(
+                    new TestCaseSupplier.TypedData(lhs, DataTypes.KEYWORD, "lhs"),
+                    new TestCaseSupplier.TypedData(rhs, DataTypes.KEYWORD, "rhs")
+                ),
+                "InsensitiveEqualsEvaluator[lhs=Attribute[channel=0], rhs=Attribute[channel=1]]",
+                DataTypes.BOOLEAN,
+                equalTo(lhs.utf8ToString().toLowerCase(Locale.ROOT) == rhs.utf8ToString().toLowerCase(Locale.ROOT))
+            );
+        })));
+    }
+
+    @Override
+    protected <T extends Comparable<T>> Matcher<Object> resultMatcher(T lhs, T rhs) {
+        return equalTo(lhs.equals(rhs));
+    }
+
+    @Override
+    protected InsensitiveBinaryComparison build(Source source, Expression lhs, Expression rhs) {
+        return new InsensitiveEquals(source, lhs, rhs);
+    }
+
+    @Override
+    protected boolean isEquality() {
+        return true;
+    }
+
+    protected boolean supportsTypes(DataType lhsType, DataType rhsType) {
+        return DataTypes.isString(lhsType) && DataTypes.isString(rhsType);
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/110_insensitive_equals.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/110_insensitive_equals.yml
@@ -1,8 +1,8 @@
 ---
 setup:
   - skip:
-      version: "all"
-      reason: "waiting for final decisions on supporting generic expressions on the right https://github.com/elastic/elasticsearch/issues/103599"
+      version: " - 8.12.99"
+      reason: "feature added in 8.13"
 
       features: allowed_warnings_regex
   - do:


### PR DESCRIPTION

WIP: DO NOT MERGE!

for now this PR also activates `field =~ field` capabilities (rather than `field =~ "literal"` as it is now).
This is not our intention for now though, so we'll have to re-enable the validation for literals only and make the tests work.

