### PR TITLE
[8.12] Always show `composed_of` field for composable index templates (#105315)

### DIFF
--- a/docs/changelog/105315.yaml
+++ b/docs/changelog/105315.yaml
@@ -1,0 +1,6 @@
+pr: 105315
+summary: Always show `composed_of` field for composable index templates
+area: Indices APIs
+type: bug
+issues:
+ - 104627

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
@@ -188,3 +188,16 @@ setup:
                   type: keyword
             lifecycle:
               data_retention: "30d"
+
+---
+"Get index template always shows composed_of":
+  - skip:
+      version: " - 8.12.99"
+      reason: "A bug was fixed in 8.13.0 to make `composed_of` always returned"
+
+  - do:
+      indices.get_index_template:
+        name: test
+
+  - match: {index_templates.0.name: test}
+  - match: {index_templates.0.index_template.composed_of: []}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -125,7 +125,7 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
     ) {
         this.indexPatterns = indexPatterns;
         this.template = template;
-        this.componentTemplates = componentTemplates;
+        this.componentTemplates = componentTemplates == null ? List.of() : componentTemplates;
         this.priority = priority;
         this.version = version;
         this.metadata = metadata;


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Always show `composed_of` field for composable index templates (#105315)