### PR TITLE
[8.13] Clarify filters can be used while creating a normalizer. (#103826)

### DIFF
--- a/docs/reference/analysis/normalizers.asciidoc
+++ b/docs/reference/analysis/normalizers.asciidoc
@@ -6,15 +6,15 @@ token. As a consequence, they do not have a tokenizer and only accept a subset
 of the available char filters and token filters. Only the filters that work on
 a per-character basis are allowed. For instance a lowercasing filter would be
 allowed, but not a stemming filter, which needs to look at the keyword as a
-whole. The current list of filters that can be used in a normalizer is
-following: `arabic_normalization`, `asciifolding`, `bengali_normalization`,
+whole. The current list of filters that can be used in a normalizer definition
+are: `arabic_normalization`, `asciifolding`, `bengali_normalization`,
 `cjk_width`, `decimal_digit`, `elision`, `german_normalization`,
 `hindi_normalization`, `indic_normalization`, `lowercase`, `pattern_replace`,
 `persian_normalization`, `scandinavian_folding`, `serbian_normalization`,
 `sorani_normalization`, `trim`, `uppercase`.
 
 Elasticsearch ships with a `lowercase` built-in normalizer. For other forms of
-normalization a custom configuration is required.
+normalization, a custom configuration is required.
 
 [discrete]
 === Custom normalizers


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Clarify filters can be used while creating a normalizer. (#103826)