### PR TITLE
[8.13] [Docs] [Remote Clusters] Note about certificates in ESS for Remote Cluster Security (#105771)

### DIFF
--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -62,6 +62,9 @@ information, refer to https://www.elastic.co/subscriptions.
 [[remote-clusters-security-api-key]]
 ==== Establish trust with a remote cluster
 
+NOTE: If a remote cluster is part of an {ess} deployment, it has a valid certificate by default. 
+You can therefore skip steps related to certificates in these instructions.
+
 ===== On the remote cluster
 
 // tag::remote-cluster-steps[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Docs] [Remote Clusters] Note about certificates in ESS for Remote Cluster Security (#105771)](https://github.com/elastic/elasticsearch/pull/105771)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)