### PR TITLE
[Docs] [Remote Clusters] Note about certificates in ESS for Remote Cluster Security

### DIFF
--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -62,6 +62,8 @@ information, refer to https://www.elastic.co/subscriptions.
 [[remote-clusters-security-api-key]]
 ==== Establish trust with a remote cluster
 
+NOTE: If the remote cluster is part of an {ess} deployment, there is already a valid certificate. In that case, you can ignore steps of this procedure related to certificates.
+
 ===== On the remote cluster
 
 // tag::remote-cluster-steps[]

--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -62,7 +62,8 @@ information, refer to https://www.elastic.co/subscriptions.
 [[remote-clusters-security-api-key]]
 ==== Establish trust with a remote cluster
 
-NOTE: If the remote cluster is part of an {ess} deployment, there is already a valid certificate. In that case, you can ignore steps of this procedure related to certificates.
+NOTE: If a remote cluster is part of an {ess} deployment, it has a valid certificate by default. 
+You can therefore skip steps related to certificates in these instructions.
 
 ===== On the remote cluster
 


### PR DESCRIPTION
This PR adds a note about setting up trust from a self-managed to an ESS cluster, stating that ESS deployments already have a valid certificate. This avoids users running into errors for that specific case when following this procedure.

For reference: [Slack thread](https://elastic.slack.com/archives/C04NYQNA6LX/p1708516828079649)