### PR TITLE
Fix testTimeoutRejectionBehaviourAtSubmission

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -2121,12 +2121,11 @@ public class MasterServiceTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/105890")
     public void testTimeoutRejectionBehaviourAtSubmission() {
 
         final var source = randomIdentifier();
         final var taskDescription = randomIdentifier();
-        final var timeout = TimeValue.timeValueMillis(between(0, 100000));
+        final var timeout = TimeValue.timeValueMillis(between(1, 100000));
 
         final var actionCount = new AtomicInteger();
         final var deterministicTaskQueue = new DeterministicTaskQueue();


### PR DESCRIPTION
This test relies on the task being rejected when creating the timeout
handler, but a zero timeout requires no timeout handler so the test
doesn't work.

Closes #105890