### PR TITLE
[8.12] (+DOC)(ILM) Shrink recovers to specific node (#105872)

### DIFF
--- a/docs/reference/indices/shrink-index.asciidoc
+++ b/docs/reference/indices/shrink-index.asciidoc
@@ -101,7 +101,8 @@ A shrink operation:
   disks)
 
 . Recovers the target index as though it were a closed index which
-  had just been re-opened.
+  had just been re-opened. Recovers shards to <<indices-get-settings,Index Setting>> 
+  `.routing.allocation.initial_recovery._id`.
 
 
 [[_shrinking_an_index]]


### PR DESCRIPTION
Backports the following commits to 8.12:
 - (+DOC)(ILM) Shrink recovers to specific node (#105872)