### PR TITLE
[DOCS] Changes element_type in index mapping for the inference tutorial

### DIFF
--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
@@ -9,7 +9,7 @@ PUT cohere-embeddings
       "content_embedding": { <1>
         "type": "dense_vector", <2>
         "dims": 1024, <3>
-        "element_type": "float"
+        "element_type": "byte"
       },
       "content": { <4>
         "type": "text" <5>


### PR DESCRIPTION
## Overview

This PR changes the `element_type` to `byte` in the mappings of the `cohere-embeddings` index in the Inference AI tutorial.