### PR TITLE
[ML] Rename the internal text embedding service to elasticsearch

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -6,11 +6,11 @@ experimental[]
 
 Creates a model to perform an {infer} task.
 
-IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in 
-{ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or 
-Hugging Face, in your cluster. For built-in models and models uploaded though 
-Eland, the {infer} APIs offer an alternative way to use and manage trained 
-models. However, if you do not plan to use the {infer} APIs to use these models 
+IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
+{ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
+Hugging Face. For built-in models and models uploaded though
+Eland, the {infer} APIs offer an alternative way to use and manage trained
+models. However, if you do not plan to use the {infer} APIs to use these models
 or if you want to use non-NLP models, use the <<ml-df-trained-models-apis>>.
 
 
@@ -41,7 +41,7 @@ The following services are available through the {infer} API:
 * ELSER
 * Hugging Face
 * OpenAI
-* text embedding (for built-in models and models uploaded through Eland)
+* Elasticsearch (for built-in models and models uploaded through Eland)
 
 
 [discrete]
@@ -68,12 +68,12 @@ The type of the {infer} task that the model will perform. Available task types:
 (Required, string)
 The type of service supported for the specified task type.
 Available services:
-* `cohere`: specify the `text_embedding` task type to use the Cohere service. 
+* `cohere`: specify the `text_embedding` task type to use the Cohere service.
 * `elser`: specify the `sparse_embedding` task type to use the ELSER service.
-* `hugging_face`: specify the `text_embedding` task type to use the Hugging Face 
+* `hugging_face`: specify the `text_embedding` task type to use the Hugging Face
 service.
 * `openai`: specify the `text_embedding` task type to use the OpenAI service.
-* `text_embedding`: specify the `text_embedding` task type to use the E5 
+* `elasticsearch`: specify the `text_embedding` task type to use the E5
 built-in model or text embedding models uploaded by Eland.
 
 `service_settings`::
@@ -86,14 +86,14 @@ Settings used to install the {infer} model. These settings are specific to the
 =====
 `api_key`:::
 (Required, string)
-A valid API key of your Cohere account. You can find your Cohere API keys or you 
-can create a new one 
+A valid API key of your Cohere account. You can find your Cohere API keys or you
+can create a new one
 https://dashboard.cohere.com/api-keys[on the API keys settings page].
 
-IMPORTANT: You need to provide the API key only once, during the {infer} model 
-creation. The <<get-inference-api>> does not retrieve your API key. After 
-creating the {infer} model, you cannot change the associated API key. If you 
-want to use a different API key, delete the {infer} model and recreate it with 
+IMPORTANT: You need to provide the API key only once, during the {infer} model
+creation. The <<get-inference-api>> does not retrieve your API key. After
+creating the {infer} model, you cannot change the associated API key. If you
+want to use a different API key, delete the {infer} model and recreate it with
 the same name and the updated API key.
 
 `embedding_type`::
@@ -105,9 +105,9 @@ Valid values are:
 
 `model_id`::
 (Optional, string)
-The name of the model to use for the {infer} task. To review the available 
-models, refer to the 
-https://docs.cohere.com/reference/embed[Cohere docs]. Defaults to 
+The name of the model to use for the {infer} task. To review the available
+models, refer to the
+https://docs.cohere.com/reference/embed[Cohere docs]. Defaults to
 `embed-english-v2.0`.
 =====
 +
@@ -116,13 +116,13 @@ https://docs.cohere.com/reference/embed[Cohere docs]. Defaults to
 =====
 `num_allocations`:::
 (Required, integer)
-The number of model allocations to create. `num_allocations` must not exceed the 
+The number of model allocations to create. `num_allocations` must not exceed the
 number of available processors per node divided by the `num_threads`.
 
 `num_threads`:::
 (Required, integer)
-The number of threads to use by each model allocation. `num_threads` must not 
-exceed the number of available processors per node divided by the number of 
+The number of threads to use by each model allocation. `num_threads` must not
+exceed the number of available processors per node divided by the number of
 allocations. Must be a power of 2. Max allowed value is 32.
 =====
 +
@@ -131,14 +131,14 @@ allocations. Must be a power of 2. Max allowed value is 32.
 =====
 `api_key`:::
 (Required, string)
-A valid access token of your Hugging Face account. You can find your Hugging 
-Face access tokens or you can create a new one 
+A valid access token of your Hugging Face account. You can find your Hugging
+Face access tokens or you can create a new one
 https://huggingface.co/settings/tokens[on the settings page].
 
-IMPORTANT: You need to provide the API key only once, during the {infer} model 
-creation. The <<get-inference-api>> does not retrieve your API key. After 
-creating the {infer} model, you cannot change the associated API key. If you 
-want to use a different API key, delete the {infer} model and recreate it with 
+IMPORTANT: You need to provide the API key only once, during the {infer} model
+creation. The <<get-inference-api>> does not retrieve your API key. After
+creating the {infer} model, you cannot change the associated API key. If you
+want to use a different API key, delete the {infer} model and recreate it with
 the same name and the updated API key.
 
 `url`:::
@@ -151,21 +151,21 @@ The URL endpoint to use for the requests.
 =====
 `api_key`:::
 (Required, string)
-A valid API key of your OpenAI account. You can find your OpenAI API keys in 
-your OpenAI account under the 
+A valid API key of your OpenAI account. You can find your OpenAI API keys in
+your OpenAI account under the
 https://platform.openai.com/api-keys[API keys section].
 
-IMPORTANT: You need to provide the API key only once, during the {infer} model 
-creation. The <<get-inference-api>> does not retrieve your API key. After 
-creating the {infer} model, you cannot change the associated API key. If you 
-want to use a different API key, delete the {infer} model and recreate it with 
+IMPORTANT: You need to provide the API key only once, during the {infer} model
+creation. The <<get-inference-api>> does not retrieve your API key. After
+creating the {infer} model, you cannot change the associated API key. If you
+want to use a different API key, delete the {infer} model and recreate it with
 the same name and the updated API key.
 
 `organization_id`:::
 (Optional, string)
-The unique identifier of your organization. You can find the Organization ID in 
-your OpenAI account under 
-https://platform.openai.com/account/organization[**Settings** > **Organizations**]. 
+The unique identifier of your organization. You can find the Organization ID in
+your OpenAI account under
+https://platform.openai.com/account/organization[**Settings** > **Organizations**].
 
 `url`:::
 (Optional, string)
@@ -173,25 +173,25 @@ The URL endpoint to use for the requests. Can be changed for testing purposes.
 Defaults to `https://api.openai.com/v1/embeddings`.
 =====
 +
-.`service_settings` for the `text_embedding` service
+.`service_settings` for the `elasticsearch` service
 [%collapsible%closed]
 =====
 `model_id`:::
 (Required, string)
-The name of the text embedding model to use for the {infer} task. It can be the 
-ID of either a built-in model (for example, `.multilingual-e5-small` for E5) or 
+The name of the model to use for the {infer} task. It can be the
+ID of either a built-in model (for example, `.multilingual-e5-small` for E5) or
 a text embedding model already
 {ml-docs}/ml-nlp-import-model.html#ml-nlp-import-script[uploaded through Eland].
 
 `num_allocations`:::
 (Required, integer)
-The number of model allocations to create. `num_allocations` must not exceed the 
+The number of model allocations to create. `num_allocations` must not exceed the
 number of available processors per node divided by the `num_threads`.
 
 `num_threads`:::
 (Required, integer)
-The number of threads to use by each model allocation. `num_threads` must not 
-exceed the number of available processors per node divided by the number of 
+The number of threads to use by each model allocation. `num_threads` must not
+exceed the number of available processors per node divided by the number of
 allocations. Must be a power of 2. Max allowed value is 32.
 =====
 
@@ -211,26 +211,26 @@ Valid values are:
   * `classification`: use it for embeddings passed through a text classifier.
   * `clusterning`: use it for the embeddings run through a clustering algorithm.
   * `ingest`: use it for storing document embeddings in a vector database.
-  * `search`: use it for storing embeddings of search queries run against a 
+  * `search`: use it for storing embeddings of search queries run against a
   vector data base to find relevant documents.
 
 `model`:::
 (Optional, string)
-For `openai` sevice only. The name of the model to use for the {infer} task. Refer 
-to the 
+For `openai` sevice only. The name of the model to use for the {infer} task. Refer
+to the
 https://platform.openai.com/docs/guides/embeddings/what-are-embeddings[OpenAI documentation]
 for the list of available text embedding models.
 
 `truncate`:::
 (Optional, string)
-For `cohere` service only. Specifies how the API handles inputs longer than the 
+For `cohere` service only. Specifies how the API handles inputs longer than the
 maximum token length. Defaults to `END`. Valid values are:
- * `NONE`: when the input exceeds the maximum input token length an error is 
+ * `NONE`: when the input exceeds the maximum input token length an error is
  returned.
- * `START`: when the input exceeds the maximum input token length the start of 
+ * `START`: when the input exceeds the maximum input token length the start of
  the input is discarded.
- * `END`: when the input exceeds the maximum input token length the end of 
- the input is discarded. 
+ * `END`: when the input exceeds the maximum input token length the end of
+ the input is discarded.
 =====
 
 
@@ -267,7 +267,7 @@ PUT _inference/text_embedding/cohere-embeddings
 
 [discrete]
 [[inference-example-e5]]
-===== E5 via the text embedding service
+===== E5 via the elasticsearch service
 
 The following example shows how to create an {infer} model called
 `my-e5-model` to perform a `text_embedding` task type.
@@ -276,7 +276,7 @@ The following example shows how to create an {infer} model called
 ------------------------------------------------------------
 PUT _inference/text_embedding/my-e5-model
 {
-  "service": "text_embedding",
+  "service": "elasticsearch",
   "service_settings": {
     "num_allocations": 1,
     "num_threads": 1,
@@ -285,8 +285,8 @@ PUT _inference/text_embedding/my-e5-model
 }
 ------------------------------------------------------------
 // TEST[skip:TBD]
-<1> The `model_id` must be the ID of one of the built-in E5 models. Valid values 
-are `.multilingual-e5-small` and `.multilingual-e5-small_linux-x86_64`. For 
+<1> The `model_id` must be the ID of one of the built-in E5 models. Valid values
+are `.multilingual-e5-small` and `.multilingual-e5-small_linux-x86_64`. For
 further details, refer to the {ml-docs}/ml-nlp-e5.html[E5 model documentation].
 
 
@@ -339,7 +339,7 @@ The following example shows how to create an {infer} model called
 
 [source,console]
 ------------------------------------------------------------
-PUT _inference/text_embedding/hugging-face-embeddings 
+PUT _inference/text_embedding/hugging-face-embeddings
 {
   "service": "hugging_face",
   "service_settings": {
@@ -349,20 +349,20 @@ PUT _inference/text_embedding/hugging-face-embeddings
 }
 ------------------------------------------------------------
 // TEST[skip:TBD]
-<1> A valid Hugging Face access token. You can find on the 
+<1> A valid Hugging Face access token. You can find on the
 https://huggingface.co/settings/tokens[settings page of your account].
-<2> The {infer} endpoint URL you created on Hugging Face. 
+<2> The {infer} endpoint URL you created on Hugging Face.
 
-Create a new {infer} endpoint on 
-https://ui.endpoints.huggingface.co/[the Hugging Face endpoint page] to get an 
-endpoint URL. Select the model you want to use on the new endpoint creation page 
-- for example `intfloat/e5-small-v2` - then select the `Sentence Embeddings` 
-task under the Advanced configuration section. Create the endpoint. Copy the URL 
+Create a new {infer} endpoint on
+https://ui.endpoints.huggingface.co/[the Hugging Face endpoint page] to get an
+endpoint URL. Select the model you want to use on the new endpoint creation page
+- for example `intfloat/e5-small-v2` - then select the `Sentence Embeddings`
+task under the Advanced configuration section. Create the endpoint. Copy the URL
 after the endpoint initialization has been finished.
 
 [discrete]
 [[inference-example-eland]]
-===== Models uploaded by Eland via the text embedding service
+===== Models uploaded by Eland via the elasticsearch service
 
 The following example shows how to create an {infer} model called
 `my-msmarco-minilm-model` to perform a `text_embedding` task type.
@@ -371,7 +371,7 @@ The following example shows how to create an {infer} model called
 ------------------------------------------------------------
 PUT _inference/text_embedding/my-msmarco-minilm-model
 {
-  "service": "text_embedding",
+  "service": "elasticsearch",
   "service_settings": {
     "num_allocations": 1,
     "num_threads": 1,
@@ -380,8 +380,8 @@ PUT _inference/text_embedding/my-msmarco-minilm-model
 }
 ------------------------------------------------------------
 // TEST[skip:TBD]
-<1> The `model_id` must be the ID of a text embedding model which has already 
-been 
+<1> The `model_id` must be the ID of a text embedding model which has already
+been
 {ml-docs}/ml-nlp-import-model.html#ml-nlp-import-script[uploaded through Eland].
 
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceNamedWriteablesProvider.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferenceNamedWriteablesProvider.java
@@ -23,6 +23,8 @@ import org.elasticsearch.xpack.core.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.inference.services.cohere.CohereServiceSettings;
 import org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.cohere.embeddings.CohereEmbeddingsTaskSettings;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalServiceSettings;
+import org.elasticsearch.xpack.inference.services.elasticsearch.MultilingualE5SmallInternalServiceSettings;
 import org.elasticsearch.xpack.inference.services.elser.ElserInternalServiceSettings;
 import org.elasticsearch.xpack.inference.services.elser.ElserMlNodeTaskSettings;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceServiceSettings;
@@ -31,8 +33,6 @@ import org.elasticsearch.xpack.inference.services.huggingface.elser.HuggingFaceE
 import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsServiceSettings;
 import org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
-import org.elasticsearch.xpack.inference.services.textembedding.MultilingualE5SmallInternalServiceSettings;
-import org.elasticsearch.xpack.inference.services.textembedding.TextEmbeddingInternalServiceSettings;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -96,8 +96,8 @@ public class InferenceNamedWriteablesProvider {
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(
                 ServiceSettings.class,
-                TextEmbeddingInternalServiceSettings.NAME,
-                TextEmbeddingInternalServiceSettings::new
+                ElasticsearchInternalServiceSettings.NAME,
+                ElasticsearchInternalServiceSettings::new
             )
         );
         namedWriteables.add(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/InferencePlugin.java
@@ -60,11 +60,11 @@ import org.elasticsearch.xpack.inference.rest.RestInferenceAction;
 import org.elasticsearch.xpack.inference.rest.RestPutInferenceModelAction;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.cohere.CohereService;
+import org.elasticsearch.xpack.inference.services.elasticsearch.ElasticsearchInternalService;
 import org.elasticsearch.xpack.inference.services.elser.ElserInternalService;
 import org.elasticsearch.xpack.inference.services.huggingface.HuggingFaceService;
 import org.elasticsearch.xpack.inference.services.huggingface.elser.HuggingFaceElserService;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiService;
-import org.elasticsearch.xpack.inference.services.textembedding.TextEmbeddingInternalService;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -182,7 +182,7 @@ public class InferencePlugin extends Plugin implements ActionPlugin, ExtensibleP
             context -> new HuggingFaceService(httpFactory, serviceComponents),
             context -> new OpenAiService(httpFactory, serviceComponents),
             context -> new CohereService(httpFactory, serviceComponents),
-            TextEmbeddingInternalService::new
+            ElasticsearchInternalService::new
         );
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandInternalServiceSettings.java
@@ -3,11 +3,9 @@
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
- *
- * this file was contributed to by a generative AI
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ValidationException;
@@ -15,62 +13,49 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
-import org.elasticsearch.xpack.inference.services.settings.InternalServiceSettings;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Map;
 
 import static org.elasticsearch.TransportVersions.ML_TEXT_EMBEDDING_INFERENCE_SERVICE_ADDED;
 
-public class MultilingualE5SmallInternalServiceSettings extends TextEmbeddingInternalServiceSettings {
+public class CustomElandInternalServiceSettings extends ElasticsearchInternalServiceSettings {
 
-    public static final String NAME = "multilingual_e5_small_service_settings";
+    public static final String NAME = "custom_eland_model_internal_service_settings";
 
-    public MultilingualE5SmallInternalServiceSettings(int numAllocations, int numThreads, String modelId) {
+    public CustomElandInternalServiceSettings(int numAllocations, int numThreads, String modelId) {
         super(numAllocations, numThreads, modelId);
     }
 
-    public MultilingualE5SmallInternalServiceSettings(StreamInput in) throws IOException {
-        super(in.readVInt(), in.readVInt(), in.readString());
-    }
-
     /**
-     * Parse the MultilingualE5SmallServiceSettings from map and validate the setting values.
+     * Parse the CustomElandServiceSettings from map and validate the setting values.
+     *
+     * This method does not verify the model variant
      *
      * If required setting are missing or the values are invalid an
      * {@link ValidationException} is thrown.
      *
      * @param map Source map containing the config
-     * @return The {@code MultilingualE5SmallServiceSettings} builder
+     * @return The {@code CustomElandServiceSettings} builder
      */
-    public static MultilingualE5SmallInternalServiceSettings.Builder fromMap(Map<String, Object> map) {
+    public static Builder fromMap(Map<String, Object> map) {
+
         ValidationException validationException = new ValidationException();
         Integer numAllocations = ServiceUtils.removeAsType(map, NUM_ALLOCATIONS, Integer.class);
         Integer numThreads = ServiceUtils.removeAsType(map, NUM_THREADS, Integer.class);
 
         validateParameters(numAllocations, validationException, numThreads);
 
-        String modelId = ServiceUtils.removeAsType(map, MODEL_ID, String.class);
-        if (modelId != null) {
-            if (TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS.contains(modelId) == false) {
-                validationException.addValidationError(
-                    "unknown Multilingual-E5-Small model ID ["
-                        + modelId
-                        + "]. Valid IDs are "
-                        + Arrays.toString(TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS.toArray())
-                );
-            }
-        }
+        String modelId = ServiceUtils.extractRequiredString(map, MODEL_ID, "ServiceSettings", validationException);
 
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
 
-        var builder = new InternalServiceSettings.Builder() {
+        var builder = new Builder() {
             @Override
-            public MultilingualE5SmallInternalServiceSettings build() {
-                return new MultilingualE5SmallInternalServiceSettings(getNumAllocations(), getNumThreads(), getModelId());
+            public CustomElandInternalServiceSettings build() {
+                return new CustomElandInternalServiceSettings(getNumAllocations(), getNumThreads(), getModelId());
             }
         };
         builder.setNumAllocations(numAllocations);
@@ -84,6 +69,10 @@ public class MultilingualE5SmallInternalServiceSettings extends TextEmbeddingInt
         return super.toXContent(builder, params);
     }
 
+    public CustomElandInternalServiceSettings(StreamInput in) throws IOException {
+        super(in.readVInt(), in.readVInt(), in.readString());
+    }
+
     @Override
     public boolean isFragment() {
         return super.isFragment();
@@ -91,7 +80,7 @@ public class MultilingualE5SmallInternalServiceSettings extends TextEmbeddingInt
 
     @Override
     public String getWriteableName() {
-        return MultilingualE5SmallInternalServiceSettings.NAME;
+        return CustomElandInternalServiceSettings.NAME;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/CustomElandModel.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
@@ -17,7 +17,7 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import static org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus.State.STARTED;
 
-public class CustomElandModel extends TextEmbeddingModel {
+public class CustomElandModel extends ElasticsearchModel {
 
     public CustomElandModel(
         String inferenceEntityId,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -53,9 +53,9 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeFrom
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.throwIfNotEmptyMap;
 import static org.elasticsearch.xpack.inference.services.settings.InternalServiceSettings.MODEL_ID;
 
-public class TextEmbeddingInternalService implements InferenceService {
+public class ElasticsearchInternalService implements InferenceService {
 
-    public static final String NAME = "text_embedding";
+    public static final String NAME = "elasticsearch";
 
     static final String MULTILINGUAL_E5_SMALL_MODEL_ID = ".multilingual-e5-small";
     static final String MULTILINGUAL_E5_SMALL_MODEL_ID_LINUX_X86 = ".multilingual-e5-small_linux-x86_64";
@@ -66,9 +66,9 @@ public class TextEmbeddingInternalService implements InferenceService {
 
     private final OriginSettingClient client;
 
-    private static final Logger logger = LogManager.getLogger(TextEmbeddingInternalService.class);
+    private static final Logger logger = LogManager.getLogger(ElasticsearchInternalService.class);
 
-    public TextEmbeddingInternalService(InferenceServiceExtension.InferenceServiceFactoryContext context) {
+    public ElasticsearchInternalService(InferenceServiceExtension.InferenceServiceFactoryContext context) {
         this.client = new OriginSettingClient(context.client(), ClientHelper.INFERENCE_ORIGIN);
     }
 
@@ -169,7 +169,7 @@ public class TextEmbeddingInternalService implements InferenceService {
     }
 
     @Override
-    public TextEmbeddingModel parsePersistedConfigWithSecrets(
+    public ElasticsearchModel parsePersistedConfigWithSecrets(
         String inferenceEntityId,
         TaskType taskType,
         Map<String, Object> config,
@@ -179,7 +179,7 @@ public class TextEmbeddingInternalService implements InferenceService {
     }
 
     @Override
-    public TextEmbeddingModel parsePersistedConfig(String inferenceEntityId, TaskType taskType, Map<String, Object> config) {
+    public ElasticsearchModel parsePersistedConfig(String inferenceEntityId, TaskType taskType, Map<String, Object> config) {
         Map<String, Object> serviceSettingsMap = removeFromMapOrThrowIfNull(config, ModelConfigurations.SERVICE_SETTINGS);
 
         String modelId = (String) serviceSettingsMap.get(MODEL_ID);
@@ -271,7 +271,7 @@ public class TextEmbeddingInternalService implements InferenceService {
 
     @Override
     public void start(Model model, ActionListener<Boolean> listener) {
-        if (model instanceof TextEmbeddingModel == false) {
+        if (model instanceof ElasticsearchModel == false) {
             listener.onFailure(notTextEmbeddingModelException(model));
             return;
         }
@@ -283,8 +283,8 @@ public class TextEmbeddingInternalService implements InferenceService {
             return;
         }
 
-        var startRequest = ((TextEmbeddingModel) model).getStartTrainedModelDeploymentActionRequest();
-        var responseListener = ((TextEmbeddingModel) model).getCreateTrainedModelAssignmentActionListener(model, listener);
+        var startRequest = ((ElasticsearchModel) model).getStartTrainedModelDeploymentActionRequest();
+        var responseListener = ((ElasticsearchModel) model).getCreateTrainedModelAssignmentActionListener(model, listener);
 
         client.execute(StartTrainedModelDeploymentAction.INSTANCE, startRequest, responseListener);
     }
@@ -300,7 +300,7 @@ public class TextEmbeddingInternalService implements InferenceService {
 
     @Override
     public void putModel(Model model, ActionListener<Boolean> listener) {
-        if (model instanceof TextEmbeddingModel == false) {
+        if (model instanceof ElasticsearchModel == false) {
             listener.onFailure(notTextEmbeddingModelException(model));
             return;
         } else if (model instanceof MultilingualE5SmallModel e5Model) {
@@ -348,7 +348,7 @@ public class TextEmbeddingInternalService implements InferenceService {
             }
         });
 
-        if (model instanceof TextEmbeddingModel == false) {
+        if (model instanceof ElasticsearchModel == false) {
             listener.onFailure(notTextEmbeddingModelException(model));
         } else if (model.getServiceSettings() instanceof InternalServiceSettings internalServiceSettings) {
             String modelId = internalServiceSettings.getModelId();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceSettings.java
@@ -3,11 +3,9 @@
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
- *
- * This file was contributed to by a generative AI
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -17,21 +15,21 @@ import java.io.IOException;
 
 import static org.elasticsearch.TransportVersions.ML_TEXT_EMBEDDING_INFERENCE_SERVICE_ADDED;
 
-public class TextEmbeddingInternalServiceSettings extends InternalServiceSettings {
+public class ElasticsearchInternalServiceSettings extends InternalServiceSettings {
 
     public static final String NAME = "text_embedding_internal_service_settings";
 
-    public TextEmbeddingInternalServiceSettings(int numAllocations, int numThreads, String modelVariant) {
+    public ElasticsearchInternalServiceSettings(int numAllocations, int numThreads, String modelVariant) {
         super(numAllocations, numThreads, modelVariant);
     }
 
-    public TextEmbeddingInternalServiceSettings(StreamInput in) throws IOException {
+    public ElasticsearchInternalServiceSettings(StreamInput in) throws IOException {
         super(in.readVInt(), in.readVInt(), in.readString());
     }
 
     @Override
     public String getWriteableName() {
-        return TextEmbeddingInternalServiceSettings.NAME;
+        return ElasticsearchInternalServiceSettings.NAME;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchModel.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.inference.Model;
@@ -14,20 +14,20 @@ import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.core.ml.action.CreateTrainedModelAssignmentAction;
 import org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction;
 
-public abstract class TextEmbeddingModel extends Model {
+public abstract class ElasticsearchModel extends Model {
 
-    public TextEmbeddingModel(
+    public ElasticsearchModel(
         String inferenceEntityId,
         TaskType taskType,
         String service,
-        TextEmbeddingInternalServiceSettings serviceSettings
+        ElasticsearchInternalServiceSettings serviceSettings
     ) {
         super(new ModelConfigurations(inferenceEntityId, taskType, service, serviceSettings));
     }
 
     @Override
-    public TextEmbeddingInternalServiceSettings getServiceSettings() {
-        return (TextEmbeddingInternalServiceSettings) super.getServiceSettings();
+    public ElasticsearchInternalServiceSettings getServiceSettings() {
+        return (ElasticsearchInternalServiceSettings) super.getServiceSettings();
     }
 
     abstract StartTrainedModelDeploymentAction.Request getStartTrainedModelDeploymentActionRequest();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettings.java
@@ -3,11 +3,9 @@
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
- *
- * this file was contributed to by a generative AI
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.ValidationException;
@@ -15,49 +13,62 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
+import org.elasticsearch.xpack.inference.services.settings.InternalServiceSettings;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.elasticsearch.TransportVersions.ML_TEXT_EMBEDDING_INFERENCE_SERVICE_ADDED;
 
-public class CustomElandInternalServiceSettings extends TextEmbeddingInternalServiceSettings {
+public class MultilingualE5SmallInternalServiceSettings extends ElasticsearchInternalServiceSettings {
 
-    public static final String NAME = "custom_eland_model_internal_service_settings";
+    public static final String NAME = "multilingual_e5_small_service_settings";
 
-    public CustomElandInternalServiceSettings(int numAllocations, int numThreads, String modelId) {
+    public MultilingualE5SmallInternalServiceSettings(int numAllocations, int numThreads, String modelId) {
         super(numAllocations, numThreads, modelId);
     }
 
+    public MultilingualE5SmallInternalServiceSettings(StreamInput in) throws IOException {
+        super(in.readVInt(), in.readVInt(), in.readString());
+    }
+
     /**
-     * Parse the CustomElandServiceSettings from map and validate the setting values.
-     *
-     * This method does not verify the model variant
+     * Parse the MultilingualE5SmallServiceSettings from map and validate the setting values.
      *
      * If required setting are missing or the values are invalid an
      * {@link ValidationException} is thrown.
      *
      * @param map Source map containing the config
-     * @return The {@code CustomElandServiceSettings} builder
+     * @return The {@code MultilingualE5SmallServiceSettings} builder
      */
-    public static Builder fromMap(Map<String, Object> map) {
-
+    public static MultilingualE5SmallInternalServiceSettings.Builder fromMap(Map<String, Object> map) {
         ValidationException validationException = new ValidationException();
         Integer numAllocations = ServiceUtils.removeAsType(map, NUM_ALLOCATIONS, Integer.class);
         Integer numThreads = ServiceUtils.removeAsType(map, NUM_THREADS, Integer.class);
 
         validateParameters(numAllocations, validationException, numThreads);
 
-        String modelId = ServiceUtils.extractRequiredString(map, MODEL_ID, "ServiceSettings", validationException);
+        String modelId = ServiceUtils.removeAsType(map, MODEL_ID, String.class);
+        if (modelId != null) {
+            if (ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS.contains(modelId) == false) {
+                validationException.addValidationError(
+                    "unknown Multilingual-E5-Small model ID ["
+                        + modelId
+                        + "]. Valid IDs are "
+                        + Arrays.toString(ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS.toArray())
+                );
+            }
+        }
 
         if (validationException.validationErrors().isEmpty() == false) {
             throw validationException;
         }
 
-        var builder = new Builder() {
+        var builder = new InternalServiceSettings.Builder() {
             @Override
-            public CustomElandInternalServiceSettings build() {
-                return new CustomElandInternalServiceSettings(getNumAllocations(), getNumThreads(), getModelId());
+            public MultilingualE5SmallInternalServiceSettings build() {
+                return new MultilingualE5SmallInternalServiceSettings(getNumAllocations(), getNumThreads(), getModelId());
             }
         };
         builder.setNumAllocations(numAllocations);
@@ -71,10 +82,6 @@ public class CustomElandInternalServiceSettings extends TextEmbeddingInternalSer
         return super.toXContent(builder, params);
     }
 
-    public CustomElandInternalServiceSettings(StreamInput in) throws IOException {
-        super(in.readVInt(), in.readVInt(), in.readString());
-    }
-
     @Override
     public boolean isFragment() {
         return super.isFragment();
@@ -82,7 +89,7 @@ public class CustomElandInternalServiceSettings extends TextEmbeddingInternalSer
 
     @Override
     public String getWriteableName() {
-        return CustomElandInternalServiceSettings.NAME;
+        return MultilingualE5SmallInternalServiceSettings.NAME;
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallModel.java
@@ -3,11 +3,9 @@
  * or more contributor license agreements. Licensed under the Elastic License
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
- *
- * this file was contributed to by a generative AI
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
@@ -19,7 +17,7 @@ import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import static org.elasticsearch.xpack.core.ml.inference.assignment.AllocationStatus.State.STARTED;
 
-public class MultilingualE5SmallModel extends TextEmbeddingModel {
+public class MultilingualE5SmallModel extends ElasticsearchModel {
 
     public MultilingualE5SmallModel(
         String inferenceEntityId,

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalServiceTests.java
@@ -7,7 +7,7 @@
  * This file was contributed to by a Generative AI
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TextEmbeddingInternalServiceTests extends ESTestCase {
+public class ElasticsearchInternalServiceTests extends ESTestCase {
 
     TaskType taskType = TaskType.TEXT_EMBEDDING;
     String randomInferenceEntityId = randomAlphaOfLength(10);
@@ -59,7 +59,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
             settings.put(
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
-                    Map.of(TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS, 1, TextEmbeddingInternalServiceSettings.NUM_THREADS, 4)
+                    Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1, ElasticsearchInternalServiceSettings.NUM_THREADS, 4)
                 )
             );
 
@@ -79,12 +79,12 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
                     Map.of(
-                        TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS,
+                        ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
                         1,
-                        TextEmbeddingInternalServiceSettings.NUM_THREADS,
+                        ElasticsearchInternalServiceSettings.NUM_THREADS,
                         4,
                         InternalServiceSettings.MODEL_ID,
-                        TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
+                        ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
                     )
                 )
             );
@@ -92,7 +92,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
             var e5ServiceSettings = new MultilingualE5SmallInternalServiceSettings(
                 1,
                 4,
-                TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
+                ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
             );
 
             service.parseRequestConfig(
@@ -111,7 +111,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
             settings.put(
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
-                    Map.of(TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS, 1, TextEmbeddingInternalServiceSettings.NUM_THREADS, 4)
+                    Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1, ElasticsearchInternalServiceSettings.NUM_THREADS, 4)
                 )
             );
             settings.put("not_a_valid_config_setting", randomAlphaOfLength(10));
@@ -132,12 +132,12 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
                     Map.of(
-                        TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS,
+                        ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
                         1,
-                        TextEmbeddingInternalServiceSettings.NUM_THREADS,
+                        ElasticsearchInternalServiceSettings.NUM_THREADS,
                         4,
                         InternalServiceSettings.MODEL_ID,
-                        TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID, // we can't directly test the eland case until we mock
+                        ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID, // we can't directly test the eland case until we mock
                                                                                      // the threadpool within the client
                         "not_a_valid_service_setting",
                         randomAlphaOfLength(10)
@@ -161,12 +161,12 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
                     Map.of(
-                        TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS,
+                        ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
                         1,
-                        TextEmbeddingInternalServiceSettings.NUM_THREADS,
+                        ElasticsearchInternalServiceSettings.NUM_THREADS,
                         4,
                         InternalServiceSettings.MODEL_ID,
-                        TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID, // we can't directly test the eland case until we mock
+                        ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID, // we can't directly test the eland case until we mock
                                                                                      // the threadpool within the client
                         "extra_setting_that_should_not_be_here",
                         randomAlphaOfLength(10)
@@ -190,12 +190,12 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
                     Map.of(
-                        TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS,
+                        ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
                         1,
-                        TextEmbeddingInternalServiceSettings.NUM_THREADS,
+                        ElasticsearchInternalServiceSettings.NUM_THREADS,
                         4,
                         InternalServiceSettings.MODEL_ID,
-                        TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID // we can't directly test the eland case until we mock
+                        ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID // we can't directly test the eland case until we mock
                         // the threadpool within the client
                     )
                 )
@@ -214,7 +214,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
     private ActionListener<Model> getModelVerificationActionListener(MultilingualE5SmallInternalServiceSettings e5ServiceSettings) {
         return ActionListener.<Model>wrap(model -> {
             assertEquals(
-                new MultilingualE5SmallModel(randomInferenceEntityId, taskType, TextEmbeddingInternalService.NAME, e5ServiceSettings),
+                new MultilingualE5SmallModel(randomInferenceEntityId, taskType, ElasticsearchInternalService.NAME, e5ServiceSettings),
                 model
             );
         }, e -> { fail("Model parsing failed " + e.getMessage()); });
@@ -229,14 +229,14 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
             settings.put(
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
-                    Map.of(TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS, 1, TextEmbeddingInternalServiceSettings.NUM_THREADS, 4)
+                    Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1, ElasticsearchInternalServiceSettings.NUM_THREADS, 4)
                 )
             );
 
             var e5ServiceSettings = new MultilingualE5SmallInternalServiceSettings(
                 1,
                 4,
-                TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
+                ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
             );
 
             expectThrows(IllegalArgumentException.class, () -> service.parsePersistedConfig(randomInferenceEntityId, taskType, settings));
@@ -253,9 +253,9 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
                     Map.of(
-                        TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS,
+                        ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
                         1,
-                        TextEmbeddingInternalServiceSettings.NUM_THREADS,
+                        ElasticsearchInternalServiceSettings.NUM_THREADS,
                         4,
                         InternalServiceSettings.MODEL_ID,
                         "invalid"
@@ -266,7 +266,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
             CustomElandModel parsedModel = (CustomElandModel) service.parsePersistedConfig(randomInferenceEntityId, taskType, settings);
             var elandServiceSettings = new CustomElandInternalServiceSettings(1, 4, "invalid");
             assertEquals(
-                new CustomElandModel(randomInferenceEntityId, taskType, TextEmbeddingInternalService.NAME, elandServiceSettings),
+                new CustomElandModel(randomInferenceEntityId, taskType, ElasticsearchInternalService.NAME, elandServiceSettings),
                 parsedModel
             );
         }
@@ -279,12 +279,12 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
                     Map.of(
-                        TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS,
+                        ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
                         1,
-                        TextEmbeddingInternalServiceSettings.NUM_THREADS,
+                        ElasticsearchInternalServiceSettings.NUM_THREADS,
                         4,
                         InternalServiceSettings.MODEL_ID,
-                        TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
+                        ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
                     )
                 )
             );
@@ -292,7 +292,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
             var e5ServiceSettings = new MultilingualE5SmallInternalServiceSettings(
                 1,
                 4,
-                TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
+                ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_MODEL_ID
             );
 
             MultilingualE5SmallModel parsedModel = (MultilingualE5SmallModel) service.parsePersistedConfig(
@@ -301,7 +301,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
                 settings
             );
             assertEquals(
-                new MultilingualE5SmallModel(randomInferenceEntityId, taskType, TextEmbeddingInternalService.NAME, e5ServiceSettings),
+                new MultilingualE5SmallModel(randomInferenceEntityId, taskType, ElasticsearchInternalService.NAME, e5ServiceSettings),
                 parsedModel
             );
         }
@@ -313,7 +313,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
             settings.put(
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
-                    Map.of(TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS, 1, TextEmbeddingInternalServiceSettings.NUM_THREADS, 4)
+                    Map.of(ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS, 1, ElasticsearchInternalServiceSettings.NUM_THREADS, 4)
                 )
             );
             settings.put("not_a_valid_config_setting", randomAlphaOfLength(10));
@@ -328,9 +328,9 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
                 ModelConfigurations.SERVICE_SETTINGS,
                 new HashMap<>(
                     Map.of(
-                        TextEmbeddingInternalServiceSettings.NUM_ALLOCATIONS,
+                        ElasticsearchInternalServiceSettings.NUM_ALLOCATIONS,
                         1,
-                        TextEmbeddingInternalServiceSettings.NUM_THREADS,
+                        ElasticsearchInternalServiceSettings.NUM_THREADS,
                         4,
                         "not_a_valid_service_setting",
                         randomAlphaOfLength(10)
@@ -403,9 +403,9 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
         assertTrue("Listener not called", gotResults.get());
     }
 
-    private TextEmbeddingInternalService createService(Client client) {
+    private ElasticsearchInternalService createService(Client client) {
         var context = new InferenceServiceExtension.InferenceServiceFactoryContext(client);
-        return new TextEmbeddingInternalService(context);
+        return new ElasticsearchInternalService(context);
     }
 
     public static Model randomModelConfig(String inferenceEntityId) {
@@ -417,7 +417,7 @@ public class TextEmbeddingInternalServiceTests extends ESTestCase {
             case "MultilingualE5SmallModel" -> new MultilingualE5SmallModel(
                 inferenceEntityId,
                 TaskType.TEXT_EMBEDDING,
-                TextEmbeddingInternalService.NAME,
+                ElasticsearchInternalService.NAME,
                 MultilingualE5SmallInternalServiceSettingsTests.createRandom()
             );
             default -> throw new IllegalArgumentException("model " + model + " is not supported for testing");

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/elasticsearch/MultilingualE5SmallInternalServiceSettingsTests.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.inference.services.textembedding;
+package org.elasticsearch.xpack.inference.services.elasticsearch;
 
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -24,7 +24,7 @@ public class MultilingualE5SmallInternalServiceSettingsTests extends AbstractWir
         return new MultilingualE5SmallInternalServiceSettings(
             randomIntBetween(1, 4),
             randomIntBetween(1, 4),
-            randomFrom(TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS)
+            randomFrom(ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS)
         );
     }
 
@@ -43,7 +43,7 @@ public class MultilingualE5SmallInternalServiceSettingsTests extends AbstractWir
     }
 
     public void testFromMap() {
-        String randomModelVariant = randomFrom(TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS);
+        String randomModelVariant = randomFrom(ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS);
         var serviceSettings = MultilingualE5SmallInternalServiceSettings.fromMap(
             new HashMap<>(
                 Map.of(
@@ -138,7 +138,7 @@ public class MultilingualE5SmallInternalServiceSettingsTests extends AbstractWir
                 instance.getModelId()
             );
             case 2 -> {
-                var versions = new HashSet<>(TextEmbeddingInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS);
+                var versions = new HashSet<>(ElasticsearchInternalService.MULTILINGUAL_E5_SMALL_VALID_IDS);
                 versions.remove(instance.getModelId());
                 yield new MultilingualE5SmallInternalServiceSettings(
                     instance.getNumAllocations(),


### PR DESCRIPTION
Backport of #105753

Renames the internal service in _inference from `text_embedding` to `elasticsearch`

For exmaple command to create an inference using the built in `multilingual-e5-small` model is:

```
PUT _inference/text_embedding/my-e5
{
  "service": "elasticsearch",
  "service_settings": {
    "model_id": ".multilingual-e5-small",
    "num_allocations": 1,
    "num_threads": 1
  }
}
```



 