### PR TITLE
[7.17] OIDC doc - mention client secret needs a restart (#106088)

### DIFF
--- a/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+++ b/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
@@ -197,6 +197,7 @@ For instance
 bin/elasticsearch-keystore add xpack.security.authc.realms.oidc.oidc1.rp.client_secret
 ----
 
+NOTE: Changes to the `client_secret` requires a restart of the {es} nodes to pick up the change.
 
 NOTE: According to the OpenID Connect specification, the OP should also make their configuration
 available at a well known URL, which is the concatenation of their `Issuer` value with the


### PR DESCRIPTION
Backports the following commits to 7.17:
 - OIDC doc - mention client secret needs a restart (#106088)