### PR TITLE
Simplify LeakTracker by using java.lang.ref.Cleaner

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockPageCacheRecycler.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockPageCacheRecycler.java
@@ -31,11 +31,11 @@ public class MockPageCacheRecycler extends PageCacheRecycler {
     private <T> V<T> wrap(final V<T> v) {
         return new V<T>() {
 
-            private final LeakTracker.Leak<V<T>> leak = LeakTracker.INSTANCE.track(v);
+            private final LeakTracker.Leak leak = LeakTracker.INSTANCE.track(v);
 
             @Override
             public void close() {
-                boolean leakReleased = leak.close(v);
+                boolean leakReleased = leak.close();
                 assert leakReleased : "leak should not have been released already";
                 final T ref = v();
                 if (ref instanceof Object[]) {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -704,7 +704,6 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     // separate method so that this can be checked again after suite scoped cluster is shut down
     protected static void checkStaticState() throws Exception {
-        LeakTracker.INSTANCE.reportLeak();
         MockBigArrays.ensureAllArraysAreReleased();
 
         // ensure no one changed the status logger level on us


### PR DESCRIPTION
Using the cleaner here simplifies the logic quite a bit and removes the need for us to reason through reference queues and weak references. Also from my testing, this solution is actually more sensitive and a leak will be reported closer to the execution that created it in the first place.
