### PR TITLE
Delegate readString in FilterStreamInput to possibly use an optimized readString of the delegate

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -27,6 +27,11 @@ public abstract class FilterStreamInput extends StreamInput {
     }
 
     @Override
+    public String readString() throws IOException {
+        return delegate.readString();
+    }
+
+    @Override
     public byte readByte() throws IOException {
         return delegate.readByte();
     }

--- a/server/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/BufferedChecksumStreamInput.java
@@ -49,6 +49,11 @@ public final class BufferedChecksumStreamInput extends FilterStreamInput {
     }
 
     @Override
+    public String readString() throws IOException {
+        return doReadString(readArraySize()); // always use the unoptimized slow path
+    }
+
+    @Override
     public byte readByte() throws IOException {
         final byte b = delegate.readByte();
         digest.update(b);


### PR DESCRIPTION
This is necessary so that the optimized `readString` added in https://github.com/elastic/elasticsearch/pull/104692 is actually used when wrapped in a `FilterStreamInput`.