### PR TITLE
CCS with minimize_roundtrips performs incremental merges of each SearchResponse

### DIFF
--- a/docs/changelog/105781.yaml
+++ b/docs/changelog/105781.yaml
@@ -1,0 +1,5 @@
+pr: 105781
+summary: CCS with `minimize_roundtrips` performs incremental merges of each `SearchResponse`
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -306,12 +306,10 @@ class MutableSearchResponse implements Releasable {
      *         (for local-only/CCS minimize_roundtrips=false)
      */
     private SearchResponseMerger createSearchResponseMerger(AsyncSearchTask task) {
-        return null;
-        // TODO uncomment this code once Kibana moves to polling the _async_search/status endpoint to determine if a search is done
-        // if (task.getSearchResponseMergerSupplier() == null) {
-        // return null; // local search and CCS minimize_roundtrips=false
-        // }
-        // return task.getSearchResponseMergerSupplier().get();
+        if (task.getSearchResponseMergerSupplier() == null) {
+            return null; // local search and CCS minimize_roundtrips=false
+        }
+        return task.getSearchResponseMergerSupplier().get();
     }
 
     private SearchResponse getMergedResponse(SearchResponseMerger merger) {


### PR DESCRIPTION
This restores the functionality that was removed from 8.13 (waiting for a change on the Kibana side). The work for this feature was added in https://github.com/elastic/elasticsearch/pull/103134 but we had to remove the yaml changelog when we turned off the functionality in https://github.com/elastic/elasticsearch/pull/105455. So this PR restores the changelog yaml as well.