### PR TITLE
[7.17] Fix random timezone id selection to be consistent with DateUtilsTests.testTimezoneIds

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
@@ -21,9 +21,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 import static org.elasticsearch.common.time.DateUtils.clampToNanosRange;
 import static org.elasticsearch.common.time.DateUtils.toInstant;
@@ -35,42 +32,15 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class DateUtilsTests extends ESTestCase {
-    // list of ignored timezones.
-    // These should be cleaned up when all tested jdks (oracle, adoptopenjdk, openjdk etc) have the timezone db included
-    // see when a timezone was included in jdk version here https://www.oracle.com/java/technologies/tzdata-versions.html
-    private static final Set<String> IGNORE = new HashSet<>(
-        Arrays.asList(
-            "Eire",
-            "Europe/Dublin", // dublin timezone in joda does not account for DST
-            "Asia/Qostanay", // part of tzdata2018h
-            "America/Godthab", // part of tzdata2020a (maps to America/Nuuk)
-            "America/Nuuk", // part of tzdata2020a
-            "America/Ciudad_Juarez", // part of tzdata2022g
-            "America/Pangnirtung", // part of tzdata2022g
-            "Europe/Kyiv", // part of tzdata2022c,
-            "Pacific/Kanton" // part of tzdata2021b
-        )
-    );
-
-    // A temporary list of zones and JDKs, where Joda and the JDK timezone data are out of sync, until either Joda or the JDK
-    // are updated, see https://github.com/elastic/elasticsearch/issues/82356
-    private static final Set<String> IGNORE_IDS = new HashSet<>(Arrays.asList("Pacific/Niue", "America/Pangnirtung", "Antarctica/Vostok"));
-
-    private static boolean maybeIgnore(String jodaId) {
-        if (IGNORE_IDS.contains(jodaId)) {
-            return true;
-        }
-        return false;
-    }
 
     public void testTimezoneIds() {
         assertNull(DateUtils.dateTimeZoneToZoneId(null));
         assertNull(DateUtils.zoneIdToDateTimeZone(null));
         for (String jodaId : DateTimeZone.getAvailableIDs()) {
-            if (IGNORE.contains(jodaId) || maybeIgnore(jodaId)) continue;
+            if (IGNORED_TIMEZONE_IDS.contains(jodaId)) continue;
             DateTimeZone jodaTz = DateTimeZone.forID(jodaId);
             // some timezones get mapped back to problematic timezones
-            if (IGNORE.contains(jodaTz.toString())) continue;
+            if (IGNORED_TIMEZONE_IDS.contains(jodaTz.toString())) continue;
             ZoneId zoneId = DateUtils.dateTimeZoneToZoneId(jodaTz); // does not throw
             long now = 0;
             assertThat(

--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcIntegrationTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcIntegrationTestCase.java
@@ -22,13 +22,8 @@ import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 public abstract class JdbcIntegrationTestCase extends ESRestTestCase {
 
@@ -142,11 +137,7 @@ public abstract class JdbcIntegrationTestCase extends ESRestTestCase {
         // from all available JDK timezones. While Joda and JDK are generally in sync, some timezones might not be known
         // to the current version of Joda and in this case the test might fail. To avoid that, we specify a timezone
         // known for both Joda and JDK
-        Set<String> timeZones = new HashSet<>(JODA_TIMEZONE_IDS);
-        timeZones.retainAll(JAVA_TIMEZONE_IDS);
-        List<String> ids = new ArrayList<>(timeZones);
-        Collections.sort(ids);
-        return randomFrom(ids);
+        return randomJodaAndJavaSupportedTimezone(JAVA_TIMEZONE_IDS);
     }
 
     private static Map<String, Object> searchStats() throws IOException {

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcIntegrationTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/JdbcIntegrationTestCase.java
@@ -21,12 +21,7 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Properties;
-import java.util.Set;
 
 import static org.elasticsearch.common.Strings.hasText;
 import static org.elasticsearch.xpack.ql.TestUtils.assertNoSearchContexts;
@@ -158,10 +153,6 @@ public abstract class JdbcIntegrationTestCase extends RemoteClusterAwareSqlRestT
         // from all available JDK timezones. While Joda and JDK are generally in sync, some timezones might not be known
         // to the current version of Joda and in this case the test might fail. To avoid that, we specify a timezone
         // known for both Joda and JDK
-        Set<String> timeZones = new HashSet<>(JODA_TIMEZONE_IDS);
-        timeZones.retainAll(JAVA_TIMEZONE_IDS);
-        List<String> ids = new ArrayList<>(timeZones);
-        Collections.sort(ids);
-        return randomFrom(ids);
+        return randomJodaAndJavaSupportedTimezone(JAVA_TIMEZONE_IDS);
     }
 }


### PR DESCRIPTION
Fix random timezone id selection to be consistent with DateUtilsTests.testTimezoneIds.

Related to #105841.