### PR TITLE
Fix a typo in #106144

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1105,7 +1105,7 @@ public abstract class ESRestTestCase extends ESTestCase {
         try {
             // remove all indices except some history indices which can pop up after deleting all data streams but shouldn't interfere
             final List<String> indexPatterns = new ArrayList<>(
-                List.of("*", "-.ds-ilm-history-*", "-.ds-.slm-history-*", ".ds-.watcher-history-*")
+                List.of("*", "-.ds-ilm-history-*", "-.ds-.slm-history-*", "-.ds-.watcher-history-*")
             );
             if (preserveSecurityIndices) {
                 indexPatterns.add("-.security-*");


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/pull/106144#issuecomment-1988529564.

We want to **avoid** deleting these indices, hence the minus sign.

😵‍💫 