### PR TITLE
Fixing compilation error  in SearchSourceBuilderTests#testStoredFieldsUsage

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -603,7 +603,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         for (String storedFieldRest : storedFieldRestVariations) {
             SearchUsageHolder searchUsageHolder = new UsageService().getSearchUsageHolder();
             try (XContentParser parser = createParser(JsonXContent.jsonXContent, storedFieldRest)) {
-                new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder);
+                new SearchSourceBuilder().parseXContent(parser, true, searchUsageHolder, nf -> false);
                 SearchUsageStats searchUsageStats = searchUsageHolder.getSearchUsageStats();
                 Map<String, Long> sectionsUsage = searchUsageStats.getSectionsUsage();
                 assertEquals(


### PR DESCRIPTION
Fixing compilation error  in `SearchSourceBuilderTests#testStoredFieldsUsage` to account for the new `SearchSourceBuilder` constructors. 