### PR TITLE
[8.13] Update min CCS version to that used by 8.12 (#104739)

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -197,7 +197,7 @@ public class TransportVersions {
      * Reference to the minimum transport version that can be used with CCS.
      * This should be the transport version used by the previous minor release.
      */
-    public static final TransportVersion MINIMUM_CCS_VERSION = V_8_11_X;
+    public static final TransportVersion MINIMUM_CCS_VERSION = V_8_12_0;
 
     static final NavigableMap<Integer, TransportVersion> VERSION_IDS = getAllVersionIds(TransportVersions.class);
 


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Update min CCS version to that used by 8.12 (#104739)