### PR TITLE
`URLRepository` should not block shutdown

### DIFF
--- a/docs/changelog/105588.yaml
+++ b/docs/changelog/105588.yaml
@@ -1,0 +1,5 @@
+pr: 105588
+summary: '`URLRepository` should not block shutdown'
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-url/src/internalClusterTest/java/org/elasticsearch/repositories/url/URLSnapshotRestoreIT.java
+++ b/modules/repository-url/src/internalClusterTest/java/org/elasticsearch/repositories/url/URLSnapshotRestoreIT.java
@@ -125,4 +125,17 @@ public class URLSnapshotRestoreIT extends ESIntegTestCase {
         getSnapshotsResponse = client.admin().cluster().prepareGetSnapshots("url-repo").get();
         assertThat(getSnapshotsResponse.getSnapshots().size(), equalTo(0));
     }
+
+    public void testUrlRepositoryPermitsShutdown() throws Exception {
+        assertAcked(
+            client().admin()
+                .cluster()
+                .preparePutRepository("url-repo")
+                .setType(URLRepository.TYPE)
+                .setVerify(false)
+                .setSettings(Settings.builder().put(URLRepository.URL_SETTING.getKey(), "http://localhost/"))
+        );
+
+        internalCluster().fullRestart(); // just checking that URL repositories don't block node shutdown
+    }
 }

--- a/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
@@ -186,5 +186,6 @@ public class URLRepository extends BlobStoreRepository {
     @Override
     protected void doClose() {
         IOUtils.closeWhileHandlingException(httpClient);
+        super.doClose();
     }
 }


### PR DESCRIPTION
Today a node with a registered `URLRepository` will not shut down
cleanly because it never releases the last of the `activityRefs`. This
commit fixes that.