### PR TITLE
Fix EsAbortPolicy to not force execution if executor is already shutting down

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -23,7 +23,7 @@ public class EsAbortPolicy extends EsRejectedExecutionHandler {
                         Thread.currentThread().interrupt();
                         throw new IllegalStateException("forced execution, but got interrupted", e);
                     }
-                    if (executor.isShutdown() == false || sizeBlockingQueue.remove(r) == false) {
+                    if ((executor.isShutdown() && sizeBlockingQueue.remove(r)) == false) {
                         return;
                     } // else fall through and reject the task since the executor is shut down
                 } else {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -23,11 +23,9 @@ public class EsAbortPolicy extends EsRejectedExecutionHandler {
                         Thread.currentThread().interrupt();
                         throw new IllegalStateException("forced execution, but got interrupted", e);
                     }
-                    // we need to check again the executor state as it might have been concurrently shut down; in this case
-                    // the executor's workers are shutting down and might have already picked up the task for execution.
                     if (executor.isShutdown() == false || sizeBlockingQueue.remove(r) == false) {
                         return;
-                    }
+                    } // else fall through and reject the task since the executor is shut down
                 } else {
                     throw new IllegalStateException("expected but did not find SizeBlockingQueue: " + executor);
                 }


### PR DESCRIPTION
Fix `EsAbortPolicy` to not attempt forcing execution if the executor is shutting down already. This leads to a more deterministic behavior. Submitting a task during shutdown is highly unreliable and in almost all cases the task will be rejected (removed) anyways. 

Fixes `EsExecutorsTests.testFixedBoundedRejectOnShutdown`.

closes #105352