### PR TITLE
Drop dead code from get-snapshots request & response

### DIFF
--- a/docs/changelog/105608.yaml
+++ b/docs/changelog/105608.yaml
@@ -1,0 +1,5 @@
+pr: 105608
+summary: Drop dead code from get-snapshots request & response
+area: Snapshot/Restore
+type: tech debt
+issues: []

--- a/docs/changelog/105608.yaml
+++ b/docs/changelog/105608.yaml
@@ -1,5 +1,0 @@
-pr: 105608
-summary: Drop dead code from get-snapshots request & response
-area: Snapshot/Restore
-type: tech debt
-issues: []

--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.http.snapshots;
 
 import org.apache.http.client.methods.HttpGet;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
@@ -23,6 +24,8 @@ import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -31,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -444,7 +448,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
             InputStream input = response.getEntity().getContent();
             XContentParser parser = JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, input)
         ) {
-            return GetSnapshotsResponse.fromXContent(parser);
+            return GET_SNAPSHOT_PARSER.parse(parser, null);
         }
     }
 
@@ -500,5 +504,36 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
         addIndexNamesParameter(includeIndices, request);
         final Response response = getRestClient().performRequest(request);
         return readSnapshotInfos(response);
+    }
+
+    private static final int UNKNOWN_COUNT = -1;
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<GetSnapshotsResponse, Void> GET_SNAPSHOT_PARSER = new ConstructingObjectParser<>(
+        GetSnapshotsResponse.class.getName(),
+        true,
+        (args) -> new GetSnapshotsResponse(
+            (List<SnapshotInfo>) args[0],
+            (Map<String, ElasticsearchException>) args[1],
+            (String) args[2],
+            args[3] == null ? UNKNOWN_COUNT : (int) args[3],
+            args[4] == null ? UNKNOWN_COUNT : (int) args[4]
+        )
+    );
+
+    static {
+        GET_SNAPSHOT_PARSER.declareObjectArray(
+            ConstructingObjectParser.constructorArg(),
+            (p, c) -> SnapshotInfo.SNAPSHOT_INFO_PARSER.apply(p, c).build(),
+            new ParseField("snapshots")
+        );
+        GET_SNAPSHOT_PARSER.declareObject(
+            ConstructingObjectParser.optionalConstructorArg(),
+            (p, c) -> p.map(HashMap::new, ElasticsearchException::fromXContent),
+            new ParseField("failures")
+        );
+        GET_SNAPSHOT_PARSER.declareStringOrNull(ConstructingObjectParser.optionalConstructorArg(), new ParseField("next"));
+        GET_SNAPSHOT_PARSER.declareIntOrNull(ConstructingObjectParser.optionalConstructorArg(), UNKNOWN_COUNT, new ParseField("total"));
+        GET_SNAPSHOT_PARSER.declareIntOrNull(ConstructingObjectParser.optionalConstructorArg(), UNKNOWN_COUNT, new ParseField("remaining"));
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -41,18 +41,6 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
     public static final String NO_POLICY_PATTERN = "_none";
     public static final boolean DEFAULT_VERBOSE_MODE = true;
 
-    public static final TransportVersion SLM_POLICY_FILTERING_VERSION = TransportVersions.V_7_16_0;
-
-    public static final TransportVersion FROM_SORT_VALUE_VERSION = TransportVersions.V_7_16_0;
-
-    public static final TransportVersion MULTIPLE_REPOSITORIES_SUPPORT_ADDED = TransportVersions.V_7_14_0;
-
-    public static final TransportVersion PAGINATED_GET_SNAPSHOTS_VERSION = TransportVersions.V_7_14_0;
-
-    public static final TransportVersion NUMERIC_PAGINATION_VERSION = TransportVersions.V_7_15_0;
-
-    private static final TransportVersion SORT_BY_SHARDS_OR_REPO_VERSION = TransportVersions.V_7_16_0;
-
     private static final TransportVersion INDICES_FLAG_VERSION = TransportVersions.V_8_3_0;
 
     public static final int NO_LIMIT = -1;
@@ -113,89 +101,36 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
 
     public GetSnapshotsRequest(StreamInput in) throws IOException {
         super(in);
-        if (in.getTransportVersion().onOrAfter(MULTIPLE_REPOSITORIES_SUPPORT_ADDED)) {
-            repositories = in.readStringArray();
-        } else {
-            repositories = new String[] { in.readString() };
-        }
+        repositories = in.readStringArray();
         snapshots = in.readStringArray();
         ignoreUnavailable = in.readBoolean();
         verbose = in.readBoolean();
-        if (in.getTransportVersion().onOrAfter(PAGINATED_GET_SNAPSHOTS_VERSION)) {
-            after = in.readOptionalWriteable(After::new);
-            sort = in.readEnum(SortBy.class);
-            size = in.readVInt();
-            order = SortOrder.readFromStream(in);
-            if (in.getTransportVersion().onOrAfter(NUMERIC_PAGINATION_VERSION)) {
-                offset = in.readVInt();
-            }
-            if (in.getTransportVersion().onOrAfter(SLM_POLICY_FILTERING_VERSION)) {
-                policies = in.readStringArray();
-            }
-            if (in.getTransportVersion().onOrAfter(FROM_SORT_VALUE_VERSION)) {
-                fromSortValue = in.readOptionalString();
-            }
-            if (in.getTransportVersion().onOrAfter(INDICES_FLAG_VERSION)) {
-                includeIndexNames = in.readBoolean();
-            }
+        after = in.readOptionalWriteable(After::new);
+        sort = in.readEnum(SortBy.class);
+        size = in.readVInt();
+        order = SortOrder.readFromStream(in);
+        offset = in.readVInt();
+        policies = in.readStringArray();
+        fromSortValue = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(INDICES_FLAG_VERSION)) {
+            includeIndexNames = in.readBoolean();
         }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        if (out.getTransportVersion().onOrAfter(MULTIPLE_REPOSITORIES_SUPPORT_ADDED)) {
-            out.writeStringArray(repositories);
-        } else {
-            if (repositories.length != 1) {
-                throw new IllegalArgumentException(
-                    "Requesting snapshots from multiple repositories is not supported in versions prior "
-                        + "to "
-                        + MULTIPLE_REPOSITORIES_SUPPORT_ADDED.toString()
-                );
-            }
-            out.writeString(repositories[0]);
-        }
+        out.writeStringArray(repositories);
         out.writeStringArray(snapshots);
         out.writeBoolean(ignoreUnavailable);
         out.writeBoolean(verbose);
-        if (out.getTransportVersion().onOrAfter(PAGINATED_GET_SNAPSHOTS_VERSION)) {
-            out.writeOptionalWriteable(after);
-            if ((sort == SortBy.SHARDS || sort == SortBy.FAILED_SHARDS || sort == SortBy.REPOSITORY)
-                && out.getTransportVersion().before(SORT_BY_SHARDS_OR_REPO_VERSION)) {
-                throw new IllegalArgumentException(
-                    "can't use sort by shard count or repository name in transport version [" + out.getTransportVersion() + "]"
-                );
-            }
-            out.writeEnum(sort);
-            out.writeVInt(size);
-            order.writeTo(out);
-            if (out.getTransportVersion().onOrAfter(NUMERIC_PAGINATION_VERSION)) {
-                out.writeVInt(offset);
-            } else if (offset != 0) {
-                throw new IllegalArgumentException(
-                    "can't use numeric offset in get snapshots request in transport version [" + out.getTransportVersion() + "]"
-                );
-            }
-        } else if (sort != SortBy.START_TIME || size != NO_LIMIT || after != null || order != SortOrder.ASC) {
-            throw new IllegalArgumentException(
-                "can't use paginated get snapshots request in transport version [" + out.getTransportVersion() + "]"
-            );
-        }
-        if (out.getTransportVersion().onOrAfter(SLM_POLICY_FILTERING_VERSION)) {
-            out.writeStringArray(policies);
-        } else if (policies.length > 0) {
-            throw new IllegalArgumentException(
-                "can't use slm policy filter in snapshots request in transport version [" + out.getTransportVersion() + "]"
-            );
-        }
-        if (out.getTransportVersion().onOrAfter(FROM_SORT_VALUE_VERSION)) {
-            out.writeOptionalString(fromSortValue);
-        } else if (fromSortValue != null) {
-            throw new IllegalArgumentException(
-                "can't use after-value in snapshot request in transport version [" + out.getTransportVersion() + "]"
-            );
-        }
+        out.writeOptionalWriteable(after);
+        out.writeEnum(sort);
+        out.writeVInt(size);
+        order.writeTo(out);
+        out.writeVInt(offset);
+        out.writeStringArray(policies);
+        out.writeOptionalString(fromSortValue);
         if (out.getTransportVersion().onOrAfter(INDICES_FLAG_VERSION)) {
             out.writeBoolean(includeIndexNames);
         }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -496,12 +496,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
      * Constructs snapshot information from stream input
      */
     public static SnapshotInfo readFrom(final StreamInput in) throws IOException {
-        final Snapshot snapshot;
-        if (in.getTransportVersion().onOrAfter(GetSnapshotsRequest.PAGINATED_GET_SNAPSHOTS_VERSION)) {
-            snapshot = new Snapshot(in);
-        } else {
-            snapshot = new Snapshot(UNKNOWN_REPO_NAME, new SnapshotId(in));
-        }
+        final Snapshot snapshot = new Snapshot(in);
         final List<String> indices = in.readStringCollectionAsImmutableList();
         final SnapshotState state = in.readBoolean() ? SnapshotState.fromValue(in.readByte()) : null;
         final String reason = in.readOptionalString();
@@ -1015,11 +1010,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
 
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
-        if (out.getTransportVersion().onOrAfter(GetSnapshotsRequest.PAGINATED_GET_SNAPSHOTS_VERSION)) {
-            snapshot.writeTo(out);
-        } else {
-            snapshot.getSnapshotId().writeTo(out);
-        }
+        snapshot.writeTo(out);
         out.writeStringCollection(indices);
         if (state != null) {
             out.writeBoolean(true);


### PR DESCRIPTION
Removes all the now-dead code related to reading pre-7.16 get-snapshots
requests and responses, and also moves the `XContent` response parsing
out of production and into the only test suite that uses it.