### PR TITLE
Fix Search Applications bug where deleting an alias before deleting an application intermittently caused errors

### DIFF
--- a/docs/changelog/106329.yaml
+++ b/docs/changelog/106329.yaml
@@ -1,0 +1,5 @@
+pr: 106329
+summary: Update delete object to never fail if alias does not exist
+area: Relevance
+type: bug
+issues: []

--- a/docs/changelog/106329.yaml
+++ b/docs/changelog/106329.yaml
@@ -1,5 +1,5 @@
 pr: 106329
-summary: Update delete object to never fail if alias does not exist
+summary: Fix Search Applications bug where deleting an alias before deleting an application intermittently caused errors
 area: Relevance
 type: bug
 issues: []

--- a/docs/changelog/106329.yaml
+++ b/docs/changelog/106329.yaml
@@ -1,5 +1,5 @@
 pr: 106329
 summary: Fix Search Applications bug where deleting an alias before deleting an application intermittently caused errors
-area: Relevance
+area: Application
 type: bug
 issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_search_application_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_search_application_delete.yml
@@ -77,3 +77,18 @@ teardown:
         name: test-search-application-to-delete
 
   - match: { acknowledged: true }
+
+---
+"Delete Search Application - Alias does not exist as alias was explicitly removed":
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - remove:
+                index: test-index
+                alias: test-search-application-to-delete
+
+      search_application.delete:
+        name: test-search-application-to-delete
+
+  - match: { acknowledged: true }


### PR DESCRIPTION
There is an intermittent error when deleting search applications, where if the alias has been removed the search application deletion call can fail with an alias not found error.

To reproduce: 
```
PUT example-index

PUT _application/search_application/test-sa
{
  "indices": ["example-index"]
}

POST _aliases
{
  "actions": [
    {
      "remove": {
        "index": "example-index",
        "alias": "test-sa"
      }
    }
  ]
}

DELETE _application/search_application/test-sa
```

It appears there is a race condition. Sometimes this returns an acknowledged response but other times it returns the following error: 
```
{
  "error": {
    "root_cause": [
      {
        "type": "aliases_not_found_exception",
        "reason": "aliases [test-sa] missing",
        "resource.type": "aliases",
        "resource.id": "test-sa"
      }
    ],
    "type": "aliases_not_found_exception",
    "reason": "aliases [test-sa] missing",
    "resource.type": "aliases",
    "resource.id": "test-sa"
  },
  "status": 404
}
```

This PR addresses this. 