### PR TITLE
[ML] Unmute model deployment BWC tests

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.restart;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.apache.http.util.EntityUtils;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
@@ -37,7 +36,6 @@ import static org.elasticsearch.client.WarningsHandler.PERMISSIVE;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103808")
 public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClusterRestartTestCase {
 
     // See PyTorchModelIT for how this model was created


### PR DESCRIPTION
The failure of #103808 might be fixed by the upgrade to PyTorch 2.1.2. It's not good that we have this entire suite muted, so I'll try unmuting for a bit and see if we get any repeat failures.