### PR TITLE
Backport 103730 to fix 104719

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregatorTests.java
@@ -162,8 +162,9 @@ public class CartesianShapeCentroidAggregatorTests extends AggregatorTestCase {
                 w.addDocument(document);
                 if (targetShapeType.compareTo(calculator.getDimensionalShapeType()) == 0) {
                     double weight = calculator.sumWeight();
-                    compensatedSumLat.add(weight * calculator.getY());
-                    compensatedSumLon.add(weight * calculator.getX());
+                    // compute the centroid of centroids in float space
+                    compensatedSumLat.add(weight * (float) calculator.getY());
+                    compensatedSumLon.add(weight * (float) calculator.getX());
                     compensatedSumWeight.add(weight);
                 }
             }


### PR DESCRIPTION
When summing cartesian centroids, use floats to reduce differences to test code (backport of #103730)

Fixes #104719 

The cartesian geometries are stored in Lucene using float space, not doubles, but the test data was entirely in doubles. This leads to accumulating differences as centroid and centroids of centroids are calculated, so we rarely (1/10000) get test failures as a result. This fix just changes the centroid of centroids calculation to use floats to reduce those differences.
