### PR TITLE
[8.13] [DOCS] [Remote clusters] Reference specific instructions for cloud trust

### DIFF
--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -30,6 +30,11 @@ capabilities, the local and remote cluster must be on the same
 [discrete]
 === Add remote clusters
 
+NOTE: The instructions that follow describe how to create a remote connection from a 
+self-managed cluster. You can also set up {ccs} and {ccr} from an 
+link:https://www.elastic.co/guide/en/cloud/current/ec-enable-ccs.html[{ess} deployment] 
+or from an link:https://www.elastic.co/guide/en/cloud-enterprise/current/ece-enable-ccs.html[{ece} deployment].
+
 To add remote clusters, you can choose between
 <<remote-clusters-security-models,two security models>> and
 <<sniff-proxy-modes,two connection modes>>. Both security models are compatible


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[DOCS] [Remote clusters] Reference specific instructions for cloud trust](https://github.com/elastic/elasticsearch/pull/105493)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)