### PR TITLE
Detach persistent task execution from `ThreadPool`

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -97,7 +97,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
     private final AtomicBoolean taskIsBootstrapped = new AtomicBoolean(false);
 
     GeoIpDownloaderTaskExecutor(Client client, HttpClient httpClient, ClusterService clusterService, ThreadPool threadPool) {
-        super(GEOIP_DOWNLOADER, ThreadPool.Names.GENERIC);
+        super(GEOIP_DOWNLOADER, threadPool.generic());
         this.client = new OriginSettingClient(client, IngestService.INGEST_ORIGIN);
         this.httpClient = httpClient;
         this.clusterService = clusterService;

--- a/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTaskInitializationFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTaskInitializationFailureIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
 import org.elasticsearch.plugins.PersistentTaskPlugin;
 import org.elasticsearch.plugins.Plugin;
@@ -65,8 +64,6 @@ public class PersistentTaskInitializationFailureIT extends ESIntegTestCase {
     }
 
     public static class FailingInitializationPersistentTasksPlugin extends Plugin implements PersistentTaskPlugin {
-        public FailingInitializationPersistentTasksPlugin(Settings settings) {}
-
         @Override
         public List<PersistentTasksExecutor<?>> getPersistentTasksExecutor(
             ClusterService clusterService,
@@ -132,10 +129,9 @@ public class PersistentTaskInitializationFailureIT extends ESIntegTestCase {
 
     static class FailingInitializationPersistentTaskExecutor extends PersistentTasksExecutor<FailingInitializationTaskParams> {
         static final String TASK_NAME = "cluster:admin/persistent/test_init_failure";
-        static final String EXECUTOR_NAME = "failing_executor";
 
         FailingInitializationPersistentTaskExecutor() {
-            super(TASK_NAME, EXECUTOR_NAME);
+            super(TASK_NAME, r -> fail("execution is unexpected"));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskExecutor.java
@@ -70,7 +70,7 @@ public final class HealthNodeTaskExecutor extends PersistentTasksExecutor<Health
         FeatureService featureService,
         Settings settings
     ) {
-        super(TASK_NAME, ThreadPool.Names.MANAGEMENT);
+        super(TASK_NAME, clusterService.threadPool().executor(ThreadPool.Names.MANAGEMENT));
         this.clusterService = clusterService;
         this.persistentTasksService = persistentTasksService;
         this.featureService = featureService;

--- a/server/src/main/java/org/elasticsearch/persistent/NodePersistentTasksExecutor.java
+++ b/server/src/main/java/org/elasticsearch/persistent/NodePersistentTasksExecutor.java
@@ -9,7 +9,6 @@ package org.elasticsearch.persistent;
 
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.threadpool.ThreadPool;
 
 /**
  * This component is responsible for execution of persistent tasks.
@@ -17,20 +16,13 @@ import org.elasticsearch.threadpool.ThreadPool;
  * It abstracts away the execution of tasks and greatly simplifies testing of PersistentTasksNodeService
  */
 public class NodePersistentTasksExecutor {
-
-    private final ThreadPool threadPool;
-
-    NodePersistentTasksExecutor(ThreadPool threadPool) {
-        this.threadPool = threadPool;
-    }
-
     public <Params extends PersistentTaskParams> void executeTask(
         final Params params,
         final @Nullable PersistentTaskState state,
         final AllocatedPersistentTask task,
         final PersistentTasksExecutor<Params> executor
     ) {
-        threadPool.executor(executor.getExecutor()).execute(new AbstractRunnable() {
+        executor.getExecutor().execute(new AbstractRunnable() {
             @Override
             public void onFailure(Exception e) {
                 task.markAsFailed(e);

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksExecutor.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksExecutor.java
@@ -17,6 +17,7 @@ import org.elasticsearch.tasks.TaskId;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.Executor;
 import java.util.function.Predicate;
 
 /**
@@ -25,10 +26,10 @@ import java.util.function.Predicate;
  */
 public abstract class PersistentTasksExecutor<Params extends PersistentTaskParams> {
 
-    private final String executor;
+    private final Executor executor;
     private final String taskName;
 
-    protected PersistentTasksExecutor(String taskName, String executor) {
+    protected PersistentTasksExecutor(String taskName, Executor executor) {
         this.taskName = taskName;
         this.executor = executor;
     }
@@ -117,7 +118,7 @@ public abstract class PersistentTasksExecutor<Params extends PersistentTaskParam
      */
     protected abstract void nodeOperation(AllocatedPersistentTask task, Params params, @Nullable PersistentTaskState state);
 
-    public String getExecutor() {
+    public Executor getExecutor() {
         return executor;
     }
 }

--- a/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
@@ -163,7 +163,7 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
                 threadPool.executor(ThreadPool.Names.GENERIC)
             );
             this.persistentTasksClusterService = persistentTasksClusterService;
-            NodePersistentTasksExecutor executor = new NodePersistentTasksExecutor(threadPool);
+            NodePersistentTasksExecutor executor = new NodePersistentTasksExecutor();
             clusterService.addListener(
                 new PersistentTasksNodeService(
                     threadPool,

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationExecutor.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationExecutor.java
@@ -23,7 +23,6 @@ import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.tasks.TaskId;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
 
@@ -52,7 +51,7 @@ public class SystemIndexMigrationExecutor extends PersistentTasksExecutor<System
         MetadataCreateIndexService metadataCreateIndexService,
         IndexScopedSettings indexScopedSettings
     ) {
-        super(SYSTEM_INDEX_UPGRADE_TASK_NAME, ThreadPool.Names.GENERIC);
+        super(SYSTEM_INDEX_UPGRADE_TASK_NAME, clusterService.threadPool().generic());
         this.client = client;
         this.clusterService = clusterService;
         this.systemIndices = systemIndices;

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
@@ -94,7 +94,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
         PersistentTasksService persistentTasksService = mock(PersistentTasksService.class);
         @SuppressWarnings("unchecked")
         PersistentTasksExecutor<TestParams> action = mock(PersistentTasksExecutor.class);
-        when(action.getExecutor()).thenReturn(ThreadPool.Names.SAME);
+        when(action.getExecutor()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         when(action.getTaskName()).thenReturn(TestPersistentTasksExecutor.NAME);
         int nonLocalNodesCount = randomInt(10);
         // need to account for 5 original tasks on each node and their relocations
@@ -208,7 +208,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
         PersistentTasksService persistentTasksService = mock(PersistentTasksService.class);
         @SuppressWarnings("unchecked")
         PersistentTasksExecutor<TestParams> action = mock(PersistentTasksExecutor.class);
-        when(action.getExecutor()).thenReturn(ThreadPool.Names.SAME);
+        when(action.getExecutor()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         when(action.getTaskName()).thenReturn(TestPersistentTasksExecutor.NAME);
         TaskId parentId = new TaskId("cluster", 1);
         AllocatedPersistentTask nodeTask = new TestPersistentTasksPlugin.TestTask(
@@ -276,7 +276,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
         };
         @SuppressWarnings("unchecked")
         PersistentTasksExecutor<TestParams> action = mock(PersistentTasksExecutor.class);
-        when(action.getExecutor()).thenReturn(ThreadPool.Names.SAME);
+        when(action.getExecutor()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         when(action.getTaskName()).thenReturn("test");
         when(action.createTask(anyLong(), anyString(), anyString(), any(), any(), any())).thenReturn(
             new TestPersistentTasksPlugin.TestTask(1, "persistent", "test", "", new TaskId("cluster", 1), Collections.emptyMap())
@@ -370,7 +370,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
         };
         @SuppressWarnings("unchecked")
         PersistentTasksExecutor<TestParams> action = mock(PersistentTasksExecutor.class);
-        when(action.getExecutor()).thenReturn(ThreadPool.Names.SAME);
+        when(action.getExecutor()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         when(action.getTaskName()).thenReturn("test");
         when(action.createTask(anyLong(), anyString(), anyString(), any(), any(), any())).thenReturn(
             new TestPersistentTasksPlugin.TestTask(1, "persistent", "test", "", new TaskId("cluster", 1), Collections.emptyMap())
@@ -478,7 +478,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
 
         @SuppressWarnings("unchecked")
         PersistentTasksExecutor<TestParams> action = mock(PersistentTasksExecutor.class);
-        when(action.getExecutor()).thenReturn(ThreadPool.Names.SAME);
+        when(action.getExecutor()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         when(action.getTaskName()).thenReturn(TestPersistentTasksExecutor.NAME);
         when(action.createTask(anyLong(), anyString(), anyString(), any(), any(), any())).thenThrow(
             new RuntimeException("Something went wrong")
@@ -559,7 +559,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
             .build();
     }
 
-    private class Execution {
+    private static class Execution {
 
         private final PersistentTaskParams params;
         private final AllocatedPersistentTask task;
@@ -573,11 +573,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
     }
 
     private class MockExecutor extends NodePersistentTasksExecutor {
-        private List<Execution> executions = new ArrayList<>();
-
-        MockExecutor() {
-            super(null);
-        }
+        private final List<Execution> executions = new ArrayList<>();
 
         @Override
         public <Params extends PersistentTaskParams> void executeTask(

--- a/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
+++ b/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
@@ -298,7 +298,7 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
         private static volatile boolean nonClusterStateCondition = true;
 
         public TestPersistentTasksExecutor(ClusterService clusterService) {
-            super(NAME, ThreadPool.Names.GENERIC);
+            super(NAME, clusterService.threadPool().generic());
             this.clusterService = clusterService;
         }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -104,10 +104,10 @@ public final class ShardFollowTasksExecutor extends PersistentTasksExecutor<Shar
     private volatile TimeValue waitForMetadataTimeOut;
 
     public ShardFollowTasksExecutor(Client client, ThreadPool threadPool, ClusterService clusterService, SettingsModule settingsModule) {
-        super(ShardFollowTask.NAME, Ccr.CCR_THREAD_POOL_NAME);
+        super(ShardFollowTask.NAME, threadPool.executor(Ccr.CCR_THREAD_POOL_NAME));
         this.client = client;
         this.threadPool = threadPool;
-        this.ccrExecutor = threadPool.executor(getExecutor());
+        this.ccrExecutor = getExecutor();
         this.clusterService = clusterService;
         this.indexScopedSettings = settingsModule.getIndexScopedSettings();
         this.retentionLeaseRenewInterval = CcrRetentionLeases.RETENTION_LEASE_RENEW_INTERVAL_SETTING.get(settingsModule.getSettings());

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Downsample.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/Downsample.java
@@ -97,7 +97,13 @@ public class Downsample extends Plugin implements ActionPlugin, PersistentTaskPl
         SettingsModule settingsModule,
         IndexNameExpressionResolver expressionResolver
     ) {
-        return List.of(new DownsampleShardPersistentTaskExecutor(client, DownsampleShardTask.TASK_NAME, DOWNSAMPLE_TASK_THREAD_POOL_NAME));
+        return List.of(
+            new DownsampleShardPersistentTaskExecutor(
+                client,
+                DownsampleShardTask.TASK_NAME,
+                threadPool.executor(DOWNSAMPLE_TASK_THREAD_POOL_NAME)
+            )
+        );
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1341,7 +1341,7 @@ public class MachineLearning extends Plugin
                 getLicenseState(),
                 machineLearningExtension.get().includeNodeInfo()
             ),
-            new TransportStartDatafeedAction.StartDatafeedPersistentTasksExecutor(datafeedRunner.get(), expressionResolver),
+            new TransportStartDatafeedAction.StartDatafeedPersistentTasksExecutor(datafeedRunner.get(), expressionResolver, threadPool),
             new TransportStartDataFrameAnalyticsAction.TaskExecutor(
                 settings,
                 client,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -473,8 +473,12 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
         private final DatafeedRunner datafeedRunner;
         private final IndexNameExpressionResolver resolver;
 
-        public StartDatafeedPersistentTasksExecutor(DatafeedRunner datafeedRunner, IndexNameExpressionResolver resolver) {
-            super(MlTasks.DATAFEED_TASK_NAME, MachineLearning.UTILITY_THREAD_POOL_NAME);
+        public StartDatafeedPersistentTasksExecutor(
+            DatafeedRunner datafeedRunner,
+            IndexNameExpressionResolver resolver,
+            ThreadPool threadPool
+        ) {
+            super(MlTasks.DATAFEED_TASK_NAME, threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME));
             this.datafeedRunner = datafeedRunner;
             this.resolver = resolver;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutor.java
@@ -92,13 +92,13 @@ public abstract class AbstractJobPersistentTasksExecutor<Params extends Persiste
 
     protected AbstractJobPersistentTasksExecutor(
         String taskName,
-        String executor,
+        String executorName,
         Settings settings,
         ClusterService clusterService,
         MlMemoryTracker memoryTracker,
         IndexNameExpressionResolver expressionResolver
     ) {
-        super(taskName, executor);
+        super(taskName, clusterService.threadPool().executor(executorName));
         this.memoryTracker = Objects.requireNonNull(memoryTracker);
         this.expressionResolver = Objects.requireNonNull(expressionResolver);
         this.maxConcurrentJobAllocations = MachineLearning.CONCURRENT_JOB_ALLOCATIONS.get(settings);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.MlConfigVersion;
 import org.elasticsearch.xpack.core.ml.MlMetadata;
@@ -134,6 +135,7 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
             )
         );
         when(clusterService.getClusterSettings()).thenReturn(clusterSettings);
+        when(clusterService.threadPool()).thenReturn(mock(ThreadPool.class));
 
         return new TaskExecutor(
             Settings.EMPTY,

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/job/RollupJobTask.java
@@ -60,7 +60,7 @@ public class RollupJobTask extends AllocatedPersistentTask implements SchedulerE
         private final ThreadPool threadPool;
 
         public RollupJobPersistentTasksExecutor(Client client, SchedulerEngine schedulerEngine, ThreadPool threadPool) {
-            super(RollupField.TASK_NAME, ThreadPool.Names.GENERIC);
+            super(RollupField.TASK_NAME, threadPool.generic());
             this.client = client;
             this.schedulerEngine = schedulerEngine;
             this.threadPool = threadPool;

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownTasksIT.java
@@ -165,7 +165,7 @@ public class NodeShutdownTasksIT extends ESIntegTestCase {
         private final PersistentTasksService persistentTasksService;
 
         protected TaskExecutor(Client client, ClusterService clusterService, ThreadPool threadPool) {
-            super("task_name", ThreadPool.Names.GENERIC);
+            super("task_name", threadPool.generic());
             persistentTasksService = new PersistentTasksService(clusterService, threadPool, client);
             clusterService.addListener(this);
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
@@ -87,7 +87,7 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         Settings transformInternalIndexAdditionalSettings,
         IndexNameExpressionResolver resolver
     ) {
-        super(TransformField.TASK_NAME, ThreadPool.Names.GENERIC);
+        super(TransformField.TASK_NAME, threadPool.generic());
         this.client = client;
         this.transformServices = transformServices;
         this.threadPool = threadPool;


### PR DESCRIPTION
Similar to #99392, #97879 etc, no need to have the
`NodePersistentTasksExecutor` look up the executor to use each time, nor
does it necessarily need to use a named executor from the `ThreadPool`.
This commit pulls the lookup earlier in initialization so we can just
use a bare `Executor` instead.