### PR TITLE
Flip dynamic mapping condition when create tsid

### DIFF
--- a/docs/changelog/105636.yaml
+++ b/docs/changelog/105636.yaml
@@ -1,0 +1,5 @@
+pr: 105636
+summary: Flip dynamic mapping condition when create tsid
+area: TSDB
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -241,8 +241,8 @@ runtime field matching routing path:
 ---
 "dynamic: runtime matches routing_path":
   - skip:
-      version: " - 8.7.99"
-      reason: routing_path error message updated in 8.8.0
+      version: " - 8.13.99"
+      reason: routing_path error message updated in 8.8.0 and has_dynamic_mapping condition fixed in 8.14.0
 
   - do:
       indices.create:
@@ -272,7 +272,7 @@ runtime field matching routing path:
         index: test
         body:
           - '{"index": {}}'
-          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "dim_kw": "dim", "dim": {"foo": "a"}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "dim_kw": "dim", "dim": {"foo": "a"}, "extra_field": 100}'
   - match: {items.0.index.error.reason: "All fields that match routing_path must be keywords with [time_series_dimension: true] or flattened fields with a list of dimensions in [time_series_dimensions] and without the [script] parameter. [dim.foo] was a runtime [keyword]."}
 
 ---

--- a/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
@@ -53,7 +53,7 @@ public class TsidExtractingIdFieldMapper extends IdFieldMapper {
         }
         long timestamp = timestampField.numericValue().longValue();
         byte[] suffix = new byte[16];
-        String id = createId(context.hasDynamicMappers() == false, routingBuilder, tsid, timestamp, suffix);
+        String id = createId(context.hasDynamicMappers(), routingBuilder, tsid, timestamp, suffix);
         /*
          * Make sure that _id from extracting the tsid matches that _id
          * from extracting the _source. This should be true for all valid

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
@@ -694,7 +694,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
         // with _id
         {
             MapperService mapper = createMapperService(IndexVersion.current(), indexSettings, () -> false);
-            SourceToParse source = new SourceToParse("itaMgKqjeKVKQJobAAABdrs-cAA", new BytesArray("""
+            SourceToParse source = new SourceToParse("no-such-tsid", new BytesArray("""
                 {
                     "@timestamp": 1609459200000,
                     "dim": "6a841a21",
@@ -720,7 +720,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
                 failure.getMessage(),
                 equalTo(
                     "[5:1] failed to parse: _id must be unset or set to [AAAAAMpxfIC8Wpr0AAABdrs-cAA]"
-                        + " but was [itaMgKqjeKVKQJobAAABdrs-cAA] because [index] is in time_series mode"
+                        + " but was [no-such-tsid] because [index] is in time_series mode"
                 )
             );
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
@@ -12,16 +12,23 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.common.lucene.uid.Versions;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.index.VersionType;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -652,5 +659,70 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
         ParsedDocument doc1 = parseDocument(docMapper, d -> d.field("a", a).field("b", b));
         ParsedDocument doc2 = parseDocument(docMapper, d -> d.field("a", a).field("b", b).field("c", c));
         assertThat(doc1.rootDoc().getBinaryValue("_tsid").bytes, not(doc2.rootDoc().getBinaryValue("_tsid").bytes));
+    }
+
+    public void testParseWithDynamicMapping() {
+        Settings indexSettings = Settings.builder()
+            .put(IndexSettings.MODE.getKey(), "time_series")
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dim")
+            .build();
+        // without _id
+        {
+            MapperService mapper = createMapperService(IndexVersion.current(), indexSettings, () -> false);
+            SourceToParse source = new SourceToParse(null, new BytesArray("""
+                {
+                    "@timestamp": 1609459200000,
+                    "dim": "6a841a21",
+                    "value": 100
+                }"""), XContentType.JSON);
+            Engine.Index index = IndexShard.prepareIndex(
+                mapper,
+                source,
+                UNASSIGNED_SEQ_NO,
+                randomNonNegativeLong(),
+                Versions.MATCH_ANY,
+                VersionType.INTERNAL,
+                Engine.Operation.Origin.PRIMARY,
+                -1,
+                false,
+                UNASSIGNED_SEQ_NO,
+                0,
+                System.nanoTime()
+            );
+            assertNotNull(index.parsedDoc().dynamicMappingsUpdate());
+        }
+        // with _id
+        {
+            MapperService mapper = createMapperService(IndexVersion.current(), indexSettings, () -> false);
+            SourceToParse source = new SourceToParse("itaMgKqjeKVKQJobAAABdrs-cAA", new BytesArray("""
+                {
+                    "@timestamp": 1609459200000,
+                    "dim": "6a841a21",
+                    "value": 100
+                }"""), XContentType.JSON);
+            var failure = expectThrows(DocumentParsingException.class, () -> {
+                IndexShard.prepareIndex(
+                    mapper,
+                    source,
+                    UNASSIGNED_SEQ_NO,
+                    randomNonNegativeLong(),
+                    Versions.MATCH_ANY,
+                    VersionType.INTERNAL,
+                    Engine.Operation.Origin.PRIMARY,
+                    -1,
+                    false,
+                    UNASSIGNED_SEQ_NO,
+                    0,
+                    System.nanoTime()
+                );
+            });
+            assertThat(
+                failure.getMessage(),
+                equalTo(
+                    "[5:1] failed to parse: _id must be unset or set to [AAAAAMpxfIC8Wpr0AAABdrs-cAA]"
+                        + " but was [itaMgKqjeKVKQJobAAABdrs-cAA] because [index] is in time_series mode"
+                )
+            );
+        }
     }
 }


### PR DESCRIPTION
We accidentally reversed the `dynamicMappersExists` condition. The impact of this bug is minor, primarily resulting in the return of a different error message.