### PR TITLE
ESQL: fix single valued query tests (backport of #105986)

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
@@ -77,7 +77,6 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
         testCase(new SingleValueQuery(new MatchAll(Source.EMPTY), "foo").asBuilder(), YesNoSometimes.NO, YesNoSometimes.NO, this::runCase);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/105952")
     public void testMatchSome() throws IOException {
         int max = between(1, 100);
         testCase(


### PR DESCRIPTION
In some cases the tests for our lucene query that makes sure a field is
single-valued was asserting incorrect things about the stats that come
from the query. That was failing the test from time to time. This fixes
the assertion in those cases.

Closes https://github.com/elastic/elasticsearch/issues/105918
Closes https://github.com/elastic/elasticsearch/issues/105952