### PR TITLE
[Fleet] added fleet-agent-components index

### DIFF
--- a/docs/reference/rest-api/security/get-service-accounts.asciidoc
+++ b/docs/reference/rest-api/security/get-service-accounts.asciidoc
@@ -143,6 +143,20 @@ GET /_security/service/elastic/fleet-server
           ],
           "allow_restricted_indices": true
         },
+                {
+          "names": [
+            ".fleet-agent-components*"
+          ],
+          "privileges": [
+            "read",
+            "write",
+            "monitor",
+            "create_index",
+            "auto_configure",
+            "maintenance"
+          ],
+          "allow_restricted_indices": true
+        },
         {
           "names": [
             ".fleet-artifacts*"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -150,6 +150,7 @@ class KibanaOwnedReservedRoleDescriptors {
                     .allowRestrictedIndices(true)
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices(".fleet-agents*").privileges("all").allowRestrictedIndices(true).build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices(".fleet-agent-components*").privileges("all").allowRestrictedIndices(true).build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-artifacts*")
                     .privileges("all")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -860,6 +860,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         Arrays.asList(
             ".fleet-agents",
+            ".fleet-agent-components",
             ".fleet-actions",
             ".fleet-enrollment-api-keys",
             ".fleet-policies",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/TestRestrictedIndices.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/test/TestRestrictedIndices.java
@@ -99,6 +99,7 @@ public class TestRestrictedIndices {
                 List.of(
                     SystemIndexDescriptorUtils.createUnmanaged(".fleet-actions~(-results*)", "fleet actions"),
                     SystemIndexDescriptorUtils.createUnmanaged(".fleet-agents*", "fleet agents"),
+                    SystemIndexDescriptorUtils.createUnmanaged(".fleet-agent-components*", "fleet agent components"),
                     SystemIndexDescriptorUtils.createUnmanaged(".fleet-enrollment-api-keys*", "fleet enrollment"),
                     SystemIndexDescriptorUtils.createUnmanaged(".fleet-policies-[0-9]+*", "fleet policies"),
                     SystemIndexDescriptorUtils.createUnmanaged(".fleet-policies-leader*", "fleet policies leader"),

--- a/x-pack/plugin/core/template-resources/src/main/resources/fleet-agent-components.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/fleet-agent-components.json
@@ -1,0 +1,55 @@
+{
+  "settings": {
+    "auto_expand_replicas": "0-1"
+  },
+  "mappings": {
+    "_doc": {
+      "dynamic": false,
+      "_meta": {
+        "version": "${fleet.version}",
+        "managed_index_mappings_version": ${fleet.managed.index.version}
+      },
+      "properties": {
+        "agent": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            }
+          }
+        },
+        "component": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            },
+             "status": {
+              "type": "keyword"
+            },
+            "message": {
+              "type": "text"
+            }
+          }
+        },
+        "unit": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "status": {
+              "type": "keyword"
+            },
+            "message": {
+              "type": "text"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
@@ -62,6 +62,22 @@ public class FleetSystemIndicesIT extends ESRestTestCase {
         assertThat(responseBody, containsString("access_api_key_id"));
     }
 
+    public void testCreationOfFleetAgentComponents() throws Exception {
+        Request request = new Request("PUT", ".fleet-agent-components");
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        request = new Request("GET", ".fleet-agent-components/_mapping");
+        response = client().performRequest(request);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        assertThat(responseBody, containsString("component"));
+
+        request = new Request("GET", ".fleet-agent-components-7/_mapping");
+        response = client().performRequest(request);
+        responseBody = EntityUtils.toString(response.getEntity());
+        assertThat(responseBody, containsString("component"));
+    }
+
     public void testCreationOfFleetActions() throws Exception {
         Request request = new Request("PUT", ".fleet-actions");
         Response response = client().performRequest(request);

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -81,6 +81,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
     private static final List<String> ALLOWED_PRODUCTS = List.of("kibana", "fleet");
     private static final int FLEET_ACTIONS_MAPPINGS_VERSION = 1;
     private static final int FLEET_AGENTS_MAPPINGS_VERSION = 1;
+    private static final int FLEET_AGENT_COMPONENTS_MAPPINGS_VERSION = 1;
     private static final int FLEET_ENROLLMENT_API_KEYS_MAPPINGS_VERSION = 1;
     private static final int FLEET_SECRETS_MAPPINGS_VERSION = 1;
     private static final int FLEET_POLICIES_MAPPINGS_VERSION = 1;
@@ -107,6 +108,7 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
         return List.of(
             fleetActionsSystemIndexDescriptor(),
             fleetAgentsSystemIndexDescriptor(),
+            fleetAgentComponentsSystemIndexDescriptor(),
             fleetEnrollmentApiKeysSystemIndexDescriptor(),
             fleetSecretsSystemIndexDescriptor(),
             fleetPoliciesSystemIndexDescriptor(),
@@ -163,6 +165,24 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
             .setPrimaryIndex(".fleet-agents-" + CURRENT_INDEX_VERSION)
             .setIndexPattern(".fleet-agents*")
             .setAliasName(".fleet-agents")
+            .setDescription("Configuration of fleet servers")
+            .build();
+    }
+
+    private static SystemIndexDescriptor fleetAgentComponentsSystemIndexDescriptor() {
+        PutIndexTemplateRequest request = new PutIndexTemplateRequest();
+        request.source(loadTemplateSource("/fleet-agent-components.json", FLEET_AGENT_COMPONENTS_MAPPINGS_VERSION), XContentType.JSON);
+
+        return SystemIndexDescriptor.builder()
+            .setType(Type.EXTERNAL_MANAGED)
+            .setAllowedElasticProductOrigins(ALLOWED_PRODUCTS)
+            .setOrigin(FLEET_ORIGIN)
+            .setVersionMetaKey(VERSION_KEY)
+            .setMappings(request.mappings())
+            .setSettings(request.settings())
+            .setPrimaryIndex(".fleet-agent-components-" + CURRENT_INDEX_VERSION)
+            .setIndexPattern(".fleet-agent-components*")
+            .setAliasName(".fleet-agent-components")
             .setDescription("Configuration of fleet servers")
             .build();
     }

--- a/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
+++ b/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
@@ -41,6 +41,7 @@ public class FleetTests extends ESTestCase {
                 ".fleet-servers*",
                 ".fleet-policies-[0-9]+*",
                 ".fleet-agents*",
+                ".fleet-agent-components*",
                 ".fleet-actions~(-results*)",
                 ".fleet-policies-leader*",
                 ".fleet-enrollment-api-keys*",
@@ -55,6 +56,7 @@ public class FleetTests extends ESTestCase {
         assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-policies-leader")));
 
         assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-agents")));
+        assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-agent-components")));
 
         assertTrue(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-actions")));
         assertFalse(fleetDescriptors.stream().anyMatch(d -> d.matchesIndexPattern(".fleet-actions-results")));

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -164,6 +164,20 @@ public class ServiceAccountIT extends ESRestTestCase {
                 },
                 {
                   "names": [
+                    ".fleet-agent-components*"
+                  ],
+                  "privileges": [
+                    "read",
+                    "write",
+                    "monitor",
+                    "create_index",
+                    "auto_configure",
+                    "maintenance"
+                  ],
+                  "allow_restricted_indices": true
+                },
+                {
+                  "names": [
                     ".fleet-artifacts*"
                   ],
                   "privileges": [

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -102,6 +102,11 @@ final class ElasticServiceAccounts {
                     .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
                     .allowRestrictedIndices(true)
                     .build(),
+                    RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".fleet-agent-components*")
+                    .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")
+                    .allowRestrictedIndices(true)
+                    .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-artifacts*")
                     .privileges("read", "write", "monitor", "create_index", "auto_configure", "maintenance")

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccountsTests.java
@@ -177,6 +177,7 @@ public class ElasticServiceAccountsTests extends ESTestCase {
         List.of(
             ".fleet-actions" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-agents" + randomAlphaOfLengthBetween(1, 20),
+            ".fleet-agent-components" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-enrollment-api-keys" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-policies" + randomAlphaOfLengthBetween(1, 20),
             ".fleet-policies-leader" + randomAlphaOfLengthBetween(1, 20),


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)? yes
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)? yes
- If submitting code, have you built your formula locally prior to submission with `gradle check`? yes
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed. yes
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)? yes
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that. yes

Added `.fleet-agent-components` index, to store Fleet agent component and unit status as separate documents. This is needed for telemetry in Fleet.
Relates https://github.com/elastic/ingest-dev/issues/2522
