### PR TITLE
[8.13] Fix typo in text_expansion example (#106265)

### DIFF
--- a/docs/reference/query-dsl/text-expansion-query.asciidoc
+++ b/docs/reference/query-dsl/text-expansion-query.asciidoc
@@ -245,7 +245,7 @@ GET my-index/_search
                "pruning_config": {
                   "tokens_freq_ratio_threshold": 5,
                   "tokens_weight_threshold": 0.4,
-                  "only_score_pruned_tokens": false
+                  "only_score_pruned_tokens": true
                }
             }
          }


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Fix typo in text_expansion example (#106265)