### PR TITLE
Avoid eager loading Netty classes in Netty4Plugin

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/ESNetty4IntegTestCase.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/ESNetty4IntegTestCase.java
@@ -12,7 +12,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.transport.netty4.Netty4Plugin;
-import org.elasticsearch.transport.netty4.Netty4Transport;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -29,7 +28,7 @@ public abstract class ESNetty4IntegTestCase extends ESIntegTestCase {
         Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal, otherSettings));
         // randomize netty settings
         if (randomBoolean()) {
-            builder.put(Netty4Transport.WORKER_COUNT.getKey(), random().nextInt(3) + 1);
+            builder.put(Netty4Plugin.WORKER_COUNT.getKey(), random().nextInt(3) + 1);
         }
         builder.put(NetworkModule.TRANSPORT_TYPE_KEY, Netty4Plugin.NETTY_TRANSPORT_NAME);
         builder.put(NetworkModule.HTTP_TYPE_KEY, Netty4Plugin.NETTY_HTTP_TRANSPORT_NAME);

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Plugin.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Plugin.java
@@ -16,8 +16,11 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.http.HttpPreRequest;
 import org.elasticsearch.http.HttpServerTransport;
@@ -38,24 +41,99 @@ import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import static org.elasticsearch.common.settings.Setting.byteSizeSetting;
+import static org.elasticsearch.common.settings.Setting.intSetting;
+import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH;
+
 public class Netty4Plugin extends Plugin implements NetworkPlugin {
 
     public static final String NETTY_TRANSPORT_NAME = "netty4";
     public static final String NETTY_HTTP_TRANSPORT_NAME = "netty4";
+    public static final Setting<Integer> SETTING_HTTP_WORKER_COUNT = Setting.intSetting(
+        "http.netty.worker_count",
+        0,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<ByteSizeValue> SETTING_HTTP_NETTY_RECEIVE_PREDICTOR_SIZE = byteSizeSetting(
+        "http.netty.receive_predictor_size",
+        new ByteSizeValue(64, ByteSizeUnit.KB),
+        Setting.Property.NodeScope
+    );
+    public static final Setting<Integer> WORKER_COUNT = new Setting<>(
+        "transport.netty.worker_count",
+        (s) -> Integer.toString(EsExecutors.allocatedProcessors(s)),
+        (s) -> Setting.parseInt(s, 1, "transport.netty.worker_count"),
+        Setting.Property.NodeScope
+    );
+    private static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_SIZE = byteSizeSetting(
+        "transport.netty.receive_predictor_size",
+        new ByteSizeValue(64, ByteSizeUnit.KB),
+        Setting.Property.NodeScope
+    );
+    public static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_MAX = byteSizeSetting(
+        "transport.netty.receive_predictor_max",
+        NETTY_RECEIVE_PREDICTOR_SIZE,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_MIN = byteSizeSetting(
+        "transport.netty.receive_predictor_min",
+        NETTY_RECEIVE_PREDICTOR_SIZE,
+        Setting.Property.NodeScope
+    );
+    public static final Setting<Integer> NETTY_BOSS_COUNT = intSetting("transport.netty.boss_count", 1, 1, Setting.Property.NodeScope);
+    /*
+     * Size in bytes of an individual message received by io.netty.handler.codec.MessageAggregator which accumulates the content for an
+     * HTTP request. This number is used for estimating the maximum number of allowed buffers before the MessageAggregator's internal
+     * collection of buffers is resized.
+     *
+     * By default we assume the Ethernet MTU (1500 bytes) but users can override it with a system property.
+     */
+    private static final ByteSizeValue MTU = ByteSizeValue.ofBytes(Long.parseLong(System.getProperty("es.net.mtu", "1500")));
+    private static final String SETTING_KEY_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS = "http.netty.max_composite_buffer_components";
+    public static Setting<Integer> SETTING_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS = new Setting<>(
+        SETTING_KEY_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS,
+        (s) -> {
+            ByteSizeValue maxContentLength = SETTING_HTTP_MAX_CONTENT_LENGTH.get(s);
+            /*
+             * Netty accumulates buffers containing data from all incoming network packets that make up one HTTP request in an instance of
+             * io.netty.buffer.CompositeByteBuf (think of it as a buffer of buffers). Once its capacity is reached, the buffer will iterate
+             * over its individual entries and put them into larger buffers (see io.netty.buffer.CompositeByteBuf#consolidateIfNeeded()
+             * for implementation details). We want to to resize that buffer because this leads to additional garbage on the heap and also
+             * increases the application's native memory footprint (as direct byte buffers hold their contents off-heap).
+             *
+             * With this setting we control the CompositeByteBuf's capacity (which is by default 1024, see
+             * io.netty.handler.codec.MessageAggregator#DEFAULT_MAX_COMPOSITEBUFFER_COMPONENTS). To determine a proper default capacity for
+             * that buffer, we need to consider that the upper bound for the size of HTTP requests is determined by `maxContentLength`. The
+             * number of buffers that are needed depend on how often Netty reads network packets which depends on the network type (MTU).
+             * We assume here that Elasticsearch receives HTTP requests via an Ethernet connection which has a MTU of 1500 bytes.
+             *
+             * Note that we are *not* pre-allocating any memory based on this setting but rather determine the CompositeByteBuf's capacity.
+             * The tradeoff is between less (but larger) buffers that are contained in the CompositeByteBuf and more (but smaller) buffers.
+             * With the default max content length of 100MB and a MTU of 1500 bytes we would allow 69905 entries.
+             */
+            long maxBufferComponentsEstimate = Math.round((double) (maxContentLength.getBytes() / MTU.getBytes()));
+            // clamp value to the allowed range
+            long maxBufferComponents = Math.max(2, Math.min(maxBufferComponentsEstimate, Integer.MAX_VALUE));
+            return String.valueOf(maxBufferComponents);
+            // Netty's CompositeByteBuf implementation does not allow less than two components.
+        },
+        s -> Setting.parseInt(s, 2, Integer.MAX_VALUE, SETTING_KEY_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS),
+        Setting.Property.NodeScope
+    );
 
     private final SetOnce<SharedGroupFactory> groupFactory = new SetOnce<>();
 
     @Override
     public List<Setting<?>> getSettings() {
         return Arrays.asList(
-            Netty4HttpServerTransport.SETTING_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS,
-            Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT,
-            Netty4HttpServerTransport.SETTING_HTTP_NETTY_RECEIVE_PREDICTOR_SIZE,
-            Netty4Transport.WORKER_COUNT,
-            Netty4Transport.NETTY_RECEIVE_PREDICTOR_SIZE,
-            Netty4Transport.NETTY_RECEIVE_PREDICTOR_MIN,
-            Netty4Transport.NETTY_RECEIVE_PREDICTOR_MAX,
-            Netty4Transport.NETTY_BOSS_COUNT
+            SETTING_HTTP_NETTY_MAX_COMPOSITE_BUFFER_COMPONENTS,
+            SETTING_HTTP_WORKER_COUNT,
+            SETTING_HTTP_NETTY_RECEIVE_PREDICTOR_SIZE,
+            WORKER_COUNT,
+            NETTY_RECEIVE_PREDICTOR_SIZE,
+            NETTY_RECEIVE_PREDICTOR_MIN,
+            NETTY_RECEIVE_PREDICTOR_MAX,
+            NETTY_BOSS_COUNT
         );
     }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4Transport.java
@@ -31,10 +31,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.recycler.Recycler;
-import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -54,8 +51,6 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Map;
 
-import static org.elasticsearch.common.settings.Setting.byteSizeSetting;
-import static org.elasticsearch.common.settings.Setting.intSetting;
 import static org.elasticsearch.common.util.concurrent.ConcurrentCollections.newConcurrentMap;
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.transport.RemoteClusterPortSettings.REMOTE_CLUSTER_PROFILE;
@@ -70,30 +65,6 @@ import static org.elasticsearch.transport.RemoteClusterPortSettings.REMOTE_CLUST
 public class Netty4Transport extends TcpTransport {
     private static final Logger logger = LogManager.getLogger(Netty4Transport.class);
 
-    public static final Setting<Integer> WORKER_COUNT = new Setting<>(
-        "transport.netty.worker_count",
-        (s) -> Integer.toString(EsExecutors.allocatedProcessors(s)),
-        (s) -> Setting.parseInt(s, 1, "transport.netty.worker_count"),
-        Property.NodeScope
-    );
-
-    public static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_SIZE = Setting.byteSizeSetting(
-        "transport.netty.receive_predictor_size",
-        new ByteSizeValue(64, ByteSizeUnit.KB),
-        Property.NodeScope
-    );
-    public static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_MIN = byteSizeSetting(
-        "transport.netty.receive_predictor_min",
-        NETTY_RECEIVE_PREDICTOR_SIZE,
-        Property.NodeScope
-    );
-    public static final Setting<ByteSizeValue> NETTY_RECEIVE_PREDICTOR_MAX = byteSizeSetting(
-        "transport.netty.receive_predictor_max",
-        NETTY_RECEIVE_PREDICTOR_SIZE,
-        Property.NodeScope
-    );
-
-    public static final Setting<Integer> NETTY_BOSS_COUNT = intSetting("transport.netty.boss_count", 1, 1, Property.NodeScope);
     public static final ChannelOption<Integer> OPTION_TCP_KEEP_IDLE = NioChannelOption.of(NetUtils.getTcpKeepIdleSocketOption());
     public static final ChannelOption<Integer> OPTION_TCP_KEEP_INTERVAL = NioChannelOption.of(NetUtils.getTcpKeepIntervalSocketOption());
     public static final ChannelOption<Integer> OPTION_TCP_KEEP_COUNT = NioChannelOption.of(NetUtils.getTcpKeepCountSocketOption());
@@ -123,8 +94,8 @@ public class Netty4Transport extends TcpTransport {
         this.sharedGroupFactory = sharedGroupFactory;
 
         // See AdaptiveReceiveBufferSizePredictor#DEFAULT_XXX for default values in netty..., we can use higher ones for us, even fixed one
-        this.receivePredictorMin = NETTY_RECEIVE_PREDICTOR_MIN.get(settings);
-        this.receivePredictorMax = NETTY_RECEIVE_PREDICTOR_MAX.get(settings);
+        this.receivePredictorMin = Netty4Plugin.NETTY_RECEIVE_PREDICTOR_MIN.get(settings);
+        this.receivePredictorMax = Netty4Plugin.NETTY_RECEIVE_PREDICTOR_MAX.get(settings);
         if (receivePredictorMax.getBytes() == receivePredictorMin.getBytes()) {
             recvByteBufAllocator = new FixedRecvByteBufAllocator((int) receivePredictorMax.getBytes());
         } else {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/SharedGroupFactory.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/SharedGroupFactory.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.http.HttpServerTransport;
-import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import org.elasticsearch.transport.TcpTransport;
 
 import java.util.concurrent.TimeUnit;
@@ -29,7 +28,7 @@ import static org.elasticsearch.common.util.concurrent.EsExecutors.daemonThreadF
 /**
  * Creates and returns {@link io.netty.channel.EventLoopGroup} instances. It will return a shared group for
  * both {@link #getHttpGroup()} and {@link #getTransportGroup()} if
- * {@link org.elasticsearch.http.netty4.Netty4HttpServerTransport#SETTING_HTTP_WORKER_COUNT} is configured to be 0.
+ * {@link Netty4Plugin#SETTING_HTTP_WORKER_COUNT} is configured to be 0.
  * If that setting is not 0, then it will return a different group in the {@link #getHttpGroup()} call.
  */
 public final class SharedGroupFactory {
@@ -45,8 +44,8 @@ public final class SharedGroupFactory {
 
     public SharedGroupFactory(Settings settings) {
         this.settings = settings;
-        this.workerCount = Netty4Transport.WORKER_COUNT.get(settings);
-        this.httpWorkerCount = Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.get(settings);
+        this.workerCount = Netty4Plugin.WORKER_COUNT.get(settings);
+        this.httpWorkerCount = Netty4Plugin.SETTING_HTTP_WORKER_COUNT.get(settings);
     }
 
     public Settings getSettings() {

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -78,6 +78,7 @@ import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.netty4.Netty4Plugin;
 import org.elasticsearch.transport.netty4.NettyAllocator;
 import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.transport.netty4.TLSConfig;
@@ -889,7 +890,7 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
 
     public void testMultipleValidationsOnTheSameChannel() throws InterruptedException {
         // ensure that there is a single channel active
-        final Settings settings = createBuilderWithPort().put(Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.getKey(), 1).build();
+        final Settings settings = createBuilderWithPort().put(Netty4Plugin.SETTING_HTTP_WORKER_COUNT.getKey(), 1).build();
         final Set<String> okURIs = ConcurrentHashMap.newKeySet();
         final Set<String> nokURIs = ConcurrentHashMap.newKeySet();
         final SetOnce<Channel> channelSetOnce = new SetOnce<>();

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SharedGroupFactoryTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SharedGroupFactoryTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.transport.netty4;
 
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.http.netty4.Netty4HttpServerTransport;
 import org.elasticsearch.test.ESTestCase;
 
 public final class SharedGroupFactoryTests extends ESTestCase {
@@ -37,9 +36,7 @@ public final class SharedGroupFactoryTests extends ESTestCase {
     }
 
     public void testNonSharedEventLoops() throws Exception {
-        Settings settings = Settings.builder()
-            .put(Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.getKey(), randomIntBetween(1, 10))
-            .build();
+        Settings settings = Settings.builder().put(Netty4Plugin.SETTING_HTTP_WORKER_COUNT.getKey(), randomIntBetween(1, 10)).build();
         SharedGroupFactory sharedGroupFactory = new SharedGroupFactory(settings);
         SharedGroupFactory.SharedGroup httpGroup = sharedGroupFactory.getHttpGroup();
         SharedGroupFactory.SharedGroup transportGroup = sharedGroupFactory.getTransportGroup();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/NativeRealmIntegTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/NativeRealmIntegTestCase.java
@@ -11,7 +11,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.transport.netty4.Netty4Transport;
+import org.elasticsearch.transport.netty4.Netty4Plugin;
 import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.security.user.APMSystemUser;
 import org.elasticsearch.xpack.core.security.user.BeatsSystemUser;
@@ -63,7 +63,7 @@ public abstract class NativeRealmIntegTestCase extends SecurityIntegTestCase {
         // we are randomly running a large number of nodes in these tests so we limit the number of worker threads
         // since the default of 2 * CPU count might use up too much direct memory for thread-local direct buffers for each node's
         // transport threads
-        builder.put(Netty4Transport.WORKER_COUNT.getKey(), random().nextInt(3) + 1);
+        builder.put(Netty4Plugin.WORKER_COUNT.getKey(), random().nextInt(3) + 1);
         return builder.build();
     }
 


### PR DESCRIPTION
When using the secure Netty4 transport (common case these days) we still load the Netty4Plugin in a separate classloader. Prior to this change this would result in 0.5M+ of needless class-loading by loading the `Netty4Transport` and `Netty4HttpServerTransportTests` classes. Moving the settings constants (no other changes than that in here) to the plugin makes it so that none of these are loaded and the plugin when unused consumes a trivial 30kB of meta-space.
