### PR TITLE
Simplify jna loading

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -11,6 +11,7 @@ package org.elasticsearch.bootstrap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.invoke.MethodHandles;
 import java.nio.file.Path;
 
 /**
@@ -31,10 +32,10 @@ final class Natives {
         try {
             // load one of the main JNA classes to see if the classes are available. this does not ensure that all native
             // libraries are available, only the ones necessary by JNA to function
-            Class.forName("com.sun.jna.Native");
+            MethodHandles.publicLookup().ensureInitialized(com.sun.jna.Native.class);
             v = true;
-        } catch (ClassNotFoundException e) {
-            logger.warn("JNA not found. native methods will be disabled.", e);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
         } catch (UnsatisfiedLinkError e) {
             logger.warn("unable to load JNA native support library, native methods will be disabled.", e);
         }


### PR DESCRIPTION
Previous versions of Elasticsearch had JNA as an optional dependency because the transport client did not need it. Since the JNA classes are now always available, ClassNotFoundException is not possible. This commit adjusts initializing jna to no longer call Class.forName.