### PR TITLE
Include user's privileges actions in IdP plugin `_has_privileges` request

### DIFF
--- a/docs/changelog/104026.yaml
+++ b/docs/changelog/104026.yaml
@@ -1,0 +1,5 @@
+pr: 104026
+summary: Include user's privileges actions in IdP plugin `_has_privileges` request
+area: IdentityProvider
+type: enhancement
+issues: []

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdentityProviderAuthenticationIT.java
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdentityProviderAuthenticationIT.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -185,8 +185,8 @@ public class IdentityProviderAuthenticationIT extends IdpRestTestCase {
                 equalTo("urn:oasis:names:tc:SAML:2.0:nameid-format:transient")
             );
             assertThat(ObjectPath.eval("metadata.saml_roles", authMap), instanceOf(List.class));
-            assertThat(ObjectPath.eval("metadata.saml_roles", authMap), hasSize(1));
-            assertThat(ObjectPath.eval("metadata.saml_roles", authMap), contains("viewer"));
+            assertThat(ObjectPath.eval("metadata.saml_roles", authMap), hasSize(2));
+            assertThat(ObjectPath.eval("metadata.saml_roles", authMap), containsInAnyOrder("viewer", "custom"));
         }
     }
 

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/resources/roles.yml
@@ -8,4 +8,4 @@ idp_user:
   applications:
     - application: elastic-cloud
       resources: ["ec:123456:abcdefg"]
