### PR TITLE
Grow buckets on GlobalAggregator and RandomSamplerAggregator eagerly

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/global/GlobalAggregator.java
@@ -43,10 +43,11 @@ public final class GlobalAggregator extends BucketsAggregator implements SingleB
         if (scorer == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
+        grow(1);
         scorer.score(new LeafCollector() {
             @Override
             public void collect(int doc) throws IOException {
-                collectBucket(sub, doc, 0);
+                collectExistingBucket(sub, doc, 0);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplerAggregator.java
@@ -97,10 +97,11 @@ public class RandomSamplerAggregator extends BucketsAggregator implements Single
         }
         // No sampling is being done, collect all docs
         if (probability >= 1.0) {
+            grow(1);
             return new LeafBucketCollector() {
                 @Override
                 public void collect(int doc, long owningBucketOrd) throws IOException {
-                    collectBucket(sub, doc, 0);
+                    collectExistingBucket(sub, doc, 0);
                 }
             };
         }
@@ -113,11 +114,12 @@ public class RandomSamplerAggregator extends BucketsAggregator implements Single
         final DocIdSetIterator docIt = scorer.iterator();
         final Bits liveDocs = aggCtx.getLeafReaderContext().reader().getLiveDocs();
         try {
+            grow(1);
             // Iterate every document provided by the scorer iterator
             for (int docId = docIt.nextDoc(); docId != DocIdSetIterator.NO_MORE_DOCS; docId = docIt.nextDoc()) {
                 // If liveDocs is null, that means that every doc is a live doc, no need to check if it has been deleted or not
                 if (liveDocs == null || liveDocs.get(docIt.docID())) {
-                    collectBucket(sub, docIt.docID(), 0);
+                    collectExistingBucket(sub, docIt.docID(), 0);
                 }
             }
             // This collector could throw `CollectionTerminatedException` if the last leaf collector has stopped collecting


### PR DESCRIPTION
GlobalAggregator and RandomSamplerAggregator are always top level aggregators with just one bucket. Therefore tlet's allocate the bucket before collecting docs and call the most efficient collectExistingBucket.