### PR TITLE
Make name getter method in Mapper.Builder final

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
@@ -138,16 +138,10 @@ public final class FieldAliasMapper extends Mapper {
     }
 
     public static class Builder extends Mapper.Builder {
-        private String name;
         private String path;
 
         protected Builder(String name) {
             super(name);
-            this.name = name;
-        }
-
-        public String name() {
-            return this.name;
         }
 
         public Builder path(String path) {
@@ -157,8 +151,8 @@ public final class FieldAliasMapper extends Mapper {
 
         @Override
         public FieldAliasMapper build(MapperBuilderContext context) {
-            String fullName = context.buildFullName(name);
-            return new FieldAliasMapper(name, fullName, path);
+            String fullName = context.buildFullName(name());
+            return new FieldAliasMapper(name(), fullName, path);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -31,7 +31,7 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         }
 
         // TODO rename this to leafName?
-        public String name() {
+        public final String name() {
             return this.name;
         }
 


### PR DESCRIPTION
FieldAliasMapper used to override it but it would not change any behaviour, it can rather call the existing getter for it.