### PR TITLE
Resolve/cluster handles IllegalArgumentException 'Unable to open connection'

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ResolveClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ResolveClusterIT.java
@@ -522,7 +522,6 @@ public class ResolveClusterIT extends AbstractMultiClustersTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/105489")
     public void testClusterResolveDisconnectedAndErrorScenarios() throws Exception {
         Map<String, Object> testClusterInfo = setupThreeClusters(false);
         String localIndex = (String) testClusterInfo.get("local.index");

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/resolve/TransportResolveClusterAction.java
@@ -253,6 +253,9 @@ public class TransportResolveClusterAction extends HandledTransportAction<Resolv
         if (e instanceof ConnectTransportException || e instanceof NoSuchRemoteClusterException) {
             return true;
         }
+        if (e instanceof IllegalStateException && e.getMessage().contains("Unable to open any connections")) {
+            return true;
+        }
         Throwable ill = ExceptionsHelper.unwrap(e, IllegalArgumentException.class);
         if (ill != null && ill.getMessage().contains("unknown host")) {
             return true;


### PR DESCRIPTION
Resolve/cluster should handle IllegalArgumentException 'Unable to open connection'
as connected=false and not display error. Scenario caught in failing IT test.

Fixes https://github.com/elastic/elasticsearch/issues/105489
