### PR TITLE
Add POC code for user metadata enrich

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -981,7 +981,8 @@ public class Security extends Plugin
                 apiKeyService,
                 serviceAccountService,
                 operatorPrivilegesService.get(),
-                telemetryProvider.getMeterRegistry()
+                telemetryProvider.getMeterRegistry(),
+                client
             )
         );
         components.add(authcService.get());

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationEnrichmentService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationEnrichmentService.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+
+import java.util.Map;
+
+import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public class AuthenticationEnrichmentService {
+    private final Client client;
+
+    public AuthenticationEnrichmentService(Client client) {
+        this.client = client;
+    }
+
+    void enrichAuthentication(Authentication authentication, ActionListener<Authentication> listener) {
+        // TODO: This needs to be configured somehow (name of source index, principal field and so on)
+        // TODO: We can only do this for some realms, add restrictions
+        final SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource()
+            .version(false)
+            .fetchSource(true)
+            .trackTotalHits(true)
+            .query(QueryBuilders.termQuery("principal", authentication.getEffectiveSubject().getUser().principal()));
+
+        final SearchRequest searchRequest = new SearchRequest(new String[] { ".acl-enrichment-test" }, searchSourceBuilder);
+        executeAsyncWithOrigin(client, SECURITY_ORIGIN, TransportSearchAction.TYPE, searchRequest, ActionListener.wrap(searchResponse -> {
+            // TODO: Assert on only one hit
+            Map<String, Object> source = null;
+            if (searchResponse.getHits().getTotalHits().value > 0) {
+                source = searchResponse.getHits().getHits()[0].getSourceAsMap();
+            }
+
+            // TODO: The idea is that there will be one access control index per connector (authz source) so "access_control_{connector_id}"
+            // TODO: Investigate if the naming can cause issues, what happens when overlan with actual metadata keys
+            if (source != null && source.containsKey("access_control")) {
+                listener.onResponse(authentication.enrichUserMetadata(source.get("access_control")));
+            } else {
+                listener.onResponse(authentication);
+            }
+        }, exception -> {
+            if (exception instanceof IndexNotFoundException) {
+                listener.onResponse(authentication);
+            } else {
+                listener.onFailure(exception);
+            }
+        }));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.settings.Setting;
@@ -90,7 +91,8 @@ public class AuthenticationService {
         ApiKeyService apiKeyService,
         ServiceAccountService serviceAccountService,
         OperatorPrivilegesService operatorPrivilegesService,
-        MeterRegistry meterRegistry
+        MeterRegistry meterRegistry,
+        Client client
     ) {
         this.realms = realms;
         this.auditTrailService = auditTrailService;
@@ -114,7 +116,8 @@ public class AuthenticationService {
             new ServiceAccountAuthenticator(serviceAccountService, nodeName, meterRegistry),
             new OAuth2TokenAuthenticator(tokenService, meterRegistry),
             new ApiKeyAuthenticator(apiKeyService, nodeName, meterRegistry),
-            new RealmsAuthenticator(numInvalidation, lastSuccessfulAuthCache, meterRegistry)
+            new RealmsAuthenticator(numInvalidation, lastSuccessfulAuthCache, meterRegistry),
+            new AuthenticationEnrichmentService(client)
         );
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticatorChain.java
@@ -47,6 +47,8 @@ class AuthenticatorChain {
     private final RealmsAuthenticator realmsAuthenticator;
     private final List<Authenticator> allAuthenticators;
 
+    private final AuthenticationEnrichmentService authenticationEnrichmentService;
+
     AuthenticatorChain(
         Settings settings,
         OperatorPrivilegesService operatorPrivilegesService,
@@ -55,7 +57,8 @@ class AuthenticatorChain {
         ServiceAccountAuthenticator serviceAccountAuthenticator,
         OAuth2TokenAuthenticator oAuth2TokenAuthenticator,
         ApiKeyAuthenticator apiKeyAuthenticator,
-        RealmsAuthenticator realmsAuthenticator
+        RealmsAuthenticator realmsAuthenticator,
+        AuthenticationEnrichmentService authenticationEnrichmentService
     ) {
         this.nodeName = Node.NODE_NAME_SETTING.get(settings);
         this.runAsEnabled = AuthenticationServiceField.RUN_AS_ENABLED.get(settings);
@@ -65,6 +68,7 @@ class AuthenticatorChain {
         this.authenticationSerializer = authenticationSerializer;
         this.realmsAuthenticator = realmsAuthenticator;
         this.allAuthenticators = List.of(serviceAccountAuthenticator, oAuth2TokenAuthenticator, apiKeyAuthenticator, realmsAuthenticator);
+        this.authenticationEnrichmentService = authenticationEnrichmentService;
     }
 
     void authenticate(Authenticator.Context context, ActionListener<Authentication> originalListener) {
@@ -106,7 +110,11 @@ class AuthenticatorChain {
                 assert result.getStatus() != AuthenticationResult.Status.TERMINATE
                     : "terminate should already be handled by each individual authenticator";
                 if (result.getStatus() == AuthenticationResult.Status.SUCCESS) {
-                    maybeLookupRunAsUser(context, result.getValue(), l);
+                    maybeLookupRunAsUser(
+                        context,
+                        result.getValue(),
+                        ActionListener.wrap(response -> authenticationEnrichmentService.enrichAuthentication(response, l), l::onFailure)
+                    );
                 } else {
                     assert result.getStatus() == AuthenticationResult.Status.CONTINUE;
                     if (context.shouldHandleNullToken()) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -367,7 +367,9 @@ public class AuthenticationServiceTests extends ESTestCase {
             apiKeyService,
             serviceAccountService,
             operatorPrivilegesService,
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            mock(Client.class)
+
         );
     }
 
@@ -667,7 +669,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             apiKeyService,
             serviceAccountService,
             operatorPrivilegesService,
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            mock(Client.class)
         );
         User user = new User("_username", "r1");
         when(firstRealm.supports(token)).thenReturn(true);
@@ -1051,7 +1054,8 @@ public class AuthenticationServiceTests extends ESTestCase {
                 apiKeyService,
                 serviceAccountService,
                 operatorPrivilegesService,
-                MeterRegistry.NOOP
+                MeterRegistry.NOOP,
+                mock(Client.class)
             );
             boolean requestIdAlreadyPresent = randomBoolean();
             SetOnce<String> reqId = new SetOnce<>();
@@ -1102,7 +1106,8 @@ public class AuthenticationServiceTests extends ESTestCase {
                     apiKeyService,
                     serviceAccountService,
                     operatorPrivilegesService,
-                    MeterRegistry.NOOP
+                    MeterRegistry.NOOP,
+                    mock(Client.class)
                 );
                 threadContext2.putHeader(AuthenticationField.AUTHENTICATION_KEY, authHeaderRef.get());
 
@@ -1126,7 +1131,8 @@ public class AuthenticationServiceTests extends ESTestCase {
                 apiKeyService,
                 serviceAccountService,
                 operatorPrivilegesService,
-                MeterRegistry.NOOP
+                MeterRegistry.NOOP,
+                mock(Client.class)
             );
             service.authenticate("_action", new InternalRequest(), InternalUsers.SYSTEM_USER, ActionListener.wrap(result -> {
                 if (requestIdAlreadyPresent) {
@@ -1189,7 +1195,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             apiKeyService,
             serviceAccountService,
             operatorPrivilegesService,
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            mock(Client.class)
         );
 
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
@@ -1234,7 +1241,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             apiKeyService,
             serviceAccountService,
             operatorPrivilegesService,
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            mock(Client.class)
         );
         doAnswer(invocationOnMock -> {
             final GetRequest request = (GetRequest) invocationOnMock.getArguments()[0];
@@ -1299,7 +1307,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             apiKeyService,
             serviceAccountService,
             operatorPrivilegesService,
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            mock(Client.class)
         );
         RestRequest request = new FakeRestRequest();
 
@@ -1336,7 +1345,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             apiKeyService,
             serviceAccountService,
             operatorPrivilegesService,
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            mock(Client.class)
         );
         RestRequest request = new FakeRestRequest();
 
@@ -1368,7 +1378,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             apiKeyService,
             serviceAccountService,
             operatorPrivilegesService,
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            mock(Client.class)
         );
         InternalRequest message = new InternalRequest();
         boolean requestIdAlreadyPresent = randomBoolean();
@@ -1404,7 +1415,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             apiKeyService,
             serviceAccountService,
             operatorPrivilegesService,
-            MeterRegistry.NOOP
+            MeterRegistry.NOOP,
+            mock(Client.class)
         );
 
         InternalRequest message = new InternalRequest();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -72,6 +72,8 @@ public class AuthenticatorChainTests extends ESTestCase {
     private User fallbackUser;
     private AuthenticatorChain authenticatorChain;
 
+    private AuthenticationEnrichmentService authenticationEnrichmentService;
+
     @Before
     public void init() {
         final Settings settings = Settings.builder()
@@ -96,6 +98,7 @@ public class AuthenticatorChainTests extends ESTestCase {
         final User user = new User(randomAlphaOfLength(8));
         authentication = AuthenticationTestHelper.builder().user(user).build(false);
         fallbackUser = AuthenticationTestHelper.randomInternalUser();
+        authenticationEnrichmentService = mock(AuthenticationEnrichmentService.class);
         authenticatorChain = new AuthenticatorChain(
             settings,
             operatorPrivilegesService,
@@ -104,7 +107,8 @@ public class AuthenticatorChainTests extends ESTestCase {
             serviceAccountAuthenticator,
             oAuth2TokenAuthenticator,
             apiKeyAuthenticator,
-            realmsAuthenticator
+            realmsAuthenticator,
+            authenticationEnrichmentService
         );
     }
 


### PR DESCRIPTION
- This adds an `AuthenticationEnrichmentService` that run at the end of the authentication. This is only for proving that we can do this and a WIP. 

- The idea is to use an enrich policy to move ACL data from the index where it was ingested to an enrich index where it's highly available on all nodes to make sure this doesn't become a bottleneck. This POC doesn't use that. 

Todo: 
- Further investigations on how to do this with enrich
- Think about and POC how to configure this feature
- Think about and POC how we should name things 
- Think about how this could clash with existing user metadata and how we should handle conflict 