### PR TITLE
[Connectors API] Add tests and method docs for assertValidStateTransition in ConnectorStateMachine

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorStateMachine.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorStateMachine.java
@@ -42,6 +42,13 @@ public class ConnectorStateMachine {
         return validNextStates(current).contains(next);
     }
 
+    /**
+     * Throws {@link ConnectorInvalidStatusTransitionException} if a
+     * transition from one {@link ConnectorStatus} to another is invalid.
+     *
+     * @param current The current {@link ConnectorStatus} of the {@link Connector}.
+     * @param next The proposed next {@link ConnectorStatus} of the {@link Connector}.
+     */
     public static void assertValidStateTransition(ConnectorStatus current, ConnectorStatus next)
         throws ConnectorInvalidStatusTransitionException {
         if (isValidTransition(current, next)) return;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorStateMachineTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorStateMachineTests.java
@@ -65,4 +65,31 @@ public class ConnectorStateMachineTests extends ESTestCase {
             assertFalse("Transition from " + state + " to itself should be invalid", ConnectorStateMachine.isValidTransition(state, state));
         }
     }
+
+    public void testAssertValidStateTransition_ExpectExceptionOnInvalidTransition() {
+        assertThrows(
+            ConnectorInvalidStatusTransitionException.class,
+            () -> ConnectorStateMachine.assertValidStateTransition(ConnectorStatus.CREATED, ConnectorStatus.CONFIGURED)
+        );
+    }
+
+    public void testAssertValidStateTransition_ExpectNoExceptionOnValidTransition() {
+        ConnectorStatus prevStatus = ConnectorStatus.CREATED;
+        ConnectorStatus nextStatus = ConnectorStatus.ERROR;
+
+        try {
+            ConnectorStateMachine.assertValidStateTransition(prevStatus, nextStatus);
+        } catch (ConnectorInvalidStatusTransitionException e) {
+            fail(
+                "Did not expect "
+                    + ConnectorInvalidStatusTransitionException.class.getSimpleName()
+                    + " to be thrown for valid state transition ["
+                    + prevStatus
+                    + "] -> "
+                    + "["
+                    + nextStatus
+                    + "]."
+            );
+        }
+    }
 }


### PR DESCRIPTION
This PR adds method docs and tests for `assertValidStateTransition` of the `ConnectorStateMachine`.