### PR TITLE
[Connectors API] Unify enum error messages and add more tests

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorStatus.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorStatus.java
@@ -37,6 +37,6 @@ public enum ConnectorStatus {
                 return connectorStatus;
             }
         }
-        throw new IllegalArgumentException("Unknown ConnectorStatus: " + status);
+        throw new IllegalArgumentException("Unknown " + ConnectorStatus.class.getSimpleName() + " [" + status + "].");
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSyncStatus.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSyncStatus.java
@@ -37,7 +37,7 @@ public enum ConnectorSyncStatus {
             }
         }
 
-        throw new IllegalArgumentException("Unknown sync status '" + syncStatusString + "'.");
+        throw new IllegalArgumentException("Unknown " + ConnectorSyncStatus.class.getSimpleName() + " [" + syncStatusString + "].");
     }
 
     @Override
@@ -51,6 +51,6 @@ public enum ConnectorSyncStatus {
                 return connectorSyncStatus;
             }
         }
-        throw new IllegalArgumentException("Unknown ConnectorSyncStatus: " + status);
+        throw new IllegalArgumentException("Unknown " + ConnectorSyncStatus.class.getSimpleName() + " [" + status + "].");
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDisplayType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDisplayType.java
@@ -28,6 +28,6 @@ public enum ConfigurationDisplayType {
                 return displayType;
             }
         }
-        throw new IllegalArgumentException("Unknown DisplayType: " + type);
+        throw new IllegalArgumentException("Unknown " + ConfigurationDisplayType.class.getSimpleName() + " [" + type + "].");
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationFieldType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationFieldType.java
@@ -30,6 +30,6 @@ public enum ConfigurationFieldType {
                 return fieldType;
             }
         }
-        throw new IllegalArgumentException("Unknown FieldType: " + type);
+        throw new IllegalArgumentException("Unknown " + ConfigurationFieldType.class.getSimpleName() + " [" + type + "].");
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidationType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidationType.java
@@ -27,6 +27,6 @@ public enum ConfigurationValidationType {
                 return displayType;
             }
         }
-        throw new IllegalArgumentException("Unknown ValidationType: " + type);
+        throw new IllegalArgumentException("Unknown " + ConfigurationValidationType.class.getSimpleName() + " [" + type + "].");
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringPolicy.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringPolicy.java
@@ -24,6 +24,6 @@ public enum FilteringPolicy {
                 return filteringPolicy;
             }
         }
-        throw new IllegalArgumentException("Unknown FilteringPolicy: " + policy);
+        throw new IllegalArgumentException("Unknown " + FilteringPolicy.class.getSimpleName() + " [" + policy + "].");
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRuleCondition.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRuleCondition.java
@@ -33,6 +33,6 @@ public enum FilteringRuleCondition {
                 return filteringRuleCondition;
             }
         }
-        throw new IllegalArgumentException("Unknown FilteringRuleCondition: " + condition);
+        throw new IllegalArgumentException("Unknown " + FilteringRuleCondition.class.getSimpleName() + " [" + condition + "].");
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringValidationState.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringValidationState.java
@@ -25,6 +25,6 @@ public enum FilteringValidationState {
                 return filteringValidationState;
             }
         }
-        throw new IllegalArgumentException("Unknown FilteringValidationState: " + validationState);
+        throw new IllegalArgumentException("Unknown " + FilteringValidationState.class.getSimpleName() + " [" + validationState + "].");
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTriggerMethod.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobTriggerMethod.java
@@ -20,7 +20,9 @@ public enum ConnectorSyncJobTriggerMethod {
             }
         }
 
-        throw new IllegalArgumentException("Unknown trigger method '" + triggerMethodString + "'.");
+        throw new IllegalArgumentException(
+            "Unknown " + ConnectorSyncJobTriggerMethod.class.getSimpleName() + " [" + triggerMethodString + "]."
+        );
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobType.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobType.java
@@ -21,7 +21,7 @@ public enum ConnectorSyncJobType {
             }
         }
 