-      privileges: ["sso:viewer"]
+      privileges: ["sso:viewer", "sso:custom"]

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolver.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolver.java
@@ -10,15 +10,20 @@ package org.elasticsearch.xpack.idp.privileges;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.action.user.GetUserPrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.user.GetUserPrivilegesRequest;
+import org.elasticsearch.xpack.core.security.action.user.GetUserPrivilegesRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.permission.ResourcePrivileges;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -128,7 +133,8 @@ public class UserPrivilegeResolver {
         ServiceProviderPrivileges service,
         ActionListener<RoleDescriptor.ApplicationResourcePrivileges> listener
     ) {
-        actionsResolver.getActions(service.getApplicationName(), listener.delegateFailureAndWrap((delegate, actions) -> {
+        var groupedListener = new GroupedActionListener<Set<String>>(2, listener.delegateFailureAndWrap((delegate, actionSets) -> {
+            final Set<String> actions = actionSets.stream().flatMap(Set::stream).collect(Collectors.toUnmodifiableSet());
             if (actions == null || actions.isEmpty()) {
                 logger.warn("No application-privilege actions defined for application [{}]", service.getApplicationName());
                 delegate.onResponse(null);
@@ -141,5 +147,24 @@ public class UserPrivilegeResolver {
                 delegate.onResponse(builder.build());
             }
         }));
+
+        // We need to enumerate possible actions that might be authorized for the user. Here we combine actions that
+        // have been granted to the user via roles and other actions that are registered privileges for the given
+        // application. These actions will be checked by a has-privileges check above
+        final GetUserPrivilegesRequest request = new GetUserPrivilegesRequestBuilder(client).username(securityContext.getUser().principal())
+            .request();
+        client.execute(
+            GetUserPrivilegesAction.INSTANCE,
+            request,
+            groupedListener.map(
+                userPrivileges -> userPrivileges.getApplicationPrivileges()
+                    .stream()
+                    .filter(appPriv -> appPriv.getApplication().equals(service.getApplicationName()))
+                    .map(appPriv -> appPriv.getPrivileges())
+                    .flatMap(Arrays::stream)
+                    .collect(Collectors.toUnmodifiableSet())
+            )
+        );
+        actionsResolver.getActions(service.getApplicationName(), groupedListener);
     }
 }

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolverTests.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/privileges/UserPrivilegeResolverTests.java
@@ -17,16 +17,20 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.action.user.GetUserPrivilegesAction;
+import org.elasticsearch.xpack.core.security.action.user.GetUserPrivilegesRequest;
+import org.elasticsearch.xpack.core.security.action.user.GetUserPrivilegesResponse;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesRequest;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesResponse;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.permission.ResourcePrivileges;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.junit.Before;
-import org.mockito.Mockito;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,11 +54,14 @@ public class UserPrivilegeResolverTests extends ESTestCase {
     private SecurityContext securityContext;
     private UserPrivilegeResolver resolver;
 
+    private String app;
+
     @Before
     @SuppressWarnings("unchecked")
     public void setupTest() {
         client = mock(Client.class);
         securityContext = new SecurityContext(Settings.EMPTY, new ThreadContext(Settings.EMPTY));
+        app = randomAlphaOfLengthBetween(3, 8);
         final ApplicationActionsResolver actionsResolver = mock(ApplicationActionsResolver.class);
         doAnswer(inv -> {
             final Object[] args = inv.getArguments();
@@ -63,12 +70,41 @@ public class UserPrivilegeResolverTests extends ESTestCase {
             listener.onResponse(Set.of("role:cluster:view", "role:cluster:admin", "role:cluster:operator", "role:cluster:monitor"));
             return null;
         }).when(actionsResolver).getActions(anyString(), any(ActionListener.class));
+        doAnswer(inv -> {
+            final Object[] args = inv.getArguments();
+            assertThat(args, arrayWithSize(3));
+            ActionListener<GetUserPrivilegesResponse> listener = (ActionListener<GetUserPrivilegesResponse>) args[args.length - 1];
+            RoleDescriptor.ApplicationResourcePrivileges appPriv1 = RoleDescriptor.ApplicationResourcePrivileges.builder()
+                .application(app)
+                .resources("resource1")
+                .privileges("role:extra1")
+                .build();
+            RoleDescriptor.ApplicationResourcePrivileges appPriv2 = RoleDescriptor.ApplicationResourcePrivileges.builder()
+                .application(app)
+                .resources("resource1")
+                .privileges("role:extra2", "role:extra3")
+                .build();
+            RoleDescriptor.ApplicationResourcePrivileges discardedAppPriv = RoleDescriptor.ApplicationResourcePrivileges.builder()
+                .application(randomAlphaOfLengthBetween(3, 8))
+                .resources("resource1")
+                .privileges("role:discarded")
+                .build();
+            GetUserPrivilegesResponse response = new GetUserPrivilegesResponse(
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of(appPriv1, appPriv2, discardedAppPriv),
+                Set.of(),
+                Set.of()
+            );
+            listener.onResponse(response);
+            return null;
+        }).when(client).execute(same(GetUserPrivilegesAction.INSTANCE), any(GetUserPrivilegesRequest.class), any(ActionListener.class));
         resolver = new UserPrivilegeResolver(client, securityContext, actionsResolver);
     }
 
     public void testResolveZeroAccess() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
-        final String app = randomAlphaOfLengthBetween(3, 8);
         setupUser(username, () -> {
             setupHasPrivileges(username, app);
             final PlainActionFuture<UserPrivilegeResolver.UserPrivileges> future = new PlainActionFuture<>();
@@ -93,7 +129,6 @@ public class UserPrivilegeResolverTests extends ESTestCase {
 
     public void testResolveSsoWithNoRoleAccess() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
-        final String app = randomAlphaOfLengthBetween(3, 8);
         final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
         final String viewerAction = "role:cluster:view";
         final String adminAction = "role:cluster:admin";
@@ -118,7 +153,6 @@ public class UserPrivilegeResolverTests extends ESTestCase {
 
     public void testResolveSsoWithSingleRole() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
-        final String app = randomAlphaOfLengthBetween(3, 8);
         final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
         final String viewerAction = "role:cluster:view";
         final String adminAction = "role:cluster:admin";
@@ -143,7 +177,6 @@ public class UserPrivilegeResolverTests extends ESTestCase {
 
     public void testResolveSsoWithMultipleRoles() throws Exception {
         final String username = randomAlphaOfLengthBetween(4, 12);
-        final String app = randomAlphaOfLengthBetween(3, 8);
         final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
         final String viewerAction = "role:cluster:view";
         final String adminAction = "role:cluster:admin";
@@ -183,6 +216,35 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         });
     }
 
+    public void testResolveSsoWithActionDefinedInUserPrivileges() throws Exception {
+        final String username = randomAlphaOfLengthBetween(4, 12);
+        final String resource = "cluster:" + MessageDigests.toHexString(randomByteArrayOfLength(16));
+        final String actionInUserPrivs = "role:extra2";
+        final String adminAction = "role:cluster:admin";
+
+        setupUser(username, () -> {
+            setupHasPrivileges(username, app, access(resource, actionInUserPrivs, true), access(resource, adminAction, false));
+
+            final PlainActionFuture<UserPrivilegeResolver.UserPrivileges> future = new PlainActionFuture<>();
+            final Function<String, Set<String>> roleMapping = Map.of(
+                actionInUserPrivs,
+                Set.of("extra2"),
+                adminAction,
+                Set.of("admin")
+            )::get;
+            resolver.resolve(service(app, resource, roleMapping), future);
+            final UserPrivilegeResolver.UserPrivileges privileges;
+            try {
+                privileges = future.get();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            assertThat(privileges.principal, equalTo(username));
+            assertThat(privileges.hasAccess, equalTo(true));
+            assertThat(privileges.roles, containsInAnyOrder("extra2"));
+        });
+    }
+
     private ServiceProviderPrivileges service(String appName, String resource, Function<String, Set<String>> roleMapping) {
         return new ServiceProviderPrivileges(appName, resource, roleMapping);
     }
@@ -209,10 +271,24 @@ public class UserPrivilegeResolverTests extends ESTestCase {
         final Map<String, Collection<ResourcePrivileges>> appPrivs = Map.of(appName, privileges);
         final HasPrivilegesResponse response = new HasPrivilegesResponse(username, isCompleteMatch, Map.of(), Set.of(), appPrivs);
 
-        Mockito.doAnswer(inv -> {
+        doAnswer(inv -> {
             final Object[] args = inv.getArguments();
             assertThat(args.length, equalTo(3));
             ActionListener<HasPrivilegesResponse> listener = (ActionListener<HasPrivilegesResponse>) args[args.length - 1];
+            HasPrivilegesRequest request = (HasPrivilegesRequest) args[1];
+            Set<String> gotPriviliges = Arrays.stream(request.applicationPrivileges())
+                .flatMap(appPriv -> Arrays.stream(appPriv.getPrivileges()))
+                .collect(Collectors.toUnmodifiableSet());
+            Set<String> expectedPrivileges = Set.of(
+                "role:cluster:view",
+                "role:cluster:admin",
+                "role:cluster:operator",
+                "role:cluster:monitor",
+                "role:extra1",
+                "role:extra2",
+                "role:extra3"
+            );
+            assertEquals(expectedPrivileges, gotPriviliges);
             listener.onResponse(response);
             return null;
         }).when(client).execute(same(HasPrivilegesAction.INSTANCE), any(HasPrivilegesRequest.class), any(ActionListener.class));


### PR DESCRIPTION


<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

Backport of #104026 to 8.12. Fixes a bug in the IdP plugin where a user's application privilege actions attached to their roles aren't considered when assigning SSO roles _unless_ the privilege is pre-registered as a named application privilege.
