### PR TITLE
Make Health API more resilient to multi-version clusters

### DIFF
--- a/docs/changelog/105789.yaml
+++ b/docs/changelog/105789.yaml
@@ -1,0 +1,6 @@
+pr: 105789
+summary: Make Health API more resilient to multi-version clusters
+area: Health
+type: bug
+issues:
+ - 90183

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -1,10 +1,8 @@
 ---
 "cluster health basic test":
   - skip:
-      version: all
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/90183"
-      # version: "- 8.3.99"
-      # reason: "health was only added in 8.2.0, and master_is_stable in 8.4.0"
+      version: "- 8.3.99"
+      reason: "health was only added in 8.2.0, and master_is_stable in 8.4.0"
 
   - do:
       health_report: { }

--- a/server/src/main/java/org/elasticsearch/health/HealthFeatures.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthFeatures.java
@@ -28,11 +28,6 @@ public class HealthFeatures implements FeatureSpecification {
 
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
-        return Map.of(
-            SUPPORTS_HEALTH,
-            Version.V_8_5_0,
-            SUPPORTS_SHARDS_CAPACITY_INDICATOR,
-            Version.V_8_8_0
-        );
+        return Map.of(SUPPORTS_HEALTH, Version.V_8_5_0, SUPPORTS_SHARDS_CAPACITY_INDICATOR, Version.V_8_8_0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/health/HealthFeatures.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthFeatures.java
@@ -13,6 +13,7 @@ import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
 
 import java.util.Map;
+import java.util.Set;
 
 public class HealthFeatures implements FeatureSpecification {
 
@@ -21,14 +22,17 @@ public class HealthFeatures implements FeatureSpecification {
     public static final NodeFeature SUPPORTS_EXTENDED_REPOSITORY_INDICATOR = new NodeFeature("health.extended_repository_indicator");
 
     @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(SUPPORTS_EXTENDED_REPOSITORY_INDICATOR);
+    }
+
+    @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
         return Map.of(
             SUPPORTS_HEALTH,
             Version.V_8_5_0,
             SUPPORTS_SHARDS_CAPACITY_INDICATOR,
-            Version.V_8_8_0,
-            SUPPORTS_EXTENDED_REPOSITORY_INDICATOR,
-            Version.V_8_13_0
+            Version.V_8_8_0
         );
     }
 }

--- a/server/src/main/java/org/elasticsearch/health/HealthFeatures.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthFeatures.java
@@ -17,9 +17,18 @@ import java.util.Map;
 public class HealthFeatures implements FeatureSpecification {
 
     public static final NodeFeature SUPPORTS_HEALTH = new NodeFeature("health.supports_health");
+    public static final NodeFeature SUPPORTS_SHARDS_CAPACITY_INDICATOR = new NodeFeature("health.shards_capacity_indicator");
+    public static final NodeFeature SUPPORTS_EXTENDED_REPOSITORY_INDICATOR = new NodeFeature("health.extended_repository_indicator");
 
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
-        return Map.of(SUPPORTS_HEALTH, Version.V_8_5_0);
+        return Map.of(
+            SUPPORTS_HEALTH,
+            Version.V_8_5_0,
+            SUPPORTS_SHARDS_CAPACITY_INDICATOR,
+            Version.V_8_8_0,
+            SUPPORTS_EXTENDED_REPOSITORY_INDICATOR,
+            Version.V_8_13_0
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorDetails;
@@ -72,9 +73,11 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
     private static final String IMPACT_CLUSTER_FUNCTIONALITY_UNAVAILABLE_ID = "cluster_functionality_unavailable";
 
     private final ClusterService clusterService;
+    private final FeatureService featureService;
 
-    public DiskHealthIndicatorService(ClusterService clusterService) {
+    public DiskHealthIndicatorService(ClusterService clusterService, FeatureService featureService) {
         this.clusterService = clusterService;
+        this.featureService = featureService;
     }
 
     @Override
@@ -87,7 +90,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
         ClusterState clusterState = clusterService.state();
         Map<String, DiskHealthInfo> diskHealthInfoMap = healthInfo.diskInfoByNode();
         if (diskHealthInfoMap == null || diskHealthInfoMap.isEmpty()) {
-            if (clusterState.clusterFeatures().clusterHasFeature(HealthFeatures.SUPPORTS_HEALTH) == false) {
+            if (featureService.clusterHasFeature(clusterState, HealthFeatures.SUPPORTS_HEALTH) == false) {
                 return createIndicator(
                     HealthStatus.GREEN,
                     "No disk usage available. This probably means a cluster upgrade is in progress.",

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.health.Diagnosis;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
@@ -83,8 +84,18 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
 
     @Override
     public HealthIndicatorResult calculate(boolean verbose, int maxAffectedResourcesCount, HealthInfo healthInfo) {
+        ClusterState clusterState = clusterService.state();
         Map<String, DiskHealthInfo> diskHealthInfoMap = healthInfo.diskInfoByNode();
         if (diskHealthInfoMap == null || diskHealthInfoMap.isEmpty()) {
+            if (clusterState.clusterFeatures().clusterHasFeature(HealthFeatures.SUPPORTS_HEALTH) == false) {
+                return createIndicator(
+                    HealthStatus.GREEN,
+                    "No disk usage available. This probably means a cluster upgrade is in progress.",
+                    HealthIndicatorDetails.EMPTY,
+                    List.of(),
+                    List.of()
+                );
+            }
             /*
              * If there is no disk health info, that either means that a new health node was just elected, or something is seriously
              * wrong with health data collection on the health node. Either way, we immediately return UNKNOWN. If there are at least
@@ -98,7 +109,6 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
                 Collections.emptyList()
             );
         }
-        ClusterState clusterState = clusterService.state();
         logNodesMissingHealthInfo(diskHealthInfoMap, clusterState);
 
         DiskHealthAnalyzer diskHealthAnalyzer = new DiskHealthAnalyzer(diskHealthInfoMap, clusterState);

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -93,7 +93,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             if (featureService.clusterHasFeature(clusterState, HealthFeatures.SUPPORTS_HEALTH) == false) {
                 return createIndicator(
                     HealthStatus.GREEN,
-                    "No disk usage available. This probably means a cluster upgrade is in progress.",
+                    "No disk usage data available. The cluster currently has mixed versions (an upgrade may be in progress).",
                     HealthIndicatorDetails.EMPTY,
                     List.of(),
                     List.of()

--- a/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.health.Diagnosis;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
@@ -105,6 +106,15 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
         var state = clusterService.state();
         var healthMetadata = HealthMetadata.getFromClusterState(state);
         if (healthMetadata == null || healthMetadata.getShardLimitsMetadata() == null) {
+            if (state.clusterFeatures().clusterHasFeature(HealthFeatures.SUPPORTS_SHARDS_CAPACITY_INDICATOR) == false) {
+                return createIndicator(
+                    HealthStatus.GREEN,
+                    "No shard limits configured yet. This probably means a cluster upgrade is in progress.",
+                    HealthIndicatorDetails.EMPTY,
+                    List.of(),
+                    List.of()
+                );
+            }
             return unknownIndicator();
         }
 

--- a/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorDetails;
@@ -91,9 +92,11 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
     );
 
     private final ClusterService clusterService;
+    private final FeatureService featureService;
 
-    public ShardsCapacityHealthIndicatorService(ClusterService clusterService) {
+    public ShardsCapacityHealthIndicatorService(ClusterService clusterService, FeatureService featureService) {
         this.clusterService = clusterService;
+        this.featureService = featureService;
     }
 
     @Override
@@ -106,7 +109,7 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
         var state = clusterService.state();
         var healthMetadata = HealthMetadata.getFromClusterState(state);
         if (healthMetadata == null || healthMetadata.getShardLimitsMetadata() == null) {
-            if (state.clusterFeatures().clusterHasFeature(HealthFeatures.SUPPORTS_SHARDS_CAPACITY_INDICATOR) == false) {
+            if (featureService.clusterHasFeature(state, HealthFeatures.SUPPORTS_SHARDS_CAPACITY_INDICATOR) == false) {
                 return createIndicator(
                     HealthStatus.GREEN,
                     "No shard limits configured yet. This probably means a cluster upgrade is in progress.",

--- a/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
@@ -112,7 +112,7 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
             if (featureService.clusterHasFeature(state, HealthFeatures.SUPPORTS_SHARDS_CAPACITY_INDICATOR) == false) {
                 return createIndicator(
                     HealthStatus.GREEN,
-                    "No shard limits configured yet. This probably means a cluster upgrade is in progress.",
+                    "No shard limits configured yet. The cluster currently has mixed versions (an upgrade may be in progress).",
                     HealthIndicatorDetails.EMPTY,
                     List.of(),
                     List.of()

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -1196,9 +1196,9 @@ class NodeConstruction {
 
         var serverHealthIndicatorServices = Stream.of(
             new StableMasterHealthIndicatorService(coordinationDiagnosticsService, clusterService),
-            new RepositoryIntegrityHealthIndicatorService(clusterService),
-            new DiskHealthIndicatorService(clusterService),
-            new ShardsCapacityHealthIndicatorService(clusterService)
+            new RepositoryIntegrityHealthIndicatorService(clusterService, featureService),
+            new DiskHealthIndicatorService(clusterService, featureService),
+            new ShardsCapacityHealthIndicatorService(clusterService, featureService)
         );
         var pluginHealthIndicatorServices = pluginsService.filterPlugins(HealthPlugin.class)
             .flatMap(plugin -> plugin.getHealthIndicatorServices().stream());

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.health.Diagnosis;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
@@ -167,7 +168,11 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
                 || invalidRepositories.isEmpty() == false) {
                 healthStatus = YELLOW;
             } else if (repositoriesHealthByNode.isEmpty()) {
-                healthStatus = UNKNOWN;
+                if (clusterState.clusterFeatures().clusterHasFeature(HealthFeatures.SUPPORTS_EXTENDED_REPOSITORY_INDICATOR) == false) {
+                    healthStatus = GREEN;
+                } else {
+                    healthStatus = UNKNOWN;
+                }
             } else {
                 healthStatus = GREEN;
             }

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorDetails;
@@ -96,9 +97,11 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     );
 
     private final ClusterService clusterService;
+    private final FeatureService featureService;
 
-    public RepositoryIntegrityHealthIndicatorService(ClusterService clusterService) {
+    public RepositoryIntegrityHealthIndicatorService(ClusterService clusterService, FeatureService featureService) {
         this.clusterService = clusterService;
+        this.featureService = featureService;
     }
 
     @Override
@@ -129,7 +132,7 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
     /**
      * Analyzer for the cluster's repositories health; aids in constructing a {@link HealthIndicatorResult}.
      */
-    static class RepositoryHealthAnalyzer {
+    class RepositoryHealthAnalyzer {
         private final ClusterState clusterState;
         private final int totalRepositories;
         private final List<String> corruptedRepositories;
@@ -168,7 +171,7 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
                 || invalidRepositories.isEmpty() == false) {
                 healthStatus = YELLOW;
             } else if (repositoriesHealthByNode.isEmpty()) {
-                if (clusterState.clusterFeatures().clusterHasFeature(HealthFeatures.SUPPORTS_EXTENDED_REPOSITORY_INDICATOR) == false) {
+                if (featureService.clusterHasFeature(clusterState, HealthFeatures.SUPPORTS_EXTENDED_REPOSITORY_INDICATOR) == false) {
                     healthStatus = GREEN;
                 } else {
                     healthStatus = UNKNOWN;

--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorImpact;
@@ -40,6 +41,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
+import org.junit.Before;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -67,6 +70,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -99,10 +103,20 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         DiscoveryNodeRole.TRANSFORM_ROLE
     );
 
+    private FeatureService featureService;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        featureService = Mockito.mock(FeatureService.class);
+        Mockito.when(featureService.clusterHasFeature(any(), any())).thenReturn(true);
+    }
+
     public void testServiceBasics() {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         {
             HealthStatus expectedStatus = HealthStatus.UNKNOWN;
             HealthInfo healthInfo = HealthInfo.EMPTY_HEALTH_INFO;
@@ -126,7 +140,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testIndicatorYieldsGreenWhenNodeHasUnknownStatus() {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
 
         HealthStatus expectedStatus = HealthStatus.GREEN;
         HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(HealthStatus.UNKNOWN, discoveryNodes);
@@ -137,7 +151,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testGreen() throws IOException {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         HealthStatus expectedStatus = HealthStatus.GREEN;
         HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(expectedStatus, discoveryNodes);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
@@ -172,7 +186,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         final var clusterService = createClusterService(Set.of(), allNodes, indexNameToNodeIdsMap);
         HealthStatus expectedStatus = HealthStatus.YELLOW;
         HealthInfo healthInfo = createHealthInfo(new HealthInfoConfig(expectedStatus, allNodes.size(), allNodes));
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
         assertThat(result.status(), equalTo(expectedStatus));
         assertThat(result.symptom(), containsString("with roles: [data"));
@@ -250,7 +264,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             indexNameToNodeIdsMap.put(indexName, new HashSet<>(randomNonEmptySubsetOf(affectedNodeIds)));
         }
         ClusterService clusterService = createClusterService(Set.of(), discoveryNodes, indexNameToNodeIdsMap);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         Map<String, DiskHealthInfo> diskInfoByNode = new HashMap<>();
         for (DiscoveryNode discoveryNode : discoveryNodes) {
             if (affectedNodeIds.contains(discoveryNode.getId())) {
@@ -314,7 +328,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testRedWithBlockedIndicesAndGreenNodes() throws IOException {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, true);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
 
         HealthStatus expectedStatus = HealthStatus.RED;
         HealthInfo healthInfo = createHealthInfoWithOneUnhealthyNode(HealthStatus.GREEN, discoveryNodes);
@@ -359,7 +373,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
     public void testRedWithBlockedIndicesAndYellowNodes() throws IOException {
         Set<DiscoveryNode> discoveryNodes = createNodesWithAllRoles();
         ClusterService clusterService = createClusterService(discoveryNodes, true);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         HealthStatus expectedStatus = HealthStatus.RED;
         int numberOfYellowNodes = randomIntBetween(1, discoveryNodes.size());
         HealthInfo healthInfo = createHealthInfo(new HealthInfoConfig(HealthStatus.YELLOW, numberOfYellowNodes, discoveryNodes));
@@ -438,7 +452,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             }
         }
         ClusterService clusterService = createClusterService(blockedIndices, discoveryNodes, indexNameToNodeIdsMap);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
         assertThat(result.status(), equalTo(expectedStatus));
         assertThat(
@@ -477,7 +491,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
             indexNameToNodeIdsMap.put(indexName, nonRedNodeIds);
         }
         ClusterService clusterService = createClusterService(Set.of(), discoveryNodes, indexNameToNodeIdsMap);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
         assertThat(result.status(), equalTo(expectedStatus));
         assertThat(result.impacts().size(), equalTo(3));
@@ -513,7 +527,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNode> discoveryNodesInClusterState = new HashSet<>(discoveryNodes);
         discoveryNodesInClusterState.add(DiscoveryNodeUtils.create(randomAlphaOfLength(30), UUID.randomUUID().toString()));
         ClusterService clusterService = createClusterService(discoveryNodesInClusterState, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         {
             HealthInfo healthInfo = HealthInfo.EMPTY_HEALTH_INFO;
             HealthIndicatorResult result = diskHealthIndicatorService.calculate(true, healthInfo);
@@ -545,7 +559,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNodeRole> roles = Set.of(DiscoveryNodeRole.MASTER_ROLE, otherRole);
         Set<DiscoveryNode> discoveryNodes = createNodes(roles);
         ClusterService clusterService = createClusterService(discoveryNodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         HealthStatus expectedStatus = randomFrom(HealthStatus.RED, HealthStatus.YELLOW);
         int numberOfProblemNodes = randomIntBetween(1, discoveryNodes.size());
         HealthInfo healthInfo = createHealthInfo(new HealthInfoConfig(expectedStatus, numberOfProblemNodes, discoveryNodes));
@@ -600,7 +614,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNodeRole> roles = new HashSet<>(randomNonEmptySubsetOf(OTHER_ROLES));
         Set<DiscoveryNode> nodes = createNodes(roles);
         ClusterService clusterService = createClusterService(nodes, false);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         HealthStatus expectedStatus = randomFrom(HealthStatus.RED, HealthStatus.YELLOW);
         int numberOfProblemNodes = randomIntBetween(1, nodes.size());
         HealthInfo healthInfo = createHealthInfo(new HealthInfoConfig(expectedStatus, numberOfProblemNodes, nodes));
@@ -656,7 +670,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNode> masterNodes = createNodes(masterRole);
         Set<DiscoveryNode> otherNodes = createNodes(otherRoles);
         ClusterService clusterService = createClusterService(Sets.union(Sets.union(dataNodes, masterNodes), otherNodes), true);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         int numberOfRedMasterNodes = randomIntBetween(1, masterNodes.size());
         int numberOfRedOtherNodes = randomIntBetween(1, otherNodes.size());
         int numberOfYellowDataNodes = randomIntBetween(1, dataNodes.size());
@@ -878,7 +892,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Set<DiscoveryNode> masterNodes = createNodes(20, masterRole);
         Set<DiscoveryNode> otherNodes = createNodes(10, otherRoles);
         ClusterService clusterService = createClusterService(Sets.union(Sets.union(dataNodes, masterNodes), otherNodes), true);
-        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService);
+        DiskHealthIndicatorService diskHealthIndicatorService = new DiskHealthIndicatorService(clusterService, featureService);
         int numberOfRedMasterNodes = masterNodes.size();
         int numberOfRedOtherNodes = otherNodes.size();
         int numberOfYellowDataNodes = dataNodes.size();

--- a/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.health.Diagnosis;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorImpact;
 import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.HealthStatus;
@@ -1055,9 +1056,11 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         Collection<DiscoveryNode> nodes,
         Map<String, Set<String>> indexNameToNodeIdsMap
     ) {
+        Map<String, Set<String>> features = new HashMap<>();
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
         for (DiscoveryNode node : nodes) {
             nodesBuilder = nodesBuilder.add(node);
+            features.put(node.getId(), Set.of(HealthFeatures.SUPPORTS_HEALTH.id()));
         }
         nodesBuilder.localNodeId(randomFrom(nodes).getId());
         nodesBuilder.masterNodeId(randomFrom(nodes).getId());
@@ -1093,6 +1096,7 @@ public class DiskHealthIndicatorServiceTests extends ESTestCase {
         state.metadata(metadata.generateClusterUuidIfNeeded().build());
         state.routingTable(routingTable.build());
         state.blocks(clusterBlocksBuilder);
+        state.nodeFeatures(features);
         return state.build();
     }
 

--- a/server/src/test/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.metadata.HealthMetadata;
 import org.elasticsearch.index.IndexVersion;
@@ -397,7 +398,11 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
             metadata.put(idxMetadata);
         }
 
-        return ClusterState.builder(clusterState).metadata(metadata).build();
+        var features = Set.of(HealthFeatures.SUPPORTS_SHARDS_CAPACITY_INDICATOR.id());
+        return ClusterState.builder(clusterState)
+            .metadata(metadata)
+            .nodeFeatures(Map.of(dataNode.getId(), features, frozenNode.getId(), features))
+            .build();
     }
 
     private static IndexMetadata.Builder createIndexInDataNode(int shards) {

--- a/server/src/test/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthStatus;
 import org.elasticsearch.health.metadata.HealthMetadata;
@@ -37,6 +38,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.List;
@@ -61,6 +63,7 @@ import static org.elasticsearch.indices.ShardLimitValidator.NORMAL_GROUP;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 
 public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
 
@@ -69,6 +72,7 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
     private static ThreadPool threadPool;
 
     private ClusterService clusterService;
+    private FeatureService featureService;
     private DiscoveryNode dataNode;
     private DiscoveryNode frozenNode;
 
@@ -87,6 +91,9 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
             .build();
 
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
+
+        featureService = Mockito.mock(FeatureService.class);
+        Mockito.when(featureService.clusterHasFeature(any(), any())).thenReturn(true);
     }
 
     @After
@@ -114,7 +121,7 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
                 createIndexInDataNode(100)
             )
         );
-        var target = new ShardsCapacityHealthIndicatorService(clusterService);
+        var target = new ShardsCapacityHealthIndicatorService(clusterService, featureService);
         var indicatorResult = target.calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
 
         assertEquals(indicatorResult.status(), HealthStatus.UNKNOWN);
@@ -128,7 +135,10 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
         int maxShardsPerNode = randomValidMaxShards();
         int maxShardsPerNodeFrozen = randomValidMaxShards();
         var clusterService = createClusterService(maxShardsPerNode, maxShardsPerNodeFrozen, createIndexInDataNode(maxShardsPerNode / 4));
-        var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService).calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
+        var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService, featureService).calculate(
+            true,
+            HealthInfo.EMPTY_HEALTH_INFO
+        );
 
         assertEquals(indicatorResult.status(), HealthStatus.GREEN);
         assertTrue(indicatorResult.impacts().isEmpty());
@@ -152,7 +162,10 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
             // Only data_nodes does not have enough space
             int maxShardsPerNodeFrozen = randomValidMaxShards();
             var clusterService = createClusterService(25, maxShardsPerNodeFrozen, createIndexInDataNode(4));
-            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService).calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
+            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService, featureService).calculate(
+                true,
+                HealthInfo.EMPTY_HEALTH_INFO
+            );
 
             assertEquals(indicatorResult.status(), YELLOW);
             assertEquals(indicatorResult.symptom(), "Cluster is close to reaching the configured maximum number of shards for data nodes.");
@@ -175,7 +188,10 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
             // Only frozen_nodes does not have enough space
             int maxShardsPerNode = randomValidMaxShards();
             var clusterService = createClusterService(maxShardsPerNode, 25, createIndexInFrozenNode(4));
-            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService).calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
+            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService, featureService).calculate(
+                true,
+                HealthInfo.EMPTY_HEALTH_INFO
+            );
 
             assertEquals(indicatorResult.status(), YELLOW);
             assertEquals(
@@ -200,7 +216,10 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
         {
             // Both data and frozen nodes does not have enough space
             var clusterService = createClusterService(25, 25, createIndexInDataNode(4), createIndexInFrozenNode(4));
-            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService).calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
+            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService, featureService).calculate(
+                true,
+                HealthInfo.EMPTY_HEALTH_INFO
+            );
 
             assertEquals(indicatorResult.status(), YELLOW);
             assertEquals(
@@ -231,7 +250,10 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
             // Only data_nodes does not have enough space
             int maxShardsPerNodeFrozen = randomValidMaxShards();
             var clusterService = createClusterService(25, maxShardsPerNodeFrozen, createIndexInDataNode(11));
-            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService).calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
+            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService, featureService).calculate(
+                true,
+                HealthInfo.EMPTY_HEALTH_INFO
+            );
 
             assertEquals(indicatorResult.status(), RED);
             assertEquals(indicatorResult.symptom(), "Cluster is close to reaching the configured maximum number of shards for data nodes.");
@@ -254,7 +276,10 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
             // Only frozen_nodes does not have enough space
             int maxShardsPerNode = randomValidMaxShards();
             var clusterService = createClusterService(maxShardsPerNode, 25, createIndexInFrozenNode(11));
-            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService).calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
+            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService, featureService).calculate(
+                true,
+                HealthInfo.EMPTY_HEALTH_INFO
+            );
 
             assertEquals(indicatorResult.status(), RED);
             assertEquals(
@@ -279,7 +304,10 @@ public class ShardsCapacityHealthIndicatorServiceTests extends ESTestCase {
         {
             // Both data and frozen nodes does not have enough space
             var clusterService = createClusterService(25, 25, createIndexInDataNode(11), createIndexInFrozenNode(11));
-            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService).calculate(true, HealthInfo.EMPTY_HEALTH_INFO);
+            var indicatorResult = new ShardsCapacityHealthIndicatorService(clusterService, featureService).calculate(
+                true,
+                HealthInfo.EMPTY_HEALTH_INFO
+            );
 
             assertEquals(indicatorResult.status(), RED);
             assertEquals(

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.snapshots;
 
-import org.elasticsearch.cluster.ClusterFeatures;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.snapshots;
 
+import org.elasticsearch.cluster.ClusterFeatures;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -20,6 +21,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.health.Diagnosis;
 import org.elasticsearch.health.Diagnosis.Resource.Type;
+import org.elasticsearch.health.HealthFeatures;
 import org.elasticsearch.health.HealthIndicatorDetails;
 import org.elasticsearch.health.HealthIndicatorResult;
 import org.elasticsearch.health.SimpleHealthIndicatorDetails;
@@ -33,6 +35,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.cluster.node.DiscoveryNode.DISCOVERY_NODE_COMPARATOR;
@@ -349,11 +352,13 @@ public class RepositoryIntegrityHealthIndicatorServiceTests extends ESTestCase {
     }
 
     private ClusterState createClusterStateWith(RepositoriesMetadata metadata) {
-        var builder = ClusterState.builder(new ClusterName("test-cluster"));
+        var features = Set.of(HealthFeatures.SUPPORTS_EXTENDED_REPOSITORY_INDICATOR.id());
+        var builder = ClusterState.builder(new ClusterName("test-cluster"))
+            .nodes(DiscoveryNodes.builder().add(node1).add(node2).build())
+            .nodeFeatures(Map.of(node1.getId(), features, node2.getId(), features));
         if (metadata != null) {
             builder.metadata(Metadata.builder().putCustom(RepositoriesMetadata.TYPE, metadata));
         }
-        builder.nodes(DiscoveryNodes.builder().add(node1).add(node2).build());
         return builder.build();
     }
 


### PR DESCRIPTION
First check whether the full cluster supports a specific indicator (feature) before we mark an indicator as "unknown" when (meta) data is missing form the cluster state.

Closes #90183