### PR TITLE
Fix search response leaks in async search tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/RestActionTestCase.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -68,6 +69,8 @@ public abstract class RestActionTestCase extends ESTestCase {
         ThreadContext threadContext = verifyingClient.threadPool().getThreadContext();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
             controller.dispatchRequest(request, channel, threadContext);
+        } finally {
+            Releasables.close(channel.capturedResponse());
         }
     }
 
@@ -154,7 +157,7 @@ public abstract class RestActionTestCase extends ESTestCase {
         ) {
             @SuppressWarnings("unchecked") // Callers are responsible for lining this up
             Response response = (Response) executeLocallyVerifier.get().apply(action, request);
-            listener.onResponse(response);
+            ActionListener.respondAndRelease(listener, response);
             return request.createTask(
                 taskIdGenerator.incrementAndGet(),
                 "transport",

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.search;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.Strings;
@@ -27,7 +26,6 @@ import java.util.Date;
 
 import static org.elasticsearch.xpack.core.async.GetAsyncResultRequestTests.randomSearchId;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104838")
 public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<AsyncStatusResponse> {
 
     @Override
@@ -266,10 +264,13 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
     public void testGetStatusFromStoredSearchRandomizedInputs() {
         boolean ccs = randomBoolean();
         String searchId = randomSearchId();
-        AsyncSearchResponse asyncSearchResponse = AsyncSearchResponseTests.randomAsyncSearchResponse(
-            searchId,
-            AsyncSearchResponseTests.randomSearchResponse(ccs)
-        );
+        SearchResponse searchResponse = AsyncSearchResponseTests.randomSearchResponse(ccs);
+        AsyncSearchResponse asyncSearchResponse;
+        try {
+            asyncSearchResponse = AsyncSearchResponseTests.randomAsyncSearchResponse(searchId, searchResponse);
+        } finally {
+            searchResponse.decRef();
+        }
         try {
             if (asyncSearchResponse.getSearchResponse() == null
                 && asyncSearchResponse.getFailure() == null
@@ -339,8 +340,12 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
             new ShardSearchFailure[] { new ShardSearchFailure(new RuntimeException("foo")) },
             clusters
         );
-
-        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        AsyncSearchResponse asyncSearchResponse;
+        try {
+            asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        } finally {
+            searchResponse.decRef();
+        }
         try {
             AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
             assertNotNull(statusFromStoredSearch);
@@ -368,8 +373,12 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
             ShardSearchFailure.EMPTY_ARRAY,
             SearchResponse.Clusters.EMPTY
         );
-
-        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        AsyncSearchResponse asyncSearchResponse;
+        try {
+            asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        } finally {
+            searchResponse.decRef();
+        }
         try {
             AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
             assertNotNull(statusFromStoredSearch);
@@ -415,8 +424,12 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
             ShardSearchFailure.EMPTY_ARRAY,
             clusters
         );
-
-        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        AsyncSearchResponse asyncSearchResponse;
+        try {
+            asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        } finally {
+            searchResponse.decRef();
+        }
         try {
             AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
             assertNotNull(statusFromStoredSearch);
@@ -464,9 +477,13 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
             ShardSearchFailure.EMPTY_ARRAY,
             clusters
         );
-
         boolean isRunning = true;
-        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, isRunning, 100, 200);
+        AsyncSearchResponse asyncSearchResponse;
+        try {
+            asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, isRunning, 100, 200);
+        } finally {
+            searchResponse.decRef();
+        }
         try {
             AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
             assertNotNull(statusFromStoredSearch);

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.search;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -30,7 +29,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.mock;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104838")
 public class RestSubmitAsyncSearchActionTests extends RestActionTestCase {
 
     private RestSubmitAsyncSearchAction action;


### PR DESCRIPTION
Fixing all of these muted test classes, tried my best to keep indention changes to a minimum but it wasn't possible to avoid them in all cases unfortunately (review is quite short using `&w=1` no worries :)).
Had to make 2 adjustments to the test infrastructure so that it releases both created transport and rest responses properly. 

closes #104838 