### PR TITLE
Support filling IntArray with stream input

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -236,6 +236,12 @@ public class BigArrays {
         }
 
         @Override
+        public void fillWith(StreamInput in) throws IOException {
+            final int numBytes = in.readVInt();
+            in.readBytes(array, 0, numBytes);
+        }
+
+        @Override
         public void set(long index, byte[] buf, int offset, int len) {
             assert index >= 0 && index < size();
             System.arraycopy(buf, offset << 2, array, (int) index << 2, len << 2);

--- a/server/src/main/java/org/elasticsearch/common/util/BigIntArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigIntArray.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -18,6 +19,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import static org.elasticsearch.common.util.BigLongArray.readPages;
 import static org.elasticsearch.common.util.BigLongArray.writePages;
 import static org.elasticsearch.common.util.PageCacheRecycler.INT_PAGE_SIZE;
 
@@ -90,6 +92,11 @@ final class BigIntArray extends AbstractBigArray implements IntArray {
             }
             fill(pages[toPage], 0, indexInPage(toIndex - 1) + 1, value);
         }
+    }
+
+    @Override
+    public void fillWith(StreamInput in) throws IOException {
+        readPages(in, pages);
     }
 
     public static void fill(byte[] page, int from, int to, int value) {

--- a/server/src/main/java/org/elasticsearch/common/util/IntArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/IntArray.java
@@ -42,6 +42,11 @@ public interface IntArray extends BigArray, Writeable {
     void fill(long fromIndex, long toIndex, int value);
 
     /**
+     * Alternative of {@link IntArray#readFrom(StreamInput)} where the written bytes are loaded into an existing {@link IntArray}
+     */
+    void fillWith(StreamInput in) throws IOException;
+
+    /**
      * Bulk set.
      */
     void set(long index, byte[] buf, int offset, int len);

--- a/server/src/main/java/org/elasticsearch/common/util/ReleasableIntArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/ReleasableIntArray.java
@@ -59,6 +59,11 @@ class ReleasableIntArray implements IntArray {
     }
 
     @Override
+    public void fillWith(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void set(long index, byte[] buf, int offset, int len) {
         throw new UnsupportedOperationException();
     }

--- a/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -271,6 +271,31 @@ public class BigArraysTests extends ESTestCase {
         Releasables.close(array1, array2, array3);
     }
 
+    public void testSerializeIntArray() throws Exception {
+        int len = randomIntBetween(1, 100_000);
+        IntArray array1 = bigArrays.newIntArray(len, randomBoolean());
+        for (int i = 0; i < len; ++i) {
+            array1.set(i, randomInt());
+        }
+        if (randomBoolean()) {
+            len = randomIntBetween(len, len * 3 / 2);
+            array1 = bigArrays.resize(array1, len);
+        }
+        BytesStreamOutput out = new BytesStreamOutput();
+        array1.writeTo(out);
+        final IntArray array2 = bigArrays.newIntArray(len, randomBoolean());
+        array2.fillWith(out.bytes().streamInput());
+        for (int i = 0; i < len; i++) {
+            assertThat(array2.get(i), equalTo(array1.get(i)));
+        }
+        final IntArray array3 = IntArray.readFrom(out.bytes().streamInput());
+        assertThat(array3.size(), equalTo((long) len));
+        for (int i = 0; i < len; i++) {
+            assertThat(array3.get(i), equalTo(array1.get(i)));
+        }
+        Releasables.close(array1, array2, array3);
+    }
+
     public void testByteArrayBulkGet() {
         final byte[] array1 = new byte[randomIntBetween(1, 4000000)];
         random().nextBytes(array1);

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -476,6 +476,11 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
+        public void fillWith(StreamInput streamInput) throws IOException {
+            in.fillWith(streamInput);
+        }
+
+        @Override
         public void set(long index, byte[] buf, int offset, int len) {
             in.set(index, buf, offset, len);
         }


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/106217, we can't use IntArray#readFrom(StreamInput in) in ES|QL because the returned big array is not tracked with the circuit breaker. This PR adds an alternative method, where we create a big array first, then fill it with bytes from a stream input.

Relates #106217