### PR TITLE
[8.13] Field caps performance pt2 (#105941)

### DIFF
--- a/docs/changelog/105941.yaml
+++ b/docs/changelog/105941.yaml
@@ -1,0 +1,5 @@
+pr: 105941
+summary: Field caps performance pt2
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -162,7 +162,6 @@ class FieldCapabilitiesFetcher {
 
         Predicate<MappedFieldType> filter = buildFilter(indexFieldfilter, filters, types, context);
         boolean isTimeSeriesIndex = context.getIndexSettings().getTimestampBounds() != null;
-        var fieldInfos = indexShard.getFieldInfos();
         Map<String, IndexFieldCapabilities> responseMap = new HashMap<>();
         for (Map.Entry<String, MappedFieldType> entry : context.getAllFields()) {
             final String field = entry.getKey();

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -162,7 +162,7 @@ class FieldCapabilitiesFetcher {
 
         Predicate<MappedFieldType> filter = buildFilter(indexFieldfilter, filters, types, context);
         boolean isTimeSeriesIndex = context.getIndexSettings().getTimestampBounds() != null;
-        includeEmptyFields = includeEmptyFields || enableFieldHasValue == false;
+        var fieldInfos = indexShard.getFieldInfos();
         Map<String, IndexFieldCapabilities> responseMap = new HashMap<>();
         for (Map.Entry<String, MappedFieldType> entry : context.getAllFields()) {
             final String field = entry.getKey();
@@ -170,9 +170,8 @@ class FieldCapabilitiesFetcher {
                 continue;
             }
             MappedFieldType ft = entry.getValue();
-            if ((includeEmptyFields || ft.fieldHasValue(fieldInfos))
-                && (indexFieldfilter.test(ft.name()) || context.isMetadataField(ft.name()))
-                && (filter == null || filter.test(ft))) {
+            boolean includeField = includeEmptyFields || enableFieldHasValue == false || ft.fieldHasValue(indexShard.getFieldInfos());
+            if (includeField && filter.test(ft)) {
                 IndexFieldCapabilities fieldCap = new IndexFieldCapabilities(
                     field,
                     ft.familyTypeName(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -211,4 +211,11 @@ final class FieldTypeLookup {
     public String parentField(String field) {
         return fullSubfieldNameToParentPath.get(field);
     }
+
+    /**
+     * @return A map from field name to the MappedFieldType
+     */
+    public Map<String, MappedFieldType> getFullNameToFieldType() {
+        return fullNameToFieldType;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -400,6 +400,13 @@ public final class MappingLookup {
     }
 
     /**
+     * @return A map from field name to the MappedFieldType
+     */
+    public Map<String, MappedFieldType> getFullNameToFieldType() {
+        return fieldTypeLookup.getFullNameToFieldType();
+    }
+
+    /**
      * Returns the mapped field type for the given field name.
      */
     public MappedFieldType getFieldType(String field) {

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -336,13 +336,13 @@ public class QueryRewriteContext {
     }
 
     /**
-     * Same as {@link #getMatchingFieldNames(String)} with pattern {@code *} but returns an {@link Iterable} instead of a set.
+     * @return An {@link Iterable} with key the field name and value the MappedFieldType
      */
-    public Iterable<String> getAllFieldNames() {
-        var allFromMapping = mappingLookup.getMatchingFieldNames("*");
+    public Iterable<Map.Entry<String, MappedFieldType>> getAllFields() {
+        var allFromMapping = mappingLookup.getFullNameToFieldType();
         // runtime mappings and non-runtime fields don't overlap, so we can simply concatenate the iterables here
         return runtimeMappings.isEmpty()
-            ? allFromMapping
-            : () -> Iterators.concat(allFromMapping.iterator(), runtimeMappings.keySet().iterator());
+            ? allFromMapping.entrySet()
+            : () -> Iterators.concat(allFromMapping.entrySet().iterator(), runtimeMappings.entrySet().iterator());
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [Field caps performance pt2 (#105941)](https://github.com/elastic/elasticsearch/pull/105941)

<!--- Backport version: 9.4.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)