### PR TITLE
Save needless TreeMap.contains in TimeSeriesIdFieldMapper

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapper.java
@@ -345,11 +345,9 @@ public class TimeSeriesIdFieldMapper extends MetadataFieldMapper {
         }
 
         private void add(String fieldName, BytesReference encoded) throws IOException {
-            final Dimension dimension = new Dimension(new BytesRef(fieldName), encoded);
-            if (dimensions.contains(dimension)) {
+            if (dimensions.add(new Dimension(new BytesRef(fieldName), encoded)) == false) {
                 throw new IllegalArgumentException("Dimension field [" + fieldName + "] cannot be a multi-valued field.");
             }
-            dimensions.add(dimension);
         }
     }
 


### PR DESCRIPTION
Random find from profiling:
We were burning quite a few cycles here on traversing the tree map twice.
