### PR TITLE
Accept `SocketException` in `Netty4HttpClient`

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
@@ -40,6 +40,7 @@ import org.elasticsearch.transport.netty4.NettyAllocator;
 
 import java.io.Closeable;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -190,7 +191,7 @@ class Netty4HttpClient implements Closeable {
 
                 @Override
                 public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                    if (cause instanceof PrematureChannelClosureException) {
+                    if (cause instanceof PrematureChannelClosureException || cause instanceof SocketException) {
                         // no more requests coming, so fast-forward the latch
                         fastForward();
                     } else {


### PR DESCRIPTION
It's also possible to get a `Connection reset` if the server closes the
channel while we're still sending requests. This commit handles that
case in these tests.