### PR TITLE
[8.12] `URLRepository` should not block shutdown (#105588)

### DIFF
--- a/docs/changelog/105588.yaml
+++ b/docs/changelog/105588.yaml
@@ -1,0 +1,5 @@
+pr: 105588
+summary: '`URLRepository` should not block shutdown'
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/modules/repository-url/src/internalClusterTest/java/org/elasticsearch/repositories/url/URLSnapshotRestoreIT.java
+++ b/modules/repository-url/src/internalClusterTest/java/org/elasticsearch/repositories/url/URLSnapshotRestoreIT.java
@@ -124,4 +124,17 @@ public class URLSnapshotRestoreIT extends ESIntegTestCase {
         getSnapshotsResponse = client.admin().cluster().prepareGetSnapshots("url-repo").get();
         assertThat(getSnapshotsResponse.getSnapshots().size(), equalTo(0));
     }
+
+    public void testUrlRepositoryPermitsShutdown() throws Exception {
+        assertAcked(
+            client().admin()
+                .cluster()
+                .preparePutRepository("url-repo")
+                .setType(URLRepository.TYPE)
+                .setVerify(false)
+                .setSettings(Settings.builder().put(URLRepository.URL_SETTING.getKey(), "http://localhost/"))
+        );
+
+        internalCluster().fullRestart(); // just checking that URL repositories don't block node shutdown
+    }
 }

--- a/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
+++ b/modules/repository-url/src/main/java/org/elasticsearch/repositories/url/URLRepository.java
@@ -186,5 +186,6 @@ public class URLRepository extends BlobStoreRepository {
     @Override
     protected void doClose() {
         IOUtils.closeWhileHandlingException(httpClient);
+        super.doClose();
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.12:
 - `URLRepository` should not block shutdown (#105588)