### PR TITLE
[DOCS] Adds more detail on disk usage of kNN quantized vectors

### DIFF
--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -18,7 +18,8 @@ can be automatically quantized during index time through
 <<dense-vector-quantization,`quantization`>>. Quantization will reduce the
 required memory by 4x, but it will also reduce the precision of the vectors and
 increase disk usage for the field (by up to 25%). Increased disk usage is a
-result of {es} storing both the quantized and the unqantized vectors.
+result of {es} storing both the quantized and the unquantized vectors.
+For example, an increase in disk usage by 10GB can result in a 30GB reduction in required memory.
 
 For `float` vectors with `dim` greater than or equal to `384`, using a
 <<dense-vector-quantization,`quantized`>> index is highly recommended.

--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -17,7 +17,8 @@ The default <<dense-vector-element-type,`element_type`>> is `float`. But this
 can be automatically quantized during index time through
 <<dense-vector-quantization,`quantization`>>. Quantization will reduce the
 required memory by 4x, but it will also reduce the precision of the vectors and
-increase disk usage for the field (by up to 25%).
+increase disk usage for the field (by up to 25%). Increased disk usage is a
+result of {es} storing both the quantized and the unqantized vectors.
 
 For `float` vectors with `dim` greater than or equal to `384`, using a
 <<dense-vector-quantization,`quantized`>> index is highly recommended.

--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -19,7 +19,7 @@ can be automatically quantized during index time through
 required memory by 4x, but it will also reduce the precision of the vectors and
 increase disk usage for the field (by up to 25%). Increased disk usage is a
 result of {es} storing both the quantized and the unquantized vectors.
-For example, an increase in disk usage by 10GB can result in a 30GB reduction in required memory.
+For example, when quantizing 40GB of floating point vectors an extra 10GB of data will be stored for the quantized vectors. The total disk usage amounts to 50GB, but the memory usage for fast search will be reduced to 10GB.
 
 For `float` vectors with `dim` greater than or equal to `384`, using a
 <<dense-vector-quantization,`quantized`>> index is highly recommended.


### PR DESCRIPTION
## Overview

This PR adds more detail about the disk usage of quantized vectors to the kNN docs.

### Preview

[Reduce vector memory footprint](https://elasticsearch_bk_105724.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/tune-knn-search.html#_reduce_vector_memory_foot_print)