### PR TITLE
email-reporting-attachment-docs: Correct auth and proxy fields.

### DIFF
--- a/docs/reference/watcher/actions/email.asciidoc
+++ b/docs/reference/watcher/actions/email.asciidoc
@@ -149,8 +149,10 @@ killed by firewalls or load balancers in-between.
                     means, by default watcher tries to download a dashboard for 10 minutes,
                     forty times fifteen seconds). The setting `xpack.notification.reporting.interval`
                     can be configured globally to change the default.
-| `request.auth`  | Additional auth configuration for the request
-| `request.proxy` | Additional proxy configuration for the request
+| `auth`          | Additional auth configuration for the request, see 
+                    {kibana-ref}/automating-report-generation.html#use-watcher[use watcher] for details
+| `proxy`         | Additional proxy configuration for the request. See <<http-input-attributes>> 
+                    on how to configure the values.
 |======
 
 


### PR DESCRIPTION
Hi team, the docs for watcher reporting attachments currently mention that there are `request.auth` and `request.proxy` fields to be configured: https://www.elastic.co/guide/en/elasticsearch/reference/8.12/actions-email.html#configuring-email-attachments

If you add these fields as detailed in this docs section you will get a http 400 response from Elasticsearch:
```
{
  "error": {
    "root_cause": [
      {
        "type": "x_content_parse_exception",
        "reason": "[39:15] [reporting_attachment] unknown field [request.auth]"
      }
    ],
    "type": "x_content_parse_exception",
    "reason": "[39:15] [reporting_attachment] unknown field [request.auth]"
  },
  "status": 400
}
```

The correct format would be:
```
        "attachments": {
          "test.csv": {
            "reporting": {
              "url": "<URL>",
              "auth": {
                "username":"user",
                "password": "password"
              }
            }
          }
        }
```

Details can be found in the Kibana docs: https://www.elastic.co/guide/en/kibana/current/automating-report-generation.html#use-watcher

The same is true for `request.proxy`. 

This PR is changing the doc and adds links to Kibana doc and http input configuration.