### PR TITLE
Enhance ENRICH LookupRequest to include input data type

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -144,6 +144,7 @@ public class TransportVersions {
     public static final TransportVersion ALLOCATION_STATS = def(8_604_00_0);
     public static final TransportVersion ESQL_EXTENDED_ENRICH_TYPES = def(8_605_00_0);
     public static final TransportVersion KNN_EXPLICIT_BYTE_QUERY_VECTOR_PARSING = def(8_606_00_0);
+    public static final TransportVersion ESQL_EXTENDED_ENRICH_INPUT_TYPE = def(8_607_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupOperator.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupOperator.java
@@ -19,6 +19,7 @@ import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.ql.expression.NamedExpression;
+import org.elasticsearch.xpack.ql.type.DataType;
 
 import java.io.IOException;
 import java.util.List;
@@ -29,6 +30,7 @@ public final class EnrichLookupOperator extends AsyncOperator {
     private final String sessionId;
     private final CancellableTask parentTask;
     private final int inputChannel;
+    private final DataType inputDataType;
     private final String enrichIndex;
     private final String matchType;
     private final String matchField;
@@ -41,6 +43,7 @@ public final class EnrichLookupOperator extends AsyncOperator {
         int maxOutstandingRequests,
         int inputChannel,
         EnrichLookupService enrichLookupService,
+        DataType inputDataType,
         String enrichIndex,
         String matchType,
         String matchField,
@@ -68,6 +71,7 @@ public final class EnrichLookupOperator extends AsyncOperator {
                 maxOutstandingRequests,
                 inputChannel,
                 enrichLookupService,
+                inputDataType,
                 enrichIndex,
                 matchType,
                 matchField,
@@ -83,6 +87,7 @@ public final class EnrichLookupOperator extends AsyncOperator {
         int maxOutstandingRequests,
         int inputChannel,
         EnrichLookupService enrichLookupService,
+        DataType inputDataType,
         String enrichIndex,
         String matchType,
         String matchField,
@@ -93,6 +98,7 @@ public final class EnrichLookupOperator extends AsyncOperator {
         this.parentTask = parentTask;
         this.inputChannel = inputChannel;
         this.enrichLookupService = enrichLookupService;
+        this.inputDataType = inputDataType;
         this.enrichIndex = enrichIndex;
         this.matchType = matchType;
         this.matchField = matchField;
@@ -107,6 +113,7 @@ public final class EnrichLookupOperator extends AsyncOperator {
             sessionId,
             parentTask,
             enrichIndex,
+            inputDataType,
             matchType,
             matchField,
             enrichFields,
@@ -119,6 +126,8 @@ public final class EnrichLookupOperator extends AsyncOperator {
     public String toString() {
         return "EnrichOperator[index="
             + enrichIndex
+            + " input_type="
+            + inputDataType
             + " match_field="
             + matchField
             + " enrich_fields="

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -460,13 +460,15 @@ public class LocalExecutionPlanner {
         if (enrichIndex == null) {
             throw new EsqlIllegalArgumentException("No concrete enrich index for cluster [" + clusterAlias + "]");
         }
+        Layout.ChannelAndType input = source.layout.get(enrich.matchField().id());
         return source.with(
             new EnrichLookupOperator.Factory(
                 sessionId,
                 parentTask,
                 context.queryPragmas().enrichMaxWorkers(),
-                source.layout.get(enrich.matchField().id()).channel(),
+                input.channel(),
                 enrichLookupService,
+                input.type(),
                 enrichIndex,
                 enrich.matchType(),
                 enrich.policyMatchField(),


### PR DESCRIPTION
This is needed for refined support of type checking when doing range ENRICH queries

The main work is being done in https://github.com/elastic/elasticsearch/pull/106186, but we wanted to get this part in early to minimise risk of TransportVersion clashes.

