### PR TITLE
[ML] Move the model parameter from task settings to service settings

### DIFF
--- a/docs/changelog/105458.yaml
+++ b/docs/changelog/105458.yaml
@@ -1,0 +1,5 @@
+pr: 105458
+summary: Move the model parameter from task settings to service settings
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/105458.yaml
+++ b/docs/changelog/105458.yaml
@@ -1,5 +1,5 @@
 pr: 105458
-summary: Move the model parameter from task settings to service settings
+summary: The OpenAI model parameter should be in service settings not task settings. Move the configuration field to service settings
 area: Machine Learning
 type: bug
 issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -132,6 +132,7 @@ public class TransportVersions {
     public static final TransportVersion ML_DIMENSIONS_SET_BY_USER_ADDED = def(8_592_00_0);
     public static final TransportVersion INDEX_REQUEST_NORMALIZED_BYTES_PARSED = def(8_593_00_0);
     public static final TransportVersion INGEST_GRAPH_STRUCTURE_EXCEPTION = def(8_594_00_0);
+    public static final TransportVersion ML_MODEL_IN_SERVICE_SETTINGS = def(8_595_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/openai/OpenAiEmbeddingsRequest.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/openai/OpenAiEmbeddingsRequest.java
@@ -56,7 +56,7 @@ public class OpenAiEmbeddingsRequest implements Request {
             Strings.toString(
                 new OpenAiEmbeddingsRequestEntity(
                     truncationResult.input(),
-                    model.getTaskSettings().modelId(),
+                    model.getServiceSettings().modelId(),
                     model.getTaskSettings().user(),
                     model.getServiceSettings().dimensions(),
                     model.getServiceSettings().dimensionsSetByUser()

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ServiceFields.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ServiceFields.java
@@ -16,6 +16,7 @@ public final class ServiceFields {
     public static final String DIMENSIONS = "dimensions";
     public static final String MAX_INPUT_TOKENS = "max_input_tokens";
     public static final String URL = "url";
+    public static final String MODEL_ID = "model_id";
 
     private ServiceFields() {
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ServiceUtils.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ServiceUtils.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -71,6 +72,15 @@ public class ServiceUtils {
         Map<String, Object> value = (Map<String, Object>) sourceMap.remove(fieldName);
         if (value == null) {
             throw new ElasticsearchStatusException("Missing required field [{}]", RestStatus.BAD_REQUEST, fieldName);
+        }
+        return value;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> removeFromMapOrDefaultEmpty(Map<String, Object> sourceMap, String fieldName) {
+        Map<String, Object> value = (Map<String, Object>) sourceMap.remove(fieldName);
+        if (value == null) {
+            return new HashMap<>();
         }
         return value;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createInvalidModelException;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.parsePersistedConfigErrorMsg;
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrDefaultEmpty;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFromMapOrThrowIfNull;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
 
@@ -65,7 +66,7 @@ public class OpenAiService extends SenderService {
     ) {
         try {
             Map<String, Object> serviceSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.SERVICE_SETTINGS);
-            Map<String, Object> taskSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.TASK_SETTINGS);
+            Map<String, Object> taskSettingsMap = removeFromMapOrDefaultEmpty(config, ModelConfigurations.TASK_SETTINGS);
 
             moveModelFromTaskToServiceSettings(taskSettingsMap, serviceSettingsMap);
 
@@ -140,7 +141,7 @@ public class OpenAiService extends SenderService {
     ) {
         Map<String, Object> serviceSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.SERVICE_SETTINGS);
         Map<String, Object> taskSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.TASK_SETTINGS);
-        Map<String, Object> secretSettingsMap = removeFromMapOrThrowIfNull(secrets, ModelSecrets.SECRET_SETTINGS);
+        Map<String, Object> secretSettingsMap = removeFromMapOrDefaultEmpty(secrets, ModelSecrets.SECRET_SETTINGS);
 
         moveModelFromTaskToServiceSettings(taskSettingsMap, serviceSettingsMap);
 
@@ -157,7 +158,7 @@ public class OpenAiService extends SenderService {
     @Override
     public OpenAiModel parsePersistedConfig(String inferenceEntityId, TaskType taskType, Map<String, Object> config) {
         Map<String, Object> serviceSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.SERVICE_SETTINGS);
-        Map<String, Object> taskSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.TASK_SETTINGS);
+        Map<String, Object> taskSettingsMap = removeFromMapOrDefaultEmpty(config, ModelConfigurations.TASK_SETTINGS);
 
         moveModelFromTaskToServiceSettings(taskSettingsMap, serviceSettingsMap);
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -31,7 +31,6 @@ import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsModel;
 import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsServiceSettings;
-import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings;
 
 import java.util.List;
 import java.util.Map;
@@ -90,7 +89,7 @@ public class OpenAiService extends SenderService {
         }
     }
 
-    private static OpenAiModel createModelWithoutLoggingDeprecations(
+    private static OpenAiModel createModelFromPersistent(
         String inferenceEntityId,
         TaskType taskType,
         Map<String, Object> serviceSettings,
@@ -145,7 +144,7 @@ public class OpenAiService extends SenderService {
 
         moveModelFromTaskToServiceSettings(taskSettingsMap, serviceSettingsMap);
 
-        return createModelWithoutLoggingDeprecations(
+        return createModelFromPersistent(
             inferenceEntityId,
             taskType,
             serviceSettingsMap,
@@ -162,7 +161,7 @@ public class OpenAiService extends SenderService {
 
         moveModelFromTaskToServiceSettings(taskSettingsMap, serviceSettingsMap);
 
-        return createModelWithoutLoggingDeprecations(
+        return createModelFromPersistent(
             inferenceEntityId,
             taskType,
             serviceSettingsMap,
@@ -272,7 +271,9 @@ public class OpenAiService extends SenderService {
         if (serviceSettings.containsKey(MODEL_ID)) {
             return;
         }
-        var oldModelId = taskSettings.remove(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD);
+
+        final String OLD_MODEL_ID_FIELD = "model";
+        var oldModelId = taskSettings.remove(OLD_MODEL_ID_FIELD);
         if (oldModelId != null) {
             serviceSettings.put(MODEL_ID, oldModelId);
         } else {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
@@ -16,25 +16,23 @@ import org.elasticsearch.inference.ModelConfigurations;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
-import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.MODEL_ID;
-import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD;
 import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.USER;
 
 /**
  * This class handles extracting OpenAI task settings from a request. The difference between this class and
  * {@link OpenAiEmbeddingsTaskSettings} is that this class considers all fields as optional. It will not throw an error if a field
  * is missing. This allows overriding persistent task settings.
- * @param modelId the name of the model to use with this request
  * @param user a unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse
  */
-public record OpenAiEmbeddingsRequestTaskSettings(@Nullable String modelId, @Nullable String user) {
+public record OpenAiEmbeddingsRequestTaskSettings(@Nullable String user) {
     private static final Logger logger = LogManager.getLogger(OpenAiEmbeddingsRequestTaskSettings.class);
 
-    public static final OpenAiEmbeddingsRequestTaskSettings EMPTY_SETTINGS = new OpenAiEmbeddingsRequestTaskSettings(null, null);
+    public static final OpenAiEmbeddingsRequestTaskSettings EMPTY_SETTINGS = new OpenAiEmbeddingsRequestTaskSettings(null);
 
     /**
      * Extracts the task settings from a map. All settings are considered optional and the absence of a setting
      * does not throw an error.
+     *
      * @param map the settings received from a request
      * @return a {@link OpenAiEmbeddingsRequestTaskSettings}
      */
@@ -45,22 +43,12 @@ public record OpenAiEmbeddingsRequestTaskSettings(@Nullable String modelId, @Nul
 
         ValidationException validationException = new ValidationException();
 
-        // I'm intentionally not logging if this is set because it would log on every request
-        String model = extractOptionalString(map, OLD_MODEL_ID_FIELD, ModelConfigurations.TASK_SETTINGS, validationException);
-
-        String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.TASK_SETTINGS, validationException);
         String user = extractOptionalString(map, USER, ModelConfigurations.TASK_SETTINGS, validationException);
-
-        var modelIdToUse = getModelId(model, modelId);
 
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
 
-        return new OpenAiEmbeddingsRequestTaskSettings(modelIdToUse, user);
-    }
-
-    private static String getModelId(@Nullable String model, @Nullable String modelId) {
-        return modelId != null ? modelId : model;
+        return new OpenAiEmbeddingsRequestTaskSettings(user);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettings.java
@@ -117,7 +117,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
     private final Boolean dimensionsSetByUser;
 
     public OpenAiEmbeddingsServiceSettings(
-        @Nullable String modelId,
+        String modelId,
         @Nullable URI uri,
         @Nullable String organizationId,
         @Nullable SimilarityMeasure similarity,
@@ -165,9 +165,9 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
             dimensionsSetByUser = false;
         }
         if (in.getTransportVersion().onOrAfter(TransportVersions.ML_MODEL_IN_SERVICE_SETTINGS)) {
-            modelId = in.readOptionalString();
+            modelId = in.readString();
         } else {
-            modelId = null;
+            modelId = "unset";
         }
     }
 
@@ -231,9 +231,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
     }
 
     private void toXContentFragmentOfExposedFields(XContentBuilder builder, Params params) throws IOException {
-        if (modelId != null) {
-            builder.field(MODEL_ID, modelId);
-        }
+        builder.field(MODEL_ID, modelId);
         if (uri != null) {
             builder.field(URL, uri.toString());
         }
@@ -283,7 +281,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
             out.writeBoolean(dimensionsSetByUser);
         }
         if (out.getTransportVersion().onOrAfter(TransportVersions.ML_MODEL_IN_SERVICE_SETTINGS)) {
-            out.writeOptionalString(modelId);
+            out.writeString(modelId);
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettings.java
@@ -28,11 +28,13 @@ import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.ServiceFields.DIMENSIONS;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.MAX_INPUT_TOKENS;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.SIMILARITY;
 import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.convertToUri;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.createOptionalUri;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractSimilarity;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeAsType;
 
@@ -92,11 +94,13 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         Integer maxInputTokens = removeAsType(map, MAX_INPUT_TOKENS, Integer.class);
         Integer dims = removeAsType(map, DIMENSIONS, Integer.class);
         URI uri = convertToUri(url, URL, ModelConfigurations.SERVICE_SETTINGS, validationException);
+        String modelId = extractRequiredString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
 
-        return new CommonFields(uri, organizationId, similarity, maxInputTokens, dims);
+        return new CommonFields(modelId, uri, organizationId, similarity, maxInputTokens, dims);
     }
 
     private record CommonFields(
+        String modelId,
         @Nullable URI uri,
         @Nullable String organizationId,
         @Nullable SimilarityMeasure similarity,
@@ -104,6 +108,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         @Nullable Integer dimensions
     ) {}
 
+    private final String modelId;
     private final URI uri;
     private final String organizationId;
     private final SimilarityMeasure similarity;
@@ -112,6 +117,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
     private final Boolean dimensionsSetByUser;
 
     public OpenAiEmbeddingsServiceSettings(
+        @Nullable String modelId,
         @Nullable URI uri,
         @Nullable String organizationId,
         @Nullable SimilarityMeasure similarity,
@@ -120,6 +126,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         Boolean dimensionsSetByUser
     ) {
         this.uri = uri;
+        this.modelId = modelId;
         this.organizationId = organizationId;
         this.similarity = similarity;
         this.dimensions = dimensions;
@@ -127,7 +134,8 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         this.dimensionsSetByUser = Objects.requireNonNull(dimensionsSetByUser);
     }
 
-    public OpenAiEmbeddingsServiceSettings(
+    OpenAiEmbeddingsServiceSettings(
+        String modelId,
         @Nullable String uri,
         @Nullable String organizationId,
         @Nullable SimilarityMeasure similarity,
@@ -135,7 +143,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         @Nullable Integer maxInputTokens,
         Boolean dimensionsSetByUser
     ) {
-        this(createOptionalUri(uri), organizationId, similarity, dimensions, maxInputTokens, dimensionsSetByUser);
+        this(modelId, createOptionalUri(uri), organizationId, similarity, dimensions, maxInputTokens, dimensionsSetByUser);
     }
 
     public OpenAiEmbeddingsServiceSettings(StreamInput in) throws IOException {
@@ -156,10 +164,23 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         } else {
             dimensionsSetByUser = false;
         }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ML_MODEL_IN_SERVICE_SETTINGS)) {
+            modelId = in.readOptionalString();
+        } else {
+            modelId = null;
+        }
     }
 
     private OpenAiEmbeddingsServiceSettings(CommonFields fields, Boolean dimensionsSetByUser) {
-        this(fields.uri, fields.organizationId, fields.similarity, fields.dimensions, fields.maxInputTokens, dimensionsSetByUser);
+        this(
+            fields.modelId,
+            fields.uri,
+            fields.organizationId,
+            fields.similarity,
+            fields.dimensions,
+            fields.maxInputTokens,
+            dimensionsSetByUser
+        );
     }
 
     public URI uri() {
@@ -186,6 +207,10 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         return maxInputTokens;
     }
 
+    public String modelId() {
+        return modelId;
+    }
+
     @Override
     public String getWriteableName() {
         return NAME;
@@ -206,6 +231,9 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
     }
 
     private void toXContentFragmentOfExposedFields(XContentBuilder builder, Params params) throws IOException {
+        if (modelId != null) {
+            builder.field(MODEL_ID, modelId);
+        }
         if (uri != null) {
             builder.field(URL, uri.toString());
         }
@@ -254,6 +282,9 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         if (out.getTransportVersion().onOrAfter(TransportVersions.ML_DIMENSIONS_SET_BY_USER_ADDED)) {
             out.writeBoolean(dimensionsSetByUser);
         }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ML_MODEL_IN_SERVICE_SETTINGS)) {
+            out.writeOptionalString(modelId);
+        }
     }
 
     @Override
@@ -262,6 +293,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
         if (o == null || getClass() != o.getClass()) return false;
         OpenAiEmbeddingsServiceSettings that = (OpenAiEmbeddingsServiceSettings) o;
         return Objects.equals(uri, that.uri)
+            && Objects.equals(modelId, that.modelId)
             && Objects.equals(organizationId, that.organizationId)
             && Objects.equals(similarity, that.similarity)
             && Objects.equals(dimensions, that.dimensions)
@@ -271,6 +303,6 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
 
     @Override
     public int hashCode() {
-        return Objects.hash(uri, organizationId, similarity, dimensions, maxInputTokens, dimensionsSetByUser);
+        return Objects.hash(uri, modelId, organizationId, similarity, dimensions, maxInputTokens, dimensionsSetByUser);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.inference.services.openai.embeddings;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.ValidationException;
@@ -18,7 +16,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiParseContext;
 
 import java.io.IOException;
@@ -30,53 +27,25 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
 /**
  * Defines the task settings for the openai service.
  *
- * @param modelId the id of the model to use in the requests to openai
- * @param user an optional unique identifier representing the end-user, which can help OpenAI to monitor and detect abuse
- *             <a href="https://platform.openai.com/docs/api-reference/embeddings/create">see the openai docs for more details</a>
+ * User is an optional unique identifier representing the end-user, which can help OpenAI to monitor and detect abuse
+ *  <a href="https://platform.openai.com/docs/api-reference/embeddings/create">see the openai docs for more details</a>
  */
-public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user) implements TaskSettings {
+public class OpenAiEmbeddingsTaskSettings implements TaskSettings {
 
     public static final String NAME = "openai_embeddings_task_settings";
     public static final String OLD_MODEL_ID_FIELD = "model";
-    public static final String MODEL_ID = "model_id";
+
     public static final String USER = "user";
-    private static final String MODEL_DEPRECATION_MESSAGE =
-        "The openai [task_settings.model] field is deprecated. Please use [task_settings.model_id] instead.";
-    private static final Logger logger = LogManager.getLogger(OpenAiEmbeddingsTaskSettings.class);
 
     public static OpenAiEmbeddingsTaskSettings fromMap(Map<String, Object> map, OpenAiParseContext context) {
         ValidationException validationException = new ValidationException();
 
-        String oldModelId = extractOptionalString(map, OLD_MODEL_ID_FIELD, ModelConfigurations.TASK_SETTINGS, validationException);
-        logOldModelDeprecation(oldModelId, context, logger);
-
-        String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.TASK_SETTINGS, validationException);
         String user = extractOptionalString(map, USER, ModelConfigurations.TASK_SETTINGS, validationException);
-
-        var modelIdToUse = getModelId(oldModelId, modelId, validationException);
-
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
 
-        return new OpenAiEmbeddingsTaskSettings(modelIdToUse, user);
-    }
-
-    // default for testing
-    static void logOldModelDeprecation(@Nullable String oldModelId, OpenAiParseContext context, Logger logger) {
-        if (OpenAiParseContext.isRequestContext(context) && oldModelId != null) {
-            logger.info(MODEL_DEPRECATION_MESSAGE);
-        }
-    }
-
-    private static String getModelId(@Nullable String oldModelId, @Nullable String modelId, ValidationException validationException) {
-        var modelIdToUse = modelId != null ? modelId : oldModelId;
-
-        if (modelIdToUse == null) {
-            validationException.addValidationError(ServiceUtils.missingSettingErrorMsg(MODEL_ID, ModelConfigurations.TASK_SETTINGS));
-        }
-
-        return modelIdToUse;
+        return new OpenAiEmbeddingsTaskSettings(user);
     }
 
     /**
@@ -90,29 +59,37 @@ public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user
         OpenAiEmbeddingsTaskSettings originalSettings,
         OpenAiEmbeddingsRequestTaskSettings requestSettings
     ) {
-        var modelToUse = requestSettings.modelId() == null ? originalSettings.modelId : requestSettings.modelId();
         var userToUse = requestSettings.user() == null ? originalSettings.user : requestSettings.user();
-
-        return new OpenAiEmbeddingsTaskSettings(modelToUse, userToUse);
+        return new OpenAiEmbeddingsTaskSettings(userToUse);
     }
 
-    public OpenAiEmbeddingsTaskSettings {
-        Objects.requireNonNull(modelId);
+    private final String user;
+
+    public OpenAiEmbeddingsTaskSettings(@Nullable String user) {
+        this.user = user;
     }
 
     public OpenAiEmbeddingsTaskSettings(StreamInput in) throws IOException {
-        this(in.readString(), in.readOptionalString());
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ML_MODEL_IN_SERVICE_SETTINGS)) {
+            this.user = in.readOptionalString();
+        } else {
+            var discard = in.readString();
+            this.user = in.readOptionalString();
+        }
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(MODEL_ID, modelId);
         if (user != null) {
             builder.field(USER, user);
         }
         builder.endObject();
         return builder;
+    }
+
+    public String user() {
+        return user;
     }
 
     @Override
@@ -127,7 +104,24 @@ public record OpenAiEmbeddingsTaskSettings(String modelId, @Nullable String user
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(modelId);
-        out.writeOptionalString(user);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ML_MODEL_IN_SERVICE_SETTINGS)) {
+            out.writeOptionalString(user);
+        } else {
+            out.writeString("m"); // write any string
+            out.writeOptionalString(user);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OpenAiEmbeddingsTaskSettings that = (OpenAiEmbeddingsTaskSettings) o;
+        return Objects.equals(user, that.user);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(user);
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
@@ -33,8 +33,6 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
 public class OpenAiEmbeddingsTaskSettings implements TaskSettings {
 
     public static final String NAME = "openai_embeddings_task_settings";
-    public static final String OLD_MODEL_ID_FIELD = "model";
-
     public static final String USER = "user";
 
     public static OpenAiEmbeddingsTaskSettings fromMap(Map<String, Object> map, OpenAiParseContext context) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/openai/OpenAiActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/openai/OpenAiActionCreatorTests.java
@@ -92,7 +92,7 @@ public class OpenAiActionCreatorTests extends ESTestCase {
 
             var model = createModel(getUrl(webServer), "org", "secret", "model", "user");
             var actionCreator = new OpenAiActionCreator(sender, createWithEmptySettings(threadPool));
-            var overriddenTaskSettings = getRequestTaskSettingsMap(null, "overridden_user");
+            var overriddenTaskSettings = getRequestTaskSettingsMap("overridden_user");
             var action = actionCreator.create(model, overriddenTaskSettings);
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
@@ -161,7 +161,7 @@ public class OpenAiActionCreatorTests extends ESTestCase {
 
             var model = createModel(getUrl(webServer), "org", "secret", "model", "user");
             var actionCreator = new OpenAiActionCreator(sender, createWithEmptySettings(threadPool));
-            var overriddenTaskSettings = getRequestTaskSettingsMap(null, "overridden_user");
+            var overriddenTaskSettings = getRequestTaskSettingsMap("overridden_user");
             var action = actionCreator.create(model, overriddenTaskSettings);
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
@@ -244,7 +244,7 @@ public class OpenAiActionCreatorTests extends ESTestCase {
 
             var model = createModel(getUrl(webServer), "org", "secret", "model", "user");
             var actionCreator = new OpenAiActionCreator(sender, createWithEmptySettings(threadPool));
-            var overriddenTaskSettings = getRequestTaskSettingsMap(null, "overridden_user");
+            var overriddenTaskSettings = getRequestTaskSettingsMap("overridden_user");
             var action = actionCreator.create(model, overriddenTaskSettings);
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();
@@ -312,7 +312,7 @@ public class OpenAiActionCreatorTests extends ESTestCase {
             // truncated to 1 token = 3 characters
             var model = createModel(getUrl(webServer), "org", "secret", "model", "user", 1);
             var actionCreator = new OpenAiActionCreator(sender, createWithEmptySettings(threadPool));
-            var overriddenTaskSettings = getRequestTaskSettingsMap(null, "overridden_user");
+            var overriddenTaskSettings = getRequestTaskSettingsMap("overridden_user");
             var action = actionCreator.create(model, overriddenTaskSettings);
 
             PlainActionFuture<InferenceServiceResults> listener = new PlainActionFuture<>();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModelTests.java
@@ -58,8 +58,8 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(url, org, SimilarityMeasure.DOT_PRODUCT, 1536, null, false),
-            new OpenAiEmbeddingsTaskSettings(modelName, user),
+            new OpenAiEmbeddingsServiceSettings(modelName, url, org, SimilarityMeasure.DOT_PRODUCT, 1536, null, false),
+            new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
     }
@@ -76,8 +76,8 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(url, org, SimilarityMeasure.DOT_PRODUCT, 1536, tokenLimit, false),
-            new OpenAiEmbeddingsTaskSettings(modelName, user),
+            new OpenAiEmbeddingsServiceSettings(modelName, url, org, SimilarityMeasure.DOT_PRODUCT, 1536, tokenLimit, false),
+            new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
     }
@@ -95,8 +95,8 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(url, org, SimilarityMeasure.DOT_PRODUCT, dimensions, tokenLimit, false),
-            new OpenAiEmbeddingsTaskSettings(modelName, user),
+            new OpenAiEmbeddingsServiceSettings(modelName, url, org, SimilarityMeasure.DOT_PRODUCT, dimensions, tokenLimit, false),
+            new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
     }
@@ -116,8 +116,8 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(url, org, similarityMeasure, dimensions, tokenLimit, dimensionsSetByUser),
-            new OpenAiEmbeddingsTaskSettings(modelName, user),
+            new OpenAiEmbeddingsServiceSettings(modelName, url, org, similarityMeasure, dimensions, tokenLimit, dimensionsSetByUser),
+            new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModelTests.java
@@ -24,7 +24,7 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
 
     public void testOverrideWith_OverridesUser() {
         var model = createModel("url", "org", "api_key", "model_name", null);
-        var requestTaskSettingsMap = getRequestTaskSettingsMap(null, "user_override");
+        var requestTaskSettingsMap = getRequestTaskSettingsMap("user_override");
 
         var overriddenModel = OpenAiEmbeddingsModel.of(model, requestTaskSettingsMap);
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
@@ -31,20 +31,6 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
         assertThat(settings.user(), is("user"));
     }
 
-    public static Map<String, Object> getRequestTaskSettingsMap(@Nullable String model, @Nullable String user) {
-        var map = new HashMap<String, Object>();
-
-        if (model != null) {
-            map.put(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, model);
-        }
-
-        if (user != null) {
-            map.put(OpenAiEmbeddingsTaskSettings.USER, user);
-        }
-
-        return map;
-    }
-
     public static Map<String, Object> getRequestTaskSettingsMap(@Nullable String user) {
         var map = new HashMap<String, Object>();
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
@@ -18,43 +18,17 @@ import static org.hamcrest.Matchers.is;
 public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
     public void testFromMap_ReturnsEmptySettings_WhenTheMapIsEmpty() {
         var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of()));
-
-        assertNull(settings.modelId());
         assertNull(settings.user());
     }
 
     public void testFromMap_ReturnsEmptySettings_WhenTheMapDoesNotContainTheFields() {
         var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of("key", "model")));
-
-        assertNull(settings.modelId());
         assertNull(settings.user());
     }
 
-    public void testFromMap_ReturnsEmptyModel_WhenTheMapDoesNotContainThatField() {
+    public void testFromMap_ReturnsUser() {
         var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")));
-
-        assertNull(settings.modelId());
         assertThat(settings.user(), is("user"));
-    }
-
-    public void testFromMap_ReturnsEmptyUser_WhenTheDoesMapNotContainThatField() {
-        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model"))
-        );
-
-        assertNull(settings.user());
-        assertThat(settings.modelId(), is("model"));
-    }
-
-    public void testFromMap_PrefersModelId_OverModel() {
-        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(
-                Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.MODEL_ID, "model_id")
-            )
-        );
-
-        assertNull(settings.user());
-        assertThat(settings.modelId(), is("model_id"));
     }
 
     public static Map<String, Object> getRequestTaskSettingsMap(@Nullable String model, @Nullable String user) {
@@ -71,16 +45,8 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
         return map;
     }
 
-    public static Map<String, Object> getRequestTaskSettingsMap(@Nullable String model, @Nullable String modelId, @Nullable String user) {
+    public static Map<String, Object> getRequestTaskSettingsMap(@Nullable String user) {
         var map = new HashMap<String, Object>();
-
-        if (model != null) {
-            map.put(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, model);
-        }
-
-        if (modelId != null) {
-            map.put(OpenAiEmbeddingsTaskSettings.MODEL_ID, model);
-        }
 
         if (user != null) {
             map.put(OpenAiEmbeddingsTaskSettings.USER, user);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
@@ -7,17 +7,12 @@
 
 package org.elasticsearch.xpack.inference.services.openai.embeddings;
 
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentFactory;
-import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiParseContext;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -25,17 +20,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTestCase<OpenAiEmbeddingsTaskSettings> {
 
     public static OpenAiEmbeddingsTaskSettings createRandomWithUser() {
-        return new OpenAiEmbeddingsTaskSettings(randomAlphaOfLength(15), randomAlphaOfLength(15));
+        return new OpenAiEmbeddingsTaskSettings(randomAlphaOfLength(15));
     }
 
     /**
@@ -43,81 +32,42 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
      */
     public static OpenAiEmbeddingsTaskSettings createRandom() {
         var user = randomBoolean() ? randomAlphaOfLength(15) : null;
-        return new OpenAiEmbeddingsTaskSettings(randomAlphaOfLength(15), user);
+        return new OpenAiEmbeddingsTaskSettings(user);
     }
 
-    public void testFromMap_MissingModel_ThrowException() {
+    public void testFromMap_WithUser() {
+        assertEquals(
+            new OpenAiEmbeddingsTaskSettings("user"),
+            OpenAiEmbeddingsTaskSettings.fromMap(
+                new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
+                OpenAiParseContext.REQUEST
+            )
+        );
+    }
+
+    public void testFromMap_UserIsEmptyString() {
         var thrownException = expectThrows(
             ValidationException.class,
             () -> OpenAiEmbeddingsTaskSettings.fromMap(
-                new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
+                new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "")),
                 OpenAiParseContext.REQUEST
             )
         );
 
         MatcherAssert.assertThat(
             thrownException.getMessage(),
-            is(
-                Strings.format(
-                    "Validation Failed: 1: [task_settings] does not contain the required setting [%s];",
-                    OpenAiEmbeddingsTaskSettings.MODEL_ID
-                )
-            )
+            is(Strings.format("Validation Failed: 1: [task_settings] Invalid value empty string. [user] must be a non-empty string;"))
         );
-    }
-
-    public void testFromMap_CreatesWithModelAndUser() {
-        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
-            OpenAiParseContext.PERSISTENT
-        );
-
-        MatcherAssert.assertThat(taskSettings.modelId(), is("model"));
-        MatcherAssert.assertThat(taskSettings.user(), is("user"));
-    }
-
-    public void testFromMap_CreatesWithModelId() {
-        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.MODEL_ID, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
-            OpenAiParseContext.PERSISTENT
-        );
-
-        MatcherAssert.assertThat(taskSettings.modelId(), is("model"));
-        MatcherAssert.assertThat(taskSettings.user(), is("user"));
-    }
-
-    public void testFromMap_PrefersModelId_OverModel() {
-        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(
-                Map.of(
-                    OpenAiEmbeddingsTaskSettings.MODEL_ID,
-                    "model",
-                    OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD,
-                    "old_model",
-                    OpenAiEmbeddingsTaskSettings.USER,
-                    "user"
-                )
-            ),
-            OpenAiParseContext.PERSISTENT
-        );
-
-        MatcherAssert.assertThat(taskSettings.modelId(), is("model"));
-        MatcherAssert.assertThat(taskSettings.user(), is("user"));
     }
 
     public void testFromMap_MissingUser_DoesNotThrowException() {
-        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model")),
-            OpenAiParseContext.PERSISTENT
-        );
-
-        MatcherAssert.assertThat(taskSettings.modelId(), is("model"));
+        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of()), OpenAiParseContext.PERSISTENT);
         assertNull(taskSettings.user());
     }
 
     public void testOverrideWith_KeepsOriginalValuesWithOverridesAreNull() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
             OpenAiParseContext.PERSISTENT
         );
 
@@ -127,86 +77,16 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
 
     public void testOverrideWith_UsesOverriddenSettings() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
             OpenAiParseContext.PERSISTENT
         );
 
         var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model2", OpenAiEmbeddingsTaskSettings.USER, "user2"))
+            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user2"))
         );
 
         var overriddenTaskSettings = OpenAiEmbeddingsTaskSettings.of(taskSettings, requestTaskSettings);
-        MatcherAssert.assertThat(overriddenTaskSettings, is(new OpenAiEmbeddingsTaskSettings("model2", "user2")));
-    }
-
-    public void testOverrideWith_UsesOverriddenSettings_UsesModel2_FromModelIdField() {
-        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
-            OpenAiParseContext.PERSISTENT
-        );
-
-        var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(
-                Map.of(
-                    OpenAiEmbeddingsTaskSettings.MODEL_ID,
-                    "model2",
-                    OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD,
-                    "model3",
-                    OpenAiEmbeddingsTaskSettings.USER,
-                    "user2"
-                )
-            )
-        );
-
-        var overriddenTaskSettings = OpenAiEmbeddingsTaskSettings.of(taskSettings, requestTaskSettings);
-        MatcherAssert.assertThat(overriddenTaskSettings, is(new OpenAiEmbeddingsTaskSettings("model2", "user2")));
-    }
-
-    public void testOverrideWith_UsesOnlyNonNullModelSetting() {
-        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model", OpenAiEmbeddingsTaskSettings.USER, "user")),
-            OpenAiParseContext.PERSISTENT
-        );
-
-        var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, "model2"))
-        );
-
-        var overriddenTaskSettings = OpenAiEmbeddingsTaskSettings.of(taskSettings, requestTaskSettings);
-        MatcherAssert.assertThat(overriddenTaskSettings, is(new OpenAiEmbeddingsTaskSettings("model2", "user")));
-    }
-
-    public void testXContent_WritesModelId() throws IOException {
-        var entity = new OpenAiEmbeddingsTaskSettings("modelId", null);
-
-        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
-        entity.toXContent(builder, null);
-        String xContentResult = Strings.toString(builder);
-
-        assertThat(xContentResult, CoreMatchers.is("""
-            {"model_id":"modelId"}"""));
-    }
-
-    public void testLogModelDeprecation_CallsInfo_WhenContextIsRequest_AndOldModelIdIsDefined() {
-        var mockLogger = mock(Logger.class);
-
-        OpenAiEmbeddingsTaskSettings.logOldModelDeprecation("model", OpenAiParseContext.REQUEST, mockLogger);
-        verify(mockLogger, times(1)).info(anyString());
-        verifyNoMoreInteractions(mockLogger);
-    }
-
-    public void testLogModelDeprecation_DoesNotCallInfo_WhenContextIsRequest_AndOldModelIdIsNull() {
-        var mockLogger = mock(Logger.class);
-
-        OpenAiEmbeddingsTaskSettings.logOldModelDeprecation(null, OpenAiParseContext.PERSISTENT, mockLogger);
-        verifyNoInteractions(mockLogger);
-    }
-
-    public void testLogModelDeprecation_DoesNotCallInfo_WhenContextIsPersistent_AndOldModelIdIsDefined() {
-        var mockLogger = mock(Logger.class);
-
-        OpenAiEmbeddingsTaskSettings.logOldModelDeprecation("model", OpenAiParseContext.PERSISTENT, mockLogger);
-        verifyNoInteractions(mockLogger);
+        MatcherAssert.assertThat(overriddenTaskSettings, is(new OpenAiEmbeddingsTaskSettings("user2")));
     }
 
     @Override
