### PR TITLE
Update tsdb binary doc value format to use compression from LUCENE-9211.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/BinaryDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/BinaryDecoder.java
@@ -44,9 +44,9 @@ final class BinaryDecoder {
 
     }
 
-    BytesRef decode(int docNumber) throws IOException {
-        int blockId = docNumber >> docsPerChunkShift;
-        int docInBlockId = docNumber % docsPerChunk;
+    BytesRef decode(int docId) throws IOException {
+        int blockId = docId >> docsPerChunkShift;
+        int docInBlockId = docId % docsPerChunk;
         assert docInBlockId < docsPerChunk;
 
         // already read and uncompressed?
@@ -56,6 +56,8 @@ final class BinaryDecoder {
             compressedData.seek(blockStartOffset);
 
             uncompressedBlockLength = 0;
+
+            int docsPerChunk = compressedData.readVInt();
 
             int onlyLength = -1;
             for (int i = 0; i < docsPerChunk; i++) {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/BinaryDecoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/BinaryDecoder.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongValues;
+import org.apache.lucene.util.compress.LZ4;
+
+import java.io.IOException;
+
+/**
+ * Decompresses binary doc values for {@link org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesProducer}
+ */
+final class BinaryDecoder {
+
+    private final LongValues addresses;
+    private final IndexInput compressedData;
+    // Cache of last uncompressed block
+    private long lastBlockId = -1;
+    private final int[] uncompressedDocStarts;
+    private int uncompressedBlockLength = 0;
+    private final byte[] uncompressedBlock;
+    private final BytesRef uncompressedBytesRef;
+    private final int docsPerChunk;
+    private final int docsPerChunkShift;
+
+    BinaryDecoder(LongValues addresses, IndexInput compressedData, int biggestUncompressedBlockSize, int docsPerChunkShift) {
+        super();
+        this.addresses = addresses;
+        this.compressedData = compressedData;
+        // pre-allocate a byte array large enough for the biggest uncompressed block needed.
+        this.uncompressedBlock = new byte[biggestUncompressedBlockSize];
+        uncompressedBytesRef = new BytesRef(uncompressedBlock);
+        this.docsPerChunk = 1 << docsPerChunkShift;
+        this.docsPerChunkShift = docsPerChunkShift;
+        uncompressedDocStarts = new int[docsPerChunk + 1];
+
+    }
+
+    BytesRef decode(int docNumber) throws IOException {
+        int blockId = docNumber >> docsPerChunkShift;
+        int docInBlockId = docNumber % docsPerChunk;
+        assert docInBlockId < docsPerChunk;
+
+        // already read and uncompressed?
+        if (blockId != lastBlockId) {
+            lastBlockId = blockId;
+            long blockStartOffset = addresses.get(blockId);
+            compressedData.seek(blockStartOffset);
+
+            uncompressedBlockLength = 0;
+
+            int onlyLength = -1;
+            for (int i = 0; i < docsPerChunk; i++) {
+                if (i == 0) {
+                    // The first length value is special. It is shifted and has a bit to denote if
+                    // all other values are the same length
+                    int lengthPlusSameInd = compressedData.readVInt();
+                    int sameIndicator = lengthPlusSameInd & 1;
+                    int firstValLength = lengthPlusSameInd >>> 1;
+                    if (sameIndicator == 1) {
+                        onlyLength = firstValLength;
+                    }
+                    uncompressedBlockLength += firstValLength;
+                } else {
+                    if (onlyLength == -1) {
+                        // Various lengths are stored - read each from disk
+                        uncompressedBlockLength += compressedData.readVInt();
+                    } else {
+                        // Only one length
+                        uncompressedBlockLength += onlyLength;
+                    }
+                }
+                uncompressedDocStarts[i + 1] = uncompressedBlockLength;
+            }
+
+            if (uncompressedBlockLength == 0) {
+                uncompressedBytesRef.offset = 0;
+                uncompressedBytesRef.length = 0;
+                return uncompressedBytesRef;
+            }
+
+            assert uncompressedBlockLength <= uncompressedBlock.length;
+            LZ4.decompress(compressedData, uncompressedBlockLength, uncompressedBlock, 0);
+        }
+
+        uncompressedBytesRef.offset = uncompressedDocStarts[docInBlockId];
+        uncompressedBytesRef.length = uncompressedDocStarts[docInBlockId + 1] - uncompressedBytesRef.offset;
+        return uncompressedBytesRef;
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/CompressedBinaryBlockWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/CompressedBinaryBlockWriter.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.codec.tsdb;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.SegmentWriteState;
+import org.apache.lucene.store.ChecksumIndexInput;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.compress.LZ4;
+import org.apache.lucene.util.packed.DirectMonotonicWriter;
+import org.elasticsearch.core.IOUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT;
+
+/**
+ * Compresses binary doc values for {@link ES87TSDBDocValuesConsumer}
+ */
+final class CompressedBinaryBlockWriter implements Closeable {
+    private final SegmentWriteState state;
+    private final IndexOutput meta, data;
+    private final long blockAddressesStart;
+    private final IndexOutput tempBinaryOffsets;
+    private final LZ4.FastCompressionHashTable ht = new LZ4.FastCompressionHashTable();
+
+    int uncompressedBlockLength = 0;
+    int maxUncompressedBlockLength = 0;
+    int numDocsInCurrentBlock = 0;
+    final int[] docLengths = new int[ES87TSDBDocValuesFormat.BINARY_DOCS_PER_COMPRESSED_BLOCK];
+    byte[] block = BytesRef.EMPTY_BYTES;
+    int totalChunks = 0;
+    long maxPointer = 0;
+
+    CompressedBinaryBlockWriter(SegmentWriteState state, IndexOutput meta, IndexOutput data) throws IOException {
+        this.state = state;
+        this.meta = meta;
+        this.data = data;
+
+        tempBinaryOffsets = state.directory.createTempOutput(state.segmentInfo.name, "binary_pointers", state.context);
+        boolean success = false;
+        try {
+            CodecUtil.writeHeader(
+                tempBinaryOffsets,
+                ES87TSDBDocValuesFormat.META_CODEC + "FilePointers",
+                ES87TSDBDocValuesFormat.VERSION_CURRENT
+            );
+            blockAddressesStart = data.getFilePointer();
+            success = true;
+        } finally {
+            if (success == false) {
+                IOUtils.closeWhileHandlingException(this); // self-close because constructor caller can't
+            }
+        }
+    }
+
+    void addDoc(int doc, BytesRef v) throws IOException {
+        docLengths[numDocsInCurrentBlock] = v.length;
+        block = ArrayUtil.grow(block, uncompressedBlockLength + v.length);
+        System.arraycopy(v.bytes, v.offset, block, uncompressedBlockLength, v.length);
+        uncompressedBlockLength += v.length;
+        numDocsInCurrentBlock++;
+        if (numDocsInCurrentBlock == ES87TSDBDocValuesFormat.BINARY_DOCS_PER_COMPRESSED_BLOCK) {
+            flushData();
+        }
+    }
+
+    void flushData() throws IOException {
+        if (numDocsInCurrentBlock > 0) {
+            // Write offset to this block to temporary offsets file
+            totalChunks++;
+            long thisBlockStartPointer = data.getFilePointer();
+
+            // Optimisation - check if all lengths are same
+            boolean allLengthsSame = true;
+            for (int i = 1; i < ES87TSDBDocValuesFormat.BINARY_DOCS_PER_COMPRESSED_BLOCK; i++) {
+                if (docLengths[i] != docLengths[i - 1]) {
+                    allLengthsSame = false;
+                    break;
+                }
+            }
+            if (allLengthsSame) {
+                // Only write one value shifted. Steal a bit to indicate all other lengths are the same
+                int onlyOneLength = (docLengths[0] << 1) | 1;
+                data.writeVInt(onlyOneLength);
+            } else {
+                for (int i = 0; i < ES87TSDBDocValuesFormat.BINARY_DOCS_PER_COMPRESSED_BLOCK; i++) {
+                    if (i == 0) {
+                        // Write first value shifted and steal a bit to indicate other lengths are to follow
+                        int multipleLengths = (docLengths[0] << 1);
+                        data.writeVInt(multipleLengths);
+                    } else {
+                        data.writeVInt(docLengths[i]);
+                    }
+                }
+            }
+            maxUncompressedBlockLength = Math.max(maxUncompressedBlockLength, uncompressedBlockLength);
+            LZ4.compress(block, 0, uncompressedBlockLength, data, ht);
+            numDocsInCurrentBlock = 0;
+            // Ensure initialized with zeroes because full array is always written
+            Arrays.fill(docLengths, 0);
+            uncompressedBlockLength = 0;
+            maxPointer = data.getFilePointer();
+            tempBinaryOffsets.writeVLong(maxPointer - thisBlockStartPointer);
+        }
+    }
+
+    void writeMetaData() throws IOException {
+        if (totalChunks == 0) {
+            return;
+        }
+
+        long startDMW = data.getFilePointer();
+        meta.writeLong(startDMW);
+
+        meta.writeVInt(totalChunks);
+        meta.writeVInt(ES87TSDBDocValuesFormat.BINARY_BLOCK_SHIFT);
+        meta.writeVInt(maxUncompressedBlockLength);
+        meta.writeVInt(DIRECT_MONOTONIC_BLOCK_SHIFT);
+
+        CodecUtil.writeFooter(tempBinaryOffsets);
+        IOUtils.close(tempBinaryOffsets);
+        // write the compressed block offsets info to the meta file by reading from temp file
+        try (ChecksumIndexInput filePointersIn = state.directory.openChecksumInput(tempBinaryOffsets.getName(), IOContext.READONCE)) {
+            CodecUtil.checkHeader(
+                filePointersIn,
+                ES87TSDBDocValuesFormat.META_CODEC + "FilePointers",
+                ES87TSDBDocValuesFormat.VERSION_CURRENT,
+                ES87TSDBDocValuesFormat.VERSION_CURRENT
+            );
+            Throwable priorE = null;
+            try {
+                final DirectMonotonicWriter filePointers = DirectMonotonicWriter.getInstance(
+                    meta,
+                    data,
+                    totalChunks,
+                    DIRECT_MONOTONIC_BLOCK_SHIFT
+                );
+                long fp = blockAddressesStart;
+                for (int i = 0; i < totalChunks; ++i) {
+                    filePointers.add(fp);
+                    fp += filePointersIn.readVLong();
+                }
+                if (maxPointer < fp) {
+                    throw new CorruptIndexException(
+                        "File pointers don't add up (" + fp + " vs expected " + maxPointer + ")",
+                        filePointersIn
+                    );
+                }
+                filePointers.finish();
+            } catch (Throwable e) {
+                priorE = e;
+            } finally {
+                CodecUtil.checkFooter(filePointersIn, priorE);
+            }
+        }
+        // Write the length of the DMW block in the data
+        meta.writeLong(data.getFilePointer() - startDMW);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (tempBinaryOffsets != null) {
+            IOUtils.close(tempBinaryOffsets);
+            state.directory.deleteFile(tempBinaryOffsets.getName());
+        }
+    }
+
+}

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesConsumer.java
@@ -47,12 +47,14 @@ import static org.elasticsearch.index.codec.tsdb.ES87TSDBDocValuesFormat.SORTED_
 
 final class ES87TSDBDocValuesConsumer extends DocValuesConsumer {
 
+    final SegmentWriteState state;
     IndexOutput data, meta;
     final int maxDoc;
     private byte[] termsDictBuffer;
 
     ES87TSDBDocValuesConsumer(SegmentWriteState state, String dataCodec, String dataExtension, String metaCodec, String metaExtension)
         throws IOException {
+        this.state = state;
         this.termsDictBuffer = new byte[1 << 14];
         boolean success = false;
         try {
@@ -195,66 +197,51 @@ final class ES87TSDBDocValuesConsumer extends DocValuesConsumer {
         meta.writeInt(field.number);
         meta.writeByte(ES87TSDBDocValuesFormat.BINARY);
 
-        BinaryDocValues values = valuesProducer.getBinary(field);
-        long start = data.getFilePointer();
-        meta.writeLong(start); // dataOffset
-        int numDocsWithField = 0;
-        int minLength = Integer.MAX_VALUE;
-        int maxLength = 0;
-        for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
-            numDocsWithField++;
-            BytesRef v = values.binaryValue();
-            int length = v.length;
-            data.writeBytes(v.bytes, v.offset, v.length);
-            minLength = Math.min(length, minLength);
-            maxLength = Math.max(length, maxLength);
-        }
-        assert numDocsWithField <= maxDoc;
-        meta.writeLong(data.getFilePointer() - start); // dataLength
-
-        if (numDocsWithField == 0) {
-            meta.writeLong(-2); // docsWithFieldOffset
-            meta.writeLong(0L); // docsWithFieldLength
-            meta.writeShort((short) -1); // jumpTableEntryCount
-            meta.writeByte((byte) -1); // denseRankPower
-        } else if (numDocsWithField == maxDoc) {
-            meta.writeLong(-1); // docsWithFieldOffset
-            meta.writeLong(0L); // docsWithFieldLength
-            meta.writeShort((short) -1); // jumpTableEntryCount
-            meta.writeByte((byte) -1); // denseRankPower
-        } else {
-            long offset = data.getFilePointer();
-            meta.writeLong(offset); // docsWithFieldOffset
-            values = valuesProducer.getBinary(field);
-            final short jumpTableEntryCount = IndexedDISI.writeBitSet(values, data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
-            meta.writeLong(data.getFilePointer() - offset); // docsWithFieldLength
-            meta.writeShort(jumpTableEntryCount);
-            meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
-        }
-
-        meta.writeInt(numDocsWithField);
-        meta.writeInt(minLength);
-        meta.writeInt(maxLength);
-        if (maxLength > minLength) {
-            start = data.getFilePointer();
-            meta.writeLong(start);
-            meta.writeVInt(ES87TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT);
-
-            final DirectMonotonicWriter writer = DirectMonotonicWriter.getInstance(
-                meta,
-                data,
-                numDocsWithField + 1,
-                ES87TSDBDocValuesFormat.DIRECT_MONOTONIC_BLOCK_SHIFT
-            );
-            long addr = 0;
-            writer.add(addr);
-            values = valuesProducer.getBinary(field);
+        try (CompressedBinaryBlockWriter blockWriter = new CompressedBinaryBlockWriter(state, meta, data)) {
+            BinaryDocValues values = valuesProducer.getBinary(field);
+            long start = data.getFilePointer();
+            meta.writeLong(start); // dataOffset
+            int numDocsWithField = 0;
+            int minLength = Integer.MAX_VALUE;
+            int maxLength = 0;
             for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
-                addr += values.binaryValue().length;
-                writer.add(addr);
+                numDocsWithField++;
+                BytesRef v = values.binaryValue();
+                blockWriter.addDoc(doc, v);
+                int length = v.length;
+                minLength = Math.min(length, minLength);
+                maxLength = Math.max(length, maxLength);
             }
-            writer.finish();
-            meta.writeLong(data.getFilePointer() - start);
+            blockWriter.flushData();
+
+            assert numDocsWithField <= maxDoc;
+            meta.writeLong(data.getFilePointer() - start); // dataLength
+
+            if (numDocsWithField == 0) {
+                meta.writeLong(-2); // docsWithFieldOffset
+                meta.writeLong(0L); // docsWithFieldLength
+                meta.writeShort((short) -1); // jumpTableEntryCount
+                meta.writeByte((byte) -1);   // denseRankPower
+            } else if (numDocsWithField == maxDoc) {
+                meta.writeLong(-1); // docsWithFieldOffset
+                meta.writeLong(0L); // docsWithFieldLength
+                meta.writeShort((short) -1); // jumpTableEntryCount
+                meta.writeByte((byte) -1);   // denseRankPower
+            } else {
+                long offset = data.getFilePointer();
+                meta.writeLong(offset); // docsWithFieldOffset
+                values = valuesProducer.getBinary(field);
+                final short jumpTableEntryCount = IndexedDISI.writeBitSet(values, data, IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+                meta.writeLong(data.getFilePointer() - offset); // docsWithFieldLength
+                meta.writeShort(jumpTableEntryCount);
+                meta.writeByte(IndexedDISI.DEFAULT_DENSE_RANK_POWER);
+            }
+
+            meta.writeInt(numDocsWithField);
+            meta.writeInt(minLength);
+            meta.writeInt(maxLength);
+
+            blockWriter.writeMetaData();
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesConsumer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesConsumer.java
@@ -207,7 +207,7 @@ final class ES87TSDBDocValuesConsumer extends DocValuesConsumer {
             for (int doc = values.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = values.nextDoc()) {
                 numDocsWithField++;
                 BytesRef v = values.binaryValue();
-                blockWriter.addDoc(doc, v);
+                blockWriter.addDoc(v);
                 int length = v.length;
                 minLength = Math.min(length, minLength);
                 maxLength = Math.max(length, maxLength);

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormat.java
@@ -42,6 +42,9 @@ public class ES87TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValuesF
     static final int TERMS_DICT_REVERSE_INDEX_SIZE = 1 << TERMS_DICT_REVERSE_INDEX_SHIFT;
     static final int TERMS_DICT_REVERSE_INDEX_MASK = TERMS_DICT_REVERSE_INDEX_SIZE - 1;
 
+    static final int BINARY_BLOCK_SHIFT = 5;
+    static final int BINARY_DOCS_PER_COMPRESSED_BLOCK = 1 << BINARY_BLOCK_SHIFT;
+
     public ES87TSDBDocValuesFormat() {
         super(CODEC_NAME);
     }

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesFormat.java
@@ -44,6 +44,7 @@ public class ES87TSDBDocValuesFormat extends org.apache.lucene.codecs.DocValuesF
 
     static final int BINARY_BLOCK_SHIFT = 5;
     static final int BINARY_DOCS_PER_COMPRESSED_BLOCK = 1 << BINARY_BLOCK_SHIFT;
+    static final long MAX_COMPRESSED_BLOCK_SIZE = 1 << 1;
 
     public ES87TSDBDocValuesFormat() {
         super(CODEC_NAME);

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
@@ -154,7 +154,12 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
             final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
             final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
             return new SparseBinaryDocValues(disi) {
-                BinaryDecoder decoder = new BinaryDecoder(addresses, data.clone(), entry.maxUncompressedChunkSize, entry.docsPerChunkShift);
+                final BinaryDecoder decoder = new BinaryDecoder(
+                    addresses,
+                    data.clone(),
+                    entry.maxUncompressedChunkSize,
+                    entry.docsPerChunkShift
+                );
 
                 @Override
                 public BytesRef binaryValue() throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesProducer.java
@@ -124,41 +124,23 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
         if (entry.docsWithFieldOffset == -2) {
             return DocValues.emptyBinary();
         }
-
-        final IndexInput bytesSlice = data.slice("fixed-binary", entry.dataOffset, entry.dataLength);
-
         if (entry.docsWithFieldOffset == -1) {
             // dense
-            if (entry.minLength == entry.maxLength) {
-                // fixed length
-                final int length = entry.maxLength;
-                return new DenseBinaryDocValues(maxDoc) {
-                    final BytesRef bytes = new BytesRef(new byte[length], 0, length);
+            final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+            final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
+            return new DenseBinaryDocValues(maxDoc) {
+                final BinaryDecoder decoder = new BinaryDecoder(
+                    addresses,
+                    data.clone(),
+                    entry.maxUncompressedChunkSize,
+                    entry.docsPerChunkShift
+                );
 
-                    @Override
-                    public BytesRef binaryValue() throws IOException {
-                        bytesSlice.seek((long) doc * length);
-                        bytesSlice.readBytes(bytes.bytes, 0, length);
-                        return bytes;
-                    }
-                };
-            } else {
-                // variable length
-                final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
-                final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
-                return new DenseBinaryDocValues(maxDoc) {
-                    final BytesRef bytes = new BytesRef(new byte[entry.maxLength], 0, entry.maxLength);
-
-                    @Override
-                    public BytesRef binaryValue() throws IOException {
-                        long startOffset = addresses.get(doc);
-                        bytes.length = (int) (addresses.get(doc + 1L) - startOffset);
-                        bytesSlice.seek(startOffset);
-                        bytesSlice.readBytes(bytes.bytes, 0, bytes.length);
-                        return bytes;
-                    }
-                };
-            }
+                @Override
+                public BytesRef binaryValue() throws IOException {
+                    return decoder.decode(doc);
+                }
+            };
         } else {
             // sparse
             final IndexedDISI disi = new IndexedDISI(
@@ -169,37 +151,16 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
                 entry.denseRankPower,
                 entry.numDocsWithField
             );
-            if (entry.minLength == entry.maxLength) {
-                // fixed length
-                final int length = entry.maxLength;
-                return new SparseBinaryDocValues(disi) {
-                    final BytesRef bytes = new BytesRef(new byte[length], 0, length);
+            final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
+            final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
+            return new SparseBinaryDocValues(disi) {
+                BinaryDecoder decoder = new BinaryDecoder(addresses, data.clone(), entry.maxUncompressedChunkSize, entry.docsPerChunkShift);
 
-                    @Override
-                    public BytesRef binaryValue() throws IOException {
-                        bytesSlice.seek((long) disi.index() * length);
-                        bytesSlice.readBytes(bytes.bytes, 0, length);
-                        return bytes;
-                    }
-                };
-            } else {
-                // variable length
-                final RandomAccessInput addressesData = this.data.randomAccessSlice(entry.addressesOffset, entry.addressesLength);
-                final LongValues addresses = DirectMonotonicReader.getInstance(entry.addressesMeta, addressesData);
-                return new SparseBinaryDocValues(disi) {
-                    final BytesRef bytes = new BytesRef(new byte[entry.maxLength], 0, entry.maxLength);
-
-                    @Override
-                    public BytesRef binaryValue() throws IOException {
-                        final int index = disi.index();
-                        long startOffset = addresses.get(index);
-                        bytes.length = (int) (addresses.get(index + 1L) - startOffset);
-                        bytesSlice.seek(startOffset);
-                        bytesSlice.readBytes(bytes.bytes, 0, bytes.length);
-                        return bytes;
-                    }
-                };
-            }
+                @Override
+                public BytesRef binaryValue() throws IOException {
+                    return decoder.decode(disi.index());
+                }
+            };
         }
     }
 
@@ -781,12 +742,12 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
         entry.numDocsWithField = meta.readInt();
         entry.minLength = meta.readInt();
         entry.maxLength = meta.readInt();
-        if (entry.minLength < entry.maxLength) {
+        if (entry.numDocsWithField > 0) {
             entry.addressesOffset = meta.readLong();
-
-            // Old count of uncompressed addresses
-            long numAddresses = entry.numDocsWithField + 1L;
-
+            entry.numCompressedChunks = meta.readVInt();
+            entry.docsPerChunkShift = meta.readVInt();
+            entry.maxUncompressedChunkSize = meta.readVInt();
+            long numAddresses = entry.numCompressedChunks;
             final int blockShift = meta.readVInt();
             entry.addressesMeta = DirectMonotonicReader.loadMeta(meta, numAddresses, blockShift);
             entry.addressesLength = meta.readLong();
@@ -1267,7 +1228,7 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
         long valuesLength;
     }
 
-    private static class BinaryEntry {
+    static class BinaryEntry {
         long dataOffset;
         long dataLength;
         long docsWithFieldOffset;
@@ -1280,6 +1241,9 @@ public class ES87TSDBDocValuesProducer extends DocValuesProducer {
         long addressesOffset;
         long addressesLength;
         DirectMonotonicReader.Meta addressesMeta;
+        int numCompressedChunks;
+        int docsPerChunkShift;
+        int maxUncompressedChunkSize;
     }
 
     private static class SortedNumericEntry extends NumericEntry {


### PR DESCRIPTION
The binary doc values implementation from LUCENE-9211 (apache/lucene-solr#1234) is used here, which stores the values in LZ4 compressed blocks, in order to reduce storage usage (in the Lucene default doc values coded binary doc values are stored without any compression).

Follow up from #105301