### PR TITLE
Support filling existing LongArray with stream input

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -298,6 +298,12 @@ public class BigArrays {
             out.writeVInt(size);
             out.write(array, 0, size);
         }
+
+        @Override
+        public void fillWith(StreamInput in) throws IOException {
+            int len = in.readVInt();
+            in.readBytes(array, 0, len);
+        }
     }
 
     private static class ByteArrayAsDoubleArrayWrapper extends AbstractArrayWrapper implements DoubleArray {

--- a/server/src/main/java/org/elasticsearch/common/util/BigLongArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigLongArray.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -132,6 +133,21 @@ final class BigLongArray extends AbstractBigArray implements LongArray {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         writePages(out, Math.toIntExact(size), pages, Long.BYTES, LONG_PAGE_SIZE);
+    }
+
+    @Override
+    public void fillWith(StreamInput in) throws IOException {
+        readPages(in, pages);
+    }
+
+    static void readPages(StreamInput in, byte[][] pages) throws IOException {
+        int remained = in.readVInt();
+        for (int i = 0; i < pages.length - 1; i++) {
+            int len = pages[0].length;
+            in.readBytes(pages[i], 0, len);
+            remained -= len;
+        }
+        in.readBytes(pages[pages.length - 1], 0, remained);
     }
 
     static void writePages(StreamOutput out, int size, byte[][] pages, int bytesPerValue, int pageSize) throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/util/LongArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongArray.java
@@ -43,6 +43,11 @@ public interface LongArray extends BigArray, Writeable {
     void fill(long fromIndex, long toIndex, long value);
 
     /**
+     * Alternative of {@link #readFrom(StreamInput)} where the written bytes are loaded into an existing {@link LongArray}
+     */
+    void fillWith(StreamInput in) throws IOException;
+
+    /**
      * Bulk set.
      */
     void set(long index, byte[] buf, int offset, int len);

--- a/server/src/main/java/org/elasticsearch/common/util/ReleasableLongArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/ReleasableLongArray.java
@@ -60,6 +60,11 @@ public class ReleasableLongArray implements LongArray {
     }
 
     @Override
+    public void fillWith(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void set(long index, byte[] buf, int offset, int len) {
         throw new UnsupportedOperationException();
     }

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -539,6 +539,11 @@ public class MockBigArrays extends BigArrays {
         public void writeTo(StreamOutput out) throws IOException {
             in.writeTo(out);
         }
+
+        @Override
+        public void fillWith(StreamInput streamInput) throws IOException {
+            in.fillWith(streamInput);
+        }
     }
 
     private class FloatArrayWrapper extends AbstractArrayWrapper implements FloatArray {


### PR DESCRIPTION
Today, we can't use `LongArray#readFrom(StreamInput in)` in ES|QL because the returned big array is not tracked with the circuit breaker. We can integrate the circuit breaker with ReleasableLongArray; however, we don't know how many bytes we should track: the whole BytesReference or just the slice.

This PR adds an alternative method, where we create a big array manually, then fill it with bytes from a stream input. If we are okay with this approach, I can make similar changes to other classes. 

Any suggestions are welcome.