### PR TITLE
Fix issue when installing multiple test cluster plugins

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterFactory.java
@@ -152,10 +152,10 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                 createConfigDirectory();
                 copyExtraConfigFiles(); // extra config files might be needed for running cli tools like plugin install
                 copyExtraJarFiles();
-                installPlugins();
                 if (distributionDescriptor.getType() == DistributionType.INTEG_TEST) {
                     installModules();
                 }
+                installPlugins();
                 currentVersion = spec.getVersion();
             } else {
                 createConfigDirectory();
@@ -591,7 +591,7 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
 
         private void installPlugins() {
             if (spec.getPlugins().isEmpty() == false) {
-                Pattern pattern = Pattern.compile("(.+)(?:-\\d\\.\\d\\.\\d-SNAPSHOT\\.zip)?");
+                Pattern pattern = Pattern.compile("(.+)(?:-\\d+\\.\\d+\\.\\d+(-SNAPSHOT)?\\.zip)");
 
                 LOGGER.info("Installing plugins {} into node '{}", spec.getPlugins(), name);
                 List<Path> pluginPaths = Arrays.stream(System.getProperty(TESTS_CLUSTER_PLUGINS_PATH_SYSPROP).split(File.pathSeparator))
@@ -603,8 +603,8 @@ public abstract class AbstractLocalClusterFactory<S extends LocalClusterSpec, H 
                     .map(
                         pluginName -> pluginPaths.stream()
                             .map(path -> Pair.of(pattern.matcher(path.getFileName().toString()), path))
-                            .filter(pair -> pair.left.matches())
-                            .map(p -> p.right.getParent().resolve(p.left.group(1)))
+                            .filter(pair -> pair.left.matches() && pair.left.group(1).equals(pluginName))
+                            .map(p -> p.right.getParent().resolve(p.left.group(0)))
                             .findFirst()
                             .orElseThrow(() -> {
                                 String taskPath = System.getProperty("tests.task");

--- a/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
+++ b/x-pack/plugin/inference/qa/inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/inference/InferenceBaseRestTest.java
@@ -35,7 +35,7 @@ public class InferenceBaseRestTest extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
-        .plugin("org.elasticsearch.xpack.inference.mock.TestInferenceServicePlugin")
+        .plugin("inference-service-test")
         .user("x_pack_rest_user", "x-pack-test-password")
         .build();
 

--- a/x-pack/plugin/ml/qa/ml-inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceBaseRestTest.java
+++ b/x-pack/plugin/ml/qa/ml-inference-service-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/InferenceBaseRestTest.java
@@ -31,7 +31,7 @@ public class InferenceBaseRestTest extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
-        .plugin("org.elasticsearch.xpack.inference.mock.TestInferenceServicePlugin")
+        .plugin("inference-service-test")
         .user("x_pack_rest_user", "x-pack-test-password")
         .build();
 

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -54,7 +54,7 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         .setting("xpack.security.http.ssl.enabled", "false")
         .setting("xpack.security.operator_privileges.enabled", "true")
         .setting("path.repo", () -> repoDirectory.getRoot().getPath())
-        .plugin("org.elasticsearch.xpack.security.operator.OperatorPrivilegesTestPlugin")
+        .plugin("operator-privileges-test")
         .rolesFile(Resource.fromClasspath("roles.yml"))
         .configFile("service_tokens", Resource.fromClasspath("service_tokens"))
         .configFile("operator_users.yml", Resource.fromClasspath("operator_users.yml"))

--- a/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/SqlTestClusterWithRemote.java
+++ b/x-pack/plugin/sql/qa/server/multi-cluster-with-security/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/multi_cluster_with_security/SqlTestClusterWithRemote.java
@@ -43,7 +43,7 @@ public class SqlTestClusterWithRemote implements TestRule {
             .setting("xpack.license.self_generated.type", "trial")
             .setting("xpack.security.autoconfiguration.enabled", "false")
             .user(USER_NAME, PASSWORD)
-            .plugin(":x-pack:qa:freeze-plugin")
+            .plugin("freeze-plugin")
             .build();
     }
 
@@ -58,7 +58,7 @@ public class SqlTestClusterWithRemote implements TestRule {
             .setting("xpack.license.self_generated.type", "trial")
             .setting("xpack.security.autoconfiguration.enabled", "false")
             .user(USER_NAME, PASSWORD)
-            .plugin(":x-pack:qa:freeze-plugin")
+            .plugin("freeze-plugin")
             .build();
     }
 

--- a/x-pack/plugin/sql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/multi_node/SqlTestCluster.java
+++ b/x-pack/plugin/sql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/multi_node/SqlTestCluster.java
@@ -20,7 +20,7 @@ public class SqlTestCluster {
             .setting("xpack.watcher.enabled", "false")
             .setting("xpack.security.enabled", "false")
             .setting("xpack.license.self_generated.type", "trial")
-            .plugin(":x-pack:qa:freeze-plugin")
+            .plugin("freeze-plugin")
             .build();
     }
 }

--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/SqlTestCluster.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/SqlTestCluster.java
@@ -23,7 +23,7 @@ public class SqlTestCluster {
             .setting("xpack.license.self_generated.type", "trial");
 
         if (enableFreezing) {
-            settings = settings.plugin(":x-pack:qa:freeze-plugin");
+            settings = settings.plugin("freeze-plugin");
         }
 
         return settings.build();


### PR DESCRIPTION
This addresses an issue where trying to install multiple plugins in a test cluster would just attempt to install the first plugin multiple times. This also ensures that users get a proper error message when a plugin dependency is missing, as well as fixing a bug where you could not install a plugin which depended on a module when using the integ-test distribution.