### PR TITLE
Extract `SnapshotSortKey`

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.get.SnapshotSortKey;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.cluster.SnapshotsInProgress;
@@ -101,38 +102,38 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
             .getSnapshots();
         assertSnapshotListSorted(defaultSorting, null, order);
         assertSnapshotListSorted(
-            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.NAME, order, includeIndexNames),
-            GetSnapshotsRequest.SortBy.NAME,
+            allSnapshotsSorted(allSnapshotNames, repoName, SnapshotSortKey.NAME, order, includeIndexNames),
+            SnapshotSortKey.NAME,
             order
         );
         assertSnapshotListSorted(
-            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.DURATION, order, includeIndexNames),
-            GetSnapshotsRequest.SortBy.DURATION,
+            allSnapshotsSorted(allSnapshotNames, repoName, SnapshotSortKey.DURATION, order, includeIndexNames),
+            SnapshotSortKey.DURATION,
             order
         );
         assertSnapshotListSorted(
-            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.INDICES, order, includeIndexNames),
-            GetSnapshotsRequest.SortBy.INDICES,
+            allSnapshotsSorted(allSnapshotNames, repoName, SnapshotSortKey.INDICES, order, includeIndexNames),
+            SnapshotSortKey.INDICES,
             order
         );
         assertSnapshotListSorted(
-            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.START_TIME, order, includeIndexNames),
-            GetSnapshotsRequest.SortBy.START_TIME,
+            allSnapshotsSorted(allSnapshotNames, repoName, SnapshotSortKey.START_TIME, order, includeIndexNames),
+            SnapshotSortKey.START_TIME,
             order
         );
         assertSnapshotListSorted(
-            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.SHARDS, order, includeIndexNames),
-            GetSnapshotsRequest.SortBy.SHARDS,
+            allSnapshotsSorted(allSnapshotNames, repoName, SnapshotSortKey.SHARDS, order, includeIndexNames),
+            SnapshotSortKey.SHARDS,
             order
         );
         assertSnapshotListSorted(
-            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.FAILED_SHARDS, order, includeIndexNames),
-            GetSnapshotsRequest.SortBy.FAILED_SHARDS,
+            allSnapshotsSorted(allSnapshotNames, repoName, SnapshotSortKey.FAILED_SHARDS, order, includeIndexNames),
+            SnapshotSortKey.FAILED_SHARDS,
             order
         );
         assertSnapshotListSorted(
-            allSnapshotsSorted(allSnapshotNames, repoName, GetSnapshotsRequest.SortBy.REPOSITORY, order, includeIndexNames),
-            GetSnapshotsRequest.SortBy.REPOSITORY,
+            allSnapshotsSorted(allSnapshotNames, repoName, SnapshotSortKey.REPOSITORY, order, includeIndexNames),
+            SnapshotSortKey.REPOSITORY,
             order
         );
     }
@@ -141,7 +142,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
         final String repoName = "test-repo";
         AbstractSnapshotIntegTestCase.createRepository(logger, repoName, "fs");
         final List<String> names = AbstractSnapshotIntegTestCase.createNSnapshots(logger, repoName, randomIntBetween(6, 20));
