### PR TITLE
Fix test in release builds

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/TSDBRestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/TSDBRestEsqlIT.java
@@ -42,7 +42,7 @@ public class TSDBRestEsqlIT extends ESRestTestCase {
     }
 
     public void testTimeSeriesQuerying() throws IOException {
-        assertTrue("time series querying relies on query pragma", Build.current().isSnapshot());
+        assumeTrue("time series querying relies on query pragma", Build.current().isSnapshot());
         var settings = Settings.builder()
             .loadFromStream("tsdb-settings.json", TSDBRestEsqlIT.class.getResourceAsStream("/tsdb-settings.json"), false)
             .build();


### PR DESCRIPTION
I believe we used an `assert` here when we wanted an `assume` to skip these tests in release builds.

Closes https://github.com/elastic/elasticsearch/issues/106128