### PR TITLE
[8.13] [Docs] Tiny format fix (#105820)

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -232,7 +232,6 @@ expense of slower indexing speed.
 +
 ^*^ This parameter can only be specified when `index` is `true`.
 +
-+
 .Properties of `index_options`
 [%collapsible%open]
 ====


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Docs] Tiny format fix (#105820)