### PR TITLE
Avoid allocations in security's Automaton cache

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
@@ -80,6 +80,7 @@ public final class Automatons {
     /**
      * Builds and returns an automaton that will represent the union of all the given patterns.
      */
+    @SuppressWarnings("unchecked")
     public static Automaton patterns(Collection<String> patterns) {
         if (patterns.isEmpty()) {
             return EMPTY;
@@ -88,7 +89,7 @@ public final class Automatons {
             return buildAutomaton(patterns);
         } else {
             try {
-                return cache.computeIfAbsent(Sets.newHashSet(patterns), ignore -> buildAutomaton(patterns));
+                return cache.computeIfAbsent(Sets.newHashSet(patterns), p -> buildAutomaton((Set<String>) p));
             } catch (ExecutionException e) {
                 throw unwrapCacheException(e);
             }
@@ -184,7 +185,7 @@ public final class Automatons {
             return buildAutomaton(pattern);
         } else {
             try {
-                return cache.computeIfAbsent(pattern, ignore -> buildAutomaton(pattern));
+                return cache.computeIfAbsent(pattern, p -> buildAutomaton((String) p));
             } catch (ExecutionException e) {
                 throw unwrapCacheException(e);
             }


### PR DESCRIPTION
Random find from SDH heap-dump:
We can just cast here instead of capturing the key in the lambda.
