### PR TITLE
Enhance LeakTracker to record thread + test that caused a leak

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -499,6 +499,7 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @Before
     public final void before() {
+        LeakTracker.setContextHint(getTestName());
         logger.info("{}before test", getTestParamsForLogging());
         assertNull("Thread context initialized twice", threadContext);
         if (enableWarningsCheck()) {
@@ -530,6 +531,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         ensureAllSearchContextsReleased();
         ensureCheckIndexPassed();
         logger.info("{}after test", getTestParamsForLogging());
+        LeakTracker.setContextHint("");
     }
 
     private String getTestParamsForLogging() {


### PR DESCRIPTION
Add recording of the current thread name to ever leak record. Also add functionality to set a global hint for the context of a leak and use it to record the current test name. This massively eases the task of correlating an observed leak with the test that caused it.

example output that shows the delay in logging the leak and new output format:
![image](https://github.com/elastic/elasticsearch/assets/6490959/d1f68f67-ad51-439c-a0cb-d9c475d5c096)
