### PR TITLE
[Profiling] Allow to override index settings

### DIFF
--- a/docs/changelog/106172.yaml
+++ b/docs/changelog/106172.yaml
@@ -1,0 +1,5 @@
+pr: 106172
+summary: "[Profiling] Allow to override index settings"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-events.json
@@ -7,10 +7,14 @@
   },
   "composed_of": [
     "profiling-events",
+    "profiling-events@custom",
     "profiling-ilm",
     "profiling-ilm@custom"
   ],
-  "ignore_missing_component_templates": ["profiling-ilm@custom"],
+  "ignore_missing_component_templates": [
+    "profiling-events@custom",
+    "profiling-ilm@custom"
+  ],
   "priority": 100,
   "_meta": {
     "description": "Index template for profiling-events",

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-executables.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-executables.json
@@ -4,11 +4,15 @@
   ],
   "composed_of": [
     "profiling-executables",
+    "profiling-executables@custom",
     "profiling-ilm",
     "profiling-hot-tier",
     "profiling-ilm@custom"
   ],
-  "ignore_missing_component_templates": ["profiling-ilm@custom"],
+  "ignore_missing_component_templates": [
+    "profiling-executables@custom",
+    "profiling-ilm@custom"
+  ],
   "priority": 100,
   "_meta": {
     "description": "Index template for .profiling-executables",

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-hosts.json
@@ -5,10 +5,14 @@
   "data_stream": {},
   "composed_of": [
     "profiling-hosts",
+    "profiling-hosts@custom",
     "profiling-ilm",
     "profiling-ilm@custom"
   ],
-  "ignore_missing_component_templates": ["profiling-ilm@custom"],
+  "ignore_missing_component_templates": [
+    "profiling-hosts@custom",
+    "profiling-ilm@custom"
+  ],
   "priority": 100,
   "_meta": {
     "description": "Index template for profiling-hosts",

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-metrics.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-metrics.json
@@ -5,10 +5,14 @@
   "data_stream": {},
   "composed_of": [
     "profiling-metrics",
+    "profiling-metrics@custom",
     "profiling-ilm",
     "profiling-ilm@custom"
   ],
-  "ignore_missing_component_templates": ["profiling-ilm@custom"],
+  "ignore_missing_component_templates": [
+    "profiling-metrics@custom",
+    "profiling-ilm@custom"
+  ],
   "priority": 100,
   "_meta": {
     "description": "Index template for profiling-metrics",

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stackframes.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stackframes.json
@@ -4,11 +4,15 @@
   ],
   "composed_of": [
     "profiling-stackframes",
+    "profiling-stackframes@custom",
     "profiling-ilm",
     "profiling-hot-tier",
     "profiling-ilm@custom"
   ],
-  "ignore_missing_component_templates": ["profiling-ilm@custom"],
+  "ignore_missing_component_templates": [
+    "profiling-stackframes@custom",
+    "profiling-ilm@custom"
+  ],
   "priority": 100,
   "_meta": {
     "description": "Index template for .profiling-stackframes",

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-stacktraces.json
@@ -4,11 +4,15 @@
   ],
   "composed_of": [
     "profiling-stacktraces",
+    "profiling-stacktraces@custom",
     "profiling-ilm",
     "profiling-hot-tier",
     "profiling-ilm@custom"
   ],
-  "ignore_missing_component_templates": ["profiling-ilm@custom"],
+  "ignore_missing_component_templates": [
+    "profiling-stacktraces@custom",
+    "profiling-ilm@custom"
+  ],
   "priority": 100,
   "_meta": {
     "description": "Index template for .profiling-stacktraces",

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-global.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-global.json
@@ -4,11 +4,15 @@
   ],
   "composed_of": [
     "profiling-symbols",
+    "profiling-symbols@custom",
     "profiling-ilm",
     "profiling-hot-tier",
     "profiling-ilm@custom"
   ],
-  "ignore_missing_component_templates": ["profiling-ilm@custom"],
+  "ignore_missing_component_templates": [
+    "profiling-symbols@custom",
+    "profiling-ilm@custom"
+  ],
   "template": {
     "settings": {
       "index": {

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-private.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/index-template/profiling-symbols-private.json
@@ -3,7 +3,11 @@
     ".profiling-symbols-private*"
   ],
   "composed_of": [
-    "profiling-symbols"
+    "profiling-symbols",
+    "profiling-symbols@custom"
+  ],
+  "ignore_missing_component_templates": [
+    "profiling-symbols@custom"
   ],
   "priority": 100,
   "_meta": {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/ProfilingIndexTemplateRegistry.java
@@ -45,7 +45,8 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 2: Added 'profiling.host.machine' keyword mapping to profiling-hosts
     // version 3: Add optional component template 'profiling-ilm@custom' to all ILM-managed index templates
     // version 4: Added 'service.name' keyword mapping to profiling-events
-    public static final int INDEX_TEMPLATE_VERSION = 4;
+    // version 5: Add optional component template '<idx-name>@custom' to all index templates that reference component templates
+    public static final int INDEX_TEMPLATE_VERSION = 5;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
     public static final int PROFILING_EVENTS_VERSION = 2;


### PR DESCRIPTION
With this commit we reference index-specific custom component templates. These component templates can be used to override e.g. the number of shards. We have used a similar approach in #99909 to allow users to customize the built-in ILM policy.
