### PR TITLE
Fix Setting.exists if key doesn't equal key in settings keys.

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/SecureSetting.java
@@ -13,6 +13,7 @@ import org.elasticsearch.core.Booleans;
 
 import java.io.InputStream;
 import java.security.GeneralSecurityException;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -67,7 +68,13 @@ public abstract class SecureSetting<T> extends Setting<T> {
     @Override
     public boolean exists(Settings settings) {
         final SecureSettings secureSettings = settings.getSecureSettings();
-        return secureSettings != null && secureSettings.getSettingNames().contains(getKey());
+        return secureSettings != null && getRawKey().exists(secureSettings.getSettingNames(), Collections.emptySet());
+    }
+
+    @Override
+    public boolean exists(Settings.Builder builder) {
+        final SecureSettings secureSettings = builder.getSecureSettings();
+        return secureSettings != null && getRawKey().exists(secureSettings.getSettingNames(), Collections.emptySet());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -519,7 +519,6 @@ public class Setting<T> implements ToXContentObject {
      * @return true if the setting including fallback settings is present in the given settings instance, otherwise false
      */
     public boolean existsOrFallbackExists(final Settings settings) {
-        // FIXME should this include (as was previously) or exclude (like exist) SecureSettings?
         return exists(settings) || (fallbackSetting != null && fallbackSetting.existsOrFallbackExists(settings));
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -15,7 +15,6 @@ import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.VersionId;
 import org.elasticsearch.common.logging.DeprecationCategory;
-import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.MemorySizeValue;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
@@ -49,6 +48,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -503,16 +503,13 @@ public class Setting<T> implements ToXContentObject {
      * @return true if the setting is present in the given settings instance, otherwise false
      */
     public boolean exists(final Settings settings) {
-        return exists(settings.keySet(), settings.getSecureSettings());
+        SecureSettings secureSettings = settings.getSecureSettings();
+        return key.exists(settings.keySet(), secureSettings == null ? Collections.emptySet() : secureSettings.getSettingNames());
     }
 
     public boolean exists(final Settings.Builder builder) {
-        return exists(builder.keys(), builder.getSecureSettings());
-    }
-
-    private boolean exists(final Set<String> keys, final SecureSettings secureSettings) {
-        final String key = getKey();
-        return keys.contains(key) && (secureSettings == null || secureSettings.getSettingNames().contains(key) == false);
+        SecureSettings secureSettings = builder.getSecureSettings();
+        return key.exists(builder.keys(), secureSettings == null ? Collections.emptySet() : secureSettings.getSettingNames());
     }
 
     /**
@@ -522,7 +519,8 @@ public class Setting<T> implements ToXContentObject {
      * @return true if the setting including fallback settings is present in the given settings instance, otherwise false
      */
     public boolean existsOrFallbackExists(final Settings settings) {
-        return settings.keySet().contains(getKey()) || (fallbackSetting != null && fallbackSetting.existsOrFallbackExists(settings));
+        // FIXME should this include (as was previously) or exclude (like exist) SecureSettings?
+        return exists(settings) || (fallbackSetting != null && fallbackSetting.existsOrFallbackExists(settings));
     }
 
     /**
@@ -1164,19 +1162,10 @@ public class Setting<T> implements ToXContentObject {
 
         @Override
         public Settings get(Settings settings) {
+            // TODO should we be checking for deprecations here?
             Settings byPrefix = settings.getByPrefix(getKey());
             validator.accept(byPrefix);
             return byPrefix;
-        }
-
-        @Override
-        public boolean exists(Settings settings) {
-            for (String settingsKey : settings.keySet()) {
-                if (settingsKey.startsWith(key)) {
-                    return true;
-                }
-            }
-            return false;
         }
 
         @Override
@@ -2108,6 +2097,13 @@ public class Setting<T> implements ToXContentObject {
 
     public interface Key {
         boolean match(String key);
+
+        /**
+         * Returns true if and only if this key is present in the given settings instance (not considering secure settings).
+         * @param keys keys to check
+         * @param exclusions exclusions to ignore
+         */
+        boolean exists(Set<String> keys, Set<String> exclusions);
     }
 
     public static class SimpleKey implements Key {
@@ -2139,9 +2135,15 @@ public class Setting<T> implements ToXContentObject {
         public int hashCode() {
             return Objects.hash(key);
         }
+
+        @Override
+        public boolean exists(Set<String> keys, Set<String> exclusions) {
+            return keys.contains(key) && exclusions.contains(key) == false;
+        }
     }
 
     public static final class GroupKey extends SimpleKey {
+
         public GroupKey(String key) {
             super(key);
             if (key.endsWith(".") == false) {
@@ -2151,7 +2153,15 @@ public class Setting<T> implements ToXContentObject {
 
         @Override
         public boolean match(String toTest) {
-            return Regex.simpleMatch(key + "*", toTest);
+            return toTest != null && toTest.startsWith(key);
+        }
+
+        @Override
+        public boolean exists(Set<String> keys, Set<String> exclusions) {
+            if (exclusions.isEmpty()) {
+                return keys.stream().anyMatch(this::match);
+            }
+            return keys.stream().filter(Predicate.not(exclusions::contains)).anyMatch(this::match);
         }
     }
 
@@ -2166,6 +2176,17 @@ public class Setting<T> implements ToXContentObject {
         @Override
         public boolean match(String toTest) {
             return pattern.matcher(toTest).matches();
+        }
+
+        @Override
+        public boolean exists(Set<String> keys, Set<String> exclusions) {
+            if (keys.contains(key)) {
+                return exclusions.contains(key) == false;
+            }
+            if (exclusions.isEmpty()) {
+                return keys.stream().anyMatch(this::match);
+            }
+            return keys.stream().filter(Predicate.not(exclusions::contains)).anyMatch(this::match);
         }
     }
 
@@ -2222,6 +2243,14 @@ public class Setting<T> implements ToXContentObject {
         @Override
         public boolean match(String key) {
             return pattern.matcher(key).matches();
+        }
+
+        @Override
+        public boolean exists(Set<String> keys, Set<String> exclusions) {
+            if (exclusions.isEmpty()) {
+                return keys.stream().anyMatch(this::match);
+            }
+            return keys.stream().filter(Predicate.not(exclusions::contains)).anyMatch(this::match);
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -2098,7 +2098,7 @@ public class Setting<T> implements ToXContentObject {
         boolean match(String key);
 
         /**
-         * Returns true if and only if this key is present in the given settings instance (not considering secure settings).
+         * Returns true if and only if this key is present in the given settings instance (ignoring given exclusions).
          * @param keys keys to check
          * @param exclusions exclusions to ignore
          */

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -25,7 +25,6 @@ import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
-import org.junit.Ignore;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -551,14 +550,6 @@ public class SettingTests extends ESTestCase {
         } catch (IllegalArgumentException ex) {
             assertEquals(ex.getMessage(), "illegal value can't update [foo.bar.] from [{}] to [{\"1.value\":\"1\",\"2.value\":\"2\"}]");
         }
-    }
-
-    @Ignore("No deprecations logged for group settings")
-    public void testGroupSettingDeprecated() {
-        Setting<Settings> setting = Setting.groupSetting("foo.deprecated.", Property.DeprecatedWarning, Property.NodeScope);
-
-        setting.get(Settings.builder().put("foo.deprecated.1.value", "1").build());
-        assertSettingDeprecationsAndWarnings(new Setting<?>[] { setting });
     }
 
     public void testGroupKeyExists() {


### PR DESCRIPTION
This fixes `Setting.exists` which is currently broken for affix settings, but also for any list setting if using the index syntax.
I ran into this when working on ES-7815, when implementing aliases to replace deprecated settings. `exists` is used when checking for deprecations, making this a prerequisite.

Additionally, this fixes some inconsistencies in different implementations of `exists` / `existsOrFallbackExists ` with respect to secure settings. Following the default implementation of `exists`, with this PR secure settings are always excluded except when actually checking `SecureSetting.exists`.

Note: I've also noticed we're not checking deprecations for group settings, though considering this out of scope here as it doesn't affect ES-7815.