-        throw new IllegalArgumentException("Unknown sync job type '" + syncJobTypeString + "'.");
+        throw new IllegalArgumentException("Unknown " + ConnectorSyncJobType.class.getSimpleName() + " [" + syncJobTypeString + "].");
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorStatusTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorStatusTests.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ConnectorStatusTests extends ESTestCase {
+
+    public void testConnectorStatus_WithValidConnectorStatusString() {
+        ConnectorStatus connectorStatus = ConnectorTestUtils.getRandomConnectorStatus();
+
+        assertThat(ConnectorStatus.connectorStatus(connectorStatus.toString()), equalTo(connectorStatus));
+    }
+
+    public void testConnectorStatus_WithInvalidConnectorStatusString_ExpectIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> ConnectorStatus.connectorStatus("invalid connector status"));
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorSyncStatusTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorSyncStatusTests.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ConnectorSyncStatusTests extends ESTestCase {
+
+    public void testConnectorSyncStatus_WithValidConnectorSyncStatusString() {
+        ConnectorSyncStatus connectorSyncStatus = ConnectorTestUtils.getRandomSyncStatus();
+
+        assertThat(ConnectorSyncStatus.connectorSyncStatus(connectorSyncStatus.toString()), equalTo(connectorSyncStatus));
+    }
+
+    public void testConnectorSyncStatus_WithInvalidConnectorSyncStatusString_ExpectIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> ConnectorSyncStatus.connectorSyncStatus("invalid connector sync status"));
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -152,7 +152,7 @@ public final class ConnectorTestUtils {
                             .setId(randomAlphaOfLength(10))
                             .setOrder(randomInt())
                             .setPolicy(getRandomFilteringPolicy())
-                            .setRule(getRandomFilteringRule())
+                            .setRule(getRandomFilteringRuleCondition())
                             .setUpdatedAt(currentTimestamp)
                             .setValue(randomAlphaOfLength(10))
                             .build()
@@ -180,7 +180,7 @@ public final class ConnectorTestUtils {
                                 .setId(randomAlphaOfLength(10))
                                 .setOrder(randomInt())
                                 .setPolicy(getRandomFilteringPolicy())
-                                .setRule(getRandomFilteringRule())
+                                .setRule(getRandomFilteringRuleCondition())
                                 .setUpdatedAt(currentTimestamp)
                                 .setValue(randomAlphaOfLength(10))
                                 .build()
@@ -378,32 +378,32 @@ public final class ConnectorTestUtils {
         return values[randomInt(values.length - 1)];
     }
 
-    private static FilteringPolicy getRandomFilteringPolicy() {
+    public static FilteringPolicy getRandomFilteringPolicy() {
         FilteringPolicy[] values = FilteringPolicy.values();
         return values[randomInt(values.length - 1)];
     }
 
-    private static FilteringRuleCondition getRandomFilteringRule() {
+    public static FilteringRuleCondition getRandomFilteringRuleCondition() {
         FilteringRuleCondition[] values = FilteringRuleCondition.values();
         return values[randomInt(values.length - 1)];
     }
 
-    private static FilteringValidationState getRandomFilteringValidationState() {
+    public static FilteringValidationState getRandomFilteringValidationState() {
         FilteringValidationState[] values = FilteringValidationState.values();
         return values[randomInt(values.length - 1)];
     }
 
-    private static ConfigurationDisplayType getRandomConfigurationDisplayType() {
+    public static ConfigurationDisplayType getRandomConfigurationDisplayType() {
         ConfigurationDisplayType[] values = ConfigurationDisplayType.values();
         return values[randomInt(values.length - 1)];
     }
 
-    private static ConfigurationFieldType getRandomConfigurationFieldType() {
+    public static ConfigurationFieldType getRandomConfigurationFieldType() {
         ConfigurationFieldType[] values = ConfigurationFieldType.values();
         return values[randomInt(values.length - 1)];
     }
 
-    private static ConfigurationValidationType getRandomConfigurationValidationType() {
+    public static ConfigurationValidationType getRandomConfigurationValidationType() {
         ConfigurationValidationType[] values = ConfigurationValidationType.values();
         return values[randomInt(values.length - 1)];
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDisplayTypeTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDisplayTypeTests.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.configuration;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ConfigurationDisplayTypeTests extends ESTestCase {
+
+    public void testDisplayType_WithValidConfigurationDisplayTypeString() {
+        ConfigurationDisplayType displayType = ConnectorTestUtils.getRandomConfigurationDisplayType();
+
+        assertThat(ConfigurationDisplayType.displayType(displayType.toString()), equalTo(displayType));
+    }
+
+    public void testDisplayType_WithInvalidConfigurationDisplayTypeString_ExpectIllegalArgumentException() {
+        expectThrows(IllegalArgumentException.class, () -> ConfigurationDisplayType.displayType("invalid configuration display type"));
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationFieldTypeTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationFieldTypeTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.configuration;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ConfigurationFieldTypeTests extends ESTestCase {
+
+    public void testFieldType_WithValidConfigurationFieldTypeString() {
+        ConfigurationFieldType fieldType = ConnectorTestUtils.getRandomConfigurationFieldType();
+
+        assertThat(ConfigurationFieldType.fieldType(fieldType.toString()), equalTo(fieldType));
+    }
+
+    public void testFieldType_WithInvalidConfigurationFieldTypeString_ExpectIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> ConfigurationFieldType.fieldType("invalid field type"));
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidationTypeTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidationTypeTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.configuration;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class ConfigurationValidationTypeTests extends ESTestCase {
+
+    public void testValidationType_WithValidConfigurationValidationTypeString() {
+        ConfigurationValidationType validationType = ConnectorTestUtils.getRandomConfigurationValidationType();
+
+        assertThat(ConfigurationValidationType.validationType(validationType.toString()), equalTo(validationType));
+    }
+
+    public void testValidationType_WithInvalidConfigurationValidationTypeString_ExpectIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> ConfigurationValidationType.validationType("invalid validation type"));
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/filtering/FilteringPolicyTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/filtering/FilteringPolicyTests.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.filtering;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class FilteringPolicyTests extends ESTestCase {
+
+    public void testFilteringPolicy_WithValidFilteringPolicyString() {
+        FilteringPolicy filteringPolicy = ConnectorTestUtils.getRandomFilteringPolicy();
+
+        assertThat(FilteringPolicy.filteringPolicy(filteringPolicy.toString()), equalTo(filteringPolicy));
+    }
+
+    public void testFilteringPolicy_WithInvalidFilteringPolicyString_ExpectIllegalArgumentException() {
+        assertThrows(IllegalArgumentException.class, () -> FilteringPolicy.filteringPolicy("invalid filtering policy"));
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRuleConditionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRuleConditionTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.filtering;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class FilteringRuleConditionTests extends ESTestCase {
+
+    public void testFilteringRuleCondition_WithValidFilteringRuleConditionString() {
+        FilteringRuleCondition ruleCondition = ConnectorTestUtils.getRandomFilteringRuleCondition();
+
+        assertThat(FilteringRuleCondition.filteringRuleCondition(ruleCondition.toString()), equalTo(ruleCondition));
+    }
+
+    public void testFilteringRuleCondition_WithInvalidFilteringRuleConditionString_ExpectIllegalArgumentException() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> FilteringRuleCondition.filteringRuleCondition("invalid filtering rule condition")
+        );
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/filtering/FilteringValidationStateTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/filtering/FilteringValidationStateTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector.filtering;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class FilteringValidationStateTests extends ESTestCase {
+
+    public void testFilteringValidationState_WithValidFilteringValidationStateString() {
+        FilteringValidationState validationState = ConnectorTestUtils.getRandomFilteringValidationState();
+
+        assertThat(FilteringValidationState.filteringValidationState(validationState.toString()), equalTo(validationState));
+    }
+
+    public void testFilteringValidationState_WithInvalidFilteringValidationStateString_ExpectIllegalArgumentException() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> FilteringValidationState.filteringValidationState("invalid filtering validation state")
+        );
+    }
+
+}


### PR DESCRIPTION
This PR includes the following changes:

- Unified the enum error messages (following the ES error message format), if an invalid string is passed - also using the class name in the error message so renaming is automatically reflected in the error message
- Added tests for enum parsing