### PR TITLE
Move test only code out of TransportShardBulkAction into test codebase

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -148,7 +148,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener
     ) {
         ClusterStateObserver observer = new ClusterStateObserver(clusterService, request.timeout(), logger, threadPool.getThreadContext());
-        performOnPrimary(request, primary, updateHelper, threadPool::absoluteTimeInMillis, (update, shardId, mappingListener) -> {
+        performOnPrimary(request, primary, updateHelper, (update, shardId, mappingListener) -> {
             assert update != null;
             assert shardId != null;
             mappingUpdatedAction.updateMappingOnMaster(shardId.getIndex(), update, mappingListener);
@@ -184,34 +184,6 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         BulkShardRequest request,
         IndexShard primary,
         UpdateHelper updateHelper,
-        LongSupplier nowInMillisSupplier,
-        MappingUpdatePerformer mappingUpdater,
-        Consumer<ActionListener<Void>> waitForMappingUpdate,
-        ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener,
-        ThreadPool threadPool,
-        String executorName
-    ) {
-        performOnPrimary(
-            request,
-            primary,
-            updateHelper,
-            nowInMillisSupplier,
-            mappingUpdater,
-            waitForMappingUpdate,
-            listener,
-            threadPool,
-            executorName,
-            null,
-            null,
-            DocumentParsingProvider.EMPTY_INSTANCE
-        );
-    }
-
-    public static void performOnPrimary(
-        BulkShardRequest request,
-        IndexShard primary,
-        UpdateHelper updateHelper,
-        LongSupplier nowInMillisSupplier,
         MappingUpdatePerformer mappingUpdater,
         Consumer<ActionListener<Void>> waitForMappingUpdate,
         ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener,
@@ -235,10 +207,9 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                     if (executeBulkItemRequest(
                         context,
                         updateHelper,
-                        nowInMillisSupplier,
+                        threadPool::absoluteTimeInMillis,
                         mappingUpdater,
                         waitForMappingUpdate,
-
                         ActionListener.wrap(v -> executor.execute(this), this::onRejection),
                         documentParsingProvider
                     ) == false) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -107,6 +107,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.bulk.stats.BulkOperationListener;
+import org.elasticsearch.index.replication.ESIndexLevelReplicationTestCase;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -1573,11 +1574,10 @@ public class AuthorizationServiceTests extends ESTestCase {
         IndexShard indexShard = mock(IndexShard.class);
         when(indexShard.getBulkOperationListener()).thenReturn(new BulkOperationListener() {
         });
-        TransportShardBulkAction.performOnPrimary(
+        ESIndexLevelReplicationTestCase.performOnPrimary(
             request,
             indexShard,
             new UpdateHelper(mock(ScriptService.class)),
-            System::currentTimeMillis,
             mappingUpdater,
             waitForMappingUpdate,
             future,


### PR DESCRIPTION
The overload is only used in tests, move it to the replication test case as a utility. Also, we always use the thread-pool for the current absolute time in production and can always use it in tests -> remove one argument here to make this code a little less confusing.
