### PR TITLE
[8.13] [DOCS] Changes element_type in index mapping for the infrence tutorial. (#106233)

### DIFF
--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
@@ -9,7 +9,7 @@ PUT cohere-embeddings
       "content_embedding": { <1>
         "type": "dense_vector", <2>
         "dims": 1024, <3>
-        "element_type": "float"
+        "element_type": "byte"
       },
       "content": { <4>
         "type": "text" <5>


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [DOCS] Changes element_type in index mapping for the infrence tutorial. (#106233)