### PR TITLE
[ML] Detect 8.x ML nodes correctly

### DIFF
--- a/docs/changelog/105653.yaml
+++ b/docs/changelog/105653.yaml
@@ -1,0 +1,5 @@
+pr: 105653
+summary: Detect 8.x ML nodes correctly
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -627,6 +627,12 @@ public class MachineLearning extends Plugin
     }
 
     public static boolean isMlNode(DiscoveryNode node) {
+        // Post 7.3.0 nodes will have this role, so if the ML nodes have been upgraded we can use this information.
+        if (node.getRoles().contains(ML_ROLE)) {
+            return true;
+        }
+        // Pre 7.3.0 nodes might still be ML nodes despite not having the ML role (as pluggable roles didn't exist
+        // then). So we use the old method to detect ML nodes for this case.
         Map<String, String> nodeAttributes = node.getAttributes();
         try {
             return Integer.parseInt(nodeAttributes.get(MAX_OPEN_JOBS_NODE_ATTR)) > 0;


### PR DESCRIPTION
It's possible that a 7.17 master node needs to assign ML jobs to 8.x ML nodes. Currently this does not work, as the 7.x mechanism for detecting ML nodes does not work with 8.x ML nodes. Currently a 7.17 master node will not assign jobs to 8.x ML nodes, so the jobs sit in limbo until the master node is upgraded to 8.x, and then they get assigned and pick up where they left off.

This change allows the 7.17 master node to correctly identify 8.x ML nodes in the cluster, allowing the ML jobs to be reassigned more quickly during a rolling upgrade from 7.17 to 8.x where master nodes are upgraded last (as recommended).