### PR TITLE
[Transforms] Unattended flag in task params

### DIFF
--- a/docs/changelog/106032.yaml
+++ b/docs/changelog/106032.yaml
@@ -1,5 +1,0 @@
-pr: 106032
-summary: Unattended transforms can still go into the failed state
-area: Transform
-type: bug
-issues: []

--- a/docs/changelog/106032.yaml
+++ b/docs/changelog/106032.yaml
@@ -1,0 +1,5 @@
+pr: 106032
+summary: Unattended transforms can still go into the failed state
+area: Transform
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -137,6 +137,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_TIMINGS = def(8_597_00_0);
     public static final TransportVersion DATA_STREAM_AUTO_SHARDING_EVENT = def(8_598_00_0);
     public static final TransportVersion ADD_FAILURE_STORE_INDICES_OPTIONS = def(8_599_00_0);
+    public static final TransportVersion TRANSFORM_PERSIST_UNATTENDED = def(8_600_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformTaskParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformTaskParams.java
@@ -86,6 +86,17 @@ public class TransformTaskParams implements SimpleDiffable<TransformTaskParams>,
         boolean remote,
         boolean unattended
     ) {
+        this(transformId, version, from, frequency, remote, Boolean.valueOf(unattended));
+    }
+
+    private TransformTaskParams(
+        String transformId,
+        TransformConfigVersion version,
+        Instant from,
+        TimeValue frequency,
+        boolean remote,
+        Boolean unattended
+    ) {
         this.transformId = transformId;
         this.version = version == null ? TransformConfigVersion.V_7_2_0 : version;
         this.from = from;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformTaskParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformTaskParamsTests.java
@@ -24,6 +24,7 @@ public class TransformTaskParamsTests extends AbstractSerializingTransformTestCa
             randomBoolean() ? TransformConfigVersionUtils.randomVersion(random()) : null,
             randomBoolean() ? Instant.ofEpochMilli(randomLongBetween(0, 1_000_000_000_000L)) : null,
             randomBoolean() ? TimeValue.timeValueSeconds(randomLongBetween(1, 24 * 60 * 60)) : null,
+            randomBoolean(),
             randomBoolean()
         );
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/TransformTests.java
@@ -30,6 +30,7 @@ public class TransformTests extends AbstractSerializingTransformTestCase<Transfo
             randomBoolean() ? null : TransformConfigVersion.CURRENT,
             randomBoolean() ? Instant.ofEpochMilli(randomLongBetween(0, 1_000_000_000_000L)) : null,
             randomBoolean() ? null : TimeValue.timeValueMillis(randomIntBetween(1_000, 3_600_000)),
+            randomBoolean(),
             randomBoolean()
         );
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -253,7 +253,8 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
                     config.getVersion(),
                     request.from(),
                     config.getFrequency(),
