### PR TITLE
[ML] Support byte string as embedding type

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -142,6 +142,7 @@ public class TransportVersions {
     public static final TransportVersion ESQL_SERIALIZE_ARRAY_BLOCK = def(8_602_00_0);
     public static final TransportVersion ADD_DATA_STREAM_GLOBAL_RETENTION = def(8_603_00_0);
     public static final TransportVersion ALLOCATION_STATS = def(8_604_00_0);
+    public static final TransportVersion ML_INFERENCE_COHERE_EMBEDDINGS_BYTE_ADDED = def(8_605_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequestEntity.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequestEntity.java
@@ -57,7 +57,7 @@ public record CohereEmbeddingsRequestEntity(
         }
 
         if (embeddingType != null) {
-            builder.field(EMBEDDING_TYPES_FIELD, List.of(embeddingType));
+            builder.field(EMBEDDING_TYPES_FIELD, List.of(embeddingType.toRequestString()));
         }
 
         if (taskSettings.getTruncation() != null) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
@@ -222,6 +222,6 @@ public class CohereService extends SenderService {
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersions.ML_INFERENCE_REQUEST_INPUT_TYPE_CLASS_CLUSTER_ADDED;
+        return TransportVersions.ML_INFERENCE_COHERE_EMBEDDINGS_BYTE_ADDED;
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingType.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingType.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.inference.services.cohere.embeddings;
 
+import org.elasticsearch.core.Nullable;
+
 import java.util.Locale;
 
 /**
@@ -24,11 +26,34 @@ public enum CohereEmbeddingType {
     /**
      * Use this when you want to get back signed int8 embeddings. Valid for only v3 models.
      */
-    INT8;
+    INT8,
+    /**
+     * Same as int8, just using the name <i>byte</i> to match with the string that Elasticsearch uses in the mapping
+     */
+    BYTE(INT8.name());
+
+    private final String requestName;
+
+    CohereEmbeddingType(@Nullable String requestName) {
+        this.requestName = requestName;
+    }
+
+    CohereEmbeddingType() {
+        this(null);
+    }
 
     @Override
     public String toString() {
         return name().toLowerCase(Locale.ROOT);
+    }
+
+    public String toRequestString() {
+        String nameToUse = name();
+
+        if (requestName != null) {
+            nameToUse = requestName;
+        }
+        return nameToUse.toLowerCase(Locale.ROOT);
     }
 
     public static String toLowerCase(CohereEmbeddingType type) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettings.java
@@ -100,7 +100,13 @@ public class CohereEmbeddingsServiceSettings implements ServiceSettings {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         commonSettings.writeTo(out);
-        out.writeOptionalEnum(embeddingType);
+
+        if (out.getTransportVersion().before(TransportVersions.ML_INFERENCE_COHERE_EMBEDDINGS_BYTE_ADDED)
+            && embeddingType == CohereEmbeddingType.BYTE) {
+            out.writeOptionalEnum(CohereEmbeddingType.INT8);
+        } else {
+            out.writeOptionalEnum(embeddingType);
+        }
     }
 
     @Override

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequestEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereEmbeddingsRequestEntityTests.java
@@ -56,6 +56,22 @@ public class CohereEmbeddingsRequestEntityTests extends ESTestCase {
             {"texts":["abc"],"model":"model","input_type":"search_query","embedding_types":["int8"],"truncate":"none"}"""));
     }
 
+    public void testXContent_TranslatesByteToInt8() throws IOException {
+        var entity = new CohereEmbeddingsRequestEntity(
+            List.of("abc"),
+            new CohereEmbeddingsTaskSettings(InputType.SEARCH, CohereTruncation.NONE),
+            "model",
+            CohereEmbeddingType.BYTE
+        );
+
+        XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
+        entity.toXContent(builder, null);
+        String xContentResult = Strings.toString(builder);
+
+        MatcherAssert.assertThat(xContentResult, is("""
+            {"texts":["abc"],"model":"model","input_type":"search_query","embedding_types":["int8"],"truncate":"none"}"""));
+    }
+
     public void testXContent_WritesNoOptionalFields_WhenTheyAreNotDefined() throws IOException {
         var entity = new CohereEmbeddingsRequestEntity(List.of("abc"), CohereEmbeddingsTaskSettings.EMPTY_SETTINGS, null, null);
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettingsTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.inference.services.cohere.CohereServiceSettingsTe
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -175,6 +176,16 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
         );
     }
 
+    public void testFromMap_EmbeddingTypeByte_ParsesCorrectly() {
+        assertThat(
+            CohereEmbeddingsServiceSettings.fromMap(
+                new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, CohereEmbeddingType.BYTE.toString())),
+                false
+            ),
+            is(new CohereEmbeddingsServiceSettings(new CohereServiceSettings((URI) null, null, null, null, null), CohereEmbeddingType.BYTE))
+        );
+    }
+
     public void testFromMap_InvalidEmbeddingType_ThrowsError() {
         var thrownException = expectThrows(
             ValidationException.class,
@@ -188,7 +199,8 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
             thrownException.getMessage(),
             is(
                 Strings.format(
-                    "Validation Failed: 1: [service_settings] Invalid value [abc] received. [embedding_type] must be one of [float, int8];"
+                    "Validation Failed: 1: [service_settings] Invalid value [abc] received. [embedding_type] must "
+                        + "be one of [byte, float, int8];"
                 )
             )
         );


### PR DESCRIPTION
This PR adds `byte` as a valid `embedding_type` value when initializing a cohere inference endpoint. This is to match what we use in the elasticsearch mapping for `"element_type": "byte"`.

`embedding_type: "int8"` is still supported.

Since we want this in 8.13.0 I think I need to follow what we did here:

https://github.com/elastic/elasticsearch/pull/100588

And then in main: https://github.com/elastic/elasticsearch/pull/100626

My understanding of the steps are:
1. Merge this PR with the new transport version (let's call it X)
2. Create a manual backport PR for 8.13.0 that adds a patch transport version (call it Y) on the last transport version in the file
3. Create a function that takes a similar approach to

```
    static boolean transportVersionIsCompatibleWithByteEnum(TransportVersion transportVersion) {
        var byteEnumAdded = new TransportVersion(X);

        if (transportVersion.onOrAfter(byteEnumAdded)) {
            return true;
        } else {
            var nextNonPatchVersion = new TransportVersion(Y + 1); // +1 increments the NNN part of the version number
            return transportVersion.onOrAfter(Y)
                && transportVersion.before(nextNonPatchVersion);
        }
    }
```
4. Create a new PR once the backport is merged for 8.14.0 that adds the above function and the patch transport versions