### PR TITLE
Remove unused field

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportPutShutdownNodeAction.java
@@ -45,8 +45,6 @@ public class TransportPutShutdownNodeAction extends AcknowledgedTransportMasterN
     private final AllocationService allocationService;
     private final MasterServiceTaskQueue<PutShutdownNodeTask> taskQueue;
 
-    private final PutShutdownNodeExecutor executor = new PutShutdownNodeExecutor();
-
     private static boolean putShutdownNodeState(
         Map<String, SingleNodeShutdownMetadata> shutdownMetadata,
         Predicate<String> nodeExists,


### PR DESCRIPTION
This change removes a field in TransportPutShutdownNodeAction that is no longer used after the refactoring.