-                    config.getSource().requiresRemoteCluster()
+                    config.getSource().requiresRemoteCluster(),
+                    TransformEffectiveSettings.isUnattended(config.getSettings())
                 )
             );
             ClientHelper.executeAsyncWithOrigin(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
@@ -52,7 +52,7 @@ public class TransportStopTransformActionTests extends ESTestCase {
             .addTask(
                 "non-failed-task",
                 TransformTaskParams.NAME,
-                new TransformTaskParams("transform-task-1", TransformConfigVersion.CURRENT, null, false),
+                new TransformTaskParams("transform-task-1", TransformConfigVersion.CURRENT, null, false, false),
                 new PersistentTasksCustomMetadata.Assignment("current-data-node-with-1-tasks", "")
             );
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name")).metadata(buildMetadata(pTasksBuilder.build()));
@@ -71,7 +71,7 @@ public class TransportStopTransformActionTests extends ESTestCase {
         pTasksBuilder.addTask(
             "failed-task",
             TransformTaskParams.NAME,
-            new TransformTaskParams("transform-task-1", TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams("transform-task-1", TransformConfigVersion.CURRENT, null, false, false),
             new PersistentTasksCustomMetadata.Assignment("current-data-node-with-1-tasks", "")
         )
             .updateTaskState(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformNodesTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformNodesTests.java
@@ -55,13 +55,13 @@ public class TransformNodesTests extends ESTestCase {
         tasksBuilder.addTask(
             transformIdFoo,
             TransformField.TASK_NAME,
-            new TransformTaskParams(transformIdFoo, TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams(transformIdFoo, TransformConfigVersion.CURRENT, null, false, false),
             new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
         );
         tasksBuilder.addTask(
             transformIdBar,
             TransformField.TASK_NAME,
-            new TransformTaskParams(transformIdBar, TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams(transformIdBar, TransformConfigVersion.CURRENT, null, false, false),
             new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
         );
         tasksBuilder.addTask("test-task1", "testTasks", new PersistentTaskParams() {
@@ -88,19 +88,19 @@ public class TransformNodesTests extends ESTestCase {
         tasksBuilder.addTask(
             transformIdFailed,
             TransformField.TASK_NAME,
-            new TransformTaskParams(transformIdFailed, TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams(transformIdFailed, TransformConfigVersion.CURRENT, null, false, false),
             new PersistentTasksCustomMetadata.Assignment(null, "awaiting reassignment after node loss")
         );
         tasksBuilder.addTask(
             transformIdBaz,
             TransformField.TASK_NAME,
-            new TransformTaskParams(transformIdBaz, TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams(transformIdBaz, TransformConfigVersion.CURRENT, null, false, false),
             new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
         );
         tasksBuilder.addTask(
             transformIdOther,
             TransformField.TASK_NAME,
-            new TransformTaskParams(transformIdOther, TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams(transformIdOther, TransformConfigVersion.CURRENT, null, false, false),
             new PersistentTasksCustomMetadata.Assignment("node-3", "test assignment")
         );
 
@@ -274,12 +274,14 @@ public class TransformNodesTests extends ESTestCase {
             "transform-1",
             TransformConfigVersion.CURRENT,
             TimeValue.timeValueSeconds(10),
+            false,
             false
         );
         TransformTaskParams transformTaskParams2 = new TransformTaskParams(
             "transform-2",
             TransformConfigVersion.CURRENT,
             TimeValue.timeValueSeconds(10),
+            false,
             false
         );
         PersistentTasksCustomMetadata.Assignment assignment2 = new PersistentTasksCustomMetadata.Assignment(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -66,7 +66,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
 
         assertThat(
             executor.getAssignment(
-                new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, true),
+                new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, true, false),
                 cs.nodes().getAllNodes(),
                 cs
             ).getExecutorNode(),
@@ -74,7 +74,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         );
         assertThat(
             executor.getAssignment(
-                new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, false),
+                new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, false, false),
                 cs.nodes().getAllNodes(),
                 cs
             ).getExecutorNode(),
@@ -82,7 +82,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         );
         assertThat(
             executor.getAssignment(
-                new TransformTaskParams("new-old-task-id", TransformConfigVersion.V_7_7_0, null, true),
+                new TransformTaskParams("new-old-task-id", TransformConfigVersion.V_7_7_0, null, true, false),
                 cs.nodes().getAllNodes(),
                 cs
             ).getExecutorNode(),
@@ -97,7 +97,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         TransformPersistentTasksExecutor executor = buildTaskExecutor();
 
         Assignment assignment = executor.getAssignment(
-            new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, false, false),
             cs.nodes().getAllNodes(),
             cs
         );
@@ -113,7 +113,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         executor = buildTaskExecutor();
 
         assignment = executor.getAssignment(
-            new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, false, false),
             cs.nodes().getAllNodes(),
             cs
         );
@@ -126,7 +126,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         executor = buildTaskExecutor();
 
         assignment = executor.getAssignment(
-            new TransformTaskParams("new-task-id", TransformConfigVersion.V_8_0_0, null, false),
+            new TransformTaskParams("new-task-id", TransformConfigVersion.V_8_0_0, null, false, false),
             cs.nodes().getAllNodes(),
             cs
         );
@@ -143,7 +143,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         );
 
         assignment = executor.getAssignment(
-            new TransformTaskParams("new-task-id", TransformConfigVersion.V_7_5_0, null, false),
+            new TransformTaskParams("new-task-id", TransformConfigVersion.V_7_5_0, null, false, false),
             cs.nodes().getAllNodes(),
             cs
         );
@@ -156,7 +156,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         executor = buildTaskExecutor();
 
         assignment = executor.getAssignment(
-            new TransformTaskParams("new-task-id", TransformConfigVersion.V_7_5_0, null, true),
+            new TransformTaskParams("new-task-id", TransformConfigVersion.V_7_5_0, null, true, false),
             cs.nodes().getAllNodes(),
             cs
         );
@@ -172,7 +172,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         );
 
         assignment = executor.getAssignment(
-            new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, false),
+            new TransformTaskParams("new-task-id", TransformConfigVersion.CURRENT, null, false, false),
             cs.nodes().getAllNodes(),
             cs
         );
@@ -185,7 +185,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         executor = buildTaskExecutor();
 
         assignment = executor.getAssignment(
-            new TransformTaskParams("new-task-id", TransformConfigVersion.V_7_5_0, null, true),
+            new TransformTaskParams("new-task-id", TransformConfigVersion.V_7_5_0, null, true, false),
             cs.nodes().getAllNodes(),
             cs
         );
@@ -207,7 +207,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         executor = buildTaskExecutor();
 
         assignment = executor.getAssignment(
-            new TransformTaskParams("new-task-id", TransformConfigVersion.V_7_5_0, null, true),
+            new TransformTaskParams("new-task-id", TransformConfigVersion.V_7_5_0, null, true, false),
             cs.nodes().getAllNodes(),
             cs
         );
@@ -391,19 +391,19 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             .addTask(
                 "transform-task-1",
                 TransformTaskParams.NAME,
-                new TransformTaskParams("transform-task-1", TransformConfigVersion.CURRENT, null, false),
+                new TransformTaskParams("transform-task-1", TransformConfigVersion.CURRENT, null, false, false),
                 new PersistentTasksCustomMetadata.Assignment("current-data-node-with-1-tasks", "")
             )
             .addTask(
                 "transform-task-2",
                 TransformTaskParams.NAME,
-                new TransformTaskParams("transform-task-2", TransformConfigVersion.CURRENT, null, false),
+                new TransformTaskParams("transform-task-2", TransformConfigVersion.CURRENT, null, false, false),
                 new PersistentTasksCustomMetadata.Assignment("current-data-node-with-2-tasks", "")
             )
             .addTask(
                 "transform-task-3",
                 TransformTaskParams.NAME,
-                new TransformTaskParams("transform-task-3", TransformConfigVersion.CURRENT, null, false),
+                new TransformTaskParams("transform-task-3", TransformConfigVersion.CURRENT, null, false, false),
                 new PersistentTasksCustomMetadata.Assignment("current-data-node-with-2-tasks", "")
             );
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -616,6 +616,6 @@ public class TransformTaskTests extends ESTestCase {
     }
 
     private static TransformTaskParams createTransformTaskParams(String transformId) {
-        return new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, TimeValue.timeValueSeconds(10), false);
+        return new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, TimeValue.timeValueSeconds(10), false, false);
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/scheduling/TransformSchedulerTests.java
@@ -74,7 +74,13 @@ public class TransformSchedulerTests extends ESTestCase {
         TimeValue frequency = TimeValue.timeValueSeconds(frequencySeconds);
         TimeValue minFrequency = TimeValue.timeValueSeconds(minFreqencySeconds);
         TimeValue fiveSeconds = TimeValue.timeValueSeconds(5);
-        TransformTaskParams transformTaskParams = new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams = new TransformTaskParams(
+            transformId,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         FakeClock clock = new FakeClock(Instant.ofEpochMilli(0));
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
         TransformScheduler.Listener listener = events::add;
@@ -133,7 +139,13 @@ public class TransformSchedulerTests extends ESTestCase {
     public void testSchedulingWithFailures() {
         String transformId = "test-failure-with-fake-clock";
         TimeValue frequency = TimeValue.timeValueHours(1);
-        TransformTaskParams transformTaskParams = new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams = new TransformTaskParams(
+            transformId,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         FakeClock clock = new FakeClock(Instant.ofEpochMilli(0));
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
         TransformScheduler.Listener listener = events::add;
@@ -185,7 +197,13 @@ public class TransformSchedulerTests extends ESTestCase {
     public void testScheduleNow() {
         String transformId = "test-schedule-now-with-fake-clock";
         TimeValue frequency = TimeValue.timeValueHours(1);
-        TransformTaskParams transformTaskParams = new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams = new TransformTaskParams(
+            transformId,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         FakeClock clock = new FakeClock(Instant.ofEpochMilli(0));
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
         TransformScheduler.Listener listener = events::add;
@@ -235,7 +253,13 @@ public class TransformSchedulerTests extends ESTestCase {
         String transformId = "test-with-fake-clock-concurrent";
         int frequencySeconds = 5;
         TimeValue frequency = TimeValue.timeValueSeconds(frequencySeconds);
-        TransformTaskParams transformTaskParams = new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams = new TransformTaskParams(
+            transformId,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         FakeClock clock = new FakeClock(Instant.ofEpochMilli(0));
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
         TransformScheduler.Listener listener = events::add;
@@ -273,7 +297,13 @@ public class TransformSchedulerTests extends ESTestCase {
         String transformId = "test-with-fake-clock-concurrent";
         int frequencySeconds = 5;
         TimeValue frequency = TimeValue.timeValueSeconds(frequencySeconds);
-        TransformTaskParams transformTaskParams = new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams = new TransformTaskParams(
+            transformId,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         FakeClock clock = new FakeClock(Instant.ofEpochMilli(0));
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
 
@@ -315,7 +345,13 @@ public class TransformSchedulerTests extends ESTestCase {
     public void testSchedulingWithSystemClock() throws Exception {
         String transformId = "test-with-system-clock";
         TimeValue frequency = TimeValue.timeValueSeconds(1);
-        TransformTaskParams transformTaskParams = new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams = new TransformTaskParams(
+            transformId,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         Clock clock = Clock.systemUTC();
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
 
@@ -340,7 +376,13 @@ public class TransformSchedulerTests extends ESTestCase {
     public void testScheduleNowWithSystemClock() throws Exception {
         String transformId = "test-schedule-now-with-system-clock";
         TimeValue frequency = TimeValue.timeValueHours(1);  // Very long pause between checkpoints
-        TransformTaskParams transformTaskParams = new TransformTaskParams(transformId, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams = new TransformTaskParams(
+            transformId,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         Clock clock = Clock.systemUTC();
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
 
@@ -394,9 +436,27 @@ public class TransformSchedulerTests extends ESTestCase {
         String transformId2 = "test-register-transforms-2";
         String transformId3 = "test-register-transforms-3";
         TimeValue frequency = TimeValue.timeValueSeconds(5);
-        TransformTaskParams transformTaskParams1 = new TransformTaskParams(transformId1, TransformConfigVersion.CURRENT, frequency, false);
-        TransformTaskParams transformTaskParams2 = new TransformTaskParams(transformId2, TransformConfigVersion.CURRENT, frequency, false);
-        TransformTaskParams transformTaskParams3 = new TransformTaskParams(transformId3, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams1 = new TransformTaskParams(
+            transformId1,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
+        TransformTaskParams transformTaskParams2 = new TransformTaskParams(
+            transformId2,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
+        TransformTaskParams transformTaskParams3 = new TransformTaskParams(
+            transformId3,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         FakeClock clock = new FakeClock(Instant.ofEpochMilli(0));
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
         TransformScheduler.Listener listener = events::add;
@@ -424,9 +484,27 @@ public class TransformSchedulerTests extends ESTestCase {
         String transformId2 = "test-register-transforms-2";
         String transformId3 = "test-register-transforms-3";
         TimeValue frequency = TimeValue.timeValueSeconds(5);
-        TransformTaskParams transformTaskParams1 = new TransformTaskParams(transformId1, TransformConfigVersion.CURRENT, frequency, false);
-        TransformTaskParams transformTaskParams2 = new TransformTaskParams(transformId2, TransformConfigVersion.CURRENT, frequency, false);
-        TransformTaskParams transformTaskParams3 = new TransformTaskParams(transformId3, TransformConfigVersion.CURRENT, frequency, false);
+        TransformTaskParams transformTaskParams1 = new TransformTaskParams(
+            transformId1,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
+        TransformTaskParams transformTaskParams2 = new TransformTaskParams(
+            transformId2,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
+        TransformTaskParams transformTaskParams3 = new TransformTaskParams(
+            transformId3,
+            TransformConfigVersion.CURRENT,
+            frequency,
+            false,
+            false
+        );
         FakeClock clock = new FakeClock(Instant.ofEpochMilli(0));
         CopyOnWriteArrayList<TransformScheduler.Event> events = new CopyOnWriteArrayList<>();
         TransformScheduler.Listener listener = events::add;


### PR DESCRIPTION
Currently, transforms may fail to start due to transient issues. For regular transforms, this is okay, because there is a user that can intervene. For unattended transforms, the system should take action.

This adds the unattended flag to the persistent task in the cluster state, enabling the persistent task to retry actions that are run outside the scope of the Transform task.