### PR TITLE
[8.13] Add Saml test connection timeout debugging output (#104801)

### DIFF
--- a/x-pack/qa/saml-idp-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticationIT.java
+++ b/x-pack/qa/saml-idp-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticationIT.java
@@ -251,7 +251,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
      * <li>Uses that token to verify the user details</li>
      * </ol>
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103595")
+    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103595")
     public void testLoginUserWithSamlRoleMapping() throws Exception {
         final Tuple<String, String> authTokens = loginViaSaml("shibboleth");
         verifyElasticsearchAccessTokenForRoleMapping(authTokens.v1());
@@ -262,7 +262,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
         verifyElasticsearchAccessTokenInvalidated(accessToken);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103595")
+    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103595")
     public void testLoginUserWithAuthorizingRealm() throws Exception {
         final Tuple<String, String> authTokens = loginViaSaml("shibboleth_native");
         verifyElasticsearchAccessTokenForAuthorizingRealms(authTokens.v1());
@@ -273,7 +273,7 @@ public class SamlAuthenticationIT extends ESRestTestCase {
         verifyElasticsearchAccessTokenInvalidated(accessToken);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103595")
+    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/103595")
     public void testLoginWithWrongRealmFails() throws Exception {
         final BasicHttpContext context = new BasicHttpContext();
         try (CloseableHttpClient client = getHttpClient()) {

--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -12,23 +12,22 @@ dependencies {
   api "junit:junit:${versions.junit}"
 }
 
+tasks.withType(DockerBuildTask).configureEach {
+  noCache = BuildParams.isCi()
+  push = true //BuildParams.isCi()
+  getPlatforms().addAll( Architecture.values().collect{ it.dockerPlatform } )
+}
+
 tasks.register("deployIdpFixtureDockerImages", DockerBuildTask) {
     dockerContext.fileValue(file("src/main/resources/idp"))
     baseImages = ["openjdk:11.0.16-jre"]
-    noCache = BuildParams.isCi()
-    tags = ["docker.elastic.co/elasticsearch-dev/idp-fixture:1.0"]
-    push = BuildParams.isCi()
-    getPlatforms().addAll( Architecture.values().collect{ it.dockerPlatform } )
+    tags = ["docker.elastic.co/elasticsearch-dev/idp-fixture:1.1"]
 }
-
 
 tasks.register("deployOpenLdapFixtureDockerImages", DockerBuildTask) {
   dockerContext.fileValue(file("src/main/resources/openldap"))
   baseImages = ["osixia/openldap:1.4.0"]
-  noCache = BuildParams.isCi()
   tags = ["docker.elastic.co/elasticsearch-dev/openldap-fixture:1.0"]
-  push = BuildParams.isCi()
-  getPlatforms().addAll( Architecture.values().collect{ it.dockerPlatform } )
 }
 
 tasks.register("deployFixtureDockerImages") {

--- a/x-pack/test/idp-fixture/src/main/java/org/elasticsearch/test/fixtures/idp/IdpTestContainer.java
+++ b/x-pack/test/idp-fixture/src/main/java/org/elasticsearch/test/fixtures/idp/IdpTestContainer.java
@@ -20,7 +20,7 @@ import static org.elasticsearch.test.fixtures.ResourceUtils.copyResourceToFile;
 
 public final class IdpTestContainer extends DockerEnvironmentAwareTestContainer {
 
-    private static final String DOCKER_BASE_IMAGE = "docker.elastic.co/elasticsearch-dev/idp-fixture:1.0";
+    private static final String DOCKER_BASE_IMAGE = "docker.elastic.co/elasticsearch-dev/idp-fixture:1.1";
     private final TemporaryFolder temporaryFolder = new TemporaryFolder();
     private Path certsPath;
 

--- a/x-pack/test/idp-fixture/src/main/resources/idp/bin/run-jetty.sh
+++ b/x-pack/test/idp-fixture/src/main/resources/idp/bin/run-jetty.sh
@@ -12,7 +12,7 @@ sed -i "s/^-Xmx.*$/-Xmx$JETTY_MAX_HEAP/g" /opt/shib-jetty-base/start.ini
 
 # For some reason, this container always immediately (in less than 1 second) exits with code 0 when starting for the first time
 # Even with a health check, docker-compose will immediately report the container as unhealthy when using --wait instead of waiting for it to become healthy
-# So, let's just start it a second time if it exits quickly
+# So, let's just start it a second time
 set +e
 start_time=$(date +%s)
 /opt/jetty-home/bin/jetty.sh run
@@ -20,9 +20,13 @@ exit_code=$?
 end_time=$(date +%s)
 
 duration=$((end_time - start_time))
-if [ $duration -lt 10 ]; then
-  /opt/jetty-home/bin/jetty.sh run
-  exit_code=$?
+echo "Duration for initial idp run was $duration seconds."
+
+if [ $duration -lt 60 ]; then
+   echo "Restarting idp."
+
+   /opt/jetty-home/bin/jetty.sh run
+   exit_code=$?
 fi
 
 exit $exit_code


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [Add Saml test connection timeout debugging output (#104801)](https://github.com/elastic/elasticsearch/pull/104801)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)