### PR TITLE
[DOCS] `time_series_dimension` fields do not support `ignore_above`

### DIFF
--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -166,7 +166,6 @@ Dimension fields have the following constraints:
 * Field values cannot be an <<array,array or multi-value>>.
 // end::dimension[]
 * <<ignore-above,`ignore_above`>> mapping parameter is not supported.
-* Field values cannot be larger than 1024 bytes.
 * The field cannot use a <<normalizer,`normalizer`>>.
 --
 

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -165,6 +165,7 @@ Dimension fields have the following constraints:
 * The `doc_values` and `index` mapping parameters must be `true`.
 * Field values cannot be an <<array,array or multi-value>>.
 // end::dimension[]
+* <<ignore-above,`ignore_above`>> mapping parameter is not supported.
 * Field values cannot be larger than 1024 bytes.
 * The field cannot use a <<normalizer,`normalizer`>>.
 --

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -165,8 +165,9 @@ Dimension fields have the following constraints:
 * The `doc_values` and `index` mapping parameters must be `true`.
 * Field values cannot be an <<array,array or multi-value>>.
 // end::dimension[]
-* <<ignore-above,`ignore_above`>> mapping parameter is not supported.
-* The field cannot use a <<normalizer,`normalizer`>>.
+* Dimension values are used to identify a document’s time series. If dimension values are altered in any way during indexing, the document will be stored as belonging to different from intended time series. As a result there are additional constraints:
+** <<ignore-above,`ignore_above`>> mapping parameter isn't supported.
+** The field cannot use a <<normalizer,`normalizer`>>.
 --
 
 [[keyword-synthetic-source]]


### PR DESCRIPTION
There is existing validation for this combination of parameters but it was not documented. I was wondering if we should explain _why_ is that but we don't really do that for other restrictions here.

Closes #99044