### PR TITLE
[8.13] [Connector API] Fix default ordering in SyncJob list endpoint (#105945)

### DIFF
--- a/docs/changelog/105945.yaml
+++ b/docs/changelog/105945.yaml
@@ -1,0 +1,5 @@
+pr: 105945
+summary: "[Connector API] Fix default ordering in `SyncJob` list endpoint"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/470_connector_sync_job_list.yml
@@ -50,10 +50,10 @@ setup:
 
   - match: { count: 3 }
 
-  # Ascending order by creation_date for results
-  - match: { results.0.id: $sync-job-one-id }
+  # Descending order by creation_date for results
+  - match: { results.0.id: $sync-job-three-id }
   - match: { results.1.id: $sync-job-two-id }
-  - match: { results.2.id: $sync-job-three-id }
+  - match: { results.2.id: $sync-job-one-id }
 
 ---
 "List Connector Sync Jobs - with from":
@@ -84,9 +84,9 @@ setup:
 
   - match: { count: 3 }
 
-  # Ascending order by creation_date for results
+  # Descending order by creation_date for results
   - match: { results.0.id: $sync-job-two-id }
-  - match: { results.1.id: $sync-job-three-id }
+  - match: { results.1.id: $sync-job-one-id }
 
 ---
 "List Connector Sync Jobs - with size":
@@ -117,7 +117,8 @@ setup:
 
   - match: { count: 3 }
 
-  - match: { results.0.id: $sync-job-one-id }
+  # Descending order by creation_date for results
+  - match: { results.0.id: $sync-job-three-id }
 
 ---
 "List Connector Sync Jobs - Get pending jobs":
@@ -216,9 +217,11 @@ setup:
       connector_sync_job.list:
         connector_id: connector-one
         job_type: full,incremental
+
+  # Descending order by creation_date for results
   - match: { count: 2 }
-  - match: { results.0.id: $sync-job-one-id }
-  - match: { results.1.id: $sync-job-two-id }
+  - match: { results.0.id: $sync-job-two-id }
+  - match: { results.1.id: $sync-job-one-id }
 
 ---
 "List Connector Sync Jobs - with invalid job type":

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -258,7 +258,7 @@ public class ConnectorSyncJobIndexService {
     }
 
     /**
-     * List the {@link ConnectorSyncJob} in ascending order of their 'created_at'.
+     * List the {@link ConnectorSyncJob} in descending order of their 'created_at'.
      *
      * @param from                  From index to start the search from.
      * @param size                  The maximum number of {@link Connector}s to return.
@@ -282,7 +282,7 @@ public class ConnectorSyncJobIndexService {
                 .size(size)
                 .query(query)
                 .fetchSource(true)
-                .sort(ConnectorSyncJob.CREATED_AT_FIELD.getPreferredName(), SortOrder.ASC);
+                .sort(ConnectorSyncJob.CREATED_AT_FIELD.getPreferredName(), SortOrder.DESC);
 
             final SearchRequest searchRequest = new SearchRequest(CONNECTOR_SYNC_JOB_INDEX_NAME).source(searchSource);
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -319,17 +319,18 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(lastSyncJobs.connectorSyncJobs().size(), equalTo(1));
         assertThat(lastSyncJobs.totalResults(), equalTo(5L));
 
-        assertThat(firstSyncJob, equalTo(syncJobs.get(0)));
-        assertThat(secondSyncJob, equalTo(syncJobs.get(1)));
+        // Sync jobs are returned in most-recently created order
+        assertThat(firstSyncJob, equalTo(syncJobs.get(4)));
+        assertThat(secondSyncJob, equalTo(syncJobs.get(3)));
         assertThat(thirdSyncJob, equalTo(syncJobs.get(2)));
-        assertThat(fourthSyncJob, equalTo(syncJobs.get(3)));
-        assertThat(fifthSyncJob, equalTo(syncJobs.get(4)));
+        assertThat(fourthSyncJob, equalTo(syncJobs.get(1)));
+        assertThat(fifthSyncJob, equalTo(syncJobs.get(0)));
 
-        // assert ordering: ascending order by creation date
-        assertTrue(fifthSyncJob.getCreatedAt().isAfter(fourthSyncJob.getCreatedAt()));
-        assertTrue(fourthSyncJob.getCreatedAt().isAfter(thirdSyncJob.getCreatedAt()));
-        assertTrue(thirdSyncJob.getCreatedAt().isAfter(secondSyncJob.getCreatedAt()));
-        assertTrue(secondSyncJob.getCreatedAt().isAfter(firstSyncJob.getCreatedAt()));
+        // assert ordering: descending order by creation date
+        assertTrue(fourthSyncJob.getCreatedAt().isAfter(fifthSyncJob.getCreatedAt()));
+        assertTrue(thirdSyncJob.getCreatedAt().isAfter(fourthSyncJob.getCreatedAt()));
+        assertTrue(secondSyncJob.getCreatedAt().isAfter(thirdSyncJob.getCreatedAt()));
+        assertTrue(firstSyncJob.getCreatedAt().isAfter(secondSyncJob.getCreatedAt()));
     }
 
     public void testListConnectorSyncJobs_WithStatusPending_GivenOnePendingTwoCancelled_ExpectOnePending() throws Exception {
@@ -535,8 +536,9 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         String idOfReturnedSyncJobTwo = connectorSyncJobsResult.connectorSyncJobs().get(1).getDocId();
 
         assertThat(numberOfResults, equalTo(2L));
-        assertThat(idOfReturnedSyncJobOne, equalTo(syncJobOneId));
-        assertThat(idOfReturnedSyncJobTwo, equalTo(syncJobTwoId));
+        // Sync jobs are returned in most-recently created order
+        assertThat(idOfReturnedSyncJobTwo, equalTo(syncJobOneId));
+        assertThat(idOfReturnedSyncJobOne, equalTo(syncJobTwoId));
     }
 
     public void testListConnectorSyncJobs_WithNoSyncJobs_ReturnEmptyResult() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Connector API] Fix default ordering in SyncJob list endpoint (#105945)