### PR TITLE
update lease sync actions not circuit breakers 

### DIFF
--- a/docs/changelog/106192.yaml
+++ b/docs/changelog/106192.yaml
@@ -1,0 +1,6 @@
+pr: 106189
+summary: update lease sync actions not circuit breakers
+area: CRUD
+type: enhancement
+issues:
+ - 105926

--- a/docs/changelog/106311.yaml
+++ b/docs/changelog/106311.yaml
@@ -1,4 +1,4 @@
-pr: 106189
+pr: 106311
 summary: update lease sync actions not circuit breakers
 area: CRUD
 type: enhancement

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncAction.java
@@ -81,7 +81,9 @@ public class RetentionLeaseBackgroundSyncAction extends TransportReplicationActi
             actionFilters,
             Request::new,
             Request::new,
-            threadPool.executor(ThreadPool.Names.MANAGEMENT)
+            threadPool.executor(ThreadPool.Names.MANAGEMENT),
+            true,
+            true
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.support.replication.ReplicationTask;
 import org.elasticsearch.action.support.replication.TransportWriteAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -89,7 +90,7 @@ public class RetentionLeaseSyncAction extends TransportWriteAction<
             RetentionLeaseSyncAction.Request::new,
             RetentionLeaseSyncAction.Request::new,
             (service, ignore) -> ThreadPool.Names.MANAGEMENT,
-            false,
+            true,
             indexingPressure,
             systemIndices
         );


### PR DESCRIPTION
RetentionLeaseSyncAction and RetentionLeaseBackgroundSyncAction  need for circuit-breaker and indexing pressure checks.
we should set forceExecutionOnPrimary=true when calling the superclass constructor.
https://github.com/elastic/elasticsearch/issues/105926