### PR TITLE
Speedup deserialization in InternalAggregations

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -165,7 +165,7 @@ public final class InternalAggregations implements Iterable<InternalAggregation>
     }
 
     public static InternalAggregations readFrom(StreamInput in) throws IOException {
-        return from(in.readCollectionAsList(stream -> stream.readNamedWriteable(InternalAggregation.class)));
+        return from(in.readNamedWriteableCollectionAsList(InternalAggregation.class));
     }
 
     @Override


### PR DESCRIPTION
We can use the faster list reader here because the category is a constant.
