### PR TITLE
[DOCS] Adds cohere service example to the inference API tutorial

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -4,18 +4,21 @@
 <titleabbrev>Semantic search with the {infer} API</titleabbrev>
 ++++
 
-The instructions in this tutorial shows you how to use the {infer} API with the
-Open AI service to perform semantic search on your data. The following example
-uses OpenAI's `text-embedding-ada-002` second generation embedding model. You
-can use any OpenAI models, they are all supported by the {infer} API.
+The instructions in this tutorial shows you how to use the {infer} API with
+various services to perform semantic search on your data. The following examples 
+use the OpenAI's `text-embedding-ada-002` second generation embedding model and 
+Cohere's `embed-english-light-v3.0` model. You can use any OpenAI and Cohere 
+models, they are all supported by the {infer} API.
+
+Click the name of the service you want to use on any of the widgets below to
+review the corresponding instructions.
 
 
 [discrete]
-[[infer-openai-requirements]]
+[[infer-service-requirements]]
 ==== Requirements
 
-An https://openai.com/[OpenAI account] is required to use the {infer} API with
-the OpenAI service.
+include::{es-repo-dir}/tab-widgets/inference-api/infer-api-requirements-widget.asciidoc[]
 
 
 [discrete]
@@ -24,113 +27,30 @@ the OpenAI service.
 
 Create the {infer} task by using the <<put-inference-api>>:
 
-[source,console]
-------------------------------------------------------------
-PUT _inference/text_embedding/openai_embeddings <1>
-{
-    "service": "openai",
-    "service_settings": {
-        "api_key": "<api_key>" <2>
-    },
-    "task_settings": {
-       "model": "text-embedding-ada-002" <3>
-    }
-}
-------------------------------------------------------------
-// TEST[skip:TBD]
-<1> The task type is `text_embedding` in the path.
-<2> The API key of your OpenAI account. You can find your OpenAI API keys in
-your OpenAI account under the
-https://platform.openai.com/api-keys[API keys section]. You need to provide
-your API key only once. The <<get-inference-api>> does not return your API
-key.
-<3> The name of the embedding model to use. You can find the list of OpenAI
-embedding models
-https://platform.openai.com/docs/guides/embeddings/embedding-models[here].
+include::{es-repo-dir}/tab-widgets/inference-api/infer-api-task-widget.asciidoc[]
 
 
 [discrete]
-[[infer-openai-mappings]]
+[[infer-service-mappings]]
 ==== Create the index mapping
 
 The mapping of the destination index - the index that contains the embeddings
 that the model will create based on your input text - must be created. The
 destination index must have a field with the <<dense-vector, `dense_vector`>>
-field type to index the output of the OpenAI model.
+field type to index the output of the used model.
 
-[source,console]
---------------------------------------------------
-PUT openai-embeddings
-{
-  "mappings": {
-    "properties": {
-      "content_embedding": { <1>
-        "type": "dense_vector", <2>
-        "dims": 1536, <3>
-        "element_type": "float",
-        "similarity": "dot_product" <4>
-      },
-      "content": { <5>
-        "type": "text" <6>
-      }
-    }
-  }
-}
---------------------------------------------------
-<1> The name of the field to contain the generated tokens. It must be refrenced
-in the {infer} pipeline configuration in the next step.
-<2> The field to contain the tokens is a `dense_vector` field.
-<3> The output dimensions of the model. Find this value in the
-https://platform.openai.com/docs/guides/embeddings/embedding-models[OpenAI documentation]
-of the model you use.
-<4> The faster` dot_product` function can be used to calculate similarity
-because OpenAI embeddings are normalised to unit length. You can check the
-https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use[OpenAI docs]
-about which similarity function to use.
-<5> The name of the field from which to create the sparse vector representation.
-In this example, the name of the field is `content`. It must be referenced in
-the {infer} pipeline configuration in the next step.
-<6> The field type which is text in this example.
+include::{es-repo-dir}/tab-widgets/inference-api/infer-api-mapping-widget.asciidoc[]
 
 
 [discrete]
-[[infer-openai-inference-ingest-pipeline]]
+[[infer-service-inference-ingest-pipeline]]
 ==== Create an ingest pipeline with an inference processor
 
 Create an <<ingest,ingest pipeline>> with an
