### PR TITLE
Revert "Tighten up preconditions and test conditions in watcher yaml rest tests"

### DIFF
--- a/x-pack/plugin/watcher/qa/common/src/main/java/org/elasticsearch/xpack/watcher/WatcherRestTestCase.java
+++ b/x-pack/plugin/watcher/qa/common/src/main/java/org/elasticsearch/xpack/watcher/WatcherRestTestCase.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.equalTo;
-
 /**
  * Parent test class for Watcher (not-YAML) based REST tests
  */
@@ -80,37 +78,20 @@ public abstract class WatcherRestTestCase extends ESRestTestCase {
     }
 
     public static void deleteAllWatcherData() throws IOException {
-        {
-            var queryWatchesRequest = new Request("GET", "/_watcher/_query/watches");
-            var response = ObjectPath.createFromResponse(ESRestTestCase.adminClient().performRequest(queryWatchesRequest));
+        var queryWatchesRequest = new Request("GET", "/_watcher/_query/watches");
+        var response = ObjectPath.createFromResponse(ESRestTestCase.adminClient().performRequest(queryWatchesRequest));
 
-            int totalCount = response.evaluate("count");
-            List<Map<?, ?>> watches = response.evaluate("watches");
-            assert watches.size() == totalCount : "number of watches returned is unequal to the total number of watches";
-            for (Map<?, ?> watch : watches) {
-                String id = (String) watch.get("_id");
-                var deleteWatchRequest = new Request("DELETE", "/_watcher/watch/" + id);
-                assertOK(ESRestTestCase.adminClient().performRequest(deleteWatchRequest));
-            }
+        int totalCount = response.evaluate("count");
+        List<Map<?, ?>> watches = response.evaluate("watches");
+        assert watches.size() == totalCount : "number of watches returned is unequal to the total number of watches";
+        for (Map<?, ?> watch : watches) {
+            String id = (String) watch.get("_id");
+            var deleteWatchRequest = new Request("DELETE", "/_watcher/watch/" + id);
+            assertOK(ESRestTestCase.adminClient().performRequest(deleteWatchRequest));
         }
 
-        {
-            var queryWatchesRequest = new Request("GET", "/_watcher/_query/watches");
-            var response = ObjectPath.createFromResponse(ESRestTestCase.adminClient().performRequest(queryWatchesRequest));
-            assertThat(response.evaluate("count"), equalTo(0));
-        }
-
-        {
-            var xpackUsageRequest = new Request("GET", "/_xpack/usage");
-            var response = ObjectPath.createFromResponse(ESRestTestCase.adminClient().performRequest(xpackUsageRequest));
-            assertThat(response.evaluate("watcher.count.active"), equalTo(0));
-            assertThat(response.evaluate("watcher.count.total"), equalTo(0));
-        }
-
-        {
-            var deleteWatchHistoryRequest = new Request("DELETE", ".watcher-history-*");
-            deleteWatchHistoryRequest.addParameter("ignore_unavailable", "true");
-            ESRestTestCase.adminClient().performRequest(deleteWatchHistoryRequest);
-        }
+        var deleteWatchHistoryRequest = new Request("DELETE", ".watcher-history-*");
+        deleteWatchHistoryRequest.addParameter("ignore_unavailable", "true");
+        ESRestTestCase.adminClient().performRequest(deleteWatchHistoryRequest);
     }
 }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/usage/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/usage/10_basic.yml
@@ -1,18 +1,21 @@
 ---
 "Test watcher usage stats output":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/65547"
   - do:
       catch: missing
       watcher.delete_watch:
         id: "usage_stats_watch"
 
-  - do: { xpack.usage: {} }
-  - match: { "watcher.count.active": 0 }
-  - match: { "watcher.count.total": 0 }
+  - do: {xpack.usage: {}}
+  - set: { "watcher.count.active": watch_count_active }
+  - set: { "watcher.count.total": watch_count_total }
 
   - do:
       watcher.put_watch:
         id: "usage_stats_watch"
-        body: >
+        body:  >
           {
             "trigger": {
               "schedule" : { "cron" : "0 0 0 1 * ? 2099" }
@@ -44,9 +47,9 @@
           }
   - match: { _id: "usage_stats_watch" }
 
-  - do: { xpack.usage: {} }
-  - match: { "watcher.count.active": 1 }
-  - match: { "watcher.count.total": 1 }
+  - do: {xpack.usage: {}}
+  - gt: { "watcher.count.active": $watch_count_active }
+  - gt: { "watcher.count.total": $watch_count_total }
   - gte: { "watcher.watch.action._all.active": 1 }
   - gte: { "watcher.watch.action.logging.active": 1 }
   - gte: { "watcher.watch.condition._all.active": 1 }
@@ -57,3 +60,4 @@
   - gte: { "watcher.watch.trigger.schedule.active": 1 }
   - gte: { "watcher.watch.trigger.schedule.cron.active": 1 }
   - gte: { "watcher.watch.trigger.schedule._all.active": 1 }
+


### PR DESCRIPTION
Reverts elastic/elasticsearch#106141

This has increased the failure load enough to be annoying, so I'm reverting it. See https://github.com/elastic/elasticsearch/issues/106192.