### PR TITLE
[Connectors Secrets API] Move null checks from constructor to validate

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsConstants.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/ConnectorSecretsConstants.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.secrets;
+
+public class ConnectorSecretsConstants {
+
+    public static final String CONNECTOR_SECRET_ID_NULL_OR_EMPTY_MESSAGE = "[id] of the connector secret cannot be null or empty.";
+
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretRequest.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsConstants;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -23,7 +24,7 @@ public class DeleteConnectorSecretRequest extends ActionRequest {
     private final String id;
 
     public DeleteConnectorSecretRequest(String id) {
-        this.id = Objects.requireNonNull(id);
+        this.id = id;
     }
 
     public DeleteConnectorSecretRequest(StreamInput in) throws IOException {
@@ -46,7 +47,10 @@ public class DeleteConnectorSecretRequest extends ActionRequest {
         ActionRequestValidationException validationException = null;
 
         if (Strings.isNullOrEmpty(id)) {
-            validationException = addValidationError("id missing", validationException);
+            validationException = addValidationError(
+                ConnectorSecretsConstants.CONNECTOR_SECRET_ID_NULL_OR_EMPTY_MESSAGE,
+                validationException
+            );
         }
 
         return validationException;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretRequest.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsConstants;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -46,7 +47,10 @@ public class GetConnectorSecretRequest extends ActionRequest {
         ActionRequestValidationException validationException = null;
 
         if (Strings.isNullOrEmpty(id)) {
-            validationException = addValidationError("id missing", validationException);
+            validationException = addValidationError(
+                ConnectorSecretsConstants.CONNECTOR_SECRET_ID_NULL_OR_EMPTY_MESSAGE,
+                validationException
+            );
         }
 
         return validationException;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/DeleteConnectorSecretActionTests.java
@@ -9,8 +9,10 @@ package org.elasticsearch.xpack.application.connector.secrets.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsConstants;
 import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsTestUtils;
 
+import static org.elasticsearch.xpack.application.connector.ConnectorTestUtils.NULL_STRING;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -29,6 +31,14 @@ public class DeleteConnectorSecretActionTests extends ESTestCase {
         ActionRequestValidationException exception = requestWithMissingConnectorId.validate();
 
         assertThat(exception, notNullValue());
-        assertThat(exception.getMessage(), containsString("id missing"));
+        assertThat(exception.getMessage(), containsString(ConnectorSecretsConstants.CONNECTOR_SECRET_ID_NULL_OR_EMPTY_MESSAGE));
+    }
+
+    public void testValidate_WhenConnectorSecretIdIsNull_ExpectValidationError() {
+        DeleteConnectorSecretRequest requestWithMissingConnectorId = new DeleteConnectorSecretRequest(NULL_STRING);
+        ActionRequestValidationException exception = requestWithMissingConnectorId.validate();
+
+        assertThat(exception, notNullValue());
+        assertThat(exception.getMessage(), containsString(ConnectorSecretsConstants.CONNECTOR_SECRET_ID_NULL_OR_EMPTY_MESSAGE));
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/secrets/action/GetConnectorSecretActionTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.application.connector.secrets.action;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsConstants;
 import org.elasticsearch.xpack.application.connector.secrets.ConnectorSecretsTestUtils;
 
 import static org.hamcrest.Matchers.containsString;
@@ -29,6 +30,14 @@ public class GetConnectorSecretActionTests extends ESTestCase {
         ActionRequestValidationException exception = requestWithMissingConnectorId.validate();
 
         assertThat(exception, notNullValue());
-        assertThat(exception.getMessage(), containsString("id missing"));
+        assertThat(exception.getMessage(), containsString(ConnectorSecretsConstants.CONNECTOR_SECRET_ID_NULL_OR_EMPTY_MESSAGE));
+    }
+
+    public void testValidate_WhenConnectorSecretIdIsNull_ExpectValidationError() {
+        GetConnectorSecretRequest requestWithMissingConnectorId = new GetConnectorSecretRequest("");
+        ActionRequestValidationException exception = requestWithMissingConnectorId.validate();
+
+        assertThat(exception, notNullValue());
+        assertThat(exception.getMessage(), containsString(ConnectorSecretsConstants.CONNECTOR_SECRET_ID_NULL_OR_EMPTY_MESSAGE));
     }
 }


### PR DESCRIPTION
This PR moves the `null` checks from the constructors of `DeleteConnectorSecretRequest` and `GetConnectorSecretRequest` to the `validate` method so we don't run into a NPE, but have a clear error message. Also adjusted the error message to adhere to ES best practices + added tests.

I'm actually not 100% sure, when you can get `null` from a request in the URL, but better be safe than sorry :)