### PR TITLE
(DOC+) Version API page for ES API Base URL

### DIFF
--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -44,6 +44,7 @@ not be included yet.
 * <<indices-reload-analyzers,Reload search analyzers API>>
 * <<repositories-metering-apis,Repositories metering APIs>>
 * <<rollup-apis,Rollup APIs>>
+* <<rest-api-root,Root API>>
 * <<script-apis,Script APIs>>
 * <<search, Search APIs>>
 * <<search-application-apis, Search Application APIs>>
@@ -57,11 +58,9 @@ not be included yet.
 * <<transform-apis,{transform-cap} APIs>>
 * <<usage-api,Usage API>>
 * <<watcher-api,Watcher APIs>>
-* <<rest-api-root,Root API>>
 --
 
 include::{es-repo-dir}/api-conventions.asciidoc[]
-include::{es-repo-dir}/rest-api/root.asciidoc[]
 include::{es-repo-dir}/rest-api/common-options.asciidoc[]
 include::{es-repo-dir}/rest-api/rest-api-compatibility.asciidoc[]
 include::{es-repo-dir}/autoscaling/apis/autoscaling-apis.asciidoc[]
@@ -95,6 +94,7 @@ include::{es-repo-dir}/query-rules/apis/index.asciidoc[]
 include::{es-repo-dir}/indices/apis/reload-analyzers.asciidoc[]
 include::{es-repo-dir}/repositories-metering-api/repositories-metering-apis.asciidoc[]
 include::{es-repo-dir}/rollup/rollup-apis.asciidoc[]
+include::{es-repo-dir}/rest-api/root.asciidoc[]
 include::{es-repo-dir}/scripting/apis/script-apis.asciidoc[]
 include::{es-repo-dir}/search.asciidoc[]
 include::{es-repo-dir}/search-application/apis/index.asciidoc[]

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -57,11 +57,11 @@ not be included yet.
 * <<transform-apis,{transform-cap} APIs>>
 * <<usage-api,Usage API>>
 * <<watcher-api,Watcher APIs>>
-* <<rest-api-version,Version API>>
+* <<rest-api-root,Root API>>
 --
 
 include::{es-repo-dir}/api-conventions.asciidoc[]
-include::{es-repo-dir}/rest-api/version.asciidoc[]
+include::{es-repo-dir}/rest-api/root.asciidoc[]
 include::{es-repo-dir}/rest-api/common-options.asciidoc[]
 include::{es-repo-dir}/rest-api/rest-api-compatibility.asciidoc[]
 include::{es-repo-dir}/autoscaling/apis/autoscaling-apis.asciidoc[]

--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -57,9 +57,11 @@ not be included yet.
 * <<transform-apis,{transform-cap} APIs>>
 * <<usage-api,Usage API>>
 * <<watcher-api,Watcher APIs>>
+* <<rest-api-version,Version API>>
 --
 
 include::{es-repo-dir}/api-conventions.asciidoc[]
+include::{es-repo-dir}/rest-api/version.asciidoc[]
 include::{es-repo-dir}/rest-api/common-options.asciidoc[]
 include::{es-repo-dir}/rest-api/rest-api-compatibility.asciidoc[]
 include::{es-repo-dir}/autoscaling/apis/autoscaling-apis.asciidoc[]

--- a/docs/reference/rest-api/root.asciidoc
+++ b/docs/reference/rest-api/root.asciidoc
@@ -12,6 +12,7 @@ version, and cluster information.
 GET /
 --------------------------------------------------
 
+[discrete]
 [[rest-api-root-prereq]]
 === {api-prereq-title}
 
@@ -20,6 +21,7 @@ GET /
 <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [role="child_attributes"]
+[discrete]
 [[rest-api-root-response-body]]
 === {api-response-body-title}
 
@@ -75,6 +77,7 @@ Minimum index version with which the responding node can read
 from disk.
 ====
 
+[discrete]
 [[rest-api-root-response-example]]
 === {api-examples-title}
 

--- a/docs/reference/rest-api/root.asciidoc
+++ b/docs/reference/rest-api/root.asciidoc
@@ -1,5 +1,5 @@
-[[rest-api-version]]
-=== Version API
+[[rest-api-root]]
+=== Root API
 ++++
 <titleabbrev>Version API</titleabbrev>
 ++++

--- a/docs/reference/rest-api/root.asciidoc
+++ b/docs/reference/rest-api/root.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 The Elasticsearch API's base url returns its basic build, 
-version, and cluster statistics. 
+version, and cluster information. 
 
 [source,console]
 --------------------------------------------------
