### PR TITLE
[DOCS] [Remote clusters] Reference specific instructions for cloud trust

### DIFF
--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -30,6 +30,11 @@ capabilities, the local and remote cluster must be on the same
 [discrete]
 === Add remote clusters
 
+NOTE: The instructions that follow describe how to create a remote connection from a 
+self-managed cluster. You can also set up {ccs} and {ccr} from an 
+link:https://www.elastic.co/guide/en/cloud/current/ec-enable-ccs.html[{ess} deployment] 
+or from an link:https://www.elastic.co/guide/en/cloud-enterprise/current/ece-enable-ccs.html[{ece} deployment].
+
 To add remote clusters, you can choose between
 <<remote-clusters-security-models,two security models>> and
 <<sniff-proxy-modes,two connection modes>>. Both security models are compatible


### PR DESCRIPTION
This PR adds a note with links to ESS and ECE docs for remote cluster setup as the steps vary a lot between the various cases (depending on where the local and remote cluster are hosted). This way, we orientate users to the correct set of instructions and avoid possible confusion. 

It would probably be better to have all the remote cluster instructions together (independently of hosting) but I'm leaving that for future consideration at the moment.

Partially addresses https://github.com/elastic/platform-docs-team/issues/303