### PR TITLE
[8.13] [Connector API] Fix serialisation of script params in connector index service (#106060)

### DIFF
--- a/docs/changelog/106060.yaml
+++ b/docs/changelog/106060.yaml
@@ -1,0 +1,5 @@
+pr: 106060
+summary: "[Connector API] Fix serialisation of script params in connector index service"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
@@ -30,7 +30,9 @@ import org.elasticsearch.xpack.application.connector.configuration.Configuration
 import org.elasticsearch.xpack.application.connector.configuration.ConfigurationValidation;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
@@ -217,6 +219,62 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
         );
     }
 
+    public String getCategory() {
+        return category;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+    public List<ConfigurationDependency> getDependsOn() {
+        return dependsOn;
+    }
+
+    public ConfigurationDisplayType getDisplay() {
+        return display;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public List<ConfigurationSelectOption> getOptions() {
+        return options;
+    }
+
+    public Integer getOrder() {
+        return order;
+    }
+
+    public String getPlaceholder() {
+        return placeholder;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public boolean isSensitive() {
+        return sensitive;
+    }
+
+    public String getTooltip() {
+        return tooltip;
+    }
+
+    public ConfigurationFieldType getType() {
+        return type;
+    }
+
+    public List<String> getUiRestrictions() {
+        return uiRestrictions;
+    }
+
+    public List<ConfigurationValidation> getValidations() {
+        return validations;
+    }
+
     public Object getValue() {
         return value;
     }
@@ -318,6 +376,46 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
         out.writeOptionalStringCollection(uiRestrictions);
         out.writeOptionalCollection(validations);
         out.writeGenericValue(value);
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        if (category != null) {
+            map.put(CATEGORY_FIELD.getPreferredName(), category);
+        }
+        map.put(DEFAULT_VALUE_FIELD.getPreferredName(), defaultValue);
+        if (dependsOn != null) {
+            map.put(DEPENDS_ON_FIELD.getPreferredName(), dependsOn.stream().map(ConfigurationDependency::toMap).toList());
+        }
+        if (display != null) {
+            map.put(DISPLAY_FIELD.getPreferredName(), display.toString());
+        }
+        map.put(LABEL_FIELD.getPreferredName(), label);
+        if (options != null) {
+            map.put(OPTIONS_FIELD.getPreferredName(), options.stream().map(ConfigurationSelectOption::toMap).toList());
+        }
+        if (order != null) {
+            map.put(ORDER_FIELD.getPreferredName(), order);
+        }
+        if (placeholder != null) {
+            map.put(PLACEHOLDER_FIELD.getPreferredName(), placeholder);
+        }
+        map.put(REQUIRED_FIELD.getPreferredName(), required);
+        map.put(SENSITIVE_FIELD.getPreferredName(), sensitive);
+        if (tooltip != null) {
+            map.put(TOOLTIP_FIELD.getPreferredName(), tooltip);
+        }
+        if (type != null) {
+            map.put(TYPE_FIELD.getPreferredName(), type.toString());
+        }
+        if (uiRestrictions != null) {
+            map.put(UI_RESTRICTIONS_FIELD.getPreferredName(), uiRestrictions);
+        }
+        if (validations != null) {
+            map.put(VALIDATIONS_FIELD.getPreferredName(), validations.stream().map(ConfigurationValidation::toMap).toList());
+        }
+        map.put(VALUE_FIELD.getPreferredName(), value);
+        return map;
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -418,7 +418,7 @@ public class ConnectorIndexService {
                         updateConfigurationScript,
                         Map.of(
                             Connector.CONFIGURATION_FIELD.getPreferredName(),
-                            request.getConfiguration(),
+                            request.getConfigurationAsMap(),
                             Connector.STATUS_FIELD.getPreferredName(),
                             ConnectorStatus.CONFIGURED.toString()
                         )

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorConfigurationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorConfigurationAction.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -68,6 +69,10 @@ public class UpdateConnectorConfigurationAction {
 
         public Map<String, ConnectorConfiguration> getConfiguration() {
             return configuration;
+        }
+
+        public Map<String, Map<String, Object>> getConfigurationAsMap() {
+            return configuration.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toMap()));
         }
 
         public Map<String, Object> getConfigurationValues() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDependency.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationDependency.java
@@ -19,6 +19,8 @@ import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
@@ -82,6 +84,13 @@ public class ConfigurationDependency implements Writeable, ToXContentObject {
         }
         builder.endObject();
         return builder;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(FIELD_FIELD.getPreferredName(), field);
+        map.put(VALUE_FIELD.getPreferredName(), value);
+        return map;
     }
 
     public static ConfigurationDependency fromXContent(XContentParser parser) throws IOException {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationSelectOption.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationSelectOption.java
@@ -17,6 +17,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
@@ -58,6 +60,13 @@ public class ConfigurationSelectOption implements Writeable, ToXContentObject {
         }
         builder.endObject();
         return builder;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(LABEL_FIELD.getPreferredName(), label);
+        map.put(VALUE_FIELD.getPreferredName(), value);
+        return map;
     }
 
     public static ConfigurationSelectOption fromXContent(XContentParser parser) throws IOException {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidation.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidation.java
@@ -19,6 +19,8 @@ import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
@@ -98,6 +100,13 @@ public class ConfigurationValidation implements Writeable, ToXContentObject {
         }
         builder.endObject();
         return builder;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> map = new HashMap<>();
+        map.put(CONSTRAINT_FIELD.getPreferredName(), constraint);
+        map.put(TYPE_FIELD.getPreferredName(), type.toString());
+        return map;
     }
 
     public static ConfigurationValidation fromXContent(XContentParser parser) throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorConfigurationTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorConfigurationTests.java
@@ -17,10 +17,14 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.application.connector.configuration.ConfigurationDependency;
+import org.elasticsearch.xpack.application.connector.configuration.ConfigurationSelectOption;
+import org.elasticsearch.xpack.application.connector.configuration.ConfigurationValidation;
 import org.junit.Before;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
@@ -186,6 +190,87 @@ public class ConnectorConfigurationTests extends ESTestCase {
             parsed = ConnectorConfiguration.fromXContent(parser);
         }
         assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
+    public void testToMap() {
+        ConnectorConfiguration configField = ConnectorTestUtils.getRandomConnectorConfigurationField();
+        Map<String, Object> configFieldAsMap = configField.toMap();
+
+        if (configField.getCategory() != null) {
+            assertThat(configFieldAsMap.get("category"), equalTo(configField.getCategory()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("category"));
+        }
+
+        assertThat(configFieldAsMap.get("default_value"), equalTo(configField.getDefaultValue()));
+
+        if (configField.getDependsOn() != null) {
+            List<Map<String, Object>> dependsOnAsList = configField.getDependsOn().stream().map(ConfigurationDependency::toMap).toList();
+            assertThat(configFieldAsMap.get("depends_on"), equalTo(dependsOnAsList));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("depends_on"));
+        }
+
+        if (configField.getDisplay() != null) {
+            assertThat(configFieldAsMap.get("display"), equalTo(configField.getDisplay().toString()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("display"));
+        }
+
+        assertThat(configFieldAsMap.get("label"), equalTo(configField.getLabel()));
+
+        if (configField.getOptions() != null) {
+            List<Map<String, Object>> optionsAsList = configField.getOptions().stream().map(ConfigurationSelectOption::toMap).toList();
+            assertThat(configFieldAsMap.get("options"), equalTo(optionsAsList));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("options"));
+        }
+
+        if (configField.getOrder() != null) {
+            assertThat(configFieldAsMap.get("order"), equalTo(configField.getOrder()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("order"));
+        }
+
+        if (configField.getPlaceholder() != null) {
+            assertThat(configFieldAsMap.get("placeholder"), equalTo(configField.getPlaceholder()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("placeholder"));
+        }
+
+        assertThat(configFieldAsMap.get("required"), equalTo(configField.isRequired()));
+        assertThat(configFieldAsMap.get("sensitive"), equalTo(configField.isSensitive()));
+
+        if (configField.getTooltip() != null) {
+            assertThat(configFieldAsMap.get("tooltip"), equalTo(configField.getTooltip()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("tooltip"));
+        }
+
+        if (configField.getType() != null) {
+            assertThat(configFieldAsMap.get("type"), equalTo(configField.getType().toString()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("type"));
+        }
+
+        if (configField.getUiRestrictions() != null) {
+            assertThat(configFieldAsMap.get("ui_restrictions"), equalTo(configField.getUiRestrictions()));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("ui_restrictions"));
+        }
+
+        if (configField.getValidations() != null) {
+            List<Map<String, Object>> validationsAsList = configField.getValidations()
+                .stream()
+                .map(ConfigurationValidation::toMap)
+                .toList();
+            assertThat(configFieldAsMap.get("validations"), equalTo(validationsAsList));
+        } else {
+            assertFalse(configFieldAsMap.containsKey("validations"));
+        }
+
+        assertThat(configFieldAsMap.get("value"), equalTo(configField.getValue()));
+
     }
 
     private void assertTransportSerialization(ConnectorConfiguration testInstance) throws IOException {


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Connector API] Fix serialisation of script params in connector index service (#106060)