### PR TITLE
Reduce overhead of (source-less) SearchHit

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchSortValues.java
@@ -32,8 +32,7 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
     private final Object[] rawSortValues;
 
     SearchSortValues(Object[] sortValues) {
-        this.formattedSortValues = Objects.requireNonNull(sortValues, "sort values must not be empty");
-        this.rawSortValues = EMPTY_ARRAY;
+        this(Objects.requireNonNull(sortValues, "sort values must not be empty"), EMPTY_ARRAY);
     }
 
     public SearchSortValues(Object[] rawSortValues, DocValueFormat[] sortValueFormats) {
@@ -52,9 +51,18 @@ public class SearchSortValues implements ToXContentFragment, Writeable {
         }
     }
 
-    SearchSortValues(StreamInput in) throws IOException {
-        this.formattedSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
-        this.rawSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
+    public static SearchSortValues readFrom(StreamInput in) throws IOException {
+        Object[] formattedSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
+        Object[] rawSortValues = in.readArray(Lucene::readSortValue, Object[]::new);
+        if (formattedSortValues.length == 0 && rawSortValues.length == 0) {
+            return EMPTY;
+        }
+        return new SearchSortValues(formattedSortValues, rawSortValues);
+    }
+
+    private SearchSortValues(Object[] formattedSortValues, Object[] rawSortValues) {
+        this.formattedSortValues = formattedSortValues;
+        this.rawSortValues = rawSortValues;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/SearchSortValuesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchSortValuesTests.java
@@ -90,7 +90,7 @@ public class SearchSortValuesTests extends AbstractXContentSerializingTestCase<S
 
     @Override
     protected Writeable.Reader<SearchSortValues> instanceReader() {
-        return SearchSortValues::new;
+        return SearchSortValues::readFrom;
     }
 
     @Override


### PR DESCRIPTION
Reduce overhead of `SearchHit` a little (and potentially more than a little if the source is empty). No need for any real ref-counting if there's neither source nor nested hits. Same goes for `SearchHits` which don't have to be ref-counted if their contents aren't. Also, don't create pointless unmodifiable maps wrapping the empty singleton for highlight fields and use the singleton for the empty search sort values.
