### PR TITLE
Move more XContent parsers that are only used in tests to test codebase

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStats.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStats.java
@@ -13,10 +13,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.ingest.geoip.GeoIpDownloader;
 import org.elasticsearch.tasks.Task;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -25,26 +23,12 @@ public class GeoIpDownloaderStats implements Task.Status {
 
     public static final GeoIpDownloaderStats EMPTY = new GeoIpDownloaderStats(0, 0, 0, 0, 0, 0);
 
-    public static final ConstructingObjectParser<GeoIpDownloaderStats, Void> PARSER = new ConstructingObjectParser<>(
-        "geoip_downloader_stats",
-        a -> new GeoIpDownloaderStats((int) a[0], (int) a[1], (long) a[2], (int) a[3], (int) a[4], a[5] == null ? 0 : (int) a[5])
-    );
-
-    private static final ParseField SUCCESSFUL_DOWNLOADS = new ParseField("successful_downloads");
-    private static final ParseField FAILED_DOWNLOADS = new ParseField("failed_downloads");
-    private static final ParseField TOTAL_DOWNLOAD_TIME = new ParseField("total_download_time");
-    private static final ParseField DATABASES_COUNT = new ParseField("databases_count");
-    private static final ParseField SKIPPED_DOWNLOADS = new ParseField("skipped_updates");
-    private static final ParseField EXPIRED_DATABASES = new ParseField("expired_databases");
-
-    static {
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), SUCCESSFUL_DOWNLOADS);
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), FAILED_DOWNLOADS);
-        PARSER.declareLong(ConstructingObjectParser.constructorArg(), TOTAL_DOWNLOAD_TIME);
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), DATABASES_COUNT);
-        PARSER.declareInt(ConstructingObjectParser.constructorArg(), SKIPPED_DOWNLOADS);
-        PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), EXPIRED_DATABASES);
-    }
+    static final ParseField SUCCESSFUL_DOWNLOADS = new ParseField("successful_downloads");
+    static final ParseField FAILED_DOWNLOADS = new ParseField("failed_downloads");
+    static final ParseField TOTAL_DOWNLOAD_TIME = new ParseField("total_download_time");
+    static final ParseField DATABASES_COUNT = new ParseField("databases_count");
+    static final ParseField SKIPPED_DOWNLOADS = new ParseField("skipped_updates");
+    static final ParseField EXPIRED_DATABASES = new ParseField("expired_databases");
 
     private final int successfulDownloads;
     private final int failedDownloads;
@@ -62,7 +46,7 @@ public class GeoIpDownloaderStats implements Task.Status {
         expiredDatabases = in.readVInt();
     }
 
