### PR TITLE
Disable parallel collection for terms aggregation with min_doc_count equals to 0

### DIFF
--- a/docs/changelog/106156.yaml
+++ b/docs/changelog/106156.yaml
@@ -1,0 +1,6 @@
+pr: 106156
+summary: Disable parallel collection for terms aggregation with `min_doc_count` equals
+  to 0
+area: Aggregations
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -139,6 +139,11 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Term
 
     @Override
     public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        if (minDocCount() == 0) {
+            // if minDocCount os zero, we collect the zero buckets looking into all segments in the index. to avoid
+            // looking into the same segment for each thread we disable concurrency
+            return false;
+        }
         /*
          * we parallelize only if the cardinality of the field is lower than shard size, this is to minimize precision issues.
          * When ordered by term, we still take cardinality into account to avoid overhead that concurrency may cause against

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsTests.java
@@ -214,5 +214,11 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
             assertTrue(terms.supportsParallelCollection(field -> randomIntBetween(1, 10)));
             assertFalse(terms.supportsParallelCollection(field -> randomIntBetween(11, 100)));
         }
+        {
+            TermsAggregationBuilder terms = new TermsAggregationBuilder("terms");
+            terms.shardSize(randomIntBetween(1, 100));
+            terms.minDocCount(0);
+            assertFalse(terms.supportsParallelCollection(field -> randomIntBetween(1, 100)));
+        }
     }
 }


### PR DESCRIPTION
When min_doc_count is equal to 0, we might need to collect all the terms on an index to complete the result of an aggregation. This is done by visiting all the segments on the index. In parallel collection it means that we might be visiting all segments per thread, leading to extra work and a performance bug.

This PR disable parallel collection when min_doc_count is equal to 0