### PR TITLE
Fix HeapBufferedAsyncResponseConsumer limit heap memory usage for chunked responses

### DIFF
--- a/client/rest/src/test/java/org/elasticsearch/client/HeapBufferedAsyncResponseConsumerTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/HeapBufferedAsyncResponseConsumerTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.client;
 
+import org.apache.http.Consts;
 import org.apache.http.ContentTooLongException;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -26,18 +27,25 @@ import org.apache.http.ProtocolVersion;
 import org.apache.http.StatusLine;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.io.HttpTransportMetricsImpl;
+import org.apache.http.impl.nio.codecs.ChunkDecoder;
+import org.apache.http.impl.nio.reactor.SessionInputBufferImpl;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.apache.http.nio.ContentDecoder;
 import org.apache.http.nio.IOControl;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
+import org.apache.http.nio.reactor.SessionInputBuffer;
 import org.apache.http.protocol.HttpContext;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
+import java.nio.ByteBuffer;
+import java.nio.channels.ReadableByteChannel;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
-
+import java.util.concurrent.atomic.AtomicInteger;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -122,6 +130,62 @@ public class HeapBufferedAsyncResponseConsumerTests extends RestClientTestCase {
 
     public void testHttpAsyncResponseConsumerFactoryVisibility() throws ClassNotFoundException {
         assertEquals(Modifier.PUBLIC, HttpAsyncResponseConsumerFactory.class.getModifiers() & Modifier.PUBLIC);
+    }
+
+    public void testChunkedConfiguredBufferLimit() throws Exception {
+        HeapBufferedAsyncResponseConsumer consumer = new HeapBufferedAsyncResponseConsumer(MAX_TEST_BUFFER_SIZE);
+        AtomicInteger chunkCount = new AtomicInteger(0);
+        ProtocolVersion protocolVersion = new ProtocolVersion("HTTP", 1, 1);
+        StatusLine statusLine = new BasicStatusLine(protocolVersion, 200, "OK");
+        consumer.onResponseReceived(new BasicHttpResponse(statusLine));
+        HttpEntity entity = new StringEntity("", ContentType.APPLICATION_JSON) {
+            @Override
+            public long getContentLength() {
+                return -1;
+            }
+        };
+        consumer.onEntityEnclosed(entity, ContentType.APPLICATION_JSON);
+        ChunkDecoder decoder = getChunkDecoder(chunkCount);
+        try {
+            for (int i = 0; i < 100; i++) {
+                consumer.onContentReceived(decoder,null);
+            }
+        } catch (ContentTooLongException e) {
+            assertEquals(
+                "entity chunkCount is too long [" + chunkCount + "] for the configured buffer limit [" + MAX_TEST_BUFFER_SIZE + "]",
+                e.getMessage()
+            );
+        }
+    }
+
+    private ChunkDecoder getChunkDecoder(AtomicInteger chunkCount) {
+        final ReadableByteChannel channel = new ReadableByteChannel() {
+            @Override
+            public boolean isOpen() {
+                return false;
+            }
+            @Override
+            public void close(){
+
+            }
+            @Override
+            public int read(ByteBuffer dst){
+                return 0;
+            }
+        };
+
+        SessionInputBuffer inbuf = new SessionInputBufferImpl(32, 32, Consts.ASCII);
+        HttpTransportMetricsImpl metrics = new HttpTransportMetricsImpl();
+        ChunkDecoder decoder = new ChunkDecoder(channel, inbuf, metrics){
+            @Override
+            public int read(ByteBuffer dst){
+                Random random = new Random();
+                int nextInt = random.nextInt(2);
+                chunkCount.addAndGet(nextInt*TEST_BUFFER_LIMIT);
+                return nextInt*TEST_BUFFER_LIMIT;
+            }
+        };
+        return decoder;
     }
 
     private static void bufferLimitTest(HeapBufferedAsyncResponseConsumer consumer, int bufferLimit) throws Exception {

--- a/docs/changelog/105979.yaml
+++ b/docs/changelog/105979.yaml
@@ -1,0 +1,6 @@
+pr: 105979
+summary: update limit heap memory usage for chunked responses
+area: REST API
+type: bug
+issues:
+  - 105684

--- a/docs/changelog/105999.yaml
+++ b/docs/changelog/105999.yaml
@@ -1,4 +1,4 @@
-pr: 105979
+pr: 105999
 summary: update limit heap memory usage for chunked responses
 area: REST API
 type: bug


### PR DESCRIPTION
The HeapBufferedAsyncResponseConsumer is used to limit heap memory usage for responses by utilizing the Content-Length header. However, this approach becomes ineffective for responses with Transfer-Encoding: chunked as the Content-Length header does not apply in this case, making it impossible the total size of the response. To address this, I can modify the onContentReceived method of the HeapBufferedAsyncResponseConsumer to cumulatively check the bufferLimitBytes during multiple chunked reads.
https://github.com/elastic/elasticsearch/issues/105684