### PR TITLE
[Transform] Fix a bug where destination index aliases are not set up for an unattended transform

### DIFF
--- a/docs/changelog/105499.yaml
+++ b/docs/changelog/105499.yaml
@@ -1,5 +1,5 @@
 pr: 105499
-summary: Make unattended transform create destination index explicitly
+summary: Fix a bug where destination index aliases are not set up for an unattended transform
 area: Transform
 type: bug
 issues: []

--- a/docs/changelog/105499.yaml
+++ b/docs/changelog/105499.yaml
@@ -1,0 +1,5 @@
+pr: 105499
+summary: Make unattended transform create destination index explicitly
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
@@ -420,8 +420,14 @@ public class TransformInsufficientPermissionsIT extends TransformRestTestCase {
 
         startTransform(config.getId(), RequestOptions.DEFAULT);
 
-        // transform is red due to lacking permissions
-        assertRed(transformId, authIssue);
+        // Give the transform indexer enough time to try creating destination index
+        Thread.sleep(5_000);
+
+        String destIndexIssue = Strings.format("Could not create destination index [%s] for transform [%s]", destIndexName, transformId);
+        // transform's auth state status is still RED due to:
+        // - lacking permissions
+        // - and the inability to create destination index in the indexer (which is also a consequence of lacking permissions)
+        assertRed(transformId, authIssue, destIndexIssue);
 
         // update transform's credentials so that the transform has permission to access source/dest indices
         updateConfig(transformId, "{}", RequestOptions.DEFAULT.toBuilder().addHeader(AUTH_KEY, Users.SENIOR.header).build());
@@ -576,6 +582,7 @@ public class TransformInsufficientPermissionsIT extends TransformRestTestCase {
         assertThat("Stats were: " + stats, extractValue(stats, "health", "issues"), is(nullValue()));
     }
 
+    // We expect exactly the issues passed as "expectedHealthIssueDetails". Not more, not less.
     @SuppressWarnings("unchecked")
     private void assertRed(String transformId, String... expectedHealthIssueDetails) throws IOException {
         Map<String, Object> stats = getBasicTransformStats(transformId);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -283,7 +283,7 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
                 threadPool,
                 clusterService,
                 settingsModule.getSettings(),
-                getTransformExtension().getTransformInternalIndexAdditionalSettings(),
+                getTransformExtension(),
                 expressionResolver
             )
         );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -27,7 +27,10 @@ import org.elasticsearch.action.search.TransportOpenPointInTimeAction;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -54,9 +57,11 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.core.transform.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.transform.TransformExtension;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
+import org.elasticsearch.xpack.transform.persistence.TransformIndex;
 import org.elasticsearch.xpack.transform.transforms.pivot.SchemaUtil;
 import org.elasticsearch.xpack.transform.utils.ExceptionRootCauseFinder;
 
