### PR TITLE
Grow buckets on FilterByFilterAggregator eagerly

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterByFilterAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterByFilterAggregator.java
@@ -296,17 +296,20 @@ public class FilterByFilterAggregator extends FiltersAggregator {
 
             @Override
             public void collect(int docId) throws IOException {
-                collectBucket(subCollector, docId, filterOrd);
+                collectExistingBucket(subCollector, docId, filterOrd);
             }
 
             @Override
-            public void setScorer(Scorable scorer) throws IOException {}
+            public void setScorer(Scorable scorer) {}
         }
         MatchCollector collector = new MatchCollector();
+        // create the buckets so we can call collectExistingBucket
+        grow(filters().size() + 1);
         filters().get(0).collect(aggCtx.getLeafReaderContext(), collector, live);
         for (int filterOrd = 1; filterOrd < filters().size(); filterOrd++) {
             collector.subCollector = collectableSubAggregators.getLeafCollector(aggCtx);
             collector.filterOrd = filterOrd;
+
             filters().get(filterOrd).collect(aggCtx.getLeafReaderContext(), collector, live);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterByFilterAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/FilterByFilterAggregator.java
@@ -309,7 +309,6 @@ public class FilterByFilterAggregator extends FiltersAggregator {
         for (int filterOrd = 1; filterOrd < filters().size(); filterOrd++) {
             collector.subCollector = collectableSubAggregators.getLeafCollector(aggCtx);
             collector.filterOrd = filterOrd;
-
             filters().get(filterOrd).collect(aggCtx.getLeafReaderContext(), collector, live);
         }
     }


### PR DESCRIPTION
We know how many buckets we are going to need so we can grow the buckets upfront so we can call collectExistingBucket in the MatchCollector.