### PR TITLE
Respect --pass option in certutil csr mode

### DIFF
--- a/docs/changelog/106105.yaml
+++ b/docs/changelog/106105.yaml
@@ -1,0 +1,5 @@
+pr: 106105
+summary: Respect --pass option in certutil csr mode
+area: TLS
+type: bug
+issues: []


### PR DESCRIPTION
elasticsearch-certutil csr generates a private key and a certificate signing request (CSR) file.
It has always accepted the "--pass" command line option, but ignore it and always generated an unencrypted private key.

This commit fixes the utility so the --pass option is respected and the private key is encrypted.

