### PR TITLE
Remove constant check in BigArrayVectorTests

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
@@ -156,7 +156,6 @@ public class BigArrayVectorTests extends SerializationTestCase {
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock, unused -> deserBlock);
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock.asVector(), unused -> deserBlock.asVector());
             assertThat(deserBlock.asVector(), is(origBlock.asVector()));
-            assertThat(deserBlock.asVector().isConstant(), is(origBlock.asVector().isConstant()));
         }
     }
 }


### PR DESCRIPTION
In these tests, we serialize a big array block and expect the copied block to have the same constant value as the original block. However, this assertion isn't hold because we still serialize value by value for big array blocks. Specifically, if a big block has a single value, the copied block will be constant while the original is not. This change removes that constant check. We can reinstate it later once we serialize the underlying structures of big array blocks.

Closes #105706