### PR TITLE
Clean up TODOs in BuildExtension and BuildVersion

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/BuildVersion.java
+++ b/server/src/main/java/org/elasticsearch/env/BuildVersion.java
@@ -92,10 +92,7 @@ public abstract class BuildVersion {
     }
 
     // only exists for NodeMetadata#toXContent
-    // TODO[wrb]: make this abstract once all downstream classes override it
-    protected int id() {
-        return -1;
-    }
+    abstract int id();
 
     private static class CurrentExtensionHolder {
         private static final BuildExtension BUILD_EXTENSION = findExtension();

--- a/server/src/main/java/org/elasticsearch/env/BuildVersion.java
+++ b/server/src/main/java/org/elasticsearch/env/BuildVersion.java
@@ -92,7 +92,7 @@ public abstract class BuildVersion {
     }
 
     // only exists for NodeMetadata#toXContent
-    abstract int id();
+    public abstract int id();
 
     private static class CurrentExtensionHolder {
         private static final BuildExtension BUILD_EXTENSION = findExtension();

--- a/server/src/main/java/org/elasticsearch/env/DefaultBuildVersion.java
+++ b/server/src/main/java/org/elasticsearch/env/DefaultBuildVersion.java
@@ -23,15 +23,14 @@ import java.util.Objects;
  * give users simple rules in terms of public-facing release versions for Elasticsearch
  * compatibility when upgrading nodes and prevents downgrades in place.</p>
  */
-// TODO[wrb]: make package-private once default implementations are removed in BuildExtension
-public final class DefaultBuildVersion extends BuildVersion {
+final class DefaultBuildVersion extends BuildVersion {
 
     public static BuildVersion CURRENT = new DefaultBuildVersion(Version.CURRENT.id());
 
     private final int versionId;
     private final Version version;
 
-    public DefaultBuildVersion(int versionId) {
+    DefaultBuildVersion(int versionId) {
         assert versionId >= 0 : "Release version IDs must be non-negative integers";
         this.versionId = versionId;
         this.version = Version.fromId(versionId);

--- a/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/BuildExtension.java
@@ -10,7 +10,6 @@ package org.elasticsearch.internal;
 
 import org.elasticsearch.Build;
 import org.elasticsearch.env.BuildVersion;
-import org.elasticsearch.env.DefaultBuildVersion;
 
 /**
  * Allows plugging in current build info.
@@ -29,13 +28,13 @@ public interface BuildExtension {
         return true;
     }
 
-    // TODO[wrb]: Remove default implementation once downstream BuildExtensions are updated
-    default BuildVersion currentBuildVersion() {
-        return DefaultBuildVersion.CURRENT;
-    }
+    /**
+     * Returns the {@link BuildVersion} for the running Elasticsearch code.
+     */
+    BuildVersion currentBuildVersion();
 
-    // TODO[wrb]: Remove default implementation once downstream BuildExtensions are updated
-    default BuildVersion fromVersionId(int versionId) {
-        return new DefaultBuildVersion(versionId);
-    }
+    /**
+     * Returns the {@link BuildVersion} for a given version identifier.
+     */
+    BuildVersion fromVersionId(int versionId);
 }


### PR DESCRIPTION
Once downstream PRs are merged, we can resolve some TODOs from https://github.com/elastic/elasticsearch/pull/105757. This involves removing some default implementations and making superclass methods abstract, then tightening up visibility on the default stateful implementation of BuildVersion.