### PR TITLE
Update health YAML REST test skip version

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -2,7 +2,7 @@
 "cluster health basic test":
   - skip:
       version: "- 8.6.99"
-      reason: "health was only added in 8.2.0, and master_is_stable in 8.4.0"
+      reason: "health was added in 8.2.0, master_is_stable in 8.4.0, and REST API updated in 8.7"
 
   - do:
       health_report: { }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -1,7 +1,7 @@
 ---
 "cluster health basic test":
   - skip:
-      version: "- 8.3.99"
+      version: "- 8.6.99"
       reason: "health was only added in 8.2.0, and master_is_stable in 8.4.0"
 
   - do:


### PR DESCRIPTION
The health report API changed names in https://github.com/elastic/elasticsearch/pull/92879, which causes this YAML REST test to fail in versions < 8.7.0.

Closes #105923 