### PR TITLE
Adding executedPipelines to the IngestDocument copy constructor

### DIFF
--- a/docs/changelog/105427.yaml
+++ b/docs/changelog/105427.yaml
@@ -1,0 +1,5 @@
+pr: 105427
+summary: Adding `executedPipelines` to the `IngestDocument` copy constructor
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
@@ -714,18 +714,9 @@ teardown:
 - do:
     ingest.simulate:
       verbose: true
+      id: "outer"
       body: >
         {
-          "pipeline": {
-            "processors" : [
-            {
-              "pipeline" : {
-                "name": "outer"
-              }
-            }
-            ]
-          }
-          ,
           "docs": [
           {
             "_index": "index",

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -62,8 +62,8 @@ public final class IngestDocument {
      */
     private final DelegatingMapView templateModel;
 
-    // Contains all pipelines that have been executed for this document
-    private final Set<String> executedPipelines = new LinkedHashSet<>();
+    // Contains all pipelines that have been executed for this document, non-private for unit testing
+    final Set<String> executedPipelines = new LinkedHashSet<>();
 
     /**
      * An ordered set of the values of the _index that have been used for this document.
@@ -91,7 +91,7 @@ public final class IngestDocument {
     }
 
     // note: these rest of these constructors deal with the data-centric view of the IngestDocument, not the execution-centric view.
-    // For example, the copy constructor doesn't populate the `executedPipelines` or `indexHistory` (as well as some other fields),
+    // For example, the copy constructor doesn't populate the `indexHistory` (as well as some other fields),
     // because those fields are execution-centric.
 
     /**
@@ -104,6 +104,7 @@ public final class IngestDocument {
             new IngestCtxMap(deepCopyMap(ensureNoSelfReferences(other.ctxMap.getSource())), other.ctxMap.getMetadata().clone()),
             deepCopyMap(other.ingestMetadata)
         );
+        this.executedPipelines.addAll(other.executedPipelines);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -104,6 +104,12 @@ public final class IngestDocument {
             new IngestCtxMap(deepCopyMap(ensureNoSelfReferences(other.ctxMap.getSource())), other.ctxMap.getMetadata().clone()),
             deepCopyMap(other.ingestMetadata)
         );
+        /*
+         * The executedPipelines field is clearly execution-centric rather than data centric. Despite what the comment above says, we're
+         * copying it here anyway. THe reason is that this constructor is only called from two non-test locations, and both of those
+         * involve the simulate pipeline logic. The simulate pipeline logic needs this information. Rather than making the code more
+         * complicated, we're just copying this over here since it does no harm.
+         */
         this.executedPipelines.addAll(other.executedPipelines);
     }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -62,8 +62,8 @@ public final class IngestDocument {
      */
     private final DelegatingMapView templateModel;
 
-    // Contains all pipelines that have been executed for this document, non-private for unit testing
-    final Set<String> executedPipelines = new LinkedHashSet<>();
+    // Contains all pipelines that have been executed for this document
+    private final Set<String> executedPipelines = new LinkedHashSet<>();
 
     /**
      * An ordered set of the values of the _index that have been used for this document.

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -1029,6 +1029,7 @@ public class IngestDocumentTests extends ESTestCase {
 
         assertThat(copy.getSourceAndMetadata().get("beforeClockChange"), equalTo(original.getSourceAndMetadata().get("beforeClockChange")));
         assertThat(copy.getSourceAndMetadata().get("afterClockChange"), equalTo(original.getSourceAndMetadata().get("afterClockChange")));
+        assertThat(copy.executedPipelines, equalTo(original.executedPipelines));
     }
 
     public void testSetInvalidSourceField() throws Exception {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -1017,6 +1017,29 @@ public class IngestDocumentTests extends ESTestCase {
         }
     }
 
+    public void testCopyConstructorWithExecutedPipelines() {
+        /*
+         * This is similar to the first part of testCopyConstructor, except that we're executing a pipeilne, and running the
+         * assertions inside the processor so that we can test that executedPipelines is correct.
+         */
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+        TestProcessor processor = new TestProcessor(ingestDocument1 -> {
+            assertThat(ingestDocument1.getPipelineStack().size(), equalTo(1));
+            IngestDocument copy = new IngestDocument(ingestDocument1);
+            assertThat(ingestDocument1.getSourceAndMetadata(), not(sameInstance(copy.getSourceAndMetadata())));
+            assertThat(ingestDocument1.getCtxMap(), not(sameInstance(copy.getCtxMap())));
+            assertThat(ingestDocument1.getCtxMap().getMetadata(), not(sameInstance(copy.getCtxMap().getMetadata())));
+            assertIngestDocument(ingestDocument1, copy);
+            assertThat(copy.getPipelineStack(), equalTo(ingestDocument1.getPipelineStack()));
+        });
+        Pipeline pipeline = new Pipeline("pipeline1", "test pipeline", 1, Map.of(), new CompoundProcessor(processor));
+        ingestDocument.executePipeline(pipeline, (ingestDocument1, exception) -> {
+            assertNotNull(ingestDocument1);
+            assertNull(exception);
+        });
+        assertThat(processor.getInvokedCounter(), equalTo(1));
+    }
+
     public void testCopyConstructorWithZonedDateTime() {
         ZoneId timezone = ZoneId.of("Europe/London");
 
@@ -1029,7 +1052,6 @@ public class IngestDocumentTests extends ESTestCase {
 
         assertThat(copy.getSourceAndMetadata().get("beforeClockChange"), equalTo(original.getSourceAndMetadata().get("beforeClockChange")));
         assertThat(copy.getSourceAndMetadata().get("afterClockChange"), equalTo(original.getSourceAndMetadata().get("afterClockChange")));
-        assertThat(copy.executedPipelines, equalTo(original.executedPipelines));
     }
 
     public void testSetInvalidSourceField() throws Exception {


### PR DESCRIPTION
The IngestDocument copy constructor does not currently copy the executedPipelines. This causes a couple of minor problems in the way it is used from TrackingResultProcessor (aka verbose simulate):
(1) TrackingResultProcessor's cycle detection is not aware that the first pipeline has run. In the event of a pipeline cycle, this causes it to report the _second_ pipeline as the source of the cycle (an admittedly very minor bug).
(2) If someone were to construct a pipeline with conditional execution of pipelines that had a cycle only if the first pipeline existed, this could cause the pipeline cycle detection to fail.
(3) We are about to add a check that we have not executed more than N pipelines. Since TrackingResultProcessor doesn't know that the first pipeline was executed, this results in the real limit being (N+1) for simulate verbose, vs N for simulate and ingest. (also a very minor bug).