### PR TITLE
Minor improvement for SparseFileTracker toString

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
@@ -525,7 +525,7 @@ public class SparseFileTracker {
 
     @Override
     public String toString() {
-        return "SparseFileTracker[" + description + ']';
+        return "SparseFileTracker{description=" + description + ", length=" + length + ", complete=" + complete + '}';
     }
 
     /**

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -715,7 +715,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         CacheFileRegion(RegionKey<KeyType> regionKey, int regionSize) {
             this.regionKey = regionKey;
             assert regionSize > 0;
-            tracker = new SparseFileTracker("file", regionSize);
+            tracker = new SparseFileTracker(regionKey.toString(), regionSize);
         }
 
         public long physicalStartOffset() {

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -715,7 +715,8 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
         CacheFileRegion(RegionKey<KeyType> regionKey, int regionSize) {
             this.regionKey = regionKey;
             assert regionSize > 0;
-            tracker = new SparseFileTracker(regionKey.toString(), regionSize);
+            // NOTE we use a constant string for description to avoid consume extra heap space
+            tracker = new SparseFileTracker("file", regionSize);
         }
 
         public long physicalStartOffset() {


### PR DESCRIPTION
Include both length and complete in toString for easier introspection. Also add a comment to the choice of using a string constant (`file`) for the description.
