### PR TITLE
Fix HeapBufferedAsyncResponseConsumer limit heap memory usage for chunked responses

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/HeapBufferedAsyncResponseConsumerTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/HeapBufferedAsyncResponseConsumerTests.java
@@ -123,7 +123,21 @@ public class HeapBufferedAsyncResponseConsumerTests extends RestClientTestCase {
     public void testHttpAsyncResponseConsumerFactoryVisibility() throws ClassNotFoundException {
         assertEquals(Modifier.PUBLIC, HttpAsyncResponseConsumerFactory.class.getModifiers() & Modifier.PUBLIC);
     }
-
+    public void testChunkedConfiguredBufferLimit() throws Exception {
+        try {
+            new HeapBufferedAsyncResponseConsumer(randomIntBetween(Integer.MIN_VALUE, 0));
+        } catch (IllegalArgumentException e) {
+            assertEquals("bufferLimit must be greater than 0", e.getMessage());
+        }
+        try {
+            new HeapBufferedAsyncResponseConsumer(0);
+        } catch (IllegalArgumentException e) {
+            assertEquals("bufferLimit must be greater than 0", e.getMessage());
+        }
+        int bufferLimit = randomIntBetween(1, MAX_TEST_BUFFER_SIZE - 100);
+        HeapBufferedAsyncResponseConsumer consumer = new HeapBufferedAsyncResponseConsumer(bufferLimit);
+        bufferLimitTest(consumer, bufferLimit);
+    }
     private static void bufferLimitTest(HeapBufferedAsyncResponseConsumer consumer, int bufferLimit) throws Exception {
         ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
         StatusLine statusLine = new BasicStatusLine(protocolVersion, 200, "OK");

--- a/docs/changelog/105782.yaml
+++ b/docs/changelog/105782.yaml
@@ -1,0 +1,6 @@
+pr: 105781
+summary: update limit heap memory usage for chunked responses
+area: REST API
+type: bug
+issues:
+  - 105684

--- a/docs/changelog/105979.yaml
+++ b/docs/changelog/105979.yaml
@@ -1,4 +1,4 @@
-pr: 105781
+pr: 105979
 summary: update limit heap memory usage for chunked responses
 area: REST API
 type: bug


### PR DESCRIPTION
The HeapBufferedAsyncResponseConsumer is used to limit heap memory usage for responses by utilizing the Content-Length header. However, this approach becomes ineffective for responses with Transfer-Encoding: chunked as the Content-Length header does not apply in this case, making it impossible the total size of the response. To address this, I can modify the onContentReceived method of the HeapBufferedAsyncResponseConsumer to cumulatively check the bufferLimitBytes during multiple chunked reads.
https://github.com/elastic/elasticsearch/issues/105684