@@ -75,6 +80,9 @@ class ClientTransformIndexer extends TransformIndexer {
     private static final Logger logger = LogManager.getLogger(ClientTransformIndexer.class);
 
     private final ParentTaskAssigningClient client;
+    private final ClusterService clusterService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final Settings destIndexSettings;
     private final AtomicBoolean oldStatsCleanedUp = new AtomicBoolean(false);
 
     private final AtomicReference<SeqNoPrimaryTermAndIndex> seqNoPrimaryTermAndIndexHolder;
@@ -84,6 +92,9 @@ class ClientTransformIndexer extends TransformIndexer {
 
     ClientTransformIndexer(
         ThreadPool threadPool,
+        ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        TransformExtension transformExtension,
         TransformServices transformServices,
         CheckpointProvider checkpointProvider,
         AtomicReference<IndexerState> initialState,
@@ -112,6 +123,9 @@ class ClientTransformIndexer extends TransformIndexer {
             context
         );
         this.client = ExceptionsHelper.requireNonNull(client, "client");
+        this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        this.destIndexSettings = transformExtension.getTransformDestinationIndexSettings();
         this.seqNoPrimaryTermAndIndexHolder = new AtomicReference<>(seqNoPrimaryTermAndIndex);
 
         // TODO: move into context constructor
@@ -286,6 +300,20 @@ class ClientTransformIndexer extends TransformIndexer {
     @Override
     void doGetFieldMappings(ActionListener<Map<String, String>> fieldMappingsListener) {
         SchemaUtil.getDestinationFieldMappings(client, getConfig().getDestination().getIndex(), fieldMappingsListener);
+    }
+
+    @Override
+    void doMaybeCreateDestIndex(Map<String, String> deducedDestIndexMappings, ActionListener<Boolean> listener) {
+        TransformIndex.createDestinationIndex(
+            client,
+            auditor,
+            indexNameExpressionResolver,
+            clusterService.state(),
+            transformConfig,
+            destIndexSettings,
+            deducedDestIndexMappings,
+            listener
+        );
     }
 
     void validate(ActionListener<ValidateTransformAction.Response> listener) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerBuilder.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerBuilder.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.transform.transforms;
 
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
@@ -15,6 +17,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerPosition;
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
+import org.elasticsearch.xpack.transform.TransformExtension;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
@@ -23,6 +26,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 class ClientTransformIndexerBuilder {
     private ParentTaskAssigningClient parentTaskClient;
+    private ClusterService clusterService;
+    private IndexNameExpressionResolver indexNameExpressionResolver;
+    private TransformExtension transformExtension;
     private TransformServices transformServices;
     private TransformConfig transformConfig;
     private TransformIndexerStats initialStats;
@@ -44,6 +50,9 @@ class ClientTransformIndexerBuilder {
 
         return new ClientTransformIndexer(
             threadPool,
+            clusterService,
+            indexNameExpressionResolver,
+            transformExtension,
             transformServices,
             checkpointProvider,
             new AtomicReference<>(this.indexerState),
@@ -70,6 +79,21 @@ class ClientTransformIndexerBuilder {
 
     ClientTransformIndexerBuilder setClient(ParentTaskAssigningClient parentTaskClient) {
         this.parentTaskClient = parentTaskClient;
+        return this;
+    }
+
+    ClientTransformIndexerBuilder setIndexNameExpressionResolver(IndexNameExpressionResolver indexNameExpressionResolver) {
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        return this;
+    }
+
+    ClientTransformIndexerBuilder setClusterService(ClusterService clusterService) {
+        this.clusterService = clusterService;
+        return this;
+    }
+
+    ClientTransformIndexerBuilder setTransformExtension(TransformExtension transformExtension) {
+        this.transformExtension = transformExtension;
         return this;
     }
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -171,6 +171,8 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
     abstract void doGetFieldMappings(ActionListener<Map<String, String>> fieldMappingsListener);
 
+    abstract void doMaybeCreateDestIndex(Map<String, String> deducedDestIndexMappings, ActionListener<Boolean> listener);
+
     abstract void doDeleteByQuery(DeleteByQueryRequest deleteByQueryRequest, ActionListener<BulkByScrollResponse> responseListener);
 
     abstract void refreshDestinationIndex(ActionListener<Void> responseListener);
@@ -288,7 +290,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
         // On each run, we need to get the total number of docs and reset the count of processed docs
         // Since multiple checkpoints can be executed in the task while it is running on the same node, we need to gather
         // the progress here, and not in the executor.
-        ActionListener<Void> configurationReadyListener = ActionListener.wrap(r -> {
+        ActionListener<Boolean> configurationReadyListener = ActionListener.wrap(unused -> {
             initializeFunction();
 
             if (initialRun()) {
@@ -339,7 +341,16 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 // ... otherwise we fall back to index mappings deduced based on source indices
                 this.fieldMappings = deducedDestIndexMappings.get();
             }
-            configurationReadyListener.onResponse(null);
+            // Since the unattended transform could not have created the destination index yet, we do it here.
+            // This is important to create the destination index explicitly before indexing first documents. Otherwise, the destination
+            // index aliases may be missing.
+            if (destIndexMappings.isEmpty()
+                && context.getCheckpoint() == 0
+                && Boolean.TRUE.equals(transformConfig.getSettings().getUnattended())) {
+                doMaybeCreateDestIndex(deducedDestIndexMappings.get(), configurationReadyListener);
+            } else {
+                configurationReadyListener.onResponse(null);
+            }
         }, listener::onFailure);
 
         ActionListener<Void> reLoadFieldMappingsListener = ActionListener.wrap(updateConfigResponse -> {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutor.java
@@ -46,6 +46,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 import org.elasticsearch.xpack.transform.Transform;
+import org.elasticsearch.xpack.transform.TransformExtension;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
 import org.elasticsearch.xpack.transform.persistence.SeqNoPrimaryTermAndIndex;
@@ -75,7 +76,7 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver resolver;
     private final TransformAuditor auditor;
-    private final Settings transformInternalIndexAdditionalSettings;
+    private final TransformExtension transformExtension;
     private volatile int numFailureRetries;
 
     public TransformPersistentTasksExecutor(
@@ -84,7 +85,7 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         ThreadPool threadPool,
         ClusterService clusterService,
         Settings settings,
-        Settings transformInternalIndexAdditionalSettings,
+        TransformExtension transformExtension,
         IndexNameExpressionResolver resolver
     ) {
         super(TransformField.TASK_NAME, ThreadPool.Names.GENERIC);
@@ -96,7 +97,7 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         this.auditor = transformServices.getAuditor();
         this.numFailureRetries = Transform.NUM_FAILURE_RETRIES_SETTING.get(settings);
         clusterService.getClusterSettings().addSettingsUpdateConsumer(Transform.NUM_FAILURE_RETRIES_SETTING, this::setNumFailureRetries);
-        this.transformInternalIndexAdditionalSettings = transformInternalIndexAdditionalSettings;
+        this.transformExtension = transformExtension;
     }
 
     @Override
@@ -192,6 +193,9 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         // We want the rest of the state to be populated in the task when it is loaded on the node so that users can force start it again
         // later if they want.
         final ClientTransformIndexerBuilder indexerBuilder = new ClientTransformIndexerBuilder().setClient(parentTaskClient)
+            .setClusterService(clusterService)
+            .setIndexNameExpressionResolver(resolver)
+            .setTransformExtension(transformExtension)
             .setTransformServices(transformServices);
 
         final SetOnce<TransformState> stateHolder = new SetOnce<>();
@@ -348,7 +352,7 @@ public class TransformPersistentTasksExecutor extends PersistentTasksExecutor<Tr
         TransformInternalIndex.createLatestVersionedIndexIfRequired(
             clusterService,
             parentTaskClient,
-            transformInternalIndexAdditionalSettings,
+            transformExtension.getTransformInternalIndexAdditionalSettings(),
             templateCheckListener
         );
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -22,6 +22,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -49,6 +51,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerPositio
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
+import org.elasticsearch.xpack.transform.TransformExtension;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
@@ -129,6 +132,9 @@ public class ClientTransformIndexerTests extends ESTestCase {
             final var client = new PitMockClient(threadPool, true);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
+                mock(ClusterService.class),
+                mock(IndexNameExpressionResolver.class),
+                mock(TransformExtension.class),
                 new TransformServices(
                     mock(IndexBasedTransformConfigManager.class),
                     mock(TransformCheckpointService.class),
@@ -223,6 +229,9 @@ public class ClientTransformIndexerTests extends ESTestCase {
             final var client = new PitMockClient(threadPool, false);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
+                mock(ClusterService.class),
+                mock(IndexNameExpressionResolver.class),
+                mock(TransformExtension.class),
                 new TransformServices(
                     mock(IndexBasedTransformConfigManager.class),
                     mock(TransformCheckpointService.class),
@@ -306,6 +315,9 @@ public class ClientTransformIndexerTests extends ESTestCase {
             final var client = new PitMockClient(threadPool, true);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
+                mock(ClusterService.class),
+                mock(IndexNameExpressionResolver.class),
+                mock(TransformExtension.class),
                 new TransformServices(
                     mock(IndexBasedTransformConfigManager.class),
                     mock(TransformCheckpointService.class),
@@ -393,6 +405,9 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
         MockClientTransformIndexer(
             ThreadPool threadPool,
+            ClusterService clusterService,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            TransformExtension transformExtension,
             TransformServices transformServices,
             CheckpointProvider checkpointProvider,
             AtomicReference<IndexerState> initialState,
@@ -409,6 +424,9 @@ public class ClientTransformIndexerTests extends ESTestCase {
         ) {
             super(
                 threadPool,
+                clusterService,
+                indexNameExpressionResolver,
+                transformExtension,
                 transformServices,
                 checkpointProvider,
                 initialState,
@@ -546,6 +564,9 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
         return new ClientTransformIndexer(
             mock(ThreadPool.class),
+            mock(ClusterService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(TransformExtension.class),
             new TransformServices(
                 mock(IndexBasedTransformConfigManager.class),
                 mock(TransformCheckpointService.class),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -20,6 +20,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker.Durability;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
@@ -48,6 +50,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.transform.Transform;
+import org.elasticsearch.xpack.transform.TransformExtension;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
@@ -109,6 +112,9 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
         MockedTransformIndexer(
             ThreadPool threadPool,
+            ClusterService clusterService,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            TransformExtension transformExtension,
             String executorName,
             IndexBasedTransformConfigManager transformsConfigManager,
             CheckpointProvider checkpointProvider,
@@ -124,6 +130,9 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         ) {
             super(
                 threadPool,
+                clusterService,
+                indexNameExpressionResolver,
+                transformExtension,
                 new TransformServices(
                     transformsConfigManager,
                     mock(TransformCheckpointService.class),
@@ -1041,6 +1050,9 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         }).when(transformConfigManager).getTransformConfiguration(any(), any());
         MockedTransformIndexer indexer = new MockedTransformIndexer(
             threadPool,
+            mock(ClusterService.class),
+            mock(IndexNameExpressionResolver.class),
+            mock(TransformExtension.class),
             executorName,
             transformConfigManager,
             mock(CheckpointProvider.class),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureOnStatePersistenceTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureOnStatePersistenceTests.java
@@ -11,6 +11,8 @@ import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -32,6 +34,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformStoredDoc;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
+import org.elasticsearch.xpack.transform.TransformExtension;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
@@ -61,6 +64,9 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
 
         MockClientTransformIndexer(
             ThreadPool threadPool,
+            ClusterService clusterService,
+            IndexNameExpressionResolver indexNameExpressionResolver,
+            TransformExtension transformExtension,
             TransformServices transformServices,
             CheckpointProvider checkpointProvider,
             AtomicReference<IndexerState> initialState,
@@ -77,6 +83,9 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
         ) {
             super(
                 threadPool,
+                clusterService,
+                indexNameExpressionResolver,
+                transformExtension,
                 transformServices,
                 checkpointProvider,
                 initialState,
@@ -214,6 +223,9 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
 
                 MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                     mock(ThreadPool.class),
+                    mock(ClusterService.class),
+                    mock(IndexNameExpressionResolver.class),
+                    mock(TransformExtension.class),
                     new TransformServices(
                         configManager,
                         mock(TransformCheckpointService.class),
@@ -296,6 +308,9 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 final var client = new NoOpClient(threadPool);
                 MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                     mock(ThreadPool.class),
+                    mock(ClusterService.class),
+                    mock(IndexNameExpressionResolver.class),
+                    mock(TransformExtension.class),
                     new TransformServices(
                         configManager,
                         mock(TransformCheckpointService.class),
@@ -427,6 +442,9 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
             final var client = new NoOpClient(threadPool);
             MockClientTransformIndexer indexer = new MockClientTransformIndexer(
                 mock(ThreadPool.class),
+                mock(ClusterService.class),
+                mock(IndexNameExpressionResolver.class),
+                mock(TransformExtension.class),
                 new TransformServices(
                     configManager,
                     mock(TransformCheckpointService.class),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -243,6 +243,11 @@ public class TransformIndexerStateTests extends ESTestCase {
         }
 
         @Override
+        void doMaybeCreateDestIndex(Map<String, String> deducedDestIndexMappings, ActionListener<Boolean> listener) {
+            listener.onResponse(null);
+        }
+
+        @Override
         void persistState(TransformState state, ActionListener<Void> listener) {
             persistedState = state;
             listener.onResponse(null);
@@ -310,6 +315,11 @@ public class TransformIndexerStateTests extends ESTestCase {
         @Override
         void doGetFieldMappings(ActionListener<Map<String, String>> fieldMappingsListener) {
             fieldMappingsListener.onResponse(Collections.emptyMap());
+        }
+
+        @Override
+        void doMaybeCreateDestIndex(Map<String, String> deducedDestIndexMappings, ActionListener<Boolean> listener) {
+            listener.onResponse(null);
         }
 
         @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -255,6 +255,11 @@ public class TransformIndexerTests extends ESTestCase {
             fieldMappingsListener.onResponse(Collections.emptyMap());
         }
 
+        @Override
+        void doMaybeCreateDestIndex(Map<String, String> deducedDestIndexMappings, ActionListener<Boolean> listener) {
+            listener.onResponse(null);
+        }
+
         public boolean waitingForNextSearch() {
             return super.getScheduledNextSearch() != null;
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.transform.TransformConfigVersion;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
+import org.elasticsearch.xpack.transform.DefaultTransformExtension;
 import org.elasticsearch.xpack.transform.Transform;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
@@ -458,7 +459,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             threadPool,
             clusterService,
             Settings.EMPTY,
-            Settings.EMPTY,
+            new DefaultTransformExtension(),
             TestIndexNameExpressionResolver.newInstance()
         );
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -43,6 +44,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
+import org.elasticsearch.xpack.transform.DefaultTransformExtension;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.TransformCheckpointService;
 import org.elasticsearch.xpack.transform.notifications.MockTransformAuditor;
@@ -196,6 +198,9 @@ public class TransformTaskTests extends ESTestCase {
 
     private ClientTransformIndexerBuilder indexerBuilder(TransformConfig transformConfig, TransformServices transformServices) {
         return new ClientTransformIndexerBuilder().setClient(new ParentTaskAssigningClient(client, TaskId.EMPTY_TASK_ID))
+            .setClusterService(mock(ClusterService.class))
+            .setIndexNameExpressionResolver(mock(IndexNameExpressionResolver.class))
+            .setTransformExtension(new DefaultTransformExtension())
             .setTransformConfig(transformConfig)
             .setTransformServices(transformServices);
     }


### PR DESCRIPTION
Currently, when unattended transform sees that the destination index is missing, it just ignores it and relies on the indexer to create the destination index dynamically i.e.: during indexing.
Unfortunately, in this case we do not perform the full destination index setup routine which includes setting destination index aliases.
This PR fixes that.
Additionally, this PR adds alias-related assertions to a number of tests (`TransformChainIT` and `TransformDestIndexIT`) which serve as a regression test for this bugfix.

Relates https://github.com/elastic/elasticsearch/issues/104146