### PR TITLE
Small time series agg improvement

### DIFF
--- a/docs/changelog/106288.yaml
+++ b/docs/changelog/106288.yaml
@@ -1,0 +1,5 @@
+pr: 106288
+summary: Small time series agg improvement
+area: TSDB
+type: enhancement
+issues: []


### PR DESCRIPTION
After tsid hashing was introduced (#98023), the time series aggregator generates the tsid (from all dimension fields) instead of using the value from the `_tsid` field directly. This generation of the tsid happens for every time serie, parent bucket and segment combination.

This changes alters that by only generating the tsid once per time serie and segment. This is done by just locally recording the current tsid.