### PR TITLE
Support filling DoubleArray with stream input

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigArrays.java
@@ -351,6 +351,12 @@ public class BigArrays {
         }
 
         @Override
+        public void fillWith(StreamInput in) throws IOException {
+            int numBytes = in.readVInt();
+            in.readBytes(array, 0, numBytes);
+        }
+
+        @Override
         public void set(long index, byte[] buf, int offset, int len) {
             assert index >= 0 && index < size();
             System.arraycopy(buf, offset << 3, array, (int) index << 3, len << 3);

--- a/server/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -18,6 +19,7 @@ import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import static org.elasticsearch.common.util.BigLongArray.readPages;
 import static org.elasticsearch.common.util.BigLongArray.writePages;
 import static org.elasticsearch.common.util.PageCacheRecycler.DOUBLE_PAGE_SIZE;
 
@@ -115,6 +117,11 @@ final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
             VH_PLATFORM_NATIVE_DOUBLE.set(page, from << 3, value);
             fillBySelfCopy(page, from << 3, to << 3, Double.BYTES);
         }
+    }
+
+    @Override
+    public void fillWith(StreamInput in) throws IOException {
+        readPages(in, pages);
     }
 
     /** Estimates the number of bytes that would be consumed by an array of the given size. */

--- a/server/src/main/java/org/elasticsearch/common/util/DoubleArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/DoubleArray.java
@@ -43,6 +43,11 @@ public interface DoubleArray extends BigArray, Writeable {
     void fill(long fromIndex, long toIndex, double value);
 
     /**
+     * Alternative of {@link DoubleArray#readFrom(StreamInput)} where the written bytes are loaded into an existing {@link DoubleArray}
+     */
+    void fillWith(StreamInput in) throws IOException;
+
+    /**
      * Bulk set.
      */
     void set(long index, byte[] buf, int offset, int len);

--- a/server/src/main/java/org/elasticsearch/common/util/ReleasableDoubleArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/ReleasableDoubleArray.java
@@ -59,6 +59,11 @@ class ReleasableDoubleArray implements DoubleArray {
     }
 
     @Override
+    public void fillWith(StreamInput in) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void set(long index, byte[] buf, int offset, int len) {
         throw new UnsupportedOperationException();
     }

--- a/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -246,6 +246,31 @@ public class BigArraysTests extends ESTestCase {
         array2.close();
     }
 
+    public void testSerializeDoubleArray() throws Exception {
+        int len = randomIntBetween(1, 100_000);
+        DoubleArray array1 = bigArrays.newDoubleArray(len, randomBoolean());
+        for (int i = 0; i < len; ++i) {
+            array1.set(i, randomDouble());
+        }
+        if (randomBoolean()) {
+            len = randomIntBetween(len, len * 3 / 2);
+            array1 = bigArrays.resize(array1, len);
+        }
+        BytesStreamOutput out = new BytesStreamOutput();
+        array1.writeTo(out);
+        final DoubleArray array2 = bigArrays.newDoubleArray(len, randomBoolean());
+        array2.fillWith(out.bytes().streamInput());
+        for (int i = 0; i < len; i++) {
+            assertThat(array2.get(i), equalTo(array1.get(i)));
+        }
+        final DoubleArray array3 = DoubleArray.readFrom(out.bytes().streamInput());
+        assertThat(array3.size(), equalTo((long) len));
+        for (int i = 0; i < len; i++) {
+            assertThat(array3.get(i), equalTo(array1.get(i)));
+        }
+        Releasables.close(array1, array2, array3);
+    }
+
     public void testSerializeLongArray() throws Exception {
         int len = randomIntBetween(1, 100_000);
         LongArray array1 = bigArrays.newLongArray(len, randomBoolean());

--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -631,6 +631,11 @@ public class MockBigArrays extends BigArrays {
         }
 
         @Override
+        public void fillWith(StreamInput streamInput) throws IOException {
+            in.fillWith(streamInput);
+        }
+
+        @Override
         public void set(long index, byte[] buf, int offset, int len) {
             in.set(index, buf, offset, len);
         }


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/106217, we can't use DoubleArray#readFrom(StreamInput in) in ES|QL because the returned big array is not tracked with the circuit breaker. This PR adds an alternative method, where we create a big array first, then fill it with bytes from a stream input.

Relates https://github.com/elastic/elasticsearch/pull/106217