### PR TITLE
Add pipeline support for bulk partial update

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -434,6 +434,10 @@ public final class BulkRequestParser {
                         if (upsertRequest != null) {
                             upsertRequest.setPipeline(pipeline).setListExecutedPipelines(listExecutedPipelines);
                         }
+                        IndexRequest docRequest = updateRequest.doc();
+                        if (docRequest != null) {
+                            docRequest.setPipeline(pipeline).setListExecutedPipelines(listExecutedPipelines);
+                        }
 
                         updateRequestConsumer.accept(updateRequest);
                     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -190,8 +190,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
     }
 
     /**
-     * Retrieves the {@link IndexRequest} from the provided {@link DocWriteRequest} for index or upsert actions.  Upserts are
-     * modeled as {@link IndexRequest} inside the {@link UpdateRequest}. Ignores {@link org.elasticsearch.action.delete.DeleteRequest}'s
+     * Retrieves the {@link IndexRequest} from the provided {@link DocWriteRequest} for index or update actions. Upserts or partial updates
+     * are modeled as {@link IndexRequest} inside the {@link UpdateRequest}. Ignores {@link org.elasticsearch.action.delete.DeleteRequest}'s
      *
      * @param docWriteRequest The request to find the {@link IndexRequest}
      * @return the found {@link IndexRequest} or {@code null} if one can not be found.
@@ -201,7 +201,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         if (docWriteRequest instanceof IndexRequest) {
             indexRequest = (IndexRequest) docWriteRequest;
         } else if (docWriteRequest instanceof UpdateRequest updateRequest) {
-            indexRequest = updateRequest.docAsUpsert() ? updateRequest.doc() : updateRequest.upsertRequest();
+            indexRequest = (updateRequest.docAsUpsert() || updateRequest.upsertRequest() == null) ? updateRequest.doc()
+                : updateRequest.upsertRequest();
         }
         return indexRequest;
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -201,7 +201,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         if (docWriteRequest instanceof IndexRequest) {
             indexRequest = (IndexRequest) docWriteRequest;
         } else if (docWriteRequest instanceof UpdateRequest updateRequest) {
-            indexRequest = (updateRequest.docAsUpsert() || updateRequest.upsertRequest() == null) ? updateRequest.doc()
+            indexRequest = (updateRequest.docAsUpsert() || updateRequest.upsertRequest() == null)
+                ? updateRequest.doc()
                 : updateRequest.upsertRequest();
         }
         return indexRequest;

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -191,11 +191,13 @@ public class TransportBulkActionTests extends ESTestCase {
         IndexRequest indexRequest = new IndexRequest("index").id("id1").source(Collections.emptyMap());
         UpdateRequest upsertRequest = new UpdateRequest("index", "id1").upsert(indexRequest).script(mockScript("1"));
         UpdateRequest docAsUpsertRequest = new UpdateRequest("index", "id2").doc(indexRequest).docAsUpsert(true);
+        UpdateRequest partialUpdateRequest = new UpdateRequest("index", "id2").doc(indexRequest);
         UpdateRequest scriptedUpsert = new UpdateRequest("index", "id2").upsert(indexRequest).script(mockScript("1")).scriptedUpsert(true);
 
         assertEquals(TransportBulkAction.getIndexWriteRequest(indexRequest), indexRequest);
         assertEquals(TransportBulkAction.getIndexWriteRequest(upsertRequest), indexRequest);
         assertEquals(TransportBulkAction.getIndexWriteRequest(docAsUpsertRequest), indexRequest);
+        assertEquals(TransportBulkAction.getIndexWriteRequest(partialUpdateRequest), indexRequest);
         assertEquals(TransportBulkAction.getIndexWriteRequest(scriptedUpsert), indexRequest);
 
         DeleteRequest deleteRequest = new DeleteRequest("index", "id");


### PR DESCRIPTION
To close #105804 

1. support default/final pipeline for partial update in bulk;
2. support `pipeline` parameter in doc body for partial update in bulk;