### PR TITLE
Remove limitation on cross lib dependencies

### DIFF
--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -12,35 +12,4 @@ configure(subprojects - project('elasticsearch-log4j')) {
    * tools.
    */
   apply plugin: 'elasticsearch.build'
-
-  /*
-   * Subprojects may depend on the "core" lib but may not depend on any
-   * other libs. This keeps our dependencies simpler.
-   * With the exception that specialised plugin apis can depend on "core" plugin api project
-   */
-  project.afterEvaluate {
-    configurations.all { Configuration conf ->
-      dependencies.matching { it instanceof ProjectDependency }.all { ProjectDependency dep ->
-        Project depProject = dep.dependencyProject
-        if (depProject != null
-          && false == isPluginApi(project, depProject)
-          && false == depProject.path.equals(':libs:elasticsearch-x-content')
-          && false == depProject.path.equals(':libs:elasticsearch-core')
-          && false == depProject.path.equals(':libs:elasticsearch-plugin-api')
-          && false == depProject.path.equals(':libs:elasticsearch-logging')
-          && false == depProject.path.equals(':libs:elasticsearch-native')
-          && depProject.path.startsWith(':libs')
-          && depProject.name.startsWith('elasticsearch-')) {
-          throw new InvalidUserDataException("projects in :libs "
-            + "may not depend on other projects libs except "
-            + ":libs:elasticsearch-core but "
-            + "${project.path} depends on ${depProject.path}")
-        }
-      }
-    }
-  }
-}
-
-boolean isPluginApi(Project project, Project depProject) {
-  return project.path.matches(".*elasticsearch-plugin-.*api")
 }


### PR DESCRIPTION
Libs were meant to be a way to break up code from server without creating full fledged modules. They still exist on the system classpath, but we did not want to introduce a spaghetti of jars depending on each other. The check that ensures libs don't depend on each other was added before Elasticsearch was modularized. Since it now runs modular, the cross module dependencies are easy to visualize with module-info, and the module system protects us from circular deps. Additionally, the number of exceptions to the no-cross-lib-deps rule has grown considerably.

Given all of the above, the check on cross lib dependencies no longer provides much benefit, and is more of a hinderance. This commit removes the check.