### PR TITLE
[DOCS] Adds an MDX file for testing purposes

### DIFF
--- a/docs-mdx/painless/painless-field-context.mdx
+++ b/docs-mdx/painless/painless-field-context.mdx
@@ -1,0 +1,136 @@
+---
+id: enElasticsearchPainlessPainlessFieldContext
+slug: /en/elasticsearch/painless/painless-field-context
+title: Field context
+description: Description to be written
+tags: []
+---
+
+<div id="painless-field-context"></div>
+
+Use a Painless script to create a
+[script field](((ref))/search-fields.html#script-fields) to return
+a customized value for each document in the results of a query.
+
+**Variables**
+
+`params` (`Map`, read-only)
+    : User-defined parameters passed in as part of the query.
+
+`doc` (`Map`, read-only)
+    : Contains the fields of the specified document where each field is a
+    `List` of values.
+
+[`params['_source']`](((ref))/mapping-source-field.html) (`Map`, read-only)
+    : Contains extracted JSON in a `Map` and `List` structure for the fields
+    existing in a stored document.
+
+**Return**
+
+`Object`
+    : The customized value for each document.
+
+**API**
+
+Both the standard <DocLink id="enElasticsearchPainlessPainlessApiReferenceShared">Painless API</DocLink> and
+<DocLink id="enElasticsearchPainlessPainlessApiReferenceField">Specialized Field API</DocLink> are available.
+
+**Example**
+
+To run this example, first follow the steps in
+<DocLink id="enElasticsearchPainlessPainlessContextExamples">context examples</DocLink>.
+
+You can then use these two example scripts to compute custom information
+for each search hit and output it to two new fields.
+
+The first script gets the doc value for the `datetime` field and calls
+the `getDayOfWeekEnum` function to determine the corresponding day of the week.
+
+```Painless
+doc['datetime'].value.getDayOfWeekEnum().getDisplayName(TextStyle.FULL, Locale.ROOT)
+```
+
+The second script calculates the number of actors. Actors' names are stored
+as a keyword array in the `actors` field.
+
+```Painless
+doc['actors'].size()   [^1]
+```
+[^1]: By default, doc values are not available for `text` fields. If `actors` was
+a `text` field, you could still calculate the number of actors by extracting
+values from `_source` with `params['_source']['actors'].size()`.
+
+The following request returns the calculated day of week and the number of
+actors that appear in each play:
+
+```console
+GET seats/_search
+{
+  "size": 2,
+  "query": {
+    "match_all": {}
+  },
+  "script_fields": {
+    "day-of-week": {
+      "script": {
+        "source": "doc['datetime'].value.getDayOfWeekEnum().getDisplayName(TextStyle.FULL, Locale.ROOT)"
+      }
+    },
+    "number-of-actors": {
+      "script": {
+        "source": "doc['actors'].size()"
+      }
+    }
+  }
+}
+```
+{/* TEST[setup:seats] */}
+
+```console-result
+{
+  "took" : 68,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 11,
+      "relation" : "eq"
+    },
+    "max_score" : 1.0,
+    "hits" : [
+      {
+        "_index" : "seats",
+        "_id" : "1",
+        "_score" : 1.0,
+        "fields" : {
+          "day-of-week" : [
+            "Thursday"
+          ],
+          "number-of-actors" : [
+            4
+          ]
+        }
+      },
+      {
+        "_index" : "seats",
+        "_id" : "2",
+        "_score" : 1.0,
+        "fields" : {
+          "day-of-week" : [
+            "Thursday"
+          ],
+          "number-of-actors" : [
+            1
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+{/* TESTRESPONSE[s/"took" : 68/"took" : "$body.took"/] */}


### PR DESCRIPTION
## Overview

This PR adds an MDX file to the repository under `docs-mdx/painless`. The file is `painless-field-context.mdx`. It's the MDX version of the [painless field context page](https://www.elastic.co/guide/en/elasticsearch/painless/current/painless-field-context.html). [Asciidoc source file in the repo](https://github.com/elastic/elasticsearch/edit/main/docs/painless/painless-contexts/painless-field-context.asciidoc).

The MDX file has a correct frontmatter, and it contains a console snippet with a test statement and an example response with a test statement.