@@ -36,7 +36,7 @@ The responding Cluster's `uuid` as confirmed by
 
 `version` ::
 (object) 
-Contains version statistics about the build.
+Contains information about the running version of Elasticsearch.
 + properties of `version`
 [%collapsible%open]
 ====
@@ -100,6 +100,3 @@ The API returns the following response:
   "tagline": "You Know, for Search"
 }
 ----
-// TESTRESPONSE[s/"name" : "instance-0000000000"/"name" : $body.name/]
-// TESTRESPONSE[s/"cluster_name" : "my_test_cluster"/"cluster_name" : $body.cluster_name/]
-// TESTRESPONSE[s/"cluster_uuid" : "5QaxoN0pRZuOmWSxstBBwQ"/"cluster_uuid" : $body.cluster_uuid/]

--- a/docs/reference/rest-api/root.asciidoc
+++ b/docs/reference/rest-api/root.asciidoc
@@ -1,7 +1,7 @@
 [[rest-api-root]]
-=== Root API
+== Root API
 ++++
-<titleabbrev>Version API</titleabbrev>
+<titleabbrev>Root API</titleabbrev>
 ++++
 
 The Elasticsearch API's base url returns its basic build, 
@@ -13,7 +13,7 @@ GET /
 --------------------------------------------------
 
 [[rest-api-root-prereq]]
-==== {api-prereq-title}
+=== {api-prereq-title}
 
 * If the {es} {security-features} are enabled, you must have the
 `monitor`, `manage`, or `all`
@@ -21,7 +21,7 @@ GET /
 
 [role="child_attributes"]
 [[rest-api-root-response-body]]
-==== {api-response-body-title}
+=== {api-response-body-title}
 
 
 `name` ::
@@ -76,7 +76,7 @@ from disk.
 ====
 
 [[rest-api-root-response-example]]
-==== {api-examples-title}
+=== {api-examples-title}
 
 The API returns the following response: 
 
@@ -100,3 +100,15 @@ The API returns the following response:
   "tagline": "You Know, for Search"
 }
 ----
+// TESTRESPONSE[s/"name": "instance-0000000000"/"name": "$body.name"/]
+// TESTRESPONSE[s/"cluster_name": "my_test_cluster"/"cluster_name": "$body.cluster_name"/]
+// TESTRESPONSE[s/"cluster_uuid": "5QaxoN0pRZuOmWSxstBBwQ"/"cluster_uuid": "$body.cluster_uuid"/]
+// TESTRESPONSE[s/"build_date": "2024-02-01T13:07:13.727175297Z"/"build_date": "$body.version.build_date"/]
+// TESTRESPONSE[s/"minimum_wire_compatibility_version": "7.17.0"/"minimum_wire_compatibility_version": "$body.version.minimum_wire_compatibility_version"/]
+// TESTRESPONSE[s/"build_hash": "6185ba65d27469afabc9bc951cded6c17c21e3f3"/"build_hash": "$body.version.build_hash"/]
+// TESTRESPONSE[s/"number": "8.12.1"/"number": "$body.version.number"/]
+// TESTRESPONSE[s/"lucene_version": "9.9.2"/"lucene_version": "$body.version.lucene_version"/]
+// TESTRESPONSE[s/"minimum_index_compatibility_version": "7.0.0"/"minimum_index_compatibility_version": "$body.version.minimum_index_compatibility_version"/]
+// TESTRESPONSE[s/"build_flavor": "default"/"build_flavor": "$body.version.build_flavor"/]
+// TESTRESPONSE[s/"build_snapshot": false/"build_snapshot": "$body.version.build_snapshot"/]
+// TESTRESPONSE[s/"build_type": "docker"/"build_type": "$body.version.build_type"/]

--- a/docs/reference/rest-api/root.asciidoc
+++ b/docs/reference/rest-api/root.asciidoc
@@ -12,7 +12,7 @@ version, and cluster statistics.
 GET /
 --------------------------------------------------
 
-[[rest-api-version-prereq]]
+[[rest-api-root-prereq]]
 ==== {api-prereq-title}
 
 * If the {es} {security-features} are enabled, you must have the
@@ -20,7 +20,7 @@ GET /
 <<privileges-list-cluster,cluster privilege>> to use this API.
 
 [role="child_attributes"]
-[[rest-api-version-response-body]]
+[[rest-api-root-response-body]]
 ==== {api-response-body-title}
 
 
