### PR TITLE
[8.13] [DOCS] Promote webinar on Elasticsearch docs landing (#105594)

### DIFF
--- a/docs/reference/landing-page.asciidoc
+++ b/docs/reference/landing-page.asciidoc
@@ -79,6 +79,11 @@
 
 <h3 class="gtk">Get to know Elasticsearch</h3>
 
+<p>
+  <em>New webinar:</em>
+  <a href="https://www.elastic.co/virtual-events/architecting-search-apps-on-google-cloud">Architect search apps with Google Cloud</a>
+</p>
+
 <div class="my-5">
   <div class="d-flex align-items-center mb-3">
     <h4 class="mt-3">


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [DOCS] Promote webinar on Elasticsearch docs landing (#105594)