### PR TITLE
Improve error message for CrossClusterAsyncSearchIT test

### DIFF
--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -582,8 +582,8 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
             assertTrue(
-                "should have 'index corrupted' in reason but was: " + localShardSearchFailure.reason(),
-                localShardSearchFailure.reason().contains("index corrupted")
+                "should have 'index corrupted' in reason but was: " + remoteShardSearchFailure.reason(),
+                remoteShardSearchFailure.reason().contains("index corrupted")
             );
         } finally {
             finishedResponse.decRef();

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -566,7 +566,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
             assertThat(localClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
+            assertTrue(
+                "should have 'index corrupted' in reason but was: " + localShardSearchFailure.reason(),
+                localShardSearchFailure.reason().contains("index corrupted")
+            );
 
             SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
             assertNotNull(remoteClusterSearchInfo);
@@ -578,7 +581,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertTrue(
+                "should have 'index corrupted' in reason but was: " + localShardSearchFailure.reason(),
+                localShardSearchFailure.reason().contains("index corrupted")
+            );
         } finally {
             finishedResponse.decRef();
         }
@@ -605,7 +611,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(localClusterSearchInfo.getFailures().size(), equalTo(1));
             assertThat(localClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure localShardSearchFailure = localClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", localShardSearchFailure.reason().contains("index corrupted"));
+            assertTrue(
+                "should have 'index corrupted' in reason but was: " + localShardSearchFailure.reason(),
+                localShardSearchFailure.reason().contains("index corrupted")
+            );
 
             SearchResponse.Cluster remoteClusterSearchInfo = clusters.getCluster(REMOTE_CLUSTER);
             assertNotNull(remoteClusterSearchInfo);
@@ -617,7 +626,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertTrue(
+                "should have 'index corrupted' in reason but was: " + remoteShardSearchFailure.reason(),
+                remoteShardSearchFailure.reason().contains("index corrupted")
+            );
         }
     }
 
@@ -726,7 +738,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(remoteClusterSearchInfo.getTook());
             assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertTrue(
+                "should have 'index corrupted' in reason but was: " + remoteShardSearchFailure.reason(),
+                remoteShardSearchFailure.reason().contains("index corrupted")
+            );
         } finally {
             finishedResponse.decRef();
         }
@@ -776,7 +791,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertNull(remoteClusterSearchInfo.getTook());
             assertFalse(remoteClusterSearchInfo.isTimedOut());
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertTrue(
+                "should have 'index corrupted' in reason but was: " + remoteShardSearchFailure.reason(),
+                remoteShardSearchFailure.reason().contains("index corrupted")
+            );
         }
     }
 
@@ -1163,7 +1181,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertTrue(
+                "should have 'index corrupted' in reason but was: " + remoteShardSearchFailure.reason(),
+                remoteShardSearchFailure.reason().contains("index corrupted")
+            );
         } finally {
             finishedResponse.decRef();
         }
@@ -1192,7 +1213,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             assertThat(remoteClusterSearchInfo.getFailures().size(), equalTo(1));
             assertThat(remoteClusterSearchInfo.getTook().millis(), greaterThan(0L));
             ShardSearchFailure remoteShardSearchFailure = remoteClusterSearchInfo.getFailures().get(0);
-            assertTrue("should have 'index corrupted' in reason", remoteShardSearchFailure.reason().contains("index corrupted"));
+            assertTrue(
+                "should have 'index corrupted' in reason but was: " + remoteShardSearchFailure.reason(),
+                remoteShardSearchFailure.reason().contains("index corrupted")
+            );
         }
     }
 
@@ -1665,7 +1689,10 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
         assertNull(cluster.getTook());
         assertFalse(cluster.isTimedOut());
         ShardSearchFailure shardSearchFailure = cluster.getFailures().get(0);
-        assertTrue("should have 'index corrupted' in reason", shardSearchFailure.reason().contains("index corrupted"));
+        assertTrue(
+            "should have 'index corrupted' in reason but was: " + shardSearchFailure.reason(),
+            shardSearchFailure.reason().contains("index corrupted")
+        );
     }
 
     protected AsyncSearchResponse submitAsyncSearch(SubmitAsyncSearchRequest request) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
Will help debug issues like https://github.com/elastic/elasticsearch/issues/105865, which is a non-reproducible occasional test error.