-<<inference-processor,{infer} processor>> and use the OpenAI model you created
-above to infer against the data that is being ingested in the
-pipeline.
+<<inference-processor,{infer} processor>> and use the model you created above to
+infer against the data that is being ingested in the pipeline.
 
-[source,console]
---------------------------------------------------
-PUT _ingest/pipeline/openai_embeddings
-{
-  "processors": [
-    {
-      "inference": {
-        "model_id": "openai_embeddings", <1>
-        "input_output": { <2>
-          "input_field": "content",
-          "output_field": "content_embedding"
-        }
-      }
-    }
-  ]
-}
---------------------------------------------------
-<1> The name of the inference model you created by using the
-<<put-inference-api>>.
-<2> Configuration object that defines the `input_field` for the {infer} process
-and the `output_field` that will contain the {infer} results.
-
-////
-[source,console]
-----
-DELETE _ingest/pipeline/openai_embeddings
-----
-// TEST[continued]
-////
+include::{es-repo-dir}/tab-widgets/inference-api/infer-api-ingest-pipeline-widget.asciidoc[]
 
 
 [discrete]
@@ -158,31 +78,9 @@ you can see an index named `test-data` with 182469 documents.
 ==== Ingest the data through the {infer} ingest pipeline
 
 Create the embeddings from the text by reindexing the data throught the {infer}
-pipeline that uses the OpenAI model as the inference model.
+pipeline that uses the chosen model as the inference model.
 
-[source,console]
-----
-POST _reindex?wait_for_completion=false
-{
-  "source": {
-    "index": "test-data",
-    "size": 50 <1>
-  },
-  "dest": {
-    "index": "openai-embeddings",
-    "pipeline": "openai_embeddings"
-  }
-}
-----
-// TEST[skip:TBD]
-<1> The default batch size for reindexing is 1000. Reducing `size` to a smaller
-number makes the update of the reindexing process quicker which enables you to
-follow the progress closely and detect errors early.
-
-NOTE: The
-https://platform.openai.com/account/limits[rate limit of your OpenAI account]
-may affect the throughput of the reindexing process. If this happens, change
-`size` to `3` or a similar value in magnitude.
+include::{es-repo-dir}/tab-widgets/inference-api/infer-api-reindex-widget.asciidoc[]
 
 The call returns a task ID to monitor the progress:
 
@@ -214,63 +112,4 @@ provide the query text and the model you have used to create the embeddings.
 NOTE: If you cancelled the reindexing process, you run the query only a part of
 the data which affects the quality of your results.
 
-[source,console]
---------------------------------------------------
-GET openai-embeddings/_search
-{
-  "knn": {
-    "field": "content_embedding",
-    "query_vector_builder": {
-      "text_embedding": {
-        "model_id": "openai_embeddings",
-        "model_text": "Calculate fuel cost"
-      }
-    },
-    "k": 10,
-    "num_candidates": 100
-  },
-  "_source": [
-    "id",
-    "content"
-  ]
-}
---------------------------------------------------
-// TEST[skip:TBD]
-
-As a result, you receive the top 10 documents that are closest in meaning to the
-query from the `openai-embeddings` index sorted by their proximity to the query:
-
-[source,consol-result]
---------------------------------------------------
-"hits": [
-      {
-        "_index": "openai-embeddings",
-        "_id": "DDd5OowBHxQKHyc3TDSC",
-        "_score": 0.83704096,
-        "_source": {
-          "id": 862114,
-          "body": "How to calculate fuel cost for a road trip. By Tara Baukus Mello • Bankrate.com. Dear Driving for Dollars, My family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost.It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes.y family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost. It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes."
-        }
-      },
-      {
-        "_index": "openai-embeddings",
-        "_id": "ajd5OowBHxQKHyc3TDSC",
-        "_score": 0.8345704,
-        "_source": {
-          "id": 820622,
-          "body": "Home Heating Calculator. Typically, approximately 50% of the energy consumed in a home annually is for space heating. When deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important.This calculator can help you estimate the cost of fuel for different heating appliances.hen deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important. This calculator can help you estimate the cost of fuel for different heating appliances."
-        }
-      },
-      {
-        "_index": "openai-embeddings",
-        "_id": "Djd5OowBHxQKHyc3TDSC",
-        "_score": 0.8327426,
-        "_source": {
-          "id": 8202683,
-          "body": "Fuel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel.If you are paying $4 per gallon, the trip would cost you $200.Most boats have much larger gas tanks than cars.uel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel."
-        }
-      },
-      (...)
-    ]
---------------------------------------------------
-// NOTCONSOLE
+include::{es-repo-dir}/tab-widgets/inference-api/infer-api-search-widget.asciidoc[]

