### PR TITLE
Avoid false-positive matches on intermediate objects in `ecs@mappings`

### DIFF
--- a/docs/changelog/105440.yaml
+++ b/docs/changelog/105440.yaml
@@ -1,0 +1,6 @@
+pr: 105440
+summary: Avoid false-positive matches on intermediate objects in `ecs@mappings`
+area: Data streams
+type: bug
+issues:
+ - 102794

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
@@ -167,8 +167,7 @@
             "path_match": [
               "location",
               "*.location"
-            ],
-            "match_mapping_type": ["object", "string"]
+            ]
           }
         },
         {

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
@@ -19,7 +19,8 @@
             "path_match": [
               "message",
               "*.message"
-            ]
+            ],
+            "unmatch_mapping_type": "object"
           }
         },
         {
@@ -45,7 +46,8 @@
               "*.message_id",
               "*registry.data.strings",
               "*url.path"
-            ]
+            ],
+            "unmatch_mapping_type": "object"
           }
         },
         {
@@ -62,7 +64,8 @@
               "*.body.content",
               "*url.full",
               "*url.original"
-            ]
+            ],
+            "unmatch_mapping_type": "object"
           }
         },
         {
@@ -78,7 +81,8 @@
             "match": [
               "*command_line",
               "*stack_trace"
-            ]
+            ],
+            "unmatch_mapping_type": "object"
           }
         },
         {
@@ -103,7 +107,8 @@
               "email.subject",
               "vulnerability.description",
               "user_agent.original"
-            ]
+            ],
+            "unmatch_mapping_type": "object"
           }
         },
         {
@@ -127,7 +132,8 @@
               "*.ingested",
               "*.start",
               "*.end"
-            ]
+            ],
+            "unmatch_mapping_type": "object"
           }
         },
         {
@@ -139,7 +145,8 @@
               "*.score.*",
               "*_score*"
             ],
-            "path_unmatch": "*.version"
+            "path_unmatch": "*.version",
+            "unmatch_mapping_type": "object"
           }
         },
         {
@@ -149,27 +156,7 @@
               "scaling_factor": 1000
             },
             "path_match": "*.usage",
-            "match_mapping_type": "double"
-          }
-        },
-        {
-          "ecs_usage_long_scaled_float": {
-            "mapping": {
-              "type": "scaled_float",
-              "scaling_factor": 1000
-            },
-            "path_match": "*.usage",
-            "match_mapping_type": "long"
-          }
-        },
-        {
-          "ecs_usage_long_scaled_float": {
-            "mapping": {
-              "type": "scaled_float",
-              "scaling_factor": 1000
-            },
-            "path_match": "*.usage",
-            "match_mapping_type": "string"
+            "match_mapping_type": ["double", "long", "string"]
           }
         },
         {
@@ -180,7 +167,8 @@
             "path_match": [
               "location",
               "*.location"
-            ]
+            ],
+            "match_mapping_type": ["object", "string"]
           }
         },
         {
@@ -192,7 +180,8 @@
               "*structured_data",
               "*exports",
               "*imports"
-            ]
+            ],
+            "match_mapping_type": "object"
           }
         },
         {

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -214,6 +214,36 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
         assertEquals("float", flatFieldMappings.get("root.usage.float"));
     }
 
+    public void testOnlyMatchLeafFields() throws IOException {
+        // tests that some of the match conditions only apply to leaf fields, not intermediate objects
+        String indexName = "test";
+        createTestIndex(indexName);
+        Map<String, Object> fieldsMap = createTestDocument(false);
+        fieldsMap.put("foo.message.bar", 123);
+        fieldsMap.put("foo.url.path.bar", 123);
+        fieldsMap.put("foo.url.full.bar", 123);
+        fieldsMap.put("foo.stack_trace.bar", 123);
+        fieldsMap.put("foo.user_agent.original.bar", 123);
+        fieldsMap.put("foo.created.bar", 123);
+        fieldsMap.put("foo._score.bar", 123);
+        fieldsMap.put("foo.location", 123);
+        fieldsMap.put("foo.structured_data", 123);
+        indexDocument(indexName, fieldsMap);
+
+        final Map<String, Object> rawMappings = getMappings(indexName);
+        final Map<String, String> flatFieldMappings = new HashMap<>();
+        processRawMappingsSubtree(rawMappings, flatFieldMappings, new HashMap<>(), "");
+        assertEquals("long", flatFieldMappings.get("foo.message.bar"));
+        assertEquals("long", flatFieldMappings.get("foo.url.path.bar"));
+        assertEquals("long", flatFieldMappings.get("foo.url.full.bar"));
+        assertEquals("long", flatFieldMappings.get("foo.stack_trace.bar"));
+        assertEquals("long", flatFieldMappings.get("foo.user_agent.original.bar"));
+        assertEquals("long", flatFieldMappings.get("foo.created.bar"));
+        assertEquals("float", flatFieldMappings.get("foo._score.bar"));
+        assertEquals("long", flatFieldMappings.get("foo.location"));
+        assertEquals("long", flatFieldMappings.get("foo.structured_data"));
+    }
+
     private static void indexDocument(String indexName, Map<String, Object> flattenedFieldsMap) throws IOException {
         try (XContentBuilder bodyBuilder = JsonXContent.contentBuilder()) {
             Request indexRequest = new Request("POST", "/" + indexName + "/_doc");

--- a/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
+++ b/x-pack/plugin/stack/src/javaRestTest/java/org/elasticsearch/xpack/stack/EcsDynamicTemplatesIT.java
@@ -226,7 +226,6 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
         fieldsMap.put("foo.user_agent.original.bar", 123);
         fieldsMap.put("foo.created.bar", 123);
         fieldsMap.put("foo._score.bar", 123);
-        fieldsMap.put("foo.location", 123);
         fieldsMap.put("foo.structured_data", 123);
         indexDocument(indexName, fieldsMap);
 
@@ -240,7 +239,6 @@ public class EcsDynamicTemplatesIT extends ESRestTestCase {
         assertEquals("long", flatFieldMappings.get("foo.user_agent.original.bar"));
         assertEquals("long", flatFieldMappings.get("foo.created.bar"));
         assertEquals("float", flatFieldMappings.get("foo._score.bar"));
-        assertEquals("long", flatFieldMappings.get("foo.location"));
         assertEquals("long", flatFieldMappings.get("foo.structured_data"));
     }
 

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -43,7 +43,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 7;
+    public static final int REGISTRY_VERSION = 8;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
Fixes #102794