### PR TITLE
Prevent long value saturation within scaled_float mappings

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -137,7 +137,13 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             );
         }
 
-        public Builder(String name, boolean ignoreMalformedByDefault, boolean coerceByDefault, IndexMode indexMode, IndexVersion indexVersion) {
+        public Builder(
+            String name,
+            boolean ignoreMalformedByDefault,
+            boolean coerceByDefault,
+            IndexMode indexMode,
+            IndexVersion indexVersion
+        ) {
             super(name);
             this.ignoreMalformed = Parameter.explicitBoolParam(
                 "ignore_malformed",
@@ -562,7 +568,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         long scaledValue = encode(
             doubleValue,
             scalingFactor,
-            ignoreMalformed.value() == false && indexVersion.onOrAfter(IndexVersions.STRICT_SCALED_FLOAT_PARSING));
+            ignoreMalformed.value() == false && indexVersion.onOrAfter(IndexVersions.STRICT_SCALED_FLOAT_PARSING)
+        );
 
         NumberFieldMapper.NumberType.LONG.addFields(context.doc(), fieldType().name(), scaledValue, indexed, hasDocValues, stored);
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
@@ -544,10 +544,10 @@ public class ScaledFloatFieldMapperTests extends NumberFieldMapperTests {
     }
 
     public void testEncodeDecodeRandom() {
-        double scalingFactor = randomDoubleBetween(0, Long.MAX_VALUE/2.0, false);
-        double v = randomBoolean() ?
-            randomDoubleBetween((Long.MIN_VALUE + 1)/scalingFactor, (Long.MAX_VALUE - 1)/scalingFactor, true) :
-            randomFloat();
+        double scalingFactor = randomDoubleBetween(0, Long.MAX_VALUE / 2.0, false);
+        double v = randomBoolean()
+            ? randomDoubleBetween((Long.MIN_VALUE + 1) / scalingFactor, (Long.MAX_VALUE - 1) / scalingFactor, true)
+            : randomFloat();
         double once = encodeDecode(v, scalingFactor, true);
         double twice = encodeDecode(once, scalingFactor, true);
         assertThat(twice, equalTo(once));

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -21,6 +21,7 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.LeafNumericFieldData;
@@ -219,14 +220,14 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType mapper = new ScaledFloatFieldMapper.Builder("field", false, false, null).scalingFactor(100)
+        MappedFieldType mapper = new ScaledFloatFieldMapper.Builder("field", false, false, null, IndexVersion.current()).scalingFactor(100)
             .build(MapperBuilderContext.root(false, false))
             .fieldType();
         assertEquals(List.of(3.14), fetchSourceValue(mapper, 3.1415926));
         assertEquals(List.of(3.14), fetchSourceValue(mapper, "3.1415"));
         assertEquals(List.of(), fetchSourceValue(mapper, ""));
 
-        MappedFieldType nullValueMapper = new ScaledFloatFieldMapper.Builder("field", false, false, null).scalingFactor(100)
+        MappedFieldType nullValueMapper = new ScaledFloatFieldMapper.Builder("field", false, false, null, IndexVersion.current()).scalingFactor(100)
             .nullValue(2.71)
             .build(MapperBuilderContext.root(false, false))
             .fieldType();

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -227,7 +227,8 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
         assertEquals(List.of(3.14), fetchSourceValue(mapper, "3.1415"));
         assertEquals(List.of(), fetchSourceValue(mapper, ""));
 
-        MappedFieldType nullValueMapper = new ScaledFloatFieldMapper.Builder("field", false, false, null, IndexVersion.current()).scalingFactor(100)
+        MappedFieldType nullValueMapper = new ScaledFloatFieldMapper.Builder("field", false, false, null, IndexVersion.current())
+            .scalingFactor(100)
             .nullValue(2.71)
             .build(MapperBuilderContext.root(false, false))
             .fieldType();

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/scaled_float/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/scaled_float/10_basic.yml
@@ -134,3 +134,32 @@ setup:
             number:
               order: asc
   - match: { hits.hits.0.fields.number: [-2.1] }
+
+---
+"Disabled saturation of long values":
+  - skip:
+      version: " - 8.13.99"
+      reason: disabled saturation of long values is not supported in versions before 8.14.0
+  - do:
+      catch: bad_request
+      index:
+        index: test
+        id: "5"
+        body: { "number" : 9223372036854775807 }
+  - do:
+      indices.create:
+        index: test-saturation
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            "properties":
+              "number":
+                "type" : "scaled_float"
+                "scaling_factor": 100
+                "ignore_malformed": true
+  - do:
+      index:
+        index: test-saturation
+        id: "5"
+        body: { "number" : 9223372036854775807 }

--- a/server/src/main/java/org/elasticsearch/index/IndexVersions.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexVersions.java
@@ -101,6 +101,7 @@ public class IndexVersions {
     public static final IndexVersion NEW_INDEXVERSION_FORMAT = def(8_501_00_0, Version.LUCENE_9_9_1);
     public static final IndexVersion UPGRADE_LUCENE_9_9_2 = def(8_502_00_0, Version.LUCENE_9_9_2);
     public static final IndexVersion TIME_SERIES_ID_HASHING = def(8_502_00_1, Version.LUCENE_9_9_2);
+    public static final IndexVersion STRICT_SCALED_FLOAT_PARSING = def(8_502_00_2, Version.LUCENE_9_9_2);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
It is easy to have long value saturation and overflow with `scaled_float` and allowing users to  saturate longs seems dangerous and confusing.

I would generally expect any saturation to be an input error by the user as it will then break subsequent queries against the field (see example range query in the issue).

This commit allows saturation to occur if the index was created in a previous version or if `ignore_malformed: true`. 

closes: https://github.com/elastic/elasticsearch/issues/105361