### PR TITLE
[8.13] Allowing byte and int8 (#106299)

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ConfigurationParseContext.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/ConfigurationParseContext.java
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.inference.services.openai;
+package org.elasticsearch.xpack.inference.services;
 
-public enum OpenAiParseContext {
+public enum ConfigurationParseContext {
     REQUEST,
     PERSISTENT;
 
-    public static boolean isRequestContext(OpenAiParseContext context) {
+    public static boolean isRequestContext(ConfigurationParseContext context) {
         return context == REQUEST;
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereService.java
@@ -25,6 +25,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.common.SimilarityMeasure;
 import org.elasticsearch.xpack.inference.external.action.cohere.CohereActionCreator;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderFactory;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.SenderService;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
@@ -72,7 +73,7 @@ public class CohereService extends SenderService {
                 taskSettingsMap,
                 serviceSettingsMap,
                 TaskType.unsupportedTaskTypeErrorMsg(taskType, NAME),
-                true
+                ConfigurationParseContext.REQUEST
             );
 
             throwIfNotEmptyMap(config, NAME);
@@ -93,7 +94,15 @@ public class CohereService extends SenderService {
         @Nullable Map<String, Object> secretSettings,
         String failureMessage
     ) {
-        return createModel(inferenceEntityId, taskType, serviceSettings, taskSettings, secretSettings, failureMessage, false);
+        return createModel(
+            inferenceEntityId,
+            taskType,
+            serviceSettings,
+            taskSettings,
+            secretSettings,
+            failureMessage,
+            ConfigurationParseContext.PERSISTENT
+        );
     }
 
     private static CohereModel createModel(
@@ -103,7 +112,7 @@ public class CohereService extends SenderService {
         Map<String, Object> taskSettings,
         @Nullable Map<String, Object> secretSettings,
         String failureMessage,
-        boolean logDeprecations
+        ConfigurationParseContext context
     ) {
         return switch (taskType) {
             case TEXT_EMBEDDING -> new CohereEmbeddingsModel(
@@ -113,7 +122,7 @@ public class CohereService extends SenderService {
                 serviceSettings,
                 taskSettings,
                 secretSettings,
-                logDeprecations
+                context
             );
             default -> throw new ElasticsearchStatusException(failureMessage, RestStatus.BAD_REQUEST);
         };

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
@@ -20,6 +20,7 @@ import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.common.SimilarityMeasure;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 
 import java.io.IOException;
 import java.net.URI;
@@ -43,7 +44,7 @@ public class CohereServiceSettings implements ServiceSettings {
     public static final String OLD_MODEL_ID_FIELD = "model";
     public static final String MODEL_ID = "model_id";
 
-    public static CohereServiceSettings fromMap(Map<String, Object> map, boolean logDeprecations) {
+    public static CohereServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
         ValidationException validationException = new ValidationException();
 
         String url = extractOptionalString(map, URL, ModelConfigurations.SERVICE_SETTINGS, validationException);
@@ -56,7 +57,7 @@ public class CohereServiceSettings implements ServiceSettings {
 
         String modelId = extractOptionalString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
 
-        if (logDeprecations && oldModelId != null) {
+        if (context == ConfigurationParseContext.REQUEST && oldModelId != null) {
             logger.info("The cohere [service_settings.model] field is deprecated. Please use [service_settings.model_id] instead.");
         }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsModel.java
@@ -14,6 +14,7 @@ import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.cohere.CohereActionVisitor;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.cohere.CohereModel;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
@@ -32,13 +33,13 @@ public class CohereEmbeddingsModel extends CohereModel {
         Map<String, Object> serviceSettings,
         Map<String, Object> taskSettings,
         @Nullable Map<String, Object> secrets,
-        boolean logDeprecations
+        ConfigurationParseContext context
     ) {
         this(
             modelId,
             taskType,
             service,
-            CohereEmbeddingsServiceSettings.fromMap(serviceSettings, logDeprecations),
+            CohereEmbeddingsServiceSettings.fromMap(serviceSettings, context),
             CohereEmbeddingsTaskSettings.fromMap(taskSettings),
             DefaultSecretSettings.fromMap(secrets)
         );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.common.SimilarityMeasure;
 import org.elasticsearch.xpack.inference.external.action.openai.OpenAiActionCreator;
 import org.elasticsearch.xpack.inference.external.http.sender.HttpRequestSenderFactory;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.SenderService;
 import org.elasticsearch.xpack.inference.services.ServiceComponents;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
@@ -76,7 +77,7 @@ public class OpenAiService extends SenderService {
                 taskSettingsMap,
                 serviceSettingsMap,
                 TaskType.unsupportedTaskTypeErrorMsg(taskType, NAME),
-                OpenAiParseContext.REQUEST
+                ConfigurationParseContext.REQUEST
             );
 
             throwIfNotEmptyMap(config, NAME);
@@ -104,7 +105,7 @@ public class OpenAiService extends SenderService {
             taskSettings,
             secretSettings,
             failureMessage,
-            OpenAiParseContext.PERSISTENT
+            ConfigurationParseContext.PERSISTENT
         );
     }
 
@@ -115,7 +116,7 @@ public class OpenAiService extends SenderService {
         Map<String, Object> taskSettings,
         @Nullable Map<String, Object> secretSettings,
         String failureMessage,
-        OpenAiParseContext context
+        ConfigurationParseContext context
     ) {
         return switch (taskType) {
             case TEXT_EMBEDDING -> new OpenAiEmbeddingsModel(

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModel.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModel.java
@@ -13,8 +13,8 @@ import org.elasticsearch.inference.ModelSecrets;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.xpack.inference.external.action.ExecutableAction;
 import org.elasticsearch.xpack.inference.external.action.openai.OpenAiActionVisitor;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.openai.OpenAiModel;
-import org.elasticsearch.xpack.inference.services.openai.OpenAiParseContext;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
 import java.util.Map;
@@ -37,7 +37,7 @@ public class OpenAiEmbeddingsModel extends OpenAiModel {
         Map<String, Object> serviceSettings,
         Map<String, Object> taskSettings,
         @Nullable Map<String, Object> secrets,
-        OpenAiParseContext context
+        ConfigurationParseContext context
     ) {
         this(
             inferenceEntityId,

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettings.java
@@ -18,8 +18,8 @@ import org.elasticsearch.inference.ServiceSettings;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.inference.common.SimilarityMeasure;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
-import org.elasticsearch.xpack.inference.services.openai.OpenAiParseContext;
 
 import java.io.IOException;
 import java.net.URI;
@@ -48,7 +48,7 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
     static final String ORGANIZATION = "organization_id";
     static final String DIMENSIONS_SET_BY_USER = "dimensions_set_by_user";
 
-    public static OpenAiEmbeddingsServiceSettings fromMap(Map<String, Object> map, OpenAiParseContext context) {
+    public static OpenAiEmbeddingsServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
         return switch (context) {
             case REQUEST -> fromRequestMap(map);
             case PERSISTENT -> fromPersistentMap(map);

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
@@ -16,7 +16,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
 import org.elasticsearch.inference.TaskSettings;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xpack.inference.services.openai.OpenAiParseContext;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 
 import java.io.IOException;
 import java.util.Map;
@@ -35,7 +35,7 @@ public class OpenAiEmbeddingsTaskSettings implements TaskSettings {
     public static final String NAME = "openai_embeddings_task_settings";
     public static final String USER = "user";
 
-    public static OpenAiEmbeddingsTaskSettings fromMap(Map<String, Object> map, OpenAiParseContext context) {
+    public static OpenAiEmbeddingsTaskSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
         ValidationException validationException = new ValidationException();
 
         String user = extractOptionalString(map, USER, ModelConfigurations.TASK_SETTINGS, validationException);

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettingsTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.SimilarityMeasure;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.hamcrest.CoreMatchers;
@@ -77,7 +78,7 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
                     model
                 )
             ),
-            true
+            ConfigurationParseContext.REQUEST
         );
 
         MatcherAssert.assertThat(
@@ -107,7 +108,7 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
                     model
                 )
             ),
-            false
+            ConfigurationParseContext.PERSISTENT
         );
 
         MatcherAssert.assertThat(
@@ -139,7 +140,7 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
                     model
                 )
             ),
-            false
+            ConfigurationParseContext.PERSISTENT
         );
 
         MatcherAssert.assertThat(
@@ -149,14 +150,14 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
     }
 
     public void testFromMap_MissingUrl_DoesNotThrowException() {
-        var serviceSettings = CohereServiceSettings.fromMap(new HashMap<>(Map.of()), false);
+        var serviceSettings = CohereServiceSettings.fromMap(new HashMap<>(Map.of()), ConfigurationParseContext.PERSISTENT);
         assertNull(serviceSettings.getUri());
     }
 
     public void testFromMap_EmptyUrl_ThrowsError() {
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, "")), false)
+            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, "")), ConfigurationParseContext.PERSISTENT)
         );
 
         MatcherAssert.assertThat(
@@ -174,7 +175,7 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
         var url = "https://www.abc^.com";
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, url)), false)
+            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, url)), ConfigurationParseContext.PERSISTENT)
         );
 
         MatcherAssert.assertThat(
@@ -187,7 +188,10 @@ public class CohereServiceSettingsTests extends AbstractWireSerializingTestCase<
         var similarity = "by_size";
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.SIMILARITY, similarity)), false)
+            () -> CohereServiceSettings.fromMap(
+                new HashMap<>(Map.of(ServiceFields.SIMILARITY, similarity)),
+                ConfigurationParseContext.PERSISTENT
+            )
         );
 
         MatcherAssert.assertThat(

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/embeddings/CohereEmbeddingsServiceSettingsTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.inference.InferenceNamedWriteablesProvider;
 import org.elasticsearch.xpack.inference.common.SimilarityMeasure;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
 import org.elasticsearch.xpack.inference.services.cohere.CohereServiceSettings;
@@ -24,6 +25,7 @@ import org.elasticsearch.xpack.inference.services.cohere.CohereServiceSettingsTe
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -63,7 +65,7 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     CohereEmbeddingType.INT8.toString()
                 )
             ),
