### PR TITLE
Fix testUpgradesLegitimateVersions

### DIFF
--- a/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeMetadataTests.java
@@ -33,7 +33,7 @@ public class NodeMetadataTests extends ESTestCase {
     // (Index)VersionUtils.randomVersion() only returns known versions, which are necessarily no later than (Index)Version.CURRENT;
     // however we want to also consider our behaviour with all versions, so occasionally pick up a truly random version.
     private Version randomVersion() {
-        return rarely() ? Version.fromId(randomInt()) : VersionUtils.randomVersion(random());
+        return rarely() ? Version.fromId(randomNonNegativeInt()) : VersionUtils.randomVersion(random());
     }
 
     private BuildVersion randomBuildVersion() {


### PR DESCRIPTION
DefaultBuildVersion has an assertion to only accept versions that are >= 0. This change updates a test generator to create versions accordingly.

Closes: #106213