### PR TITLE
[7.17] Fix :plugins:repository-hdfs:forbiddenApisJavaRestTest (#102983)

### DIFF
--- a/plugins/repository-hdfs/build.gradle
+++ b/plugins/repository-hdfs/build.gradle
@@ -187,7 +187,11 @@ for (int hadoopVersion = minTestedHadoopVersion; hadoopVersion <= maxTestedHadoo
                 }
             }
             testClassesDirs = sourceSets.javaRestTest.output.classesDirs
-            classpath = sourceSets.javaRestTest.runtimeClasspath + files(portsFileDir)
+            // Set the keytab files in the classpath so that we can access them from test code without the security manager
+            // freaking out.
+            classpath = sourceSets.javaRestTest.runtimeClasspath +
+              configurations.krb5Keytabs +
+              files(portsFileDir)
         }
     }
 

--- a/test/fixtures/krb5kdc-fixture/build.gradle
+++ b/test/fixtures/krb5kdc-fixture/build.gradle
@@ -52,6 +52,6 @@ artifacts {
     builtBy("postProcessFixture")
   }
   krb5KeytabsHdfsDir(file("$testFixturesDir/shared/hdfs/keytabs/")) {
-    builtBy("preProcessFixture")
+    builtBy("postProcessFixture")
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fix :plugins:repository-hdfs:forbiddenApisJavaRestTest (#102983)](https://github.com/elastic/elasticsearch/pull/102983)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)