### PR TITLE
Update node.asciidoc | english dialect clarity

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -69,7 +69,7 @@ A node that has the `master` role, which makes it eligible to be
 <<data-node,Data node>>::
 
 A node that has the `data` role. Data nodes hold data and perform data
-related operations such as CRUD, search, and aggregations. A node with the `data` role can fill any of the specialised data node roles.
+related operations such as CRUD, search, and aggregations. A node with the `data` role can fill any of the specialized data node roles.
 
 <<node-ingest-node,Ingest node>>::
 


### PR DESCRIPTION
I noticed that "specialized" is used twice is this doc and "specialised" is also used once in this doc. I'd like to clarify the english dialect (American vs British) we want to use for consistency.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
