### PR TITLE
ESQL: Add MATCHING_ROW and VALUE_AT

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -17,31 +17,26 @@ import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.HashAggregationOperator;
 import org.elasticsearch.core.Releasable;
 
 import java.util.List;
 
 /**
- * A specialized hash table implementation maps values of a {@link Block} to ids (in longs).
- * This class delegates to {@link LongHash} or {@link BytesRefHash}.
- *
- * @see LongHash
- * @see BytesRefHash
+ * A specialized hash table implementation maps values of a {@link Block} to ids (ints).
+ * This class delegates to mostly {@link LongHash}, {@link LongLongHash} or {@link BytesRefHash}.
  */
 public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
     permits BooleanBlockHash, BytesRefBlockHash, DoubleBlockHash, IntBlockHash, LongBlockHash,//
     NullBlockHash, PackedValuesBlockHash, BytesRefLongBlockHash, LongLongBlockHash {
 
-    protected final BigArrays bigArrays;
     protected final BlockFactory blockFactory;
 
-    BlockHash(DriverContext driverContext) {
-        bigArrays = driverContext.bigArrays();
-        blockFactory = driverContext.blockFactory();
+    BlockHash(BlockFactory blockFactory) {
+        this.blockFactory = blockFactory;
     }
 
     /**
@@ -49,6 +44,12 @@ public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
      * pass the ordinals to the provided {@link GroupingAggregatorFunction.AddInput}.
      */
     public abstract void add(Page page, GroupingAggregatorFunction.AddInput addInput);
+
+    /**
+     * Lookup all values form the "group by" columns in the page and return the
+     * ordinals of each row.
+     */
+    public abstract IntBlock lookup(Page page);
 
     /**
      * Returns a {@link Block} that contains all the keys that are inserted by {@link #add}.
@@ -79,40 +80,40 @@ public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
      */
     public static BlockHash build(
         List<HashAggregationOperator.GroupSpec> groups,
-        DriverContext driverContext,
+        BlockFactory blockFactory,
         int emitBatchSize,
         boolean allowBrokenOptimizations
     ) {
         if (groups.size() == 1) {
-            return newForElementType(groups.get(0).channel(), groups.get(0).elementType(), driverContext);
+            return newForElementType(groups.get(0).channel(), groups.get(0).elementType(), blockFactory);
         }
         if (allowBrokenOptimizations && groups.size() == 2) {
             var g1 = groups.get(0);
             var g2 = groups.get(1);
             if (g1.elementType() == ElementType.LONG && g2.elementType() == ElementType.LONG) {
-                return new LongLongBlockHash(driverContext, g1.channel(), g2.channel(), emitBatchSize);
+                return new LongLongBlockHash(blockFactory, g1.channel(), g2.channel(), emitBatchSize);
             }
             if (g1.elementType() == ElementType.BYTES_REF && g2.elementType() == ElementType.LONG) {
-                return new BytesRefLongBlockHash(driverContext, g1.channel(), g2.channel(), false, emitBatchSize);
+                return new BytesRefLongBlockHash(blockFactory, g1.channel(), g2.channel(), false, emitBatchSize);
             }
             if (g1.elementType() == ElementType.LONG && g2.elementType() == ElementType.BYTES_REF) {
-                return new BytesRefLongBlockHash(driverContext, g2.channel(), g1.channel(), true, emitBatchSize);
+                return new BytesRefLongBlockHash(blockFactory, g2.channel(), g1.channel(), true, emitBatchSize);
             }
         }
-        return new PackedValuesBlockHash(groups, driverContext, emitBatchSize);
+        return new PackedValuesBlockHash(groups, blockFactory, emitBatchSize);
     }
 
     /**
      * Creates a specialized hash table that maps a {@link Block} of the given input element type to ids.
      */
-    private static BlockHash newForElementType(int channel, ElementType type, DriverContext driverContext) {
+    private static BlockHash newForElementType(int channel, ElementType type, BlockFactory blockFactory) {
         return switch (type) {
-            case NULL -> new NullBlockHash(channel, driverContext);
-            case BOOLEAN -> new BooleanBlockHash(channel, driverContext);
-            case INT -> new IntBlockHash(channel, driverContext);
-            case LONG -> new LongBlockHash(channel, driverContext);
-            case DOUBLE -> new DoubleBlockHash(channel, driverContext);
-            case BYTES_REF -> new BytesRefBlockHash(channel, driverContext);
+            case NULL -> new NullBlockHash(channel, blockFactory);
+            case BOOLEAN -> new BooleanBlockHash(channel, blockFactory);
+            case INT -> new IntBlockHash(channel, blockFactory);
+            case LONG -> new LongBlockHash(channel, blockFactory);
+            case DOUBLE -> new DoubleBlockHash(channel, blockFactory);
+            case BYTES_REF -> new BytesRefBlockHash(channel, blockFactory);
             default -> throw new IllegalArgumentException("unsupported grouping element type [" + type + "]");
         };
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BooleanBlockHash.java
@@ -10,6 +10,7 @@ package org.elasticsearch.compute.aggregation.blockhash;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BooleanVector;
 import org.elasticsearch.compute.data.IntBlock;
@@ -30,8 +31,8 @@ final class BooleanBlockHash extends BlockHash {
     private final int channel;
     private final boolean[] everSeen = new boolean[TRUE_ORD + 1];
 
-    BooleanBlockHash(int channel, DriverContext driverContext) {
-        super(driverContext);
+    BooleanBlockHash(int channel, BlockFactory blockFactory) {
+        super(blockFactory);
         this.channel = channel;
     }
 
@@ -70,6 +71,11 @@ final class BooleanBlockHash extends BlockHash {
 
     private IntBlock add(BooleanBlock block) {
         return new MultivalueDedupeBoolean(block).hash(blockFactory, everSeen);
+    }
+
+    @Override
+    public IntBlock lookup(Page page) {
+        throw new UnsupportedOperationException("NOCOMMIT");
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefLongBlockHash.java
@@ -16,8 +16,10 @@ import org.elasticsearch.common.util.LongLongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.LongVector;
@@ -36,8 +38,8 @@ final class BytesRefLongBlockHash extends BlockHash {
     private final BytesRefHash bytesHash;
     private final LongLongHash finalHash;
 
-    BytesRefLongBlockHash(DriverContext driverContext, int channel1, int channel2, boolean reverseOutput, int emitBatchSize) {
-        super(driverContext);
+    BytesRefLongBlockHash(BlockFactory blockFactory, int channel1, int channel2, boolean reverseOutput, int emitBatchSize) {
+        super(blockFactory);
         this.channel1 = channel1;
         this.channel2 = channel2;
         this.reverseOutput = reverseOutput;
@@ -47,8 +49,8 @@ final class BytesRefLongBlockHash extends BlockHash {
         BytesRefHash bytesHash = null;
         LongLongHash longHash = null;
         try {
-            bytesHash = new BytesRefHash(1, bigArrays);
-            longHash = new LongLongHash(1, bigArrays);
+            bytesHash = new BytesRefHash(1, blockFactory.bigArrays());
+            longHash = new LongLongHash(1, blockFactory.bigArrays());
             this.bytesHash = bytesHash;
             this.finalHash = longHash;
             success = true;
@@ -79,6 +81,11 @@ final class BytesRefLongBlockHash extends BlockHash {
                 work.add();
             }
         }
+    }
+
+    @Override
+    public IntBlock lookup(Page page) {
+        throw new UnsupportedOperationException("NOCOMMIT");
     }
 
     public IntVector add(BytesRefVector vector1, LongVector vector2) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DoubleBlock;
 import org.elasticsearch.compute.data.DoubleVector;
 import org.elasticsearch.compute.data.IntBlock;
@@ -40,10 +41,10 @@ final class DoubleBlockHash extends BlockHash {
      */
     private boolean seenNull;
 
-    DoubleBlockHash(int channel, DriverContext driverContext) {
-        super(driverContext);
+    DoubleBlockHash(int channel, BlockFactory blockFactory) {
+        super(blockFactory);
         this.channel = channel;
-        this.longHash = new LongHash(1, bigArrays);
+        this.longHash = new LongHash(1, blockFactory.bigArrays());
     }
 
     @Override
@@ -83,6 +84,11 @@ final class DoubleBlockHash extends BlockHash {
         MultivalueDedupe.HashResult result = new MultivalueDedupeDouble(block).hash(blockFactory, longHash);
         seenNull |= result.sawNull();
         return result.ords();
+    }
+
+    @Override
+    public IntBlock lookup(Page page) {
+        throw new UnsupportedOperationException("NOCOMMIT");
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.util.LongHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
@@ -40,10 +41,10 @@ final class LongBlockHash extends BlockHash {
      */
     private boolean seenNull;
 
-    LongBlockHash(int channel, DriverContext driverContext) {
-        super(driverContext);
+    LongBlockHash(int channel, BlockFactory blockFactory) {
+        super(blockFactory);
         this.channel = channel;
-        this.longHash = new LongHash(1, bigArrays);
+        this.longHash = new LongHash(1, blockFactory.bigArrays());
     }
 
     @Override
@@ -83,6 +84,11 @@ final class LongBlockHash extends BlockHash {
         MultivalueDedupe.HashResult result = new MultivalueDedupeLong(block).hash(blockFactory, longHash);
         seenNull |= result.sawNull();
         return result.ords();
+    }
+
+    @Override
+    public IntBlock lookup(Page page) {
+        throw new UnsupportedOperationException("NOCOMMIT");
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongLongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongLongBlockHash.java
@@ -33,12 +33,12 @@ final class LongLongBlockHash extends BlockHash {
     private final int emitBatchSize;
     private final LongLongHash hash;
 
-    LongLongBlockHash(DriverContext driverContext, int channel1, int channel2, int emitBatchSize) {
-        super(driverContext);
+    LongLongBlockHash(BlockFactory blockFactory, int channel1, int channel2, int emitBatchSize) {
+        super(blockFactory);
         this.channel1 = channel1;
         this.channel2 = channel2;
         this.emitBatchSize = emitBatchSize;
-        this.hash = new LongLongHash(1, bigArrays);
+        this.hash = new LongLongHash(1, blockFactory.bigArrays());
     }
 
     @Override
@@ -196,6 +196,11 @@ final class LongLongBlockHash extends BlockHash {
         }
         seen[nextSeen] = v;
         return nextSeen + 1;
+    }
+
+    @Override
+    public IntBlock lookup(Page page) {
+        throw new UnsupportedOperationException("NOCOMMIT");
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/NullBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/NullBlockHash.java
@@ -11,7 +11,9 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
@@ -24,8 +26,8 @@ final class NullBlockHash extends BlockHash {
     private final int channel;
     private boolean seenNull = false;
 
-    NullBlockHash(int channel, DriverContext driverContext) {
-        super(driverContext);
+    NullBlockHash(int channel, BlockFactory blockFactory) {
+        super(blockFactory);
         this.channel = channel;
     }
 
@@ -40,6 +42,11 @@ final class NullBlockHash extends BlockHash {
         } else {
             throw new IllegalArgumentException("can't use NullBlockHash for non-null blocks");
         }
+    }
+
+    @Override
+    public IntBlock lookup(Page page) {
+        throw new UnsupportedOperationException("NOCOMMIT");
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -16,11 +16,12 @@ import org.elasticsearch.common.util.BytesRefHash;
 import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
 import org.elasticsearch.compute.aggregation.SeenGroupIds;
 import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.BatchEncoder;
-import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.HashAggregationOperator;
 import org.elasticsearch.compute.operator.MultivalueDedupe;
 import org.elasticsearch.core.Releasables;
@@ -59,11 +60,11 @@ final class PackedValuesBlockHash extends BlockHash {
     private final BytesRefBuilder bytes = new BytesRefBuilder();
     private final Group[] groups;
 
-    PackedValuesBlockHash(List<HashAggregationOperator.GroupSpec> specs, DriverContext driverContext, int emitBatchSize) {
-        super(driverContext);
+    PackedValuesBlockHash(List<HashAggregationOperator.GroupSpec> specs, BlockFactory blockFactory, int emitBatchSize) {
+        super(blockFactory);
         this.groups = specs.stream().map(Group::new).toArray(Group[]::new);
         this.emitBatchSize = emitBatchSize;
-        this.bytesRefHash = new BytesRefHash(1, bigArrays);
+        this.bytesRefHash = new BytesRefHash(1, blockFactory.bigArrays());
         this.nullTrackingBytes = (groups.length + 7) / 8;
     }
 
@@ -76,6 +77,12 @@ final class PackedValuesBlockHash extends BlockHash {
         try (AddWork work = new AddWork(page, addInput, batchSize)) {
             work.add();
         }
+    }
+
+    @Override
+    public IntBlock lookup(Page page) {
+        // NOCOMMIT if there are many value combinations this can make huge blocks. What do?
+        throw new UnsupportedOperationException("NOCOMMIT");
     }
 
     private static class Group {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashAggregationOperator.java
@@ -47,7 +47,7 @@ public class HashAggregationOperator implements Operator {
         public Operator get(DriverContext driverContext) {
             return new HashAggregationOperator(
                 aggregators,
-                () -> BlockHash.build(groups, driverContext, maxPageSize, false),
+                () -> BlockHash.build(groups, driverContext.blockFactory(), maxPageSize, false),
                 driverContext
             );
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
@@ -478,7 +478,12 @@ public class OrdinalsGroupingOperator implements Operator {
             );
             this.aggregator = new HashAggregationOperator(
                 aggregatorFactories,
-                () -> BlockHash.build(List.of(new GroupSpec(channelIndex, groupingElementType)), driverContext, maxPageSize, false),
+                () -> BlockHash.build(
+                    List.of(new GroupSpec(channelIndex, groupingElementType)),
+                    driverContext.blockFactory(),
+                    maxPageSize,
+                    false
+                ),
                 driverContext
             );
         }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
@@ -423,3 +423,18 @@ ROW deg = [90.0, 180.0, 270.0]
 [90.0, 180.0, 270.0] | [1.5707963267948966, 3.141592653589793, 4.71238898038469]
 // end::to_radians-result[]
 ;
+
+valueAt
+FROM employees
+| EVAL languages_table = VALUE_AT(languages, [1.0, 2.2, 3.2, -1.02, -1.02])
+| SORT emp_no
+| LIMIT 4
+| KEEP first_name, languages, languages_table
+;
+
+first_name:keyword | languages:integer | languages_table:double
+Georgi             |                 2 | 3.2
+Bezalel            |                 5 | null
+Parto              |                 4 | -1.02
+Chirstian          |                 5 | null
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
@@ -559,3 +559,48 @@ warning:Line 1:76: org.elasticsearch.xpack.ql.InvalidArgumentException: [1002000
 
 x:long
 ;
+
+valueAtInt
+FROM employees
+| EVAL languages_table = VALUE_AT(languages, [-12, 12, 32, 0, 99])
+| SORT emp_no
+| LIMIT 4
+| KEEP first_name, languages, languages_table
+;
+
+first_name:keyword | languages:integer | languages_table:integer
+Georgi             |                 2 | 32
+Bezalel            |                 5 | null
+Parto              |                 4 | 99
+Chirstian          |                 5 | null
+;
+
+matchingRowInt
+FROM employees
+| EVAL languages_row = MATCHING_ROW(languages, [2, 3, 5, 8, 9, 4])
+| SORT emp_no
+| LIMIT 4
+| KEEP first_name, languages, languages_row
+;
+
+first_name:keyword | languages:integer | languages_row:integer
+Georgi             |                 2 | 0
+Bezalel            |                 5 | 2
+Parto              |                 4 | 5
+Chirstian          |                 5 | 2
+;
+
+valueAtLong
+FROM employees
+| EVAL languages_table = VALUE_AT(languages, [-121233243412, 12, 32, 0, 99])
+| SORT emp_no
+| LIMIT 4
+| KEEP first_name, languages, languages_table
+;
+
+first_name:keyword | languages:integer | languages_table:long
+Georgi             |                 2 | 32
+Bezalel            |                 5 | null
+Parto              |                 4 | 99
+Chirstian          |                 5 | null
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/show.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/show.csv-spec
@@ -224,5 +224,5 @@ countFunctions#[skip:-8.13.99]
 show functions |  stats  a = count(*), b = count(*), c = count(*) |  mv_expand c;
 
 a:long | b:long | c:long
-92     | 92     | 92
+94     | 94     | 94
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -1005,3 +1005,49 @@ row a = "π/2 + a + B + Λ ºC" | eval lower = to_lower(a), upper = to_upper(a) 
 a:keyword           | upper:keyword         | lower:keyword
 π/2 + a + B + Λ ºC  | Π/2 + A + B + Λ ºC    | π/2 + a + b + λ ºc
 ;
+
+valueAt
+FROM employees
+| EVAL languages_word = VALUE_AT(languages, ["zero", "one", "two", "three", "four"])
+| SORT emp_no
+| LIMIT 4
+| KEEP first_name, languages, languages_word
+;
+
+first_name:keyword | languages:integer | languages_word:keyword
+Georgi             |                 2 | two
+Bezalel            |                 5 | null
+Parto              |                 4 | four
+Chirstian          |                 5 | null
+;
+
+matchingRow
+FROM employees
+| EVAL first_name_row = MATCHING_ROW(first_name, ["Bezalel", "Parto"])
+| SORT emp_no
+| LIMIT 4
+| KEEP first_name, first_name_row
+;
+
+first_name:keyword | first_name_row:integer
+Georgi             | null
+Bezalel            | 0
+Parto              | 1
+Chirstian          | null
+;
+
+localJoin
+FROM employees
+| EVAL first_name_row = MATCHING_ROW(first_name, ["Bezalel", "Parto"])
+| EVAL looked_up = VALUE_AT(first_name_row, ["foo", "bar"])
+| SORT emp_no
+| LIMIT 4
+| KEEP first_name, looked_up
+;
+
+first_name:keyword | looked_up:keyword
+Georgi             | null
+Bezalel            | foo
+Parto              | bar
+Chirstian          | null
+;

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAtBytesRefEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAtBytesRefEvaluator.java
@@ -1,0 +1,116 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.conditional;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ValueAt}.
+ * This class is generated. Do not edit it.
+ */
+public final class ValueAtBytesRefEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
+  private final EvalOperator.ExpressionEvaluator index;
+
+  private final BytesRefBlock copyFrom;
+
+  private final DriverContext driverContext;
+
+  public ValueAtBytesRefEvaluator(Source source, EvalOperator.ExpressionEvaluator index,
+      BytesRefBlock copyFrom, DriverContext driverContext) {
+    this.warnings = new Warnings(source);
+    this.index = index;
+    this.copyFrom = copyFrom;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock indexBlock = (IntBlock) index.eval(page)) {
+      IntVector indexVector = indexBlock.asVector();
+      if (indexVector == null) {
+        return eval(page.getPositionCount(), indexBlock);
+      }
+      return eval(page.getPositionCount(), indexVector);
+    }
+  }
+
+  public BytesRefBlock eval(int positionCount, IntBlock indexBlock) {
+    try(BytesRefBlock.Builder result = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        if (indexBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
+        if (indexBlock.getValueCount(p) != 1) {
+          if (indexBlock.getValueCount(p) > 1) {
+            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+          }
+          result.appendNull();
+          continue position;
+        }
+        ValueAt.processBytesRef(result, indexBlock.getInt(indexBlock.getFirstValueIndex(p)), copyFrom);
+      }
+      return result.build();
+    }
+  }
+
+  public BytesRefBlock eval(int positionCount, IntVector indexVector) {
+    try(BytesRefBlock.Builder result = driverContext.blockFactory().newBytesRefBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        ValueAt.processBytesRef(result, indexVector.getInt(p), copyFrom);
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "ValueAtBytesRefEvaluator[" + "index=" + index + ", copyFrom=" + copyFrom + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(index, copyFrom);
+  }
+
+  static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory index;
+
+    private final BytesRefBlock copyFrom;
+
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory index,
+        BytesRefBlock copyFrom) {
+      this.source = source;
+      this.index = index;
+      this.copyFrom = copyFrom;
+    }
+
+    @Override
+    public ValueAtBytesRefEvaluator get(DriverContext context) {
+      return new ValueAtBytesRefEvaluator(source, index.get(context), copyFrom, context);
+    }
+
+    @Override
+    public String toString() {
+      return "ValueAtBytesRefEvaluator[" + "index=" + index + ", copyFrom=" + copyFrom + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAtDoubleEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAtDoubleEvaluator.java
@@ -1,0 +1,116 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.conditional;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ValueAt}.
+ * This class is generated. Do not edit it.
+ */
+public final class ValueAtDoubleEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
+  private final EvalOperator.ExpressionEvaluator index;
+
+  private final DoubleBlock copyFrom;
+
+  private final DriverContext driverContext;
+
+  public ValueAtDoubleEvaluator(Source source, EvalOperator.ExpressionEvaluator index,
+      DoubleBlock copyFrom, DriverContext driverContext) {
+    this.warnings = new Warnings(source);
+    this.index = index;
+    this.copyFrom = copyFrom;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock indexBlock = (IntBlock) index.eval(page)) {
+      IntVector indexVector = indexBlock.asVector();
+      if (indexVector == null) {
+        return eval(page.getPositionCount(), indexBlock);
+      }
+      return eval(page.getPositionCount(), indexVector);
+    }
+  }
+
+  public DoubleBlock eval(int positionCount, IntBlock indexBlock) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        if (indexBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
+        if (indexBlock.getValueCount(p) != 1) {
+          if (indexBlock.getValueCount(p) > 1) {
+            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+          }
+          result.appendNull();
+          continue position;
+        }
+        ValueAt.processDouble(result, indexBlock.getInt(indexBlock.getFirstValueIndex(p)), copyFrom);
+      }
+      return result.build();
+    }
+  }
+
+  public DoubleBlock eval(int positionCount, IntVector indexVector) {
+    try(DoubleBlock.Builder result = driverContext.blockFactory().newDoubleBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        ValueAt.processDouble(result, indexVector.getInt(p), copyFrom);
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "ValueAtDoubleEvaluator[" + "index=" + index + ", copyFrom=" + copyFrom + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(index, copyFrom);
+  }
+
+  static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory index;
+
+    private final DoubleBlock copyFrom;
+
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory index,
+        DoubleBlock copyFrom) {
+      this.source = source;
+      this.index = index;
+      this.copyFrom = copyFrom;
+    }
+
+    @Override
+    public ValueAtDoubleEvaluator get(DriverContext context) {
+      return new ValueAtDoubleEvaluator(source, index.get(context), copyFrom, context);
+    }
+
+    @Override
+    public String toString() {
+      return "ValueAtDoubleEvaluator[" + "index=" + index + ", copyFrom=" + copyFrom + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAtIntEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAtIntEvaluator.java
@@ -1,0 +1,115 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.conditional;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ValueAt}.
+ * This class is generated. Do not edit it.
+ */
+public final class ValueAtIntEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
+  private final EvalOperator.ExpressionEvaluator index;
+
+  private final IntBlock copyFrom;
+
+  private final DriverContext driverContext;
+
+  public ValueAtIntEvaluator(Source source, EvalOperator.ExpressionEvaluator index,
+      IntBlock copyFrom, DriverContext driverContext) {
+    this.warnings = new Warnings(source);
+    this.index = index;
+    this.copyFrom = copyFrom;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock indexBlock = (IntBlock) index.eval(page)) {
+      IntVector indexVector = indexBlock.asVector();
+      if (indexVector == null) {
+        return eval(page.getPositionCount(), indexBlock);
+      }
+      return eval(page.getPositionCount(), indexVector);
+    }
+  }
+
+  public IntBlock eval(int positionCount, IntBlock indexBlock) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        if (indexBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
+        if (indexBlock.getValueCount(p) != 1) {
+          if (indexBlock.getValueCount(p) > 1) {
+            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+          }
+          result.appendNull();
+          continue position;
+        }
+        ValueAt.processInt(result, indexBlock.getInt(indexBlock.getFirstValueIndex(p)), copyFrom);
+      }
+      return result.build();
+    }
+  }
+
+  public IntBlock eval(int positionCount, IntVector indexVector) {
+    try(IntBlock.Builder result = driverContext.blockFactory().newIntBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        ValueAt.processInt(result, indexVector.getInt(p), copyFrom);
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "ValueAtIntEvaluator[" + "index=" + index + ", copyFrom=" + copyFrom + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(index, copyFrom);
+  }
+
+  static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory index;
+
+    private final IntBlock copyFrom;
+
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory index,
+        IntBlock copyFrom) {
+      this.source = source;
+      this.index = index;
+      this.copyFrom = copyFrom;
+    }
+
+    @Override
+    public ValueAtIntEvaluator get(DriverContext context) {
+      return new ValueAtIntEvaluator(source, index.get(context), copyFrom, context);
+    }
+
+    @Override
+    public String toString() {
+      return "ValueAtIntEvaluator[" + "index=" + index + ", copyFrom=" + copyFrom + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAtLongEvaluator.java
+++ b/x-pack/plugin/esql/src/main/java/generated/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAtLongEvaluator.java
@@ -1,0 +1,116 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License
+// 2.0; you may not use this file except in compliance with the Elastic License
+// 2.0.
+package org.elasticsearch.xpack.esql.expression.function.scalar.conditional;
+
+import java.lang.IllegalArgumentException;
+import java.lang.Override;
+import java.lang.String;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.expression.function.Warnings;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+/**
+ * {@link EvalOperator.ExpressionEvaluator} implementation for {@link ValueAt}.
+ * This class is generated. Do not edit it.
+ */
+public final class ValueAtLongEvaluator implements EvalOperator.ExpressionEvaluator {
+  private final Warnings warnings;
+
+  private final EvalOperator.ExpressionEvaluator index;
+
+  private final LongBlock copyFrom;
+
+  private final DriverContext driverContext;
+
+  public ValueAtLongEvaluator(Source source, EvalOperator.ExpressionEvaluator index,
+      LongBlock copyFrom, DriverContext driverContext) {
+    this.warnings = new Warnings(source);
+    this.index = index;
+    this.copyFrom = copyFrom;
+    this.driverContext = driverContext;
+  }
+
+  @Override
+  public Block eval(Page page) {
+    try (IntBlock indexBlock = (IntBlock) index.eval(page)) {
+      IntVector indexVector = indexBlock.asVector();
+      if (indexVector == null) {
+        return eval(page.getPositionCount(), indexBlock);
+      }
+      return eval(page.getPositionCount(), indexVector);
+    }
+  }
+
+  public LongBlock eval(int positionCount, IntBlock indexBlock) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        if (indexBlock.isNull(p)) {
+          result.appendNull();
+          continue position;
+        }
+        if (indexBlock.getValueCount(p) != 1) {
+          if (indexBlock.getValueCount(p) > 1) {
+            warnings.registerException(new IllegalArgumentException("single-value function encountered multi-value"));
+          }
+          result.appendNull();
+          continue position;
+        }
+        ValueAt.processLong(result, indexBlock.getInt(indexBlock.getFirstValueIndex(p)), copyFrom);
+      }
+      return result.build();
+    }
+  }
+
+  public LongBlock eval(int positionCount, IntVector indexVector) {
+    try(LongBlock.Builder result = driverContext.blockFactory().newLongBlockBuilder(positionCount)) {
+      position: for (int p = 0; p < positionCount; p++) {
+        ValueAt.processLong(result, indexVector.getInt(p), copyFrom);
+      }
+      return result.build();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "ValueAtLongEvaluator[" + "index=" + index + ", copyFrom=" + copyFrom + "]";
+  }
+
+  @Override
+  public void close() {
+    Releasables.closeExpectNoException(index, copyFrom);
+  }
+
+  static class Factory implements EvalOperator.ExpressionEvaluator.Factory {
+    private final Source source;
+
+    private final EvalOperator.ExpressionEvaluator.Factory index;
+
+    private final LongBlock copyFrom;
+
+    public Factory(Source source, EvalOperator.ExpressionEvaluator.Factory index,
+        LongBlock copyFrom) {
+      this.source = source;
+      this.index = index;
+      this.copyFrom = copyFrom;
+    }
+
+    @Override
+    public ValueAtLongEvaluator get(DriverContext context) {
+      return new ValueAtLongEvaluator(source, index.get(context), copyFrom, context);
+    }
+
+    @Override
+    public String toString() {
+      return "ValueAtLongEvaluator[" + "index=" + index + ", copyFrom=" + copyFrom + "]";
+    }
+  }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/EsqlFunctionRegistry.java
@@ -20,6 +20,8 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Case;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Greatest;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Least;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.MatchingRow;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.ValueAt;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToBoolean;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToCartesianPoint;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToCartesianShape;
@@ -74,7 +76,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMax;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMedian;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMin;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvSum;
-import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Coalesce;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StX;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StY;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Concat;
@@ -138,10 +140,9 @@ public final class EsqlFunctionRegistry extends FunctionRegistry {
                 def(Cosh.class, Cosh::new, "cosh"),
                 def(E.class, E::new, "e"),
                 def(Floor.class, Floor::new, "floor"),
-                def(Greatest.class, Greatest::new, "greatest"),
                 def(Log.class, Log::new, "log"),
                 def(Log10.class, Log10::new, "log10"),
-                def(Least.class, Least::new, "least"),
+
                 def(Pi.class, Pi::new, "pi"),
                 def(Pow.class, Pow::new, "pow"),
                 def(Round.class, Round::new, "round"),
@@ -179,9 +180,14 @@ public final class EsqlFunctionRegistry extends FunctionRegistry {
             new FunctionDefinition[] { def(StX.class, StX::new, "st_x") },
             new FunctionDefinition[] { def(StY.class, StY::new, "st_y") },
             // conditional
-            new FunctionDefinition[] { def(Case.class, Case::new, "case") },
-            // null
-            new FunctionDefinition[] { def(Coalesce.class, Coalesce::new, "coalesce"), },
+            new FunctionDefinition[] {
+                def(Case.class, Case::new, "case"),
+                def(Coalesce.class, Coalesce::new, "coalesce"),
+                def(Greatest.class, Greatest::new, "greatest"),
+                def(MatchingRow.class, MatchingRow::new, "matching_row"),
+                def(Least.class, Least::new, "least"),
+                def(ValueAt.class, ValueAt::new, "value_at"),
+            },
             // IP
             new FunctionDefinition[] { def(CIDRMatch.class, CIDRMatch::new, "cidr_match") },
             // conversion functions

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Coalesce.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/Coalesce.java
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.expression.function.scalar.nulls;
+package org.elasticsearch.xpack.esql.expression.function.scalar.conditional;
 
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.ElementType;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/MatchingRow.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/MatchingRow.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.conditional;
+
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.aggregation.blockhash.BlockHash;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.compute.operator.HashAggregationOperator;
+import org.elasticsearch.core.Releasables;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.ql.QlIllegalArgumentException;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.function.OptionalArgument;
+import org.elasticsearch.xpack.ql.tree.NodeInfo;
+import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
+import org.elasticsearch.xpack.ql.type.DataTypes;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.elasticsearch.xpack.ql.expression.Expressions.name;
+
+public class MatchingRow extends EsqlScalarFunction implements OptionalArgument {
+    public record Match(Expression toMatch, Expression values) {}
+
+    private final Match[] matches;
+
+    public MatchingRow(Source source, Expression firstToMatch, Expression firstValues, List<Expression> remainingMatches) {
+        super(source, Stream.concat(Stream.of(firstToMatch, firstValues), remainingMatches.stream()).toList());
+        if (remainingMatches.size() % 2 == 1) {
+            throw new QlIllegalArgumentException("[MATCHING_ROW] needs pairs of matching rows");
+        }
+        matches = new Match[remainingMatches.size() / 2 + 1];
+        matches[0] = new Match(firstToMatch, firstValues);
+        for (int i = 1; i < matches.length; i++) {
+            matches[i] = new Match(remainingMatches.get(2 * i - 2), remainingMatches.get(2 * i - 1));
+        }
+    }
+
+    public Match[] matches() {
+        return matches;
+    }
+
+    @Override
+    public DataType dataType() {
+        return DataTypes.INTEGER;
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        for (Match m : matches) {
+            if (m.values.foldable() == false) {
+                return new TypeResolution(
+                    format(
+                        null,
+                        "values position arguments of [{}] must be constants, found value [{}] type [{}]",
+                        source(),
+                        name(m.values),
+                        m.values.dataType()
+                    )
+                );
+            }
+            if (m.toMatch.dataType() != m.values.dataType()) {
+                return new TypeResolution(
+                    format(
+                        null,
+                        "to_match position arguments of [{}] must match the type of their "
+                            + "values position arguments, found value [{}] type [{}] which didn't match [{}] type [{}]",
+                        source(),
+                        name(m.toMatch),
+                        m.toMatch.dataType(),
+                        name(m.values),
+                        m.values.dataType()
+                    )
+                );
+            }
+        }
+        return TypeResolution.TYPE_RESOLVED;
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new MatchingRow(source(), newChildren.get(0), newChildren.get(1), newChildren.subList(2, newChildren.size()));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(
+            this,
+            MatchingRow::new,
+            matches[0].toMatch,
+            matches[0].values,
+            Arrays.stream(matches).skip(1).flatMap(m -> Stream.of(m.toMatch, m.values)).toList()
+        );
+    }
+
+    @Override
+    public EvalOperator.ExpressionEvaluator.Factory toEvaluator(
+        Function<Expression, EvalOperator.ExpressionEvaluator.Factory> toEvaluator
+    ) {
+        if (matches.length != 1) {
+            throw new UnsupportedOperationException("NOCOMMIT");
+        }
+        // NOCOMMIT track me
+        BlockFactory blockFactory = BlockFactory.getInstance(new NoopCircuitBreaker("test-noop"), BigArrays.NON_RECYCLING_INSTANCE);
+
+        Block[] values = new Block[matches.length];
+        BlockHash hash = null;
+        try {
+            List<HashAggregationOperator.GroupSpec> groups = new ArrayList<>(matches.length);
+            EvalOperator.ExpressionEvaluator.Factory[] toMatchFactories = new EvalOperator.ExpressionEvaluator.Factory[matches.length];
+            for (int i = 0; i < values.length; i++) {
+                Match m = matches[i];
+                ElementType elementType = PlannerUtils.toElementType(m.values.dataType());
+                values[i] = switch (elementType) {
+                    case BYTES_REF -> ValueAt.valuesAsBytesRefBlock(blockFactory, m.values);
+                    case INT -> ValueAt.valuesAsIntBlock(blockFactory, m.values);
+                    default -> throw new UnsupportedOperationException("NOCOMMIT");
+                };
+                groups.add(new HashAggregationOperator.GroupSpec(i, elementType));
+                toMatchFactories[i] = toEvaluator.apply(matches[i].toMatch);
+            }
+            hash = BlockHash.build(groups, blockFactory, Integer.MAX_VALUE, false);
+            hash.add(new Page(values), new GroupingAggregatorFunction.AddInput() {
+                @Override
+                public void add(int positionOffset, IntBlock groupIds) {
+                    // NOCOMMIT make sure no dupes in input data.
+                }
+
+                @Override
+                public void add(int positionOffset, IntVector groupIds) {
+                    // NOCOMMIT make sure no dupes in input data.
+                }
+            });
+            Factory factory = new Factory(toMatchFactories, hash);
+            hash = null;
+            return factory;
+        } finally {
+            Releasables.closeExpectNoException(Releasables.wrap(values), hash);
+        }
+    }
+
+    record Factory(EvalOperator.ExpressionEvaluator.Factory[] toMatch, BlockHash hash) implements EvalOperator.ExpressionEvaluator.Factory {
+        @Override
+        public EvalOperator.ExpressionEvaluator get(DriverContext context) {
+            EvalOperator.ExpressionEvaluator[] evaluators = new EvalOperator.ExpressionEvaluator[toMatch.length];
+            for (int i = 0; i < evaluators.length; i++) {
+                evaluators[i] = toMatch[i].get(context);
+            }
+            return new Evaluator(evaluators, hash);
+        }
+
+        @Override
+        public String toString() {
+            return "MatchingRow[" + hash + "]";
+        }
+    }
+
+    record Evaluator(EvalOperator.ExpressionEvaluator[] toMatch, BlockHash hash) implements EvalOperator.ExpressionEvaluator {
+        @Override
+        public Block eval(Page page) {
+            Block[] blocks = new Block[toMatch.length];
+            try {
+                for (int i = 0; i < blocks.length; i++) {
+                    blocks[i] = toMatch[i].eval(page);
+                }
+                return hash.lookup(new Page(blocks));
+            } finally {
+                Releasables.closeExpectNoException(blocks);
+            }
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public String toString() {
+            return "MatchingRow[" + hash + "]";
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAt.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/conditional/ValueAt.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.conditional;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.compute.ann.Evaluator;
+import org.elasticsearch.compute.ann.Fixed;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.LongBlock;
+import org.elasticsearch.compute.operator.EvalOperator;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.planner.PlannerUtils;
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.TypeResolutions;
+import org.elasticsearch.xpack.ql.tree.NodeInfo;
+import org.elasticsearch.xpack.ql.tree.Source;
+import org.elasticsearch.xpack.ql.type.DataType;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class ValueAt extends EsqlScalarFunction {
+    private final Expression index;
+    private final Expression values;
+
+    // NOCOMMIT description annotations
+    public ValueAt(Source source, Expression index, Expression values) {
+        super(source, List.of(index, values));
+        this.index = index;
+        this.values = values;
+    }
+
+    public Expression index() {
+        return index;
+    }
+
+    public Expression values() {
+        return values;
+    }
+
+    @Override
+    public DataType dataType() {
+        return values.dataType();
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        if (childrenResolved() == false) {
+            return new TypeResolution("Unresolved children");
+        }
+        TypeResolution resolution = TypeResolutions.isInteger(index, sourceText(), TypeResolutions.ParamOrdinal.FIRST);
+        if (resolution.unresolved()) {
+            return resolution;
+        }
+        return TypeResolutions.isFoldable(values, sourceText(), TypeResolutions.ParamOrdinal.SECOND);
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ValueAt(source(), newChildren.get(0), newChildren.get(1));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ValueAt::new, index, values);
+    }
+
+    @Override
+    public EvalOperator.ExpressionEvaluator.Factory toEvaluator(
+        Function<Expression, EvalOperator.ExpressionEvaluator.Factory> toEvaluator
+    ) {
+        BlockFactory nonBreakingBlockFactory = BlockFactory.getInstance(
+            new NoopCircuitBreaker("NOCOMMIT"),
+            BigArrays.NON_RECYCLING_INSTANCE
+        ); // NOCOMMIT track me
+        return switch (PlannerUtils.toElementType(values.dataType())) {
+            case BYTES_REF -> new ValueAtBytesRefEvaluator.Factory(
+                source(),
+                toEvaluator.apply(index),
+                valuesAsBytesRefBlock(nonBreakingBlockFactory, values)
+            );
+            case INT -> new ValueAtIntEvaluator.Factory(
+                source(),
+                toEvaluator.apply(index),
+                valuesAsIntBlock(nonBreakingBlockFactory, values)
+            );
+            case LONG -> new ValueAtLongEvaluator.Factory(
+                source(),
+                toEvaluator.apply(index),
+                valuesAsLongBlock(nonBreakingBlockFactory, values)
+            );
+            case DOUBLE -> new ValueAtDoubleEvaluator.Factory(
+                source(),
+                toEvaluator.apply(index),
+                valuesAsDoubleBlock(nonBreakingBlockFactory, values)
+            );
+            default -> throw new UnsupportedOperationException("NOCOMMIT");
+        };
+    }
+
+    static BytesRefBlock valuesAsBytesRefBlock(BlockFactory factory, Expression values) {
+        Object v = values.fold();
+        if (v instanceof List<?> vl) {
+            try (BytesRefBlock.Builder b = factory.newBytesRefBlockBuilder(vl.size())) {
+                for (int i = 0; i < vl.size(); i++) {
+                    b.appendBytesRef((BytesRef) vl.get(i));
+                }
+                return b.build();
+            }
+        }
+        throw new UnsupportedOperationException("NOCOMMIT think about this");
+    }
+
+    static IntBlock valuesAsIntBlock(BlockFactory factory, Expression values) {
+        Object v = values.fold();
+        if (v instanceof List<?> vl) {
+            try (IntBlock.Builder b = factory.newIntBlockBuilder(vl.size())) {
+                for (int i = 0; i < vl.size(); i++) {
+                    b.appendInt(((Number) vl.get(i)).intValue());
+                }
+                return b.build();
+            }
+        }
+        throw new UnsupportedOperationException("NOCOMMIT think about this");
+    }
+
+    static LongBlock valuesAsLongBlock(BlockFactory factory, Expression values) {
+        Object v = values.fold();
+        if (v instanceof List<?> vl) {
+            try (LongBlock.Builder b = factory.newLongBlockBuilder(vl.size())) {
+                for (int i = 0; i < vl.size(); i++) {
+                    b.appendLong(((Number) vl.get(i)).longValue());
+                }
+                return b.build();
+            }
+        }
+        throw new UnsupportedOperationException("NOCOMMIT think about this");
+    }
+
+    static DoubleBlock valuesAsDoubleBlock(BlockFactory factory, Expression values) {
+        Object v = values.fold();
+        if (v instanceof List<?> vl) {
+            try (DoubleBlock.Builder b = factory.newDoubleBlockBuilder(vl.size())) {
+                for (int i = 0; i < vl.size(); i++) {
+                    b.appendDouble(((Number) vl.get(i)).doubleValue());
+                }
+                return b.build();
+            }
+        }
+        throw new UnsupportedOperationException("NOCOMMIT think about this");
+    }
+
+    @Evaluator(extraName = "BytesRef")
+    public static void processBytesRef(BytesRefBlock.Builder copyTo, int index, @Fixed BytesRefBlock copyFrom) {
+        // TODO call copyFromBlock and copyFromVector directly and pass in fixed scratch
+        if (index >= 0 && index < copyFrom.getPositionCount()) {
+            copyTo.copyFrom(copyFrom, index, index + 1);
+        } else {
+            copyTo.appendNull();
+        }
+    }
+
+    @Evaluator(extraName = "Int")
+    public static void processInt(IntBlock.Builder copyTo, int index, @Fixed IntBlock copyFrom) {
+        // TODO call copyFromBlock and copyFromVector directly. Maybe copy a single position?
+        if (index >= 0 && index < copyFrom.getPositionCount()) {
+            copyTo.copyFrom(copyFrom, index, index + 1);
+        } else {
+            copyTo.appendNull();
+        }
+    }
+
+    @Evaluator(extraName = "Long")
+    public static void processLong(LongBlock.Builder copyTo, int index, @Fixed LongBlock copyFrom) {
+        // TODO call copyFromBlock and copyFromVector directly. Maybe copy a single position?
+        if (index >= 0 && index < copyFrom.getPositionCount()) {
+            copyTo.copyFrom(copyFrom, index, index + 1);
+        } else {
+            copyTo.appendNull();
+        }
+    }
+
+    @Evaluator(extraName = "Double")
+    public static void processDouble(DoubleBlock.Builder copyTo, int index, @Fixed DoubleBlock copyFrom) {
+        // TODO call copyFromBlock and copyFromVector directly. Maybe copy a single position?
+        if (index >= 0 && index < copyFrom.getPositionCount()) {
+            copyTo.copyFrom(copyFrom, index, index + 1);
+        } else {
+            copyTo.appendNull();
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -13,7 +13,7 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockUtils;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
-import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Coalesce;
 import org.elasticsearch.xpack.esql.optimizer.LogicalPlanOptimizer.PropagateEmptyRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -38,7 +38,7 @@ import org.elasticsearch.xpack.esql.TestBlockFactory;
 import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Greatest;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.AbstractMultivalueFunctionTestCase;
-import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Coalesce;
 import org.elasticsearch.xpack.esql.optimizer.FoldNull;
 import org.elasticsearch.xpack.esql.parser.ExpressionBuilder;
 import org.elasticsearch.xpack.esql.planner.Layout;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/CoalesceTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xpack.esql.evaluator.EvalMapper;
 import org.elasticsearch.xpack.esql.expression.function.AbstractFunctionTestCase;
 import org.elasticsearch.xpack.esql.expression.function.TestCaseSupplier;
 import org.elasticsearch.xpack.esql.expression.function.scalar.VaragsTestCaseBuilder;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Coalesce;
 import org.elasticsearch.xpack.esql.planner.Layout;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.xpack.esql.EsqlTestUtils;
 import org.elasticsearch.xpack.esql.analysis.Analyzer;
 import org.elasticsearch.xpack.esql.analysis.AnalyzerContext;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
-import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
+import org.elasticsearch.xpack.esql.expression.function.scalar.conditional.Coalesce;
 import org.elasticsearch.xpack.esql.parser.EsqlParser;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/TestPhysicalOperationProviders.java
@@ -277,7 +277,7 @@ public class TestPhysicalOperationProviders extends AbstractPhysicalOperationPro
                 aggregators,
                 () -> BlockHash.build(
                     List.of(new HashAggregationOperator.GroupSpec(groupByChannel, groupElementType)),
-                    driverContext,
+                    driverContext.blockFactory(),
                     pageSize,
                     false
                 ),

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionRegistry.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/function/FunctionRegistry.java
@@ -362,6 +362,27 @@ public class FunctionRegistry {
     }
 
     /**
+     * Build a {@linkplain FunctionDefinition} for functions with a mandatory argument followed by a varidic list.
+     */
+    @SuppressWarnings("overloads")  // These are ambiguous if you aren't using ctor references but we always do
+    protected static <T extends Function> FunctionDefinition def(Class<T> function, BinaryVariadicBuilder<T> ctorRef, String... names) {
+        FunctionBuilder builder = (source, children, cfg) -> {
+            boolean hasMinimumOne = OptionalArgument.class.isAssignableFrom(function);
+            if (hasMinimumOne && children.size() < 1) {
+                throw new QlIllegalArgumentException("expects at least one argument");
+            } else if (hasMinimumOne == false && children.size() < 2) {
+                throw new QlIllegalArgumentException("expects at least two arguments");
+            }
+            return ctorRef.build(source, children.get(0), children.get(1), children.subList(2, children.size()));
+        };
+        return def(function, builder, names);
+    }
+
+    protected interface BinaryVariadicBuilder<T> {
+        T build(Source source, Expression first, Expression second, List<Expression> variadic);
+    }
+
+    /**
      * Build a {@linkplain FunctionDefinition} for a no-argument function that is configuration aware.
      */
     @SuppressWarnings("overloads")


### PR DESCRIPTION
This adds two functions: `MATCHING_ROW` and `VALUE_AT`. `MATCHING_ROW` takes pairs of values and the second one must always be a constant and matches the variable value to offset in the constant value. It looks like:
```
  FROM inventory
| EVAL r=MATCHING_ROW(size, ["XS", "S, "M", "L", "XL"])
```

That'd generate these hypothetical results
```
     Cool-Shirt |  20.00 | XL | 4
Expensive-Shirt | 120.00 | XL | 4
     Cool-Shirt |  20.00 |  S | 1
```

`VALUE_AT` takes an index and an array of values and returns the value at that offset. So:
```
  FROM employees
| EVAL languages_word = VALUE_AT(languages, ["zero", "one", "two", "three", "four"])
| SORT emp_no
| LIMIT 4
| KEEP first_name, languages, languages_word
```

Would make:
```
Georgi             |                 2 | two
Bezalel            |                 5 | null
Parto              |                 4 | four
Chirstian          |                 5 | null
```

You can combine them together:
```
  FROM inventory
| EVAL r=MATCHING_ROW(size, ["XS", "S, "M", "L", "XL"])
| EVAL avg_price=VALUE_AT(r, [null, 20.00, null, null, 70.00])
| DROP r
| WHERE price > avg_price
```

Which would yield:
```
Expensive-Shirt | 120.00 | XL | 70.00
```

If *that* looks familiar then you've been paying close attention! It's another join strategy, specifically one that makes sense when the data you are joining against is small. Which is precisely what should happen for the `INLINESTATS` command that we implemented in the grammar a long time ago but never implemented in the engine.
