### PR TITLE
[Doc] Mark `secure_bind_password` settings as reloadable

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -404,7 +404,7 @@ Defaults to Empty. Due to its potential security impact, `bind_password` is not
 exposed via the <<cluster-nodes-info,nodes info API>>.
 
 `secure_bind_password`::
-(<<secure-settings,Secure>>)
+(<<secure-settings,Secure>>, <<reloadable-secure-settings,Reloadable>>)
 The password for the user that is used to bind to the LDAP directory.
 Defaults to Empty.
 
@@ -749,7 +749,7 @@ potential security impact, `bind_password` is not exposed via the
 <<cluster-nodes-info,nodes info API>>.
 
 `secure_bind_password`::
-(<<secure-settings,Secure>>)
+(<<secure-settings,Secure>>, <<reloadable-secure-settings,Reloadable>>)
 The password for the user that is used to bind to Active Directory.
 Defaults to Empty.
 

--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -61,3 +61,6 @@ There are reloadable secure settings for:
 * <<repository-s3,The S3 repository plugin>>
 * <<monitoring-settings>>
 * <<notification-settings>>
+* <<ref-jwt-settings, JWT realm>>
+* <<ref-ad-settings, Active Directory realm>>
+* <<ref-ldap-settings, LDAP realm>>


### PR DESCRIPTION
This is a followup to https://github.com/elastic/elasticsearch/pull/104320, which updates the docs for `secure_bind_password` settings and marks them as reloadable. 
