### PR TITLE
Support MatchType in EnrichExec

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -142,6 +142,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_SERIALIZE_ARRAY_BLOCK = def(8_602_00_0);
     public static final TransportVersion ADD_DATA_STREAM_GLOBAL_RETENTION = def(8_603_00_0);
     public static final TransportVersion ALLOCATION_STATS = def(8_604_00_0);
+    public static final TransportVersion ESQL_EXTENDED_ENRICH_TYPES = def(8_605_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EnrichExec.java
@@ -21,6 +21,7 @@ import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutp
 public class EnrichExec extends UnaryExec implements EstimatesRowSize {
 
     private final Enrich.Mode mode;
+    private final String matchType;
     private final NamedExpression matchField;
     private final String policyName;
     private final String policyMatchField;
@@ -41,6 +42,7 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
         Source source,
         PhysicalPlan child,
         Enrich.Mode mode,
+        String matchType,
         NamedExpression matchField,
         String policyName,
         String policyMatchField,
@@ -49,6 +51,7 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
     ) {
         super(source, child);
         this.mode = mode;
+        this.matchType = matchType;
         this.matchField = matchField;
         this.policyName = policyName;
         this.policyMatchField = policyMatchField;
@@ -63,6 +66,7 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
             EnrichExec::new,
             child(),
             mode,
+            matchType,
             matchField,
             policyName,
             policyMatchField,
@@ -73,11 +77,15 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
 
     @Override
     public EnrichExec replaceChild(PhysicalPlan newChild) {
-        return new EnrichExec(source(), newChild, mode, matchField, policyName, policyMatchField, concreteIndices, enrichFields);
+        return new EnrichExec(source(), newChild, mode, matchType, matchField, policyName, policyMatchField, concreteIndices, enrichFields);
     }
 
     public Enrich.Mode mode() {
         return mode;
+    }
+
+    public String matchType() {
+        return matchType;
     }
 
     public NamedExpression matchField() {
@@ -118,6 +126,7 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
         if (super.equals(o) == false) return false;
         EnrichExec that = (EnrichExec) o;
         return mode.equals(that.mode)
+            && Objects.equals(matchType, that.matchType)
             && Objects.equals(matchField, that.matchField)
             && Objects.equals(policyName, that.policyName)
             && Objects.equals(policyMatchField, that.policyMatchField)
@@ -127,6 +136,6 @@ public class EnrichExec extends UnaryExec implements EstimatesRowSize {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), mode, matchField, policyName, policyMatchField, concreteIndices, enrichFields);
+        return Objects.hash(super.hashCode(), mode, matchType, matchField, policyName, policyMatchField, concreteIndices, enrichFields);
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -468,7 +468,7 @@ public class LocalExecutionPlanner {
                 source.layout.get(enrich.matchField().id()).channel(),
                 enrichLookupService,
                 enrichIndex,
-                "match", // TODO: enrich should also resolve the match_type
+                enrich.matchType(),
                 enrich.policyMatchField(),
                 enrich.enrichFields()
             ),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Mapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/Mapper.java
@@ -149,6 +149,7 @@ public class Mapper {
                 enrich.source(),
                 child,
                 enrich.mode(),
+                enrich.policy().getType(),
                 enrich.matchField(),
                 BytesRefs.toString(enrich.policyName().fold()),
                 enrich.policy().getMatchField(),


### PR DESCRIPTION
In preparation for supporting more ENRICH match types, this change includes the TransportVersion changes required for serialization support.

This work was extracted from the actual ENRICH feature work at https://github.com/elastic/elasticsearch/pull/106186, so we can get it merged faster and have less hassle with TransportVersion conflicts.
