### PR TITLE
Speedup BytesArray.indexOf

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -59,9 +59,6 @@ public final class BytesArray extends AbstractBytesReference {
     @Override
     public int indexOf(byte marker, int from) {
         final int len = length - from;
-        if (len <= 0) {
-            return -1;
-        }
         int off = offset + from;
         final int toIndex = offset + length;
         // First, try to find the marker in the first few bytes, so we can enter the faster 8-byte aligned loop below.

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -108,6 +108,9 @@ public final class CompositeBytesReference extends AbstractBytesReference {
 
     @Override
     public int indexOf(byte marker, int from) {
+        final int remainingBytes = Math.max(length - from, 0);
+        Objects.checkFromIndexSize(from, remainingBytes, length);
+
         int result = -1;
         if (length == 0) {
             return result;

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -108,9 +108,6 @@ public final class CompositeBytesReference extends AbstractBytesReference {
 
     @Override
     public int indexOf(byte marker, int from) {
-        final int remainingBytes = Math.max(length - from, 0);
-        Objects.checkFromIndexSize(from, remainingBytes, length);
-
         int result = -1;
         if (length == 0) {
             return result;

--- a/server/src/test/java/org/elasticsearch/common/bytes/BytesArrayTests.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/BytesArrayTests.java
@@ -7,22 +7,22 @@
  */
 package org.elasticsearch.common.bytes;
 
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.hamcrest.Matchers;
 
 import java.io.IOException;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class BytesArrayTests extends AbstractBytesReferenceTestCase {
 
     @Override
-    protected BytesReference newBytesReference(int length) throws IOException {
+    protected BytesReference newBytesReference(int length) {
         return newBytesReference(length, randomInt(length));
     }
 
     @Override
-    protected BytesReference newBytesReferenceWithOffsetOfZero(int length) throws IOException {
+    protected BytesReference newBytesReferenceWithOffsetOfZero(int length) {
         return newBytesReference(length, 0);
     }
 
@@ -31,28 +31,29 @@ public class BytesArrayTests extends AbstractBytesReferenceTestCase {
         return new BytesArray(content);
     }
 
-    private BytesReference newBytesReference(int length, int offset) throws IOException {
-        // we know bytes stream output always creates a paged bytes reference, we use it to create randomized content
-        final BytesStreamOutput out = new BytesStreamOutput(length + offset);
-        for (int i = 0; i < length + offset; i++) {
-            out.writeByte((byte) random().nextInt(1 << 8));
+    private BytesReference newBytesReference(int length, int offset) {
+        // randomly add some bytes at the end of the bytes reference
+        int tail = randomBoolean() ? 0 : randomIntBetween(0, length + offset);
+        final byte[] out = new byte[length + offset + tail];
+        for (int i = 0; i < length + offset + tail; i++) {
+            out[i] = (byte) random().nextInt(1 << 8);
         }
-        assertEquals(length + offset, out.size());
-        BytesArray ref = new BytesArray(out.bytes().toBytesRef().bytes, offset, length);
+        BytesArray ref = new BytesArray(out, offset, length);
         assertEquals(length, ref.length());
         assertTrue(ref instanceof BytesArray);
         assertThat(ref.length(), Matchers.equalTo(length));
         return ref;
     }
 
-    public void testArray() throws IOException {
+    public void testArray() {
         int[] sizes = { 0, randomInt(PAGE_SIZE), PAGE_SIZE, randomIntBetween(2, PAGE_SIZE * randomIntBetween(2, 5)) };
 
         for (int i = 0; i < sizes.length; i++) {
             BytesArray pbr = (BytesArray) newBytesReference(sizes[i]);
             byte[] array = pbr.array();
             assertNotNull(array);
-            assertEquals(sizes[i], array.length - pbr.arrayOffset());
+            assertEquals(sizes[i], pbr.length());
+            assertThat(pbr.array().length, greaterThanOrEqualTo(pbr.arrayOffset() + pbr.length()));
             assertSame(array, pbr.array());
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
@@ -661,13 +661,16 @@ public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
         map.forEach((value, positions) -> {
             for (int i = 0; i < positions.size(); i++) {
                 final int pos = positions.get(i);
-                final int from = i == 0 ? randomIntBetween(0, pos) : positions.get(i - 1) + 1;
+                final int from = randomIntBetween(i == 0 ? 0 : positions.get(i - 1) + 1, pos);
                 assertEquals(bytesReference.indexOf(value, from), pos);
+            }
+            final int firstNotFoundPos = positions.get(positions.size() - 1) + 1;
+            if (firstNotFoundPos < bytesReference.length()) {
+                assertEquals(-1, bytesReference.indexOf(value, between(firstNotFoundPos, bytesReference.length() - 1)));
             }
         });
         final byte missing = randomValueOtherThanMany(map::containsKey, ESTestCase::randomByte);
         assertEquals(-1, bytesReference.indexOf(missing, randomIntBetween(0, Math.max(0, size - 1))));
-        assertEquals(-1, bytesReference.indexOf(missing, bytesReference.length() + randomIntBetween(0, 100)));
     }
 
     public void testWriteWithIterator() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReferenceTestCase.java
@@ -667,6 +667,7 @@ public abstract class AbstractBytesReferenceTestCase extends ESTestCase {
         });
         final byte missing = randomValueOtherThanMany(map::containsKey, ESTestCase::randomByte);
         assertEquals(-1, bytesReference.indexOf(missing, randomIntBetween(0, Math.max(0, size - 1))));
+        assertEquals(-1, bytesReference.indexOf(missing, bytesReference.length() + randomIntBetween(0, 100)));
     }
 
     public void testWriteWithIterator() throws IOException {


### PR DESCRIPTION
This method is only relevant for searching the line breaks in bulk requests. We can assume that in most cases the number of bytes between two line breaks is well above 8. This makes the SIMD(ish)/SWAR logic this PR introduces much faster than the simple loop.
Benchmarking this using the TSDB track indexing step, shows about a 3x to 4x speedup when searching for the next byte during bulk request parsing.

Profiling from running this on AWS ARM instances shows the massive relative reduction in cost from using the SWAR logic. The logic here is essentially the same as in Netty but optimized for searching `byte[]` directly was well and does not contain a branch for big endian.

Before:

<img width="2039" alt="image" src="https://github.com/elastic/elasticsearch/assets/6490959/09b698e0-b570-4d69-be05-4620e727e1a5">


After:
<img width="1371" alt="image" src="https://github.com/elastic/elasticsearch/assets/6490959/c198cff0-768a-4a90-a5d3-6bb1de654c60">
