### PR TITLE
[Connectors API] Update ingestion stats test - Add sync job id null check test

### DIFF
--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobIngestionStatsActionRequestTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobIngestionStatsActionRequestTests.java
@@ -47,6 +47,21 @@ public class UpdateConnectorSyncJobIngestionStatsActionRequestTests extends ESTe
         assertThat(exception.getMessage(), containsString(EMPTY_CONNECTOR_SYNC_JOB_ID_ERROR_MESSAGE));
     }
 
+    public void testValidate_WhenConnectorSyncJobIdIsNull_ExpectValidationError() {
+        UpdateConnectorSyncJobIngestionStatsAction.Request request = new UpdateConnectorSyncJobIngestionStatsAction.Request(
+            null,
+            0L,
+            0L,
+            0L,
+            0L,
+            Instant.now()
+        );
+        ActionRequestValidationException exception = request.validate();
+
+        assertThat(exception, notNullValue());
+        assertThat(exception.getMessage(), containsString(EMPTY_CONNECTOR_SYNC_JOB_ID_ERROR_MESSAGE));
+    }
+
     public void testValidate_WhenDeletedDocumentCountIsNegative_ExpectValidationError() {
         UpdateConnectorSyncJobIngestionStatsAction.Request request = new UpdateConnectorSyncJobIngestionStatsAction.Request(
             randomAlphaOfLength(10),


### PR DESCRIPTION
Another instance, where we should test that `null` ids are always caught correctly