### PR TITLE
[8.13] ES|QL: Set default query LIMIT to 1000 (#105618)

### DIFF
--- a/docs/reference/esql/esql-get-started.asciidoc
+++ b/docs/reference/esql/esql-get-started.asciidoc
@@ -37,7 +37,7 @@ image::images/esql/source-command.svg[A source command producing a table from {e
 
 The <<esql-from>> source command returns a table with documents from a data
 stream, index, or alias. Each row in the resulting table represents a document.
-This query returns up to 500 documents from the `sample_data` index:
+This query returns up to 1000 documents from the `sample_data` index:
 
 [source,esql]
 ----
@@ -237,7 +237,7 @@ include::{esql-specs}/eval.csv-spec[tag=gs-eval-stats-backticks]
 To track statistics over time, {esql} enables you to create histograms using the
 <<esql-auto_bucket>> function. `AUTO_BUCKET` creates human-friendly bucket sizes
 and returns a value for each row that corresponds to the resulting bucket the
-row falls into. 
+row falls into.
 
 For example, to create hourly buckets for the data on October 23rd:
 
@@ -272,7 +272,7 @@ image::images/esql/esql-enrich.png[align="center"]
 
 Before you can use `ENRICH`, you first need to
 <<esql-create-enrich-policy,create>> and <<esql-execute-enrich-policy,execute>>
-an <<esql-enrich-policy,enrich policy>>. 
+an <<esql-enrich-policy,enrich policy>>.
 
 include::{es-repo-dir}/tab-widgets/esql/esql-getting-started-widget-enrich-policy.asciidoc[]
 

--- a/docs/reference/esql/esql-kibana.asciidoc
+++ b/docs/reference/esql/esql-kibana.asciidoc
@@ -103,7 +103,7 @@ detailed warning, expand the query bar, and click *warnings*.
 === The results table
 
 For the example query, the results table shows 10 rows. Omitting the `LIMIT`
-command, the results table defaults to up to 500 rows. Using `LIMIT`, you can
+command, the results table defaults to up to 1000 rows. Using `LIMIT`, you can
 increase the limit to up to 10,000 rows.
 
 NOTE: the 10,000 row limit only applies to the number of rows that are retrieved

--- a/docs/reference/esql/esql-limitations.asciidoc
+++ b/docs/reference/esql/esql-limitations.asciidoc
@@ -9,7 +9,7 @@
 [[esql-max-rows]]
 === Result set size limit
 
-By default, an {esql} query returns up to 500 rows. You can increase the number
+By default, an {esql} query returns up to 1000 rows. You can increase the number
 of rows up to 10,000 using the <<esql-limit>> command.
 include::processing-commands/limit.asciidoc[tag=limitation]
 

--- a/docs/reference/esql/source-commands/from.asciidoc
+++ b/docs/reference/esql/source-commands/from.asciidoc
@@ -26,7 +26,7 @@ corresponds to a field, and can be accessed by the name of that field.
 [NOTE]
 ====
 By default, an {esql} query without an explicit <<esql-limit>> uses an implicit
-limit of 500. This applies to `FROM` too. A `FROM` command without `LIMIT`:
+limit of 1000. This applies to `FROM` too. A `FROM` command without `LIMIT`:
 
 [source,esql]
 ----
@@ -38,7 +38,7 @@ is executed as:
 [source,esql]
 ----
 FROM employees
-| LIMIT 500
+| LIMIT 1000
 ----
 ====
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -817,7 +817,10 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
     }
 
     private static Set<String> mutedWarnings() {
-        return Set.of("No limit defined, adding default limit of [500]");
+        return Set.of(
+            "No limit defined, adding default limit of [1000]",
+            "No limit defined, adding default limit of [500]" // this is for bwc tests, the limit in v 8.12.x is 500
+        );
     }
 
     private static void bulkLoadTestData(int count) throws IOException {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -185,7 +185,7 @@ public final class EsqlTestUtils {
 
     public static List<String> withDefaultLimitWarning(List<String> warnings) {
         List<String> result = warnings == null ? new ArrayList<>() : new ArrayList<>(warnings);
-        result.add("No limit defined, adding default limit of [500]");
+        result.add("No limit defined, adding default limit of [1000]");
         return result;
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
@@ -71,7 +71,7 @@ public class EsqlActionTaskIT extends AbstractPausableIntegTestCase {
             \\_ExchangeSourceOperator[]
             \\_AggregationOperator[mode = FINAL, aggs = sum of longs]
             \\_ProjectOperator[projection = [0]]
-            \\_LimitOperator[limit = 500]
+            \\_LimitOperator[limit = 1000]
             \\_OutputOperator[columns = [sum(pause_me)]]""";
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlPlugin.java
@@ -79,7 +79,7 @@ public class EsqlPlugin extends Plugin implements ActionPlugin {
 
     public static final Setting<Integer> QUERY_RESULT_TRUNCATION_DEFAULT_SIZE = Setting.intSetting(
         "esql.query.result_truncation_default_size",
-        500,
+        1000,
         1,
         10000,
         Setting.Property.NodeScope,

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -152,7 +152,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS c],FINAL,null]
      *   \_ExchangeExec[[count{r}#24, seen{r}#25],true]
      *     \_EsStatsQueryExec[test], stats[Stat[name=*, type=COUNT, query=null]]], query[{"esql_single_value":{"field":"emp_no","next":
@@ -171,7 +171,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS c],FINAL,null]
      *   \_ExchangeExec[[count{r}#14, seen{r}#15],true]
      *     \_EsStatsQueryExec[test], stats[Stat[name=*, type=COUNT, query=null]]],
@@ -187,7 +187,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[COUNT(emp_no{f}#5) AS c],FINAL,null]
      *   \_ExchangeExec[[count{r}#15, seen{r}#16],true]
      *     \_EsStatsQueryExec[test], stats[Stat[name=emp_no, type=COUNT, query={
@@ -207,7 +207,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[COUNT(salary{f}#20) AS c],FINAL,null]
      *   \_ExchangeExec[[count{r}#25, seen{r}#26],true]
      *     \_EsStatsQueryExec[test], stats[Stat[name=salary, type=COUNT, query={
@@ -302,7 +302,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expected
      * ProjectExec[[c{r}#3, c{r}#3 AS call, c_literal{r}#7]]
-     * \_LimitExec[500[INTEGER]]
+     * \_LimitExec[1000[INTEGER]]
      *   \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS c, COUNT(1[INTEGER]) AS c_literal],FINAL,null]
      *     \_ExchangeExec[[count{r}#18, seen{r}#19, count{r}#20, seen{r}#21],true]
      *       \_EsStatsQueryExec[test], stats[Stat[name=*, type=COUNT, query=null], Stat[name=*, type=COUNT, query=null]]],
@@ -346,7 +346,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expecting
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS c],FINAL,null]
      *   \_ExchangeExec[[count{r}#14, seen{r}#15],true]
      *     \_LocalSourceExec[[c{r}#3],[LongVectorBlock[vector=ConstantLongVector[positions=1, value=0]]]]
@@ -377,12 +377,12 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_ExchangeExec[[],false]
      *   \_ProjectExec[[_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gender{f}#5, job{f}#10, job.raw{f}#11, languages{f}#6, last_n
      * ame{f}#7, long_noidx{f}#12, salary{f}#8]]
      *     \_FieldExtractExec[_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gen..]
-     *       \_EsQueryExec[test], query[{"exists":{"field":"emp_no","boost":1.0}}][_doc{f}#13], limit[500], sort[] estimatedRowSize[324]
+     *       \_EsQueryExec[test], query[{"exists":{"field":"emp_no","boost":1.0}}][_doc{f}#13], limit[1000], sort[] estimatedRowSize[324]
      */
     public void testIsNotNullPushdownFilter() {
         var plan = plan("from test | where emp_no is not null");
@@ -392,20 +392,20 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
         var project = as(exchange.child(), ProjectExec.class);
         var field = as(project.child(), FieldExtractExec.class);
         var query = as(field.child(), EsQueryExec.class);
-        assertThat(query.limit().fold(), is(500));
+        assertThat(query.limit().fold(), is(1000));
         var expected = QueryBuilders.existsQuery("emp_no");
         assertThat(query.query().toString(), is(expected.toString()));
     }
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_ExchangeExec[[],false]
      *   \_ProjectExec[[_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gender{f}#5, job{f}#10, job.raw{f}#11, languages{f}#6, last_n
      * ame{f}#7, long_noidx{f}#12, salary{f}#8]]
      *     \_FieldExtractExec[_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gen..]
      *       \_EsQueryExec[test], query[{"bool":{"must_not":[{"exists":{"field":"emp_no","boost":1.0}}],"boost":1.0}}][_doc{f}#13],
-     *         limit[500], sort[] estimatedRowSize[324]
+     *         limit[1000], sort[] estimatedRowSize[324]
      */
     public void testIsNullPushdownFilter() {
         var plan = plan("from test | where emp_no is null");
@@ -415,21 +415,21 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
         var project = as(exchange.child(), ProjectExec.class);
         var field = as(project.child(), FieldExtractExec.class);
         var query = as(field.child(), EsQueryExec.class);
-        assertThat(query.limit().fold(), is(500));
+        assertThat(query.limit().fold(), is(1000));
         var expected = QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery("emp_no"));
         assertThat(query.query().toString(), is(expected.toString()));
     }
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_ExchangeExec[[],false]
      *   \_ProjectExec[[!alias_integer, boolean{f}#4, byte{f}#5, constant_keyword-foo{f}#6, date{f}#7, double{f}#8, float{f}#9,
      *     half_float{f}#10, integer{f}#12, ip{f}#13, keyword{f}#14, long{f}#15, scaled_float{f}#11, short{f}#17, text{f}#18,
      *     unsigned_long{f}#16, version{f}#19, wildcard{f}#20]]
      *     \_FieldExtractExec[!alias_integer, boolean{f}#4, byte{f}#5, constant_k..][]
      *       \_EsQueryExec[test], query[{"esql_single_value":{"field":"ip","next":{"terms":{"ip":["127.0.0.0/24"],"boost":1.0}},"source":
-     *         "cidr_match(ip, \"127.0.0.0/24\")@1:19"}}][_doc{f}#21], limit[500], sort[] estimatedRowSize[389]
+     *         "cidr_match(ip, \"127.0.0.0/24\")@1:19"}}][_doc{f}#21], limit[1000], sort[] estimatedRowSize[389]
      */
     public void testCidrMatchPushdownFilter() {
         var allTypeMappingAnalyzer = makeAnalyzer("mapping-ip.json", new EnrichResolution());
@@ -451,7 +451,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
         var project = as(exchange.child(), ProjectExec.class);
         var field = as(project.child(), FieldExtractExec.class);
         var queryExec = as(field.child(), EsQueryExec.class);
-        assertThat(queryExec.limit().fold(), is(500));
+        assertThat(queryExec.limit().fold(), is(1000));
 
         var expectedInnerQuery = QueryBuilders.termsQuery(fieldName, cidrBlocks);
         var expectedQuery = wrapWithSingleQuery(expectedInnerQuery, fieldName, new Source(1, 18, cidrMatch));
@@ -549,7 +549,7 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects e.g.
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_ExchangeExec[[],false]
      *   \_ProjectExec[[!alias_integer, boolean{f}#190, byte{f}#191, constant_keyword-foo{f}#192, date{f}#193, double{f}#194, ...]]
      *     \_FieldExtractExec[!alias_integer, boolean{f}#190, byte{f}#191, consta..][]
@@ -569,13 +569,13 @@ public class LocalPhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_ExchangeExec[[],false]
      *   \_ProjectExec[[_meta_field{f}#8, emp_no{r}#2, first_name{r}#3, gender{f}#4, job{f}#9, job.raw{f}#10, languages{f}#5, first_n
      * ame{r}#3 AS last_name, long_noidx{f}#11, emp_no{r}#2 AS salary]]
      *     \_FieldExtractExec[_meta_field{f}#8, gender{f}#4, job{f}#9, job.raw{f}..]
      *       \_EvalExec[[null[INTEGER] AS emp_no, null[KEYWORD] AS first_name]]
-     *         \_EsQueryExec[test], query[][_doc{f}#12], limit[500], sort[] estimatedRowSize[270]
+     *         \_EsQueryExec[test], query[][_doc{f}#12], limit[1000], sort[] estimatedRowSize[270]
      */
     public void testMissingFieldsDoNotGetExtracted() {
         var stats = EsqlTestUtils.statsForMissingField("first_name", "last_name", "emp_no", "salary");

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -238,7 +238,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Project[[s{r}#4 AS d, s{r}#4, last_name{f}#21, first_name{f}#18]]
-     * \_Limit[500[INTEGER]]
+     * \_Limit[1000[INTEGER]]
      *   \_Aggregate[[last_name{f}#21, first_name{f}#18],[SUM(salary{f}#22) AS s, last_name{f}#21, first_name{f}#18]]
      *     \_EsRelation[test][_meta_field{f}#23, emp_no{f}#17, first_name{f}#18, ..]
      */
@@ -297,7 +297,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[f{r}#7],[SUM(emp_no{f}#15) AS s, COUNT(first_name{f}#16) AS c, first_name{f}#16 AS f]]
      *   \_EsRelation[test][_meta_field{f}#21, emp_no{f}#15, first_name{f}#16, ..]
      */
@@ -327,7 +327,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[f{r}#7],[SUM(emp_no{f}#15) AS s, first_name{f}#16 AS f]]
      *   \_EsRelation[test][_meta_field{f}#21, emp_no{f}#15, first_name{f}#16, ..]
      */
@@ -987,9 +987,9 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expected
-     * TopN[[Order[first_name{f}#170,ASC,LAST]],500[INTEGER]]
+     * TopN[[Order[first_name{f}#170,ASC,LAST]],1000[INTEGER]]
      *  \_MvExpand[first_name{f}#170]
-     *    \_TopN[[Order[emp_no{f}#169,ASC,LAST]],500[INTEGER]]
+     *    \_TopN[[Order[emp_no{f}#169,ASC,LAST]],1000[INTEGER]]
      *      \_EsRelation[test][avg_worked_seconds{f}#167, birth_date{f}#168, emp_n..]
      */
     public void testDontCombineOrderByThroughMvExpand() {
@@ -1009,10 +1009,10 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expected
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      *  \_MvExpand[x{r}#159]
      *    \_EsqlProject[[first_name{f}#162 AS x]]
-     *      \_Limit[500[INTEGER]]
+     *      \_Limit[1000[INTEGER]]
      *        \_EsRelation[test][first_name{f}#162]
      */
     public void testCopyDefaultLimitPastMvExpand() {
@@ -1969,7 +1969,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[],[COUNT(salary{f}#1345) AS c]]
      *   \_EsRelation[test][_meta_field{f}#1346, emp_no{f}#1340, first_name{f}#..]
      */
@@ -2008,7 +2008,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[],[COUNT(salary{f}#19) AS x]]
      *   \_EsRelation[test][_meta_field{f}#20, emp_no{f}#14, first_name{f}#15, ..]
      */
@@ -2053,7 +2053,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * Project[[c{r}#342]]
-     * \_Limit[500[INTEGER]]
+     * \_Limit[1000[INTEGER]]
      *   \_Filter[min{r}#348 > 10[INTEGER]]
      *     \_Aggregate[[],[COUNT(salary{f}#367) AS c, MIN(salary{f}#367) AS min]]
      *       \_EsRelation[test][_meta_field{f}#368, emp_no{f}#362, first_name{f}#36..]
@@ -2084,7 +2084,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * Eval[[max{r}#6 + min{r}#9 + c{r}#3 AS x, min{r}#9 AS y, c{r}#3 AS z]]
-     * \_Limit[500[INTEGER]]
+     * \_Limit[1000[INTEGER]]
      *   \_Aggregate[[],[COUNT(salary{f}#26) AS c, MAX(salary{f}#26) AS max, MIN(salary{f}#26) AS min]]
      *     \_EsRelation[test][_meta_field{f}#27, emp_no{f}#21, first_name{f}#22, ..]
      */
@@ -2106,7 +2106,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      * Expects
      * Project[[y{r}#6 AS z]]
      * \_Eval[[emp_no{f}#11 + 1[INTEGER] AS y]]
-     *   \_Limit[500[INTEGER]]
+     *   \_Limit[1000[INTEGER]]
      *     \_EsRelation[test][_meta_field{f}#17, emp_no{f}#11, first_name{f}#12, ..]
      */
     public void testNoPruningWhenChainedEvals() {
@@ -2127,7 +2127,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * Project[[salary{f}#20 AS x, emp_no{f}#15 AS y]]
-     * \_Limit[500[INTEGER]]
+     * \_Limit[1000[INTEGER]]
      *   \_EsRelation[test][_meta_field{f}#21, emp_no{f}#15, first_name{f}#16, ..]
      */
     public void testPruningDuplicateEvals() {
@@ -2153,7 +2153,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[],[COUNT(salary{f}#24) AS cx, COUNT(emp_no{f}#19) AS cy]]
      *   \_EsRelation[test][_meta_field{f}#25, emp_no{f}#19, first_name{f}#20, ..]
      */
@@ -2177,7 +2177,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[x{r}#6],[COUNT(emp_no{f}#17) AS cy, salary{f}#22 AS x]]
      *   \_EsRelation[test][_meta_field{f}#23, emp_no{f}#17, first_name{f}#18, ..]
      */
@@ -2202,7 +2202,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[gender{f}#22],[COUNT(emp_no{f}#20) AS cy, MIN(salary{f}#25) AS cx, gender{f}#22]]
      *   \_EsRelation[test][_meta_field{f}#26, emp_no{f}#20, first_name{f}#21, ..]
      */
@@ -2228,7 +2228,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[gender{f}#21],[COUNT(emp_no{f}#19) AS cy, MIN(salary{f}#24) AS cx, gender{f}#21]]
      *   \_EsRelation[test][_meta_field{f}#25, emp_no{f}#19, first_name{f}#20, ..]
      */
@@ -2254,7 +2254,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[gender{f}#19],[COUNT(x{r}#3) AS cy, MIN(x{r}#3) AS cx, gender{f}#19]]
      *   \_Eval[[emp_no{f}#17 + 1[INTEGER] AS x]]
      *     \_EsRelation[test][_meta_field{f}#23, emp_no{f}#17, first_name{f}#18, ..]
@@ -2283,7 +2283,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[gender{f}#19],[COUNT(x{r}#3) AS cy, MIN(x{r}#3) AS cx, gender{f}#19]]
      *   \_Eval[[emp_no{f}#17 + 1[INTEGER] AS x]]
      *     \_EsRelation[test][_meta_field{f}#23, emp_no{f}#17, first_name{f}#18, ..]
@@ -2310,7 +2310,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[gender{f}#22],[COUNT(z{r}#9) AS cy, MIN(x{r}#3) AS cx, gender{f}#22]]
      *   \_Eval[[emp_no{f}#20 + 1[INTEGER] AS x, x{r}#3 + 1[INTEGER] AS z]]
      *     \_EsRelation[test][_meta_field{f}#26, emp_no{f}#20, first_name{f}#21, ..]
@@ -2355,7 +2355,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[gender{f}#14],[COUNT(salary{f}#17) AS cy, MIN(emp_no{f}#12) AS cx, gender{f}#14]]
      *   \_EsRelation[test][_meta_field{f}#18, emp_no{f}#12, first_name{f}#13, ..]
      */
@@ -2383,7 +2383,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      * Expects
      * Project[[c1{r}#2, c2{r}#4, cs{r}#6, cm{r}#8, cexp{r}#10]]
      * \_Eval[[c1{r}#2 AS c2, c1{r}#2 AS cs, c1{r}#2 AS cm, c1{r}#2 AS cexp]]
-     *   \_Limit[500[INTEGER]]
+     *   \_Limit[1000[INTEGER]]
      *     \_Aggregate[[],[COUNT([2a][KEYWORD]) AS c1]]
      *       \_EsRelation[test][_meta_field{f}#17, emp_no{f}#11, first_name{f}#12, ..]
      */
@@ -2414,7 +2414,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      * Expects
      * Project[[c1{r}#7, cx{r}#10, cs{r}#12, cy{r}#15]]
      * \_Eval[[c1{r}#7 AS cx, c1{r}#7 AS cs, c1{r}#7 AS cy]]
-     *   \_Limit[500[INTEGER]]
+     *   \_Limit[1000[INTEGER]]
      *     \_Aggregate[[],[COUNT([2a][KEYWORD]) AS c1]]
      *       \_EsRelation[test][_meta_field{f}#22, emp_no{f}#16, first_name{f}#17, ..]
      */
@@ -2446,7 +2446,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * Project[[min{r}#1385, max{r}#1388, min{r}#1385 AS min2, max{r}#1388 AS max2, gender{f}#1398]]
-     * \_Limit[500[INTEGER]]
+     * \_Limit[1000[INTEGER]]
      *   \_Aggregate[[gender{f}#1398],[MIN(salary{f}#1401) AS min, MAX(salary{f}#1401) AS max, gender{f}#1398]]
      *     \_EsRelation[test][_meta_field{f}#1402, emp_no{f}#1396, first_name{f}#..]
      */
@@ -2492,7 +2492,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * Project[[max(x){r}#11, max(x){r}#11 AS max(y), max(x){r}#11 AS max(z)]]
-     * \_Limit[500[INTEGER]]
+     * \_Limit[1000[INTEGER]]
      *   \_Aggregate[[],[MAX(salary{f}#21) AS max(x)]]
      *     \_EsRelation[test][_meta_field{f}#22, emp_no{f}#16, first_name{f}#17, ..]
      */
@@ -2546,7 +2546,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expected
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[a{r}#2],[COUNT([2a][KEYWORD]) AS bar]]
      *   \_Row[[1[INTEGER] AS a]]
      */
@@ -2565,7 +2565,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expected
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[a{r}#2, bar{r}#8],[COUNT([2a][KEYWORD]) AS baz, b{r}#4 AS bar]]
      *   \_Row[[1[INTEGER] AS a, 2[INTEGER] AS b]]
      */
@@ -2584,7 +2584,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expected
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[emp_no{f}#11, bar{r}#4],[MAX(salary{f}#16) AS baz, gender{f}#13 AS bar]]
      *   \_EsRelation[test][_meta_field{f}#17, emp_no{f}#11, first_name{f}#12, ..]
      */
@@ -2626,7 +2626,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[],[SUM(emp_no{f}#4) AS sum(emp_no)]]
      *   \_EsRelation[test][_meta_field{f}#10, emp_no{f}#4, first_name{f}#5, ge..]
      */
@@ -2658,7 +2658,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expected
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[salary{f}#1185],[SUM(salary{f}#1185) AS sum(salary), salary{f}#1185]]
      *   \_EsRelation[test][_meta_field{f}#1186, emp_no{f}#1180, first_name{f}#..]
      */
@@ -2677,7 +2677,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[x{r}#4],[SUM(salary{f}#13) AS sum(salary), salary{f}#13 AS x]]
      *   \_EsRelation[test][_meta_field{f}#14, emp_no{f}#8, first_name{f}#9, ge..]
      */
@@ -2697,7 +2697,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[salary{f}#13],[SUM(emp_no{f}#8) AS sum(x), salary{f}#13]]
      *   \_EsRelation[test][_meta_field{f}#14, emp_no{f}#8, first_name{f}#9, ge..]
      */
@@ -2719,7 +2719,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[],[SUM(emp_no{f}#8) AS a, MIN(salary{f}#13) AS b]]
      *   \_EsRelation[test][_meta_field{f}#14, emp_no{f}#8, first_name{f}#9, ge..]
      */
@@ -2738,7 +2738,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[gender{f}#11],[SUM(emp_no{f}#9) AS a, MIN(salary{f}#14) AS b, gender{f}#11]]
      *   \_EsRelation[test][_meta_field{f}#15, emp_no{f}#9, first_name{f}#10, g..]
      */
@@ -2757,7 +2757,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[emp_no{f}#9],[SUM(emp_no{f}#9) AS a, MIN(salary{f}#14) AS b, emp_no{f}#9]]
      *   \_EsRelation[test][_meta_field{f}#15, emp_no{f}#9, first_name{f}#10, g..]
      */
@@ -2776,7 +2776,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[w{r}#14, g{r}#16],[COUNT(b{r}#24) AS c, w{r}#14, gender{f}#32 AS g]]
      *   \_Eval[[emp_no{f}#30 / 10[INTEGER] AS x, x{r}#4 + salary{f}#35 AS y, y{r}#8 / 4[INTEGER] AS z, z{r}#11 * 2[INTEGER] +
      *  3[INTEGER] AS w, salary{f}#35 + 4[INTEGER] / 2[INTEGER] AS a, a{r}#21 + 3[INTEGER] AS b]]
@@ -2804,7 +2804,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[],[SPATIALCENTROID(location{f}#9) AS centroid]]
      *   \_EsRelation[airports][abbrev{f}#5, location{f}#9, name{f}#6, scalerank{f}..]
      */
@@ -2829,7 +2829,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[emp_no%2{r}#6],[COUNT(salary{f}#12) AS c, emp_no%2{r}#6]]
      *   \_Eval[[emp_no{f}#7 % 2[INTEGER] AS emp_no%2]]
      *     \_EsRelation[test][_meta_field{f}#13, emp_no{f}#7, first_name{f}#8, ge..]
@@ -2854,7 +2854,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[emp_no{f}#6],[COUNT(__c_COUNT@1bd45f36{r}#16) AS c, emp_no{f}#6]]
      *   \_Eval[[salary{f}#11 + 1[INTEGER] AS __c_COUNT@1bd45f36]]
      *     \_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..]
@@ -2879,7 +2879,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     }
 
     /**
-     * Limit[500[INTEGER]]
+     * Limit[1000[INTEGER]]
      * \_Aggregate[[emp_no%2{r}#7],[COUNT(__c_COUNT@fb7855b0{r}#18) AS c, emp_no%2{r}#7]]
      *   \_Eval[[emp_no{f}#8 % 2[INTEGER] AS emp_no%2, 100[INTEGER] / languages{f}#11 + salary{f}#13 + 1[INTEGER] AS __c_COUNT
      * @fb7855b0]]
@@ -2952,7 +2952,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      * Project[[x{r}#5]]
      * \_Eval[[____x_AVG@9efc3cf3_SUM@daf9f221{r}#18 / ____x_AVG@9efc3cf3_COUNT@53cd08ed{r}#19 AS __x_AVG@9efc3cf3, __x_AVG@
      * 9efc3cf3{r}#16 / 2[INTEGER] + __x_MAX@475d0e4d{r}#17 AS x]]
-     *   \_Limit[500[INTEGER]]
+     *   \_Limit[1000[INTEGER]]
      *     \_Aggregate[[],[SUM(salary{f}#11) AS ____x_AVG@9efc3cf3_SUM@daf9f221, COUNT(salary{f}#11) AS ____x_AVG@9efc3cf3_COUNT@53cd0
      * 8ed, MAX(salary{f}#11) AS __x_MAX@475d0e4d]]
      *       \_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..]
@@ -2990,7 +2990,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      * \_Eval[[$$SUM$$$AVG$avg(salary_%_3)>$0$0{r}#29 / $$COUNT$$$AVG$avg(salary_%_3)>$0$1{r}#30 AS $$AVG$avg(salary_%_3)>$0,
      *   $$AVG$avg(salary_%_3)>$0{r}#23 + $$MAX$avg(salary_%_3)>$1{r}#24 AS x,
      *   $$MIN$min(emp_no_/_3)>$2{r}#25 + 10[INTEGER] - $$MEDIAN$min(emp_no_/_3)>$3{r}#26 AS y]]
-     *   \_Limit[500[INTEGER]]
+     *   \_Limit[1000[INTEGER]]
      *     \_Aggregate[[z{r}#12],[SUM($$salary_%_3$AVG$0{r}#27) AS $$SUM$$$AVG$avg(salary_%_3)>$0$0,
      *     COUNT($$salary_%_3$AVG$0{r}#27) AS $$COUNT$$$AVG$avg(salary_%_3)>$0$1,
      *     MAX(emp_no{f}#13) AS $$MAX$avg(salary_%_3)>$1,
@@ -3047,7 +3047,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      *        CONCAT(TOSTRING($$AVG$CONCAT(TO_STRIN>$0{r}#23),TOSTRING($$MAX$CONCAT(TO_STRIN>$1{r}#24)) AS x,
      *        $$MIN$(MIN(emp_no_/_3>$2{r}#25 + 3.141592653589793[DOUBLE] - $$MEDIAN$(MIN(emp_no_/_3>$3{r}#26 / 2.718281828459045[DOUBLE]
      *         AS y]]
-     *   \_Limit[500[INTEGER]]
+     *   \_Limit[1000[INTEGER]]
      *     \_Aggregate[[z{r}#12],[SUM($$salary_%_3$AVG$0{r}#27) AS $$SUM$$$AVG$CONCAT(TO_STRIN>$0$0,
      *      COUNT($$salary_%_3$AVG$0{r}#27) AS $$COUNT$$$AVG$CONCAT(TO_STRIN>$0$1,
      *      MAX(emp_no{f}#13) AS $$MAX$CONCAT(TO_STRIN>$1,
@@ -3109,7 +3109,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      * \_Eval[[$$$$avg(salary)_+_m>$AVG$0$SUM$0{r}#48 / $$max(salary)_+_3>$COUNT$2{r}#46 AS $$avg(salary)_+_m>$AVG$0, $$avg(
      * salary)_+_m>$AVG$0{r}#44 + $$avg(salary)_+_m>$MAX$1{r}#45 AS a, $$avg(salary)_+_m>$MAX$1{r}#45 + 3[INTEGER] +
      * 3.141592653589793[DOUBLE] + $$max(salary)_+_3>$COUNT$2{r}#46 AS b]]
-     *   \_Limit[500[INTEGER]]
+     *   \_Limit[1000[INTEGER]]
      *     \_Aggregate[[w{r}#28],[SUM(salary{f}#39) AS $$$$avg(salary)_+_m>$AVG$0$SUM$0, MAX(salary{f}#39) AS $$avg(salary)_+_m>$MAX$1
      * , COUNT(salary{f}#39) AS $$max(salary)_+_3>$COUNT$2, MIN(salary{f}#39) AS $$count(salary)_->$MIN$3]]
      *       \_Eval[[languages{f}#37 % 2[INTEGER] AS w]]
@@ -3176,7 +3176,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * Project[[a{r}#5, a{r}#5 AS b, w{r}#12]]
-     * \_Limit[500[INTEGER]]
+     * \_Limit[1000[INTEGER]]
      *   \_Aggregate[[w{r}#12],[SUM($$salary_/_2_+_la>$SUM$0{r}#26) AS a, w{r}#12]]
      *     \_Eval[[emp_no{f}#16 % 2[INTEGER] AS w, salary{f}#21 / 2[INTEGER] + languages{f}#19 AS $$salary_/_2_+_la>$SUM$0]]
      *       \_EsRelation[test][_meta_field{f}#22, emp_no{f}#16, first_name{f}#17, ..]

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -349,7 +349,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SUM(salary{f}#882) AS x],FINAL,null]
      *   \_ExchangeExec[[sum{r}#887, seen{r}#888],true]
      *     \_FragmentExec[filter=null, estimatedRowSize=0, fragment=[
@@ -615,7 +615,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * EvalExec[[agg_emp{r}#4 + 7[INTEGER] AS x]]
-     * \_LimitExec[500[INTEGER]]
+     * \_LimitExec[1000[INTEGER]]
      *   \_AggregateExec[[],[SUM(emp_no{f}#8) AS agg_emp],FINAL,16]
      *     \_ExchangeExec[[sum{r}#18, seen{r}#19],true]
      *       \_AggregateExec[[],[SUM(emp_no{f}#8) AS agg_emp],PARTIAL,8]
@@ -647,7 +647,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * EvalExec[[agg_emp{r}#4 + 7[INTEGER] AS x]]
-     * \_LimitExec[500[INTEGER]]
+     * \_LimitExec[1000[INTEGER]]
      *   \_AggregateExec[[],[SUM(emp_no{f}#8) AS agg_emp],FINAL,16]
      *     \_ExchangeExec[[sum{r}#18, seen{r}#19],true]
      *       \_AggregateExec[[],[SUM(emp_no{f}#8) AS agg_emp],PARTIAL,8]
@@ -1562,14 +1562,14 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     }
 
     /**
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_ExchangeExec[[],false]
      *   \_ProjectExec[[_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gender{f}#5, job{f}#10, job.raw{f}#11, languages{f}#6, last_n
      * ame{f}#7, long_noidx{f}#12, salary{f}#8]]
      *     \_FieldExtractExec[_meta_field{f}#9, emp_no{f}#3, first_name{f}#4, gen..]
      *       \_EsQueryExec[test], query[{"esql_single_value":{"field":"first_name","next":
      *       {"term":{"first_name":{"value":"foo","case_insensitive":true}}},"source":"first_name =~ \"foo\"@2:9"}}]
-     *       [_doc{f}#23], limit[500], sort[] estimatedRowSize[324]
+     *       [_doc{f}#23], limit[1000], sort[] estimatedRowSize[324]
      */
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103599")
     public void testPushDownEqualsIgnoreCase() {
@@ -1591,12 +1591,12 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     }
 
     /**
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_ExchangeExec[[],false]
      *   \_ProjectExec[[_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, gender{f}#8, job{f}#13, job.raw{f}#14, languages{f}#9, last_
      * name{f}#10, long_noidx{f}#15, salary{f}#11, x{r}#4]]
      *     \_FieldExtractExec[_meta_field{f}#12, emp_no{f}#6, gender{f}#8, job{f}..]
-     *       \_LimitExec[500[INTEGER]]
+     *       \_LimitExec[1000[INTEGER]]
      *         \_FilterExec[x{r}#4 =~ [66 6f 6f][KEYWORD]]
      *           \_EvalExec[[CONCAT(first_name{f}#7,[66 6f 6f][KEYWORD]) AS x]]
      *             \_FieldExtractExec[first_name{f}#7]
@@ -2081,7 +2081,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
 
     /**
      * Expects
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[languages{f}#9],[MIN(salary{f}#11) AS m, languages{f}#9],FINAL,8]
      *   \_ExchangeExec[[languages{f}#9, min{r}#16, seen{r}#17],true]
      *     \_LocalSourceExec[[languages{f}#9, min{r}#16, seen{r}#17],EMPTY]
@@ -2113,7 +2113,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Expects
      * intermediate plan
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[COUNT(emp_no{f}#6) AS c],FINAL,null]
      *   \_ExchangeExec[[count{r}#16, seen{r}#17],true]
      *     \_FragmentExec[filter=null, estimatedRowSize=0, fragment=[
@@ -2122,7 +2122,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *   \_EsRelation[test][_meta_field{f}#12, emp_no{f}#6, first_name{f}#7, ge..]]]
      *
      * and final plan is
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[COUNT(emp_no{f}#6) AS c],FINAL,8]
      *   \_ExchangeExec[[count{r}#16, seen{r}#17],true]
      *     \_LocalSourceExec[[count{r}#16, seen{r}#17],[LongVectorBlock[vector=ConstantLongVector[positions=1, value=0]]]]
@@ -2184,7 +2184,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      * Expects
      * ProjectExec[[a{r}#5]]
      * \_EvalExec[[__a_SUM@734e2841{r}#16 / __a_COUNT@12536eab{r}#17 AS a]]
-     *   \_LimitExec[500[INTEGER]]
+     *   \_LimitExec[1000[INTEGER]]
      *     \_AggregateExec[[],[SUM(emp_no{f}#6) AS __a_SUM@734e2841, COUNT(emp_no{f}#6) AS __a_COUNT@12536eab],FINAL,24]
      *       \_ExchangeExec[[sum{r}#18, seen{r}#19, count{r}#20, seen{r}#21],true]
      *         \_LocalSourceExec[[sum{r}#18, seen{r}#19, count{r}#20, seen{r}#21],[LongArrayBlock[positions=1, mvOrdering=UNORDERED,
@@ -2217,7 +2217,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Before local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(location{f}#9) AS centroid],FINAL,null]
      *   \_ExchangeExec[[xVal{r}#10, xDel{r}#11, yVal{r}#12, yDel{r}#13, count{r}#14],true]
      *     \_FragmentExec[filter=null, estimatedRowSize=0, fragment=[
@@ -2226,7 +2226,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *
      * After local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(location{f}#9) AS centroid],FINAL,50]
      *   \_ExchangeExec[[xVal{r}#10, xDel{r}#11, yVal{r}#12, yDel{r}#13, count{r}#14],true]
      *     \_AggregateExec[[],[SPATIALCENTROID(location{f}#9) AS centroid],PARTIAL,50]
@@ -2274,7 +2274,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Before local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(__centroid_SPATIALCENTROID@b54a93a7{r}#10) AS centroid],FINAL,null]
      *   \_ExchangeExec[[xVal{r}#11, xDel{r}#12, yVal{r}#13, yDel{r}#14, count{r}#15],true]
      *     \_FragmentExec[filter=null, estimatedRowSize=0, fragment=[
@@ -2284,7 +2284,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *
      * After local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(__centroid_SPATIALCENTROID@ad2847b6{r}#10) AS centroid],FINAL,50]
      *   \_ExchangeExec[[xVal{r}#11, xDel{r}#12, yVal{r}#13, yDel{r}#14, count{r}#15],true]
      *     \_AggregateExec[[],[SPATIALCENTROID(__centroid_SPATIALCENTROID@ad2847b6{r}#10) AS centroid],PARTIAL,50]
@@ -2337,7 +2337,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Before local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(__centroid_SPATIALCENTROID@ec8dd77e{r}#7) AS centroid],FINAL,null]
      *   \_AggregateExec[[],[SPATIALCENTROID(__centroid_SPATIALCENTROID@ec8dd77e{r}#7) AS centroid],PARTIAL,null]
      *     \_EvalExec[[[1 1 0 0 0 0 0 30 e2 4c 7c 45 40 0 0 e0 92 b0 82 2d 40][GEO_POINT] AS __centroid_SPATIALCENTROID@ec8dd77e]]
@@ -2346,7 +2346,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *
      * After local optimizations we expect no changes because field is extracted:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(__centroid_SPATIALCENTROID@7ff910a{r}#7) AS centroid],FINAL,50]
      *   \_AggregateExec[[],[SPATIALCENTROID(__centroid_SPATIALCENTROID@7ff910a{r}#7) AS centroid],PARTIAL,50]
      *     \_EvalExec[[[1 1 0 0 0 0 0 30 e2 4c 7c 45 40 0 0 e0 92 b0 82 2d 40][GEO_POINT] AS __centroid_SPATIALCENTROID@7ff910a]]
@@ -2389,7 +2389,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Before local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(location{f}#11) AS centroid, COUNT([2a][KEYWORD]) AS count],FINAL,null]
      *   \_ExchangeExec[[xVal{r}#12, xDel{r}#13, yVal{r}#14, yDel{r}#15, count{r}#16, count{r}#17, seen{r}#18],true]
      *     \_FragmentExec[filter=null, estimatedRowSize=0, fragment=[
@@ -2398,7 +2398,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *
      * After local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(location{f}#11) AS centroid, COUNT([2a][KEYWORD]) AS count],FINAL,58]
      *   \_ExchangeExec[[xVal{r}#12, xDel{r}#13, yVal{r}#14, yDel{r}#15, count{r}#16, count{r}#17, seen{r}#18],true]
      *     \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS count, SPATIALCENTROID(location{f}#11) AS centroid],PARTIAL,58]
@@ -2449,7 +2449,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Before local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(location{f}#14) AS airports, SPATIALCENTROID(city_location{f}#17) AS cities, COUNT([2a][KEY
      * WORD]) AS count],FINAL,null]
      *   \_ExchangeExec[[xVal{r}#18, xDel{r}#19, yVal{r}#20, yDel{r}#21, count{r}#22, xVal{r}#23, xDel{r}#24, yVal{r}#25, yDel{r}#26,
@@ -2461,7 +2461,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *
      * After local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(location{f}#14) AS airports, SPATIALCENTROID(city_location{f}#17) AS cities, COUNT([2a][KEY
      * WORD]) AS count],FINAL,108]
      *   \_ExchangeExec[[xVal{r}#18, xDel{r}#19, yVal{r}#20, yDel{r}#21, count{r}#22, xVal{r}#23, xDel{r}#24, yVal{r}#25, yDel{r}#26,
@@ -2518,7 +2518,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Before local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(location{f}#12) AS centroid, COUNT([2a][KEYWORD]) AS count],FINAL,null]
      *   \_ExchangeExec[[xVal{r}#13, xDel{r}#14, yVal{r}#15, yDel{r}#16, count{r}#17, count{r}#18, seen{r}#19],true]
      *     \_FragmentExec[filter=null, estimatedRowSize=0, fragment=[
@@ -2528,7 +2528,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *
      * After local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(location{f}#11) AS centroid, COUNT([2a][KEYWORD]) AS count],FINAL,58]
      *   \_ExchangeExec[[xVal{r}#12, xDel{r}#13, yVal{r}#14, yDel{r}#15, count{r}#16, count{r}#17, seen{r}#18],true]
      *     \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS count, SPATIALCENTROID(location{f}#11) AS centroid],PARTIAL,58]
@@ -2585,7 +2585,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Before local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[scalerank{f}#10],[SPATIALCENTROID(location{f}#12) AS centroid, COUNT([2a][KEYWORD]) AS count, scalerank{f}#10],
      * FINAL,null]
      *   \_ExchangeExec[[scalerank{f}#10, xVal{r}#13, xDel{r}#14, yVal{r}#15, yDel{r}#16, count{r}#17, count{r}#18, seen{r}#19],true]
@@ -2595,7 +2595,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *
      * After local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[scalerank{f}#10],[SPATIALCENTROID(location{f}#12) AS centroid, COUNT([2a][KEYWORD]) AS count, scalerank{f}#10],
      * FINAL,62]
      *   \_ExchangeExec[[scalerank{f}#10, xVal{r}#13, xDel{r}#14, yVal{r}#15, yDel{r}#16, count{r}#17, count{r}#18, seen{r}#19],true]
@@ -2654,7 +2654,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
     /**
      * Before local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(centroid{r}#4) AS centroid, SUM(count{r}#6) AS count],FINAL,null]
      *   \_AggregateExec[[],[SPATIALCENTROID(centroid{r}#4) AS centroid, SUM(count{r}#6) AS count],PARTIAL,null]
      *     \_AggregateExec[[scalerank{f}#16],[SPATIALCENTROID(location{f}#18) AS centroid, COUNT([2a][KEYWORD]) AS count],FINAL,null]
@@ -2665,7 +2665,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
      *
      * After local optimizations:
      *
-     * LimitExec[500[INTEGER]]
+     * LimitExec[1000[INTEGER]]
      * \_AggregateExec[[],[SPATIALCENTROID(centroid{r}#4) AS centroid, SUM(count{r}#6) AS count],FINAL,58]
      *   \_AggregateExec[[],[SPATIALCENTROID(centroid{r}#4) AS centroid, SUM(count{r}#6) AS count],PARTIAL,58]
      *     \_AggregateExec[[scalerank{f}#16],[SPATIALCENTROID(location{f}#18) AS centroid, COUNT([2a][KEYWORD]) AS count],FINAL,58]

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/100_bug_fix.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/100_bug_fix.yml
@@ -3,7 +3,7 @@
   - skip:
       version: " - 8.11.99"
       reason: "fixes in 8.12 or later"
-      features: warnings
+      features: allowed_warnings_regex
   - do:
       bulk:
         index: test
@@ -14,10 +14,11 @@
           - { "index": { } }
           - { "emp_no": 20 }
   - do:
-      warnings:
-        - "Line 1:37: evaluation of [to_ip(coalesce(ip1.keyword, \"255.255.255.255\"))] failed, treating result as null. Only first 20 failures recorded."
+      allowed_warnings_regex:
+        - "Line 1:37: evaluation of \\[to_ip\\(coalesce\\(ip1.keyword, \\\\\"255.255.255.255\\\\\"\\)\\)\\] failed, treating result as null. Only first 20 failures recorded."
         - "Line 1:37: java.lang.IllegalArgumentException: '127.0' is not an IP string literal."
-        - "No limit defined, adding default limit of [500]"
+        - "No limit defined, adding default limit of \\[.*\\]"
+
       esql.query:
         body:
           query: 'FROM test | sort emp_no | eval ip = to_ip(coalesce(ip1.keyword, "255.255.255.255")) | keep emp_no, ip'
@@ -33,10 +34,10 @@
 
 
   - do:
-      warnings:
-        - "Line 1:98: evaluation of [to_ip(x2)] failed, treating result as null. Only first 20 failures recorded."
+      allowed_warnings_regex:
+        - "Line 1:98: evaluation of \\[to_ip\\(x2\\)\\] failed, treating result as null. Only first 20 failures recorded."
         - "Line 1:98: java.lang.IllegalArgumentException: '127.00.1' is not an IP string literal."
-        - "No limit defined, adding default limit of [500]"
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'FROM test | sort emp_no | eval x1 = concat(ip1, ip2), x2 = coalesce(x1, "255.255.255.255"), x3 = to_ip(x2) | keep emp_no, x*'

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/20_aggs.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/20_aggs.yml
@@ -3,7 +3,7 @@ setup:
   - skip:
       version: " - 8.10.99"
       reason: "ESQL is available in 8.11+"
-      features: warnings
+      features: allowed_warnings_regex
   - do:
       indices.create:
         index:  test
@@ -115,8 +115,8 @@ setup:
 ---
 "Test From":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -140,8 +140,8 @@ setup:
 ---
 "Test simple grouping avg":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | where color == "red" | stats avg(data) by color'
@@ -156,8 +156,8 @@ setup:
 ---
 "Test From Stats Avg":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats avg(count)'
@@ -170,8 +170,8 @@ setup:
 ---
 "Test From Stats Avg With Alias":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats f1 = avg(count)'
@@ -184,8 +184,8 @@ setup:
 ---
 "Test From Stats Count":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats count(data)'
@@ -198,8 +198,8 @@ setup:
 ---
 "Test From Stats Count With Alias":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats dataCount = count(data)'
@@ -212,8 +212,8 @@ setup:
 ---
 "Test From Stats Min":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats min(count)'
@@ -226,8 +226,8 @@ setup:
 ---
 "Test From Stats Min With Alias":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats minCount=min(count)'
@@ -240,8 +240,8 @@ setup:
 ---
 "Test From Stats Max":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats max(count)'
@@ -254,8 +254,8 @@ setup:
 ---
 "Test From Stats Max With Alias":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats maxCount=max(count)'
@@ -283,8 +283,8 @@ setup:
 ---
 "Test Median On Long":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats med=median(count)'
@@ -297,8 +297,8 @@ setup:
 ---
 "Test Median On Double":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats med=median(count_d)'
@@ -311,8 +311,8 @@ setup:
 ---
 "Test Grouping Median On Long":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats med=median(count) by color | sort med'
@@ -328,8 +328,8 @@ setup:
 ---
 "Test Grouping Median On Double":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats med=median(count_d) by color | sort med'
@@ -345,8 +345,8 @@ setup:
 ---
 "Test Median Absolute Deviation On Long":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats med=median_absolute_deviation(count)'
@@ -359,8 +359,8 @@ setup:
 ---
 "Test Median Absolute Deviation On Double":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats med=median_absolute_deviation(count_d)'
@@ -373,8 +373,8 @@ setup:
 ---
 "Test Grouping Median Absolute Deviation On Long":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats med=median_absolute_deviation(count) by color | sort color'
@@ -390,8 +390,8 @@ setup:
 ---
 "Test Grouping Median Absolute Deviation On Double":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats med=median_absolute_deviation(count_d) by color | sort color'
@@ -407,8 +407,8 @@ setup:
 ---
 "Test From Stats Eval":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats avg_count = avg(count) | eval x = avg_count + 7'
@@ -420,8 +420,8 @@ setup:
 ---
 "Test Stats Where":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats x = avg(count) | where x > 100'
@@ -444,8 +444,8 @@ setup:
 ---
 "Test Eval Row With Null":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'row a = 1, b = 2, c = null | eval z = c + b + a'
@@ -469,8 +469,8 @@ setup:
 ---
 "Test Eval With Null And Count":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | eval nullsum = count_d + null | stats count(nullsum)'
@@ -485,8 +485,8 @@ setup:
 ---
 "Test Eval With Multiple Expressions":
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'row l=1, d=1.0, ln=1 + null, dn=1.0 + null | stats sum(l), sum(d), sum(ln), sum(dn)'
@@ -510,8 +510,8 @@ setup:
 ---
 grouping on text:
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'FROM test | STATS med=median(count) BY text | SORT med'

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
@@ -3,7 +3,7 @@ setup:
   - skip:
       version: " - 8.11.99"
       reason: "more field loading added in 8.12+"
-      features: warnings
+      features: allowed_warnings_regex
 
 ---
 constant_keyword:
@@ -30,8 +30,8 @@ constant_keyword:
           - { "color": "red" }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -44,8 +44,8 @@ constant_keyword:
   - match: { values.0.1: wow such constant }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | eval l=length(kind) | keep l'
@@ -108,8 +108,8 @@ multivalued keyword:
           - { "card": ["jack", "of", "diamonds"] }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -139,8 +139,8 @@ keyword no doc_values:
           - { "card": ["jack", "of", "diamonds"] }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -169,8 +169,8 @@ wildcard:
           - { "card": "jack of diamonds" }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -180,8 +180,8 @@ wildcard:
   - match: {values.0.0: jack of diamonds}
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | eval l=length(card) | keep l'
@@ -220,8 +220,8 @@ numbers:
           - { i: 123, l: -1234567891011121131, d: 1.234567891234568, mv_i: [123456, -123456], mv_l: [1234567891011121131, -1234567891011121131], mv_d: [1.234567891234568, -1.234567891234568] }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -271,8 +271,8 @@ small_numbers:
           - { b: 1, s: 1245, hf: 12.01, f: 112.0 }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -291,8 +291,8 @@ small_numbers:
   - match: {values.0.3: 1245}
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | eval sum_d = b + f + hf + s, sum_i = b + s | keep sum_d, sum_i'
@@ -305,8 +305,8 @@ small_numbers:
   - match: {values.0.1: 1246}
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | eval r_f = round(f), r_hf = round(hf) | keep r_f, r_hf'
@@ -341,8 +341,8 @@ scaled_float:
           - { f: 112.01, d: 1.0 }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -355,8 +355,8 @@ scaled_float:
   - match: {values.0.1: 112.01}
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | eval sum = d + f | keep sum'
@@ -385,8 +385,8 @@ multivalued boolean:
           - { "booleans": [ true, false, false, false ] }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -417,8 +417,8 @@ ip:
           - { "ip": "127.0.0.1", "keyword": "127.0.0.2" }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -431,8 +431,8 @@ ip:
   - match: { values.0.1: "127.0.0.2" }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | where keyword == "127.0.0.2" | rename ip as IP | drop keyword'
@@ -487,8 +487,8 @@ alias:
           - { "foo": "def", "level1": {"level2": 50}, "some_long": 15, "some_date": "2015-01-01T12:00:00.000Z" }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | keep foo, bar, level1.level2, level2_alias, some_long, some_long_alias, some_long_alias2, some_date, some_date_alias | sort level2_alias'
@@ -531,8 +531,8 @@ alias:
   - match: { values.1.8: 2015-01-01T12:00:00.000Z }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | where bar == "abc" | keep foo, bar, level1.level2, level2_alias'
@@ -551,8 +551,8 @@ alias:
   - match: { values.0.3: 10 }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | where level2_alias == 10 | keep foo, bar, level1.level2, level2_alias'
@@ -571,16 +571,16 @@ alias:
   - match: { values.0.3: 10 }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | where level2_alias == 20'
   - length: { values: 0 }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test | stats x = max(level2_alias)'
@@ -609,8 +609,8 @@ version:
           - { "version": [ "1.2.3", "4.5.6-SNOOPY" ] }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -642,8 +642,8 @@ id:
           - { "kw": "keyword1" }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test metadata _id | keep _id, kw'
@@ -673,8 +673,8 @@ unsigned_long:
           - { "number": [ "1", "9223372036854775808", "0", "18446744073709551615" ] }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -892,8 +892,8 @@ geo_point:
           - { "location": "POINT(1 -1)" }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'
@@ -925,8 +925,8 @@ cartesian_point:
           - { "location": "POINT(4321 -1234)" }
 
   - do:
-      warnings:
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
           query: 'from test'

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/90_non_indexed.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/90_non_indexed.yml
@@ -2,7 +2,7 @@ setup:
   - skip:
       version: " - 8.11.99"
       reason: "extracting non-indexed fields available in 8.12+"
-      features: allowed_warnings
+      features: allowed_warnings_regex
   - do:
       indices.create:
         index: test
@@ -95,9 +95,10 @@ setup:
 ---
 fetch:
   - do:
-      allowed_warnings:
-        - "Field [ip_noidx] cannot be retrieved, it is unsupported or not indexed; returning null"
-        - "No limit defined, adding default limit of [500]"
+      allowed_warnings_regex:
+        - "Field \\[ip_noidx\\] cannot be retrieved, it is unsupported or not indexed; returning null"
+        - "No limit defined, adding default limit of \\[.*\\]"
+
       esql.query:
         body:
           query: 'from test'


### PR DESCRIPTION
Backports the following commits to 8.13:
 - ES|QL: Set default query LIMIT to 1000 (#105618)