-    private GeoIpDownloaderStats(
+    GeoIpDownloaderStats(
         int successfulDownloads,
         int failedDownloads,
         long totalDownloadTime,
@@ -168,10 +152,6 @@ public class GeoIpDownloaderStats implements Task.Status {
         builder.field(EXPIRED_DATABASES.getPreferredName(), expiredDatabases);
         builder.endObject();
         return builder;
-    }
-
-    public static GeoIpDownloaderStats fromXContent(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
     }
 
     @Override

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsSerializingTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsSerializingTests.java
@@ -10,15 +10,30 @@ package org.elasticsearch.ingest.geoip.stats;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
 public class GeoIpDownloaderStatsSerializingTests extends AbstractXContentSerializingTestCase<GeoIpDownloaderStats> {
 
+    private static final ConstructingObjectParser<GeoIpDownloaderStats, Void> PARSER = new ConstructingObjectParser<>(
+        "geoip_downloader_stats",
+        a -> new GeoIpDownloaderStats((int) a[0], (int) a[1], (long) a[2], (int) a[3], (int) a[4], a[5] == null ? 0 : (int) a[5])
+    );
+
+    static {
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), GeoIpDownloaderStats.SUCCESSFUL_DOWNLOADS);
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), GeoIpDownloaderStats.FAILED_DOWNLOADS);
+        PARSER.declareLong(ConstructingObjectParser.constructorArg(), GeoIpDownloaderStats.TOTAL_DOWNLOAD_TIME);
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), GeoIpDownloaderStats.DATABASES_COUNT);
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), GeoIpDownloaderStats.SKIPPED_DOWNLOADS);
+        PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), GeoIpDownloaderStats.EXPIRED_DATABASES);
+    }
+
     @Override
     protected GeoIpDownloaderStats doParseInstance(XContentParser parser) throws IOException {
-        return GeoIpDownloaderStats.fromXContent(parser);
+        return PARSER.parse(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -309,7 +309,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
      * {@link DocWriteResponse} objects. It always parses the current token, updates the given parsing context accordingly
      * if needed and then immediately returns.
      */
-    protected static void parseInnerToXContent(XContentParser parser, Builder context) throws IOException {
+    public static void parseInnerToXContent(XContentParser parser, Builder context) throws IOException {
         XContentParser.Token token = parser.currentToken();
         ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponse.java
@@ -14,11 +14,8 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -34,12 +31,6 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
     static final String NAME = "name";
 
     public static class NodeView implements Writeable, ToXContentObject {
-        private static final ObjectParser.NamedObjectParser<NodeView, Void> PARSER;
-        static {
-            ObjectParser<NodeView, Void> internalParser = new ObjectParser<>(NODES, true, null);
-            internalParser.declareString(NodeView::setName, new ParseField(NAME));
-            PARSER = (p, v, name) -> internalParser.parse(p, new NodeView(name), null);
-        }
 
         final String nodeId;
         String name;
@@ -104,15 +95,6 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
 
     private List<NodeView> nodes;
 
-    private static final ObjectParser<VerifyRepositoryResponse, Void> PARSER = new ObjectParser<>(
-        VerifyRepositoryResponse.class.getName(),
-        true,
-        VerifyRepositoryResponse::new
-    );
-    static {
-        PARSER.declareNamedObjects(VerifyRepositoryResponse::setNodes, NodeView.PARSER, new ParseField("nodes"));
-    }
-
     public VerifyRepositoryResponse() {}
 
     public VerifyRepositoryResponse(StreamInput in) throws IOException {
@@ -155,10 +137,6 @@ public class VerifyRepositoryResponse extends ActionResponse implements ToXConte
         }
         builder.endObject();
         return builder;
-    }
-
-    public static VerifyRepositoryResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsResponse.java
@@ -12,36 +12,19 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * A response for a cluster update settings action.
  */
 public class ClusterUpdateSettingsResponse extends AcknowledgedResponse {
 
-    private static final ParseField PERSISTENT = new ParseField("persistent");
-    private static final ParseField TRANSIENT = new ParseField("transient");
-
-    private static final ConstructingObjectParser<ClusterUpdateSettingsResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "cluster_update_settings_response",
-        true,
-        args -> {
-            return new ClusterUpdateSettingsResponse((boolean) args[0], (Settings) args[1], (Settings) args[2]);
-        }
-    );
-    static {
-        declareAcknowledgedField(PARSER);
-        PARSER.declareObject(constructorArg(), (p, c) -> Settings.fromXContent(p), TRANSIENT);
-        PARSER.declareObject(constructorArg(), (p, c) -> Settings.fromXContent(p), PERSISTENT);
-    }
+    static final ParseField PERSISTENT = new ParseField("persistent");
+    static final ParseField TRANSIENT = new ParseField("transient");
 
     final Settings transientSettings;
     final Settings persistentSettings;
@@ -81,10 +64,6 @@ public class ClusterUpdateSettingsResponse extends AcknowledgedResponse {
         builder.startObject(TRANSIENT.getPreferredName());
         transientSettings.toXContent(builder, params);
         builder.endObject();
-    }
-
-    public static ClusterUpdateSettingsResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -13,17 +13,12 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * Snapshot status response
@@ -53,23 +48,6 @@ public class SnapshotsStatusResponse extends ActionResponse implements ChunkedTo
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeCollection(snapshots);
-    }
-
-    private static final ConstructingObjectParser<SnapshotsStatusResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "snapshots_status_response",
-        true,
-        (Object[] parsedObjects) -> {
-            @SuppressWarnings("unchecked")
-            List<SnapshotStatus> snapshots = (List<SnapshotStatus>) parsedObjects[0];
-            return new SnapshotsStatusResponse(snapshots);
-        }
-    );
-    static {
-        PARSER.declareObjectArray(constructorArg(), SnapshotStatus.PARSER, new ParseField("snapshots"));
-    }
-
-    public static SnapshotsStatusResponse fromXContent(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptContextResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptContextResponse.java
@@ -13,11 +13,9 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.script.ScriptContextInfo;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -31,27 +29,8 @@ import java.util.stream.Collectors;
 
 public class GetScriptContextResponse extends ActionResponse implements ToXContentObject {
 
-    private static final ParseField CONTEXTS = new ParseField("contexts");
+    static final ParseField CONTEXTS = new ParseField("contexts");
     final Map<String, ScriptContextInfo> contexts;
-
-    @SuppressWarnings("unchecked")
-    public static final ConstructingObjectParser<GetScriptContextResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "get_script_context",
-        true,
-        (a) -> {
-            Map<String, ScriptContextInfo> contexts = ((List<ScriptContextInfo>) a[0]).stream()
-                .collect(Collectors.toMap(ScriptContextInfo::getName, c -> c));
-            return new GetScriptContextResponse(contexts);
-        }
-    );
-
-    static {
-        PARSER.declareObjectArray(
-            ConstructingObjectParser.constructorArg(),
-            (parser, ctx) -> ScriptContextInfo.PARSER.apply(parser, ctx),
-            CONTEXTS
-        );
-    }
 
     GetScriptContextResponse(StreamInput in) throws IOException {
         super(in);
@@ -70,7 +49,7 @@ public class GetScriptContextResponse extends ActionResponse implements ToXConte
     }
 
     // Parser constructor
-    private GetScriptContextResponse(Map<String, ScriptContextInfo> contexts) {
+    GetScriptContextResponse(Map<String, ScriptContextInfo> contexts) {
         this.contexts = Map.copyOf(contexts);
     }
 
@@ -94,10 +73,6 @@ public class GetScriptContextResponse extends ActionResponse implements ToXConte
         }
         builder.endArray().endObject(); // CONTEXTS
         return builder;
-    }
-
-    public static GetScriptContextResponse fromXContent(XContentParser parser) throws IOException {
-        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
@@ -9,27 +9,20 @@
 package org.elasticsearch.action.admin.indices.analyze;
 
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BaseBroadcastResponse;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * The response object that will be returned when reloading analyzers
@@ -38,10 +31,10 @@ public class ReloadAnalyzersResponse extends BroadcastResponse {
 
     private final Map<String, ReloadDetails> reloadDetails;
 
-    private static final ParseField RELOAD_DETAILS_FIELD = new ParseField("reload_details");
-    private static final ParseField INDEX_FIELD = new ParseField("index");
-    private static final ParseField RELOADED_ANALYZERS_FIELD = new ParseField("reloaded_analyzers");
-    private static final ParseField RELOADED_NODE_IDS_FIELD = new ParseField("reloaded_node_ids");
+    static final ParseField RELOAD_DETAILS_FIELD = new ParseField("reload_details");
+    static final ParseField INDEX_FIELD = new ParseField("index");
+    static final ParseField RELOADED_ANALYZERS_FIELD = new ParseField("reloaded_analyzers");
+    static final ParseField RELOADED_NODE_IDS_FIELD = new ParseField("reloaded_node_ids");
 
     public ReloadAnalyzersResponse(StreamInput in) throws IOException {
         super(in);
@@ -78,48 +71,6 @@ public class ReloadAnalyzersResponse extends BroadcastResponse {
             builder.endObject();
         }
         builder.endArray();
-    }
-
-    @SuppressWarnings({ "unchecked" })
-    private static final ConstructingObjectParser<ReloadAnalyzersResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "reload_analyzer",
-        true,
-        arg -> {
-            BaseBroadcastResponse response = (BaseBroadcastResponse) arg[0];
-            List<ReloadDetails> results = (List<ReloadDetails>) arg[1];
-            Map<String, ReloadDetails> reloadedNodeIds = new HashMap<>();
-            for (ReloadDetails result : results) {
-                reloadedNodeIds.put(result.getIndexName(), result);
-            }
-            return new ReloadAnalyzersResponse(
-                response.getTotalShards(),
-                response.getSuccessfulShards(),
-                response.getFailedShards(),
-                Arrays.asList(response.getShardFailures()),
-                reloadedNodeIds
-            );
-        }
-    );
-
-    @SuppressWarnings({ "unchecked" })
-    private static final ConstructingObjectParser<ReloadDetails, Void> ENTRY_PARSER = new ConstructingObjectParser<>(
-        "reload_analyzer.entry",
-        true,
-        arg -> {
-            return new ReloadDetails((String) arg[0], new HashSet<>((List<String>) arg[1]), new HashSet<>((List<String>) arg[2]));
-        }
-    );
-
-    static {
-        declareBroadcastFields(PARSER);
-        PARSER.declareObjectArray(constructorArg(), ENTRY_PARSER, RELOAD_DETAILS_FIELD);
-        ENTRY_PARSER.declareString(constructorArg(), INDEX_FIELD);
-        ENTRY_PARSER.declareStringArray(constructorArg(), RELOADED_ANALYZERS_FIELD);
-        ENTRY_PARSER.declareStringArray(constructorArg(), RELOADED_NODE_IDS_FIELD);
-    }
-
-    public static ReloadAnalyzersResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/open/OpenIndexResponse.java
@@ -11,8 +11,6 @@ package org.elasticsearch.action.admin.indices.open;
 import org.elasticsearch.action.support.master.ShardsAcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
@@ -20,16 +18,6 @@ import java.io.IOException;
  * A response for a open index action.
  */
 public class OpenIndexResponse extends ShardsAcknowledgedResponse {
-
-    private static final ConstructingObjectParser<OpenIndexResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "open_index",
-        true,
-        args -> new OpenIndexResponse((boolean) args[0], (boolean) args[1])
-    );
-
-    static {
-        declareAcknowledgedAndShardsAcknowledgedFields(PARSER);
-    }
 
     public OpenIndexResponse(StreamInput in) throws IOException {
         super(in, true);
@@ -43,9 +31,5 @@ public class OpenIndexResponse extends ShardsAcknowledgedResponse {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         writeShardsAcknowledged(out);
-    }
-
-    public static OpenIndexResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponse.java
@@ -9,22 +9,13 @@
 package org.elasticsearch.action.admin.indices.validate.query;
 
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BaseBroadcastResponse;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * The response of the validate action.
@@ -36,37 +27,9 @@ public class ValidateQueryResponse extends BroadcastResponse {
     public static final String VALID_FIELD = "valid";
     public static final String EXPLANATIONS_FIELD = "explanations";
 
-    @SuppressWarnings("unchecked")
-    static final ConstructingObjectParser<ValidateQueryResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "validate_query",
-        true,
-        arg -> {
-            BaseBroadcastResponse response = (BaseBroadcastResponse) arg[0];
-            return new ValidateQueryResponse(
-                (boolean) arg[1],
-                (List<QueryExplanation>) arg[2],
-                response.getTotalShards(),
-                response.getSuccessfulShards(),
-                response.getFailedShards(),
-                Arrays.asList(response.getShardFailures())
-            );
-        }
-    );
-    static {
-        declareBroadcastFields(PARSER);
-        PARSER.declareBoolean(constructorArg(), new ParseField(VALID_FIELD));
-        PARSER.declareObjectArray(optionalConstructorArg(), QueryExplanation.PARSER, new ParseField(EXPLANATIONS_FIELD));
-    }
-
     private final boolean valid;
 
     private final List<QueryExplanation> queryExplanations;
-
-    ValidateQueryResponse(StreamInput in) throws IOException {
-        super(in);
-        valid = in.readBoolean();
-        queryExplanations = in.readCollectionAsList(QueryExplanation::new);
-    }
 
     ValidateQueryResponse(
         boolean valid,
@@ -114,9 +77,5 @@ public class ValidateQueryResponse extends BroadcastResponse {
             }
             builder.endArray();
         }
-    }
-
-    public static ValidateQueryResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -12,11 +12,8 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * The response of the delete action.
@@ -62,23 +59,6 @@ public class DeleteResponse extends DocWriteResponse {
         builder.append(",result=").append(getResult().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();
-    }
-
-    public static DeleteResponse fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-
-        Builder context = new Builder();
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            parseXContentFields(parser, context);
-        }
-        return context.build();
-    }
-
-    /**
-     * Parse the current token and update the parsing context appropriately.
-     */
-    public static void parseXContentFields(XContentParser parser, Builder context) throws IOException {
-        DocWriteResponse.parseInnerToXContent(parser, context);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/explain/ExplainResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/explain/ExplainResponse.java
@@ -17,14 +17,11 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Objects;
 
 import static org.elasticsearch.common.lucene.Lucene.readExplanation;
@@ -35,14 +32,14 @@ import static org.elasticsearch.common.lucene.Lucene.writeExplanation;
  */
 public class ExplainResponse extends ActionResponse implements ToXContentObject {
 
-    private static final ParseField _INDEX = new ParseField("_index");
-    private static final ParseField _ID = new ParseField("_id");
+    static final ParseField _INDEX = new ParseField("_index");
+    static final ParseField _ID = new ParseField("_id");
     private static final ParseField MATCHED = new ParseField("matched");
-    private static final ParseField EXPLANATION = new ParseField("explanation");
-    private static final ParseField VALUE = new ParseField("value");
-    private static final ParseField DESCRIPTION = new ParseField("description");
-    private static final ParseField DETAILS = new ParseField("details");
-    private static final ParseField GET = new ParseField("get");
+    static final ParseField EXPLANATION = new ParseField("explanation");
+    static final ParseField VALUE = new ParseField("value");
+    static final ParseField DESCRIPTION = new ParseField("description");
+    static final ParseField DETAILS = new ParseField("details");
+    static final ParseField GET = new ParseField("get");
 
     private final String index;
     private final String id;
@@ -134,43 +131,6 @@ public class ExplainResponse extends ActionResponse implements ToXContentObject 
             out.writeBoolean(true);
             getResult.writeTo(out);
         }
-    }
-
-    private static final ConstructingObjectParser<ExplainResponse, Boolean> PARSER = new ConstructingObjectParser<>(
-        "explain",
-        true,
-        (arg, exists) -> new ExplainResponse((String) arg[0], (String) arg[1], exists, (Explanation) arg[2], (GetResult) arg[3])
-    );
-
-    static {
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), _INDEX);
-        PARSER.declareString(ConstructingObjectParser.constructorArg(), _ID);
-        final ConstructingObjectParser<Explanation, Boolean> explanationParser = getExplanationsParser();
-        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), explanationParser, EXPLANATION);
-        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> GetResult.fromXContentEmbedded(p), GET);
-    }
-
-    @SuppressWarnings("unchecked")
-    private static ConstructingObjectParser<Explanation, Boolean> getExplanationsParser() {
-        final ConstructingObjectParser<Explanation, Boolean> explanationParser = new ConstructingObjectParser<>(
-            "explanation",
-            true,
-            arg -> {
-                if ((float) arg[0] > 0) {
-                    return Explanation.match((float) arg[0], (String) arg[1], (Collection<Explanation>) arg[2]);
-                } else {
-                    return Explanation.noMatch((String) arg[1], (Collection<Explanation>) arg[2]);
-                }
-            }
-        );
-        explanationParser.declareFloat(ConstructingObjectParser.constructorArg(), VALUE);
-        explanationParser.declareString(ConstructingObjectParser.constructorArg(), DESCRIPTION);
-        explanationParser.declareObjectArray(ConstructingObjectParser.constructorArg(), explanationParser, DETAILS);
-        return explanationParser;
-    }
-
-    public static ExplainResponse fromXContent(XContentParser parser, boolean exists) {
-        return PARSER.apply(parser, exists);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -17,12 +17,9 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.List;
-
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * A response of an index operation,
@@ -132,23 +129,6 @@ public class IndexResponse extends DocWriteResponse {
         builder.append(",primaryTerm=").append(getPrimaryTerm());
         builder.append(",shards=").append(Strings.toString(getShardInfo()));
         return builder.append("]").toString();
-    }
-
-    public static IndexResponse fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-
-        Builder context = new Builder();
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            parseXContentFields(parser, context);
-        }
-        return context.build();
-    }
-
-    /**
-     * Parse the current token and update the parsing context appropriately.
-     */
-    public static void parseXContentFields(XContentParser parser, Builder context) throws IOException {
-        DocWriteResponse.parseInnerToXContent(parser, context);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedResponse.java
@@ -40,7 +40,7 @@ public class AcknowledgedResponse extends ActionResponse implements IsAcknowledg
     public static final String ACKNOWLEDGED_KEY = "acknowledged";
     private static final ParseField ACKNOWLEDGED = new ParseField(ACKNOWLEDGED_KEY);
 
-    protected static <T extends AcknowledgedResponse> void declareAcknowledgedField(ConstructingObjectParser<T, Void> objectParser) {
+    public static <T extends AcknowledgedResponse> void declareAcknowledgedField(ConstructingObjectParser<T, Void> objectParser) {
         objectParser.declareField(
             constructorArg(),
             (parser, context) -> parser.booleanValue(),

--- a/server/src/main/java/org/elasticsearch/action/support/master/ShardsAcknowledgedResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/ShardsAcknowledgedResponse.java
@@ -24,7 +24,7 @@ public class ShardsAcknowledgedResponse extends AcknowledgedResponse {
 
     protected static final ParseField SHARDS_ACKNOWLEDGED = new ParseField("shards_acknowledged");
 
-    protected static <T extends ShardsAcknowledgedResponse> void declareAcknowledgedAndShardsAcknowledgedFields(
+    public static <T extends ShardsAcknowledgedResponse> void declareAcknowledgedAndShardsAcknowledgedFields(
         ConstructingObjectParser<T, Void> objectParser
     ) {
         declareAcknowledgedField(objectParser);

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksResponse.java
@@ -32,8 +32,8 @@ import static org.elasticsearch.ExceptionsHelper.rethrowAndSuppress;
  * Base class for responses of task-related operations
  */
 public class BaseTasksResponse extends ActionResponse {
-    protected static final String TASK_FAILURES = "task_failures";
-    protected static final String NODE_FAILURES = "node_failures";
+    public static final String TASK_FAILURES = "task_failures";
+    public static final String NODE_FAILURES = "node_failures";
 
     private List<TaskOperationFailure> taskFailures;
     private List<ElasticsearchException> nodeFailures;

--- a/server/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -15,15 +15,12 @@ import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-
 public class UpdateResponse extends DocWriteResponse {
 
-    private static final String GET = "get";
+    static final String GET = "get";
 
     private GetResult getResult;
 
@@ -112,32 +109,6 @@ public class UpdateResponse extends DocWriteResponse {
         builder.append(",result=").append(getResult().getLowercase());
         builder.append(",shards=").append(getShardInfo());
         return builder.append("]").toString();
-    }
-
-    public static UpdateResponse fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-
-        Builder context = new Builder();
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            parseXContentFields(parser, context);
-        }
-        return context.build();
-    }
-
-    /**
-     * Parse the current token and update the parsing context appropriately.
-     */
-    public static void parseXContentFields(XContentParser parser, Builder context) throws IOException {
-        XContentParser.Token token = parser.currentToken();
-        String currentFieldName = parser.currentName();
-
-        if (GET.equals(currentFieldName)) {
-            if (token == XContentParser.Token.START_OBJECT) {
-                context.setGetResult(GetResult.fromXContentEmbedded(parser));
-            }
-        } else {
-            DocWriteResponse.parseInnerToXContent(parser, context);
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Collections.emptyMap;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
@@ -282,16 +281,6 @@ public final class ClusterIndexHealth implements Writeable, ToXContentFragment {
 
     public static ClusterIndexHealth innerFromXContent(XContentParser parser, String index) {
         return PARSER.apply(parser, index);
-    }
-
-    public static ClusterIndexHealth fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-        XContentParser.Token token = parser.nextToken();
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
-        String index = parser.currentName();
-        ClusterIndexHealth parsed = innerFromXContent(parser, index);
-        ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
-        return parsed;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/BulkByScrollTask.java
@@ -20,14 +20,9 @@ import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskInfo;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParseException;
-import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentParser.Token;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,9 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.lang.Math.min;
 import static java.util.Collections.emptyList;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.core.TimeValue.timeValueNanos;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * Task storing information about a currently running BulkByScroll request.
@@ -380,37 +373,6 @@ public class BulkByScrollTask extends CancellableTask {
             FIELDS_SET.add(SLICES_FIELD);
         }
 
-        static final ConstructingObjectParser<Tuple<Long, Long>, Void> RETRIES_PARSER = new ConstructingObjectParser<>(
-            "bulk_by_scroll_task_status_retries",
-            true,
-            a -> new Tuple<>(((Long) a[0]), (Long) a[1])
-        );
-        static {
-            RETRIES_PARSER.declareLong(constructorArg(), new ParseField(RETRIES_BULK_FIELD));
-            RETRIES_PARSER.declareLong(constructorArg(), new ParseField(RETRIES_SEARCH_FIELD));
-        }
-
-        public static void declareFields(ObjectParser<? extends StatusBuilder, Void> parser) {
-            parser.declareInt(StatusBuilder::setSliceId, new ParseField(SLICE_ID_FIELD));
-            parser.declareLong(StatusBuilder::setTotal, new ParseField(TOTAL_FIELD));
-            parser.declareLong(StatusBuilder::setUpdated, new ParseField(UPDATED_FIELD));
-            parser.declareLong(StatusBuilder::setCreated, new ParseField(CREATED_FIELD));
-            parser.declareLong(StatusBuilder::setDeleted, new ParseField(DELETED_FIELD));
-            parser.declareInt(StatusBuilder::setBatches, new ParseField(BATCHES_FIELD));
-            parser.declareLong(StatusBuilder::setVersionConflicts, new ParseField(VERSION_CONFLICTS_FIELD));
-            parser.declareLong(StatusBuilder::setNoops, new ParseField(NOOPS_FIELD));
-            parser.declareObject(StatusBuilder::setRetries, RETRIES_PARSER, new ParseField(RETRIES_FIELD));
-            parser.declareLong(StatusBuilder::setThrottled, new ParseField(THROTTLED_RAW_FIELD));
-            parser.declareFloat(StatusBuilder::setRequestsPerSecond, new ParseField(REQUESTS_PER_SEC_FIELD));
-            parser.declareString(StatusBuilder::setReasonCancelled, new ParseField(CANCELED_FIELD));
-            parser.declareLong(StatusBuilder::setThrottledUntil, new ParseField(THROTTLED_UNTIL_RAW_FIELD));
-            parser.declareObjectArray(
-                StatusBuilder::setSliceStatuses,
-                (p, c) -> StatusOrException.fromXContent(p),
-                new ParseField(SLICES_FIELD)
-            );
-        }
-
         private final Integer sliceId;
         private final long total;
         private final long updated;
@@ -571,11 +533,6 @@ public class BulkByScrollTask extends CancellableTask {
             return builder.endObject();
         }
 
-        /**
-         * We need to write a manual parser for this because of {@link StatusOrException}. Since
-         * {@link StatusOrException#fromXContent(XContentParser)} tries to peek at a field first before deciding
-         * what needs to be it cannot use an {@link ObjectParser}.
-         */
         public XContentBuilder innerXContent(XContentBuilder builder, Params params) throws IOException {
             if (sliceId != null) {
                 builder.field(SLICE_ID_FIELD, sliceId);
@@ -615,61 +572,6 @@ public class BulkByScrollTask extends CancellableTask {
                 builder.endArray();
             }
             return builder;
-        }
-
-        public static Status fromXContent(XContentParser parser) throws IOException {
-            XContentParser.Token token;
-            if (parser.currentToken() == Token.START_OBJECT) {
-                token = parser.nextToken();
-            } else {
-                token = parser.nextToken();
-            }
-            ensureExpectedToken(Token.START_OBJECT, token, parser);
-            token = parser.nextToken();
-            ensureExpectedToken(Token.FIELD_NAME, token, parser);
-            return innerFromXContent(parser);
-        }
-
-        public static Status innerFromXContent(XContentParser parser) throws IOException {
-            Token token = parser.currentToken();
-            String fieldName = parser.currentName();
-            ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
-            StatusBuilder builder = new StatusBuilder();
-            while ((token = parser.nextToken()) != Token.END_OBJECT) {
-                if (token == Token.FIELD_NAME) {
-                    fieldName = parser.currentName();
-                } else if (token == Token.START_OBJECT) {
-                    if (fieldName.equals(Status.RETRIES_FIELD)) {
-                        builder.setRetries(Status.RETRIES_PARSER.parse(parser, null));
-                    } else {
-                        parser.skipChildren();
-                    }
-                } else if (token == Token.START_ARRAY) {
-                    if (fieldName.equals(Status.SLICES_FIELD)) {
-                        while ((token = parser.nextToken()) != Token.END_ARRAY) {
-                            builder.addToSliceStatuses(StatusOrException.fromXContent(parser));
-                        }
-                    } else {
-                        parser.skipChildren();
-                    }
-                } else { // else if it is a value
-                    switch (fieldName) {
-                        case Status.SLICE_ID_FIELD -> builder.setSliceId(parser.intValue());
-                        case Status.TOTAL_FIELD -> builder.setTotal(parser.longValue());
-                        case Status.UPDATED_FIELD -> builder.setUpdated(parser.longValue());
-                        case Status.CREATED_FIELD -> builder.setCreated(parser.longValue());
-                        case Status.DELETED_FIELD -> builder.setDeleted(parser.longValue());
-                        case Status.BATCHES_FIELD -> builder.setBatches(parser.intValue());
-                        case Status.VERSION_CONFLICTS_FIELD -> builder.setVersionConflicts(parser.longValue());
-                        case Status.NOOPS_FIELD -> builder.setNoops(parser.longValue());
-                        case Status.THROTTLED_RAW_FIELD -> builder.setThrottled(parser.longValue());
-                        case Status.REQUESTS_PER_SEC_FIELD -> builder.setRequestsPerSecond(parser.floatValue());
-                        case Status.CANCELED_FIELD -> builder.setReasonCancelled(parser.text());
-                        case Status.THROTTLED_UNTIL_RAW_FIELD -> builder.setThrottledUntil(parser.longValue());
-                    }
-                }
-            }
-            return builder.buildStatus();
         }
 
         @Override
@@ -935,46 +837,6 @@ public class BulkByScrollTask extends CancellableTask {
                 builder.endObject();
             }
             return builder;
-        }
-
-        /**
-         * Since {@link StatusOrException} can contain either an {@link Exception} or a {@link Status} we need to peek
-         * at a field first before deciding what needs to be parsed since the same object could contains either.
-         * The {@link #EXPECTED_EXCEPTION_FIELDS} contains the fields that are expected when the serialised object
-         * was an instance of exception and the {@link Status#FIELDS_SET} is the set of fields expected when the
-         * serialized object was an instance of Status.
-         */
-        public static StatusOrException fromXContent(XContentParser parser) throws IOException {
-            XContentParser.Token token = parser.currentToken();
-            if (token == null) {
-                token = parser.nextToken();
-            }
-            if (token == Token.VALUE_NULL) {
-                return null;
-            } else {
-                ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
-                token = parser.nextToken();
-                // This loop is present only to ignore unknown tokens. It breaks as soon as we find a field
-                // that is allowed.
-                while (token != Token.END_OBJECT) {
-                    ensureExpectedToken(Token.FIELD_NAME, token, parser);
-                    String fieldName = parser.currentName();
-                    // weird way to ignore unknown tokens
-                    if (Status.FIELDS_SET.contains(fieldName)) {
-                        return new StatusOrException(Status.innerFromXContent(parser));
-                    } else if (EXPECTED_EXCEPTION_FIELDS.contains(fieldName)) {
-                        return new StatusOrException(ElasticsearchException.innerFromXContent(parser, false));
-                    } else {
-                        // Ignore unknown tokens
-                        token = parser.nextToken();
-                        if (token == Token.START_OBJECT || token == Token.START_ARRAY) {
-                            parser.skipChildren();
-                        }
-                        token = parser.nextToken();
-                    }
-                }
-                throw new XContentParseException("Unable to parse StatusFromException. Expected fields not found.");
-            }
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
@@ -15,23 +15,15 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.search.profile.aggregation.AggregationProfileShardResult;
-import org.elasticsearch.search.profile.query.QueryProfileShardResult;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * Profile results for all shards.
@@ -39,12 +31,12 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
 public final class SearchProfileResults implements Writeable, ToXContentFragment {
 
     private static final Logger logger = LogManager.getLogger(SearchProfileResults.class);
-    private static final String ID_FIELD = "id";
+    public static final String ID_FIELD = "id";
     private static final String NODE_ID_FIELD = "node_id";
     private static final String CLUSTER_FIELD = "cluster";
     private static final String INDEX_NAME_FIELD = "index";
     private static final String SHARD_ID_FIELD = "shard_id";
-    private static final String SHARDS_FIELD = "shards";
+    public static final String SHARDS_FIELD = "shards";
     public static final String PROFILE_FIELD = "profile";
 
     // map key is the composite "id" of form [nodeId][(clusterName:)indexName][shardId] created from SearchShardTarget.toString
@@ -115,75 +107,6 @@ public final class SearchProfileResults implements Writeable, ToXContentFragment
     @Override
     public String toString() {
         return Strings.toString(this);
-    }
-
-    public static SearchProfileResults fromXContent(XContentParser parser) throws IOException {
-        XContentParser.Token token = parser.currentToken();
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
-        Map<String, SearchProfileShardResult> profileResults = new HashMap<>();
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.START_ARRAY) {
-                if (SHARDS_FIELD.equals(parser.currentName())) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        parseProfileResultsEntry(parser, profileResults);
-                    }
-                } else {
-                    parser.skipChildren();
-                }
-            } else if (token == XContentParser.Token.START_OBJECT) {
-                parser.skipChildren();
-            }
-        }
-        return new SearchProfileResults(profileResults);
-    }
-
-    private static void parseProfileResultsEntry(XContentParser parser, Map<String, SearchProfileShardResult> searchProfileResults)
-        throws IOException {
-        XContentParser.Token token = parser.currentToken();
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
-        SearchProfileDfsPhaseResult searchProfileDfsPhaseResult = null;
-        List<QueryProfileShardResult> queryProfileResults = new ArrayList<>();
-        AggregationProfileShardResult aggProfileShardResult = null;
-        ProfileResult fetchResult = null;
-        String id = null;
-        String currentFieldName = null;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else if (token.isValue()) {
-                if (ID_FIELD.equals(currentFieldName)) {
-                    id = parser.text();
-                } else {
-                    parser.skipChildren();
-                }
-            } else if (token == XContentParser.Token.START_ARRAY) {
-                if ("searches".equals(currentFieldName)) {
-                    while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        queryProfileResults.add(QueryProfileShardResult.fromXContent(parser));
-                    }
-                } else if (AggregationProfileShardResult.AGGREGATIONS.equals(currentFieldName)) {
-                    aggProfileShardResult = AggregationProfileShardResult.fromXContent(parser);
-                } else {
-                    parser.skipChildren();
-                }
-            } else if (token == XContentParser.Token.START_OBJECT) {
-                if ("dfs".equals(currentFieldName)) {
-                    searchProfileDfsPhaseResult = SearchProfileDfsPhaseResult.fromXContent(parser);
-                } else if ("fetch".equals(currentFieldName)) {
-                    fetchResult = ProfileResult.fromXContent(parser);
-                } else {
-                    parser.skipChildren();
-                }
-            } else {
-                parser.skipChildren();
-            }
-        }
-        SearchProfileShardResult result = new SearchProfileShardResult(
-            new SearchProfileQueryPhaseResult(queryProfileResults, aggProfileShardResult),
-            fetchResult
-        );
-        result.getQueryPhase().setSearchProfileDfsPhaseResult(searchProfileDfsPhaseResult);
-        searchProfileResults.put(id, result);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/repositories/verify/VerifyRepositoryResponseTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.action.admin.cluster.repositories.verify;
 
 import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.util.ArrayList;
@@ -15,9 +17,28 @@ import java.util.List;
 
 public class VerifyRepositoryResponseTests extends AbstractXContentTestCase<VerifyRepositoryResponse> {
 
+    private static final ObjectParser<VerifyRepositoryResponse, Void> PARSER = new ObjectParser<>(
+        VerifyRepositoryResponse.class.getName(),
+        true,
+        VerifyRepositoryResponse::new
+    );
+    static {
+        ObjectParser<VerifyRepositoryResponse.NodeView, Void> internalParser = new ObjectParser<>(
+            VerifyRepositoryResponse.NODES,
+            true,
+            null
+        );
+        internalParser.declareString(VerifyRepositoryResponse.NodeView::setName, new ParseField(VerifyRepositoryResponse.NAME));
+        PARSER.declareNamedObjects(
+            VerifyRepositoryResponse::setNodes,
+            (p, v, name) -> internalParser.parse(p, new VerifyRepositoryResponse.NodeView(name), null),
+            new ParseField("nodes")
+        );
+    }
+
     @Override
     protected VerifyRepositoryResponse doParseInstance(XContentParser parser) {
-        return VerifyRepositoryResponse.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/settings/ClusterUpdateSettingsResponseTests.java
@@ -14,17 +14,32 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.action.support.master.AcknowledgedResponse.declareAcknowledgedField;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
 public class ClusterUpdateSettingsResponseTests extends AbstractXContentSerializingTestCase<ClusterUpdateSettingsResponse> {
+
+    private static final ConstructingObjectParser<ClusterUpdateSettingsResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "cluster_update_settings_response",
+        true,
+        args -> new ClusterUpdateSettingsResponse((boolean) args[0], (Settings) args[1], (Settings) args[2])
+    );
+    static {
+        declareAcknowledgedField(PARSER);
+        PARSER.declareObject(constructorArg(), (p, c) -> Settings.fromXContent(p), ClusterUpdateSettingsResponse.TRANSIENT);
+        PARSER.declareObject(constructorArg(), (p, c) -> Settings.fromXContent(p), ClusterUpdateSettingsResponse.PERSISTENT);
+    }
 
     @Override
     protected ClusterUpdateSettingsResponse doParseInstance(XContentParser parser) {
-        return ClusterUpdateSettingsResponse.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponseTests.java
@@ -10,6 +10,8 @@ package org.elasticsearch.action.admin.cluster.snapshots.status;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -17,11 +19,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
 public class SnapshotsStatusResponseTests extends AbstractChunkedSerializingTestCase<SnapshotsStatusResponse> {
+
+    private static final ConstructingObjectParser<SnapshotsStatusResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "snapshots_status_response",
+        true,
+        (Object[] parsedObjects) -> {
+            @SuppressWarnings("unchecked")
+            List<SnapshotStatus> snapshots = (List<SnapshotStatus>) parsedObjects[0];
+            return new SnapshotsStatusResponse(snapshots);
+        }
+    );
+    static {
+        PARSER.declareObjectArray(constructorArg(), SnapshotStatus.PARSER, new ParseField("snapshots"));
+    }
 
     @Override
     protected SnapshotsStatusResponse doParseInstance(XContentParser parser) throws IOException {
-        return SnapshotsStatusResponse.fromXContent(parser);
+        return PARSER.parse(parser, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptContextResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptContextResponseTests.java
@@ -8,13 +8,37 @@
 package org.elasticsearch.action.admin.cluster.storedscripts;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.script.ScriptContextInfo;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class GetScriptContextResponseTests extends AbstractXContentSerializingTestCase<GetScriptContextResponse> {
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<GetScriptContextResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "get_script_context",
+        true,
+        (a) -> {
+            Map<String, ScriptContextInfo> contexts = ((List<ScriptContextInfo>) a[0]).stream()
+                .collect(Collectors.toMap(ScriptContextInfo::getName, c -> c));
+            return new GetScriptContextResponse(contexts);
+        }
+    );
+
+    static {
+        PARSER.declareObjectArray(
+            ConstructingObjectParser.constructorArg(),
+            ScriptContextInfo.PARSER::apply,
+            GetScriptContextResponse.CONTEXTS
+        );
+    }
 
     @Override
     protected GetScriptContextResponse createTestInstance() {
@@ -31,7 +55,7 @@ public class GetScriptContextResponseTests extends AbstractXContentSerializingTe
 
     @Override
     protected GetScriptContextResponse doParseInstance(XContentParser parser) throws IOException {
-        return GetScriptContextResponse.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponseTests.java
@@ -8,10 +8,12 @@
 package org.elasticsearch.action.admin.indices.analyze;
 
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BaseBroadcastResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.AbstractBroadcastResponseTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -23,7 +25,51 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.action.support.broadcast.BaseBroadcastResponse.declareBroadcastFields;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
 public class ReloadAnalyzersResponseTests extends AbstractBroadcastResponseTestCase<ReloadAnalyzersResponse> {
+
+    @SuppressWarnings({ "unchecked" })
+    private static final ConstructingObjectParser<ReloadAnalyzersResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "reload_analyzer",
+        true,
+        arg -> {
+            BaseBroadcastResponse response = (BaseBroadcastResponse) arg[0];
+            List<ReloadAnalyzersResponse.ReloadDetails> results = (List<ReloadAnalyzersResponse.ReloadDetails>) arg[1];
+            Map<String, ReloadAnalyzersResponse.ReloadDetails> reloadedNodeIds = new HashMap<>();
+            for (ReloadAnalyzersResponse.ReloadDetails result : results) {
+                reloadedNodeIds.put(result.getIndexName(), result);
+            }
+            return new ReloadAnalyzersResponse(
+                response.getTotalShards(),
+                response.getSuccessfulShards(),
+                response.getFailedShards(),
+                Arrays.asList(response.getShardFailures()),
+                reloadedNodeIds
+            );
+        }
+    );
+
+    @SuppressWarnings({ "unchecked" })
+    private static final ConstructingObjectParser<ReloadAnalyzersResponse.ReloadDetails, Void> ENTRY_PARSER =
+        new ConstructingObjectParser<>(
+            "reload_analyzer.entry",
+            true,
+            arg -> new ReloadAnalyzersResponse.ReloadDetails(
+                (String) arg[0],
+                new HashSet<>((List<String>) arg[1]),
+                new HashSet<>((List<String>) arg[2])
+            )
+        );
+
+    static {
+        declareBroadcastFields(PARSER);
+        PARSER.declareObjectArray(constructorArg(), ENTRY_PARSER, ReloadAnalyzersResponse.RELOAD_DETAILS_FIELD);
+        ENTRY_PARSER.declareString(constructorArg(), ReloadAnalyzersResponse.INDEX_FIELD);
+        ENTRY_PARSER.declareStringArray(constructorArg(), ReloadAnalyzersResponse.RELOADED_ANALYZERS_FIELD);
+        ENTRY_PARSER.declareStringArray(constructorArg(), ReloadAnalyzersResponse.RELOADED_NODE_IDS_FIELD);
+    }
 
     @Override
     protected ReloadAnalyzersResponse createTestInstance(
@@ -50,7 +96,7 @@ public class ReloadAnalyzersResponseTests extends AbstractBroadcastResponseTestC
 
     @Override
     protected ReloadAnalyzersResponse doParseInstance(XContentParser parser) throws IOException {
-        return ReloadAnalyzersResponse.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/open/OpenIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/open/OpenIndexResponseTests.java
@@ -10,13 +10,26 @@ package org.elasticsearch.action.admin.indices.open;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
+
+import static org.elasticsearch.action.support.master.ShardsAcknowledgedResponse.declareAcknowledgedAndShardsAcknowledgedFields;
 
 public class OpenIndexResponseTests extends AbstractXContentSerializingTestCase<OpenIndexResponse> {
 
+    private static final ConstructingObjectParser<OpenIndexResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "open_index",
+        true,
+        args -> new OpenIndexResponse((boolean) args[0], (boolean) args[1])
+    );
+
+    static {
+        declareAcknowledgedAndShardsAcknowledgedFields(PARSER);
+    }
+
     @Override
     protected OpenIndexResponse doParseInstance(XContentParser parser) {
-        return OpenIndexResponse.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponseTests.java
@@ -10,18 +10,52 @@ package org.elasticsearch.action.admin.indices.validate.query;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BaseBroadcastResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.AbstractBroadcastResponseTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.action.support.broadcast.BaseBroadcastResponse.declareBroadcastFields;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
 public class ValidateQueryResponseTests extends AbstractBroadcastResponseTestCase<ValidateQueryResponse> {
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<ValidateQueryResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "validate_query",
+        true,
+        arg -> {
+            BaseBroadcastResponse response = (BaseBroadcastResponse) arg[0];
+            return new ValidateQueryResponse(
+                (boolean) arg[1],
+                (List<QueryExplanation>) arg[2],
+                response.getTotalShards(),
+                response.getSuccessfulShards(),
+                response.getFailedShards(),
+                Arrays.asList(response.getShardFailures())
+            );
+        }
+    );
+    static {
+        declareBroadcastFields(PARSER);
+        PARSER.declareBoolean(constructorArg(), new ParseField(ValidateQueryResponse.VALID_FIELD));
+        PARSER.declareObjectArray(
+            optionalConstructorArg(),
+            QueryExplanation.PARSER,
+            new ParseField(ValidateQueryResponse.EXPLANATIONS_FIELD)
+        );
+    }
 
     private static ValidateQueryResponse createRandomValidateQueryResponse(
         int totalShards,
@@ -60,7 +94,7 @@ public class ValidateQueryResponseTests extends AbstractBroadcastResponseTestCas
 
     @Override
     protected ValidateQueryResponse doParseInstance(XContentParser parser) throws IOException {
-        return ValidateQueryResponse.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -192,17 +192,16 @@ public class BulkItemResponseTests extends ESTestCase {
         if (opType == DocWriteRequest.OpType.INDEX || opType == DocWriteRequest.OpType.CREATE) {
             final IndexResponse.Builder indexResponseBuilder = new IndexResponse.Builder();
             builder = indexResponseBuilder;
-            itemParser = (indexParser) -> IndexResponse.parseXContentFields(indexParser, indexResponseBuilder);
-
+            itemParser = indexParser -> DocWriteResponse.parseInnerToXContent(indexParser, indexResponseBuilder);
         } else if (opType == DocWriteRequest.OpType.UPDATE) {
             final UpdateResponse.Builder updateResponseBuilder = new UpdateResponse.Builder();
             builder = updateResponseBuilder;
-            itemParser = (updateParser) -> UpdateResponse.parseXContentFields(updateParser, updateResponseBuilder);
+            itemParser = updateParser -> UpdateResponseTests.parseXContentFields(updateParser, updateResponseBuilder);
 
         } else if (opType == DocWriteRequest.OpType.DELETE) {
             final DeleteResponse.Builder deleteResponseBuilder = new DeleteResponse.Builder();
             builder = deleteResponseBuilder;
-            itemParser = (deleteParser) -> DeleteResponse.parseXContentFields(deleteParser, deleteResponseBuilder);
+            itemParser = deleteParser -> DocWriteResponse.parseInnerToXContent(deleteParser, deleteResponseBuilder);
         } else {
             throwUnknownField(currentFieldName, parser);
         }

--- a/server/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.delete;
 
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -26,6 +27,7 @@ import java.util.function.Predicate;
 
 import static org.elasticsearch.action.index.IndexResponseTests.assertDocWriteResponse;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_UUID_NA_VALUE;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 
 public class DeleteResponseTests extends ESTestCase {
@@ -102,7 +104,7 @@ public class DeleteResponseTests extends ESTestCase {
         }
         DeleteResponse parsedDeleteResponse;
         try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
-            parsedDeleteResponse = DeleteResponse.fromXContent(parser);
+            parsedDeleteResponse = parseInstance(parser);
             assertNull(parser.nextToken());
         }
 
@@ -110,6 +112,16 @@ public class DeleteResponseTests extends ESTestCase {
         // because the random delete response can contain shard failures with exceptions,
         // and those exceptions are not parsed back with the same types.
         assertDocWriteResponse(expectedDeleteResponse, parsedDeleteResponse);
+    }
+
+    private static DeleteResponse parseInstance(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+
+        DeleteResponse.Builder context = new DeleteResponse.Builder();
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            DocWriteResponse.parseInnerToXContent(parser, context);
+        }
+        return context.build();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/explain/ExplainResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/explain/ExplainResponseTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.test.RandomObjects;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -24,6 +25,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -34,9 +36,46 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ExplainResponseTests extends AbstractXContentSerializingTestCase<ExplainResponse> {
 
+    private static final ConstructingObjectParser<ExplainResponse, Boolean> PARSER = new ConstructingObjectParser<>(
+        "explain",
+        true,
+        (arg, exists) -> new ExplainResponse((String) arg[0], (String) arg[1], exists, (Explanation) arg[2], (GetResult) arg[3])
+    );
+
+    static {
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), ExplainResponse._INDEX);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), ExplainResponse._ID);
+        final ConstructingObjectParser<Explanation, Boolean> explanationParser = getExplanationsParser();
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), explanationParser, ExplainResponse.EXPLANATION);
+        PARSER.declareObject(
+            ConstructingObjectParser.optionalConstructorArg(),
+            (p, c) -> GetResult.fromXContentEmbedded(p),
+            ExplainResponse.GET
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ConstructingObjectParser<Explanation, Boolean> getExplanationsParser() {
+        final ConstructingObjectParser<Explanation, Boolean> explanationParser = new ConstructingObjectParser<>(
+            "explanation",
+            true,
+            arg -> {
+                if ((float) arg[0] > 0) {
+                    return Explanation.match((float) arg[0], (String) arg[1], (Collection<Explanation>) arg[2]);
+                } else {
+                    return Explanation.noMatch((String) arg[1], (Collection<Explanation>) arg[2]);
+                }
+            }
+        );
+        explanationParser.declareFloat(ConstructingObjectParser.constructorArg(), ExplainResponse.VALUE);
+        explanationParser.declareString(ConstructingObjectParser.constructorArg(), ExplainResponse.DESCRIPTION);
+        explanationParser.declareObjectArray(ConstructingObjectParser.constructorArg(), explanationParser, ExplainResponse.DETAILS);
+        return explanationParser;
+    }
+
     @Override
     protected ExplainResponse doParseInstance(XContentParser parser) throws IOException {
-        return ExplainResponse.fromXContent(parser, randomBoolean());
+        return PARSER.apply(parser, randomBoolean());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 
 import static org.elasticsearch.action.support.replication.ReplicationResponseTests.assertShardInfo;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_UUID_NA_VALUE;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 
 public class IndexResponseTests extends ESTestCase {
@@ -111,7 +112,7 @@ public class IndexResponseTests extends ESTestCase {
         }
         IndexResponse parsedIndexResponse;
         try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
-            parsedIndexResponse = IndexResponse.fromXContent(parser);
+            parsedIndexResponse = parseInstanceFromXContent(parser);
             assertNull(parser.nextToken());
         }
 
@@ -119,6 +120,15 @@ public class IndexResponseTests extends ESTestCase {
         // because the random index response can contain shard failures with exceptions,
         // and those exceptions are not parsed back with the same types.
         assertDocWriteResponse(expectedIndexResponse, parsedIndexResponse);
+    }
+
+    private static IndexResponse parseInstanceFromXContent(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        IndexResponse.Builder context = new IndexResponse.Builder();
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            DocWriteResponse.parseInnerToXContent(parser, context);
+        }
+        return context.build();
     }
 
     public static void assertDocWriteResponse(DocWriteResponse expected, DocWriteResponse actual) {

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterIndexHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterIndexHealthTests.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class ClusterIndexHealthTests extends AbstractXContentSerializingTestCase<ClusterIndexHealth> {
@@ -101,7 +102,13 @@ public class ClusterIndexHealthTests extends AbstractXContentSerializingTestCase
 
     @Override
     protected ClusterIndexHealth doParseInstance(XContentParser parser) throws IOException {
-        return ClusterIndexHealth.fromXContent(parser);
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        XContentParser.Token token = parser.nextToken();
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
+        String index = parser.currentName();
+        ClusterIndexHealth parsed = ClusterIndexHealth.innerFromXContent(parser, index);
+        ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
+        return parsed;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollResponseTests.java
@@ -51,7 +51,7 @@ public class BulkByScrollResponseTests extends AbstractXContentTestCase<BulkBySc
             new ParseField(BulkByScrollResponse.FAILURES_FIELD)
         );
         // since the result of BulkByScrollResponse.Status are mixed we also parse that in this
-        Status.declareFields(PARSER);
+        BulkByScrollTaskStatusTests.declareFields(PARSER);
     }
 
     private static Object parseFailure(XContentParser parser) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskStatusOrExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskStatusOrExceptionTests.java
@@ -41,7 +41,7 @@ public class BulkByScrollTaskStatusOrExceptionTests extends AbstractXContentTest
 
     @Override
     protected StatusOrException doParseInstance(XContentParser parser) throws IOException {
-        return StatusOrException.fromXContent(parser);
+        return BulkByScrollTaskStatusTests.parseStatusOrException(parser);
     }
 
     public static void assertEqualStatusOrException(

--- a/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/BulkByScrollTaskStatusTests.java
@@ -15,9 +15,14 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.reindex.BulkByScrollTask.Status;
 import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 import org.hamcrest.Matchers;
 
@@ -32,6 +37,8 @@ import java.util.stream.IntStream;
 import static java.lang.Math.abs;
 import static java.util.stream.Collectors.toList;
 import static org.apache.lucene.tests.util.TestUtil.randomSimpleString;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.hamcrest.Matchers.equalTo;
 
 public class BulkByScrollTaskStatusTests extends AbstractXContentTestCase<BulkByScrollTask.Status> {
@@ -177,7 +184,142 @@ public class BulkByScrollTaskStatusTests extends AbstractXContentTestCase<BulkBy
 
     @Override
     protected BulkByScrollTask.Status doParseInstance(XContentParser parser) throws IOException {
-        return BulkByScrollTask.Status.fromXContent(parser);
+        XContentParser.Token token;
+        if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
+            token = parser.nextToken();
+        } else {
+            token = parser.nextToken();
+        }
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
+        token = parser.nextToken();
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
+        return innerParseStatus(parser);
+    }
+
+    private static final ConstructingObjectParser<Tuple<Long, Long>, Void> RETRIES_PARSER = new ConstructingObjectParser<>(
+        "bulk_by_scroll_task_status_retries",
+        true,
+        a -> new Tuple<>(((Long) a[0]), (Long) a[1])
+    );
+    static {
+        RETRIES_PARSER.declareLong(constructorArg(), new ParseField(BulkByScrollTask.Status.RETRIES_BULK_FIELD));
+        RETRIES_PARSER.declareLong(constructorArg(), new ParseField(BulkByScrollTask.Status.RETRIES_SEARCH_FIELD));
+    }
+
+    public static void declareFields(ObjectParser<? extends BulkByScrollTask.StatusBuilder, Void> parser) {
+        parser.declareInt(BulkByScrollTask.StatusBuilder::setSliceId, new ParseField(BulkByScrollTask.Status.SLICE_ID_FIELD));
+        parser.declareLong(BulkByScrollTask.StatusBuilder::setTotal, new ParseField(BulkByScrollTask.Status.TOTAL_FIELD));
+        parser.declareLong(BulkByScrollTask.StatusBuilder::setUpdated, new ParseField(BulkByScrollTask.Status.UPDATED_FIELD));
+        parser.declareLong(BulkByScrollTask.StatusBuilder::setCreated, new ParseField(BulkByScrollTask.Status.CREATED_FIELD));
+        parser.declareLong(BulkByScrollTask.StatusBuilder::setDeleted, new ParseField(BulkByScrollTask.Status.DELETED_FIELD));
+        parser.declareInt(BulkByScrollTask.StatusBuilder::setBatches, new ParseField(BulkByScrollTask.Status.BATCHES_FIELD));
+        parser.declareLong(
+            BulkByScrollTask.StatusBuilder::setVersionConflicts,
+            new ParseField(BulkByScrollTask.Status.VERSION_CONFLICTS_FIELD)
+        );
+        parser.declareLong(BulkByScrollTask.StatusBuilder::setNoops, new ParseField(BulkByScrollTask.Status.NOOPS_FIELD));
+        parser.declareObject(
+            BulkByScrollTask.StatusBuilder::setRetries,
+            RETRIES_PARSER,
+            new ParseField(BulkByScrollTask.Status.RETRIES_FIELD)
+        );
+        parser.declareLong(BulkByScrollTask.StatusBuilder::setThrottled, new ParseField(BulkByScrollTask.Status.THROTTLED_RAW_FIELD));
+        parser.declareFloat(
+            BulkByScrollTask.StatusBuilder::setRequestsPerSecond,
+            new ParseField(BulkByScrollTask.Status.REQUESTS_PER_SEC_FIELD)
+        );
+        parser.declareString(BulkByScrollTask.StatusBuilder::setReasonCancelled, new ParseField(BulkByScrollTask.Status.CANCELED_FIELD));
+        parser.declareLong(
+            BulkByScrollTask.StatusBuilder::setThrottledUntil,
+            new ParseField(BulkByScrollTask.Status.THROTTLED_UNTIL_RAW_FIELD)
+        );
+        parser.declareObjectArray(
+            BulkByScrollTask.StatusBuilder::setSliceStatuses,
+            (p, c) -> parseStatusOrException(p),
+            new ParseField(BulkByScrollTask.Status.SLICES_FIELD)
+        );
+    }
+
+    private static Status innerParseStatus(XContentParser parser) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        String fieldName = parser.currentName();
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
+        BulkByScrollTask.StatusBuilder builder = new BulkByScrollTask.StatusBuilder();
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                fieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if (fieldName.equals(Status.RETRIES_FIELD)) {
+                    builder.setRetries(RETRIES_PARSER.parse(parser, null));
+                } else {
+                    parser.skipChildren();
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (fieldName.equals(Status.SLICES_FIELD)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        builder.addToSliceStatuses(parseStatusOrException(parser));
+                    }
+                } else {
+                    parser.skipChildren();
+                }
+            } else { // else if it is a value
+                switch (fieldName) {
+                    case Status.SLICE_ID_FIELD -> builder.setSliceId(parser.intValue());
+                    case Status.TOTAL_FIELD -> builder.setTotal(parser.longValue());
+                    case Status.UPDATED_FIELD -> builder.setUpdated(parser.longValue());
+                    case Status.CREATED_FIELD -> builder.setCreated(parser.longValue());
+                    case Status.DELETED_FIELD -> builder.setDeleted(parser.longValue());
+                    case Status.BATCHES_FIELD -> builder.setBatches(parser.intValue());
+                    case Status.VERSION_CONFLICTS_FIELD -> builder.setVersionConflicts(parser.longValue());
+                    case Status.NOOPS_FIELD -> builder.setNoops(parser.longValue());
+                    case Status.THROTTLED_RAW_FIELD -> builder.setThrottled(parser.longValue());
+                    case Status.REQUESTS_PER_SEC_FIELD -> builder.setRequestsPerSecond(parser.floatValue());
+                    case Status.CANCELED_FIELD -> builder.setReasonCancelled(parser.text());
+                    case Status.THROTTLED_UNTIL_RAW_FIELD -> builder.setThrottledUntil(parser.longValue());
+                }
+            }
+        }
+        return builder.buildStatus();
+    }
+
+    /**
+     * Since {@link BulkByScrollTask.StatusOrException} can contain either an {@link Exception} or a {@link Status} we need to peek
+     * at a field first before deciding what needs to be parsed since the same object could contains either.
+     * The {@link BulkByScrollTask.StatusOrException#EXPECTED_EXCEPTION_FIELDS} contains the fields that are expected when the serialised
+     * object was an instance of exception and the {@link Status#FIELDS_SET} is the set of fields expected when the
+     * serialized object was an instance of Status.
+     */
+    public static BulkByScrollTask.StatusOrException parseStatusOrException(XContentParser parser) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        if (token == null) {
+            token = parser.nextToken();
+        }
+        if (token == XContentParser.Token.VALUE_NULL) {
+            return null;
+        } else {
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
+            token = parser.nextToken();
+            // This loop is present only to ignore unknown tokens. It breaks as soon as we find a field
+            // that is allowed.
+            while (token != XContentParser.Token.END_OBJECT) {
+                ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
+                String fieldName = parser.currentName();
+                // weird way to ignore unknown tokens
+                if (Status.FIELDS_SET.contains(fieldName)) {
+                    return new BulkByScrollTask.StatusOrException(innerParseStatus(parser));
+                } else if (BulkByScrollTask.StatusOrException.EXPECTED_EXCEPTION_FIELDS.contains(fieldName)) {
+                    return new BulkByScrollTask.StatusOrException(ElasticsearchException.innerFromXContent(parser, false));
+                } else {
+                    // Ignore unknown tokens
+                    token = parser.nextToken();
+                    if (token == XContentParser.Token.START_OBJECT || token == XContentParser.Token.START_ARRAY) {
+                        parser.skipChildren();
+                    }
+                    token = parser.nextToken();
+                }
+            }
+            throw new XContentParseException("Unable to parse StatusFromException. Expected fields not found.");
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/profile/SearchProfileResultsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/SearchProfileResultsTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -114,7 +115,7 @@ public class SearchProfileResultsTests extends AbstractXContentSerializingTestCa
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         ensureFieldName(parser, parser.nextToken(), SearchProfileResults.PROFILE_FIELD);
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-        SearchProfileResults result = SearchProfileResults.fromXContent(parser);
+        SearchProfileResults result = SearchResponseUtils.parseSearchProfileResults(parser);
         assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
         assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
         return result;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponse.java
@@ -12,18 +12,13 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * The response object returned by the Explain Lifecycle API.
@@ -36,26 +31,6 @@ public class ExplainLifecycleResponse extends ActionResponse implements ToXConte
     public static final ParseField INDICES_FIELD = new ParseField("indices");
 
     private Map<String, IndexLifecycleExplainResponse> indexResponses;
-
-    @SuppressWarnings("unchecked")
-    private static final ConstructingObjectParser<ExplainLifecycleResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "explain_lifecycle_response",
-        a -> new ExplainLifecycleResponse(
-            ((List<IndexLifecycleExplainResponse>) a[0]).stream()
-                .collect(Collectors.toMap(IndexLifecycleExplainResponse::getIndex, Function.identity()))
-        )
-    );
-    static {
-        PARSER.declareNamedObjects(
-            ConstructingObjectParser.constructorArg(),
-            (p, c, n) -> IndexLifecycleExplainResponse.PARSER.apply(p, c),
-            INDICES_FIELD
-        );
-    }
-
-    public static ExplainLifecycleResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
-    }
 
     public ExplainLifecycleResponse(StreamInput in) throws IOException {
         super(in);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
@@ -21,7 +21,6 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -42,7 +41,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class PreviewTransformAction extends ActionType<PreviewTransformAction.Response> {
 
@@ -154,26 +152,6 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
         private final List<Map<String, Object>> docs;
         private final TransformDestIndexSettings generatedDestIndexSettings;
 
-        private static final ConstructingObjectParser<Response, Void> PARSER = new ConstructingObjectParser<>(
-            "data_frame_transform_preview",
-            true,
-            args -> {
-                @SuppressWarnings("unchecked")
-                List<Map<String, Object>> docs = (List<Map<String, Object>>) args[0];
-                TransformDestIndexSettings generatedDestIndex = (TransformDestIndexSettings) args[1];
-
-                return new Response(docs, generatedDestIndex);
-            }
-        );
-        static {
-            PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> p.mapOrdered(), PREVIEW);
-            PARSER.declareObject(
-                optionalConstructorArg(),
-                (p, c) -> TransformDestIndexSettings.fromXContent(p),
-                GENERATED_DEST_INDEX_SETTINGS
-            );
-        }
-
         public Response(List<Map<String, Object>> docs, TransformDestIndexSettings generatedDestIndexSettings) {
             this.docs = docs;
             this.generatedDestIndexSettings = generatedDestIndexSettings;
@@ -236,10 +214,6 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
         @Override
         public String toString() {
             return Strings.toString(this, true, true);
-        }
-
-        public static Response fromXContent(final XContentParser parser) throws IOException {
-            return PARSER.parse(parser, null);
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/ExplainLifecycleResponseTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
@@ -19,9 +20,28 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ExplainLifecycleResponseTests extends AbstractXContentSerializingTestCase<ExplainLifecycleResponse> {
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<ExplainLifecycleResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "explain_lifecycle_response",
+        a -> new ExplainLifecycleResponse(
+            ((List<IndexLifecycleExplainResponse>) a[0]).stream()
+                .collect(Collectors.toMap(IndexLifecycleExplainResponse::getIndex, Function.identity()))
+        )
+    );
+    static {
+        PARSER.declareNamedObjects(
+            ConstructingObjectParser.constructorArg(),
+            (p, c, n) -> IndexLifecycleExplainResponse.PARSER.apply(p, c),
+            ExplainLifecycleResponse.INDICES_FIELD
+        );
+    }
 
     @Override
     protected ExplainLifecycleResponse createTestInstance() {
@@ -51,7 +71,7 @@ public class ExplainLifecycleResponseTests extends AbstractXContentSerializingTe
 
     @Override
     protected ExplainLifecycleResponse doParseInstance(XContentParser parser) throws IOException {
-        return ExplainLifecycleResponse.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformsActionResponseTests.java
@@ -9,8 +9,10 @@ package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.transform.action.PreviewTransformAction.Response;
+import org.elasticsearch.xpack.core.transform.transforms.TransformDestIndexSettings;
 import org.elasticsearch.xpack.core.transform.transforms.TransformDestIndexSettingsTests;
 
 import java.io.IOException;
@@ -18,7 +20,30 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
 public class PreviewTransformsActionResponseTests extends AbstractXContentSerializingTestCase<Response> {
+
+    private static final ConstructingObjectParser<Response, Void> PARSER = new ConstructingObjectParser<>(
+        "data_frame_transform_preview",
+        true,
+        args -> {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> docs = (List<Map<String, Object>>) args[0];
+            TransformDestIndexSettings generatedDestIndex = (TransformDestIndexSettings) args[1];
+
+            return new Response(docs, generatedDestIndex);
+        }
+    );
+
+    static {
+        PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> p.mapOrdered(), PreviewTransformAction.Response.PREVIEW);
+        PARSER.declareObject(
+            optionalConstructorArg(),
+            (p, c) -> TransformDestIndexSettings.fromXContent(p),
+            PreviewTransformAction.Response.GENERATED_DEST_INDEX_SETTINGS
+        );
+    }
 
     public static Response randomPreviewResponse() {
         int size = randomIntBetween(0, 10);
@@ -32,7 +57,7 @@ public class PreviewTransformsActionResponseTests extends AbstractXContentSerial
 
     @Override
     protected Response doParseInstance(XContentParser parser) throws IOException {
-        return Response.fromXContent(parser);
+        return PARSER.parse(parser, null);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionAction.java
@@ -146,20 +146,5 @@ public class PutAnalyticsCollectionAction {
             builder.field(COLLECTION_NAME_FIELD.getPreferredName(), name);
         }
 
-        private static final ConstructingObjectParser<Response, String> PARSER = new ConstructingObjectParser<>(
-            "put_analytics_collection_response",
-            false,
-            (p) -> {
-                return new Response((boolean) p[0], (String) p[1]);
-            }
-        );
-        static {
-            PARSER.declareString(constructorArg(), COLLECTION_NAME_FIELD);
-        }
-
-        public static Response fromXContent(String resourceName, XContentParser parser) throws IOException {
-            return new Response(AcknowledgedResponse.fromXContent(parser).isAcknowledged(), resourceName);
-        }
-
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionResponseBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionResponseBWCSerializingTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.application.analytics.action;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
@@ -40,7 +41,7 @@ public class PutAnalyticsCollectionResponseBWCSerializingTests extends AbstractB
 
     @Override
     protected PutAnalyticsCollectionAction.Response doParseInstance(XContentParser parser) throws IOException {
-        return PutAnalyticsCollectionAction.Response.fromXContent(this.name, parser);
+        return new PutAnalyticsCollectionAction.Response(AcknowledgedResponse.fromXContent(parser).isAcknowledged(), this.name);
     }
 
     @Override


### PR DESCRIPTION
Just like a couple times before, moving a couple more of the test only parsers to the test codebase to save code-size etc.
Most I just moved to the single use they had in their unit test class, some that were more widely applicable and related to search responses I moved to `SearchResponseUtil`.

relates #98070 #104338 etc.