### PR TITLE
Ensure LTR models are cached when used as a rescorer.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -811,8 +811,7 @@ public class ModelLoadingService implements ClusterStateListener {
                 if (oldModelAliasesNotReferenced && newModelAliasesNotReferenced && modelIsNotReferenced) {
                     ModelAndConsumer modelAndConsumer = localModelCache.get(modelId);
                     if (modelAndConsumer != null
-                        && (modelAndConsumer.consumers.contains(Consumer.SEARCH_AGGS) == false
-                            || modelAndConsumer.consumers.contains(Consumer.SEARCH_RESCORER) == false)) {
+                        && modelAndConsumer.consumers.stream().noneMatch(c -> c.isAnyOf(Consumer.SEARCH_AGGS, Consumer.SEARCH_RESCORER))) {
                         logger.trace("[{} ({})] invalidated from cache", modelId, modelAliasOrId);
                         localModelCache.invalidate(modelId);
                     }
@@ -822,6 +821,8 @@ public class ModelLoadingService implements ClusterStateListener {
                     // Either way, we know we won't put it back in cache as we are synchronized on `loadingListeners`
                     if (modelAndConsumer == null) {
                         ML_MODEL_INFERENCE_FEATURE.stopTracking(licenseState, modelId);
+                    } else {
+
                     }
                 }
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -647,7 +647,7 @@ public class ModelLoadingService implements ClusterStateListener {
             // Also, if the consumer is a search consumer, we should always cache it
             if (referencedModels.contains(modelId)
                 || Sets.haveNonEmptyIntersection(modelIdToModelAliases.getOrDefault(modelId, new HashSet<>()), referencedModels)
-                || consumer.equals(Consumer.SEARCH_AGGS)) {
+                || consumer.isAnyOf(Consumer.SEARCH_AGGS, Consumer.SEARCH_RESCORER)) {
                 try {
                     // The local model may already be in cache. If it is, we don't bother adding it to cache.
                     // If it isn't, we flip an `isLoaded` flag, and increment the model counter to make sure if it is evicted
@@ -810,7 +810,9 @@ public class ModelLoadingService implements ClusterStateListener {
                 );
                 if (oldModelAliasesNotReferenced && newModelAliasesNotReferenced && modelIsNotReferenced) {
                     ModelAndConsumer modelAndConsumer = localModelCache.get(modelId);
-                    if (modelAndConsumer != null && modelAndConsumer.consumers.contains(Consumer.SEARCH_AGGS) == false) {
+                    if (modelAndConsumer != null
+                        && (modelAndConsumer.consumers.contains(Consumer.SEARCH_AGGS) == false
+                            || modelAndConsumer.consumers.contains(Consumer.SEARCH_RESCORER) == false)) {
                         logger.trace("[{} ({})] invalidated from cache", modelId, modelAliasOrId);
                         localModelCache.invalidate(modelId);
                     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/loadingservice/ModelLoadingService.java
@@ -821,8 +821,6 @@ public class ModelLoadingService implements ClusterStateListener {
                     // Either way, we know we won't put it back in cache as we are synchronized on `loadingListeners`
                     if (modelAndConsumer == null) {
                         ML_MODEL_INFERENCE_FEATURE.stopTracking(licenseState, modelId);
-                    } else {
-
                     }
                 }
             }


### PR DESCRIPTION
When used are a rescorer, LTR model are cached leading to poort performance.
This PR fix this bug.
