### PR TITLE
Unmute test fixed by #106104

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -1842,7 +1842,6 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
         assertThat(failureStoreDataStream.getFailureStoreWriteIndex(), is(writeFailureIndex));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106123")
     public void testIsFailureIndex() {
         boolean hidden = randomBoolean();
         boolean system = hidden && randomBoolean();


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/106123 was fixed by https://github.com/elastic/elasticsearch/pull/106104.

In this PR we unmute the test.

Closes https://github.com/elastic/elasticsearch/issues/106123