### PR TITLE
Reset job if existing reset fails

### DIFF
--- a/docs/changelog/106020.yaml
+++ b/docs/changelog/106020.yaml
@@ -1,0 +1,5 @@
+pr: 106020
+summary: Reset job if existing reset fails
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/changelog/106020.yaml
+++ b/docs/changelog/106020.yaml
@@ -1,5 +1,6 @@
 pr: 106020
-summary: Reset job if existing reset fails
+summary: Fix resetting a job if an existing reset task has failed.
 area: Machine Learning
 type: bug
-issues: []
+issues:
+ - 105928

--- a/docs/changelog/106020.yaml
+++ b/docs/changelog/106020.yaml
@@ -1,5 +1,5 @@
 pr: 106020
-summary: Fix resetting a job if an existing reset task has failed.
+summary: Fix resetting a job if the original reset task no longer exists.
 area: Machine Learning
 type: bug
 issues: []

--- a/docs/changelog/106020.yaml
+++ b/docs/changelog/106020.yaml
@@ -2,5 +2,4 @@ pr: 106020
 summary: Fix resetting a job if an existing reset task has failed.
 area: Machine Learning
 type: bug
-issues:
- - 105928
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -209,7 +209,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
 
         client.get(get, ActionListener.wrap(r -> onGetFinishedTaskFromIndex(r, listener), e -> {
             if (ExceptionsHelper.unwrap(e, IndexNotFoundException.class) != null) {
-                // We haven't yet created the index for the task results so it can't be found.
+                // We haven't yet created the index for the task results, so it can't be found.
                 listener.onFailure(
                     new ResourceNotFoundException("task [{}] isn't running and hasn't stored its results", e, request.getTaskId())
                 );

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ResetJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ResetJobIT.java
@@ -47,7 +47,7 @@ public class ResetJobIT extends MlNativeAutodetectIntegTestCase {
         TimeValue bucketSpan = TimeValue.timeValueMinutes(30);
         long startTime = 1514764800000L;
         final int bucketCount = 100;
-        Job.Builder job = createJob(bucketSpan);
+        Job.Builder job = createJob("test-reset-" + previousResetFailed, bucketSpan);
 
         openJob(job.getId());
         postData(
@@ -88,11 +88,11 @@ public class ResetJobIT extends MlNativeAutodetectIntegTestCase {
         assertThat("Audit messages: " + auditMessages, auditMessages.get(auditMessages.size() - 1), equalTo("Job has been reset"));
     }
 
-    private Job.Builder createJob(TimeValue bucketSpan) {
+    private Job.Builder createJob(String jobId, TimeValue bucketSpan) {
         Detector.Builder detector = new Detector.Builder("count", null);
         AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(detector.build()));
         analysisConfig.setBucketSpan(bucketSpan);
-        Job.Builder job = new Job.Builder(randomIdentifier());
+        Job.Builder job = new Job.Builder(jobId);
         job.setAnalysisConfig(analysisConfig);
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         job.setDataDescription(dataDescription);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ResetJobIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ResetJobIT.java
@@ -8,11 +8,13 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.ml.job.config.AnalysisConfig;
 import org.elasticsearch.xpack.core.ml.job.config.Blocked;
 import org.elasticsearch.xpack.core.ml.job.config.DataDescription;
 import org.elasticsearch.xpack.core.ml.job.config.Detector;
 import org.elasticsearch.xpack.core.ml.job.config.Job;
+import org.elasticsearch.xpack.core.ml.job.config.JobUpdate;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 import org.elasticsearch.xpack.core.ml.job.results.Bucket;
 import org.junit.After;
@@ -34,10 +36,18 @@ public class ResetJobIT extends MlNativeAutodetectIntegTestCase {
     }
 
     public void testReset() throws Exception {
+        testReset(false);
+    }
+
+    public void testReset_previousResetFailed() throws Exception {
+        testReset(true);
+    }
+
+    private void testReset(boolean previousResetFailed) throws Exception {
         TimeValue bucketSpan = TimeValue.timeValueMinutes(30);
         long startTime = 1514764800000L;
         final int bucketCount = 100;
-        Job.Builder job = createJob("test-reset", bucketSpan);
+        Job.Builder job = createJob(bucketSpan);
 
         openJob(job.getId());
         postData(
@@ -52,6 +62,13 @@ public class ResetJobIT extends MlNativeAutodetectIntegTestCase {
 
         DataCounts dataCounts = getJobStats(job.getId()).get(0).getDataCounts();
         assertThat(dataCounts.getProcessedRecordCount(), greaterThan(0L));
+
+        if (previousResetFailed) {
+            JobUpdate jobUpdate = new JobUpdate.Builder(job.getId()).setBlocked(
+                new Blocked(Blocked.Reason.RESET, new TaskId(randomIdentifier(), randomInt()))
+            ).build();
+            updateJob(job.getId(), jobUpdate);
+        }
 
         resetJob(job.getId());
 
@@ -71,11 +88,11 @@ public class ResetJobIT extends MlNativeAutodetectIntegTestCase {
         assertThat("Audit messages: " + auditMessages, auditMessages.get(auditMessages.size() - 1), equalTo("Job has been reset"));
     }
 
-    private Job.Builder createJob(String jobId, TimeValue bucketSpan) {
+    private Job.Builder createJob(TimeValue bucketSpan) {
         Detector.Builder detector = new Detector.Builder("count", null);
         AnalysisConfig.Builder analysisConfig = new AnalysisConfig.Builder(Collections.singletonList(detector.build()));
         analysisConfig.setBucketSpan(bucketSpan);
-        Job.Builder job = new Job.Builder(jobId);
+        Job.Builder job = new Job.Builder(randomIdentifier());
         job.setAnalysisConfig(analysisConfig);
         DataDescription.Builder dataDescription = new DataDescription.Builder();
         job.setDataDescription(dataDescription);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportResetJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportResetJobAction.java
@@ -124,7 +124,10 @@ public class TransportResetJobAction extends AcknowledgedTransportMasterNodeActi
                 waitExistingResetTaskToComplete(
                     job.getBlocked().getTaskId(),
                     request,
-                    ActionListener.wrap(r -> resetIfJobIsStillBlockedOnReset(task, request, listener), listener::onFailure)
+                    ActionListener.wrap(
+                        r -> resetIfJobIsStillBlockedOnReset(task, request, listener),
+                        e -> resetIfJobIsStillBlockedOnReset(task, request, listener)
+                    )
                 );
             } else {
                 ParentTaskAssigningClient taskClient = new ParentTaskAssigningClient(client, taskId);


### PR DESCRIPTION
This implements the item 1 of https://github.com/elastic/elasticsearch/issues/105928.