@@ -224,8 +104,8 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
         return createRandomWithUser();
     }
 
-    public static Map<String, Object> getTaskSettingsMap(String model, @Nullable String user) {
-        var map = new HashMap<String, Object>(Map.of(OpenAiEmbeddingsTaskSettings.OLD_MODEL_ID_FIELD, model));
+    public static Map<String, Object> getTaskSettingsMap(@Nullable String user) {
+        var map = new HashMap<String, Object>();
 
         if (user != null) {
             map.put(OpenAiEmbeddingsTaskSettings.USER, user);


### PR DESCRIPTION
When configuring an OpenAI text embedding service the `model_id` should have always been part of the service settings rather than task settings. Task settings are overridable, service settings cannot be changed. If different models are used the configured entities are considered distinct. 

task_settings is now optional as it contains a single optional field (`user`)

```
PUT _inference/text_embedding/openai_embeddings
{
  "service": "openai",
  "service_settings": {
    "api_key": "XXX",
    "model_id": "text-embedding-ada-002"
  }
}
```

Backwards compatibility with previously configured models is maintained by moving the `model_id` (or `model`) from task settings to service settings at the first stage of parsing. New configurations are persisted with `model_id` in service settings, old configurations with `model_id` in task settings are not modified and will be tolerated by a lenient parser. 
