### PR TITLE
Make use of ActionListener#delegateFailureAndWrap in more spots in ML codebase

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -121,9 +121,8 @@ public final class DatafeedManager {
                 final RoleDescriptor.IndicesPrivileges.Builder indicesPrivilegesBuilder = RoleDescriptor.IndicesPrivileges.builder()
                     .indices(indices);
 
-                ActionListener<HasPrivilegesResponse> privResponseListener = ActionListener.wrap(
-                    r -> handlePrivsResponse(username, request, r, state, threadPool, listener),
-                    listener::onFailure
+                ActionListener<HasPrivilegesResponse> privResponseListener = listener.delegateFailureAndWrap(
+                    (l, r) -> handlePrivsResponse(username, request, r, state, threadPool, l)
                 );
 
                 ActionListener<GetRollupIndexCapsAction.Response> getRollupIndexCapsActionHandler = ActionListener.wrap(response -> {
@@ -173,15 +172,14 @@ public final class DatafeedManager {
             request.getDatafeedId(),
             request.allowNoMatch(),
             parentTaskId,
-            ActionListener.wrap(
-                datafeedBuilders -> listener.onResponse(
+            listener.delegateFailureAndWrap(
+                (l, datafeedBuilders) -> l.onResponse(
                     new QueryPage<>(
                         datafeedBuilders.stream().map(DatafeedConfig.Builder::build).collect(Collectors.toList()),
                         datafeedBuilders.size(),
                         DatafeedConfig.RESULTS_FIELD
                     )
-                ),
-                listener::onFailure
+                )
             )
         );
     }
@@ -222,10 +220,7 @@ public final class DatafeedManager {
                 request.getUpdate(),
                 headers,
                 jobConfigProvider::validateDatafeedJob,
-                ActionListener.wrap(
-                    updatedConfig -> listener.onResponse(new PutDatafeedAction.Response(updatedConfig)),
-                    listener::onFailure
-                )
+                listener.delegateFailureAndWrap((l, updatedConfig) -> l.onResponse(new PutDatafeedAction.Response(updatedConfig)))
             );
         });
 
@@ -254,19 +249,18 @@ public final class DatafeedManager {
 
         String datafeedId = request.getDatafeedId();
 
-        datafeedConfigProvider.getDatafeedConfig(datafeedId, null, ActionListener.wrap(datafeedConfigBuilder -> {
+        datafeedConfigProvider.getDatafeedConfig(datafeedId, null, listener.delegateFailureAndWrap((delegate, datafeedConfigBuilder) -> {
             String jobId = datafeedConfigBuilder.build().getJobId();
             JobDataDeleter jobDataDeleter = new JobDataDeleter(client, jobId);
             jobDataDeleter.deleteDatafeedTimingStats(
-                ActionListener.wrap(
-                    unused1 -> datafeedConfigProvider.deleteDatafeedConfig(
+                delegate.delegateFailureAndWrap(
+                    (l, unused1) -> datafeedConfigProvider.deleteDatafeedConfig(
                         datafeedId,
-                        ActionListener.wrap(unused2 -> listener.onResponse(AcknowledgedResponse.TRUE), listener::onFailure)
-                    ),
-                    listener::onFailure
+                        l.delegateFailureAndWrap((ll, unused2) -> ll.onResponse(AcknowledgedResponse.TRUE))
+                    )
                 )
             );
-        }, listener::onFailure));
+        }));
 
     }
 
@@ -316,7 +310,7 @@ public final class DatafeedManager {
         CheckedConsumer<Boolean, Exception> mappingsUpdated = ok -> datafeedConfigProvider.putDatafeedConfig(
             request.getDatafeed(),
             headers,
-            ActionListener.wrap(response -> listener.onResponse(new PutDatafeedAction.Response(response.v1())), listener::onFailure)
+            listener.delegateFailureAndWrap((l, response) -> l.onResponse(new PutDatafeedAction.Response(response.v1())))
         );
 
         CheckedConsumer<Boolean, Exception> validationOk = ok -> {
@@ -345,16 +339,19 @@ public final class DatafeedManager {
     }
 
     private void checkJobDoesNotHaveADatafeed(String jobId, ActionListener<Boolean> listener) {
-        datafeedConfigProvider.findDatafeedIdsForJobIds(Collections.singletonList(jobId), ActionListener.wrap(datafeedIds -> {
-            if (datafeedIds.isEmpty()) {
-                listener.onResponse(Boolean.TRUE);
-            } else {
-                listener.onFailure(
-                    ExceptionsHelper.conflictStatusException(
-                        "A datafeed [" + datafeedIds.iterator().next() + "] already exists for job [" + jobId + "]"
-                    )
-                );
-            }
-        }, listener::onFailure));
+        datafeedConfigProvider.findDatafeedIdsForJobIds(
+            Collections.singletonList(jobId),
+            listener.delegateFailureAndWrap((delegate, datafeedIds) -> {
+                if (datafeedIds.isEmpty()) {
+                    delegate.onResponse(Boolean.TRUE);
+                } else {
+                    delegate.onFailure(
+                        ExceptionsHelper.conflictStatusException(
+                            "A datafeed [" + datafeedIds.iterator().next() + "] already exists for job [" + jobId + "]"
+                        )
+                    );
+                }
+            })
+        );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactory.java
@@ -59,13 +59,12 @@ public interface DataExtractorFactory {
     ) {
         final boolean hasAggs = datafeed.hasAggregations();
         final boolean isComposite = hasAggs && datafeed.hasCompositeAgg(xContentRegistry);
-        ActionListener<DataExtractorFactory> factoryHandler = ActionListener.wrap(
-            factory -> listener.onResponse(
+        ActionListener<DataExtractorFactory> factoryHandler = listener.delegateFailureAndWrap(
+            (l, factory) -> l.onResponse(
                 datafeed.getChunkingConfig().isEnabled()
                     ? new ChunkedDataExtractorFactory(datafeed, job, xContentRegistry, factory)
                     : factory
-            ),
-            listener::onFailure
+            )
         );
 
         ActionListener<GetRollupIndexCapsAction.Response> getRollupIndexCapsActionHandler = ActionListener.wrap(response -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsManager.java
@@ -33,7 +33,6 @@ import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsState;
 import org.elasticsearch.xpack.core.ml.job.persistence.AnomalyDetectorsIndex;
 import org.elasticsearch.xpack.core.ml.job.persistence.ElasticsearchMappings;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
-import org.elasticsearch.xpack.ml.dataframe.extractor.ExtractedFieldsDetector;
 import org.elasticsearch.xpack.ml.dataframe.extractor.ExtractedFieldsDetectorFactory;
 import org.elasticsearch.xpack.ml.dataframe.inference.InferenceRunner;
 import org.elasticsearch.xpack.ml.dataframe.persistence.DataFrameAnalyticsConfigProvider;
@@ -171,9 +170,8 @@ public class DataFrameAnalyticsManager {
         }, task::setFailed);
 
         // Retrieve configuration
-        ActionListener<Boolean> statsIndexListener = ActionListener.wrap(
-            aBoolean -> configProvider.get(task.getParams().getId(), configListener),
-            configListener::onFailure
+        ActionListener<Boolean> statsIndexListener = configListener.delegateFailureAndWrap(
+            (l, aBoolean) -> configProvider.get(task.getParams().getId(), l)
         );
 
         // Make sure the stats index and alias exist
@@ -203,25 +201,22 @@ public class DataFrameAnalyticsManager {
         TimeValue masterNodeTimeout,
         ActionListener<Boolean> listener
     ) {
-        ActionListener<Boolean> createIndexListener = ActionListener.wrap(
-            aBoolean -> ElasticsearchMappings.addDocMappingIfMissing(
-                MlStatsIndex.writeAlias(),
-                MlStatsIndex::wrappedMapping,
-                clientToUse,
-                clusterState,
-                masterNodeTimeout,
-                listener,
-                MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION
-            ),
-            listener::onFailure
-        );
-
         MlStatsIndex.createStatsIndexAndAliasIfNecessary(
             clientToUse,
             clusterState,
             expressionResolver,
             masterNodeTimeout,
-            createIndexListener
+            listener.delegateFailureAndWrap(
+                (l, aBoolean) -> ElasticsearchMappings.addDocMappingIfMissing(
+                    MlStatsIndex.writeAlias(),
+                    MlStatsIndex::wrappedMapping,
+                    clientToUse,
+                    clusterState,
+                    masterNodeTimeout,
+                    l,
+                    MlStatsIndex.STATS_INDEX_MAPPINGS_VERSION
+                )
+            )
         );
     }
 
@@ -306,25 +301,25 @@ public class DataFrameAnalyticsManager {
 
     private void buildInferenceStep(DataFrameAnalyticsTask task, DataFrameAnalyticsConfig config, ActionListener<InferenceStep> listener) {
         ParentTaskAssigningClient parentTaskClient = new ParentTaskAssigningClient(client, task.getParentTaskId());
-
-        ActionListener<ExtractedFieldsDetector> extractedFieldsDetectorListener = ActionListener.wrap(extractedFieldsDetector -> {
-            ExtractedFields extractedFields = extractedFieldsDetector.detect().v1();
-            InferenceRunner inferenceRunner = new InferenceRunner(
-                settings,
-                parentTaskClient,
-                modelLoadingService,
-                resultsPersisterService,
-                task.getParentTaskId(),
-                config,
-                extractedFields,
-                task.getStatsHolder().getProgressTracker(),
-                task.getStatsHolder().getDataCountsTracker()
-            );
-            InferenceStep inferenceStep = new InferenceStep(client, task, auditor, config, threadPool, inferenceRunner);
-            listener.onResponse(inferenceStep);
-        }, listener::onFailure);
-
-        new ExtractedFieldsDetectorFactory(parentTaskClient).createFromDest(config, extractedFieldsDetectorListener);
+        new ExtractedFieldsDetectorFactory(parentTaskClient).createFromDest(
+            config,
+            listener.delegateFailureAndWrap((delegate, extractedFieldsDetector) -> {
+                ExtractedFields extractedFields = extractedFieldsDetector.detect().v1();
+                InferenceRunner inferenceRunner = new InferenceRunner(
+                    settings,
+                    parentTaskClient,
+                    modelLoadingService,
+                    resultsPersisterService,
+                    task.getParentTaskId(),
+                    config,
+                    extractedFields,
+                    task.getStatsHolder().getProgressTracker(),
+                    task.getStatsHolder().getDataCountsTracker()
+                );
+                InferenceStep inferenceStep = new InferenceStep(client, task, auditor, config, threadPool, inferenceRunner);
+                delegate.onResponse(inferenceStep);
+            })
+        );
     }
 
     public boolean isNodeShuttingDown() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndex.java
@@ -134,9 +134,11 @@ public final class DestinationIndex {
         AtomicReference<Settings> settingsHolder = new AtomicReference<>();
         AtomicReference<MappingMetadata> mappingsHolder = new AtomicReference<>();
 
-        ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesListener = ActionListener.wrap(fieldCapabilitiesResponse -> {
-            listener.onResponse(createIndexRequest(clock, config, settingsHolder.get(), mappingsHolder.get(), fieldCapabilitiesResponse));
-        }, listener::onFailure);
+        ActionListener<FieldCapabilitiesResponse> fieldCapabilitiesListener = listener.delegateFailureAndWrap(
+            (l, fieldCapabilitiesResponse) -> l.onResponse(
+                createIndexRequest(clock, config, settingsHolder.get(), mappingsHolder.get(), fieldCapabilitiesResponse)
+            )
+        );
 
         ActionListener<MappingMetadata> mappingsListener = ActionListener.wrap(mappings -> {
             mappingsHolder.set(mappings);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/DataFrameDataExtractorFactory.java
@@ -147,22 +147,22 @@ public class DataFrameDataExtractorFactory {
         ActionListener<DataFrameDataExtractorFactory> listener
     ) {
         ExtractedFieldsDetectorFactory extractedFieldsDetectorFactory = new ExtractedFieldsDetectorFactory(client);
-        extractedFieldsDetectorFactory.createFromDest(config, ActionListener.wrap(extractedFieldsDetector -> {
+        extractedFieldsDetectorFactory.createFromDest(config, listener.delegateFailureAndWrap((delegate, extractedFieldsDetector) -> {
             ExtractedFields extractedFields = extractedFieldsDetector.detect().v1();
-
-            DataFrameDataExtractorFactory extractorFactory = new DataFrameDataExtractorFactory(
-                client,
-                config.getId(),
-                Collections.singletonList(config.getDest().getIndex()),
-                config.getSource().getParsedQuery(),
-                extractedFields,
-                config.getAnalysis().getRequiredFields(),
-                config.getHeaders(),
-                config.getAnalysis().supportsMissingValues(),
-                createTrainTestSplitterFactory(client, config, extractedFields),
-                Collections.emptyMap()
+            delegate.onResponse(
+                new DataFrameDataExtractorFactory(
+                    client,
+                    config.getId(),
+                    Collections.singletonList(config.getDest().getIndex()),
+                    config.getSource().getParsedQuery(),
+                    extractedFields,
+                    config.getAnalysis().getRequiredFields(),
+                    config.getHeaders(),
+                    config.getAnalysis().supportsMissingValues(),
+                    createTrainTestSplitterFactory(client, config, extractedFields),
+                    Collections.emptyMap()
+                )
             );
-            listener.onResponse(extractorFactory);
-        }, listener::onFailure));
+        }));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/extractor/ExtractedFieldsDetectorFactory.java
@@ -112,11 +112,6 @@ public class ExtractedFieldsDetectorFactory {
             return;
         }
 
-        ActionListener<SearchResponse> searchListener = ActionListener.wrap(
-            searchResponse -> buildFieldCardinalitiesMap(config, searchResponse, listener),
-            listener::onFailure
-        );
-
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder().size(0)
             .query(config.getSource().getParsedQuery())
             .runtimeMappings(config.getSource().getRuntimeMappings());
@@ -147,7 +142,7 @@ public class ExtractedFieldsDetectorFactory {
             client,
             TransportSearchAction.TYPE,
             searchRequest,
-            searchListener
+            listener.delegateFailureAndWrap((l, searchResponse) -> buildFieldCardinalitiesMap(config, searchResponse, l))
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AbstractDataFrameAnalyticsStep.java
@@ -67,11 +67,11 @@ abstract class AbstractDataFrameAnalyticsStep implements DataFrameAnalyticsStep 
             listener.onResponse(new StepResponse(true));
             return;
         }
-        doExecute(ActionListener.wrap(stepResponse -> {
+        doExecute(listener.delegateFailureAndWrap((l, stepResponse) -> {
             // We persist progress at the end of each step to ensure we do not have
             // to repeat the step in case the node goes down without getting a chance to persist progress.
-            task.persistProgress(() -> listener.onResponse(stepResponse));
-        }, listener::onFailure));
+            task.persistProgress(() -> l.onResponse(stepResponse));
+        }));
     }
 
     protected abstract void doExecute(ActionListener<StepResponse> listener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AnalysisStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/AnalysisStep.java
@@ -58,17 +58,16 @@ public class AnalysisStep extends AbstractDataFrameAnalyticsStep {
 
         final ParentTaskAssigningClient parentTaskClient = parentTaskClient();
         // Update state to ANALYZING and start process
-        ActionListener<DataFrameDataExtractorFactory> dataExtractorFactoryListener = ActionListener.wrap(
-            dataExtractorFactory -> processManager.runJob(task, config, dataExtractorFactory, listener),
-            listener::onFailure
+        ActionListener<DataFrameDataExtractorFactory> dataExtractorFactoryListener = listener.delegateFailureAndWrap(
+            (l, dataExtractorFactory) -> processManager.runJob(task, config, dataExtractorFactory, l)
         );
 
-        ActionListener<BroadcastResponse> refreshListener = ActionListener.wrap(refreshResponse -> {
+        ActionListener<BroadcastResponse> refreshListener = dataExtractorFactoryListener.delegateFailureAndWrap((l, refreshResponse) -> {
             // TODO This could fail with errors. In that case we get stuck with the copied index.
             // We could delete the index in case of failure or we could try building the factory before reindexing
             // to catch the error early on.
-            DataFrameDataExtractorFactory.createForDestinationIndex(parentTaskClient, config, dataExtractorFactoryListener);
-        }, dataExtractorFactoryListener::onFailure);
+            DataFrameDataExtractorFactory.createForDestinationIndex(parentTaskClient, config, l);
+        });
 
         // First we need to refresh the dest index to ensure data is searchable in case the job
         // was stopped after reindexing was complete but before the index was refreshed.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/FinalStep.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/dataframe/steps/FinalStep.java
@@ -59,18 +59,13 @@ public class FinalStep extends AbstractDataFrameAnalyticsStep {
 
     @Override
     protected void doExecute(ActionListener<StepResponse> listener) {
-
-        ActionListener<BroadcastResponse> refreshListener = ActionListener.wrap(
-            refreshResponse -> listener.onResponse(new StepResponse(false)),
-            listener::onFailure
+        indexDataCounts(
+            listener.delegateFailureAndWrap(
+                (l, indexResponse) -> refreshIndices(
+                    l.delegateFailureAndWrap((ll, refreshResponse) -> ll.onResponse(new StepResponse(false)))
+                )
+            )
         );
-
-        ActionListener<DocWriteResponse> dataCountsIndexedListener = ActionListener.wrap(
-            indexResponse -> refreshIndices(refreshListener),
-            listener::onFailure
-        );
-
-        indexDataCounts(dataCountsIndexedListener);
     }
 
     private void indexDataCounts(ActionListener<DocWriteResponse> listener) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -142,14 +142,8 @@ public class JobManager {
      *                    a ResourceNotFoundException is returned
      */
     public void getJob(String jobId, ActionListener<Job> jobListener) {
-        jobConfigProvider.getJob(
-            jobId,
-            null,
-            ActionListener.wrap(
-                r -> jobListener.onResponse(r.build()), // TODO JIndex we shouldn't be building the job here
-                jobListener::onFailure
-            )
-        );
+        // TODO JIndex we shouldn't be building the job here
+        jobConfigProvider.getJob(jobId, null, jobListener.delegateFailureAndWrap((l, r) -> l.onResponse(r.build())));
     }
 
     /**
@@ -183,15 +177,14 @@ public class JobManager {
             expression,
             allowNoMatch,
             null,
-            ActionListener.wrap(
-                jobBuilders -> jobsListener.onResponse(
+            jobsListener.delegateFailureAndWrap(
+                (l, jobBuilders) -> l.onResponse(
                     new QueryPage<>(
                         jobBuilders.stream().map(Job.Builder::build).collect(Collectors.toList()),
                         jobBuilders.size(),
                         Job.RESULTS_FIELD
                     )
-                ),
-                jobsListener::onFailure
+                )
             )
         );
     }
@@ -253,10 +246,10 @@ public class JobManager {
             @Override
             public void onResponse(Boolean mappingsUpdated) {
 
-                jobConfigProvider.putJob(job, ActionListener.wrap(response -> {
+                jobConfigProvider.putJob(job, actionListener.delegateFailureAndWrap((l, response) -> {
                     auditor.info(job.getId(), Messages.getMessage(Messages.JOB_AUDIT_CREATED));
-                    actionListener.onResponse(new PutJobAction.Response(job));
-                }, actionListener::onFailure));
+                    l.onResponse(new PutJobAction.Response(job));
+                }));
             }
 
             @Override
@@ -275,17 +268,16 @@ public class JobManager {
             }
         };
 
-        ActionListener<Boolean> addDocMappingsListener = ActionListener.wrap(
-            indicesCreated -> ElasticsearchMappings.addDocMappingIfMissing(
+        ActionListener<Boolean> addDocMappingsListener = putJobListener.delegateFailureAndWrap(
+            (l, indicesCreated) -> ElasticsearchMappings.addDocMappingIfMissing(
                 MlConfigIndex.indexName(),
                 MlConfigIndex::mapping,
                 client,
                 state,
                 request.masterNodeTimeout(),
-                putJobListener,
+                l,
                 MlConfigIndex.CONFIG_INDEX_MAPPINGS_VERSION
-            ),
-            putJobListener::onFailure
+            )
         );
 
         ActionListener<List<String>> checkForLeftOverDocs = ActionListener.wrap(matchedIds -> {
@@ -634,14 +626,15 @@ public class JobManager {
         // calendarJobIds may be a group or job
         jobConfigProvider.expandGroupIds(
             calendarJobIds,
-            ActionListener.wrap(expandedIds -> threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
-                // Merge the expanded group members with the request Ids.
-                // Ids that aren't jobs will be filtered by isJobOpen()
-                expandedIds.addAll(calendarJobIds);
-
-                openJobIds.retainAll(expandedIds);
-                submitJobEventUpdate(openJobIds, updateListener);
-            }), updateListener::onFailure)
+            updateListener.delegateFailureAndWrap(
+                (delegate, expandedIds) -> threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME).execute(() -> {
+                    // Merge the expanded group members with the request Ids.
+                    // Ids that aren't jobs will be filtered by isJobOpen()
+                    expandedIds.addAll(calendarJobIds);
+                    openJobIds.retainAll(expandedIds);
+                    submitJobEventUpdate(openJobIds, delegate);
+                })
+            )
         );
     }
 
@@ -678,12 +671,13 @@ public class JobManager {
             jobResultsPersister.persistQuantiles(
                 modelSnapshot.getQuantiles(),
                 WriteRequest.RefreshPolicy.IMMEDIATE,
-                ActionListener.wrap(quantilesResponse -> {
-                    // The quantiles can be large, and totally dominate the output -
-                    // it's clearer to remove them as they are not necessary for the revert op
-                    ModelSnapshot snapshotWithoutQuantiles = new ModelSnapshot.Builder(modelSnapshot).setQuantiles(null).build();
-                    actionListener.onResponse(new RevertModelSnapshotAction.Response(snapshotWithoutQuantiles));
-                }, actionListener::onFailure)
+                // The quantiles can be large, and totally dominate the output -
+                // it's clearer to remove them as they are not necessary for the revert op
+                actionListener.delegateFailureAndWrap(
+                    (l, quantilesResponse) -> l.onResponse(
+                        new RevertModelSnapshotAction.Response(new ModelSnapshot.Builder(modelSnapshot).setQuantiles(null).build())
+                    )
+                )
             );
         };
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/AbstractExpiredJobDataRemover.java
@@ -70,19 +70,19 @@ abstract class AbstractExpiredJobDataRemover implements MlDataRemover {
             return;
         }
 
-        calcCutoffEpochMs(job.getId(), retentionDays, ActionListener.wrap(response -> {
+        calcCutoffEpochMs(job.getId(), retentionDays, listener.delegateFailureAndWrap((delegate, response) -> {
             if (response == null) {
-                removeData(jobIterator, requestsPerSecond, listener, isTimedOutSupplier);
+                removeData(jobIterator, requestsPerSecond, delegate, isTimedOutSupplier);
             } else {
                 removeDataBefore(
                     job,
                     requestsPerSecond,
                     response.latestTimeMs,
                     response.cutoffEpochMs,
-                    ActionListener.wrap(r -> removeData(jobIterator, requestsPerSecond, listener, isTimedOutSupplier), listener::onFailure)
+                    delegate.delegateFailureAndWrap((l, r) -> removeData(jobIterator, requestsPerSecond, l, isTimedOutSupplier))
                 );
             }
-        }, listener::onFailure));
+        }));
     }
 
     abstract void calcCutoffEpochMs(String jobId, long retentionDays, ActionListener<CutoffDetails> listener);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredModelSnapshotsRemover.java
@@ -249,7 +249,7 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
             return;
         }
         JobDataDeleter deleter = new JobDataDeleter(client, jobId);
-        deleter.deleteModelSnapshots(modelSnapshots, ActionListener.wrap(bulkResponse -> {
+        deleter.deleteModelSnapshots(modelSnapshots, listener.delegateFailureAndWrap((l, bulkResponse) -> {
             auditor.info(jobId, Messages.getMessage(Messages.JOB_AUDIT_SNAPSHOTS_DELETED, modelSnapshots.size()));
             LOGGER.debug(
                 () -> format(
@@ -259,8 +259,8 @@ public class ExpiredModelSnapshotsRemover extends AbstractExpiredJobDataRemover 
                     modelSnapshots.stream().map(ModelSnapshot::getDescription).collect(toList())
                 )
             );
-            listener.onResponse(true);
-        }, listener::onFailure));
+            l.onResponse(true);
+        }));
     }
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemover.java
@@ -195,11 +195,11 @@ public class ExpiredResultsRemover extends AbstractExpiredJobDataRemover {
         searchRequest.indicesOptions(MlIndicesUtils.addIgnoreUnavailable(SearchRequest.DEFAULT_INDICES_OPTIONS));
         searchRequest.setParentTask(parentTaskId);
 
-        client.search(searchRequest, ActionListener.wrap(response -> {
+        client.search(searchRequest, listener.delegateFailureAndWrap((delegate, response) -> {
             SearchHit[] hits = response.getHits().getHits();
             if (hits.length == 0) {
                 // no buckets found
-                listener.onResponse(null);
+                delegate.onResponse(null);
             } else {
 
                 try (
@@ -210,12 +210,12 @@ public class ExpiredResultsRemover extends AbstractExpiredJobDataRemover {
                     )
                 ) {
                     Bucket bucket = Bucket.LENIENT_PARSER.apply(parser, null);
-                    listener.onResponse(bucket.getTimestamp().getTime());
+                    delegate.onResponse(bucket.getTimestamp().getTime());
                 } catch (IOException e) {
-                    listener.onFailure(new ElasticsearchParseException("failed to parse bucket", e));
+                    delegate.onFailure(new ElasticsearchParseException("failed to parse bucket", e));
                 }
             }
-        }, listener::onFailure));
+        }));
     }
 
     private void auditResultsWereDeleted(String jobId, long cutoffEpochMs) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutor.java
@@ -398,18 +398,18 @@ public class OpenJobPersistentTasksExecutor extends AbstractJobPersistentTasksEx
     }
 
     private void getRunningDatafeed(String jobId, ActionListener<String> listener) {
-        ActionListener<Set<String>> datafeedListener = ActionListener.wrap(datafeeds -> {
+        ActionListener<Set<String>> datafeedListener = listener.delegateFailureAndWrap((delegate, datafeeds) -> {
             assert datafeeds.size() <= 1;
             if (datafeeds.isEmpty()) {
-                listener.onResponse(null);
+                delegate.onResponse(null);
                 return;
             }
 
             String datafeedId = datafeeds.iterator().next();
             PersistentTasksCustomMetadata tasks = clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
             PersistentTasksCustomMetadata.PersistentTask<?> datafeedTask = MlTasks.getDatafeedTask(datafeedId, tasks);
-            listener.onResponse(datafeedTask != null ? datafeedId : null);
-        }, listener::onFailure);
+            delegate.onResponse(datafeedTask != null ? datafeedId : null);
+        });
 
         datafeedConfigProvider.findDatafeedIdsForJobIds(Collections.singleton(jobId), datafeedListener);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/EmptyStateIndexRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/EmptyStateIndexRemoverTests.java
@@ -27,6 +27,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 import java.util.Map;
@@ -57,6 +58,7 @@ public class EmptyStateIndexRemoverTests extends ESTestCase {
         client = mock(Client.class);
         OriginSettingClient originSettingClient = MockOriginSettingClient.mockOriginSettingClient(client, ClientHelper.ML_ORIGIN);
         listener = mock(ActionListener.class);
+        when(listener.delegateFailureAndWrap(any())).thenCallRealMethod();
         deleteIndexRequestCaptor = ArgumentCaptor.forClass(DeleteIndexRequest.class);
 
         remover = new EmptyStateIndexRemover(originSettingClient, new TaskId("test", 0L));
@@ -66,6 +68,7 @@ public class EmptyStateIndexRemoverTests extends ESTestCase {
     public void verifyNoOtherInteractionsWithMocks() {
         verify(client).settings();
         verify(client, atLeastOnce()).threadPool();
+        verify(listener, Mockito.atLeast(0)).delegateFailureAndWrap(any());
         verifyNoMoreInteractions(client, listener);
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredAnnotationsRemoverTests.java
@@ -60,6 +60,7 @@ public class ExpiredAnnotationsRemoverTests extends ESTestCase {
         client = mock(Client.class);
         originSettingClient = MockOriginSettingClient.mockOriginSettingClient(client, ClientHelper.ML_ORIGIN);
         listener = mock(ActionListener.class);
+        when(listener.delegateFailureAndWrap(any())).thenCallRealMethod();
     }
 
     public void testRemove_GivenNoJobs() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemoverTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/retention/ExpiredResultsRemoverTests.java
@@ -60,6 +60,7 @@ public class ExpiredResultsRemoverTests extends ESTestCase {
         client = mock(Client.class);
         originSettingClient = MockOriginSettingClient.mockOriginSettingClient(client, ClientHelper.ML_ORIGIN);
         listener = mock(ActionListener.class);
+        when(listener.delegateFailureAndWrap(any())).thenCallRealMethod();
     }
 
     public void testRemove_GivenNoJobs() {


### PR DESCRIPTION
Found a bunch more spots where this shortcut helps save both memory and brainpower for thinking through potential leaks.
=> made use of it and sometimes also inlined a couple local variables for readability.