-            false
+            ConfigurationParseContext.PERSISTENT
         );
 
         MatcherAssert.assertThat(
@@ -100,7 +102,7 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     CohereEmbeddingType.INT8.toString()
                 )
             ),
-            false
+            ConfigurationParseContext.PERSISTENT
         );
 
         MatcherAssert.assertThat(
@@ -139,7 +141,7 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     CohereEmbeddingType.INT8.toString()
                 )
             ),
-            false
+            ConfigurationParseContext.PERSISTENT
         );
 
         MatcherAssert.assertThat(
@@ -154,14 +156,17 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
     }
 
     public void testFromMap_MissingEmbeddingType_DoesNotThrowException() {
-        var serviceSettings = CohereEmbeddingsServiceSettings.fromMap(new HashMap<>(Map.of()), false);
+        var serviceSettings = CohereEmbeddingsServiceSettings.fromMap(new HashMap<>(Map.of()), ConfigurationParseContext.PERSISTENT);
         assertNull(serviceSettings.getEmbeddingType());
     }
 
     public void testFromMap_EmptyEmbeddingType_ThrowsError() {
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> CohereEmbeddingsServiceSettings.fromMap(new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, "")), true)
+            () -> CohereEmbeddingsServiceSettings.fromMap(
+                new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, "")),
+                ConfigurationParseContext.REQUEST
+            )
         );
 
         MatcherAssert.assertThat(
@@ -180,7 +185,7 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
             ValidationException.class,
             () -> CohereEmbeddingsServiceSettings.fromMap(
                 new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, "abc")),
