### PR TITLE
[DOCS] Updates the list of community contributed clients

### DIFF
--- a/docs/community-clients/index.asciidoc
+++ b/docs/community-clients/index.asciidoc
@@ -43,12 +43,12 @@ a number of clients that have been contributed by the community for various lang
 [[b4j]]
 == B4J
 * https://www.b4x.com/android/forum/threads/server-jelasticsearch-search-and-text-analytics.73335/[jElasticsearch]:
-  B4J client based on the official Java REST client.
+  B4J client based on the official Java REST client. **- Last release more than a year ago**
 
 [[cpp]]
 == C++
 * https://github.com/seznam/elasticlient[elasticlient]: simple library for
-  simplified work with Elasticsearch in C++.
+  simplified work with Elasticsearch in C++. **- Last commit more than a year ago**
 
 [[clojure]]
 == Clojure
@@ -57,7 +57,7 @@ a number of clients that have been contributed by the community for various lang
   Clojure client, based on the new official low-level REST client.
 
 * https://github.com/clojurewerkz/elastisch[Elastisch]:
-  Clojure client.
+  Clojure client. **- Last commit more than a year ago**
 
 [[coldfusion]]
 == ColdFusion (CFML)
@@ -71,17 +71,17 @@ a number of clients that have been contributed by the community for various lang
 == Erlang
 
 * https://github.com/tsloughter/erlastic_search[erlastic_search]:
-  Erlang client using HTTP.
+  Erlang client using HTTP. **- Last commit more than a year ago**
 
 * https://github.com/datahogs/tirexs[Tirexs]:
   An https://github.com/elixir-lang/elixir[Elixir] based API/DSL, inspired by
   https://github.com/karmi/tire[Tire]. Ready to use in pure Erlang
-  environment.
+  environment. **- Last commit more than a year ago** 
 
 * https://github.com/sashman/elasticsearch_elixir_bulk_processor[Elixir Bulk
   Processor]: Dynamically configurable Elixir port of the
   {client}/java-api/current/java-docs-bulk-processor.html[Bulk Processor].
-  Implemented using GenStages to handle back pressure.
+  Implemented using GenStages to handle back pressure. **- Last commit more than a year ago**
 
 [[go]]
 == Go
@@ -90,13 +90,13 @@ Also see the {client}/go-api/current/index.html[official Elasticsearch Go
 client].
 
 * https://github.com/mattbaird/elastigo[elastigo]:
-  Go client.
+  Go client. **- Last commit more than a year ago** 
 
 * https://github.com/olivere/elastic[elastic]:
-  Elasticsearch client for Google Go.
+  Elasticsearch client for Google Go. **- Last commit more than a year ago**
 
 * https://github.com/softctrl/elk[elk]:
-  Golang lib for Elasticsearch client.
+  Golang lib for Elasticsearch client. **- Last commit more than a year ago**
 
 
 [[haskell]]
@@ -114,7 +114,7 @@ client].
   Java Rest client with comprehensive Query DSL API.
 
 * https://github.com/searchbox-io/Jest[Jest]:
-  Java Rest client.
+  Java Rest client. ** - No longer maintained**
 
 [[javascript]]
 == JavaScript
@@ -133,19 +133,19 @@ Elasticsearch client inspired by the {client}/ruby-api/current/index.html[offici
 
 * https://github.com/mbuhot/eskotlin[ES Kotlin]:
   Elasticsearch Query DSL for kotlin based on the
-  {client}/java-api/current/index.html[official Elasticsearch Java client].
+  {client}/java-api/current/index.html[official Elasticsearch Java client]. **- Last commit more than a year ago**
 
 * https://github.com/jillesvangurp/es-kotlin-wrapper-client[ES Kotlin Wrapper
 Client]: Kotlin extension functions and abstractions for the
   {client}/java-api/current/index.html[official Elasticsearch high-level
   client]. Aims to reduce the amount of boilerplate needed to do searches, bulk
-  indexing and other common things users do with the client.
+  indexing and other common things users do with the client. **- No longer maintained**
 
 [[lua]]
 == Lua
 
 * https://github.com/DhavalKapil/elasticsearch-lua[elasticsearch-lua]:
-  Lua client for Elasticsearch
+  Lua client for Elasticsearch **- Last commit more than a year ago**
 
 [[dotnet]]
 == .NET
