### PR TITLE
[8.13] ESQL: push down "[text_field] is not null" and "[text_field] is null"(#105593) (#105593)

### DIFF
--- a/docs/changelog/105593.yaml
+++ b/docs/changelog/105593.yaml
@@ -1,0 +1,5 @@
+pr: 105593
+summary: "ESQL: push down \"[text_field] is not null\""
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1195,3 +1195,25 @@ ROW a = 1 | STATS couNt(*) | SORT `couNt(*)`
 couNt(*):l
 1
 ;
+
+isNullWithStatsCount_On_TextField
+FROM airports
+| EVAL s = name, x = name
+| WHERE s IS NULL
+| STATS c = COUNT(x)
+;
+
+c:l
+0
+;
+
+isNotNullWithStatsCount_On_TextField
+FROM airports
+| EVAL s = name, x = name
+| WHERE s IS NOT NULL
+| STATS c = COUNT(x)
+;
+
+c:l
+891
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -249,6 +249,11 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
                 return canPushToSource(not.field(), hasIdenticalDelegate);
             } else if (exp instanceof UnaryScalarFunction usf) {
                 if (usf instanceof RegexMatch<?> || usf instanceof IsNull || usf instanceof IsNotNull) {
+                    if (usf instanceof IsNull || usf instanceof IsNotNull) {
+                        if (usf.field() instanceof FieldAttribute fa && fa.dataType().equals(DataTypes.TEXT)) {
+                            return true;
+                        }
+                    }
                     return isAttributePushable(usf.field(), usf, hasIdenticalDelegate);
                 }
             } else if (exp instanceof CIDRMatch cidrMatch) {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/81_text_exact_subfields.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/81_text_exact_subfields.yml
@@ -152,6 +152,29 @@ setup:
         - "No limit defined, adding default limit of \\[.*\\]"
       esql.query:
         body:
+          query: 'from test | where text_ignore_above is not null | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
+
+  - match: { columns.0.name: "text_ignore_above" }
+  - match: { columns.0.type: "text" }
+  - match: { columns.1.name: "text_ignore_above.raw" }
+  - match: { columns.1.type: "keyword" }
+  - match: { columns.2.name: "text_normalizer" }
+  - match: { columns.2.type: "text" }
+  - match: { columns.3.name: "text_normalizer.raw" }
+  - match: { columns.3.type: "keyword" }
+  - match: { columns.4.name: "non_indexed" }
+  - match: { columns.4.type: "text" }
+  - match: { columns.5.name: "non_indexed.raw" }
+  - match: { columns.5.type: "keyword" }
+
+  - length: { values: 2 }
+
+
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
           query: 'from test | where text_ignore_above LIKE "*long*" | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
 
   - match: { columns.0.name: "text_ignore_above" }


### PR DESCRIPTION
Backports the following commits to 8.13:
 - ESQL: push down "[text_field] is not null" and "[text_field] is null"(#105593) (#105593)