### PR TITLE
[Profiling] Use seed for consistent test results

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/GetStackTracesRequest.java
@@ -69,6 +69,9 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
     // sample counts by default and remove this flag.
     private Boolean adjustSampleCount;
 
+    // This is only meant for testing and is intentionally not exposed in the REST API.
+    private Integer shardSeed;
+
     public GetStackTracesRequest() {
         this(null, null, null, null, null, null, null, null, null, null, null, null);
     }
@@ -165,6 +168,14 @@ public class GetStackTracesRequest extends ActionRequest implements IndicesReque
 
     public void setAdjustSampleCount(Boolean adjustSampleCount) {
         this.adjustSampleCount = adjustSampleCount;
+    }
+
+    public Integer getShardSeed() {
+        return shardSeed;
+    }
+
+    public void setShardSeed(Integer shardSeed) {
+        this.shardSeed = shardSeed;
     }
 
     public void parseXContent(XContentParser parser) throws IOException {


### PR DESCRIPTION
In some cases (APM integration) profiling APIs may use the random sampler aggregation which inherently produces random results. To have consistent results in tests we have implemented a hack that kept the seed used by random sampler constant. With #104830 it is now possible to provide the shard seed directly to random sampler so we can now remove this hack.

Relates #104830
