### PR TITLE
Add data stream lifecycle to kibana reporting template

### DIFF
--- a/docs/changelog/106259.yaml
+++ b/docs/changelog/106259.yaml
@@ -1,0 +1,5 @@
+pr: 106259
+summary: Add data stream lifecycle to kibana reporting template
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/kibana-reporting@template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/kibana-reporting@template.json
@@ -5,7 +5,10 @@
     "hidden": true
   },
   "allow_auto_create": true,
+  "composed_of": ["kibana-reporting@custom"],
+  "ignore_missing_component_templates": ["kibana-reporting@custom"],
   "template": {
+    "lifecycle": {},
     "settings": {
       "number_of_shards": 1,
       "auto_expand_replicas": "0-1"

--- a/x-pack/plugin/stack/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
+++ b/x-pack/plugin/stack/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/stack/10_basic.yml
@@ -239,6 +239,7 @@ setup:
   - match: { data_streams.0.timestamp_field.name: '@timestamp' }
   - match: { data_streams.0.generation: 1 }
   - length: { data_streams.0.indices: 1 }
+  - match: { data_streams.0.lifecycle.enabled: true }
   - match: { data_streams.0.indices.0.index_name: '/\.ds-.kibana-reporting-foo-(\d{4}\.\d{2}\.\d{2}-)?000001/' }
 
   - set: { data_streams.0.indices.0.index_name: idx0name }


### PR DESCRIPTION
As a follow-up to #97765 this commit adds a lifecycle with infinite retention for Kibana reporting data streams. It also adds customization that follows our best practices with the optional `kibana-reporting@custom` component template.
