### PR TITLE
[Connector API] Add native_connector_api_keys feature definition

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorFeatures.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorFeatures.java
@@ -41,28 +41,34 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
     @Nullable
     private final FeatureEnabled incrementalSyncEnabled;
     @Nullable
+    private final FeatureEnabled nativeConnectorAPIKeysEnabled;
+    @Nullable
     private final SyncRulesFeatures syncRulesFeatures;
 
     /**
      * Constructs a new instance of ConnectorFeatures.
      *
-     * @param documentLevelSecurityEnabled A flag indicating whether document-level security is enabled.
-     * @param filteringAdvancedConfig      A flag indicating whether advanced filtering configuration is enabled.
-     * @param filteringRules               A flag indicating whether filtering rules are enabled.
-     * @param incrementalSyncEnabled       A flag indicating whether incremental sync is enabled.
-     * @param syncRulesFeatures            An {@link SyncRulesFeatures} object indicating whether basic and advanced sync rules are enabled.
+     * @param documentLevelSecurityEnabled  A flag indicating whether document-level security is enabled.
+     * @param filteringAdvancedConfig       A flag indicating whether advanced filtering configuration is enabled.
+     * @param filteringRules                A flag indicating whether filtering rules are enabled.
+     * @param incrementalSyncEnabled        A flag indicating whether incremental sync is enabled.
+     * @param nativeConnectorAPIKeysEnabled A flag indicating whether support for api keys is enabled for native connectors.
+     * @param syncRulesFeatures             An {@link SyncRulesFeatures} object indicating if basic and advanced sync rules are enabled.
      */
     private ConnectorFeatures(
         FeatureEnabled documentLevelSecurityEnabled,
         Boolean filteringAdvancedConfig,
         Boolean filteringRules,
         FeatureEnabled incrementalSyncEnabled,
+        FeatureEnabled nativeConnectorAPIKeysEnabled,
         SyncRulesFeatures syncRulesFeatures
+
     ) {
         this.documentLevelSecurityEnabled = documentLevelSecurityEnabled;
         this.filteringAdvancedConfigEnabled = filteringAdvancedConfig;
         this.filteringRulesEnabled = filteringRules;
         this.incrementalSyncEnabled = incrementalSyncEnabled;
+        this.nativeConnectorAPIKeysEnabled = nativeConnectorAPIKeysEnabled;
         this.syncRulesFeatures = syncRulesFeatures;
     }
 
@@ -71,6 +77,7 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
         this.filteringAdvancedConfigEnabled = in.readOptionalBoolean();
         this.filteringRulesEnabled = in.readOptionalBoolean();
         this.incrementalSyncEnabled = in.readOptionalWriteable(FeatureEnabled::new);
+        this.nativeConnectorAPIKeysEnabled = in.readOptionalWriteable(FeatureEnabled::new);
         this.syncRulesFeatures = in.readOptionalWriteable(SyncRulesFeatures::new);
     }
 
@@ -78,19 +85,19 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
     private static final ParseField FILTERING_ADVANCED_CONFIG_ENABLED_FIELD = new ParseField("filtering_advanced_config");
     private static final ParseField FILTERING_RULES_ENABLED_FIELD = new ParseField("filtering_rules");
     private static final ParseField INCREMENTAL_SYNC_ENABLED_FIELD = new ParseField("incremental_sync");
+    private static final ParseField NATIVE_CONNECTOR_API_KEYS_ENABLED_FIELD = new ParseField("native_connector_api_keys");
     private static final ParseField SYNC_RULES_FIELD = new ParseField("sync_rules");
 
     private static final ConstructingObjectParser<ConnectorFeatures, Void> PARSER = new ConstructingObjectParser<>(
         "connector_features",
         true,
-        args -> {
-            return new Builder().setDocumentLevelSecurityEnabled((FeatureEnabled) args[0])
-                .setFilteringAdvancedConfig((Boolean) args[1])
-                .setFilteringRules((Boolean) args[2])
-                .setIncrementalSyncEnabled((FeatureEnabled) args[3])
-                .setSyncRulesFeatures((SyncRulesFeatures) args[4])
-                .build();
-        }
+        args -> new Builder().setDocumentLevelSecurityEnabled((FeatureEnabled) args[0])
+            .setFilteringAdvancedConfig((Boolean) args[1])
+            .setFilteringRules((Boolean) args[2])
+            .setIncrementalSyncEnabled((FeatureEnabled) args[3])
+            .setNativeConnectorAPIKeysEnabled((FeatureEnabled) args[4])
+            .setSyncRulesFeatures((SyncRulesFeatures) args[5])
+            .build()
     );
 
     static {
@@ -98,6 +105,7 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
         PARSER.declareBoolean(optionalConstructorArg(), FILTERING_ADVANCED_CONFIG_ENABLED_FIELD);
         PARSER.declareBoolean(optionalConstructorArg(), FILTERING_RULES_ENABLED_FIELD);
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> FeatureEnabled.fromXContent(p), INCREMENTAL_SYNC_ENABLED_FIELD);
+        PARSER.declareObject(optionalConstructorArg(), (p, c) -> FeatureEnabled.fromXContent(p), NATIVE_CONNECTOR_API_KEYS_ENABLED_FIELD);
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> SyncRulesFeatures.fromXContent(p), SYNC_RULES_FIELD);
     }
 
