### PR TITLE
(+DOC)(ILM) Shrink recovers to specific node

### DIFF
--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -101,7 +101,8 @@ A shrink operation:
   disks)
 
 . Recovers the target index as though it were a closed index which
-  had just been re-opened.
+  had just been re-opened. Recovers shards to <<indices-get-settings,Index Setting>> 
+  `.routing.allocation.initial_recovery._id`.
 
 
 [[_shrinking_an_index]]


### PR DESCRIPTION
👋 howdy, team!

As note per [this code](https://github.com/elastic/elasticsearch/blob/5d8e297340580259af913594d88ab4ededf273f5/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java#L1537-L1544) to backing [code](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java#L1224) that when the [Shrink API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-shrink-index.html#how-shrink-works) is processing it adds a node ID into the Index Settings .routing.allocation.initial_recovery._id (which can also then be used as a search to find current indices shrinking).

TIA!

---

👋  @leemthompo thanks for your feedback on https://github.com/elastic/elasticsearch/pull/103664, but I couldn't figure out how to rebase sufficiently so ported over to here 🙏