### PR TITLE
Fix test lib path separator on windows

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestUtil.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/TestUtil.java
@@ -11,6 +11,7 @@ package org.elasticsearch.gradle.internal.test;
 import org.elasticsearch.gradle.Architecture;
 import org.elasticsearch.gradle.ElasticsearchDistribution;
 
+import java.io.File;
 import java.util.Locale;
 
 public class TestUtil {
@@ -20,6 +21,6 @@ public class TestUtil {
         String platform = String.format(Locale.ROOT, "%s-%s", ElasticsearchDistribution.CURRENT_PLATFORM, arch);
         String existingLibraryPath = System.getProperty("java.library.path");
 
-        return String.format(Locale.ROOT, "%s/%s:%s", nativeLibsDir, platform, existingLibraryPath);
+        return String.format(Locale.ROOT, "%s/%s%c%s", nativeLibsDir, platform, File.pathSeparatorChar, existingLibraryPath);
     }
 }


### PR DESCRIPTION
Fallout from https://github.com/elastic/elasticsearch/pull/105715