### PR TITLE
Remove end of life Java versions from our testing matrix

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -69,9 +69,6 @@ steps:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
               - openjdk17
-              - openjdk18
-              - openjdk19
-              - openjdk20
               - openjdk21
               - openjdk22
             GRADLE_TASK:

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -1250,9 +1250,6 @@ steps:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
               - openjdk17
-              - openjdk18
-              - openjdk19
-              - openjdk20
               - openjdk21
               - openjdk22
             GRADLE_TASK:


### PR DESCRIPTION
These Java versions are EOL and no longer supported by Elasticsearch so we can remove them from our CI testing. We only need to support LTS versions >= 17 and the currently latest bundled JDK version.