### PR TITLE
NOOP update  _bulk operation, the noop_update_total is updated

### DIFF
--- a/docs/changelog/105518.yaml
+++ b/docs/changelog/105518.yaml
@@ -1,0 +1,6 @@
+pr: 105518
+summary: NOOP update  _bulk operation, the noop_update_total is updated
+area: CRUD
+type: bug
+issues:
+  - 105742

--- a/docs/changelog/105874.yaml
+++ b/docs/changelog/105874.yaml
@@ -1,4 +1,4 @@
-pr: 105518
+pr: 105874
 summary: NOOP update  _bulk operation, the noop_update_total is updated
 area: CRUD
 type: bug

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -339,6 +339,10 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             if (updateResult.getResponseResult() == DocWriteResponse.Result.NOOP) {
                 context.markOperationAsNoOp(updateResult.action());
                 context.markAsCompleted(context.getExecutionResult());
+                IndexShard shard = context.getPrimary();
+                if (shard != null) {
+                    shard.noopUpdate();
+                }
                 return true;
             }
             context.setRequestToExecute(updateResult.action());

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -528,6 +528,8 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         assertThat(bulkShardRequest.items().length, equalTo(1));
         assertEquals(primaryRequest, bulkShardRequest.items()[0]); // check that bulk item was not mutated
         assertThat(primaryResponse.getResponse().getSeqNo(), equalTo(0L));
+        //When a NOOP update occurs, the noopUpdate() method is executed.
+        verify(shard).noopUpdate();
     }
 
     public void testUpdateRequestWithFailure() throws Exception {


### PR DESCRIPTION
When a no-op update occurs during a _bulk operation, the noop_update_total is updated.
https://github.com/elastic/elasticsearch/issues/105742
