### PR TITLE
[ML] Changed system auditor to use levels

### DIFF
--- a/docs/changelog/105429.yaml
+++ b/docs/changelog/105429.yaml
@@ -1,0 +1,5 @@
+pr: 105429
+summary: Changed system auditor to use levels
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/SystemAuditor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/notifications/SystemAuditor.java
@@ -42,12 +42,12 @@ public class SystemAuditor extends AbstractMlAuditor<SystemAuditMessage> {
     @Override
     public void warning(String resourceId, String message) {
         assert resourceId == null;
-        super.info(null, message);
+        super.warning(null, message);
     }
 
     @Override
     public void error(String resourceId, String message) {
         assert resourceId == null;
-        super.info(null, message);
+        super.error(null, message);
     }
 }


### PR DESCRIPTION
Previously the system auditor was providing all notifications at the "info" level. Notifications can now be sent at "error" and "warn" levels.