### PR TITLE
Avoid computing currentInferenceProcessors on every cluster state

### DIFF
--- a/docs/changelog/106057.yaml
+++ b/docs/changelog/106057.yaml
@@ -1,0 +1,5 @@
+pr: 106057
+summary: Avoid computing `currentInferenceProcessors` on every cluster state
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -367,14 +367,13 @@ public class InferenceProcessor extends AbstractProcessor {
         private static final Logger logger = LogManager.getLogger(Factory.class);
 
         private final Client client;
-        private final ClusterService clusterService;
         private final InferenceAuditor auditor;
+        private volatile ClusterState clusterState = ClusterState.EMPTY_STATE;
         private volatile int maxIngestProcessors;
         private volatile MlConfigVersion minNodeVersion = MlConfigVersion.CURRENT;
 
         public Factory(Client client, ClusterService clusterService, Settings settings, boolean includeNodeInfo) {
             this.client = client;
-            this.clusterService = clusterService;
             this.maxIngestProcessors = MAX_INFERENCE_PROCESSORS.get(settings);
             this.auditor = new InferenceAuditor(client, clusterService, includeNodeInfo);
             clusterService.getClusterSettings().addSettingsUpdateConsumer(MAX_INFERENCE_PROCESSORS, this::setMaxIngestProcessors);
@@ -383,7 +382,8 @@ public class InferenceProcessor extends AbstractProcessor {
         @Override
         public void accept(ClusterState state) {
             try {
-                minNodeVersion = MlConfigVersion.getMinMlConfigVersion(state.nodes());
+                this.clusterState = state;
+                this.minNodeVersion = MlConfigVersion.getMinMlConfigVersion(state.nodes());
             } catch (Exception ex) {
                 // We cannot throw any exception here. It might break other pipelines.
                 logger.debug("failed gathering processors for pipelines", ex);
@@ -397,7 +397,7 @@ public class InferenceProcessor extends AbstractProcessor {
             String description,
             Map<String, Object> config
         ) {
-            final var currentInferenceProcessors = InferenceProcessorInfoExtractor.countInferenceProcessors(clusterService.state());
+            final var currentInferenceProcessors = InferenceProcessorInfoExtractor.countInferenceProcessors(clusterState);
             if (this.maxIngestProcessors <= currentInferenceProcessors) {
                 throw new ElasticsearchStatusException(
                     "Max number of inference processors reached, total inference processors [{}]. "

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.inference.ingest;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -27,11 +26,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
-import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -61,7 +58,6 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConf
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfigUpdate;
 import org.elasticsearch.xpack.ml.MachineLearning;
-import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -91,7 +87,6 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
     @Before
     public void setUpVariables() {
         ThreadPool tp = mock(ThreadPool.class);
-        when(tp.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         when(tp.generic()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
         client = mock(Client.class);
         Settings settings = Settings.builder().put("node.name", "InferenceProcessorFactoryTests_node").build();
@@ -108,15 +103,6 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             )
         );
         clusterService = new ClusterService(settings, clusterSettings, tp, null);
-        final var clusterApplierService = clusterService.getClusterApplierService();
-        clusterApplierService.setInitialState(ClusterState.EMPTY_STATE);
-        clusterApplierService.setNodeConnectionsService(ClusterServiceUtils.createNoOpNodeConnectionsService());
-        clusterApplierService.start();
-    }
-
-    @After
-    public void cleanUp() {
-        clusterService.getClusterApplierService().close();
     }
 
     public void testCreateProcessorWithTooManyExisting() {
@@ -131,12 +117,7 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             );
 
             try {
-                final var clusterState = buildClusterStateWithModelReferences("model1");
-                safeAwait(
-                    SubscribableListener.<Void>newForked(
-                        l -> clusterService.getClusterApplierService().onNewClusterState("test", () -> clusterState, l)
-                    )
-                );
+                processorFactory.accept(buildClusterStateWithModelReferences("model1"));
             } catch (IOException ioe) {
                 throw new AssertionError(ioe.getMessage());
             }


### PR DESCRIPTION
This computation involves parsing all the pipeline metadata on the
cluster applier thread. It's pretty expensive if there are lots of
pipelines, and seems mostly unnecessary because it's only needed for a
validation check when creating new processors.