### PR TITLE
Fix error 500 on invalid ParentIdQuery

### DIFF
--- a/docs/changelog/105693.yaml
+++ b/docs/changelog/105693.yaml
@@ -1,0 +1,6 @@
+pr: 105693
+summary: Fix error 500 on invalid `ParentIdQuery`
+area: Search
+type: bug
+issues:
+ - 105366

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/query/ParentIdQueryBuilder.java
@@ -51,8 +51,8 @@ public final class ParentIdQueryBuilder extends AbstractQueryBuilder<ParentIdQue
     private boolean ignoreUnmapped = DEFAULT_IGNORE_UNMAPPED;
 
     public ParentIdQueryBuilder(String type, String id) {
-        this.type = type;
-        this.id = id;
+        this.type = requireValue(type, "[" + NAME + "] requires '" + TYPE_FIELD.getPreferredName() + "' field");
+        this.id = requireValue(id, "[" + NAME + "] requires '" + ID_FIELD.getPreferredName() + "' field");
     }
 
     /**

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
@@ -156,6 +156,11 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
         assertThat(e.getMessage(), containsString("[" + ParentIdQueryBuilder.NAME + "] no relation found for child [unmapped]"));
     }
 
+    public void testThrowsOnNullTypeOrId() {
+        expectThrows(IllegalArgumentException.class, () -> new ParentIdQueryBuilder(null, randomAlphaOfLength(5)));
+        expectThrows(IllegalArgumentException.class, () -> new ParentIdQueryBuilder(randomAlphaOfLength(5), null));
+    }
+
     public void testDisallowExpensiveQueries() {
         SearchExecutionContext searchExecutionContext = mock(SearchExecutionContext.class);
         when(searchExecutionContext.allowExpensiveQueries()).thenReturn(false);


### PR DESCRIPTION
We need to enforce non-null values here, otherwise we'll error out and return a 500 when a user fails to set either id or type.

closes #105366
