### PR TITLE
Introduce Predicate Utilities for always true/false use-cases

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/Predicates.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Predicates.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.core;
+
+import java.util.function.Predicate;
+
+/**
+ * Utilities around predicates.
+ */
+public enum Predicates {
+    ;
+
+    @SuppressWarnings("rawtypes")
+    private static final Predicate NEVER = new Predicate() {
+        @Override
+        public boolean test(Object o) {
+            return false;
+        }
+
+        @Override
+        public Predicate and(Predicate other) {
+            return this;
+        }
+
+        @Override
+        public Predicate negate() {
+            return ALWAYS;
+        }
+
+        @Override
+        public Predicate or(Predicate other) {
+            return other;
+        }
+
+        @Override
+        public String toString() {
+            return "Predicate[NEVER]";
+        }
+    };
+
+    @SuppressWarnings("rawtypes")
+    private static final Predicate ALWAYS = new Predicate() {
+        @Override
+        public boolean test(Object o) {
+            return true;
+        }
+
+        @Override
+        public Predicate and(Predicate other) {
+            return other;
+        }
+
+        @Override
+        public Predicate negate() {
+            return NEVER;
+        }
+
+        @Override
+        public Predicate or(Predicate other) {
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return "Predicate[ALWAYS]";
+        }
+    };
+
+    /**
+     * @return a predicate that accepts all input values
+     * @param <T> type of the predicate
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Predicate<T> always() {
+        return (Predicate<T>) ALWAYS;
+    }
+
+    /**
+     * @return a predicate that rejects all input values
+     * @param <T> type of the predicate
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Predicate<T> never() {
+        return (Predicate<T>) NEVER;
+    }
+}

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/KeyValueProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/KeyValueProcessor.java
@@ -11,6 +11,7 @@ package org.elasticsearch.ingest.common;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
 import org.elasticsearch.ingest.IngestDocument;
@@ -100,7 +101,7 @@ public final class KeyValueProcessor extends AbstractProcessor {
         final Predicate<String> keyFilter;
         if (includeKeys == null) {
             if (excludeKeys == null) {
-                keyFilter = key -> true;
+                keyFilter = Predicates.always();
             } else {
                 keyFilter = key -> excludeKeys.contains(key) == false;
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/TransportClusterSearchShardsAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.search.internal.AliasFilter;
@@ -85,8 +86,8 @@ public class TransportClusterSearchShardsAction extends TransportMasterNodeReadA
             final String[] aliases = indexNameExpressionResolver.indexAliases(
                 clusterState,
                 index,
-                aliasMetadata -> true,
-                dataStreamAlias -> true,
+                Predicates.always(),
+                Predicates.always(),
                 true,
                 indicesAndAliases
             );

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
@@ -89,7 +90,7 @@ public class TransportClusterStateAction extends TransportMasterNodeReadAction<C
         final CancellableTask cancellableTask = (CancellableTask) task;
 
         final Predicate<ClusterState> acceptableClusterStatePredicate = request.waitForMetadataVersion() == null
-            ? clusterState -> true
+            ? Predicates.always()
             : clusterState -> clusterState.metadata().version() >= request.waitForMetadataVersion();
 
         final Predicate<ClusterState> acceptableClusterStateOrFailedPredicate = request.local()

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/TransportGetAliasesAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.DeprecationCategory;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.SystemIndices.SystemIndexAccessLevel;
@@ -160,7 +161,7 @@ public class TransportGetAliasesAction extends TransportLocalClusterStateAction<
     ) {
         final Predicate<String> systemIndexAccessAllowPredicate;
         if (systemIndexAccessLevel == SystemIndexAccessLevel.NONE) {
-            systemIndexAccessAllowPredicate = indexName -> false;
+            systemIndexAccessAllowPredicate = Predicates.never();
         } else if (systemIndexAccessLevel == SystemIndexAccessLevel.RESTRICTED) {
             systemIndexAccessAllowPredicate = systemIndices.getProductSystemIndexNamePredicate(threadContext);
         } else {

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.Scheduler;
@@ -104,14 +105,14 @@ public class Retry {
         public void onResponse(BulkResponse bulkItemResponses) {
             if (bulkItemResponses.hasFailures() == false) {
                 // we're done here, include all responses
-                addResponses(bulkItemResponses, (r -> true));
+                addResponses(bulkItemResponses, Predicates.always());
                 finishHim();
             } else {
                 if (canRetry(bulkItemResponses)) {
                     addResponses(bulkItemResponses, (r -> r.isFailed() == false));
                     retry(createBulkRequestForRetry(bulkItemResponses));
                 } else {
-                    addResponses(bulkItemResponses, (r -> true));
+                    addResponses(bulkItemResponses, Predicates.always());
                     finishHim();
                 }
             }

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry2.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry2.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 
@@ -183,7 +184,7 @@ class Retry2 {
                     bulkItemResponses.getItems().length
                 );
                 // we're done here, include all responses
-                addResponses(bulkItemResponses, (r -> true));
+                addResponses(bulkItemResponses, Predicates.always());
                 listener.onResponse(getAccumulatedResponse());
             } else {
                 if (canRetry(bulkItemResponses)) {
@@ -201,7 +202,7 @@ class Retry2 {
                         bulkItemResponses.getTook(),
                         bulkItemResponses.getItems().length
                     );
-                    addResponses(bulkItemResponses, (r -> true));
+                    addResponses(bulkItemResponses, Predicates.always());
                     listener.onResponse(getAccumulatedResponse());
                 }
             }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.InstantiatingObjectParser;
@@ -567,7 +568,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
         }
 
         FieldCapabilities build(boolean withIndices) {
-            final String[] indices = withIndices ? filterIndices(totalIndices, ic -> true) : null;
+            final String[] indices = withIndices ? filterIndices(totalIndices, Predicates.always()) : null;
 
             // Iff this field is searchable in some indices AND non-searchable in others
             // we record the list of non-searchable indices
@@ -603,7 +604,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
                 // Collect all indices that have this field. If it is marked differently in different indices, we cannot really
                 // make a decisions which index is "right" and which index is "wrong" so collecting all indices where this field
                 // is present is probably the only sensible thing to do here
-                metricConflictsIndices = Objects.requireNonNullElseGet(indices, () -> filterIndices(totalIndices, ic -> true));
+                metricConflictsIndices = Objects.requireNonNullElseGet(indices, () -> filterIndices(totalIndices, Predicates.always()));
             } else {
                 metricConflictsIndices = null;
             }

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/ResponseRewriter.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/ResponseRewriter.java
@@ -10,6 +10,7 @@ package org.elasticsearch.action.fieldcaps;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
+import org.elasticsearch.core.Predicates;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +50,7 @@ final class ResponseRewriter {
         String[] filters,
         String[] allowedTypes
     ) {
-        Predicate<IndexFieldCapabilities> test = ifc -> true;
+        Predicate<IndexFieldCapabilities> test = Predicates.always();
         Set<String> objects = null;
         Set<String> nestedObjects = null;
         if (allowedTypes.length > 0) {

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -51,6 +51,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.CountDown;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -198,8 +199,8 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             String[] aliases = indexNameExpressionResolver.indexAliases(
                 clusterState,
                 index,
-                aliasMetadata -> true,
-                dataStreamAlias -> true,
+                Predicates.always(),
+                Predicates.always(),
                 true,
                 indicesAndAliases
             );

--- a/server/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ESPolicy.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.bootstrap;
 
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.SuppressForbidden;
 
 import java.io.FilePermission;
@@ -201,7 +202,10 @@ final class ESPolicy extends Policy {
     // from this policy file or further restrict it to code sources
     // that you specify, because Thread.stop() is potentially unsafe."
     // not even sure this method still works...
-    private static final Permission BAD_DEFAULT_NUMBER_ONE = new BadDefaultPermission(new RuntimePermission("stopThread"), p -> true);
+    private static final Permission BAD_DEFAULT_NUMBER_ONE = new BadDefaultPermission(
+        new RuntimePermission("stopThread"),
+        Predicates.always()
+    );
 
     // default policy file states:
     // "allows anyone to listen on dynamic ports"

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -32,8 +33,6 @@ public class ClusterStateObserver {
     protected final Logger logger;
 
     public static final Predicate<ClusterState> NON_NULL_MASTER_PREDICATE = state -> state.nodes().getMasterNode() != null;
-
-    private static final Predicate<ClusterState> MATCH_ALL_CHANGES_PREDICATE = state -> true;
 
     private final ClusterApplierService clusterApplierService;
     private final ThreadPool threadPool;
@@ -109,11 +108,11 @@ public class ClusterStateObserver {
     }
 
     public void waitForNextChange(Listener listener) {
-        waitForNextChange(listener, MATCH_ALL_CHANGES_PREDICATE);
+        waitForNextChange(listener, Predicates.always());
     }
 
     public void waitForNextChange(Listener listener, @Nullable TimeValue timeOutValue) {
-        waitForNextChange(listener, MATCH_ALL_CHANGES_PREDICATE, timeOutValue);
+        waitForNextChange(listener, Predicates.always(), timeOutValue);
     }
 
     public void waitForNextChange(Listener listener, Predicate<ClusterState> statePredicate) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -54,11 +55,10 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
 
     private static final List<Predicate<ShardRouting>> PRIORITY_REMOVE_CLAUSES = Stream.<Predicate<ShardRouting>>of(
         shardRouting -> shardRouting.isPromotableToPrimary() == false,
-        shardRouting -> true
+        Predicates.always()
     )
         .flatMap(
-            p1 -> Stream.<Predicate<ShardRouting>>of(ShardRouting::unassigned, ShardRouting::initializing, shardRouting -> true)
-                .map(p1::and)
+            p1 -> Stream.<Predicate<ShardRouting>>of(ShardRouting::unassigned, ShardRouting::initializing, Predicates.always()).map(p1::and)
         )
         .toList();
     private final Index index;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
@@ -249,7 +250,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
     }
 
     public ShardsIterator allShards(String[] indices) {
-        return allShardsSatisfyingPredicate(indices, shardRouting -> true, false);
+        return allShardsSatisfyingPredicate(indices, Predicates.always(), false);
     }
 
     public ShardsIterator allActiveShards(String[] indices) {
@@ -257,7 +258,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
     }
 
     public ShardsIterator allShardsIncludingRelocationTargets(String[] indices) {
-        return allShardsSatisfyingPredicate(indices, shardRouting -> true, true);
+        return allShardsSatisfyingPredicate(indices, Predicates.always(), true);
     }
 
     private ShardsIterator allShardsSatisfyingPredicate(

--- a/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/network/NetworkUtils.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.network;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.core.Predicates;
 
 import java.io.IOException;
 import java.net.Inet4Address;
@@ -188,7 +189,7 @@ public abstract class NetworkUtils {
     /** Returns all addresses (any scope) for interfaces that are up.
      *  This is only used to pick a publish address, when the user set network.host to a wildcard */
     public static InetAddress[] getAllAddresses() throws IOException {
-        return filterAllAddresses(address -> true, "no up-and-running addresses found");
+        return filterAllAddresses(Predicates.always(), "no up-and-running addresses found");
     }
 
     static Optional<NetworkInterface> maybeGetInterfaceByName(List<NetworkInterface> networkInterfaces, String name) {

--- a/server/src/main/java/org/elasticsearch/common/regex/Regex.java
+++ b/server/src/main/java/org/elasticsearch/common/regex/Regex.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.Predicates;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -102,12 +103,12 @@ public class Regex {
      */
     public static Predicate<String> simpleMatcher(String... patterns) {
         if (patterns == null || patterns.length == 0) {
-            return str -> false;
+            return Predicates.never();
         }
         boolean hasWildcard = false;
         for (String pattern : patterns) {
             if (isMatchAllPattern(pattern)) {
-                return str -> true;
+                return Predicates.always();
             }
             if (isSimpleMatchPattern(pattern)) {
                 hasWildcard = true;

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
@@ -1119,7 +1120,7 @@ public final class NodeEnvironment implements Closeable {
      * Returns all folder names in ${data.paths}/indices folder
      */
     public Set<String> availableIndexFolders() throws IOException {
-        return availableIndexFolders(p -> false);
+        return availableIndexFolders(Predicates.never());
     }
 
     /**
@@ -1147,7 +1148,7 @@ public final class NodeEnvironment implements Closeable {
      * @throws IOException if an I/O exception occurs traversing the filesystem
      */
     public Set<String> availableIndexFoldersForPath(final DataPath dataPath) throws IOException {
-        return availableIndexFoldersForPath(dataPath, p -> false);
+        return availableIndexFoldersForPath(dataPath, Predicates.never());
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/shard/ShardSplittingQuery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/ShardSplittingQuery.java
@@ -33,6 +33,7 @@ import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexRouting;
 import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.cache.bitset.BitsetFilterCache;
 import org.elasticsearch.index.mapper.IdFieldMapper;
@@ -140,7 +141,12 @@ final class ShardSplittingQuery extends Query {
                              * of the document that contains them.
                              */
                             FixedBitSet hasRoutingValue = new FixedBitSet(leafReader.maxDoc());
-                            findSplitDocs(RoutingFieldMapper.NAME, ref -> false, leafReader, maybeWrapConsumer.apply(hasRoutingValue::set));
+                            findSplitDocs(
+                                RoutingFieldMapper.NAME,
+                                Predicates.never(),
+                                leafReader,
+                                maybeWrapConsumer.apply(hasRoutingValue::set)
+                            );
                             IntConsumer bitSetConsumer = maybeWrapConsumer.apply(bitSet::set);
                             findSplitDocs(IdFieldMapper.NAME, includeInShard, leafReader, docId -> {
                                 if (hasRoutingValue.get(docId) == false) {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesQueryCache.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.cache.query.QueryCacheStats;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -78,7 +79,7 @@ public class IndicesQueryCache implements QueryCache, Closeable {
         logger.debug("using [node] query cache with size [{}] max filter count [{}]", size, count);
         if (INDICES_QUERIES_CACHE_ALL_SEGMENTS_SETTING.get(settings)) {
             // Use the default skip_caching_factor (i.e., 10f) in Lucene
-            cache = new ElasticsearchLRUQueryCache(count, size.getBytes(), context -> true, 10f);
+            cache = new ElasticsearchLRUQueryCache(count, size.getBytes(), Predicates.always(), 10f);
         } else {
             cache = new ElasticsearchLRUQueryCache(count, size.getBytes());
         }

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.plugins.SystemIndexPlugin;
@@ -384,11 +385,11 @@ public class SystemIndices {
     public Predicate<String> getProductSystemIndexNamePredicate(ThreadContext threadContext) {
         final String product = threadContext.getHeader(EXTERNAL_SYSTEM_INDEX_ACCESS_CONTROL_HEADER_KEY);
         if (product == null) {
-            return name -> false;
+            return Predicates.never();
         }
         final CharacterRunAutomaton automaton = productToSystemIndicesMatcher.get(product);
         if (automaton == null) {
-            return name -> false;
+            return Predicates.never();
         }
         return automaton::run;
     }

--- a/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.plugins;
 
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeField;
@@ -69,7 +70,7 @@ public interface MapperPlugin {
      * The default field predicate applied, which doesn't filter anything. That means that by default get mappings, get index
      * get field mappings and field capabilities API will return every field that's present in the mappings.
      */
-    Predicate<String> NOOP_FIELD_PREDICATE = field -> true;
+    Predicate<String> NOOP_FIELD_PREDICATE = Predicates.always();
 
     /**
      * The default field filter applied, which doesn't filter anything. That means that by default get mappings, get index

--- a/server/src/main/java/org/elasticsearch/plugins/internal/RestExtension.java
+++ b/server/src/main/java/org/elasticsearch/plugins/internal/RestExtension.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.plugins.internal;
 
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.action.cat.AbstractCatAction;
 
@@ -38,12 +39,12 @@ public interface RestExtension {
         return new RestExtension() {
             @Override
             public Predicate<AbstractCatAction> getCatActionsFilter() {
-                return action -> true;
+                return Predicates.always();
             }
 
             @Override
             public Predicate<RestHandler> getActionsFilter() {
-                return handler -> true;
+                return Predicates.always();
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -9,6 +9,7 @@ package org.elasticsearch.search.aggregations.bucket.terms;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
@@ -208,7 +209,7 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
         } else if (format == DocValueFormat.UNSIGNED_LONG_SHIFTED) {
             needsPromoting = docFormat -> docFormat == DocValueFormat.RAW;
         } else {
-            needsPromoting = docFormat -> false;
+            needsPromoting = Predicates.never();
         }
         return new AggregatorReducer() {
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -73,6 +73,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
@@ -2266,7 +2267,7 @@ public final class SnapshotsService extends AbstractLifecycleComponent implement
         IndexVersion minCompatVersion = minNodeVersion;
         final Collection<SnapshotId> snapshotIds = repositoryData.getSnapshotIds();
         for (SnapshotId snapshotId : snapshotIds.stream()
-            .filter(excluded == null ? sn -> true : Predicate.not(excluded::contains))
+            .filter(excluded == null ? Predicates.always() : Predicate.not(excluded::contains))
             .toList()) {
             final IndexVersion known = repositoryData.getVersion(snapshotId);
             // If we don't have the version cached in the repository data yet we load it from the snapshot info blobs

--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.CountDown;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
@@ -182,7 +183,7 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
                     connectionManager.getCredentialsManager()
                 ),
                 actualProfile.getHandshakeTimeout(),
-                cn -> true,
+                Predicates.always(),
                 listener.map(resp -> {
                     ClusterName remote = resp.getClusterName();
                     if (remoteClusterName.compareAndSet(null, remote)) {

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -37,6 +37,7 @@ import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.UpdateForV9;
@@ -356,7 +357,7 @@ public class TransportService extends AbstractLifecycleComponent
             // but there may still be pending handlers for node-local requests since this connection is not closed, and we may also
             // (briefly) track handlers for requests which are sent concurrently with stopping even though the underlying connection is
             // now closed. We complete all these outstanding handlers here:
-            for (final Transport.ResponseContext<?> holderToNotify : responseHandlers.prune(h -> true)) {
+            for (final Transport.ResponseContext<?> holderToNotify : responseHandlers.prune(Predicates.always())) {
                 try {
                     final TransportResponseHandler<?> handler = holderToNotify.handler();
                     final var targetNode = holderToNotify.connection().getNode();
@@ -499,7 +500,7 @@ public class TransportService extends AbstractLifecycleComponent
     public ConnectionManager.ConnectionValidator connectionValidator(DiscoveryNode node) {
         return (newConnection, actualProfile, listener) -> {
             // We don't validate cluster names to allow for CCS connections.
-            handshake(newConnection, actualProfile.getHandshakeTimeout(), cn -> true, listener.map(resp -> {
+            handshake(newConnection, actualProfile.getHandshakeTimeout(), Predicates.always(), listener.map(resp -> {
                 final DiscoveryNode remote = resp.discoveryNode;
                 if (node.equals(remote) == false) {
                     throw new ConnectTransportException(node, "handshake failed. unexpected remote node " + remote);

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsRequestTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.admin.indices.settings.put;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.xcontent.ToXContent;
@@ -110,7 +111,7 @@ public class UpdateSettingsRequestTests extends AbstractXContentTestCase<UpdateS
         if (enclosedSettings) {
             return field -> field.startsWith("settings");
         }
-        return field -> true;
+        return Predicates.always();
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.util.iterable.Iterables;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
@@ -783,7 +784,7 @@ public class MetadataTests extends ESTestCase {
                         && field.equals("address.location") == false;
                 }
                 if (index.equals("index2")) {
-                    return field -> false;
+                    return Predicates.never();
                 }
                 return MapperPlugin.NOOP_FIELD_PREDICATE;
             }, Metadata.ON_NEXT_INDEX_FIND_MAPPINGS_NOOP);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
@@ -113,7 +114,7 @@ public class AllocationDecidersTests extends ESAllocationTestCase {
     }
 
     private static Decision.Multi collectToMultiDecision(List<Decision> decisions) {
-        return collectToMultiDecision(decisions, ignored -> true);
+        return collectToMultiDecision(decisions, Predicates.always());
     }
 
     private static Decision.Multi collectToMultiDecision(List<Decision> decisions, Predicate<Decision> filter) {

--- a/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/index/reindex/ReindexRequestTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.slice.SliceBuilder;
@@ -115,7 +116,7 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
 
     @Override
     protected ReindexRequest doParseInstance(XContentParser parser) throws IOException {
-        return ReindexRequest.fromXContent(parser, nf -> false);
+        return ReindexRequest.fromXContent(parser, Predicates.never());
     }
 
     @Override
@@ -403,7 +404,7 @@ public class ReindexRequestTests extends AbstractBulkByScrollRequestTestCase<Rei
             request = BytesReference.bytes(b);
         }
         try (XContentParser p = createParser(JsonXContent.jsonXContent, request)) {
-            return ReindexRequest.fromXContent(p, nf -> false);
+            return ReindexRequest.fromXContent(p, Predicates.never());
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldFilterPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldFilterPlugin.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 
@@ -19,6 +20,6 @@ public class MockFieldFilterPlugin extends Plugin implements MapperPlugin {
     @Override
     public Function<String, Predicate<String>> getFieldFilter() {
         // this filter doesn't filter any field out, but it's used to exercise the code path executed when the filter is not no-op
-        return index -> field -> true;
+        return index -> Predicates.always();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractSerializationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractSerializationTestCase.java
@@ -10,6 +10,7 @@ package org.elasticsearch.test;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -126,7 +127,7 @@ public abstract class AbstractSerializationTestCase<T extends Writeable> extends
      * Returns a predicate that given the field name indicates whether the field has to be excluded from random fields insertion or not
      */
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> false;
+        return Predicates.never();
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.CheckedFunction;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -326,7 +327,7 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
      * Returns a predicate that given the field name indicates whether the field has to be excluded from random fields insertion or not
      */
     protected Predicate<String> getRandomFieldsExcludeFilter() {
-        return field -> false;
+        return Predicates.never();
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -64,6 +64,7 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -650,7 +651,7 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     private NodeAndClient getRandomNodeAndClient() {
-        return getRandomNodeAndClient(nc -> true);
+        return getRandomNodeAndClient(Predicates.always());
     }
 
     private synchronized NodeAndClient getRandomNodeAndClient(Predicate<NodeAndClient> predicate) {
@@ -1621,7 +1622,7 @@ public final class InternalTestCluster extends TestCluster {
      * Returns a reference to a random nodes instances of the given class &gt;T&lt;
      */
     public <T> T getInstance(Class<T> clazz) {
-        return getInstance(clazz, nc -> true);
+        return getInstance(clazz, Predicates.always());
     }
 
     private static <T> T getInstanceFromNode(Class<T> clazz, Node node) {
@@ -1990,7 +1991,7 @@ public final class InternalTestCluster extends TestCluster {
      * @return the name of a random node in a cluster
      */
     public String getRandomNodeName() {
-        return getNodeNameThat(ignored -> true);
+        return getNodeNameThat(Predicates.always());
     }
 
     /**

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/VersionRange.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/VersionRange.java
@@ -9,6 +9,7 @@ package org.elasticsearch.test.rest.yaml.section;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.Version;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.rest.ESRestTestCase;
 
@@ -23,9 +24,9 @@ class VersionRange {
 
     private VersionRange() {}
 
-    static final Predicate<Set<String>> NEVER = v -> false;
+    static final Predicate<Set<String>> NEVER = Predicates.never();
 
-    static final Predicate<Set<String>> ALWAYS = v -> true;
+    static final Predicate<Set<String>> ALWAYS = Predicates.always();
 
     static final Predicate<Set<String>> CURRENT = versions -> versions.size() == 1 && versions.contains(Build.current().version());
 

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -48,6 +48,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
@@ -199,11 +200,11 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
     }
 
     static boolean isDiskOnlyNoDecision(Decision decision) {
-        return singleNoDecision(decision, single -> true).map(DiskThresholdDecider.NAME::equals).orElse(false);
+        return singleNoDecision(decision, Predicates.always()).map(DiskThresholdDecider.NAME::equals).orElse(false);
     }
 
     static boolean isResizeOnlyNoDecision(Decision decision) {
-        return singleNoDecision(decision, single -> true).map(ResizeAllocationDecider.NAME::equals).orElse(false);
+        return singleNoDecision(decision, Predicates.always()).map(ResizeAllocationDecider.NAME::equals).orElse(false);
     }
 
     static boolean isFilterTierOnlyDecision(Decision decision, IndexMetadata indexMetadata) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportFollowInfoAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportFollowInfoAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -89,7 +90,7 @@ public class TransportFollowInfoAction extends TransportMasterNodeReadAction<Fol
             if (ccrCustomData != null) {
                 Optional<ShardFollowTask> result;
                 if (persistentTasks != null) {
-                    result = persistentTasks.findTasks(ShardFollowTask.NAME, task -> true)
+                    result = persistentTasks.findTasks(ShardFollowTask.NAME, Predicates.always())
                         .stream()
                         .map(task -> (ShardFollowTask) task.getParams())
                         .filter(shardFollowTask -> index.equals(shardFollowTask.getFollowShardId().getIndexName()))

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.ml;
 
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -308,7 +309,7 @@ public final class MlTasks {
             return Collections.emptyList();
         }
 
-        return tasks.findTasks(JOB_TASK_NAME, task -> true);
+        return tasks.findTasks(JOB_TASK_NAME, Predicates.always());
     }
 
     public static Collection<PersistentTasksCustomMetadata.PersistentTask<?>> datafeedTasksOnNode(
@@ -360,7 +361,7 @@ public final class MlTasks {
             return Collections.emptyList();
         }
 
-        return tasks.findTasks(JOB_SNAPSHOT_UPGRADE_TASK_NAME, task -> true);
+        return tasks.findTasks(JOB_SNAPSHOT_UPGRADE_TASK_NAME, Predicates.always());
     }
 
     public static Collection<PersistentTasksCustomMetadata.PersistentTask<?>> snapshotUpgradeTasksOnNode(
@@ -439,7 +440,7 @@ public final class MlTasks {
             return Collections.emptySet();
         }
 
-        return tasks.findTasks(DATAFEED_TASK_NAME, task -> true)
+        return tasks.findTasks(DATAFEED_TASK_NAME, Predicates.always())
             .stream()
             .map(t -> t.getId().substring(DATAFEED_TASK_ID_PREFIX.length()))
             .collect(Collectors.toSet());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/UserRoleMapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/UserRoleMapper.java
@@ -15,6 +15,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.ExpressionModel;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.FieldExpression;
@@ -87,7 +88,7 @@ public interface UserRoleMapper {
                 groups,
                 groups.stream().<Predicate<FieldExpression.FieldValue>>map(g -> new DistinguishedNamePredicate(g, dnNormalizer))
                     .reduce(Predicate::or)
-                    .orElse(fieldValue -> false)
+                    .orElse(Predicates.never())
             );
             metadata.keySet().forEach(k -> model.defineField("metadata." + k, metadata.get(k)));
             model.defineField("realm.name", realm.name());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModel.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Numbers;
+import org.elasticsearch.core.Predicates;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -100,7 +101,7 @@ public class ExpressionModel {
             return ((Collection<?>) object).stream()
                 .map(element -> buildPredicate(element))
                 .reduce((a, b) -> a.or(b))
-                .orElse(fieldValue -> false);
+                .orElse(Predicates.never());
         }
         throw new IllegalArgumentException("Unsupported value type " + object.getClass());
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/restriction/WorkflowsRestriction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/restriction/WorkflowsRestriction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.security.authz.restriction;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 
 import java.util.Set;
 import java.util.function.Predicate;
@@ -26,10 +27,10 @@ public final class WorkflowsRestriction {
         this.names = names;
         if (names == null) {
             // No restriction, all workflows are allowed
-            this.predicate = name -> true;
+            this.predicate = Predicates.always();
         } else if (names.isEmpty()) {
             // Empty restriction, no workflow is allowed
-            this.predicate = name -> false;
+            this.predicate = Predicates.never();
         } else {
             this.predicate = name -> {
                 if (name == null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/Automatons.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 
 import java.util.ArrayList;
@@ -312,6 +313,11 @@ public final class Automatons {
     }
 
     private static Predicate<String> predicate(Automaton automaton, final String toString) {
+        if (automaton == MATCH_ALL) {
+            return Predicates.always();
+        } else if (automaton == EMPTY) {
+            return Predicates.never();
+        }
         CharacterRunAutomaton runAutomaton = new CharacterRunAutomaton(automaton, maxDeterminizedStates);
         return new Predicate<String>() {
             @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/StringMatcher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/StringMatcher.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.Predicates;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,9 +35,7 @@ import java.util.stream.Collectors;
  */
 public class StringMatcher implements Predicate<String> {
 
-    private static final StringMatcher MATCH_NOTHING = new StringMatcher("(empty)", s -> false);
-
-    protected static final Predicate<String> ALWAYS_TRUE_PREDICATE = s -> true;
+    private static final StringMatcher MATCH_NOTHING = new StringMatcher("(empty)", Predicates.never());
 
     private final String description;
     private final Predicate<String> predicate;
@@ -70,7 +69,7 @@ public class StringMatcher implements Predicate<String> {
     }
 
     public boolean isTotal() {
-        return predicate == ALWAYS_TRUE_PREDICATE;
+        return predicate == Predicates.<String>always();
     }
 
     // For testing
@@ -130,7 +129,7 @@ public class StringMatcher implements Predicate<String> {
 
             final String description = describe(allText);
             if (nonExactMatch.contains("*")) {
-                return new StringMatcher(description, ALWAYS_TRUE_PREDICATE);
+                return new StringMatcher(description, Predicates.always());
             }
             if (exactMatch.isEmpty()) {
                 return new StringMatcher(description, buildAutomataPredicate(nonExactMatch));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/StringMatcherTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/support/StringMatcherTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.security.support;
 
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.List;
@@ -49,7 +50,7 @@ public class StringMatcherTests extends ESTestCase {
             assertMatch(matcher, randomAlphaOfLengthBetween(i, 20));
         }
 
-        assertThat(matcher.getPredicate(), sameInstance(StringMatcher.ALWAYS_TRUE_PREDICATE));
+        assertThat(matcher.getPredicate(), sameInstance(Predicates.always()));
     }
 
     public void testSingleWildcard() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlDailyMaintenanceService.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -288,8 +289,8 @@ public class MlDailyMaintenanceService implements Releasable {
             }
             TypedChainTaskExecutor<Tuple<DeleteJobAction.Request, AcknowledgedResponse>> chainTaskExecutor = new TypedChainTaskExecutor<>(
                 EsExecutors.DIRECT_EXECUTOR_SERVICE,
-                unused -> true,
-                unused -> true
+                Predicates.always(),
+                Predicates.always()
             );
             for (String jobId : jobsInStateDeletingWithoutDeletionTask) {
                 DeleteJobAction.Request request = new DeleteJobAction.Request(jobId);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportEvaluateDataFrameAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
@@ -128,7 +129,7 @@ public class TransportEvaluateDataFrameAction extends HandledTransportAction<
             EvaluateDataFrameAction.Request request,
             SecurityContext securityContext
         ) {
-            super(threadPool.generic(), unused -> true, unused -> true);
+            super(threadPool.generic(), Predicates.always(), Predicates.always());
             this.client = client;
             this.parameters = parameters;
             this.request = request;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.license.License;
@@ -175,9 +176,9 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
             TypedChainTaskExecutor<InferenceResults> typedChainTaskExecutor = new TypedChainTaskExecutor<>(
                 EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 // run through all tasks
-                r -> true,
+                Predicates.always(),
                 // Always fail immediately and return an error
-                ex -> true
+                Predicates.always()
             );
             request.getObjectsToInfer().forEach(stringObjectMap -> typedChainTaskExecutor.add(chainedTask -> {
                 if (task.isCancelled()) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -300,7 +301,7 @@ public class TransportSetUpgradeModeAction extends AcknowledgedTransportMasterNo
 
         TypedChainTaskExecutor<PersistentTask<?>> chainTaskExecutor = new TypedChainTaskExecutor<>(
             executor,
-            r -> true,
+            Predicates.always(),
             // Another process could modify tasks and thus we cannot find them via the allocation_id and name
             // If the task was removed from the node, all is well
             // We handle the case of allocation_id changing later in this transport class by timing out waiting for task completion
@@ -330,8 +331,8 @@ public class TransportSetUpgradeModeAction extends AcknowledgedTransportMasterNo
         logger.info("Isolating datafeeds: " + datafeedsToIsolate.toString());
         TypedChainTaskExecutor<IsolateDatafeedAction.Response> isolateDatafeedsExecutor = new TypedChainTaskExecutor<>(
             executor,
-            r -> true,
-            ex -> true
+            Predicates.always(),
+            Predicates.always()
         );
 
         datafeedsToIsolate.forEach(datafeedId -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDecider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDecider.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.logging.LogManager;
@@ -913,7 +914,7 @@ class MlMemoryAutoscalingDecider {
             return List.of();
         }
 
-        return tasksCustomMetadata.findTasks(MlTasks.DATAFEED_TASK_NAME, t -> true)
+        return tasksCustomMetadata.findTasks(MlTasks.DATAFEED_TASK_NAME, Predicates.always())
             .stream()
             .map(p -> (PersistentTasksCustomMetadata.PersistentTask<StartDatafeedAction.DatafeedParams>) p)
             .toList();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/VoidChainTaskExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/VoidChainTaskExecutor.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.ml.utils;
 
+import org.elasticsearch.core.Predicates;
+
 import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 
@@ -16,7 +18,7 @@ import java.util.function.Predicate;
 public class VoidChainTaskExecutor extends TypedChainTaskExecutor<Void> {
 
     public VoidChainTaskExecutor(ExecutorService executorService, boolean shortCircuit) {
-        this(executorService, (a) -> true, (e) -> shortCircuit);
+        this(executorService, Predicates.always(), shortCircuit ? Predicates.always() : Predicates.never());
     }
 
     VoidChainTaskExecutor(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountAction.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.security.action.service.GetServiceAccountAction;
@@ -38,7 +39,7 @@ public class TransportGetServiceAccountAction extends HandledTransportAction<Get
 
     @Override
     protected void doExecute(Task task, GetServiceAccountRequest request, ActionListener<GetServiceAccountResponse> listener) {
-        Predicate<ServiceAccount> filter = v -> true;
+        Predicate<ServiceAccount> filter = Predicates.always();
         if (request.getNamespace() != null) {
             filter = filter.and(v -> v.id().namespace().equals(request.getNamespace()));
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrail.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.http.HttpPreRequest;
 import org.elasticsearch.node.Node;
@@ -1908,7 +1909,7 @@ public class LoggingAuditTrail implements AuditTrail, ClusterStateListener {
         }
 
         private static Predicate<AuditEventMetaInfo> buildIgnorePredicate(Map<String, EventFilterPolicy> policyMap) {
-            return policyMap.values().stream().map(EventFilterPolicy::ignorePredicate).reduce(x -> false, (x, y) -> x.or(y));
+            return policyMap.values().stream().map(EventFilterPolicy::ignorePredicate).reduce(Predicates.never(), Predicate::or);
         }
 
         @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/FileTokensTool.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/FileTokensTool.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cli.UserException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.cli.EnvironmentAwareCommand;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.authc.support.Hasher;
@@ -132,7 +133,7 @@ class FileTokensTool extends MultiCommand {
                         + "]"
                 );
             }
-            Predicate<String> filter = k -> true;
+            Predicate<String> filter = Predicates.always();
             if (args.size() == 1) {
                 final String principal = args.get(0);
                 if (false == ServiceAccountService.isServiceAccountPrincipal(principal)) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -17,6 +17,7 @@ import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -607,7 +608,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
     }
 
     public static Collection<PersistentTask<?>> findAllTransformTasks(ClusterState clusterState) {
-        return findTransformTasks(task -> true, clusterState);
+        return findTransformTasks(Predicates.always(), clusterState);
     }
 
     public static Collection<PersistentTask<?>> findTransformTasks(Set<String> transformIds, ClusterState clusterState) {
@@ -616,7 +617,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
 
     public static Collection<PersistentTask<?>> findTransformTasks(String transformIdPattern, ClusterState clusterState) {
         Predicate<PersistentTasksCustomMetadata.PersistentTask<?>> taskMatcher = transformIdPattern == null
-            || Strings.isAllOrWildcard(transformIdPattern) ? t -> true : t -> {
+            || Strings.isAllOrWildcard(transformIdPattern) ? Predicates.always() : t -> {
                 TransformTaskParams transformParams = (TransformTaskParams) t.getParams();
                 return Regex.simpleMatch(transformIdPattern, transformParams.getId());
             };


### PR DESCRIPTION
Just a suggetion. I think this would save us a bit of memory here and there. We have loads of places where the always true lambdas are used with `Predicate.or/and`. Found this initially when looking into field caps performance where we used to heavily compose these but many spots in security and index name resolution gain from these predicates. The better toString also helps in some cases at least when debugging.
