### PR TITLE
Reduce InternalBinaryRange and InternalRandomSampler in a streaming fashion (take 2)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -12,18 +12,18 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.FixedMultiBucketAggregatorsReducer;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -248,50 +248,32 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
 
         return new AggregatorReducer() {
 
-            final List<InternalBinaryRange> aggregations = new ArrayList<>(size);
+            final FixedMultiBucketAggregatorsReducer<Bucket> reducer = new FixedMultiBucketAggregatorsReducer<>(
+                reduceContext,
+                size,
+                getBuckets()
+            ) {
+
+                @Override
+                protected Bucket createBucket(Bucket proto, long docCount, InternalAggregations aggregations) {
+                    return new Bucket(proto.format, proto.keyed, proto.key, proto.from, proto.to, docCount, aggregations);
+                }
+            };
 
             @Override
             public void accept(InternalAggregation aggregation) {
-                aggregations.add((InternalBinaryRange) aggregation);
+                InternalBinaryRange binaryRange = (InternalBinaryRange) aggregation;
+                reducer.accept(binaryRange.getBuckets());
             }
 
             @Override
             public InternalAggregation get() {
-                reduceContext.consumeBucketsAndMaybeBreak(buckets.size());
-                long[] docCounts = new long[buckets.size()];
-                InternalAggregations[][] aggs = new InternalAggregations[buckets.size()][];
-                for (int i = 0; i < aggs.length; ++i) {
-                    aggs[i] = new InternalAggregations[aggregations.size()];
-                }
-                for (int i = 0; i < aggregations.size(); ++i) {
-                    InternalBinaryRange range = aggregations.get(i);
-                    if (range.buckets.size() != buckets.size()) {
-                        throw new IllegalStateException(
-                            "Expected [" + buckets.size() + "] buckets, but got [" + range.buckets.size() + "]"
-                        );
-                    }
-                    for (int j = 0; j < buckets.size(); ++j) {
-                        Bucket bucket = range.buckets.get(j);
-                        docCounts[j] += bucket.docCount;
-                        aggs[j][i] = bucket.aggregations;
-                    }
-                }
-                List<Bucket> buckets = new ArrayList<>(getBuckets().size());
-                for (int i = 0; i < getBuckets().size(); ++i) {
-                    Bucket b = getBuckets().get(i);
-                    buckets.add(
-                        new Bucket(
-                            format,
-                            keyed,
-                            b.key,
-                            b.from,
-                            b.to,
-                            docCounts[i],
-                            InternalAggregations.reduce(Arrays.asList(aggs[i]), reduceContext)
-                        )
-                    );
-                }
-                return new InternalBinaryRange(name, format, keyed, buckets, metadata);
+                return new InternalBinaryRange(name, format, keyed, reducer.get(), metadata);
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(reducer);
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/InternalRandomSampler.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/InternalRandomSampler.java
@@ -10,8 +10,10 @@ package org.elasticsearch.search.aggregations.bucket.sampler.random;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
+import org.elasticsearch.search.aggregations.AggregatorsReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.InternalSingleBucketAggregation;
@@ -20,8 +22,6 @@ import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 public class InternalRandomSampler extends InternalSingleBucketAggregation implements Sampler {
@@ -79,23 +79,27 @@ public class InternalRandomSampler extends InternalSingleBucketAggregation imple
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
         return new AggregatorReducer() {
             long docCount = 0L;
-            final List<InternalAggregations> subAggregationsList = new ArrayList<>(size);
+            final AggregatorsReducer subAggregatorReducer = new AggregatorsReducer(reduceContext, size);
 
             @Override
             public void accept(InternalAggregation aggregation) {
                 docCount += ((InternalSingleBucketAggregation) aggregation).getDocCount();
-                subAggregationsList.add(((InternalSingleBucketAggregation) aggregation).getAggregations());
+                subAggregatorReducer.accept(((InternalSingleBucketAggregation) aggregation).getAggregations());
             }
 
             @Override
             public InternalAggregation get() {
-                InternalAggregations aggs = InternalAggregations.reduce(subAggregationsList, reduceContext);
+                InternalAggregations aggs = subAggregatorReducer.get();
                 if (reduceContext.isFinalReduce() && aggs != null) {
                     SamplingContext context = buildContext();
                     aggs = InternalAggregations.from(aggs.asList().stream().map(agg -> agg.finalizeSampling(context)).toList());
                 }
-
                 return newAggregation(getName(), docCount, aggs);
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(subAggregatorReducer);
             }
         };
     }


### PR DESCRIPTION
Similarly to https://github.com/elastic/elasticsearch/pull/105323 and https://github.com/elastic/elasticsearch/pull/105348, InternalBinaryRange and InternalRandomSampler can be wasteful and can be reduced in a streaming fashion.

relates https://github.com/elastic/elasticsearch/pull/105207

this is the same PR as https://github.com/elastic/elasticsearch/pull/105381 but properly closing resources.