@@ -158,7 +158,8 @@ See the {client}/net-api/current/index.html[official Elasticsearch .NET client].
 Also see the {client}/perl-api/current/index.html[official Elasticsearch Perl
 client].
 
-* https://metacpan.org/pod/Elastijk[Elastijk]: A low-level, minimal HTTP client.
+* https://metacpan.org/pod/Elastijk[Elastijk]: A low-level, minimal HTTP client. 
+**- Last commit more than a year ago**
 
 
 [[php]]
@@ -171,11 +172,13 @@ client].
   PHP client.
 
 * https://github.com/nervetattoo/elasticsearch[elasticsearch]: PHP client.
+**- Last commit more than a year ago**
 
 * https://github.com/madewithlove/elasticsearcher[elasticsearcher]: Agnostic
 lightweight package on top of the Elasticsearch PHP client. Its main goal is to
 allow for easier structuring of queries and indices in your application. It does
 not want to hide or replace functionality of the Elasticsearch PHP client.
+**- Last commit more than a year ago**
 
 [[python]]
 == Python
@@ -191,9 +194,11 @@ client].
 
 * https://github.com/ropensci/elasticdsl[elasticdsl]:
   A high-level R DSL for Elasticsearch, wrapping the elastic R client.
+  **- No longer maintained**
 
 * https://github.com/uptake/uptasticsearch[uptasticsearch]:
-  An R client tailored to data science workflows.
+  An R client tailored to data science workflows. 
+  **- Last commit more than a year ago**
 
 [[ruby]]
 == Ruby
@@ -202,6 +207,7 @@ Also see the {client}/ruby-api/current/index.html[official Elasticsearch Ruby cl
 
 * https://github.com/printercu/elastics-rb[elastics]:
   Tiny client with built-in zero-downtime migrations and ActiveRecord integration.
+  **- Last commit more than a year ago**
 
 * https://github.com/toptal/chewy[chewy]:
   An ODM and wrapper for the official Elasticsearch client.
@@ -219,10 +225,12 @@ Also see the {client}/rust-api/current/index.html[official Elasticsearch Rust
 client].
 
 * https://github.com/benashford/rs-es[rs-es]:
-  A REST API client with a strongly-typed Query DSL.
+  A REST API client with a strongly-typed Query DSL. 
+  **- Last commit more than a year ago**
 
 * https://github.com/elastic-rs/elastic[elastic]:
   A modular REST API client that supports freeform queries.
+  **- Last commit more than a year ago**
 
 [[scala]]
 == Scala
@@ -231,19 +239,23 @@ client].
   Scala DSL.
 
 * https://github.com/gphat/wabisabi[wabisabi]:
-  Asynchronous REST API Scala client.
+  Asynchronous REST API Scala client. **- No longer maintained**
 
 * https://github.com/workday/escalar[escalar]:
-  Type-safe Scala wrapper for the REST API.
+  Type-safe Scala wrapper for the REST API. 
+  **- Last commit more than a year ago**
 
 * https://github.com/SumoLogic/elasticsearch-client[elasticsearch-client]:
   Scala DSL that uses the REST API. Akka and AWS helpers included.
+  **- No longer maintained**
+
 
 [[smalltalk]]
 == Smalltalk
 
 * https://github.com/newapplesho/elasticsearch-smalltalk[elasticsearch-smalltalk]:
-  Pharo Smalltalk client for Elasticsearch.
+  Pharo Smalltalk client for Elasticsearch. 
+  **- Last commit more than a year ago**
   
 [[swift]]
 == Swift
@@ -254,4 +266,5 @@ client].
 == Vert.x
 
 * https://github.com/reactiverse/elasticsearch-client[elasticsearch-client]:
-  An Elasticsearch client for Eclipse Vert.x.
+  An Elasticsearch client for Eclipse Vert.x 
+  **- Last commit more than a year ago**


### PR DESCRIPTION
## Overview

This PR reviews the list of community-contributed clients and indicates if the client is no longer maintained or if the last commit was made more than a year ago.

### Preview

* [Community contributed clients](https://elasticsearch_bk_105623.docs-preview.app.elstc.co/guide/en/elasticsearch/client/community/master/index.html)