### PR TITLE
Add JDK 22 release candidate to oracle jdk toolchain resolver

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/OracleOpenJdkToolchainResolver.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/OracleOpenJdkToolchainResolver.java
@@ -26,14 +26,17 @@ import java.util.regex.Pattern;
 
 public abstract class OracleOpenJdkToolchainResolver extends AbstractCustomJavaToolchainResolver {
 
-    record JdkBuild(JavaLanguageVersion languageVersion, String version, String buildNumber, String hash)  {}
+    record JdkBuild(JavaLanguageVersion languageVersion, String version, String buildNumber, String hash) {}
 
     private static final Pattern VERSION_PATTERN = Pattern.compile(
         "(\\d+)(\\.\\d+\\.\\d+(?:\\.\\d+)?)?\\+(\\d+(?:\\.\\d+)?)(@([a-f0-9]{32}))?"
     );
 
-    private static final List<OperatingSystem> supportedOperatingSystems =
-        List.of(OperatingSystem.MAC_OS, OperatingSystem.LINUX, OperatingSystem.WINDOWS);
+    private static final List<OperatingSystem> supportedOperatingSystems = List.of(
+        OperatingSystem.MAC_OS,
+        OperatingSystem.LINUX,
+        OperatingSystem.WINDOWS
+    );
 
     // package private so it can be replaced by tests
     List<JdkBuild> builds = List.of(
@@ -107,8 +110,8 @@ public abstract class OracleOpenJdkToolchainResolver extends AbstractCustomJavaT
         BuildPlatform buildPlatform = request.getBuildPlatform();
         Architecture architecture = buildPlatform.getArchitecture();
         OperatingSystem operatingSystem = buildPlatform.getOperatingSystem();
-        if (supportedOperatingSystems.contains(operatingSystem) == false ||
-            Architecture.AARCH64 == architecture && OperatingSystem.WINDOWS == operatingSystem) {
+        if (supportedOperatingSystems.contains(operatingSystem) == false
+            || Architecture.AARCH64 == architecture && OperatingSystem.WINDOWS == operatingSystem) {
             return null;
         }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/OracleOpenJdkToolchainResolver.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/OracleOpenJdkToolchainResolver.java
@@ -26,25 +26,25 @@ import java.util.regex.Pattern;
 
 public abstract class OracleOpenJdkToolchainResolver extends AbstractCustomJavaToolchainResolver {
 
-    private record JdkBuild(JavaLanguageVersion languageVersion, String version, String buildNumber, String hash)  {}
+    record JdkBuild(JavaLanguageVersion languageVersion, String version, String buildNumber, String hash)  {}
 
     private static final Pattern VERSION_PATTERN = Pattern.compile(
         "(\\d+)(\\.\\d+\\.\\d+(?:\\.\\d+)?)?\\+(\\d+(?:\\.\\d+)?)(@([a-f0-9]{32}))?"
     );
 
-    // for testing reasons we keep that a package private field
-    String bundledJdkVersion = VersionProperties.getBundledJdkVersion();
-    JavaLanguageVersion bundledJdkMajorVersion = JavaLanguageVersion.of(VersionProperties.getBundledJdkMajorVersion());
-
-    private final List<OperatingSystem> supportedOperatingSystems =
+    private static final List<OperatingSystem> supportedOperatingSystems =
         List.of(OperatingSystem.MAC_OS, OperatingSystem.LINUX, OperatingSystem.WINDOWS);
-    private final List<JdkBuild> builds = List.of(
+
+    // package private so it can be replaced by tests
+    List<JdkBuild> builds = List.of(
         getBundledJdkBuild(),
         // 22 release candidate
         new JdkBuild(JavaLanguageVersion.of(22), "22", "36", "830ec9fcccef480bb3e73fb7ecafe059")
     );
 
     private JdkBuild getBundledJdkBuild() {
+        String bundledJdkVersion = VersionProperties.getBundledJdkVersion();
+        JavaLanguageVersion bundledJdkMajorVersion = JavaLanguageVersion.of(VersionProperties.getBundledJdkMajorVersion());
         Matcher jdkVersionMatcher = VERSION_PATTERN.matcher(bundledJdkVersion);
         if (jdkVersionMatcher.matches() == false) {
             throw new IllegalStateException("Unable to parse bundled JDK version " + bundledJdkVersion);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/OracleOpenJdkToolchainResolver.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/toolchain/OracleOpenJdkToolchainResolver.java
@@ -19,11 +19,14 @@ import org.gradle.platform.BuildPlatform;
 import org.gradle.platform.OperatingSystem;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public abstract class OracleOpenJdkToolchainResolver extends AbstractCustomJavaToolchainResolver {
+
+    private record JdkBuild(JavaLanguageVersion languageVersion, String version, String buildNumber, String hash)  {}
 
     private static final Pattern VERSION_PATTERN = Pattern.compile(
         "(\\d+)(\\.\\d+\\.\\d+(?:\\.\\d+)?)?\\+(\\d+(?:\\.\\d+)?)(@([a-f0-9]{32}))?"
@@ -33,14 +36,15 @@ public abstract class OracleOpenJdkToolchainResolver extends AbstractCustomJavaT
     String bundledJdkVersion = VersionProperties.getBundledJdkVersion();
     JavaLanguageVersion bundledJdkMajorVersion = JavaLanguageVersion.of(VersionProperties.getBundledJdkMajorVersion());
 
-    /**
-     * We need some place to map JavaLanguageVersion to build, minor version etc.
-     * */
-    @Override
-    public Optional<JavaToolchainDownload> resolve(JavaToolchainRequest request) {
-        if (requestIsSupported(request) == false) {
-            return Optional.empty();
-        }
+    private final List<OperatingSystem> supportedOperatingSystems =
+        List.of(OperatingSystem.MAC_OS, OperatingSystem.LINUX, OperatingSystem.WINDOWS);
+    private final List<JdkBuild> builds = List.of(
+        getBundledJdkBuild(),
+        // 22 release candidate
+        new JdkBuild(JavaLanguageVersion.of(22), "22", "36", "830ec9fcccef480bb3e73fb7ecafe059")
+    );
+
+    private JdkBuild getBundledJdkBuild() {
         Matcher jdkVersionMatcher = VERSION_PATTERN.matcher(bundledJdkVersion);
         if (jdkVersionMatcher.matches() == false) {
             throw new IllegalStateException("Unable to parse bundled JDK version " + bundledJdkVersion);
@@ -48,6 +52,18 @@ public abstract class OracleOpenJdkToolchainResolver extends AbstractCustomJavaT
         String baseVersion = jdkVersionMatcher.group(1) + (jdkVersionMatcher.group(2) != null ? (jdkVersionMatcher.group(2)) : "");
         String build = jdkVersionMatcher.group(3);
         String hash = jdkVersionMatcher.group(5);
+        return new JdkBuild(bundledJdkMajorVersion, baseVersion, build, hash);
+    }
+
+    /**
+     * We need some place to map JavaLanguageVersion to buildNumber, minor version etc.
+     * */
+    @Override
+    public Optional<JavaToolchainDownload> resolve(JavaToolchainRequest request) {
+        JdkBuild build = findSupportedBuild(request);
+        if (build == null) {
+            return Optional.empty();
+        }
 
         OperatingSystem operatingSystem = request.getBuildPlatform().getOperatingSystem();
         String extension = operatingSystem.equals(OperatingSystem.WINDOWS) ? "zip" : "tar.gz";
@@ -56,13 +72,13 @@ public abstract class OracleOpenJdkToolchainResolver extends AbstractCustomJavaT
         return Optional.of(
             () -> URI.create(
                 "https://download.oracle.com/java/GA/jdk"
-                    + baseVersion
+                    + build.version
                     + "/"
-                    + hash
+                    + build.hash
                     + "/"
-                    + build
+                    + build.buildNumber
                     + "/GPL/openjdk-"
-                    + baseVersion
+                    + build.version
                     + "_"
                     + os
                     + "-"
@@ -80,20 +96,28 @@ public abstract class OracleOpenJdkToolchainResolver extends AbstractCustomJavaT
      * 3. vendor must be any or oracle
      * 4. Aarch64 windows images are not supported
      */
-    private boolean requestIsSupported(JavaToolchainRequest request) {
+    private JdkBuild findSupportedBuild(JavaToolchainRequest request) {
         if (VersionProperties.getBundledJdkVendor().toLowerCase().equals("openjdk") == false) {
-            return false;
+            return null;
         }
         JavaToolchainSpec javaToolchainSpec = request.getJavaToolchainSpec();
-        if (javaToolchainSpec.getLanguageVersion().get().equals(bundledJdkMajorVersion) == false) {
-            return false;
-        }
         if (anyVendorOr(javaToolchainSpec.getVendor().get(), JvmVendorSpec.ORACLE) == false) {
-            return false;
+            return null;
         }
         BuildPlatform buildPlatform = request.getBuildPlatform();
         Architecture architecture = buildPlatform.getArchitecture();
         OperatingSystem operatingSystem = buildPlatform.getOperatingSystem();
-        return Architecture.AARCH64 != architecture || OperatingSystem.WINDOWS != operatingSystem;
+        if (supportedOperatingSystems.contains(operatingSystem) == false ||
+            Architecture.AARCH64 == architecture && OperatingSystem.WINDOWS == operatingSystem) {
+            return null;
+        }
+
+        JavaLanguageVersion languageVersion = javaToolchainSpec.getLanguageVersion().get();
+        for (JdkBuild build : builds) {
+            if (build.languageVersion.equals(languageVersion)) {
+                return build;
+            }
+        }
+        return null;
     }
 }

--- a/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/toolchain/OracleOpenJdkToolchainResolverSpec.groovy
+++ b/build-tools-internal/src/test/groovy/org/elasticsearch/gradle/internal/toolchain/OracleOpenJdkToolchainResolverSpec.groovy
@@ -24,8 +24,9 @@ class OracleOpenJdkToolchainResolverSpec extends AbstractToolchainResolverSpec {
                 return null
             }
         }
-        toolChain.bundledJdkVersion = "20+36@bdc68b4b9cbc4ebcb30745c85038d91d"
-        toolChain.bundledJdkMajorVersion = JavaLanguageVersion.of(20)
+        toolChain.builds = [
+            new OracleOpenJdkToolchainResolver.JdkBuild(JavaLanguageVersion.of(20), "20", "36", "bdc68b4b9cbc4ebcb30745c85038d91d")
+        ]
         toolChain
     }
 
@@ -39,7 +40,8 @@ class OracleOpenJdkToolchainResolverSpec extends AbstractToolchainResolverSpec {
          [20, anyVendor(), MAC_OS, AARCH64, "https://download.oracle.com/java/GA/jdk20/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/openjdk-20_macos-aarch64_bin.tar.gz"],
          [20, anyVendor(), LINUX, X86_64, "https://download.oracle.com/java/GA/jdk20/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/openjdk-20_linux-x64_bin.tar.gz"],
          [20, anyVendor(), LINUX, AARCH64, "https://download.oracle.com/java/GA/jdk20/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/openjdk-20_linux-aarch64_bin.tar.gz"],
-         [20, anyVendor(), WINDOWS, X86_64, "https://download.oracle.com/java/GA/jdk20/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/openjdk-20_windows-x64_bin.zip"]]
+         [20, anyVendor(), WINDOWS, X86_64, "https://download.oracle.com/java/GA/jdk20/bdc68b4b9cbc4ebcb30745c85038d91d/36/GPL/openjdk-20_windows-x64_bin.zip"]
+        ]
     }
 
     def unsupportedRequests() {


### PR DESCRIPTION
This commit adds the upcoming JDK22 release candidate build to be resolvable within Elasticsearch.