### PR TITLE
Additional logging for testRestoreSnapshotAllocationDoesNotExceedWatermarkWithMultipleShards

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -164,7 +164,9 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
     @TestIssueLogging(
         value = "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceComputer:TRACE,"
             + "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceReconciler:DEBUG,"
-            + "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceShardsAllocator:TRACE",
+            + "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceShardsAllocator:TRACE,"
+            + "org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator:TRACE,"
+            + "org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders:TRACE",
         issueUrl = "https://github.com/elastic/elasticsearch/issues/105331"
     )
     public void testRestoreSnapshotAllocationDoesNotExceedWatermarkWithMultipleShards() throws Exception {
@@ -290,10 +292,6 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
         public Set<ShardId> getSmallestShardIds() {
             return getShardIdsWithSizeSmallerOrEqual(getSmallestShardSize());
-        }
-
-        public Set<ShardId> getAllShardIds() {
-            return sizes.stream().map(ShardSize::shardId).collect(toSet());
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -166,7 +166,8 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
             + "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceReconciler:DEBUG,"
             + "org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceShardsAllocator:TRACE,"
             + "org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator:TRACE,"
-            + "org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders:TRACE",
+            + "org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders:TRACE,"
+            + "org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider:TRACE",
         issueUrl = "https://github.com/elastic/elasticsearch/issues/105331"
     )
     public void testRestoreSnapshotAllocationDoesNotExceedWatermarkWithMultipleShards() throws Exception {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -1299,6 +1299,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             );
         }, DesiredBalanceComputer.class, expectation);
     }
+
     private static ShardId findShardId(ClusterState clusterState, String name) {
         return clusterState.getRoutingTable().index(name).shard(0).shardId();
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -1299,11 +1299,6 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             );
         }, DesiredBalanceComputer.class, expectation);
     }
-
-    private static Map.Entry<String, Long> indexSize(ClusterState clusterState, String name, long size, boolean primary) {
-        return Map.entry(shardIdentifierFromRouting(findShardId(clusterState, name), primary), size);
-    }
-
     private static ShardId findShardId(ClusterState clusterState, String name) {
         return clusterState.getRoutingTable().index(name).shard(0).shardId();
     }


### PR DESCRIPTION
I tried to stage the allocator state from the information available in the logs https://github.com/elastic/elasticsearch/issues/105331#issuecomment-1992139762 however I was unable to reproduce the failure locally. I am adding even more logs to see if any decider returns unexpected result in delegate allocator

Related to: #105331