### PR TITLE
[DOCS] Changes the cohere example to use a different model

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -6,9 +6,9 @@
 
 The instructions in this tutorial shows you how to use the {infer} API with
 various services to perform semantic search on your data. The following examples 
-use Cohere's `embed-english-light-v3.0` model and OpenAI's 
-`text-embedding-ada-002` second generation embedding model. You can use any
-Cohere and OpenAI models, they are all supported by the {infer} API.
+use Cohere's `embed-english-v3.0` model and OpenAI's `text-embedding-ada-002`
+second generation embedding model. You can use any Cohere and OpenAI models,
+they are all supported by the {infer} API.
 
 Click the name of the service you want to use on any of the widgets below to
 review the corresponding instructions.

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
@@ -8,7 +8,7 @@ PUT cohere-embeddings
     "properties": {
       "content_embedding": { <1>
         "type": "dense_vector", <2>
-        "dims": 384, <3>
+        "dims": 1024, <3>
         "element_type": "float"
       },
       "content": { <4>

--- a/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
@@ -9,7 +9,7 @@ GET cohere-embeddings/_search
     "query_vector_builder": {
       "text_embedding": {
         "model_id": "cohere_embeddings",
-        "model_text": "Calculate fuel cost"
+        "model_text": "Muscles in human body"
       }
     },
     "k": 10,

--- a/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
@@ -7,7 +7,7 @@ PUT _inference/text_embedding/cohere_embeddings <1>
     "service": "cohere",
     "service_settings": {
         "api_key": "<api_key>", <2>
-        "model_id": "embed-english-light-v3.0", <3>
+        "model_id": "embed-english-v3.0", <3>
         "embedding_type": "int8"
     },
     "task_settings": {


### PR DESCRIPTION
## Overview

This PR changes the Cohere service inference API tutorial to use the `embed-english-v3.0` model with `1024` dimensions.