### PR TITLE
Update skip version on rule_query tests

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
@@ -239,7 +239,7 @@ setup:
 ---
 "Perform a rule query with an organic query that must be rewritten to another query type":
   - skip:
-      version: " - 8.13.99"
+      version: " - 8.12.2"
       reason: Bugfix that was broken in previous versions
 
   - do:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
@@ -239,7 +239,7 @@ setup:
 ---
 "Perform a rule query with an organic query that must be rewritten to another query type":
   - skip:
-      version: " - 8.12.2"
+      version: " - 8.12.1"
       reason: Bugfix that was broken in previous versions
 
   - do:

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
@@ -140,6 +140,7 @@ public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansio
 
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+
         if (weightedTokensSupplier != null) {
             if (weightedTokensSupplier.get() == null) {
                 return this;


### PR DESCRIPTION
Now that https://github.com/elastic/elasticsearch/pull/105365 has been merged and backported this updates the skip version on tests