### PR TITLE
[8.13] Fix EsAbortPolicy to not force execution if executor is already shutting down

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsAbortPolicy.java
@@ -14,7 +14,7 @@ public class EsAbortPolicy extends EsRejectedExecutionHandler {
 
     @Override
     public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
-        if (r instanceof AbstractRunnable abstractRunnable) {
+        if (executor.isShutdown() == false && r instanceof AbstractRunnable abstractRunnable) {
             if (abstractRunnable.isForceExecution()) {
                 if (executor.getQueue() instanceof SizeBlockingQueue<Runnable> sizeBlockingQueue) {
                     try {


### PR DESCRIPTION
Submitting a task during shutdown is highly unreliable and in almost all cases the task will be rejected (removed) anyways. Not forcing execution if the executor is already shutting down leads to more deterministic behavior and fixes EsExecutorsTests.testFixedBoundedRejectOnShutdown.

(cherry picked from commit 954c428cde5f3dcab7b1dc99c24ee0ea00a724fa)