### PR TITLE
Remove dead comment in ActionRequest ctor

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRequest.java
@@ -18,9 +18,6 @@ public abstract class ActionRequest extends TransportRequest {
 
     public ActionRequest() {
         super();
-        // this does not set the listenerThreaded API, if needed, its up to the caller to set it
-        // since most times, we actually want it to not be threaded...
-        // this.listenerThreaded = request.listenerThreaded();
     }
 
     public ActionRequest(StreamInput in) throws IOException {


### PR DESCRIPTION
The `listenerThreaded` concept only existed before 2.x, it was
removed[^1] almost 9 years ago. This comment is definitely no longer
needed.

[^1]: see b87d360e79726813db90c7acecc965057a4a39ed.