@@ -75,7 +75,7 @@ Minimum index version with which the responding node can read
 from disk.
 ====
 
-[[rest-api-version-response-example]]
+[[rest-api-root-response-example]]
 ==== {api-examples-title}
 
 The API returns the following response: 

--- a/docs/reference/rest-api/version.asciidoc
+++ b/docs/reference/rest-api/version.asciidoc
@@ -1,0 +1,105 @@
+[[rest-api-version]]
+=== Version API
+++++
+<titleabbrev>Version API</titleabbrev>
+++++
+
+The Elasticsearch API's base url returns its basic build, 
+version, and cluster statistics. 
+
+[source,console]
+--------------------------------------------------
+GET /
+--------------------------------------------------
+
+[[rest-api-version-prereq]]
+==== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`monitor`, `manage`, or `all`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
+[role="child_attributes"]
+[[rest-api-version-response-body]]
+==== {api-response-body-title}
+
+
+`name` ::
+The responding <<node-name,Node's `name`>>.
+
+`cluster_name` ::
+The responding <<cluster-name,Cluster's `name`>>.
+
+`cluster_uuid` ::
+The responding Cluster's `uuid` as confirmed by 
+<<cluster-state,Cluster State>>.
+
+`version` ::
+(object) 
+Contains version statistics about the build.
++ properties of `version`
+[%collapsible%open]
+====
+`number` ::
+Version number of responding 
+https://www.elastic.co/downloads/past-releases#elasticsearch[Elasticsearch release].
+
+`build_flavor` ::
+Build flavor, e.g. `default`.
+
+`build_type` ::
+Build type corresponding to how 
+<<install-elasticsearch,Elasticsearch was installed>, 
+e.g. `docker`, `rpm`, `tar`.
+
+`build_hash` ::
+Elasticsearch's Git commit's SHA hash.
+
+`build_date` ::
+Elasticsearch's Git commit's date.
+
+`build_snapshot` ::
+If Elasticsearch's build was from a snapshot.
+
+`lucene_version` ::
+Version number of Elasticsearch's 
+<<https://archive.apache.org/dist/lucene/java/,underlying Lucene software>>.
+
+`minimum_wire_compatibility_version` ::
+Minimum node version with which the responding node can 
+communicate. Also minimum  version from which you can perform 
+a <<rolling-upgrades,Rolling Upgrade>>.
+
+`minimum_index_compatibility_version` ::
+Minimum index version with which the responding node can read 
+from disk.
+====
+
+[[rest-api-version-response-example]]
+==== {api-examples-title}
+
+The API returns the following response: 
+
+[source,console-result]
+----
+{
+  "name": "instance-0000000000",
+  "cluster_name": "my_test_cluster",
+  "cluster_uuid": "5QaxoN0pRZuOmWSxstBBwQ",
+  "version": {
+    "build_date": "2024-02-01T13:07:13.727175297Z",
+    "minimum_wire_compatibility_version": "7.17.0",
+    "build_hash": "6185ba65d27469afabc9bc951cded6c17c21e3f3",
+    "number": "8.12.1",
+    "lucene_version": "9.9.2",
+    "minimum_index_compatibility_version": "7.0.0",
+    "build_flavor": "default",
+    "build_snapshot": false,
+    "build_type": "docker"
+  },
+  "tagline": "You Know, for Search"
+}
+----
+// TESTRESPONSE[s/"name" : "instance-0000000000"/"name" : $body.name/]
+// TESTRESPONSE[s/"cluster_name" : "my_test_cluster"/"cluster_name" : $body.cluster_name/]
+// TESTRESPONSE[s/"cluster_uuid" : "5QaxoN0pRZuOmWSxstBBwQ"/"cluster_uuid" : $body.cluster_uuid/]


### PR DESCRIPTION
👋 howdy, team! 

I would like to add an ES API doc page for the default/base URL `GET /` which the [Elasticsearch Support Diagnostic](https://github.com/elastic/support-diagnostics/blob/main/src/main/resources/elastic-rest.yml#L342-L345) refers to as `version.json`. 

Kindly confirm details before approving as I was guessing+googling. Related definitions from:
- ([discuss](https://discuss.elastic.co/t/elasticsearch-version-values/201899), [SO](https://stackoverflow.com/questions/58520467/elasticsearch-version-minimum-compatibility-fields)) `minimum_wire_compatibility_version` & `minimum_index_compatibility_version` 
- ([github](https://github.com/elastic/elasticsearch/issues/44323)) `build_hash` 