### PR TITLE
[ML] Preserving thread context in inference API request executor

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
@@ -275,7 +275,7 @@ class RequestExecutorService implements RequestExecutor {
             input,
             timeout,
             threadPool,
-            // TODO when multi-tenancy (as well as batching) is implemented we need to be vary careful that we preserve
+            // TODO when multi-tenancy (as well as batching) is implemented we need to be very careful that we preserve
             // the thread contexts correctly to avoid accidentally retrieving the credentials for the wrong user
             ContextPreservingActionListener.wrapPreservingContext(listener, threadPool.getThreadContext())
         );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorService.java
@@ -11,6 +11,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Strings;
@@ -269,7 +270,15 @@ class RequestExecutorService implements RequestExecutor {
         @Nullable TimeValue timeout,
         ActionListener<InferenceServiceResults> listener
     ) {
-        var task = new RequestTask(requestCreator, input, timeout, threadPool, listener);
+        var task = new RequestTask(
+            requestCreator,
+            input,
+            timeout,
+            threadPool,
+            // TODO when multi-tenancy (as well as batching) is implemented we need to be vary careful that we preserve
+            // the thread contexts correctly to avoid accidentally retrieving the credentials for the wrong user
+            ContextPreservingActionListener.wrapPreservingContext(listener, threadPool.getThreadContext())
+        );
 
         if (isShutdown()) {
             EsRejectedExecutionException rejected = new EsRejectedExecutionException(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableRequestCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableRequestCreatorTests.java
@@ -9,13 +9,15 @@ package org.elasticsearch.xpack.inference.external.http.sender;
 
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.xpack.inference.external.http.retry.RequestSender;
 import org.elasticsearch.xpack.inference.external.http.retry.ResponseHandler;
 import org.elasticsearch.xpack.inference.external.request.RequestTests;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -33,16 +35,30 @@ public class ExecutableRequestCreatorTests {
 
     public static ExecutableRequestCreator createMock(RequestSender requestSender, String modelId) {
         var mockCreator = mock(ExecutableRequestCreator.class);
-        when(mockCreator.create(anyList(), any(), any(), any(), any())).thenReturn(() -> {
-            requestSender.send(
+
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            ActionListener<InferenceServiceResults> listener = (ActionListener<InferenceServiceResults>) invocation.getArguments()[4];
+            return (Runnable) () -> requestSender.send(
                 mock(Logger.class),
                 RequestTests.mockRequest(modelId),
                 HttpClientContext.create(),
                 () -> false,
                 mock(ResponseHandler.class),
-                new PlainActionFuture<>()
+                listener
             );
-        });
+        }).when(mockCreator).create(anyList(), any(), any(), any(), any());
+
+        // when(mockCreator.create(anyList(), any(), any(), any(), any())).thenReturn(
+        // () -> requestSender.send(
+        // mock(Logger.class),
+        // RequestTests.mockRequest(modelId),
+        // HttpClientContext.create(),
+        // () -> false,
+        // mock(ResponseHandler.class),
+        // new PlainActionFuture<>()
+        // )
+        // );
 
         return mockCreator;
     }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableRequestCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/ExecutableRequestCreatorTests.java
@@ -49,17 +49,6 @@ public class ExecutableRequestCreatorTests {
             );
         }).when(mockCreator).create(anyList(), any(), any(), any(), any());
 
-        // when(mockCreator.create(anyList(), any(), any(), any(), any())).thenReturn(
-        // () -> requestSender.send(
-        // mock(Logger.class),
-        // RequestTests.mockRequest(modelId),
-        // HttpClientContext.create(),
-        // () -> false,
-        // mock(ResponseHandler.class),
-        // new PlainActionFuture<>()
-        // )
-        // );
-
         return mockCreator;
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
@@ -53,7 +53,7 @@ public class RequestExecutorServiceTests extends ESTestCase {
     private ThreadPool threadPool;
 
     @Before
-    public void init() throws Exception {
+    public void init() {
         threadPool = createThreadPool(inferenceUtilityPool());
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/sender/RequestExecutorServiceTests.java
@@ -9,9 +9,11 @@ package org.elasticsearch.xpack.inference.external.http.sender;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchTimeoutException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.inference.InferenceServiceResults;
@@ -51,7 +53,7 @@ public class RequestExecutorServiceTests extends ESTestCase {
     private ThreadPool threadPool;
 
     @Before
-    public void init() {
+    public void init() throws Exception {
         threadPool = createThreadPool(inferenceUtilityPool());
     }
 
@@ -213,6 +215,61 @@ public class RequestExecutorServiceTests extends ESTestCase {
             thrownException.getMessage(),
             is(format("Request timed out waiting to be sent after [%s]", TimeValue.timeValueNanos(1)))
         );
+    }
+
+    public void testSend_PreservesThreadContext() throws InterruptedException, ExecutionException, TimeoutException {
+        var service = createRequestExecutorServiceWithMocks();
+
+        // starting this on a separate thread to ensure we aren't using the same thread context that the rest of the test will execute with
+        threadPool.generic().execute(service::start);
+
+        ThreadContext threadContext = threadPool.getThreadContext();
+        threadContext.putHeader("not empty", "value");
+
+        var requestSender = mock(RetryingHttpSender.class);
+
+        var waitToShutdown = new CountDownLatch(1);
+        var waitToReturnFromSend = new CountDownLatch(1);
+
+        // this code will be executed by the queue's thread
+        doAnswer(invocation -> {
+            var serviceThreadContext = threadPool.getThreadContext();
+            // ensure that the spawned thread didn't pick up the header that was set initially on a separate thread
+            assertNull(serviceThreadContext.getHeader("not empty"));
+
+            @SuppressWarnings("unchecked")
+            ActionListener<InferenceServiceResults> listener = (ActionListener<InferenceServiceResults>) invocation.getArguments()[5];
+            listener.onResponse(null);
+
+            waitToShutdown.countDown();
+            waitToReturnFromSend.await(TIMEOUT.getSeconds(), TimeUnit.SECONDS);
+            return Void.TYPE;
+        }).when(requestSender).send(any(), any(), any(), any(), any(), any());
+
+        var finishedOnResponse = new CountDownLatch(1);
+        ActionListener<InferenceServiceResults> listener = new ActionListener<>() {
+            @Override
+            public void onResponse(InferenceServiceResults ignore) {
+                // if we've preserved the thread context correctly then the header should still exist
+                ThreadContext listenerContext = threadPool.getThreadContext();
+                assertThat(listenerContext.getHeader("not empty"), is("value"));
+                finishedOnResponse.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new RuntimeException("onFailure shouldn't be called", e);
+            }
+        };
+
+        service.execute(ExecutableRequestCreatorTests.createMock(requestSender), List.of(), null, listener);
+
+        Future<?> executorTermination = submitShutdownRequest(waitToShutdown, waitToReturnFromSend, service);
+
+        executorTermination.get(TIMEOUT.millis(), TimeUnit.MILLISECONDS);
+        assertTrue(service.isTerminated());
+
+        finishedOnResponse.await(TIMEOUT.getSeconds(), TimeUnit.SECONDS);
     }
 
     public void testSend_NotifiesTasksOfShutdown() {


### PR DESCRIPTION
This PR fixes a bug introduced in this PR: https://github.com/elastic/elasticsearch/pull/105526

After the refactoring I accidentally forgot to preserve the thread context like we were doing previously. I added a test to ensure it doesn't get removed again in the future.