### PR TITLE
[8.13] Fix typo in the LTR guide. (#106276)

### DIFF
--- a/docs/reference/search/search-your-data/learning-to-rank-model-training.asciidoc
+++ b/docs/reference/search/search-your-data/learning-to-rank-model-training.asciidoc
@@ -109,7 +109,7 @@ The FeatureLogger provides an `extract_features` method which enables you to ext
 [source,python]
 ----
 feature_logger.extract_features(
-    query_params:{"query": "foo"},
+    query_params={"query": "foo"},
     doc_ids=["doc-1", "doc-2"]
 )
 ----


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Fix typo in the LTR guide. (#106276)