### PR TITLE
Cross cluster search minimize roundtrips avoids incremental merges until Kibana polls via async-search-status endpoint

### DIFF
--- a/docs/changelog/103134.yaml
+++ b/docs/changelog/103134.yaml
@@ -1,5 +1,0 @@
-pr: 103134
-summary: CCS with `minimize_roundtrips` performs incremental merges of each `SearchResponse`
-area: Search
-type: enhancement
-issues: []

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -306,10 +306,12 @@ class MutableSearchResponse implements Releasable {
      *         (for local-only/CCS minimize_roundtrips=false)
      */
     private SearchResponseMerger createSearchResponseMerger(AsyncSearchTask task) {
-        if (task.getSearchResponseMergerSupplier() == null) {
-            return null; // local search and CCS minimize_roundtrips=false
-        }
-        return task.getSearchResponseMergerSupplier().get();
+        return null;
+        // TODO uncomment this code once Kibana moves to polling the _async_search/status endpoint to determine if a search is done
+        // if (task.getSearchResponseMergerSupplier() == null) {
+        // return null; // local search and CCS minimize_roundtrips=false
+        // }
+        // return task.getSearchResponseMergerSupplier().get();
     }
 
     private SearchResponse getMergedResponse(SearchResponseMerger merger) {


### PR DESCRIPTION
This is a temporary change to avoid doing incremental merges in
cross-cluster async-search when minimize_roundtrips=true.

Currently, Kibana polls for status of the async-search via the 
`_async_search` endpoint, which (without this change) will
do an incremental merge of all search results. Once Kibana
moves to polling status via `_async_search/status`, then
we will undo the change in this commit.