--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -6,9 +6,9 @@
 
 The instructions in this tutorial shows you how to use the {infer} API with
 various services to perform semantic search on your data. The following examples 
-use the OpenAI's `text-embedding-ada-002` second generation embedding model and 
-Cohere's `embed-english-light-v3.0` model. You can use any OpenAI and Cohere 
-models, they are all supported by the {infer} API.
+use Cohere's `embed-english-light-v3.0` model and OpenAI's 
+`text-embedding-ada-002` second generation embedding model. You can use any
+Cohere and OpenAI models, they are all supported by the {infer} API.
 
 Click the name of the service you want to use on any of the widgets below to
 review the corresponding instructions.

--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -77,7 +77,7 @@ you can see an index named `test-data` with 182469 documents.
 [[reindexing-data-infer]]
 ==== Ingest the data through the {infer} ingest pipeline
 
-Create the embeddings from the text by reindexing the data throught the {infer}
+Create the embeddings from the text by reindexing the data through the {infer}
 pipeline that uses the chosen model as the inference model.
 
 include::{es-repo-dir}/tab-widgets/inference-api/infer-api-reindex-widget.asciidoc[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="model">
+  <div role="tablist" aria-label="model">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="infer-api-ingest-cohere-tab"
+            id="infer-api-ingest-cohere">
+      Cohere
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-ingest-openai-tab"
+            id="infer-api-ingest-openai">
+      OpenAI
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-ingest-cohere-tab"
+       aria-labelledby="infer-api-ingest-cohere">
+++++
+
+include::infer-api-ingest-pipeline.asciidoc[tag=cohere]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-ingest-openai-tab"
+       aria-labelledby="infer-api-ingest-openai"
+       hidden="">
+++++
+
+include::infer-api-ingest-pipeline.asciidoc[tag=openai]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
@@ -1,0 +1,70 @@
+////
+
+[source,console]
+----
+DELETE _ingest/pipeline/cohere_embeddings
+----
+// TEST
+// TEARDOWN
+
+[source,console]
+----
+DELETE _ingest/pipeline/openai_embeddings
+----
+// TEST
+// TEARDOWN
+
+////
+
+// tag::cohere[]
+
+[source,console]
+--------------------------------------------------
+PUT _ingest/pipeline/cohere_embeddings
+{
+  "processors": [
+    {
+      "inference": {
+        "model_id": "cohere_embeddings", <1>
+        "input_output": { <2>
+          "input_field": "content",
+          "output_field": "content_embedding"
+        }
+      }
+    }
+  ]
+}
+--------------------------------------------------
+<1> The name of the inference model you created by using the
+<<put-inference-api>>.
+<2> Configuration object that defines the `input_field` for the {infer} process
+and the `output_field` that will contain the {infer} results.
+
+// end::cohere[]
+
+
+// tag::openai[]
+
+[source,console]
+--------------------------------------------------
+PUT _ingest/pipeline/openai_embeddings
+{
+  "processors": [
+    {
+      "inference": {
+        "model_id": "openai_embeddings", <1>
+        "input_output": { <2>
+          "input_field": "content",
+          "output_field": "content_embedding"
+        }
+      }
+    }
+  ]
+}
+--------------------------------------------------
+<1> The name of the inference model you created by using the
+<<put-inference-api>>.
+<2> Configuration object that defines the `input_field` for the {infer} process
+and the `output_field` that will contain the {infer} results.
+
+// end::openai[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
@@ -2,14 +2,7 @@
 
 [source,console]
 ----
-DELETE _ingest/pipeline/cohere_embeddings
-----
-// TEST
-// TEARDOWN
-
-[source,console]
-----
-DELETE _ingest/pipeline/openai_embeddings
+DELETE _ingest/pipeline/*_embeddings
 ----
 // TEST
 // TEARDOWN

--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
@@ -18,7 +18,7 @@ PUT _ingest/pipeline/cohere_embeddings
   "processors": [
     {
       "inference": {
-        "inference_id": "cohere_embeddings", <1>
+        "model_id": "cohere_embeddings", <1>
         "input_output": { <2>
           "input_field": "content",
           "output_field": "content_embedding"
@@ -45,7 +45,7 @@ PUT _ingest/pipeline/openai_embeddings
   "processors": [
     {
       "inference": {
-        "inference_id": "openai_embeddings", <1>
+        "model_id": "openai_embeddings", <1>
         "input_output": { <2>
           "input_field": "content",
           "output_field": "content_embedding"

--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
@@ -18,7 +18,7 @@ PUT _ingest/pipeline/cohere_embeddings
   "processors": [
     {
       "inference": {
-        "model_id": "cohere_embeddings", <1>
+        "inference_id": "cohere_embeddings", <1>
         "input_output": { <2>
           "input_field": "content",
           "output_field": "content_embedding"
@@ -28,7 +28,7 @@ PUT _ingest/pipeline/cohere_embeddings
   ]
 }
 --------------------------------------------------
-<1> The name of the inference model you created by using the
+<1> The name of the inference configuration you created by using the
 <<put-inference-api>>.
 <2> Configuration object that defines the `input_field` for the {infer} process
 and the `output_field` that will contain the {infer} results.
@@ -45,7 +45,7 @@ PUT _ingest/pipeline/openai_embeddings
   "processors": [
     {
       "inference": {
-        "model_id": "openai_embeddings", <1>
+        "inference_id": "openai_embeddings", <1>
         "input_output": { <2>
           "input_field": "content",
           "output_field": "content_embedding"
@@ -55,7 +55,7 @@ PUT _ingest/pipeline/openai_embeddings
   ]
 }
 --------------------------------------------------
-<1> The name of the inference model you created by using the
+<1> The name of the inference configuration you created by using the
 <<put-inference-api>>.
 <2> Configuration object that defines the `input_field` for the {infer} process
 and the `output_field` that will contain the {infer} results.

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="model">
+  <div role="tablist" aria-label="model">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="infer-api-mapping-cohere-tab"
+            id="infer-api-mapping-cohere">
+      Cohere
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-mapping-openai-tab"
+            id="infer-api-mapping-openai">
+      OpenAI
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-mapping-cohere-tab"
+       aria-labelledby="infer-api-mapping-cohere">
+++++
+
+include::infer-api-mapping.asciidoc[tag=cohere]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-mapping-openai-tab"
+       aria-labelledby="infer-api-mapping-openai"
+       hidden="">
+++++
+
+include::infer-api-mapping.asciidoc[tag=openai]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
@@ -1,0 +1,71 @@
+// tag::cohere[]
+
+[source,console]
+--------------------------------------------------
+PUT cohere-embeddings
+{
+  "mappings": {
+    "properties": {
+      "content_embedding": { <1>
+        "type": "dense_vector", <2>
+        "dims": 384, <3>
+        "element_type": "float"
+      },
+      "content": { <4>
+        "type": "text" <5>
+      }
+    }
+  }
+}
+--------------------------------------------------
+<1> The name of the field to contain the generated tokens. It must be refrenced
+in the {infer} pipeline configuration in the next step.
+<2> The field to contain the tokens is a `dense_vector` field.
+<3> The output dimensions of the model. Find this value in the
+https://docs.cohere.com/reference/embed[Cohere documentation] of the model you
+use.
+<4> The name of the field from which to create the sparse vector representation.
+In this example, the name of the field is `content`. It must be referenced in
+the {infer} pipeline configuration in the next step.
+<5> The field type which is text in this example.
+
+// end::cohere[]
+
+
+// tag::openai[]
+
+[source,console]
+--------------------------------------------------
+PUT openai-embeddings
+{
+  "mappings": {
+    "properties": {
+      "content_embedding": { <1>
+        "type": "dense_vector", <2>
+        "dims": 1536, <3>
+        "element_type": "float",
+        "similarity": "dot_product" <4>
+      },
+      "content": { <5>
+        "type": "text" <6>
+      }
+    }
+  }
+}
+--------------------------------------------------
+<1> The name of the field to contain the generated tokens. It must be refrenced
+in the {infer} pipeline configuration in the next step.
+<2> The field to contain the tokens is a `dense_vector` field.
+<3> The output dimensions of the model. Find this value in the
+https://platform.openai.com/docs/guides/embeddings/embedding-models[OpenAI documentation]
+of the model you use.
+<4> The faster` dot_product` function can be used to calculate similarity
+because OpenAI embeddings are normalised to unit length. You can check the
+https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use[OpenAI docs]
+about which similarity function to use.
+<5> The name of the field from which to create the sparse vector representation.
+In this example, the name of the field is `content`. It must be referenced in
+the {infer} pipeline configuration in the next step.
+<6> The field type which is text in this example.
+
+// end::openai[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
@@ -24,7 +24,7 @@ in the {infer} pipeline configuration in the next step.
 <3> The output dimensions of the model. Find this value in the
 https://docs.cohere.com/reference/embed[Cohere documentation] of the model you
 use.
-<4> The name of the field from which to create the sparse vector representation.
+<4> The name of the field from which to create the dense vector representation.
 In this example, the name of the field is `content`. It must be referenced in
 the {infer} pipeline configuration in the next step.
 <5> The field type which is text in this example.
@@ -63,7 +63,7 @@ of the model you use.
 because OpenAI embeddings are normalised to unit length. You can check the
 https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use[OpenAI docs]
 about which similarity function to use.
-<5> The name of the field from which to create the sparse vector representation.
+<5> The name of the field from which to create the dense vector representation.
 In this example, the name of the field is `content`. It must be referenced in
 the {infer} pipeline configuration in the next step.
 <6> The field type which is text in this example.

--- a/docs/reference/tab-widgets/inference-api/infer-api-reindex-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-reindex-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="model">
+  <div role="tablist" aria-label="model">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="infer-api-reindex-cohere-tab"
+            id="infer-api-reindex-cohere">
+      Cohere
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-reindex-openai-tab"
+            id="infer-api-reindex-openai">
+      OpenAI
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-reindex-cohere-tab"
+       aria-labelledby="infer-api-reindex-cohere">
+++++
+
+include::infer-api-reindex.asciidoc[tag=cohere]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-reindex-openai-tab"
+       aria-labelledby="infer-api-reindex-openai"
+       hidden="">
+++++
+
+include::infer-api-reindex.asciidoc[tag=openai]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/inference-api/infer-api-reindex.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-reindex.asciidoc
@@ -1,0 +1,55 @@
+// tag::cohere[]
+
+[source,console]
+----
+POST _reindex?wait_for_completion=false
+{
+  "source": {
+    "index": "test-data",
+    "size": 50 <1>
+  },
+  "dest": {
+    "index": "cohere-embeddings",
+    "pipeline": "cohere_embeddings"
+  }
+}
+----
+// TEST[skip:TBD]
+<1> The default batch size for reindexing is 1000. Reducing `size` to a smaller
+number makes the update of the reindexing process quicker which enables you to
+follow the progress closely and detect errors early.
+
+NOTE: The
+https://dashboard.cohere.com/billing[rate limit of your Cohere account]
+may affect the throughput of the reindexing process.
+
+// end::cohere[]
+
+
+// tag::openai[]
+
+[source,console]
+----
+POST _reindex?wait_for_completion=false
+{
+  "source": {
+    "index": "test-data",
+    "size": 50 <1>
+  },
+  "dest": {
+    "index": "openai-embeddings",
+    "pipeline": "openai_embeddings"
+  }
+}
+----
+// TEST[skip:TBD]
+<1> The default batch size for reindexing is 1000. Reducing `size` to a smaller
+number makes the update of the reindexing process quicker which enables you to
+follow the progress closely and detect errors early.
+
+NOTE: The
+https://platform.openai.com/account/limits[rate limit of your OpenAI account]
+may affect the throughput of the reindexing process. If this happens, change
+`size` to `3` or a similar value in magnitude.
+
+// end::openai[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-requirements-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-requirements-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="model">
+  <div role="tablist" aria-label="model">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="infer-api-requirements-cohere-tab"
+            id="infer-api-requirements-cohere">
+      Cohere
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-requirements-openai-tab"
+            id="infer-api-requirements-openai">
+      OpenAI
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-requirements-cohere-tab"
+       aria-labelledby="infer-api-requirements-cohere">
+++++
+
+include::infer-api-requirements.asciidoc[tag=cohere]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-requirements-openai-tab"
+       aria-labelledby="infer-api-requirements-openai"
+       hidden="">
+++++
+
+include::infer-api-requirements.asciidoc[tag=openai]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/inference-api/infer-api-requirements.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-requirements.asciidoc
@@ -1,0 +1,14 @@
+// tag::cohere[]
+
+A https://cohere.com/[Cohere account] is required to use the {infer} API with
+the Cohere service.
+
+// end::cohere[]
+
+
+// tag::openai[]
+
+An https://openai.com/[OpenAI account] is required to use the {infer} API with
+the OpenAI service.
+
+// end::openai[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-search-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="model">
+  <div role="tablist" aria-label="model">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="infer-api-search-cohere-tab"
+            id="infer-api-search-cohere">
+      Cohere
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-search-openai-tab"
+            id="infer-api-search-openai">
+      OpenAI
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-search-cohere-tab"
+       aria-labelledby="infer-api-search-cohere">
+++++
+
+include::infer-api-search.asciidoc[tag=cohere]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-search-openai-tab"
+       aria-labelledby="infer-api-search-openai"
+       hidden="">
+++++
+
+include::infer-api-search.asciidoc[tag=openai]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
@@ -30,30 +30,39 @@ query from the `cohere-embeddings` index sorted by their proximity to the query:
 --------------------------------------------------
 "hits": [
       {
-        "_index": "openai-embeddings",
-        "_id": "DDd5OowBHxQKHyc3TDSC",
-        "_score": 0.83704096,
+        "_index": "cohere-embeddings",
+        "_id": "-eFWCY4BECzWLnMZuI78",
+        "_score": 0.737484,
         "_source": {
-          "id": 862114,
-          "body": "How to calculate fuel cost for a road trip. By Tara Baukus Mello • Bankrate.com. Dear Driving for Dollars, My family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost.It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes.y family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost. It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes."
+          "id": 1690948,
+          "content": "Oxygen is supplied to the muscles via red blood cells. Red blood cells carry hemoglobin which oxygen bonds with as the hemoglobin rich blood cells pass through the blood vessels of the lungs.The now oxygen rich blood cells carry that oxygen to the cells that are demanding it, in this case skeletal muscle cells.ther ways in which muscles are supplied with oxygen include: 1  Blood flow from the heart is increased. 2  Blood flow to your muscles in increased. 3  Blood flow from nonessential organs is transported to working muscles."
         }
       },
       {
-        "_index": "openai-embeddings",
-        "_id": "ajd5OowBHxQKHyc3TDSC",
-        "_score": 0.8345704,
+        "_index": "cohere-embeddings",
+        "_id": "HuFWCY4BECzWLnMZuI_8",
+        "_score": 0.7176013,
         "_source": {
-          "id": 820622,
-          "body": "Home Heating Calculator. Typically, approximately 50% of the energy consumed in a home annually is for space heating. When deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important.This calculator can help you estimate the cost of fuel for different heating appliances.hen deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important. This calculator can help you estimate the cost of fuel for different heating appliances."
+          "id": 1692482,
+          "content": "The thoracic cavity is separated from the abdominal cavity by the  diaphragm. This is a broad flat muscle.    (muscular) diaphragm The diaphragm is a muscle that separat…e the thoracic from the abdominal cavity. The pelvis is the lowest part of the abdominal cavity and it has no physical separation from it    Diaphragm."
         }
       },
       {
-        "_index": "openai-embeddings",
-        "_id": "Djd5OowBHxQKHyc3TDSC",
-        "_score": 0.8327426,
+        "_index": "cohere-embeddings",
+        "_id": "IOFWCY4BECzWLnMZuI_8",
+        "_score": 0.7154432,
         "_source": {
-          "id": 8202683,
-          "body": "Fuel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel.If you are paying $4 per gallon, the trip would cost you $200.Most boats have much larger gas tanks than cars.uel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel."
+          "id": 1692489,
+          "content": "Muscular Wall Separating the Abdominal and Thoracic Cavities; Thoracic Cavity of a Fetal Pig; In Mammals the Diaphragm Separates the Abdominal Cavity from the"
+        }
+      },
+      {
+        "_index": "cohere-embeddings",
+        "_id": "C-FWCY4BECzWLnMZuI_8",
+        "_score": 0.695313,
+        "_source": {
+          "id": 1691493,
+          "content": "Burning, aching, tenderness and stiffness are just some descriptors of the discomfort you may feel in the muscles you exercised one to two days ago.For the most part, these sensations you experience after exercise are collectively known as delayed onset muscle soreness.urning, aching, tenderness and stiffness are just some descriptors of the discomfort you may feel in the muscles you exercised one to two days ago."
         }
       },
       (...)

--- a/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
@@ -1,0 +1,130 @@
+// tag::cohere[]
+
+[source,console]
+--------------------------------------------------
+GET cohere-embeddings/_search
+{
+  "knn": {
+    "field": "content_embedding",
+    "query_vector_builder": {
+      "text_embedding": {
+        "model_id": "cohere_embeddings",
+        "model_text": "Calculate fuel cost"
+      }
+    },
+    "k": 10,
+    "num_candidates": 100
+  },
+  "_source": [
+    "id",
+    "content"
+  ]
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+
+As a result, you receive the top 10 documents that are closest in meaning to the
+query from the `cohere-embeddings` index sorted by their proximity to the query:
+
+[source,consol-result]
+--------------------------------------------------
+"hits": [
+      {
+        "_index": "openai-embeddings",
+        "_id": "DDd5OowBHxQKHyc3TDSC",
+        "_score": 0.83704096,
+        "_source": {
+          "id": 862114,
+          "body": "How to calculate fuel cost for a road trip. By Tara Baukus Mello • Bankrate.com. Dear Driving for Dollars, My family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost.It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes.y family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost. It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes."
+        }
+      },
+      {
+        "_index": "openai-embeddings",
+        "_id": "ajd5OowBHxQKHyc3TDSC",
+        "_score": 0.8345704,
+        "_source": {
+          "id": 820622,
+          "body": "Home Heating Calculator. Typically, approximately 50% of the energy consumed in a home annually is for space heating. When deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important.This calculator can help you estimate the cost of fuel for different heating appliances.hen deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important. This calculator can help you estimate the cost of fuel for different heating appliances."
+        }
+      },
+      {
+        "_index": "openai-embeddings",
+        "_id": "Djd5OowBHxQKHyc3TDSC",
+        "_score": 0.8327426,
+        "_source": {
+          "id": 8202683,
+          "body": "Fuel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel.If you are paying $4 per gallon, the trip would cost you $200.Most boats have much larger gas tanks than cars.uel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel."
+        }
+      },
+      (...)
+    ]
+--------------------------------------------------
+// NOTCONSOLE
+
+// end::cohere[]
+
+
+// tag::openai[]
+
+[source,console]
+--------------------------------------------------
+GET openai-embeddings/_search
+{
+  "knn": {
+    "field": "content_embedding",
+    "query_vector_builder": {
+      "text_embedding": {
+        "model_id": "openai_embeddings",
+        "model_text": "Calculate fuel cost"
+      }
+    },
+    "k": 10,
+    "num_candidates": 100
+  },
+  "_source": [
+    "id",
+    "content"
+  ]
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+
+As a result, you receive the top 10 documents that are closest in meaning to the
+query from the `openai-embeddings` index sorted by their proximity to the query:
+
+[source,consol-result]
+--------------------------------------------------
+"hits": [
+      {
+        "_index": "openai-embeddings",
+        "_id": "DDd5OowBHxQKHyc3TDSC",
+        "_score": 0.83704096,
+        "_source": {
+          "id": 862114,
+          "body": "How to calculate fuel cost for a road trip. By Tara Baukus Mello • Bankrate.com. Dear Driving for Dollars, My family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost.It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes.y family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost. It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes."
+        }
+      },
+      {
+        "_index": "openai-embeddings",
+        "_id": "ajd5OowBHxQKHyc3TDSC",
+        "_score": 0.8345704,
+        "_source": {
+          "id": 820622,
+          "body": "Home Heating Calculator. Typically, approximately 50% of the energy consumed in a home annually is for space heating. When deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important.This calculator can help you estimate the cost of fuel for different heating appliances.hen deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important. This calculator can help you estimate the cost of fuel for different heating appliances."
+        }
+      },
+      {
+        "_index": "openai-embeddings",
+        "_id": "Djd5OowBHxQKHyc3TDSC",
+        "_score": 0.8327426,
+        "_source": {
+          "id": 8202683,
+          "body": "Fuel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel.If you are paying $4 per gallon, the trip would cost you $200.Most boats have much larger gas tanks than cars.uel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel."
+        }
+      },
+      (...)
+    ]
+--------------------------------------------------
+// NOTCONSOLE
+
+// end::openai[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-task-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task-widget.asciidoc
@@ -1,0 +1,39 @@
+++++
+<div class="tabs" data-tab-group="model">
+  <div role="tablist" aria-label="model">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="infer-api-task-cohere-tab"
+            id="infer-api-task-cohere">
+      Cohere
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-task-openai-tab"
+            id="infer-api-task-openai">
+      OpenAI
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-task-cohere-tab"
+       aria-labelledby="infer-api-task-cohere">
+++++
+
+include::infer-api-task.asciidoc[tag=cohere]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-task-openai-tab"
+       aria-labelledby="infer-api-task-openai"
+       hidden="">
+++++
+
+include::infer-api-task.asciidoc[tag=openai]
+
+++++
+  </div>
+</div>
+++++

--- a/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
@@ -7,7 +7,8 @@ PUT _inference/text_embedding/cohere_embeddings <1>
     "service": "cohere",
     "service_settings": {
         "api_key": "<api_key>", <2>
-        "model": "embed-english-light-v3.0" <3>
+        "model_id": "embed-english-light-v3.0", <3>
+        "embedding_type": "int8"
     },
     "task_settings": {
     }
@@ -34,10 +35,10 @@ PUT _inference/text_embedding/openai_embeddings <1>
 {
     "service": "openai",
     "service_settings": {
-        "api_key": "<api_key>" <2>
+        "api_key": "<api_key>", <2>
+        "model_id": "text-embedding-ada-002" <3>
     },
     "task_settings": {
-       "model": "text-embedding-ada-002" <3>
     }
 }
 ------------------------------------------------------------

--- a/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
@@ -1,0 +1,55 @@
+// tag::cohere[]
+
+[source,console]
+------------------------------------------------------------
+PUT _inference/text_embedding/cohere_embeddings <1>
+{
+    "service": "cohere",
+    "service_settings": {
+        "api_key": "<api_key>", <2>
+        "model": "embed-english-light-v3.0" <3>
+    },
+    "task_settings": {
+    }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+<1> The task type is `text_embedding` in the path.
+<2> The API key of your Cohere account. You can find your API keys in your
+Cohere dashboard under the
+https://dashboard.cohere.com/api-keys[API keys section]. You need to provide
+your API key only once. The <<get-inference-api>> does not return your API
+key.
+<3> The name of the embedding model to use. You can find the list of Cohere
+embedding models https://docs.cohere.com/reference/embed[here].
+
+// end::cohere[]
+
+
+// tag::openai[]
+
+[source,console]
+------------------------------------------------------------
+PUT _inference/text_embedding/openai_embeddings <1>
+{
+    "service": "openai",
+    "service_settings": {
+        "api_key": "<api_key>" <2>
+    },
+    "task_settings": {
+       "model": "text-embedding-ada-002" <3>
+    }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+<1> The task type is `text_embedding` in the path.
+<2> The API key of your OpenAI account. You can find your OpenAI API keys in
+your OpenAI account under the
+https://platform.openai.com/api-keys[API keys section]. You need to provide
+your API key only once. The <<get-inference-api>> does not return your API
+key.
+<3> The name of the embedding model to use. You can find the list of OpenAI
+embedding models
+https://platform.openai.com/docs/guides/embeddings/embedding-models[here].
+
+// end::openai[]


### PR DESCRIPTION
## Overview

This PR adds an inference API example that uses the `cohere` service to the Inference API tutorial. The PR reworks the page to use tabular widgets in the instructions which make it possible to cover both the `cohere` and the `openai` service cases on the same page. The widgets are extendable.

### Preview

[Semantic search with the inference API](https://elasticsearch_bk_105904.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-inference.html)