### PR TITLE
Only apply build to direct libs

### DIFF
--- a/libs/build.gradle
+++ b/libs/build.gradle
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-configure(subprojects - project('elasticsearch-log4j')) {
+configure(childProjects.values() - project('elasticsearch-log4j')) {
   /*
    * All subprojects are java projects using Elasticsearch's standard build
    * tools.

--- a/libs/native/jna/build.gradle
+++ b/libs/native/jna/build.gradle
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-apply plugin: 'elasticsearch.java'
+apply plugin: 'elasticsearch.build'
 
 base {
   archivesName = "native-access-jna"

--- a/libs/x-content/impl/build.gradle
+++ b/libs/x-content/impl/build.gradle
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-apply plugin: 'elasticsearch.java'
+apply plugin: 'elasticsearch.build'
 
 base {
   archivesName = "x-content-impl"


### PR DESCRIPTION
Sometimes libs have subprojects that may not be java projects. This commit adjusts the shared configuration for libs to only affect direct subprojects of :lib.