### PR TITLE
Reduce usage of instanceof in QL translation layer

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/BinaryComparison.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/BinaryComparison.java
@@ -13,6 +13,7 @@ import org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal;
 import org.elasticsearch.xpack.ql.expression.gen.pipeline.Pipe;
 import org.elasticsearch.xpack.ql.expression.predicate.BinaryOperator;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.planner.Translatable;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
@@ -20,7 +21,7 @@ import org.elasticsearch.xpack.ql.type.DataTypes;
 import java.time.ZoneId;
 
 // marker class to indicate operations that rely on values
-public abstract class BinaryComparison extends BinaryOperator<Object, Object, Boolean, BinaryComparisonOperation> {
+public abstract class BinaryComparison extends BinaryOperator<Object, Object, Boolean, BinaryComparisonOperation> implements Translatable {
 
     private final ZoneId zoneId;
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/Equals.java
@@ -7,8 +7,10 @@
 package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 
 import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.TypedAttribute;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.planner.ExpressionTranslator;
 import org.elasticsearch.xpack.ql.querydsl.query.Query;
 import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.TermQuery;
@@ -59,6 +61,9 @@ public class Equals extends BinaryComparison implements Negatable<BinaryComparis
 
     @Override
     public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        if (left() instanceof TypedAttribute typedLeft) {
+            name = ExpressionTranslator.pushableAttributeName(typedLeft);
+        }
         if (isDateLiteralComparison) {
             // dates equality uses a range query because it's the one that has a "format" parameter
             return new RangeQuery(source(), name, value, true, value, true, format, zoneId);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/Equals.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/Equals.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.querydsl.query.Query;
+import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
+import org.elasticsearch.xpack.ql.querydsl.query.TermQuery;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -52,5 +55,15 @@ public class Equals extends BinaryComparison implements Negatable<BinaryComparis
     @Override
     protected boolean isCommutative() {
         return true;
+    }
+
+    @Override
+    public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        if (isDateLiteralComparison) {
+            // dates equality uses a range query because it's the one that has a "format" parameter
+            return new RangeQuery(source(), name, value, true, value, true, format, zoneId);
+        } else {
+            return new TermQuery(source(), name, value);
+        }
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/GreaterThan.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/GreaterThan.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.querydsl.query.Query;
+import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -43,5 +45,10 @@ public class GreaterThan extends BinaryComparison implements Negatable<BinaryCom
     @Override
     public BinaryComparison reverse() {
         return new LessThan(source(), left(), right(), zoneId());
+    }
+
+    @Override
+    public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        return new RangeQuery(source(), name, value, false, null, false, format, zoneId);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/GreaterThanOrEqual.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/GreaterThanOrEqual.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.querydsl.query.Query;
+import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -43,5 +45,10 @@ public class GreaterThanOrEqual extends BinaryComparison implements Negatable<Bi
     @Override
     public BinaryComparison reverse() {
         return new LessThanOrEqual(source(), left(), right(), zoneId());
+    }
+
+    @Override
+    public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        return new RangeQuery(source(), name, value, true, null, false, format, zoneId);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/LessThan.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/LessThan.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.querydsl.query.Query;
+import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -43,5 +45,10 @@ public class LessThan extends BinaryComparison implements Negatable<BinaryCompar
     @Override
     public BinaryComparison reverse() {
         return new GreaterThan(source(), left(), right(), zoneId());
+    }
+
+    @Override
+    public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        return new RangeQuery(source(), name, null, false, value, false, format, zoneId);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/LessThanOrEqual.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/LessThanOrEqual.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.querydsl.query.Query;
+import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -43,5 +45,10 @@ public class LessThanOrEqual extends BinaryComparison implements Negatable<Binar
     @Override
     public BinaryComparison reverse() {
         return new GreaterThanOrEqual(source(), left(), right(), zoneId());
+    }
+
+    @Override
+    public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        return new RangeQuery(source(), name, null, false, value, true, format, zoneId);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/NotEquals.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/NotEquals.java
@@ -9,6 +9,10 @@ package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.querydsl.query.NotQuery;
+import org.elasticsearch.xpack.ql.querydsl.query.Query;
+import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
+import org.elasticsearch.xpack.ql.querydsl.query.TermQuery;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -48,5 +52,16 @@ public class NotEquals extends BinaryComparison implements Negatable<BinaryCompa
     @Override
     protected boolean isCommutative() {
         return true;
+    }
+
+    @Override
+    public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        Query query;
+        if (isDateLiteralComparison) {
+            // dates equality uses a range query because it's the one that has a "format" parameter
+            return new NotQuery(source(), new RangeQuery(source(), name, value, true, value, true, format, zoneId));
+        } else {
+            return new NotQuery(source(), new TermQuery(source(), name, value));
+        }
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/NotEquals.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/NotEquals.java
@@ -7,8 +7,10 @@
 package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 
 import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.TypedAttribute;
 import org.elasticsearch.xpack.ql.expression.predicate.Negatable;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.planner.ExpressionTranslator;
 import org.elasticsearch.xpack.ql.querydsl.query.NotQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.Query;
 import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
@@ -56,7 +58,9 @@ public class NotEquals extends BinaryComparison implements Negatable<BinaryCompa
 
     @Override
     public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
-        Query query;
+        if (left() instanceof TypedAttribute typedLeft) {
+            name = ExpressionTranslator.pushableAttributeName(typedLeft);
+        }
         if (isDateLiteralComparison) {
             // dates equality uses a range query because it's the one that has a "format" parameter
             return new NotQuery(source(), new RangeQuery(source(), name, value, true, value, true, format, zoneId));

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/NullEquals.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/NullEquals.java
@@ -8,7 +8,9 @@ package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Nullability;
+import org.elasticsearch.xpack.ql.expression.TypedAttribute;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.planner.ExpressionTranslator;
 import org.elasticsearch.xpack.ql.querydsl.query.Query;
 import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.TermQuery;
@@ -58,6 +60,9 @@ public class NullEquals extends BinaryComparison {
 
     @Override
     public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        if (left() instanceof TypedAttribute typedLeft) {
+            name = ExpressionTranslator.pushableAttributeName(typedLeft);
+        }
         if (isDateLiteralComparison) {
             // dates equality uses a range query because it's the one that has a "format" parameter
             return new RangeQuery(source(), name, value, true, value, true, format, zoneId);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/NullEquals.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/operator/comparison/NullEquals.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.ql.expression.predicate.operator.comparison;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Nullability;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparisonProcessor.BinaryComparisonOperation;
+import org.elasticsearch.xpack.ql.querydsl.query.Query;
+import org.elasticsearch.xpack.ql.querydsl.query.RangeQuery;
+import org.elasticsearch.xpack.ql.querydsl.query.TermQuery;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 
@@ -51,5 +54,15 @@ public class NullEquals extends BinaryComparison {
     @Override
     protected boolean isCommutative() {
         return true;
+    }
+
+    @Override
+    public Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId) {
+        if (isDateLiteralComparison) {
+            // dates equality uses a range query because it's the one that has a "format" parameter
+            return new RangeQuery(source(), name, value, true, value, true, format, zoneId);
+        } else {
+            return new TermQuery(source(), name, value);
+        }
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -29,11 +29,7 @@ import org.elasticsearch.xpack.ql.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.ql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThan;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.In;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThan;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullEquals;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.Like;
@@ -324,35 +320,14 @@ public final class ExpressionTranslators {
             if (DataTypes.isDateTime(attribute.dataType())) {
                 zoneId = bc.zoneId();
             }
-            if (bc instanceof GreaterThan) {
-                return new RangeQuery(source, name, value, false, null, false, format, zoneId);
-            }
-            if (bc instanceof GreaterThanOrEqual) {
-                return new RangeQuery(source, name, value, true, null, false, format, zoneId);
-            }
-            if (bc instanceof LessThan) {
-                return new RangeQuery(source, name, null, false, value, false, format, zoneId);
-            }
-            if (bc instanceof LessThanOrEqual) {
-                return new RangeQuery(source, name, null, false, value, true, format, zoneId);
-            }
             if (bc instanceof Equals || bc instanceof NullEquals || bc instanceof NotEquals) {
                 name = pushableAttributeName(attribute);
-
-                Query query;
-                if (isDateLiteralComparison) {
-                    // dates equality uses a range query because it's the one that has a "format" parameter
-                    query = new RangeQuery(source, name, value, true, value, true, format, zoneId);
-                } else {
-                    query = new TermQuery(source, name, value);
-                }
-                if (bc instanceof NotEquals) {
-                    query = new NotQuery(source, query);
-                }
-                return query;
             }
 
-            throw new QlIllegalArgumentException("Don't know how to translate binary comparison [{}] in [{}]", bc.right().nodeString(), bc);
+            return bc.getQuery(name, value, format, isDateLiteralComparison, zoneId);
+
+            // throw new QlIllegalArgumentException("Don't know how to translate binary comparison [{}] in [{}]", bc.right().nodeString(),
+            // bc);
         }
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -30,8 +30,6 @@ import org.elasticsearch.xpack.ql.expression.predicate.nulls.IsNull;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.In;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEquals;
-import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullEquals;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.Like;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RLike;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RegexMatch;
@@ -280,7 +278,6 @@ public final class ExpressionTranslators {
 
         static Query translate(BinaryComparison bc, TranslatorHandler handler) {
             TypedAttribute attribute = checkIsPushableAttribute(bc.left());
-            Source source = bc.source();
             String name = handler.nameOf(attribute);
             Object value = valueOf(bc.right());
             String format = null;
@@ -320,14 +317,8 @@ public final class ExpressionTranslators {
             if (DataTypes.isDateTime(attribute.dataType())) {
                 zoneId = bc.zoneId();
             }
-            if (bc instanceof Equals || bc instanceof NullEquals || bc instanceof NotEquals) {
-                name = pushableAttributeName(attribute);
-            }
 
             return bc.getQuery(name, value, format, isDateLiteralComparison, zoneId);
-
-            // throw new QlIllegalArgumentException("Don't know how to translate binary comparison [{}] in [{}]", bc.right().nodeString(),
-            // bc);
         }
     }
 

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/Translatable.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/Translatable.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ql.planner;
+
+import org.elasticsearch.xpack.ql.querydsl.query.Query;
+
+import java.time.ZoneId;
+
+public interface Translatable {
+    Query getQuery(String name, Object value, String format, boolean isDateLiteralComparison, ZoneId zoneId);
+}


### PR DESCRIPTION
This refactoring moves a small part of the Translator logic into the expression classes. Prior to this work, the use of `instanceof` to exhaustively list out the possible leaf classes and implement a distinct behavior for each of them effectively turns what should be a compile time exception (forgetting to implement such a method) into a runtime exception.  Furthermore, adding the correct behavior requires editing a class far from the expression being worked on.

I tripped over this quite painfully in https://github.com/elastic/elasticsearch/pull/105217 , and my proposal here is the smallest change I can think of to get that PR unblocked. 