### PR TITLE
Adjust terminal  to new behavior in JDK 22. (#103614)

### DIFF
--- a/libs/cli/build.gradle
+++ b/libs/cli/build.gradle
@@ -11,9 +11,12 @@ apply plugin: 'elasticsearch.publish'
 dependencies {
   api 'net.sf.jopt-simple:jopt-simple:5.0.2'
   api project(':libs:elasticsearch-core')
+
+  testImplementation(project(":test:framework")) {
+    exclude group: 'org.elasticsearch', module: 'elasticsearch-cli'
+  }
 }
 
-tasks.named("test").configure { enabled = false }
 // Since CLI does not depend on :server, it cannot run the jarHell task
 tasks.named("jarHell").configure { enabled = false }
 

--- a/libs/cli/src/test/java/org/elasticsearch/cli/TerminalTests.java
+++ b/libs/cli/src/test/java/org/elasticsearch/cli/TerminalTests.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cli;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ESTestCase.WithoutSecurityManager;
+
+@WithoutSecurityManager
+public class TerminalTests extends ESTestCase {
+
+    public void testSystemTerminalIfRedirected() {
+        // Expect system terminal if redirected for tests.
+        // To force new behavior in JDK 22 this should run without security manager.
+        // Otherwise, JDK 22 doesn't provide a console if redirected.
+        assertEquals(Terminal.SystemTerminal.class, Terminal.DEFAULT.getClass());
+    }
+}


### PR DESCRIPTION
JDK 22 may return a console even if the terminal is redirected. These cases are detected using the new Console#isTerminal() to maintain the current behavior (closes #98033).