### PR TITLE
[ML] Unmute KDETests.testCdfAndSf

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/KDETests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/changepoint/KDETests.java
@@ -23,7 +23,6 @@ public class KDETests extends ESTestCase {
         assertThat(kde.data(), equalTo(new double[0]));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102876")
     public void testCdfAndSf() {
 
         double[] data = DoubleStream.generate(() -> randomDoubleBetween(0.0, 100.0, true)).limit(101).toArray();


### PR DESCRIPTION
This test was supposed to be fixed by #102878, however, the test was not unmuted in that PR.

Relates #102876