### PR TITLE
[8.13] Field-caps field has value lookup use map instead of looping array (#105770)

### DIFF
--- a/docs/changelog/105770.yaml
+++ b/docs/changelog/105770.yaml
@@ -1,0 +1,5 @@
+pr: 105770
+summary: Field-caps field has value lookup use map instead of looping array
+area: Search
+type: enhancement
+issues: []

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.mapper.extras;
 
 import org.apache.lucene.document.FeatureField;
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
@@ -136,12 +135,7 @@ public class RankFeatureFieldMapper extends FieldMapper {
 
         @Override
         public boolean fieldHasValue(FieldInfos fieldInfos) {
-            for (FieldInfo fieldInfo : fieldInfos) {
-                if (fieldInfo.getName().equals(NAME)) {
-                    return true;
-                }
-            }
-            return false;
+            return fieldInfos.fieldInfo(NAME) != null;
         }
 
         @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureMetaFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureMetaFieldMapper.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.mapper.extras;
 
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -59,12 +58,7 @@ public class RankFeatureMetaFieldMapper extends MetadataFieldMapper {
 
         @Override
         public boolean fieldHasValue(FieldInfos fieldInfos) {
-            for (FieldInfo fieldInfo : fieldInfos) {
-                if (fieldInfo.getName().equals(NAME)) {
-                    return true;
-                }
-            }
-            return false;
+            return fieldInfos.fieldInfo(NAME) != null;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappedFieldType.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.FieldInfos;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.PrefixCodedTerms;
@@ -644,12 +643,7 @@ public abstract class MappedFieldType {
      * @return {@code true} if field is present in fieldInfos {@code false} otherwise
      */
     public boolean fieldHasValue(FieldInfos fieldInfos) {
-        for (FieldInfo fieldInfo : fieldInfos) {
-            if (fieldInfo.getName().equals(name())) {
-                return true;
-            }
-        }
-        return false;
+        return fieldInfos.fieldInfo(name()) != null;
     }
 
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [Field-caps field has value lookup use map instead of looping array (#105770)](https://github.com/elastic/elasticsearch/pull/105770)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)