### PR TITLE
Docs typo fix

### DIFF
--- a/docs/reference/data-streams/lifecycle/index.asciidoc
+++ b/docs/reference/data-streams/lifecycle/index.asciidoc
@@ -36,8 +36,8 @@ each data stream and performs the following steps:
 automatically tail merges the index. Data stream lifecycle executes a merge operation that only targets
 the long tail of small segments instead of the whole shard. As the segments are organised
 into tiers of exponential sizes, merging the long tail of small segments is only a 
-fraction of the cost of force mergeing to a single segment. The small segments would usually
-hold the most recent data so tail mergeing will focus the merging resources on the higher-value
+fraction of the cost of force merging to a single segment. The small segments would usually
+hold the most recent data so tail merging will focus the merging resources on the higher-value
 data that is most likely to keep being queried.
 4. If <<data-streams-put-lifecycle-downsampling-example, downsampling>> is configured it will execute 
 all the configured downsampling rounds.


### PR DESCRIPTION
`mergeing` typo fixed to `merging`
