### PR TITLE
Simplify TransportGetSnapshotsAction#sortSnapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -524,7 +524,8 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             if (size == GetSnapshotsRequest.NO_LIMIT) {
                 return new SnapshotsInRepo(resultsStream.toList(), totalCount, 0);
             } else {
-                final var results = new ArrayList<SnapshotInfo>(size);
+                final var allocateSize = Math.min(size, 1000); // ignore excessively-large sizes in request params
+                final var results = new ArrayList<SnapshotInfo>(allocateSize);
                 var remaining = 0;
                 for (var iterator = resultsStream.iterator(); iterator.hasNext();) {
                     final var snapshotInfo = iterator.next();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -519,7 +519,26 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             return sortSnapshots(snapshotInfos.stream(), snapshotInfos.size(), 0, GetSnapshotsRequest.NO_LIMIT);
         }
 
-        private SnapshotsInRepo sortSnapshots(Stream<SnapshotInfo> infos, int totalCount, int offset, int size) {
+        private SnapshotsInRepo sortSnapshots(Stream<SnapshotInfo> snapshotInfoStream, int totalCount, int offset, int size) {
+            final var resultsStream = snapshotInfoStream.filter(buildAfterPredicate()).sorted(buildComparator()).skip(offset);
+            if (size == GetSnapshotsRequest.NO_LIMIT) {
+                return new SnapshotsInRepo(resultsStream.toList(), totalCount, 0);
+            } else {
+                final var results = new ArrayList<SnapshotInfo>(size);
+                var remaining = 0;
+                for (var iterator = resultsStream.iterator(); iterator.hasNext();) {
+                    final var snapshotInfo = iterator.next();
+                    if (results.size() < size) {
+                        results.add(snapshotInfo);
+                    } else {
+                        remaining += 1;
+                    }
+                }
+                return new SnapshotsInRepo(results, totalCount, remaining);
+            }
+        }
+
+        private Comparator<SnapshotInfo> buildComparator() {
             final Comparator<SnapshotInfo> comparator = switch (sortBy) {
                 case START_TIME -> BY_START_TIME;
                 case NAME -> BY_NAME;
@@ -529,26 +548,16 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 case FAILED_SHARDS -> BY_FAILED_SHARDS_COUNT;
                 case REPOSITORY -> BY_REPOSITORY;
             };
-
-            if (after != null) {
-                assert offset == 0 : "can't combine after and offset but saw [" + after + "] and offset [" + offset + "]";
-                infos = infos.filter(buildAfterPredicate());
-            }
-            infos = infos.sorted(order == SortOrder.DESC ? comparator.reversed() : comparator).skip(offset);
-            final List<SnapshotInfo> allSnapshots = infos.toList();
-            final List<SnapshotInfo> snapshots;
-            if (size != GetSnapshotsRequest.NO_LIMIT) {
-                snapshots = allSnapshots.stream().limit(size + 1).toList();
-            } else {
-                snapshots = allSnapshots;
-            }
-            final List<SnapshotInfo> resultSet = size != GetSnapshotsRequest.NO_LIMIT && size < snapshots.size()
-                ? snapshots.subList(0, size)
-                : snapshots;
-            return new SnapshotsInRepo(resultSet, totalCount, allSnapshots.size() - resultSet.size());
+            return order == SortOrder.DESC ? comparator.reversed() : comparator;
         }
 
         private Predicate<SnapshotInfo> buildAfterPredicate() {
+            if (after == null) {
+                // TODO use constant when https://github.com/elastic/elasticsearch/pull/105881 merged
+                return snapshotInfo -> true;
+            }
+            assert offset == 0 : "can't combine after and offset but saw [" + after + "] and offset [" + offset + "]";
+
             final String snapshotName = after.snapshotName();
             final String repoName = after.repoName();
             final String value = after.value();


### PR DESCRIPTION
No need to copy all the matching snapshots into a separate list before
applying the size limit, we can allocate the final list straight away.