-                false
+                ConfigurationParseContext.PERSISTENT
             )
         );
 
@@ -194,18 +199,62 @@ public class CohereEmbeddingsServiceSettingsTests extends AbstractWireSerializin
         );
     }
 
+    public void testFromMap_InvalidEmbeddingType_ThrowsError_WhenByteFromPersistedConfig() {
+        var thrownException = expectThrows(
+            ValidationException.class,
+            () -> CohereEmbeddingsServiceSettings.fromMap(
+                new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, CohereEmbeddingsServiceSettings.EMBEDDING_TYPE_BYTE)),
+                ConfigurationParseContext.PERSISTENT
+            )
+        );
+
+        MatcherAssert.assertThat(
+            thrownException.getMessage(),
+            is(
+                Strings.format(
+                    "Validation Failed: 1: [service_settings] Invalid value [byte] received. [embedding_type] must be one of [float, int8];"
+                )
+            )
+        );
+    }
+
     public void testFromMap_ReturnsFailure_WhenEmbeddingTypesAreNotValid() {
         var exception = expectThrows(
             ElasticsearchStatusException.class,
             () -> CohereEmbeddingsServiceSettings.fromMap(
                 new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, List.of("abc"))),
-                false
+                ConfigurationParseContext.PERSISTENT
             )
         );
 
         MatcherAssert.assertThat(
             exception.getMessage(),
             is("field [embedding_type] is not of the expected type. The value [[abc]] cannot be converted to a [String]")
+        );
+    }
+
+    public void testFromMap_ConvertsCohereEmbeddingType_FromByteToInt8() {
+        assertThat(
+            CohereEmbeddingsServiceSettings.fromMap(
+                new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, CohereEmbeddingsServiceSettings.EMBEDDING_TYPE_BYTE)),
+                ConfigurationParseContext.REQUEST
+            ),
+            is(new CohereEmbeddingsServiceSettings(new CohereServiceSettings((URI) null, null, null, null, null), CohereEmbeddingType.INT8))
+        );
+    }
+
+    public void testFromMap_PreservesEmbeddingTypeFloat() {
+        assertThat(
+            CohereEmbeddingsServiceSettings.fromMap(
+                new HashMap<>(Map.of(CohereEmbeddingsServiceSettings.EMBEDDING_TYPE, CohereEmbeddingType.FLOAT.toString())),
+                ConfigurationParseContext.REQUEST
+            ),
+            is(
+                new CohereEmbeddingsServiceSettings(
+                    new CohereServiceSettings((URI) null, null, null, null, null),
+                    CohereEmbeddingType.FLOAT
+                )
+            )
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettingsTests.java
@@ -16,9 +16,9 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.common.SimilarityMeasure;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
-import org.elasticsearch.xpack.inference.services.openai.OpenAiParseContext;
 import org.hamcrest.CoreMatchers;
 
 import java.io.IOException;
@@ -89,7 +89,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     maxInputTokens
                 )
             ),
