### PR TITLE
[Query rules] Fix transport bug handling errors in rule query

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/260_rule_query_search.yml
@@ -70,6 +70,44 @@ setup:
 
 
 ---
+"Perform a rule query specifying a ruleset that does not exist":
+  - skip:
+      version: " - 8.12.99"
+      reason: Bugfix that was broken in previous versions
+
+  - do:
+      catch: /resource_not_found_exception/
+      search:
+        body:
+          query:
+            rule_query:
+              organic:
+                query_string:
+                  default_field: text
+                  query: search
+              match_criteria:
+                foo: bar
+              ruleset_id: nonexistent-ruleset
+
+---
+"Perform a rule query with malformed rule":
+  - skip:
+      version: " - 8.12.99"
+      reason: Bugfix that was broken in previous versions
+
+  - do:
+      catch: bad_request
+      search:
+        body:
+          query:
+            rule_query:
+              organic:
+                query_string:
+                  default_field: text
+                  query: search
+              ruleset_id: test-ruleset
+
+---
 "Perform a rule query with an ID match":
 
   - do:


### PR DESCRIPTION
Note: This is not tagged as a bug because it only impacts locally running in dev mode, production will not crash. 

Below is an example of a working script, the final request is the one that would crash ES in dev mode. The script is not necessary to reproduce the crash. 

```
POST /_bulk
{ "index" : { "_index" : "classic_books", "_id" : "1" } }
{ "title" : "Pride and Prejudice", "author" : "Jane Austen"}
{ "index" : { "_index" : "classic_books", "_id" : "2" } }
{ "title" : "Moby-Dick", "author" : "Herman Melville" }
{ "index" : { "_index" : "classic_books", "_id" : "3" } }
{ "title" : "War and Peace", "author" : "Leo Tolstoy" }
{ "index" : { "_index" : "classic_books", "_id" : "4" } }
{ "title" : "The Great Gatsby", "author" : "F. Scott Fitzgerald" }
{ "index" : { "_index" : "classic_books", "_id" : "5" } }
{ "title" : "1984", "author" : "George Orwell" }


PUT /_query_rules/movies-based-on-books
{
  "rules": [
    {
      "rule_id": "leo",
      "type": "pinned",
      "criteria": [
        {
          "type": "exact",
          "metadata": "actor",
          "values": ["leonardo dicaprio"]
        }
      ],
      "actions": {
        "ids": [ "4" ]
      }
    },
    {
      "rule_id": "keira",
      "type": "pinned",
      "criteria": [
        {
          "type": "exact",
          "metadata": "actor",
          "values": ["kiera knightley"]
        }
      ],
      "actions": {
        "ids": [ "1" ]
      }
    }
  ]
}

# Working request just to show this example works as expected
GET /classic_books/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "match_all": {} 
      },
      "ruleset_id": "movies-based-on-books",
      "match_criteria": {
        "actor": "leonardo dicaprio"
      }
    }
  }
}

# Contrive an error - This is what caused ES to crash before the bug fix 
GET /books/_search
{
  "query": {
    "rule_query": {
      "organic": {
        "match_all": {} 
      },
      "ruleset_id": "i-dont-exist",
      "match_criteria": {
        "actor": "leonardo dicaprio"
      }
    }
  }
}
```
