### PR TITLE
Standardize build distribution internals on os/architecture

### DIFF
--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -11,7 +11,8 @@ import java.nio.file.Path
 
 apply plugin: 'elasticsearch.internal-distribution-archive-setup'
 
-CopySpec archiveFiles(CopySpec modulesFiles, String distributionType, String platform, String architecture, boolean isTestDistro) {
+CopySpec archiveFiles(String distributionType, String os, String architecture) {
+  boolean isTestDistro = os == null;
   return copySpec {
     into("elasticsearch-${version}") {
       into('lib') {
@@ -29,9 +30,9 @@ CopySpec archiveFiles(CopySpec modulesFiles, String distributionType, String pla
       into('bin') {
         with binFiles(distributionType, isTestDistro)
       }
-      into("darwin".equals(platform) ? 'jdk.app' : 'jdk') {
+      into("darwin".equals(os) ? 'jdk.app' : 'jdk') {
         if (isTestDistro == false) {
-          with jdkFiles(project, platform, architecture)
+          with jdkFiles(project, os, architecture)
         }
       }
       into('') {
@@ -56,7 +57,11 @@ CopySpec archiveFiles(CopySpec modulesFiles, String distributionType, String pla
 
       with noticeFile(isTestDistro)
       into('modules') {
-        with modulesFiles
+        if (isTestDistro) {
+          with integTestModulesFiles
+        } else {
+          with modulesFiles(os, architecture)
+        }
       }
     }
   }
@@ -65,42 +70,42 @@ CopySpec archiveFiles(CopySpec modulesFiles, String distributionType, String pla
 distribution_archives {
   integTestZip {
     content {
-      archiveFiles(integTestModulesFiles, 'zip', null, 'x64', true)
+      archiveFiles('zip', null, null)
     }
   }
 
   windowsZip {
     archiveClassifier = 'windows-x86_64'
     content {
-      archiveFiles(modulesFiles('windows-x86_64'), 'zip', 'windows', 'x64', false)
+      archiveFiles('zip', 'windows', 'x64')
     }
   }
 
   darwinTar {
     archiveClassifier = 'darwin-x86_64'
     content {
-      archiveFiles(modulesFiles('darwin-x86_64'), 'tar', 'darwin', 'x64', false)
+      archiveFiles('tar', 'darwin', 'x64')
     }
   }
 
   darwinAarch64Tar {
     archiveClassifier = 'darwin-aarch64'
     content {
-      archiveFiles(modulesFiles('darwin-aarch64'), 'tar', 'darwin', 'aarch64', false)
+      archiveFiles('tar', 'darwin', 'aarch64')
     }
   }
 
   linuxAarch64Tar {
     archiveClassifier = 'linux-aarch64'
     content {
-      archiveFiles(modulesFiles('linux-aarch64'), 'tar', 'linux', 'aarch64', false)
+      archiveFiles('tar', 'linux', 'aarch64')
     }
   }
 
   linuxTar {
     archiveClassifier = 'linux-x86_64'
     content {
-      archiveFiles(modulesFiles('linux-x86_64'), 'tar', 'linux', 'x64', false)
+      archiveFiles('tar', 'linux', 'x64')
     }
   }
 }

--- a/distribution/archives/build.gradle
+++ b/distribution/archives/build.gradle
@@ -11,8 +11,7 @@ import java.nio.file.Path
 
 apply plugin: 'elasticsearch.internal-distribution-archive-setup'
 
-CopySpec archiveFiles(String distributionType, String os, String architecture) {
-  boolean isTestDistro = os == null;
+CopySpec archiveFiles(String distributionType, String os, String architecture, boolean isTestDistro) {
   return copySpec {
     into("elasticsearch-${version}") {
       into('lib') {
@@ -70,42 +69,42 @@ CopySpec archiveFiles(String distributionType, String os, String architecture) {
 distribution_archives {
   integTestZip {
     content {
-      archiveFiles('zip', null, null)
+      archiveFiles('zip', null, null, true)
     }
   }
 
   windowsZip {
     archiveClassifier = 'windows-x86_64'
     content {
-      archiveFiles('zip', 'windows', 'x64')
+      archiveFiles('zip', 'windows', 'x64', false)
     }
   }
 
   darwinTar {
     archiveClassifier = 'darwin-x86_64'
     content {
-      archiveFiles('tar', 'darwin', 'x64')
+      archiveFiles('tar', 'darwin', 'x64', false)
     }
   }
 
   darwinAarch64Tar {
     archiveClassifier = 'darwin-aarch64'
     content {
-      archiveFiles('tar', 'darwin', 'aarch64')
+      archiveFiles('tar', 'darwin', 'aarch64', false)
     }
   }
 
   linuxAarch64Tar {
     archiveClassifier = 'linux-aarch64'
     content {
-      archiveFiles('tar', 'linux', 'aarch64')
+      archiveFiles('tar', 'linux', 'aarch64', false)
     }
   }
 
   linuxTar {
     archiveClassifier = 'linux-x86_64'
     content {
-      archiveFiles('tar', 'linux', 'x64')
+      archiveFiles('tar', 'linux', 'x64', false)
     }
   }
 }

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -332,10 +332,10 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         }
       }
 
-    modulesFiles = { platform ->
+    modulesFiles = { os, architecture ->
       copySpec {
         eachFile {
-          if (it.relativePath.segments[-2] == 'bin' || ((platform == 'darwin-x86_64' || platform == 'darwin-aarch64') && it.relativePath.segments[-2] == 'MacOS')) {
+          if (it.relativePath.segments[-2] == 'bin' || (os == 'darwin' && it.relativePath.segments[-2] == 'MacOS')) {
             // bin files, wherever they are within modules (eg platform specific) should be executable
             // and MacOS is an alternative to bin on macOS
             it.mode = 0755
@@ -344,8 +344,12 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
           }
         }
         List excludePlatforms = ['linux-x86_64', 'linux-aarch64', 'windows-x86_64', 'darwin-x86_64', 'darwin-aarch64']
-        if (platform != null) {
-          excludePlatforms.remove(excludePlatforms.indexOf(platform))
+        if (os != null) {
+          if (architecture == 'x64') {
+            // ML platform dir uses the x86_64 nomenclature
+            architecture = 'x86_64'
+          }
+          excludePlatforms.remove(excludePlatforms.indexOf(os + '-' + architecture))
         } else {
           excludePlatforms = []
         }
@@ -430,15 +434,15 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
       }
     }
 
-    jdkFiles = { Project project, String platform, String architecture ->
+    jdkFiles = { Project project, String os, String architecture ->
       return copySpec {
-        from project.jdks."bundled_${platform}_${architecture}"
+        from project.jdks."bundled_${os}_${architecture}"
         exclude "demo/**"
         /*
          * The Contents/MacOS directory interferes with notarization, and is unused by our distribution, so we exclude
          * it from the build.
          */
-        if ("darwin".equals(platform)) {
+        if ("darwin".equals(os)) {
           exclude "Contents/MacOS"
         }
         eachFile { FileCopyDetails details ->

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -345,11 +345,12 @@ configure(subprojects.findAll { ['archives', 'packages'].contains(it.name) }) {
         }
         List excludePlatforms = ['linux-x86_64', 'linux-aarch64', 'windows-x86_64', 'darwin-x86_64', 'darwin-aarch64']
         if (os != null) {
+          String platform = os + '-' + architecture
           if (architecture == 'x64') {
             // ML platform dir uses the x86_64 nomenclature
-            architecture = 'x86_64'
+            platform = os + '-x86_64'
           }
-          excludePlatforms.remove(excludePlatforms.indexOf(os + '-' + architecture))
+          excludePlatforms.remove(excludePlatforms.indexOf(platform))
         } else {
           excludePlatforms = []
         }

--- a/distribution/packages/build.gradle
+++ b/distribution/packages/build.gradle
@@ -143,7 +143,7 @@ def commonPackageConfig(String type, String architecture) {
         with libFiles
       }
       into('modules') {
-        with modulesFiles('linux-' + ((architecture == 'x64') ? 'x86_64' : architecture))
+        with modulesFiles('linux', architecture)
       }
       into('jdk') {
         with jdkFiles(project, 'linux', architecture)


### PR DESCRIPTION
The build handles platform specific code which may be for arm or x86. Yet there are multiple ways to describe 64bit x86, and the build converts between the two in several places. This commit consolidates on the x64 nomenclature in most places, except where necessary (eg ML still uses x86_64).

relates #105715