### PR TITLE
ESQL: Reenable svq tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
@@ -77,7 +77,6 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
         testCase(new SingleValueQuery(new MatchAll(Source.EMPTY), "foo").asBuilder(), YesNoSometimes.NO, YesNoSometimes.NO, this::runCase);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/105952")
     public void testMatchSome() throws IOException {
         int max = between(1, 100);
         testCase(


### PR DESCRIPTION
We fixed the test failure in #105986 but this snuck in.

Closes #105952
