### PR TITLE
Make security module extend transport-netty4 to avoid double loading classes

### DIFF
--- a/modules/reindex/build.gradle
+++ b/modules/reindex/build.gradle
@@ -37,7 +37,6 @@ testClusters.configureEach {
 
 dependencies {
   api project(":client:rest")
-  api project(":libs:elasticsearch-ssl-config")
   // for parent/child testing
   testImplementation project(':modules:parent-join')
   testImplementation project(':modules:rest-root')

--- a/modules/transport-netty4/build.gradle
+++ b/modules/transport-netty4/build.gradle
@@ -34,8 +34,6 @@ configurations {
 }
 
 dependencies {
-  api project(":libs:elasticsearch-ssl-config")
-
   // network stack
   api "io.netty:netty-buffer:${versions.netty}"
   api "io.netty:netty-codec:${versions.netty}"

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Plugin.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Plugin.java
@@ -23,6 +23,7 @@ import org.elasticsearch.http.HttpPreRequest;
 import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestRequest;
@@ -38,7 +39,7 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
-public class Netty4Plugin extends Plugin implements NetworkPlugin {
+public class Netty4Plugin extends Plugin implements NetworkPlugin, ExtensiblePlugin {
 
     public static final String NETTY_TRANSPORT_NAME = "netty4";
     public static final String NETTY_HTTP_TRANSPORT_NAME = "netty4";

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,10 +26,9 @@ base {
 }
 
 dependencies {
-
-  api project(':libs:elasticsearch-core')
   api project(':libs:elasticsearch-logging')
   api project(':libs:elasticsearch-secure-sm')
+  api project(":libs:elasticsearch-ssl-config")
   api project(':libs:elasticsearch-x-content')
   api project(":libs:elasticsearch-geo")
   api project(":libs:elasticsearch-lz4")

--- a/test/framework/build.gradle
+++ b/test/framework/build.gradle
@@ -13,7 +13,6 @@ apply plugin: 'elasticsearch.publish'
 dependencies {
   api project(":client:rest")
   api project(':modules:transport-netty4')
-  api project(':libs:elasticsearch-ssl-config')
   api project(":server")
   api project(":libs:elasticsearch-cli")
   api project(':libs:elasticsearch-preallocate')

--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -36,7 +36,6 @@ configurations {
 dependencies {
   compileOnly project(":server")
   api project(':libs:elasticsearch-grok')
-  api project(":libs:elasticsearch-ssl-config")
   api "org.apache.httpcomponents:httpclient:${versions.httpclient}"
   api "org.apache.httpcomponents:httpcore:${versions.httpcore}"
   api "org.apache.httpcomponents:httpcore-nio:${versions.httpcore}"

--- a/x-pack/plugin/security/build.gradle
+++ b/x-pack/plugin/security/build.gradle
@@ -8,7 +8,7 @@ esplugin {
   description 'Elasticsearch Expanded Pack Plugin - Security'
   classname 'org.elasticsearch.xpack.security.Security'
   requiresKeystore true
-  extendedPlugins = ['x-pack-core']
+  extendedPlugins = ['x-pack-core', 'transport-netty4']
 }
 
 base {
@@ -17,7 +17,7 @@ base {
 
 dependencies {
   compileOnly project(path: xpackModule('core'))
-  api project(path: ':modules:transport-netty4')
+  compileOnly project(path: ':modules:transport-netty4')
 
   testImplementation project(path: xpackModule('ilm'))
   testImplementation project(path: xpackModule('downsample'))

--- a/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.codebases
+++ b/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.codebases
@@ -1,2 +1,0 @@
-netty-common: io.netty.util.NettyRuntime
-netty-transport: io.netty.channel.Channel

--- a/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/security/src/main/plugin-metadata/plugin-security.policy
@@ -32,16 +32,3 @@ grant {
   permission java.lang.RuntimePermission "accessUserInformation";
   permission java.lang.RuntimePermission "getFileStoreAttributes";
 };
-
-grant codeBase "${codebase.netty-common}" {
-   // for reading the system-wide configuration for the backlog of established sockets
-   permission java.io.FilePermission "/proc/sys/net/core/somaxconn", "read";
-   // Netty sets custom classloader for some of its internal threads
-   permission java.lang.RuntimePermission "setContextClassLoader";
-};
-
-grant codeBase "${codebase.netty-transport}" {
-   // Netty NioEventLoop wants to change this, because of https://bugs.openjdk.java.net/browse/JDK-6427854
-   // the bug says it only happened rarely, and that its fixed, but apparently it still happens rarely!
-   permission java.util.PropertyPermission "sun.nio.ch.bugLevel", "write";
-};


### PR DESCRIPTION
We waste a considerable amount of memory loading Netty twice (as well as a couple other classes in transport-netty4 and the ssl-config lib).

Moving the ssl-config lib to `:server` and making the security plugin extend `transport-netty4` saves memory, startup time, bundle size (Netty jars not included redundantly in the security module) and some code duplication around the security manager.