-            OpenAiParseContext.REQUEST
+            ConfigurationParseContext.REQUEST
         );
 
         assertThat(
@@ -129,7 +129,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     maxInputTokens
                 )
             ),
-            OpenAiParseContext.REQUEST
+            ConfigurationParseContext.REQUEST
         );
 
         assertThat(
@@ -174,7 +174,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     false
                 )
             ),
-            OpenAiParseContext.PERSISTENT
+            ConfigurationParseContext.PERSISTENT
         );
 
         assertThat(
@@ -196,7 +196,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
     public void testFromMap_PersistentContext_DoesNotThrowException_WhenDimensionsIsNull() {
         var settings = OpenAiEmbeddingsServiceSettings.fromMap(
             new HashMap<>(Map.of(OpenAiEmbeddingsServiceSettings.DIMENSIONS_SET_BY_USER, true, ServiceFields.MODEL_ID, "m")),
-            OpenAiParseContext.PERSISTENT
+            ConfigurationParseContext.PERSISTENT
         );
 
         assertThat(settings, is(new OpenAiEmbeddingsServiceSettings("m", (URI) null, null, null, null, null, true)));
@@ -207,7 +207,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
             ValidationException.class,
             () -> OpenAiEmbeddingsServiceSettings.fromMap(
                 new HashMap<>(Map.of(ServiceFields.DIMENSIONS, 1, ServiceFields.MODEL_ID, "m")),
-                OpenAiParseContext.PERSISTENT
+                ConfigurationParseContext.PERSISTENT
             )
         );
 
@@ -220,7 +220,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
     public void testFromMap_MissingUrl_DoesNotThrowException() {
         var serviceSettings = OpenAiEmbeddingsServiceSettings.fromMap(
             new HashMap<>(Map.of(ServiceFields.MODEL_ID, "m", OpenAiEmbeddingsServiceSettings.ORGANIZATION, "org")),
-            OpenAiParseContext.REQUEST
+            ConfigurationParseContext.REQUEST
         );
         assertNull(serviceSettings.uri());
         assertThat(serviceSettings.modelId(), is("m"));
@@ -232,7 +232,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
             ValidationException.class,
             () -> OpenAiEmbeddingsServiceSettings.fromMap(
                 new HashMap<>(Map.of(ServiceFields.URL, "", ServiceFields.MODEL_ID, "m")),
-                OpenAiParseContext.REQUEST
+                ConfigurationParseContext.REQUEST
             )
         );
 
@@ -250,7 +250,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
     public void testFromMap_MissingOrganization_DoesNotThrowException() {
         var serviceSettings = OpenAiEmbeddingsServiceSettings.fromMap(
             new HashMap<>(Map.of(ServiceFields.MODEL_ID, "m")),
-            OpenAiParseContext.REQUEST
+            ConfigurationParseContext.REQUEST
         );
         assertNull(serviceSettings.uri());
         assertNull(serviceSettings.organizationId());
@@ -261,7 +261,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
             ValidationException.class,
             () -> OpenAiEmbeddingsServiceSettings.fromMap(
                 new HashMap<>(Map.of(OpenAiEmbeddingsServiceSettings.ORGANIZATION, "", ServiceFields.MODEL_ID, "m")),
-                OpenAiParseContext.REQUEST
+                ConfigurationParseContext.REQUEST
             )
         );
 
@@ -282,7 +282,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
             ValidationException.class,
             () -> OpenAiEmbeddingsServiceSettings.fromMap(
                 new HashMap<>(Map.of(ServiceFields.URL, url, ServiceFields.MODEL_ID, "m")),
-                OpenAiParseContext.REQUEST
+                ConfigurationParseContext.REQUEST
             )
         );
 
