### PR TITLE
Introduce setting aliases to migrate settings more easily.

### DIFF
--- a/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/telemetry/apm/internal/APMAgentSettingsTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.mockito.Mockito;
@@ -187,6 +188,8 @@ public class APMAgentSettingsTests extends ESTestCase {
 
         verify(apmAgentSettings).setAgentSetting("recording", "true");
         verify(apmAgentSettings).setAgentSetting("span_compression_enabled", "true");
+
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] { APM_AGENT_SETTINGS });
     }
 
     /**
@@ -204,6 +207,8 @@ public class APMAgentSettingsTests extends ESTestCase {
             Settings settings = Settings.builder().put(prefix + "global_labels." + randomAlphaOfLength(5), "123").build();
             APM_AGENT_SETTINGS.getAsMap(settings);
         }
+
+        assertSettingDeprecationsAndWarnings(new Setting<?>[] { APM_AGENT_SETTINGS });
     }
 
     public void testTelemetryTracingNamesIncludeFallback() {

--- a/server/src/main/java/org/elasticsearch/node/NodeRoleSettings.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeRoleSettings.java
@@ -18,7 +18,6 @@ public class NodeRoleSettings {
 
     public static final Setting<List<DiscoveryNodeRole>> NODE_ROLES_SETTING = Setting.listSetting(
         "node.roles",
-        null,
         DiscoveryNodeRole::getRoleFromRoleName,
         settings -> DiscoveryNodeRole.roles()
             .stream()

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -580,11 +580,13 @@ public abstract class ESTestCase extends LuceneTestCase {
      */
     protected final void assertSettingDeprecationsAndWarnings(final Setting<?>[] settings, final DeprecationWarning... warnings) {
         assertWarnings(true, Stream.concat(Arrays.stream(settings).map(setting -> {
-            String warningMessage = String.format(
-                Locale.ROOT,
-                "[%s] setting was deprecated in Elasticsearch and will be removed in a future release.",
-                setting.getKey()
-            );
+            String warningMessage = setting.hasAlias()
+                ? Strings.format(
+                    "[%s] setting was deprecated in Elasticsearch and will be removed in a future release. Please use [%s] instead.",
+                    setting.getAliasKey(),
+                    setting.getKey()
+                )
+                : Strings.format("[%s] setting was deprecated in Elasticsearch and will be removed in a future release.", setting.getKey());
             return new DeprecationWarning(
                 setting.getProperties().contains(Setting.Property.Deprecated) ? DeprecationLogger.CRITICAL : Level.WARN,
                 warningMessage


### PR DESCRIPTION
Fallback settings are not well-suited when migrating a setting from one key to another. The problem is that update consumers are not properly triggered if both the old (fallback) and new setting are present causing changes to be silently ignored if the old version is used.

Alias settings behave similar to fallback settings with the difference that updates to the deprecated alias are copied to the new setting in addition. This ensures that update consumers are always triggered properly to ensure a more intuitive / less confusing behavior.

Usage of a setting alias will always trigger a deprecation warning.

(relates to ES-7815)