### PR TITLE
Fix: old node_selector syntax from new esql test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/120_profile.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/120_profile.yml
@@ -121,11 +121,10 @@ setup:
 ---
 avg 8.14 or after:
   - skip:
-      features: ["node_selector"]
+      version: " - 8.13.99"
+      reason: "avg changed starting 8.14"
 
   - do:
-      node_selector:
-        version: "8.13.99 - "
       esql.query:
         body:
           query: 'FROM test | STATS AVG(data) | LIMIT 1'


### PR DESCRIPTION
An usage of version in node_selector sneaked in between CI testing of #103954 and its merge. 
This fixes it and restore working builds.

I am changing it to a version-based skip; after https://github.com/elastic/elasticsearch/pull/105763 is merged we can review if this is better expressed as a cluster feature-based check.