### PR TITLE
[Transform] Retry destination index creation

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -294,14 +294,15 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     }
 
     protected void waitUntilCheckpoint(String id, long checkpoint, TimeValue waitTime) throws Exception {
-        assertBusy(
-            () -> assertEquals(
-                checkpoint,
-                ((Integer) XContentMapValues.extractValue("checkpointing.last.checkpoint", getBasicTransformStats(id))).longValue()
-            ),
-            waitTime.getMillis(),
-            TimeUnit.MILLISECONDS
-        );
+        assertBusy(() -> assertEquals(checkpoint, getCheckpoint(id)), waitTime.getMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    protected long getCheckpoint(String id) throws IOException {
+        return getCheckpoint(getBasicTransformStats(id));
+    }
+
+    protected long getCheckpoint(Map<String, Object> stats) {
+        return ((Integer) XContentMapValues.extractValue("checkpointing.last.checkpoint", stats)).longValue();
     }
 
     protected DateHistogramGroupSource createDateHistogramGroupSourceWithFixedInterval(


### PR DESCRIPTION
For Unattended Transforms, if we fail to create the destination index on the first run, we will retry the transformation iteration, but we will not retry the destination index creation on that next iteration.

This change stops the Unattended Transform from progressing beyond the 0th checkpoint, so all retries will include the destination index creation.

Fix #105683
Relates #104146
