### PR TITLE
ESQL: Introduce expression validation phase

### DIFF
--- a/docs/changelog/105477.yaml
+++ b/docs/changelog/105477.yaml
@@ -1,0 +1,6 @@
+pr: 105477
+summary: "ESQL: Introduce expression validation phase"
+area: ES|QL
+type: enhancement
+issues:
+ - 105425

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/VerificationException.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/VerificationException.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql;
 
 import org.elasticsearch.xpack.ql.common.Failure;
+import org.elasticsearch.xpack.ql.common.Failures;
 
 import java.util.Collection;
 
@@ -18,6 +19,10 @@ public class VerificationException extends EsqlClientException {
 
     public VerificationException(Collection<Failure> sources) {
         super(Failure.failMessage(sources));
+    }
+
+    public VerificationException(Failures failures) {
+        super(failures.toString());
     }
 
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/Validatable.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/Validatable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.capabilities;
+
+import org.elasticsearch.xpack.ql.common.Failures;
+
+/**
+ * Interface implemented by expressions that require validation post logical optimization,
+ * when the plan and references have been not just resolved but also replaced.
+ */
+public interface Validatable {
+
+    /**
+     * Validates the implementing expression - discovered failures are reported to the given
+     * {@link Failures} class.
+     */
+    default void validate(Failures failures) {}
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Validations.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Validations.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression;
+
+import org.elasticsearch.xpack.ql.common.Failure;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.Expression.TypeResolution;
+import org.elasticsearch.xpack.ql.expression.TypeResolutions;
+
+public final class Validations {
+
+    private Validations() {}
+
+    public static Failure isLiteral(Expression e, String operationName, TypeResolutions.ParamOrdinal paramOrd) {
+        TypeResolution resolution = TypeResolutions.isFoldable(e, operationName, paramOrd);
+        return resolution.unresolved() ? Failure.fail(e, resolution.message()) : null;
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Validations.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Validations.java
@@ -16,7 +16,10 @@ public final class Validations {
 
     private Validations() {}
 
-    public static Failure isLiteral(Expression e, String operationName, TypeResolutions.ParamOrdinal paramOrd) {
+    /**
+     * Validates if the given expression is foldable - if not returns a Failure.
+     */
+    public static Failure isFoldable(Expression e, String operationName, TypeResolutions.ParamOrdinal paramOrd) {
         TypeResolution resolution = TypeResolutions.isFoldable(e, operationName, paramOrd);
         return resolution.unresolved() ? Failure.fail(e, resolution.message()) : null;
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AutoBucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/AutoBucket.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import static org.elasticsearch.xpack.esql.expression.Validations.isLiteral;
+import static org.elasticsearch.xpack.esql.expression.Validations.isFoldable;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.FOURTH;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.SECOND;
@@ -208,7 +208,7 @@ public class AutoBucket extends EsqlScalarFunction implements Validatable {
     public void validate(Failures failures) {
         String operation = sourceText();
 
-        failures.add(isLiteral(buckets, operation, SECOND)).add(isLiteral(from, operation, THIRD)).add(isLiteral(to, operation, FOURTH));
+        failures.add(isFoldable(buckets, operation, SECOND)).add(isFoldable(from, operation, THIRD)).add(isFoldable(to, operation, FOURTH));
     }
 
     private long foldToLong(Expression e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -27,7 +27,7 @@ import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
-import org.elasticsearch.xpack.ql.common.Failure;
+import org.elasticsearch.xpack.ql.common.Failures;
 import org.elasticsearch.xpack.ql.expression.Alias;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.AttributeMap;
@@ -70,7 +70,6 @@ import org.elasticsearch.xpack.ql.util.StringUtils;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -98,8 +97,8 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
     public LogicalPlan optimize(LogicalPlan verified) {
         var optimized = execute(verified);
 
-        Collection<Failure> failures = verifier.verify(optimized);
-        if (failures.isEmpty() == false) {
+        Failures failures = verifier.verify(optimized);
+        if (failures.hasFailures()) {
             throw new VerificationException(failures);
         }
         return optimized;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalVerifier.java
@@ -9,12 +9,8 @@ package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.xpack.esql.capabilities.Validatable;
 import org.elasticsearch.xpack.esql.optimizer.OptimizerRules.LogicalPlanDependencyCheck;
-import org.elasticsearch.xpack.ql.common.Failure;
 import org.elasticsearch.xpack.ql.common.Failures;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
-
-import java.util.LinkedHashSet;
-import java.util.Set;
 
 public final class LogicalVerifier {
 
@@ -25,24 +21,22 @@ public final class LogicalVerifier {
 
     /** Verifies the optimized logical plan. */
     public Failures verify(LogicalPlan plan) {
-        Set<Failure> set = new LinkedHashSet<>();
-        Failures f = new Failures(set);
+        Failures failures = new Failures();
 
         plan.forEachUp(p -> {
             // dependency check
             // FIXME: re-enable
             // DEPENDENCY_CHECK.checkPlan(p, failures);
 
-            if (set.isEmpty()) {
-                // post optimization folding check
+            if (failures.hasFailures() == false) {
                 p.forEachExpression(ex -> {
                     if (ex instanceof Validatable v) {
-                        v.validate(f);
+                        v.validate(failures);
                     }
                 });
             }
         });
 
-        return f;
+        return failures;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalVerifier.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalVerifier.java
@@ -7,20 +7,14 @@
 
 package org.elasticsearch.xpack.esql.optimizer;
 
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.AutoBucket;
+import org.elasticsearch.xpack.esql.capabilities.Validatable;
 import org.elasticsearch.xpack.esql.optimizer.OptimizerRules.LogicalPlanDependencyCheck;
 import org.elasticsearch.xpack.ql.common.Failure;
-import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.common.Failures;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
 
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
-
-import static org.elasticsearch.xpack.ql.common.Failure.fail;
-import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.FOURTH;
-import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.THIRD;
-import static org.elasticsearch.xpack.ql.expression.TypeResolutions.isFoldable;
 
 public final class LogicalVerifier {
 
@@ -30,27 +24,25 @@ public final class LogicalVerifier {
     private LogicalVerifier() {}
 
     /** Verifies the optimized logical plan. */
-    public Collection<Failure> verify(LogicalPlan plan) {
-        Set<Failure> failures = new LinkedHashSet<>();
+    public Failures verify(LogicalPlan plan) {
+        Set<Failure> set = new LinkedHashSet<>();
+        Failures f = new Failures(set);
 
         plan.forEachUp(p -> {
             // dependency check
             // FIXME: re-enable
             // DEPENDENCY_CHECK.checkPlan(p, failures);
 
-            // post optimization folding check
-            p.forEachExpression(AutoBucket.class, e -> {
-                Expression.TypeResolution resolution = isFoldable(e.from(), e.sourceText(), THIRD);
-                if (resolution.unresolved()) {
-                    failures.add(fail(e, resolution.message()));
-                }
-                resolution = isFoldable(e.to(), e.sourceText(), FOURTH);
-                if (resolution.unresolved()) {
-                    failures.add(fail(e, resolution.message()));
-                }
-            });
+            if (set.isEmpty()) {
+                // post optimization folding check
+                p.forEachExpression(ex -> {
+                    if (ex instanceof Validatable v) {
+                        v.validate(f);
+                    }
+                });
+            }
         });
 
-        return failures;
+        return f;
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -2942,7 +2942,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         assertTrue(e.getMessage().startsWith("Found "));
         final String header = "Found 1 problem\nline ";
         assertEquals(
-            "3:8: third argument of [auto_bucket(salary, 10, emp_no, bucket_end)] must be a constant, received [emp_no]",
+            "3:32: third argument of [auto_bucket(salary, 10, emp_no, bucket_end)] must be a constant, received [emp_no]",
             e.getMessage().substring(header.length())
         );
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/common/Failures.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/common/Failures.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ql.common;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * Glorified list for managing {@link Failure}s.
+ */
+public class Failures {
+
+    private final Collection<Failure> failures;
+
+    public Failures() {
+        this(new ArrayList<>());
+    }
+
+    public Failures(Collection<Failure> failures) {
+        this.failures = failures;
+    }
+
+    public Failures add(Failure failure) {
+        if (failure != null) {
+            failures.add(failure);
+        }
+        return this;
+    }
+
+    public boolean hasFailures() {
+        return failures.size() > 0;
+    }
+
+    public Collection<Failure> failures() {
+        return failures;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(failures);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Failures failures1 = (Failures) o;
+        return Objects.equals(failures, failures1.failures);
+    }
+
+    @Override
+    public String toString() {
+        return failures.isEmpty() ? "[]" : Failure.failMessage(failures);
+    }
+}

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/common/Failures.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/common/Failures.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.ql.common;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 
 /**
@@ -19,11 +19,7 @@ public class Failures {
     private final Collection<Failure> failures;
 
     public Failures() {
-        this(new ArrayList<>());
-    }
-
-    public Failures(Collection<Failure> failures) {
-        this.failures = failures;
+        this.failures = new LinkedHashSet<>();
     }
 
     public Failures add(Failure failure) {


### PR DESCRIPTION
Introduce dedicated phase through Validate interface that allows
 interested expressions to perform post logical optimization
 verification for things like literals/foldables which might be hidden
 through references after analysis.

Fix #105425