### PR TITLE
Consider context in raw serialization

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentGenerator.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentGenerator.java
@@ -500,7 +500,7 @@ public class JsonXContentGenerator implements XContentGenerator {
     public void writeRawValue(String value) throws IOException {
         try {
             if (supportsRawWrites()) {
-                generator.writeRaw(value);
+                generator.writeRawValue(value);
             } else {
                 // fallback to a regular string for formats that don't allow writing the value as is
                 generator.writeString(value);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
@@ -166,9 +166,6 @@ teardown:
 
 ---
 "Test flamegraph from profiling-events":
-  - skip:
-      reason: "https://github.com/elastic/elasticsearch/issues/106103"
-      version: "all"
   - do:
       profiling.flamegraph:
         body: >
@@ -195,9 +192,6 @@ teardown:
 
 ---
 "Test flamegraph from test-events":
-  - skip:
-      reason: "https://github.com/elastic/elasticsearch/issues/106103"
-      version: "all"
   - do:
       profiling.flamegraph:
         body: >


### PR DESCRIPTION
With this commit we use `writeRawValue` instead of `writeRaw` when serializing raw strings as XContent. The latter method does not consider context (e.g. is the value being written as part of an array and requires a comma separator?) whereas the former does. This ensures that pre-rendered double values as we use them in the flamegraph response are rendered correctly as XContent when they are part of an array.

Closes #106103