### PR TITLE
[DOCS] Fixes get settings and update settings security API docs

### DIFF
--- a/docs/reference/rest-api/security.asciidoc
+++ b/docs/reference/rest-api/security.asciidoc
@@ -12,6 +12,8 @@ Use the following APIs to perform security activities.
 * <<security-api-has-privileges>>
 * <<security-api-ssl>>
 * <<security-api-get-builtin-privileges>>
+* <<security-api-get-settings>>
+* <<security-api-update-settings>>
 * <<security-api-get-user-privileges>>
 
 [discrete]

--- a/docs/reference/rest-api/security/get-settings.asciidoc
+++ b/docs/reference/rest-api/security/get-settings.asciidoc
@@ -5,6 +5,8 @@
 <titleabbrev>Get Security settings</titleabbrev>
 ++++
 
+Retrieves settings for the security internal index.
+
 [[security-api-get-settings-prereqs]]
 ==== {api-prereq-title}
 
@@ -14,10 +16,15 @@
 ==== {api-description-title}
 This API allows a user to retrieve the user-configurable settings for the 
 Security internal index (`.security` and associated indices). Only a subset of 
-the index settings — those that are user-configurable—will be shown. This includes:
+the index settings — those that are user-configurable—will be shown. This
+includes:
 
 - `index.auto_expand_replicas`
 - `index.number_of_replicas`
+
+
+[[security-api-get-settings-example]]
+==== {api-examples-title}
 
 An example of retrieving the security settings:
 

--- a/docs/reference/rest-api/security/get-settings.asciidoc
+++ b/docs/reference/rest-api/security/get-settings.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Get Security settings</titleabbrev>
 ++++
 
-Retrieves settings for the security internal index.
+Retrieves settings for the security internal indices.
 
 [[security-api-get-settings-prereqs]]
 ==== {api-prereq-title}

--- a/docs/reference/rest-api/security/update-settings.asciidoc
+++ b/docs/reference/rest-api/security/update-settings.asciidoc
@@ -5,10 +5,30 @@
 <titleabbrev>Update Security settings</titleabbrev>
 ++++
 
+Updates the settings of the security internal indices.
+
+
 [[security-api-update-settings-prereqs]]
 ==== {api-prereq-title}
 
 * To use this API, you must have at least the `manage_security` cluster privilege.
+
+
+[[security-api-update-settings-request-body]]
+==== {api-request-body-title}
+
+`security`::
+(Optional, object) Settings to be used for the index used for most security 
+configuration, including Native realm users and roles configured via the API.
+
+`security-tokens`::
+(Optional, object) Settings to be used for the index used to store 
+<<security-api-get-token,tokens>>.
+
+`security`::
+(Optional, object) Settings to be used for the index used to store 
+<<security-api-activate-user-profile, profile>> information.
+
 
 [[security-api-update-settings-desc]]
 ==== {api-description-title}
@@ -18,6 +38,10 @@ be modified. This includes:
 
 - `index.auto_expand_replicas`
 - `index.number_of_replicas`
+
+
+[[security-api-update-settings-example]]
+==== {api-examples-title}
 
 An example of modifying the Security settings:
 
@@ -43,18 +67,3 @@ The configured settings can be retrieved using the
 is not in use on the system, but settings are provided for it, the request will 
 be rejected - this API does not yet support configuring the settings for these 
 indices before they are in use.
-
-
-==== {api-request-body-title}
-
-`security`::
-(Optional, object) Settings to be used for the index used for most security 
-configuration, including Native realm users and roles configured via the API.
-
-`security-tokens`::
-(Optional, object) Settings to be used for the index used to store 
-<<security-api-get-token,tokens>>.
-
-`security`::
-(Optional, object) Settings to be used for the index used to store 
-<<security-api-activate-user-profile, profile>> information.


### PR DESCRIPTION
## Overview

This PR makes adjustments on the GET and UPDATE security settings API docs:
* fixes the page structure to match the API template criteria,
* adds short description to the APIs,
* adds the page IDs to the Security APIs index file so they are listed in the TOC.

### Preview

* [Security APIs](https://elasticsearch_bk_105686.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-api.html)
* [GET security settings](https://elasticsearch_bk_105686.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-api-get-settings.html)
* [UPDATE security settings](https://elasticsearch_bk_105686.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/security-api-update-settings.html)