### PR TITLE
Fix write pages in BigArray

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BigByteArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigByteArray.java
@@ -44,7 +44,7 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        writePages(out, Math.toIntExact(size), pages, Byte.BYTES, BYTE_PAGE_SIZE);
+        writePages(out, size, pages, Byte.BYTES);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
@@ -129,6 +129,6 @@ final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        writePages(out, Math.toIntExact(size), pages, Double.BYTES, DOUBLE_PAGE_SIZE);
+        writePages(out, size, pages, Double.BYTES);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/util/BigIntArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigIntArray.java
@@ -44,7 +44,7 @@ final class BigIntArray extends AbstractBigArray implements IntArray {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        writePages(out, (int) size, pages, Integer.BYTES, INT_PAGE_SIZE);
+        writePages(out, size, pages, Integer.BYTES);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -247,10 +247,14 @@ public class BigArraysTests extends ESTestCase {
     }
 
     public void testSerializeLongArray() throws Exception {
-        final int len = randomIntBetween(1, 1000_000);
-        final LongArray array1 = bigArrays.newLongArray(len, randomBoolean());
+        int len = randomIntBetween(1, 100_000);
+        LongArray array1 = bigArrays.newLongArray(len, randomBoolean());
         for (int i = 0; i < len; ++i) {
             array1.set(i, randomLong());
+        }
+        if (randomBoolean()) {
+            len = randomIntBetween(len, len * 3 / 2);
+            array1 = bigArrays.resize(array1, len);
         }
         BytesStreamOutput out = new BytesStreamOutput();
         array1.writeTo(out);
@@ -259,7 +263,12 @@ public class BigArraysTests extends ESTestCase {
         for (int i = 0; i < len; i++) {
             assertThat(array2.get(i), equalTo(array1.get(i)));
         }
-        Releasables.close(array1, array2);
+        final LongArray array3 = LongArray.readFrom(out.bytes().streamInput());
+        assertThat(array3.size(), equalTo((long) len));
+        for (int i = 0; i < len; i++) {
+            assertThat(array3.get(i), equalTo(array1.get(i)));
+        }
+        Releasables.close(array1, array2, array3);
     }
 
     public void testByteArrayBulkGet() {


### PR DESCRIPTION
While making the BitArray serializable, I found that the writePages function breaks when the input big array is resized. When resizing a big array, we [overly allocate](https://github.com/elastic/elasticsearch/blob/8ebf5bf73d1b475f003c2901b85db4d7b57848aa/server/src/main/java/org/elasticsearch/common/util/BigLongArray.java#L89) the pages array and assign null to the extra pages.

I marked this non-issue as we haven't used these yet. 