### PR TITLE
ESQL: Support chunked bulk loading of larger data files in CSV tests

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestsDataLoader.java
@@ -48,6 +48,7 @@ import static org.elasticsearch.xpack.esql.CsvTestUtils.ESCAPED_COMMA_SEQUENCE;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.multiValuesAwareCsvToStringArray;
 
 public class CsvTestsDataLoader {
+    private static final int BULK_DATA_SIZE = 100_000;
     private static final TestsDataset EMPLOYEES = new TestsDataset("employees", "mapping-default.json", "employees.csv");
     private static final TestsDataset HOSTS = new TestsDataset("hosts", "mapping-hosts.json", "hosts.csv");
     private static final TestsDataset APPS = new TestsDataset("apps", "mapping-apps.json", "apps.csv");
@@ -243,8 +244,6 @@ public class CsvTestsDataLoader {
         CheckedBiFunction<XContent, InputStream, XContentParser, IOException> p,
         Logger logger
     ) throws IOException {
-        // The indexName is optional for a bulk request, but we use it for routing in MultiClusterSpecIT.
-        Request request = new Request("POST", "/" + indexName + "/_bulk");
         StringBuilder builder = new StringBuilder();
         try (BufferedReader reader = org.elasticsearch.xpack.ql.TestUtils.reader(resource)) {
             String line;
@@ -359,10 +358,22 @@ public class CsvTestsDataLoader {
                     }
                 }
                 lineNumber++;
+                if (builder.length() > BULK_DATA_SIZE) {
+                    sendBulkRequest(indexName, builder, client, logger);
+                    builder.setLength(0);
+                }
             }
-            builder.append("\n");
         }
+        if (builder.length() > 0) {
+            sendBulkRequest(indexName, builder, client, logger);
+        }
+    }
 
+    private static void sendBulkRequest(String indexName, StringBuilder builder, RestClient client, Logger logger) throws IOException {
+        // The indexName is optional for a bulk request, but we use it for routing in MultiClusterSpecIT.
+        builder.append("\n");
+        logger.debug("Sending bulk request of [{}] bytes for [{}]", builder.length(), indexName);
+        Request request = new Request("POST", "/" + indexName + "/_bulk");
         request.setJsonEntity(builder.toString());
         request.addParameter("refresh", "false"); // will be _forcemerge'd next
         Response response = client.performRequest(request);
@@ -373,7 +384,7 @@ public class CsvTestsDataLoader {
                 Map<String, Object> result = XContentHelper.convertToMap(xContentType.xContent(), content, false);
                 Object errors = result.get("errors");
                 if (Boolean.FALSE.equals(errors)) {
-                    logger.info("Data loading of [{}] OK", indexName);
+                    logger.info("Data loading of [{}] bytes into [{}] OK", builder.length(), indexName);
                 } else {
                     throw new IOException("Data loading of [" + indexName + "] failed with errors: " + errors);
                 }


### PR DESCRIPTION
When recently adding additional test data to the ESQL CSV tests, I experienced import failures. Some existing files are over 200k, but the new file was over 300k, only a little larger, and yet it failed. This change sends the uploads in 100k chunks, so will work for more cases.

For example, the existing file `airports.csv` is over 200k, and the new import log looks like this:

```
[2024-02-21T07:35:49,032][INFO ][o.e.x.e.CsvTestsDataLoader] [test] Data loading of [100005] bytes into [airports] OK
[2024-02-21T07:35:49,089][INFO ][o.e.x.e.CsvTestsDataLoader] [test] Data loading of [100156] bytes into [airports] OK
[2024-02-21T07:35:49,116][INFO ][o.e.x.e.CsvTestsDataLoader] [test] Data loading of [26440] bytes into [airports] OK
```

So the import is done in three chunks.