### PR TITLE
[8.13] [DOCS] Documents scripted metric aggregation limitation in datafeeds (#106059)

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -76,6 +76,10 @@ chart.
 * Your {dfeed} can contain multiple aggregations, but only the ones with names
 that match values in the job configuration are fed to the job.
 
+* Using 
+{ref}/search-aggregations-metrics-scripted-metric-aggregation.html[scripted metric]
+aggregations is not supported in {dfeeds}.
+
 
 [discrete]
 [[aggs-recommendations-dfeeds]]


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [DOCS] Documents scripted metric aggregation limitation in datafeeds (#106059)