### PR TITLE
[8.13] [Connector API] Bugfix: support list type in filtering advanced snippet value (#105633)

### DIFF
--- a/docs/changelog/105633.yaml
+++ b/docs/changelog/105633.yaml
@@ -1,0 +1,6 @@
+pr: 105633
+summary: "[Connector API] Bugfix: support list type in filtering advenced snippet\
+  \ value"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/332_connector_update_filtering.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/332_connector_update_filtering.yml
@@ -23,7 +23,10 @@ setup:
                 advanced_snippet:
                   created_at: "2023-05-25T12:30:00.000Z"
                   updated_at: "2023-05-25T12:30:00.000Z"
-                  value: {}
+                  value:
+                    - tables:
+                        - some_table
+                      query: 'SELECT id, st_geohash(coordinates) FROM my_db.some_table;'
                 rules:
                   - created_at: "2023-05-25T12:30:00.000Z"
                     field: _
@@ -41,7 +44,13 @@ setup:
                 advanced_snippet:
                   created_at: "2023-05-25T12:30:00.000Z"
                   updated_at: "2023-05-25T12:30:00.000Z"
-                  value: {}
+                  value:
+                    - tables:
+                        - some_table
+                      query: 'SELECT id, st_geohash(coordinates) FROM my_db.some_table;'
+                    - tables:
+                        - another_table
+                      query: 'SELECT id, st_geohash(coordinates) FROM my_db.another_table;'
                 rules:
                   - created_at: "2023-05-25T12:30:00.000Z"
                     field: _

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorFilteringTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorFilteringTests.java
@@ -110,6 +110,73 @@ public class ConnectorFilteringTests extends ESTestCase {
 
     }
 
+    public void testToXContent_WithAdvancedSnippetPopulated() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+                {
+                    "active": {
+                        "advanced_snippet": {
+                            "created_at": "2023-11-09T15:13:08.231Z",
+                            "updated_at": "2023-11-09T15:13:08.231Z",
+                            "value": [
+                               {"service": "Incident", "query": "user_nameSTARTSWITHa"},
+                               {"service": "Incident", "query": "user_nameSTARTSWITHj"}
+                            ]
+                        },
+                        "rules": [
+                            {
+                                "created_at": "2023-11-09T15:13:08.231Z",
+                                "field": "_",
+                                "id": "DEFAULT",
+                                "order": 0,
+                                "policy": "include",
+                                "rule": "regex",
+                                "updated_at": "2023-11-09T15:13:08.231Z",
+                                "value": ".*"
+                            }
+                        ],
+                        "validation": {
+                            "errors": [],
+                            "state": "valid"
+                        }
+                    },
+                    "domain": "DEFAULT",
+                    "draft": {
+                        "advanced_snippet": {
+                            "created_at": "2023-11-09T15:13:08.231Z",
+                            "updated_at": "2023-11-09T15:13:08.231Z",
+                            "value": {}
+                        },
+                        "rules": [
+                            {
+                                "created_at": "2023-11-09T15:13:08.231Z",
+                                "field": "_",
+                                "id": "DEFAULT",
+                                "order": 0,
+                                "policy": "include",
+                                "rule": "regex",
+                                "updated_at": "2023-11-09T15:13:08.231Z",
+                                "value": ".*"
+                            }
+                        ],
+                        "validation": {
+                            "errors": [],
+                            "state": "valid"
+                        }
+                    }
+                }
+            """);
+
+        ConnectorFiltering filtering = ConnectorFiltering.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(filtering, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        ConnectorFiltering parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = ConnectorFiltering.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+
+    }
+
     private void assertTransportSerialization(ConnectorFiltering testInstance) throws IOException {
         ConnectorFiltering deserializedInstance = copyInstance(testInstance);
         assertNotSame(testInstance, deserializedInstance);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTests.java
@@ -147,7 +147,14 @@ public class ConnectorTests extends ESTestCase {
                         "advanced_snippet":{
                            "created_at":"2023-11-09T15:13:08.231Z",
                            "updated_at":"2023-11-09T15:13:08.231Z",
-                           "value":{}
+                           "value":[
+                             {
+                                 "tables": [
+                                     "some_table"
+                                 ],
+                                 "query": "SELECT id, st_geohash(coordinates) FROM my_db.some_table;"
+                             }
+                           ]
                         },
                         "rules":[
                            {
@@ -171,7 +178,14 @@ public class ConnectorTests extends ESTestCase {
                         "advanced_snippet":{
                            "created_at":"2023-11-09T15:13:08.231Z",
                            "updated_at":"2023-11-09T15:13:08.231Z",
-                           "value":{}
+                           "value":[
+                             {
+                                 "tables": [
+                                     "some_table"
+                                 ],
+                                 "query": "SELECT id, st_geohash(coordinates) FROM my_db.some_table;"
+                             }
+                           ]
                         },
                         "rules":[
                            {


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Connector API] Bugfix: support list type in filtering advanced snippet value (#105633)