### PR TITLE
Ignore America/Pangnirtung and Pacific/Kanton in timezone tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
@@ -46,7 +46,9 @@ public class DateUtilsTests extends ESTestCase {
             "America/Godthab", // part of tzdata2020a (maps to America/Nuuk)
             "America/Nuuk", // part of tzdata2020a
             "America/Ciudad_Juarez", // part of tzdata2022g
-            "Europe/Kyiv" // part of tzdata2022c
+            "America/Pangnirtung", // part of tzdata2022g
+            "Europe/Kyiv", // part of tzdata2022c,
+            "Pacific/Kanton" // part of tzdata2021b
         )
     );
 


### PR DESCRIPTION
Ignore more timezones on 7.17 due to updates to timezone db on various jdks.
Related to #105841