### PR TITLE
Add `failure_store` parameter (data structure changes only)

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -537,3 +537,4 @@ The API returns the following results:
 // TESTRESPONSE[s/"job_version" : "8.4.0"/"job_version" : $body.job_version/]
 // TESTRESPONSE[s/1656087283340/$body.$_path/]
 // TESTRESPONSE[s/"superuser"/"_es_test_root"/]
+// TESTRESPONSE[s/"ignore_throttled" : true/"ignore_throttled" : true,"failure_store":"false"/]

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -29,6 +29,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.AutoscalingMissedIndicesUpdateException;
+import org.elasticsearch.indices.FailureIndexException;
 import org.elasticsearch.indices.recovery.RecoveryCommitTooNewException;
 import org.elasticsearch.ingest.GraphStructureException;
 import org.elasticsearch.rest.ApiNotAvailableException;
@@ -1910,6 +1911,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             GraphStructureException::new,
             177,
             TransportVersions.INGEST_GRAPH_STRUCTURE_EXCEPTION
+        ),
+        FAILURE_INDEX_EXCEPTION(
+            FailureIndexException.class,
+            FailureIndexException::new,
+            178,
+            TransportVersions.ADD_FAILURE_STORE_INDICES_OPTIONS
         );
 
         final Class<? extends ElasticsearchException> exceptionClass;

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -133,6 +133,7 @@ public class TransportVersions {
     public static final TransportVersion INDEX_REQUEST_NORMALIZED_BYTES_PARSED = def(8_593_00_0);
     public static final TransportVersion INGEST_GRAPH_STRUCTURE_EXCEPTION = def(8_594_00_0);
     public static final TransportVersion ML_MODEL_IN_SERVICE_SETTINGS = def(8_595_00_0);
+    public static final TransportVersion ADD_FAILURE_STORE_INDICES_OPTIONS = def(8_596_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -8,8 +8,11 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.core.Nullable;
@@ -47,8 +50,17 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeSt
 public record IndicesOptions(
     ConcreteTargetOptions concreteTargetOptions,
     WildcardOptions wildcardOptions,
-    GatekeeperOptions gatekeeperOptions
+    GatekeeperOptions gatekeeperOptions,
+    FailureStoreOptions failureStoreOptions
 ) implements ToXContentFragment {
+
+    public IndicesOptions(
+        ConcreteTargetOptions concreteTargetOptions,
+        WildcardOptions wildcardOptions,
+        GatekeeperOptions gatekeeperOptions
+    ) {
+        this(concreteTargetOptions, wildcardOptions, gatekeeperOptions, FailureStoreOptions.DEFAULT);
+    }
 
     public static IndicesOptions.Builder builder() {
         return new Builder();
@@ -289,18 +301,26 @@ public record IndicesOptions(
     }
 
     /**
-     * These options apply on all indices that have been selected by the other Options. It can either filter the response or
-     * define what type of indices or aliases are not allowed which will result in an error response.
+     * The "gatekeeper" options apply on all indices that have been selected by the other Options. It contains two type of flags:
+     * - The "allow*" flags, which purpose is to enable actions to define certain conditions that need to apply on the concrete indices
+     * they accept. For example, single-index actions will set allowAliasToMultipleIndices to false, while search will not accept a
+     * closed index etc. These options are not configurable by the end-user.
+     * - The ignoreThrottled flag, which is a depricared flag that will filter out frozen indices.
      * @param allowAliasToMultipleIndices, allow aliases to multiple indices, true by default.
      * @param allowClosedIndices, allow closed indices, true by default.
-     * @param ignoreThrottled, filters out throttled (aka frozen indices), defaults to true.
+     * @param allowFailureIndices, allow failure indices in the response, true by default
+     * @param ignoreThrottled, filters out throttled (aka frozen indices), defaults to true. This is deprecated and the only one
+     *                         that only filters and never throws an error.
      */
-    public record GatekeeperOptions(boolean allowAliasToMultipleIndices, boolean allowClosedIndices, @Deprecated boolean ignoreThrottled)
-        implements
-            ToXContentFragment {
+    public record GatekeeperOptions(
+        boolean allowAliasToMultipleIndices,
+        boolean allowClosedIndices,
+        boolean allowFailureIndices,
+        @Deprecated boolean ignoreThrottled
+    ) implements ToXContentFragment {
 
         public static final String IGNORE_THROTTLED = "ignore_throttled";
-        public static final GatekeeperOptions DEFAULT = new GatekeeperOptions(true, true, false);
+        public static final GatekeeperOptions DEFAULT = new GatekeeperOptions(true, true, true, false);
 
         public static GatekeeperOptions parseParameter(Object ignoreThrottled, GatekeeperOptions defaultOptions) {
             if (ignoreThrottled == null && defaultOptions != null) {
@@ -319,6 +339,7 @@ public record IndicesOptions(
         public static class Builder {
             private boolean allowAliasToMultipleIndices;
             private boolean allowClosedIndices;
+            private boolean allowFailureIndices;
             private boolean ignoreThrottled;
 
             public Builder() {
@@ -328,6 +349,7 @@ public record IndicesOptions(
             Builder(GatekeeperOptions options) {
                 allowAliasToMultipleIndices = options.allowAliasToMultipleIndices;
                 allowClosedIndices = options.allowClosedIndices;
+                allowFailureIndices = options.allowFailureIndices;
                 ignoreThrottled = options.ignoreThrottled;
             }
 
@@ -350,6 +372,15 @@ public record IndicesOptions(
             }
 
             /**
+             * Failure indices are accepted when true, otherwise the resolution will throw an error.
+             * Defaults to true.
+             */
+            public Builder allowFailureIndices(boolean allowFailureIndices) {
+                this.allowFailureIndices = allowFailureIndices;
+                return this;
+            }
+
+            /**
              * Throttled indices will not be included in the result. Defaults to false.
              */
             public Builder ignoreThrottled(boolean ignoreThrottled) {
@@ -358,7 +389,7 @@ public record IndicesOptions(
             }
 
             public GatekeeperOptions build() {
-                return new GatekeeperOptions(allowAliasToMultipleIndices, allowClosedIndices, ignoreThrottled);
+                return new GatekeeperOptions(allowAliasToMultipleIndices, allowClosedIndices, allowFailureIndices, ignoreThrottled);
             }
         }
 
@@ -368,6 +399,100 @@ public record IndicesOptions(
 
         public static Builder builder(GatekeeperOptions gatekeeperOptions) {
             return new Builder(gatekeeperOptions);
+        }
+    }
+
+    /**
+     * Applies to all indices already matched and controls the type of indices that will be returned. There are two types, data stream
+     * failure indices (only certain data streams have them) and data stream backing indices or stand-alone indices.
+     * @param includeRegularIndices, when true regular or data stream backing indices will be retrieved.
+     * @param includeFailureIndices, when true data stream failure indices will be included.
+     */
+    public record FailureStoreOptions(boolean includeRegularIndices, boolean includeFailureIndices)
+        implements
+            Writeable,
+            ToXContentFragment {
+
+        public static final String FAILURE_STORE = "failure_store";
+        public static final String INCLUDE_ALL = "true";
+        public static final String INCLUDE_ONLY_REGULAR_INDICES = "false";
+        public static final String INCLUDE_ONLY_FAILURE_INDICES = "only";
+
+        public static final FailureStoreOptions DEFAULT = new FailureStoreOptions(true, false);
+
+        public static FailureStoreOptions read(StreamInput in) throws IOException {
+            return new FailureStoreOptions(in.readBoolean(), in.readBoolean());
+        }
+
+        public static FailureStoreOptions parseParameters(Object failureStoreValue, FailureStoreOptions defaultOptions) {
+            if (failureStoreValue == null) {
+                return defaultOptions;
+            }
+            FailureStoreOptions.Builder builder = defaultOptions == null
+                ? new FailureStoreOptions.Builder()
+                : new FailureStoreOptions.Builder(defaultOptions);
+            return switch (failureStoreValue.toString()) {
+                case INCLUDE_ALL -> builder.includeRegularIndices(true).includeFailureIndices(true).build();
+                case INCLUDE_ONLY_REGULAR_INDICES -> builder.includeRegularIndices(true).includeFailureIndices(false).build();
+                case INCLUDE_ONLY_FAILURE_INDICES -> builder.includeRegularIndices(false).includeFailureIndices(true).build();
+                default -> throw new IllegalArgumentException("No valid " + FAILURE_STORE + " value [" + failureStoreValue + "]");
+            };
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.field(FAILURE_STORE, displayValue());
+        }
+
+        public String displayValue() {
+            if (includeRegularIndices && includeFailureIndices) {
+                return INCLUDE_ALL;
+            } else if (includeRegularIndices) {
+                return INCLUDE_ONLY_REGULAR_INDICES;
+            }
+            return INCLUDE_ONLY_FAILURE_INDICES;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(includeRegularIndices);
+            out.writeBoolean(includeFailureIndices);
+        }
+
+        public static class Builder {
+            private boolean includeRegularIndices;
+            private boolean includeFailureIndices;
+
+            public Builder() {
+                this(DEFAULT);
+            }
+
+            Builder(FailureStoreOptions options) {
+                includeRegularIndices = options.includeRegularIndices;
+                includeFailureIndices = options.includeFailureIndices;
+            }
+
+            public Builder includeRegularIndices(boolean includeRegularIndices) {
+                this.includeRegularIndices = includeRegularIndices;
+                return this;
+            }
+
+            public Builder includeFailureIndices(boolean includeFailureIndices) {
+                this.includeFailureIndices = includeFailureIndices;
+                return this;
+            }
+
+            public FailureStoreOptions build() {
+                return new FailureStoreOptions(includeRegularIndices, includeFailureIndices);
+            }
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder builder(FailureStoreOptions failureStoreOptions) {
+            return new Builder(failureStoreOptions);
         }
     }
 
@@ -403,9 +528,10 @@ public record IndicesOptions(
         EXCLUDE_ALIASES,
         ALLOW_EMPTY_WILDCARD_EXPRESSIONS,
         ERROR_WHEN_ALIASES_TO_MULTIPLE_INDICES,
-
         ERROR_WHEN_CLOSED_INDICES,
-        IGNORE_THROTTLED
+        IGNORE_THROTTLED,
+
+        ALLOW_FAILURE_INDICES // Added in 8.14
     }
 
     private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(IndicesOptions.class);
@@ -418,7 +544,8 @@ public record IndicesOptions(
     public static final IndicesOptions DEFAULT = new IndicesOptions(
         ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS,
         WildcardOptions.DEFAULT,
-        GatekeeperOptions.DEFAULT
+        GatekeeperOptions.DEFAULT,
+        FailureStoreOptions.DEFAULT
     );
 
     public static final IndicesOptions STRICT_EXPAND_OPEN = IndicesOptions.builder()
@@ -431,7 +558,14 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowAliasToMultipleIndices(true).allowClosedIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowAliasToMultipleIndices(true)
+                .allowClosedIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions LENIENT_EXPAND_OPEN = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS)
@@ -443,7 +577,14 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowAliasToMultipleIndices(true).allowClosedIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowAliasToMultipleIndices(true)
+                .allowClosedIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions LENIENT_EXPAND_OPEN_HIDDEN = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS)
@@ -455,7 +596,14 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowAliasToMultipleIndices(true).allowClosedIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowAliasToMultipleIndices(true)
+                .allowClosedIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions LENIENT_EXPAND_OPEN_CLOSED = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS)
@@ -467,14 +615,28 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowAliasToMultipleIndices(true).allowClosedIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowAliasToMultipleIndices(true)
+                .allowClosedIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions LENIENT_EXPAND_OPEN_CLOSED_HIDDEN = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS)
         .wildcardOptions(
             WildcardOptions.builder().matchOpen(true).matchClosed(true).includeHidden(true).allowEmptyExpressions(true).resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowAliasToMultipleIndices(true).allowClosedIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowAliasToMultipleIndices(true)
+                .allowClosedIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions STRICT_EXPAND_OPEN_CLOSED = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
@@ -486,14 +648,28 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowAliasToMultipleIndices(true).allowClosedIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowAliasToMultipleIndices(true)
+                .allowClosedIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions STRICT_EXPAND_OPEN_CLOSED_HIDDEN = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
         .wildcardOptions(
             WildcardOptions.builder().matchOpen(true).matchClosed(true).includeHidden(true).allowEmptyExpressions(true).resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowAliasToMultipleIndices(true).allowClosedIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowAliasToMultipleIndices(true)
+                .allowClosedIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions STRICT_EXPAND_OPEN_FORBID_CLOSED = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
@@ -505,7 +681,14 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowClosedIndices(false).allowAliasToMultipleIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowClosedIndices(false)
+                .allowAliasToMultipleIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
@@ -517,7 +700,14 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowClosedIndices(false).allowAliasToMultipleIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowClosedIndices(false)
+                .allowAliasToMultipleIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions STRICT_EXPAND_OPEN_FORBID_CLOSED_IGNORE_THROTTLED = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
@@ -529,7 +719,14 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().ignoreThrottled(true).allowClosedIndices(false).allowAliasToMultipleIndices(true))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .ignoreThrottled(true)
+                .allowClosedIndices(false)
+                .allowFailureIndices(true)
+                .allowAliasToMultipleIndices(true)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions STRICT_SINGLE_INDEX_NO_EXPAND_FORBID_CLOSED = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
@@ -541,7 +738,14 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowAliasToMultipleIndices(false).allowClosedIndices(false).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowAliasToMultipleIndices(false)
+                .allowClosedIndices(false)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
     public static final IndicesOptions STRICT_NO_EXPAND_FORBID_CLOSED = IndicesOptions.builder()
         .concreteTargetOptions(ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS)
@@ -553,7 +757,14 @@ public record IndicesOptions(
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .gatekeeperOptions(GatekeeperOptions.builder().allowClosedIndices(false).allowAliasToMultipleIndices(true).ignoreThrottled(false))
+        .gatekeeperOptions(
+            GatekeeperOptions.builder()
+                .allowClosedIndices(false)
+                .allowAliasToMultipleIndices(true)
+                .allowFailureIndices(true)
+                .ignoreThrottled(false)
+        )
+        .failureStoreOptions(FailureStoreOptions.builder().includeRegularIndices(true).includeFailureIndices(false))
         .build();
 
     /**
@@ -611,6 +822,13 @@ public record IndicesOptions(
     }
 
     /**
+     * @return Whether execution on closed indices is allowed.
+     */
+    public boolean allowFailureIndices() {
+        return gatekeeperOptions.allowFailureIndices();
+    }
+
+    /**
      * @return whether aliases pointing to multiple indices are allowed
      */
     public boolean allowAliasesToMultipleIndices() {
@@ -629,6 +847,20 @@ public record IndicesOptions(
      */
     public boolean ignoreThrottled() {
         return gatekeeperOptions().ignoreThrottled();
+    }
+
+    /**
+     * @return whether regular indices (stand-alone or backing indices) will be included in the response
+     */
+    public boolean includeRegularIndices() {
+        return failureStoreOptions().includeRegularIndices();
+    }
+
+    /**
+     * @return whether failure indices (only supported by certain data streams) will be included in the response
+     */
+    public boolean includeFailureIndices() {
+        return failureStoreOptions().includeFailureIndices();
     }
 
     public void writeIndicesOptions(StreamOutput out) throws IOException {
@@ -651,6 +883,11 @@ public record IndicesOptions(
         if (ignoreUnavailable()) {
             backwardsCompatibleOptions.add(Option.ALLOW_UNAVAILABLE_CONCRETE_TARGETS);
         }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ADD_FAILURE_STORE_INDICES_OPTIONS)) {
+            if (allowFailureIndices()) {
+                backwardsCompatibleOptions.add(Option.ALLOW_FAILURE_INDICES);
+            }
+        }
         out.writeEnumSet(backwardsCompatibleOptions);
 
         EnumSet<WildcardStates> states = EnumSet.noneOf(WildcardStates.class);
@@ -664,6 +901,9 @@ public record IndicesOptions(
             states.add(WildcardStates.HIDDEN);
         }
         out.writeEnumSet(states);
+        if (out.getTransportVersion().onOrAfter(TransportVersions.ADD_FAILURE_STORE_INDICES_OPTIONS)) {
+            failureStoreOptions.writeTo(out);
+        }
     }
 
     public static IndicesOptions readIndicesOptions(StreamInput in) throws IOException {
@@ -673,17 +913,26 @@ public record IndicesOptions(
             options.contains(Option.ALLOW_EMPTY_WILDCARD_EXPRESSIONS),
             options.contains(Option.EXCLUDE_ALIASES)
         );
+        boolean allowFailureIndices = true;
+        if (in.getTransportVersion().onOrAfter(TransportVersions.ADD_FAILURE_STORE_INDICES_OPTIONS)) {
+            allowFailureIndices = options.contains(Option.ALLOW_FAILURE_INDICES);
+        }
         GatekeeperOptions gatekeeperOptions = GatekeeperOptions.builder()
             .allowClosedIndices(options.contains(Option.ERROR_WHEN_CLOSED_INDICES) == false)
             .allowAliasToMultipleIndices(options.contains(Option.ERROR_WHEN_ALIASES_TO_MULTIPLE_INDICES) == false)
+            .allowFailureIndices(allowFailureIndices)
             .ignoreThrottled(options.contains(Option.IGNORE_THROTTLED))
             .build();
+        FailureStoreOptions failureStoreOptions = in.getTransportVersion().onOrAfter(TransportVersions.ADD_FAILURE_STORE_INDICES_OPTIONS)
+            ? FailureStoreOptions.read(in)
+            : FailureStoreOptions.DEFAULT;
         return new IndicesOptions(
             options.contains(Option.ALLOW_UNAVAILABLE_CONCRETE_TARGETS)
                 ? ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS
                 : ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS,
             wildcardOptions,
-            gatekeeperOptions
+            gatekeeperOptions,
+            failureStoreOptions
         );
     }
 
@@ -691,6 +940,7 @@ public record IndicesOptions(
         private ConcreteTargetOptions concreteTargetOptions;
         private WildcardOptions wildcardOptions;
         private GatekeeperOptions gatekeeperOptions;
+        private FailureStoreOptions failureStoreOptions;
 
         Builder() {
             this(DEFAULT);
@@ -700,6 +950,7 @@ public record IndicesOptions(
             concreteTargetOptions = indicesOptions.concreteTargetOptions;
             wildcardOptions = indicesOptions.wildcardOptions;
             gatekeeperOptions = indicesOptions.gatekeeperOptions;
+            failureStoreOptions = indicesOptions.failureStoreOptions;
         }
 
         public Builder concreteTargetOptions(ConcreteTargetOptions concreteTargetOptions) {
@@ -722,13 +973,23 @@ public record IndicesOptions(
             return this;
         }
 
-        public Builder gatekeeperOptions(GatekeeperOptions.Builder gatekeeperOptions) {
-            this.gatekeeperOptions = gatekeeperOptions.build();
+        public Builder gatekeeperOptions(GatekeeperOptions.Builder generalOptions) {
+            this.gatekeeperOptions = generalOptions.build();
+            return this;
+        }
+
+        public Builder failureStoreOptions(FailureStoreOptions failureStoreOptions) {
+            this.failureStoreOptions = failureStoreOptions;
+            return this;
+        }
+
+        public Builder failureStoreOptions(FailureStoreOptions.Builder failureStoreOptions) {
+            this.failureStoreOptions = failureStoreOptions.build();
             return this;
         }
 
         public IndicesOptions build() {
-            return new IndicesOptions(concreteTargetOptions, wildcardOptions, gatekeeperOptions);
+            return new IndicesOptions(concreteTargetOptions, wildcardOptions, gatekeeperOptions, failureStoreOptions);
         }
     }
 
@@ -830,7 +1091,8 @@ public record IndicesOptions(
         return new IndicesOptions(
             ignoreUnavailable ? ConcreteTargetOptions.ALLOW_UNAVAILABLE_TARGETS : ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS,
             wildcards,
-            gatekeeperOptions
+            gatekeeperOptions,
+            FailureStoreOptions.DEFAULT
         );
     }
 
@@ -844,11 +1106,28 @@ public record IndicesOptions(
             request.param(ConcreteTargetOptions.IGNORE_UNAVAILABLE),
             request.param(WildcardOptions.ALLOW_NO_INDICES),
             request.param(GatekeeperOptions.IGNORE_THROTTLED),
+            DataStream.isFailureStoreEnabled()
+                ? request.param(FailureStoreOptions.FAILURE_STORE)
+                : FailureStoreOptions.INCLUDE_ONLY_REGULAR_INDICES,
             defaultSettings
         );
     }
 
     public static IndicesOptions fromMap(Map<String, Object> map, IndicesOptions defaultSettings) {
+        if (DataStream.isFailureStoreEnabled()) {
+            return fromParameters(
+                map.containsKey(WildcardOptions.EXPAND_WILDCARDS) ? map.get(WildcardOptions.EXPAND_WILDCARDS) : map.get("expandWildcards"),
+                map.containsKey(ConcreteTargetOptions.IGNORE_UNAVAILABLE)
+                    ? map.get(ConcreteTargetOptions.IGNORE_UNAVAILABLE)
+                    : map.get("ignoreUnavailable"),
+                map.containsKey(WildcardOptions.ALLOW_NO_INDICES) ? map.get(WildcardOptions.ALLOW_NO_INDICES) : map.get("allowNoIndices"),
+                map.containsKey(GatekeeperOptions.IGNORE_THROTTLED)
+                    ? map.get(GatekeeperOptions.IGNORE_THROTTLED)
+                    : map.get("ignoreThrottled"),
+                map.containsKey(FailureStoreOptions.FAILURE_STORE) ? map.get(FailureStoreOptions.FAILURE_STORE) : map.get("failureStore"),
+                defaultSettings
+            );
+        }
         return fromParameters(
             map.containsKey(WildcardOptions.EXPAND_WILDCARDS) ? map.get(WildcardOptions.EXPAND_WILDCARDS) : map.get("expandWildcards"),
             map.containsKey(ConcreteTargetOptions.IGNORE_UNAVAILABLE)
@@ -872,7 +1151,9 @@ public record IndicesOptions(
             || GatekeeperOptions.IGNORE_THROTTLED.equals(name)
             || "ignoreThrottled".equals(name)
             || WildcardOptions.ALLOW_NO_INDICES.equals(name)
-            || "allowNoIndices".equals(name);
+            || "allowNoIndices".equals(name)
+            || (DataStream.isFailureStoreEnabled() && FailureStoreOptions.FAILURE_STORE.equals(name))
+            || (DataStream.isFailureStoreEnabled() && "failureStore".equals(name));
     }
 
     public static IndicesOptions fromParameters(
@@ -882,18 +1163,37 @@ public record IndicesOptions(
         Object ignoreThrottled,
         IndicesOptions defaultSettings
     ) {
-        if (wildcardsString == null && ignoreUnavailableString == null && allowNoIndicesString == null && ignoreThrottled == null) {
+        return fromParameters(wildcardsString, ignoreUnavailableString, allowNoIndicesString, ignoreThrottled, null, defaultSettings);
+    }
+
+    public static IndicesOptions fromParameters(
+        Object wildcardsString,
+        Object ignoreUnavailableString,
+        Object allowNoIndicesString,
+        Object ignoreThrottled,
+        Object failureStoreString,
+        IndicesOptions defaultSettings
+    ) {
+        if (wildcardsString == null
+            && ignoreUnavailableString == null
+            && allowNoIndicesString == null
+            && ignoreThrottled == null
+            && failureStoreString == null) {
             return defaultSettings;
         }
 
         WildcardOptions wildcards = WildcardOptions.parseParameters(wildcardsString, allowNoIndicesString, defaultSettings.wildcardOptions);
         GatekeeperOptions gatekeeperOptions = GatekeeperOptions.parseParameter(ignoreThrottled, defaultSettings.gatekeeperOptions);
+        FailureStoreOptions failureStoreOptions = DataStream.isFailureStoreEnabled()
+            ? FailureStoreOptions.parseParameters(failureStoreString, defaultSettings.failureStoreOptions)
+            : FailureStoreOptions.DEFAULT;
 
         // note that allowAliasesToMultipleIndices is not exposed, always true (only for internal use)
         return IndicesOptions.builder()
             .concreteTargetOptions(ConcreteTargetOptions.fromParameter(ignoreUnavailableString, defaultSettings.concreteTargetOptions))
             .wildcardOptions(wildcards)
             .gatekeeperOptions(gatekeeperOptions)
+            .failureStoreOptions(failureStoreOptions)
             .build();
     }
 
@@ -902,6 +1202,9 @@ public record IndicesOptions(
         concreteTargetOptions.toXContent(builder, params);
         wildcardOptions.toXContent(builder, params);
         gatekeeperOptions.toXContent(builder, params);
+        if (DataStream.isFailureStoreEnabled()) {
+            failureStoreOptions.toXContent(builder, params);
+        }
         return builder;
     }
 
@@ -909,6 +1212,7 @@ public record IndicesOptions(
     private static final ParseField IGNORE_UNAVAILABLE_FIELD = new ParseField(ConcreteTargetOptions.IGNORE_UNAVAILABLE);
     private static final ParseField IGNORE_THROTTLED_FIELD = new ParseField(GatekeeperOptions.IGNORE_THROTTLED).withAllDeprecated();
     private static final ParseField ALLOW_NO_INDICES_FIELD = new ParseField(WildcardOptions.ALLOW_NO_INDICES);
+    private static final ParseField FAILURE_STORE_FIELD = new ParseField(FailureStoreOptions.FAILURE_STORE);
 
     public static IndicesOptions fromXContent(XContentParser parser) throws IOException {
         return fromXContent(parser, null);
@@ -919,6 +1223,7 @@ public record IndicesOptions(
         WildcardOptions.Builder wildcards = defaults == null ? null : WildcardOptions.builder(defaults.wildcardOptions());
         GatekeeperOptions.Builder generalOptions = GatekeeperOptions.builder()
             .ignoreThrottled(defaults != null && defaults.gatekeeperOptions().ignoreThrottled());
+        FailureStoreOptions failureStoreOptions = defaults == null ? FailureStoreOptions.DEFAULT : defaults.failureStoreOptions();
         Boolean allowNoIndices = defaults == null ? null : defaults.allowNoIndices();
         Boolean ignoreUnavailable = defaults == null ? null : defaults.ignoreUnavailable();
         Token token = parser.currentToken() == Token.START_OBJECT ? parser.currentToken() : parser.nextToken();
@@ -968,13 +1273,16 @@ public record IndicesOptions(
                     allowNoIndices = parser.booleanValue();
                 } else if (IGNORE_THROTTLED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     generalOptions.ignoreThrottled(parser.booleanValue());
-                } else {
-                    throw new ElasticsearchParseException(
-                        "could not read indices options. unexpected index option [" + currentFieldName + "]"
-                    );
-                }
+                } else if (DataStream.isFailureStoreEnabled()
+                    && FAILURE_STORE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        failureStoreOptions = FailureStoreOptions.parseParameters(parser.text(), failureStoreOptions);
+                    } else {
+                        throw new ElasticsearchParseException(
+                            "could not read indices options. Unexpected index option [" + currentFieldName + "]"
+                        );
+                    }
             } else {
-                throw new ElasticsearchParseException("could not read indices options. unexpected object field [" + currentFieldName + "]");
+                throw new ElasticsearchParseException("could not read indices options. Unexpected object field [" + currentFieldName + "]");
             }
         }
 
@@ -998,6 +1306,7 @@ public record IndicesOptions(
             .concreteTargetOptions(new ConcreteTargetOptions(ignoreUnavailable))
             .wildcardOptions(wildcards)
             .gatekeeperOptions(generalOptions)
+            .failureStoreOptions(failureStoreOptions)
             .build();
     }
 
@@ -1111,6 +1420,14 @@ public record IndicesOptions(
             + ignoreAliases()
             + ", ignore_throttled="
             + ignoreThrottled()
+            + (DataStream.isFailureStoreEnabled()
+                ? ", include_regular_indices="
+                    + includeRegularIndices()
+                    + ", include_failure_indices="
+                    + includeFailureIndices()
+                    + ", allow_failure_indices="
+                    + allowFailureIndices()
+                : "")
             + ']';
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/FailureIndexException.java
+++ b/server/src/main/java/org/elasticsearch/indices/FailureIndexException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+
+/**
+ * Exception indicating that one or more requested indices are failure indices.
+ */
+public final class FailureIndexException extends ElasticsearchException {
+
+    public FailureIndexException(Index index) {
+        super("failure_index");
+        setIndex(index);
+    }
+
+    public FailureIndexException(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.BAD_REQUEST;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -60,6 +60,7 @@ import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotInPrimaryModeException;
 import org.elasticsearch.indices.AutoscalingMissedIndicesUpdateException;
+import org.elasticsearch.indices.FailureIndexException;
 import org.elasticsearch.indices.IndexTemplateMissingException;
 import org.elasticsearch.indices.InvalidIndexTemplateException;
 import org.elasticsearch.indices.recovery.PeerRecoveryNotFound;
@@ -827,6 +828,7 @@ public class ExceptionSerializationTests extends ESTestCase {
         ids.put(175, AutoscalingMissedIndicesUpdateException.class);
         ids.put(176, SearchTimeoutException.class);
         ids.put(177, GraphStructureException.class);
+        ids.put(178, FailureIndexException.class);
 
         Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
         for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.action.support.IndicesOptions.ConcreteTargetOptions;
+import org.elasticsearch.action.support.IndicesOptions.FailureStoreOptions;
 import org.elasticsearch.action.support.IndicesOptions.GatekeeperOptions;
 import org.elasticsearch.action.support.IndicesOptions.WildcardOptions;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -40,17 +41,25 @@ public class IndicesOptionsTests extends ESTestCase {
     public void testSerialization() throws Exception {
         int iterations = randomIntBetween(5, 20);
         for (int i = 0; i < iterations; i++) {
-            IndicesOptions indicesOptions = IndicesOptions.fromOptions(
-                randomBoolean(),
-                randomBoolean(),
-                randomBoolean(),
-                randomBoolean(),
-                randomBoolean(),
-                randomBoolean(),
-                randomBoolean(),
-                randomBoolean(),
-                randomBoolean()
-            );
+            IndicesOptions indicesOptions = IndicesOptions.builder()
+                .wildcardOptions(
+                    WildcardOptions.builder()
+                        .matchOpen(randomBoolean())
+                        .matchClosed(randomBoolean())
+                        .includeHidden(randomBoolean())
+                        .allowEmptyExpressions(randomBoolean())
+                        .resolveAliases(randomBoolean())
+                )
+                .gatekeeperOptions(
+                    GatekeeperOptions.builder()
+                        .ignoreThrottled(randomBoolean())
+                        .allowAliasToMultipleIndices(randomBoolean())
+                        .allowClosedIndices(randomBoolean())
+                )
+                .failureStoreOptions(
+                    FailureStoreOptions.builder().includeRegularIndices(randomBoolean()).includeFailureIndices(randomBoolean())
+                )
+                .build();
 
             BytesStreamOutput output = new BytesStreamOutput();
             indicesOptions.writeIndicesOptions(output);
@@ -58,16 +67,7 @@ public class IndicesOptionsTests extends ESTestCase {
             StreamInput streamInput = output.bytes().streamInput();
             IndicesOptions indicesOptions2 = IndicesOptions.readIndicesOptions(streamInput);
 
-            assertThat(indicesOptions2.ignoreUnavailable(), equalTo(indicesOptions.ignoreUnavailable()));
-            assertThat(indicesOptions2.allowNoIndices(), equalTo(indicesOptions.allowNoIndices()));
-            assertThat(indicesOptions2.expandWildcardsOpen(), equalTo(indicesOptions.expandWildcardsOpen()));
-            assertThat(indicesOptions2.expandWildcardsClosed(), equalTo(indicesOptions.expandWildcardsClosed()));
-            assertThat(indicesOptions2.expandWildcardsHidden(), equalTo(indicesOptions.expandWildcardsHidden()));
-
-            assertThat(indicesOptions2.forbidClosedIndices(), equalTo(indicesOptions.forbidClosedIndices()));
-            assertThat(indicesOptions2.allowAliasesToMultipleIndices(), equalTo(indicesOptions.allowAliasesToMultipleIndices()));
-
-            assertEquals(indicesOptions2.ignoreAliases(), indicesOptions.ignoreAliases());
+            assertThat(indicesOptions2, equalTo(indicesOptions));
         }
     }
 
@@ -343,9 +343,10 @@ public class IndicesOptionsTests extends ESTestCase {
             randomBoolean(),
             randomBoolean()
         );
-        GatekeeperOptions gatekeeperOptions = new GatekeeperOptions(randomBoolean(), randomBoolean(), randomBoolean());
+        GatekeeperOptions gatekeeperOptions = new GatekeeperOptions(randomBoolean(), randomBoolean(), randomBoolean(), randomBoolean());
+        FailureStoreOptions failureStoreOptions = new IndicesOptions.FailureStoreOptions(randomBoolean(), randomBoolean());
 
-        IndicesOptions indicesOptions = new IndicesOptions(concreteTargetOptions, wildcardOptions, gatekeeperOptions);
+        IndicesOptions indicesOptions = new IndicesOptions(concreteTargetOptions, wildcardOptions, gatekeeperOptions, failureStoreOptions);
 
         XContentType type = randomFrom(XContentType.values());
         BytesReference xContentBytes = toXContentBytes(indicesOptions, type);
@@ -360,6 +361,7 @@ public class IndicesOptionsTests extends ESTestCase {
         assertThat(map.get("ignore_unavailable"), equalTo(concreteTargetOptions.allowUnavailableTargets()));
         assertThat(map.get("allow_no_indices"), equalTo(wildcardOptions.allowEmptyExpressions()));
         assertThat(map.get("ignore_throttled"), equalTo(gatekeeperOptions.ignoreThrottled()));
+        assertThat(map.get("failure_store"), equalTo(failureStoreOptions.displayValue()));
     }
 
     public void testFromXContent() throws IOException {

--- a/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/IndicesOptionsTests.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.action.support;
 
 import org.elasticsearch.action.support.IndicesOptions.ConcreteTargetOptions;
-import org.elasticsearch.action.support.IndicesOptions.GeneralOptions;
+import org.elasticsearch.action.support.IndicesOptions.GatekeeperOptions;
 import org.elasticsearch.action.support.IndicesOptions.WildcardOptions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -343,9 +343,9 @@ public class IndicesOptionsTests extends ESTestCase {
             randomBoolean(),
             randomBoolean()
         );
-        GeneralOptions generalOptions = new GeneralOptions(randomBoolean(), randomBoolean(), randomBoolean());
+        GatekeeperOptions gatekeeperOptions = new GatekeeperOptions(randomBoolean(), randomBoolean(), randomBoolean());
 
-        IndicesOptions indicesOptions = new IndicesOptions(concreteTargetOptions, wildcardOptions, generalOptions);
+        IndicesOptions indicesOptions = new IndicesOptions(concreteTargetOptions, wildcardOptions, gatekeeperOptions);
 
         XContentType type = randomFrom(XContentType.values());
         BytesReference xContentBytes = toXContentBytes(indicesOptions, type);
@@ -359,7 +359,7 @@ public class IndicesOptionsTests extends ESTestCase {
         assertThat(((List<?>) map.get("expand_wildcards")).contains("hidden"), equalTo(wildcardOptions.includeHidden()));
         assertThat(map.get("ignore_unavailable"), equalTo(concreteTargetOptions.allowUnavailableTargets()));
         assertThat(map.get("allow_no_indices"), equalTo(wildcardOptions.allowEmptyExpressions()));
-        assertThat(map.get("ignore_throttled"), equalTo(generalOptions.ignoreThrottled()));
+        assertThat(map.get("ignore_throttled"), equalTo(gatekeeperOptions.ignoreThrottled()));
     }
 
     public void testFromXContent() throws IOException {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -2294,7 +2294,7 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
                 new IndicesOptions(
                     IndicesOptions.ConcreteTargetOptions.ERROR_WHEN_UNAVAILABLE_TARGETS,
                     IndicesOptions.WildcardOptions.DEFAULT,
-                    IndicesOptions.GeneralOptions.builder().ignoreThrottled(true).build()
+                    IndicesOptions.GatekeeperOptions.builder().ignoreThrottled(true).build()
                 ),
                 "ind*",
                 "test-index"

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedNodeSelectorTests.java
@@ -338,8 +338,8 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
                 "cannot start datafeed [datafeed_id] because it failed resolving indices given [not_foo] and "
                     + "indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, expand_wildcards_open=true, "
                     + "expand_wildcards_closed=false, expand_wildcards_hidden=false, allow_aliases_to_multiple_indices=true, "
-                    + "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true]] "
-                    + "with exception [no such index [not_foo]]"
+                    + "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true, include_regular_indices=true, "
+                    + "include_failure_indices=false, allow_failure_indices=true]] with exception [no such index [not_foo]]"
             )
         );
 
@@ -361,8 +361,9 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
                     + "[cannot start datafeed [datafeed_id] because it failed resolving "
                     + "indices given [not_foo] and indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, "
                     + "expand_wildcards_open=true, expand_wildcards_closed=false, expand_wildcards_hidden=false, "
-                    + "allow_aliases_to_multiple_indices=true, forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true"
-                    + "]] with exception [no such index [not_foo]]]"
+                    + "allow_aliases_to_multiple_indices=true, forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true, "
+                    + "include_regular_indices=true, include_failure_indices=false, allow_failure_indices=true]] "
+                    + "with exception [no such index [not_foo]]]"
             )
         );
     }
@@ -527,8 +528,8 @@ public class DatafeedNodeSelectorTests extends ESTestCase {
                     + "[cannot start datafeed [datafeed_id] because it failed resolving indices given [not_foo] and "
                     + "indices_options [IndicesOptions[ignore_unavailable=false, allow_no_indices=true, expand_wildcards_open=true, "
                     + "expand_wildcards_closed=false, expand_wildcards_hidden=false, allow_aliases_to_multiple_indices=true, "
-                    + "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true]] "
-                    + "with exception [no such index [not_foo]]]"
+                    + "forbid_closed_indices=true, ignore_aliases=false, ignore_throttled=true, include_regular_indices=true, "
+                    + "include_failure_indices=false, allow_failure_indices=true]] with exception [no such index [not_foo]]]"
             )
         );
     }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/index/IndexResolver.java
@@ -124,8 +124,8 @@ public class IndexResolver {
                 .allowEmptyExpressions(true)
                 .resolveAliases(false)
         )
-        .generalOptions(
-            IndicesOptions.GeneralOptions.builder().ignoreThrottled(true).allowClosedIndices(true).allowAliasToMultipleIndices(true)
+        .gatekeeperOptions(
+            IndicesOptions.GatekeeperOptions.builder().ignoreThrottled(true).allowClosedIndices(true).allowAliasToMultipleIndices(true)
         )
         .build();
     private static final IndicesOptions FROZEN_INDICES_OPTIONS = IndicesOptions.builder()
@@ -138,8 +138,8 @@ public class IndexResolver {
                 .allowEmptyExpressions(true)
                 .resolveAliases(false)
         )
-        .generalOptions(
-            IndicesOptions.GeneralOptions.builder().ignoreThrottled(false).allowClosedIndices(true).allowAliasToMultipleIndices(true)
+        .gatekeeperOptions(
+            IndicesOptions.GatekeeperOptions.builder().ignoreThrottled(false).allowClosedIndices(true).allowAliasToMultipleIndices(true)
         )
         .build();
 
@@ -153,8 +153,8 @@ public class IndexResolver {
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .generalOptions(
-            IndicesOptions.GeneralOptions.builder().ignoreThrottled(true).allowClosedIndices(true).allowAliasToMultipleIndices(true)
+        .gatekeeperOptions(
+            IndicesOptions.GatekeeperOptions.builder().ignoreThrottled(true).allowClosedIndices(true).allowAliasToMultipleIndices(true)
         )
         .build();
     public static final IndicesOptions FIELD_CAPS_FROZEN_INDICES_OPTIONS = IndicesOptions.builder()
@@ -167,8 +167,8 @@ public class IndexResolver {
                 .allowEmptyExpressions(true)
                 .resolveAliases(true)
         )
-        .generalOptions(
-            IndicesOptions.GeneralOptions.builder().ignoreThrottled(false).allowClosedIndices(true).allowAliasToMultipleIndices(true)
+        .gatekeeperOptions(
+            IndicesOptions.GatekeeperOptions.builder().ignoreThrottled(false).allowClosedIndices(true).allowAliasToMultipleIndices(true)
         )
         .build();
 


### PR DESCRIPTION
This PR is the first part of https://github.com/elastic/elasticsearch/pull/105386. It contains all the changes behind the transport version and it is meant to help with the reviewing process.

In this PR we introduce the `FailureStoreOptions` and the `FailureIndexException` which will be used later by the `org.elasticsearch.cluster.metadata.IndexNameExpressionResolver`.