### PR TITLE
ESQL: Allow tests to depend on cluster features

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -132,6 +132,9 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
     }
 
     protected void shouldSkipTest(String testName) {
+        for (String feature : testCase.requiredFeatures) {
+            assumeTrue("Test " + testName + " requires " + feature, clusterHasFeature(feature));
+        }
         assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, Version.CURRENT));
     }
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -300,7 +300,7 @@ emp_no:integer | name:keyword
 
 // Note: no matches in MV returned
 in
-required_feature: esql.mv
+required_feature: esql.mv_load
 
 from employees | where job_positions in ("Internship", first_name) | keep emp_no, job_positions;
 ignoreOrder:true

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -299,7 +299,9 @@ emp_no:integer | name:keyword
 ;
 
 // Note: no matches in MV returned
-in#[skip:-8.11.99, reason:Lucene multivalue warning introduced in 8.12 only]
+in
+required_feature: esql.mv
+
 from employees | where job_positions in ("Internship", first_name) | keep emp_no, job_positions;
 ignoreOrder:true
 warning:Line 1:24: evaluation of [job_positions in (\"Internship\", first_name)] failed, treating result as null. Only first 20 failures recorded.

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFeatures.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFeatures.java
@@ -12,10 +12,18 @@ import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
 
 import java.util.Map;
+import java.util.Set;
 
 public class EsqlFeatures implements FeatureSpecification {
+    private static final NodeFeature MV = new NodeFeature("esql.mv");
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(MV);
+    }
+
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
-        return Map.of(TransportEsqlStatsAction.ESQL_STATS_FEATURE, Version.V_8_11_0);
+        return Map.ofEntries(Map.entry(TransportEsqlStatsAction.ESQL_STATS_FEATURE, Version.V_8_11_0), Map.entry(MV, Version.V_8_12_0));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFeatures.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFeatures.java
@@ -12,18 +12,15 @@ import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
 
 import java.util.Map;
-import java.util.Set;
 
 public class EsqlFeatures implements FeatureSpecification {
-    private static final NodeFeature MV = new NodeFeature("esql.mv");
-
-    @Override
-    public Set<NodeFeature> getFeatures() {
-        return Set.of(MV);
-    }
+    private static final NodeFeature MV_LOAD = new NodeFeature("esql.mv_load");
 
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
-        return Map.ofEntries(Map.entry(TransportEsqlStatsAction.ESQL_STATS_FEATURE, Version.V_8_11_0), Map.entry(MV, Version.V_8_12_0));
+        return Map.ofEntries(
+            Map.entry(TransportEsqlStatsAction.ESQL_STATS_FEATURE, Version.V_8_11_0),
+            Map.entry(MV_LOAD, Version.V_8_12_0)
+        );
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.CancellableTask;
@@ -72,6 +73,7 @@ import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecution
 import org.elasticsearch.xpack.esql.planner.Mapper;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.planner.TestPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.plugin.EsqlFeatures;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
 import org.elasticsearch.xpack.esql.stats.DisabledSearchStats;
@@ -218,6 +220,12 @@ public class CsvTests extends ESTestCase {
 
     public final void test() throws Throwable {
         try {
+            for (String feature : testCase.requiredFeatures) {
+                assumeTrue(
+                    "Test " + testName + " requires " + feature,
+                    new EsqlFeatures().getFeatures().contains(new NodeFeature(feature))
+                );
+            }
             assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, Version.CURRENT));
             doTest();
         } catch (Throwable th) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -32,7 +32,6 @@ import org.elasticsearch.compute.operator.exchange.ExchangeSourceHandler;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.CancellableTask;
@@ -73,7 +72,6 @@ import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecution
 import org.elasticsearch.xpack.esql.planner.Mapper;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.planner.TestPhysicalOperationProviders;
-import org.elasticsearch.xpack.esql.plugin.EsqlFeatures;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
 import org.elasticsearch.xpack.esql.stats.DisabledSearchStats;
@@ -94,7 +92,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -149,17 +146,6 @@ public class CsvTests extends ESTestCase {
 
     private static final Logger LOGGER = LogManager.getLogger(CsvTests.class);
     private static final String IGNORED_CSV_FILE_NAMES_PATTERN = "-IT_tests_only";
-
-    private static final Set<NodeFeature> LIVE_FEATURES = new HashSet<>();
-    static {
-        EsqlFeatures features = new EsqlFeatures();
-        LIVE_FEATURES.addAll(features.getFeatures());
-        for (Map.Entry<NodeFeature, Version> e : features.getHistoricalFeatures().entrySet()) {
-            if (Version.CURRENT.onOrAfter(e.getValue())) {
-                LIVE_FEATURES.add(e.getKey());
-            }
-        }
-    }
 
     private final String fileName;
     private final String groupName;
@@ -232,12 +218,10 @@ public class CsvTests extends ESTestCase {
 
     public final void test() throws Throwable {
         try {
-            for (String feature : testCase.requiredFeatures) {
-                assumeTrue(
-                    "Test " + testName + " requires " + feature,
-                    LIVE_FEATURES.contains(new NodeFeature(feature))
-                );
-            }
+            /*
+             * We're intentionally not NodeFeatures here because we expect all
+             * of the features to be supported in this unit test.
+             */
             assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, Version.CURRENT));
             doTest();
         } catch (Throwable th) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -94,6 +94,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -148,6 +149,17 @@ public class CsvTests extends ESTestCase {
 
     private static final Logger LOGGER = LogManager.getLogger(CsvTests.class);
     private static final String IGNORED_CSV_FILE_NAMES_PATTERN = "-IT_tests_only";
+
+    private static final Set<NodeFeature> LIVE_FEATURES = new HashSet<>();
+    static {
+        EsqlFeatures features = new EsqlFeatures();
+        LIVE_FEATURES.addAll(features.getFeatures());
+        for (Map.Entry<NodeFeature, Version> e : features.getHistoricalFeatures().entrySet()) {
+            if (Version.CURRENT.onOrAfter(e.getValue())) {
+                LIVE_FEATURES.add(e.getKey());
+            }
+        }
+    }
 
     private final String fileName;
     private final String groupName;
@@ -223,7 +235,7 @@ public class CsvTests extends ESTestCase {
             for (String feature : testCase.requiredFeatures) {
                 assumeTrue(
                     "Test " + testName + " requires " + feature,
-                    new EsqlFeatures().getFeatures().contains(new NodeFeature(feature))
+                    LIVE_FEATURES.contains(new NodeFeature(feature))
                 );
             }
             assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, Version.CURRENT));


### PR DESCRIPTION
This allows writing `required_feature:` in a test to skip the test on versions of elasticsearch that are missing a feature, opting ESQL into the same versioning as the yaml tests.
