### PR TITLE
[Transform] Fix testStopAtCheckpoint

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -106,7 +107,7 @@ public class TransformIndexerStateTests extends ESTestCase {
         private final ThreadPool threadPool;
 
         private TransformState persistedState;
-        private int saveStateListenerCallCount = 0;
+        private AtomicInteger saveStateListenerCallCount = new AtomicInteger(0);
         // used for synchronizing with the test
         private CountDownLatch searchLatch;
         private CountDownLatch doProcessLatch;
@@ -206,10 +207,10 @@ public class TransformIndexerStateTests extends ESTestCase {
 
         @Override
         protected void doSaveState(IndexerState state, TransformIndexerPosition position, Runnable next) {
-            Collection<ActionListener<Void>> saveStateListenersAtTheMomentOfCalling = saveStateListeners.get();
-            saveStateListenerCallCount += (saveStateListenersAtTheMomentOfCalling != null)
-                ? saveStateListenersAtTheMomentOfCalling.size()
-                : 0;
+            var saveStateListenersAtTheMomentOfCalling = saveStateListeners.get();
+            if (saveStateListenersAtTheMomentOfCalling != null) {
+                saveStateListenerCallCount.updateAndGet(count -> count + saveStateListenersAtTheMomentOfCalling.size());
+            }
             super.doSaveState(state, position, next);
         }
 
@@ -225,7 +226,7 @@ public class TransformIndexerStateTests extends ESTestCase {
         }
 
         public int getSaveStateListenerCallCount() {
-            return saveStateListenerCallCount;
+            return saveStateListenerCallCount.get();
         }
 
         public int getSaveStateListenerCount() {
@@ -592,12 +593,12 @@ public class TransformIndexerStateTests extends ESTestCase {
                 new TransformIndexerStats(),
                 context
             );
+
+            // stop the indexer before it dispatches a search thread so we can load the listeners first
+            CountDownLatch searchLatch = indexer.createAwaitForSearchLatch(1);
             indexer.start();
             assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
             assertEquals(indexer.getState(), IndexerState.INDEXING);
-
-            // slow down the indexer
-            CountDownLatch searchLatch = indexer.createAwaitForSearchLatch(1);
 
             // this time call 5 times and change stopAtCheckpoint every time
             List<CountDownLatch> responseLatches = new ArrayList<>();


### PR DESCRIPTION
Currently, there is a small chance that testStopAtCheckpoint will fail to correctly count the amount of times `doSaveState` is invoked:
```
Expected: <5>
     but: was <4>
```

There are two potential issues:
1. The test thread starts the Transform thread, which starts a Search thread. If the Search thread starts reading from the `saveStateListeners` while the test thread writes to the `saveStateListeners`, then there is a chance our testing logic will not be able to count the number of times we read from `saveStateListeners`.
2. The non-volatile integer may be read as one value and written as another value.

Two fixes:
1. The test thread blocks the Transform thread until after the test thread writes all the listeners. The subsequent test will continue to verify that we can safely interlace reading and writing.
2. The counter is now an AtomicInteger to provide thread safety.

Fixes #90549
