### PR TITLE
fixing RejectedExecutionTests

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/RejectedExecutionTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/RejectedExecutionTests.java
@@ -37,7 +37,6 @@ public class RejectedExecutionTests extends AbstractWatcherIntegrationTestCase {
         return false;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/105951")
     public void testHistoryOnRejection() throws Exception {
         createIndex("idx");
         prepareIndex("idx").setSource("field", "a").get();
@@ -73,11 +72,11 @@ public class RejectedExecutionTests extends AbstractWatcherIntegrationTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
-
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(XPackSettings.SECURITY_ENABLED.getKey(), false)
             .put(LicenseSettings.SELF_GENERATED_LICENSE_TYPE.getKey(), "trial")
+            .put("xpack.watcher.thread_pool.size", 1)
             .put("xpack.watcher.thread_pool.queue_size", 0)
             .build();
     }


### PR DESCRIPTION
In #106134 I fixed RejectedExecutionTests to not throw EsRejectedExcecutionExceptions when writing history. But I inadvertently sometimes made watches themselves succeed. The reason is that even though I left the watch queue size at 0, I increased the thread pool size. So it was possible for a watch to get rejected by the executor queue but still run on an available thread. This restores the original `xpack.watcher.thread_pool.size`.
Closes #105951