### PR TITLE
Do not trip circuit breaker in GET /_cluster/allocation/explain

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -66,6 +66,7 @@ public class TransportClusterAllocationExplainAction extends TransportMasterNode
     ) {
         super(
             TYPE.name(),
+            false,
             transportService,
             clusterService,
             threadPool,

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainAction.java
@@ -60,4 +60,9 @@ public class RestClusterAllocationExplainAction extends BaseRestHandler {
         req.includeDiskInfo(request.paramAsBoolean("include_disk_info", false));
         return channel -> client.admin().cluster().allocationExplain(req, new RestRefCountedChunkedToXContentListener<>(channel));
     }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return false;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainActionTests.java
@@ -37,7 +37,7 @@ public class TransportClusterAllocationExplainActionTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        threadPool = new TestThreadPool("TransportClusterAllocationExplainActionTests");
+        threadPool = new TestThreadPool(TransportClusterAllocationExplainActionTests.class.getName());
         clusterService = ClusterServiceUtils.createClusterService(threadPool);
         transportService = new CapturingTransport().createTransportService(
             clusterService.getSettings(),
@@ -60,8 +60,11 @@ public class TransportClusterAllocationExplainActionTests extends ESTestCase {
         );
     }
 
-    public void testCanTripCircuitBreaker() {
-        assertThat(transportService.getRequestHandler("cluster:monitor/allocation/explain").canTripCircuitBreaker(), is(false));
+    public void testCanNotTripCircuitBreaker() {
+        assertThat(
+            transportService.getRequestHandler(TransportClusterAllocationExplainAction.TYPE.name()).canTripCircuitBreaker(),
+            is(false)
+        );
     }
 
     @After

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainActionTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.allocation;
+
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.snapshots.EmptySnapshotsInfoService;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.transport.CapturingTransport;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+
+public class TransportClusterAllocationExplainActionTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+    private ClusterService clusterService;
+    private TransportService transportService;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool("TransportClusterAllocationExplainActionTests");
+        clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        transportService = new CapturingTransport().createTransportService(
+            clusterService.getSettings(),
+            threadPool,
+            TransportService.NOOP_TRANSPORT_INTERCEPTOR,
+            address -> clusterService.localNode(),
+            clusterService.getClusterSettings(),
+            Set.of()
+        );
+        new TransportClusterAllocationExplainAction(
+            transportService,
+            clusterService,
+            threadPool,
+            new ActionFilters(Set.of()),
+            null,
+            () -> ClusterInfo.EMPTY,
+            EmptySnapshotsInfoService.INSTANCE,
+            new AllocationDeciders(List.of()),
+            null
+        );
+    }
+
+    public void testCanTripCircuitBreaker() {
+        assertThat(transportService.getRequestHandler("cluster:monitor/allocation/explain").canTripCircuitBreaker(), is(false));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdown();
+        clusterService.close();
+        transportService.close();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainActionTests.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.is;
 
 public class RestClusterAllocationExplainActionTests extends ESTestCase {
 
-    public void testHealthReportAPIDoesNotTripCircuitBreakers() {
+    public void testCanNotTripCircuitBreaker() {
         assertThat(new RestClusterAllocationExplainAction().canTripCircuitBreaker(), is(false));
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/cluster/RestClusterAllocationExplainActionTests.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest.action.admin.cluster;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.is;
+
+public class RestClusterAllocationExplainActionTests extends ESTestCase {
+
+    public void testHealthReportAPIDoesNotTripCircuitBreakers() {
+        assertThat(new RestClusterAllocationExplainAction().canTripCircuitBreaker(), is(false));
+    }
+}


### PR DESCRIPTION
This changes allocation explain API to not trip circuit breaker so that it is always available for troubleshooting even if cluster is overloaded.

Fixes: ES-7192