### PR TITLE
Fix flaky test with sort order variation

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -115,6 +115,7 @@ stXFromAirportsSupportsNull#[skip:-8.13.99, reason:st_x and st_y added in 8.14]
 FROM airports
 | EVAL x = FLOOR(ABS(ST_X(city_location))/200), y = FLOOR(ABS(ST_Y(city_location))/100)
 | STATS c = count(*) BY x, y
+| SORT c DESC
 ;
 
 c:long  | x:double  | y:double


### PR DESCRIPTION
Very rarely (once so far in CI) the STATS order is reversed

Fixes #106019 