### PR TITLE
Fix skip version for rrf retriever yaml test

### DIFF
--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/300_rrf_retriever.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/300_rrf_retriever.yml
@@ -1,7 +1,7 @@
 setup:
-  - skip:
-      version: ' - 8.13.99'
-      reason: 'rrf retriever added in 8.14'
+  - requires:
+      cluster_features: 'rrf_retriever_supported'
+      reason: 'test requires rrf retriever implementation'
 
   - do:
       indices.create:

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/300_rrf_retriever.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/300_rrf_retriever.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: ' - 8.12.99'
-      reason: 'rrf retriever added in 8.13'
+      version: ' - 8.13.99'
+      reason: 'rrf retriever added in 8.14'
 
   - do:
       indices.create:

--- a/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/400_rrf_retriever_script.yml
+++ b/x-pack/plugin/rank-rrf/src/yamlRestTest/resources/rest-api-spec/test/rrf/400_rrf_retriever_script.yml
@@ -1,8 +1,10 @@
 setup:
   - skip:
       features: close_to
-      version: ' - 8.13.99'
-      reason: 'rrf retriever added in 8.14'
+
+  - requires:
+      cluster_features: 'rrf_retriever_supported'
+      reason: 'test requires rrf retriever implementation'
 
   - do:
       indices.create:


### PR DESCRIPTION
This updates the skip version to 8.14 for this set of rrf retriever tests.