@@ -129,6 +137,9 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
             if (incrementalSyncEnabled != null) {
                 builder.field(INCREMENTAL_SYNC_ENABLED_FIELD.getPreferredName(), incrementalSyncEnabled);
             }
+            if (nativeConnectorAPIKeysEnabled != null) {
+                builder.field(NATIVE_CONNECTOR_API_KEYS_ENABLED_FIELD.getPreferredName(), nativeConnectorAPIKeysEnabled);
+            }
             if (syncRulesFeatures != null) {
                 builder.field(SYNC_RULES_FIELD.getPreferredName(), syncRulesFeatures);
             }
@@ -143,6 +154,7 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
         out.writeOptionalBoolean(filteringAdvancedConfigEnabled);
         out.writeOptionalBoolean(filteringRulesEnabled);
         out.writeOptionalWriteable(incrementalSyncEnabled);
+        out.writeOptionalWriteable(nativeConnectorAPIKeysEnabled);
         out.writeOptionalWriteable(syncRulesFeatures);
     }
 
@@ -155,6 +167,7 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
             && Objects.equals(filteringAdvancedConfigEnabled, features.filteringAdvancedConfigEnabled)
             && Objects.equals(filteringRulesEnabled, features.filteringRulesEnabled)
             && Objects.equals(incrementalSyncEnabled, features.incrementalSyncEnabled)
+            && Objects.equals(nativeConnectorAPIKeysEnabled, features.nativeConnectorAPIKeysEnabled)
             && Objects.equals(syncRulesFeatures, features.syncRulesFeatures);
     }
 
@@ -165,6 +178,7 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
             filteringAdvancedConfigEnabled,
             filteringRulesEnabled,
             incrementalSyncEnabled,
+            nativeConnectorAPIKeysEnabled,
             syncRulesFeatures
         );
     }
@@ -175,6 +189,7 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
         private Boolean filteringAdvancedConfig;
         private Boolean filteringRules;
         private FeatureEnabled incrementalSyncEnabled;
+        private FeatureEnabled nativeConnectorAPIKeysEnabled;
         private SyncRulesFeatures syncRulesFeatures;
 
         public Builder setDocumentLevelSecurityEnabled(FeatureEnabled documentLevelSecurityEnabled) {
@@ -197,6 +212,11 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
             return this;
         }
 
+        public Builder setNativeConnectorAPIKeysEnabled(FeatureEnabled nativeConnectorAPIKeysEnabled) {
+            this.nativeConnectorAPIKeysEnabled = nativeConnectorAPIKeysEnabled;
+            return this;
+        }
+
         public Builder setSyncRulesFeatures(SyncRulesFeatures syncRulesFeatures) {
             this.syncRulesFeatures = syncRulesFeatures;
             return this;
@@ -208,6 +228,7 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
                 filteringAdvancedConfig,
                 filteringRules,
                 incrementalSyncEnabled,
+                nativeConnectorAPIKeysEnabled,
                 syncRulesFeatures
             );
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorFeatures.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorFeatures.java
@@ -62,7 +62,6 @@ public class ConnectorFeatures implements Writeable, ToXContentObject {
         FeatureEnabled incrementalSyncEnabled,
         FeatureEnabled nativeConnectorAPIKeysEnabled,
         SyncRulesFeatures syncRulesFeatures
-
     ) {
         this.documentLevelSecurityEnabled = documentLevelSecurityEnabled;
         this.filteringAdvancedConfigEnabled = filteringAdvancedConfig;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorFeaturesTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorFeaturesTests.java
@@ -110,6 +110,30 @@ public class ConnectorFeaturesTests extends ESTestCase {
         testToXContentChecker(content);
     }
 
+    public void testToXContent_NativeConnectorAPIKeysEnabled() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+                {
+                    "document_level_security": {
+                        "enabled": true
+                    },
+                    "filtering_advanced_config": true,
+                    "sync_rules": {
+                        "advanced": {
+                            "enabled": false
+                        },
+                        "basic": {
+                            "enabled": true
+                        }
+                    },
+                    "native_connector_api_keys": {
+                        "enabled": true
+                    }
+                }
+            """);
+
+        testToXContentChecker(content);
+    }
+
     private void testToXContentChecker(String content) throws IOException {
         ConnectorFeatures features = ConnectorFeatures.fromXContentBytes(new BytesArray(content), XContentType.JSON);
         boolean humanReadable = true;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -114,6 +114,7 @@ public final class ConnectorTestUtils {
             .setFilteringRules(randomFrom(new Boolean[] { null, randomBoolean() }))
             .setFilteringAdvancedConfig(randomFrom(new Boolean[] { null, randomBoolean() }))
             .setIncrementalSyncEnabled(randomBoolean() ? randomConnectorFeatureEnabled() : null)
+            .setNativeConnectorAPIKeysEnabled(randomBoolean() ? randomConnectorFeatureEnabled() : null)
             .setSyncRulesFeatures(randomBoolean() ? randomSyncRulesFeatures() : null)
             .build();
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTests.java
@@ -139,6 +139,9 @@ public class ConnectorTests extends ESTestCase {
                      "basic":{
                         "enabled":true
                      }
+                  },
+                  "native_connector_api_keys": {
+                     "enabled": true
                   }
                },
                "filtering":[


### PR DESCRIPTION
### Changes
- Add new `native_connector_api_keys` feature definition
- It doesn't break anything in 8.13 so no need to backport
- Added unit tests