@@ -298,7 +298,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
             ValidationException.class,
             () -> OpenAiEmbeddingsServiceSettings.fromMap(
                 new HashMap<>(Map.of(ServiceFields.SIMILARITY, similarity, ServiceFields.MODEL_ID, "m")),
-                OpenAiParseContext.REQUEST
+                ConfigurationParseContext.REQUEST
             )
         );
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xpack.inference.services.openai.OpenAiParseContext;
+import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -40,7 +40,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
             new OpenAiEmbeddingsTaskSettings("user"),
             OpenAiEmbeddingsTaskSettings.fromMap(
                 new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
-                OpenAiParseContext.REQUEST
+                ConfigurationParseContext.REQUEST
             )
         );
     }
@@ -50,7 +50,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
             ValidationException.class,
             () -> OpenAiEmbeddingsTaskSettings.fromMap(
                 new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "")),
-                OpenAiParseContext.REQUEST
+                ConfigurationParseContext.REQUEST
             )
         );
 
@@ -61,14 +61,14 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
     }
 
     public void testFromMap_MissingUser_DoesNotThrowException() {
-        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of()), OpenAiParseContext.PERSISTENT);
+        var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of()), ConfigurationParseContext.PERSISTENT);
         assertNull(taskSettings.user());
     }
 
     public void testOverrideWith_KeepsOriginalValuesWithOverridesAreNull() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
             new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
-            OpenAiParseContext.PERSISTENT
+            ConfigurationParseContext.PERSISTENT
         );
 
         var overriddenTaskSettings = OpenAiEmbeddingsTaskSettings.of(taskSettings, OpenAiEmbeddingsRequestTaskSettings.EMPTY_SETTINGS);
@@ -78,7 +78,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
     public void testOverrideWith_UsesOverriddenSettings() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
             new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
-            OpenAiParseContext.PERSISTENT
+            ConfigurationParseContext.PERSISTENT
         );
 
         var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [Allowing byte and int8 (#106299)](https://github.com/elastic/elasticsearch/pull/106299)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)