### PR TITLE
Mute ConcurrentSnapshotsIT#testDeleteIndexWithOutOfOrderFinalization

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -2024,6 +2024,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(snapshot2.get().getSnapshotInfo().state(), is(SnapshotState.PARTIAL));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/105484")
     public void testDeleteIndexWithOutOfOrderFinalization() throws Exception {
 
         final String indexToDelete = "index-to-delete";


### PR DESCRIPTION
Mute https://github.com/elastic/elasticsearch/issues/105484