### PR TITLE
[DOCS] Documents scripted metric aggregation limitation in datafeeds

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -17,6 +17,10 @@ There are a number of requirements for using aggregations in {dfeeds}.
 [[aggs-aggs]]
 === Aggregations
 
+* Using 
+<<search-aggregations-metrics-scripted-metric-aggregation, scripted metric>>
+aggregations is not supported in {dfeeds}.
+
 * Your aggregation must include a `date_histogram` aggregation or a top level 
 `composite` aggregation, which in turn must contain a `max` aggregation on the 
 time field. It ensures that the aggregated data is a time series and the 
@@ -75,6 +79,10 @@ chart.
 
 * Your {dfeed} can contain multiple aggregations, but only the ones with names
 that match values in the job configuration are fed to the job.
+
+* Using 
+<<search-aggregations-metrics-scripted-metric-aggregation, scripted metric>>
+aggregations is not supported in {dfeeds}.
 
 
 [discrete]

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -18,7 +18,7 @@ There are a number of requirements for using aggregations in {dfeeds}.
 === Aggregations
 
 * Using 
-<<search-aggregations-metrics-scripted-metric-aggregation, scripted metric>>
+{ref}/search-aggregations-metrics-scripted-metric-aggregation.html[scripted metric]
 aggregations is not supported in {dfeeds}.
 
 * Your aggregation must include a `date_histogram` aggregation or a top level 
@@ -81,7 +81,7 @@ chart.
 that match values in the job configuration are fed to the job.
 
 * Using 
-<<search-aggregations-metrics-scripted-metric-aggregation, scripted metric>>
+{ref}/search-aggregations-metrics-scripted-metric-aggregation.html[scripted metric]
 aggregations is not supported in {dfeeds}.
 
 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -17,10 +17,6 @@ There are a number of requirements for using aggregations in {dfeeds}.
 [[aggs-aggs]]
 === Aggregations
 
-* Using 
-{ref}/search-aggregations-metrics-scripted-metric-aggregation.html[scripted metric]
-aggregations is not supported in {dfeeds}.
-
 * Your aggregation must include a `date_histogram` aggregation or a top level 
 `composite` aggregation, which in turn must contain a `max` aggregation on the 
 time field. It ensures that the aggregated data is a time series and the 


### PR DESCRIPTION
## Overview

Related issue: https://github.com/elastic/elasticsearch/issues/105878
This PR documents that scripted metric aggregations are not supported in anomaly detection datafeeds.

### Preview

[Aggregating data for faster performance](https://elasticsearch_bk_106059.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-configuring-aggregation.html)