### PR TITLE
[8.12] Remove end of life Java versions from our testing matrix (#106042)

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -69,9 +69,6 @@ steps:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
               - openjdk17
-              - openjdk18
-              - openjdk19
-              - openjdk20
               - openjdk21
               - openjdk22
             GRADLE_TASK:

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -1230,9 +1230,6 @@ steps:
             ES_RUNTIME_JAVA:
               - graalvm-ce17
               - openjdk17
-              - openjdk18
-              - openjdk19
-              - openjdk20
               - openjdk21
               - openjdk22
             GRADLE_TASK:


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Remove end of life Java versions from our testing matrix (#106042)