### PR TITLE
Reset root logger to info after any test

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -233,7 +233,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     private static final AtomicInteger portGenerator = new AtomicInteger();
 
     private static final Collection<String> loggedLeaks = new ArrayList<>();
-    private static Level originalLogLevel;
+    private static Level originalRootLoggerLevel;
 
     private HeaderWarningAppender headerWarningAppender;
 
@@ -471,12 +471,12 @@ public abstract class ESTestCase extends LuceneTestCase {
 
     @BeforeClass
     public static void storeRootLoggerLevel() throws Exception {
-        originalLogLevel = LogManager.getRootLogger().getLevel();
+        originalRootLoggerLevel = LogManager.getRootLogger().getLevel();
     }
 
     @AfterClass
     public static void resetRootLogger() {
-        Loggers.setLevel(LogManager.getRootLogger(), originalLogLevel);
+        Loggers.setLevel(LogManager.getRootLogger(), originalRootLoggerLevel);
     }
 
     @AfterClass

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -469,6 +469,11 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     @AfterClass
+    public static void resetRootLogger(){
+        Loggers.setLevel(LogManager.getLogger(), Level.INFO);
+    }
+
+    @AfterClass
     public static void restoreContentType() {
         Requests.INDEX_CONTENT_TYPE = XContentType.JSON;
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -233,6 +233,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     private static final AtomicInteger portGenerator = new AtomicInteger();
 
     private static final Collection<String> loggedLeaks = new ArrayList<>();
+    private static Level originalLogLevel;
 
     private HeaderWarningAppender headerWarningAppender;
 
@@ -468,9 +469,14 @@ public abstract class ESTestCase extends LuceneTestCase {
         Requests.INDEX_CONTENT_TYPE = randomFrom(XContentType.values());
     }
 
+    @BeforeClass
+    public static void storeRootLoggerLevel() throws Exception {
+        originalLogLevel = LogManager.getRootLogger().getLevel();
+    }
+
     @AfterClass
-    public static void resetRootLogger(){
-        Loggers.setLevel(LogManager.getLogger(), Level.INFO);
+    public static void resetRootLogger() {
+        Loggers.setLevel(LogManager.getRootLogger(), originalLogLevel);
     }
 
     @AfterClass


### PR DESCRIPTION
Some tests might be playing with a root level and might not correctly reset it back to the original level.
this commit adds an afterclass rule to always reset this logger