-        for (GetSnapshotsRequest.SortBy sort : GetSnapshotsRequest.SortBy.values()) {
+        for (SnapshotSortKey sort : SnapshotSortKey.values()) {
             for (SortOrder order : SortOrder.values()) {
                 logger.info("--> testing pagination for [{}] [{}]", sort, order);
                 doTestPagination(repoName, names, sort, order);
@@ -149,8 +150,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
         }
     }
 
-    private void doTestPagination(String repoName, List<String> names, GetSnapshotsRequest.SortBy sort, SortOrder order)
-        throws IOException {
+    private void doTestPagination(String repoName, List<String> names, SnapshotSortKey sort, SortOrder order) throws IOException {
         final boolean includeIndexNames = randomBoolean();
         final List<SnapshotInfo> allSnapshotsSorted = allSnapshotsSorted(names, repoName, sort, order, includeIndexNames);
         final GetSnapshotsResponse batch1 = sortedWithLimit(repoName, sort, null, 2, order, includeIndexNames);
@@ -220,18 +220,18 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
                 .equals(Map.of(SnapshotsInProgress.ShardState.INIT, 1L, SnapshotsInProgress.ShardState.QUEUED, (long) inProgressCount - 1));
             return firstIndexSuccessfullySnapshot && secondIndexIsBlocked;
         });
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.START_TIME);
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.NAME);
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.INDICES);
+        assertStablePagination(repoName, allSnapshotNames, SnapshotSortKey.START_TIME);
+        assertStablePagination(repoName, allSnapshotNames, SnapshotSortKey.NAME);
+        assertStablePagination(repoName, allSnapshotNames, SnapshotSortKey.INDICES);
 
         AbstractSnapshotIntegTestCase.unblockAllDataNodes(repoName);
         for (ActionFuture<CreateSnapshotResponse> inProgressSnapshot : inProgressSnapshots) {
             AbstractSnapshotIntegTestCase.assertSuccessful(logger, inProgressSnapshot);
         }
 
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.START_TIME);
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.NAME);
-        assertStablePagination(repoName, allSnapshotNames, GetSnapshotsRequest.SortBy.INDICES);
+        assertStablePagination(repoName, allSnapshotNames, SnapshotSortKey.START_TIME);
+        assertStablePagination(repoName, allSnapshotNames, SnapshotSortKey.NAME);
+        assertStablePagination(repoName, allSnapshotNames, SnapshotSortKey.INDICES);
     }
 
     public void testFilterBySLMPolicy() throws Exception {
@@ -240,7 +240,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
         AbstractSnapshotIntegTestCase.createNSnapshots(logger, repoName, randomIntBetween(1, 5));
         final List<SnapshotInfo> snapshotsWithoutPolicy = clusterAdmin().prepareGetSnapshots("*")
             .setSnapshots("*")
-            .setSort(GetSnapshotsRequest.SortBy.NAME)
+            .setSort(SnapshotSortKey.NAME)
             .get()
             .getSnapshots();
         final String snapshotWithPolicy = "snapshot-with-policy";
@@ -277,7 +277,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
         assertThat(getAllSnapshotsForPolicies(policyName, otherPolicyName, "no-such-policy*"), is(List.of(withOtherPolicy, withPolicy)));
         final List<SnapshotInfo> allSnapshots = clusterAdmin().prepareGetSnapshots("*")
             .setSnapshots("*")
-            .setSort(GetSnapshotsRequest.SortBy.NAME)
+            .setSort(SnapshotSortKey.NAME)
             .get()
             .getSnapshots();
         assertThat(getAllSnapshotsForPolicies(GetSnapshotsRequest.NO_POLICY_PATTERN, policyName, otherPolicyName), is(allSnapshots));
@@ -294,7 +294,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
 
         final List<SnapshotInfo> allSnapshotInfo = clusterAdmin().prepareGetSnapshots(matchAllPattern())
             .setSnapshots(matchAllPattern())
-            .setSort(GetSnapshotsRequest.SortBy.START_TIME)
+            .setSort(SnapshotSortKey.START_TIME)
             .get()
             .getSnapshots();
         assertThat(allSnapshotInfo, is(List.of(snapshot1, snapshot2, snapshot3)));
@@ -311,7 +311,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
 
         final List<SnapshotInfo> allSnapshotInfoDesc = clusterAdmin().prepareGetSnapshots(matchAllPattern())
             .setSnapshots(matchAllPattern())
-            .setSort(GetSnapshotsRequest.SortBy.START_TIME)
+            .setSort(SnapshotSortKey.START_TIME)
             .setOrder(SortOrder.DESC)
             .get()
             .getSnapshots();
@@ -340,7 +340,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
 
     private List<SnapshotInfo> allAfterStartTimeAscending(long timestamp) throws IOException {
         final Request request = baseGetSnapshotsRequest("*");
-        request.addParameter("sort", GetSnapshotsRequest.SortBy.START_TIME.toString());
+        request.addParameter("sort", SnapshotSortKey.START_TIME.toString());
         request.addParameter("from_sort_value", String.valueOf(timestamp));
         final Response response = getRestClient().performRequest(request);
         return readSnapshotInfos(response).getSnapshots();
@@ -348,7 +348,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
 
     private List<SnapshotInfo> allBeforeStartTimeDescending(long timestamp) throws IOException {
         final Request request = baseGetSnapshotsRequest("*");
-        request.addParameter("sort", GetSnapshotsRequest.SortBy.START_TIME.toString());
+        request.addParameter("sort", SnapshotSortKey.START_TIME.toString());
         request.addParameter("from_sort_value", String.valueOf(timestamp));
         request.addParameter("order", SortOrder.DESC.toString());
         final Response response = getRestClient().performRequest(request);
@@ -358,7 +358,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
     private static List<SnapshotInfo> getAllSnapshotsForPolicies(String... policies) throws IOException {
         final Request requestWithPolicy = new Request(HttpGet.METHOD_NAME, "/_snapshot/*/*");
         requestWithPolicy.addParameter("slm_policy_filter", Strings.arrayToCommaDelimitedString(policies));
-        requestWithPolicy.addParameter("sort", GetSnapshotsRequest.SortBy.NAME.toString());
+        requestWithPolicy.addParameter("sort", SnapshotSortKey.NAME.toString());
         return readSnapshotInfos(getRestClient().performRequest(requestWithPolicy)).getSnapshots();
     }
 
@@ -369,10 +369,10 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
         indexDoc(indexName, "some_id", "foo", "bar");
     }
 
-    private static void assertStablePagination(String repoName, Collection<String> allSnapshotNames, GetSnapshotsRequest.SortBy sort)
+    private static void assertStablePagination(String repoName, Collection<String> allSnapshotNames, SnapshotSortKey sort)
         throws IOException {
         final SortOrder order = randomFrom(SortOrder.values());
-        final boolean includeIndexNames = sort == GetSnapshotsRequest.SortBy.INDICES || randomBoolean();
+        final boolean includeIndexNames = sort == SnapshotSortKey.INDICES || randomBoolean();
         final List<SnapshotInfo> allSorted = allSnapshotsSorted(allSnapshotNames, repoName, sort, order, includeIndexNames);
 
         for (int i = 1; i <= allSnapshotNames.size(); i++) {
@@ -413,7 +413,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
     private static List<SnapshotInfo> allSnapshotsSorted(
         Collection<String> allSnapshotNames,
         String repoName,
-        GetSnapshotsRequest.SortBy sortBy,
+        SnapshotSortKey sortBy,
         SortOrder order,
         boolean includeIndices
     ) throws IOException {
@@ -454,7 +454,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
 
     private static GetSnapshotsResponse sortedWithLimit(
         String repoName,
-        GetSnapshotsRequest.SortBy sortBy,
+        SnapshotSortKey sortBy,
         String after,
         int size,
         SortOrder order,
@@ -486,7 +486,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
 
     private static GetSnapshotsResponse sortedWithLimit(
         String repoName,
-        GetSnapshotsRequest.SortBy sortBy,
+        SnapshotSortKey sortBy,
         int offset,
         int size,
         SortOrder order,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequest.java
@@ -61,7 +61,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
     @Nullable
     private String fromSortValue;
 
-    private SortBy sort = SortBy.START_TIME;
+    private SnapshotSortKey sort = SnapshotSortKey.START_TIME;
 
     private SortOrder order = SortOrder.ASC;
 
@@ -106,7 +106,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         ignoreUnavailable = in.readBoolean();
         verbose = in.readBoolean();
         after = in.readOptionalWriteable(After::new);
-        sort = in.readEnum(SortBy.class);
+        sort = in.readEnum(SnapshotSortKey.class);
         size = in.readVInt();
         order = SortOrder.readFromStream(in);
         offset = in.readVInt();
@@ -146,7 +146,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
             validationException = addValidationError("size must be -1 or greater than 0", validationException);
         }
         if (verbose == false) {
-            if (sort != SortBy.START_TIME) {
+            if (sort != SnapshotSortKey.START_TIME) {
                 validationException = addValidationError("can't use non-default sort with verbose=false", validationException);
             }
             if (size > 0) {
@@ -287,7 +287,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         return after;
     }
 
-    public SortBy sort() {
+    public SnapshotSortKey sort() {
         return sort;
     }
 
@@ -306,7 +306,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         return fromSortValue;
     }
 
-    public GetSnapshotsRequest sort(SortBy sort) {
+    public GetSnapshotsRequest sort(SnapshotSortKey sort) {
         this.sort = sort;
         return this;
     }
@@ -350,40 +350,6 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         return new CancellableTask(id, type, action, getDescription(), parentTaskId, headers);
     }
 
-    public enum SortBy {
-        START_TIME("start_time"),
-        NAME("name"),
-        DURATION("duration"),
-        INDICES("index_count"),
-        SHARDS("shard_count"),
-        FAILED_SHARDS("failed_shard_count"),
-        REPOSITORY("repository");
-
-        private final String param;
-
-        SortBy(String param) {
-            this.param = param;
-        }
-
-        @Override
-        public String toString() {
-            return param;
-        }
-
-        public static SortBy of(String value) {
-            return switch (value) {
-                case "start_time" -> START_TIME;
-                case "name" -> NAME;
-                case "duration" -> DURATION;
-                case "index_count" -> INDICES;
-                case "shard_count" -> SHARDS;
-                case "failed_shard_count" -> FAILED_SHARDS;
-                case "repository" -> REPOSITORY;
-                default -> throw new IllegalArgumentException("unknown sort order [" + value + "]");
-            };
-        }
-    }
-
     public static final class After implements Writeable {
 
         private final String value;
@@ -405,7 +371,7 @@ public class GetSnapshotsRequest extends MasterNodeRequest<GetSnapshotsRequest> 
         }
 
         @Nullable
-        public static After from(@Nullable SnapshotInfo snapshotInfo, SortBy sortBy) {
+        public static After from(@Nullable SnapshotInfo snapshotInfo, SnapshotSortKey sortBy) {
             if (snapshotInfo == null) {
                 return null;
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestBuilder.java
@@ -122,7 +122,7 @@ public class GetSnapshotsRequestBuilder extends MasterNodeOperationRequestBuilde
         return this;
     }
 
-    public GetSnapshotsRequestBuilder setSort(GetSnapshotsRequest.SortBy sort) {
+    public GetSnapshotsRequestBuilder setSort(SnapshotSortKey sort) {
         request.sort(sort);
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/SnapshotSortKey.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/SnapshotSortKey.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.snapshots.get;
+
+import org.elasticsearch.snapshots.SnapshotInfo;
+
+import java.util.Comparator;
+
+/**
+ * Sort key for snapshots e.g. returned from the get-snapshots API. All values break ties using {@link SnapshotInfo#snapshotId} (i.e. by
+ * name).
+ */
+public enum SnapshotSortKey {
+    /**
+     * Sort by snapshot start time.
+     */
+    START_TIME("start_time", Comparator.comparingLong(SnapshotInfo::startTime)),
+
+    /**
+     * Sort by snapshot name.
+     */
+    NAME("name", Comparator.comparing(sni -> sni.snapshotId().getName())),
+
+    /**
+     * Sort by snapshot duration (end time minus start time).
+     */
+    DURATION("duration", Comparator.comparingLong(sni -> sni.endTime() - sni.startTime())),
+    /**
+     * Sort by number of indices in the snapshot.
+     */
+    INDICES("index_count", Comparator.comparingInt(sni -> sni.indices().size())),
+
+    /**
+     * Sort by number of shards in the snapshot.
+     */
+    SHARDS("shard_count", Comparator.comparingInt(SnapshotInfo::totalShards)),
+
+    /**
+     * Sort by number of failed shards in the snapshot.
+     */
+    FAILED_SHARDS("failed_shard_count", Comparator.comparingInt(SnapshotInfo::failedShards)),
+
+    /**
+     * Sort by repository name.
+     */
+    REPOSITORY("repository", Comparator.comparing(SnapshotInfo::repository));
+
+    private final String name;
+    private final Comparator<SnapshotInfo> snapshotInfoComparator;
+
+    SnapshotSortKey(String name, Comparator<SnapshotInfo> snapshotInfoComparator) {
+        this.name = name;
+        this.snapshotInfoComparator = snapshotInfoComparator.thenComparing(SnapshotInfo::snapshotId);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    public final Comparator<SnapshotInfo> getSnapshotInfoComparator() {
+        return snapshotInfoComparator;
+    }
+
+    public static SnapshotSortKey of(String name) {
+        return switch (name) {
+            case "start_time" -> START_TIME;
+            case "name" -> NAME;
+            case "duration" -> DURATION;
+            case "index_count" -> INDICES;
+            case "shard_count" -> SHARDS;
+            case "failed_shard_count" -> FAILED_SHARDS;
+            case "repository" -> REPOSITORY;
+            default -> throw new IllegalArgumentException("unknown sort key [" + name + "]");
+        };
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetSnapshotsAction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest.action.admin.cluster;
 
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.get.SnapshotSortKey;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -59,7 +60,7 @@ public class RestGetSnapshotsAction extends BaseRestHandler {
         GetSnapshotsRequest getSnapshotsRequest = new GetSnapshotsRequest(repositories).snapshots(snapshots);
         getSnapshotsRequest.ignoreUnavailable(request.paramAsBoolean("ignore_unavailable", getSnapshotsRequest.ignoreUnavailable()));
         getSnapshotsRequest.verbose(request.paramAsBoolean("verbose", getSnapshotsRequest.verbose()));
-        final GetSnapshotsRequest.SortBy sort = GetSnapshotsRequest.SortBy.of(request.param("sort", getSnapshotsRequest.sort().toString()));
+        final SnapshotSortKey sort = SnapshotSortKey.of(request.param("sort", getSnapshotsRequest.sort().toString()));
         getSnapshotsRequest.sort(sort);
         final int size = request.paramAsInt("size", getSnapshotsRequest.size());
         getSnapshotsRequest.size(size);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsRequestTests.java
@@ -39,8 +39,7 @@ public class GetSnapshotsRequestTests extends ESTestCase {
             assertThat(e.getMessage(), containsString("can't use offset with verbose=false"));
         }
         {
-            final GetSnapshotsRequest request = new GetSnapshotsRequest("repo", "snapshot").verbose(false)
-                .sort(GetSnapshotsRequest.SortBy.INDICES);
+            final GetSnapshotsRequest request = new GetSnapshotsRequest("repo", "snapshot").verbose(false).sort(SnapshotSortKey.INDICES);
             final ActionRequestValidationException e = request.validate();
             assertThat(e.getMessage(), containsString("can't use non-default sort with verbose=false"));
         }

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
-import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
+import org.elasticsearch.action.admin.cluster.snapshots.get.SnapshotSortKey;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -734,11 +734,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
         });
     }
 
-    public static void assertSnapshotListSorted(
-        List<SnapshotInfo> snapshotInfos,
-        @Nullable GetSnapshotsRequest.SortBy sort,
-        SortOrder sortOrder
-    ) {
+    public static void assertSnapshotListSorted(List<SnapshotInfo> snapshotInfos, @Nullable SnapshotSortKey sort, SortOrder sortOrder) {
         final BiConsumer<SnapshotInfo, SnapshotInfo> assertion;
         if (sort == null) {
             assertion = (s1, s2) -> assertThat(s2, greaterThanOrEqualTo(s1));


### PR DESCRIPTION
The behaviour of the get-snapshots API varies quite considerably
depending on the sort key chosen. Today this logic is implemented using
scattered `switch` statements and other conditionals but it'd be clearer
if we delegated this stuff to the sort key instances themselves. This
commit moves the sort key enum to the top level and replaces one of the
`switch` statements with a method on the enum instances.