### PR TITLE
Refactor how roundup parsers are created

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -1538,13 +1538,13 @@ public class DateFormatters {
      */
     private static final DateFormatter DATE = newDateFormatter(
         "date",
-        DateTimeFormatter.ISO_LOCAL_DATE.withResolverStyle(ResolverStyle.STRICT),
+        DateTimeFormatter.ISO_LOCAL_DATE.withLocale(Locale.ROOT).withResolverStyle(ResolverStyle.STRICT),
         DATE_FORMATTER
     );
 
     // only the formatter, nothing optional here
     private static final DateTimeFormatter DATE_TIME_NO_MILLIS_PRINTER = new DateTimeFormatterBuilder().append(
-        DateTimeFormatter.ISO_LOCAL_DATE.withResolverStyle(ResolverStyle.LENIENT)
+        DateTimeFormatter.ISO_LOCAL_DATE.withLocale(Locale.ROOT).withResolverStyle(ResolverStyle.LENIENT)
     )
         .appendLiteral('T')
         .appendPattern("HH:mm")

--- a/server/src/main/java/org/elasticsearch/common/time/DateTimeParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateTimeParser.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.common.time;
 
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
@@ -23,13 +22,9 @@ interface DateTimeParser {
 
     Locale getLocale();
 
-    String getFormatString();
-
     DateTimeParser withZone(ZoneId zone);
 
     DateTimeParser withLocale(Locale locale);
-
-    void applyToBuilder(DateTimeFormatterBuilder builder);
 
     /**
      * Parses the specified string.

--- a/server/src/main/java/org/elasticsearch/common/time/EpochTime.java
+++ b/server/src/main/java/org/elasticsearch/common/time/EpochTime.java
@@ -252,7 +252,7 @@ class EpochTime {
     static final DateFormatter SECONDS_FORMATTER = new JavaDateFormatter(
         "epoch_second",
         new JavaTimeDateTimePrinter(SECONDS_FORMATTER1),
-        (builder, parser) -> builder.parseDefaulting(ChronoField.NANO_OF_SECOND, 999_999_999L),
+        JavaTimeDateTimeParser.createRoundUpParserGenerator(builder -> builder.parseDefaulting(ChronoField.NANO_OF_SECOND, 999_999_999L)),
         new JavaTimeDateTimeParser(SECONDS_FORMATTER1),
         new JavaTimeDateTimeParser(SECONDS_FORMATTER2)
     );
@@ -260,7 +260,7 @@ class EpochTime {
     static final DateFormatter MILLIS_FORMATTER = new JavaDateFormatter(
         "epoch_millis",
         new JavaTimeDateTimePrinter(MILLISECONDS_FORMATTER1),
-        (builder, parser) -> builder.parseDefaulting(EpochTime.NANOS_OF_MILLI, 999_999L),
+        JavaTimeDateTimeParser.createRoundUpParserGenerator(builder -> builder.parseDefaulting(EpochTime.NANOS_OF_MILLI, 999_999L)),
         new JavaTimeDateTimeParser(MILLISECONDS_FORMATTER1),
         new JavaTimeDateTimeParser(MILLISECONDS_FORMATTER2)
     );

--- a/server/src/main/java/org/elasticsearch/common/time/JavaTimeDateTimeParser.java
+++ b/server/src/main/java/org/elasticsearch/common/time/JavaTimeDateTimeParser.java
@@ -15,13 +15,28 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 class JavaTimeDateTimeParser implements DateTimeParser {
+
+    static UnaryOperator<JavaTimeDateTimeParser> createRoundUpParserGenerator(Consumer<DateTimeFormatterBuilder> modifyBuilder) {
+        return p -> {
+            var builder = new DateTimeFormatterBuilder();
+            builder.append(p.formatter);
+            modifyBuilder.accept(builder);
+            return new JavaTimeDateTimeParser(builder.toFormatter(p.getLocale()));
+        };
+    }
 
     private final DateTimeFormatter formatter;
 
     JavaTimeDateTimeParser(DateTimeFormatter formatter) {
         this.formatter = formatter;
+    }
+
+    DateTimeFormatter formatter() {
+        return formatter;
     }
 
     @Override
@@ -35,11 +50,6 @@ class JavaTimeDateTimeParser implements DateTimeParser {
     }
 
     @Override
-    public String getFormatString() {
-        return formatter.toString();
-    }
-
-    @Override
     public DateTimeParser withZone(ZoneId zone) {
         return new JavaTimeDateTimeParser(formatter.withZone(zone));
     }
@@ -47,11 +57,6 @@ class JavaTimeDateTimeParser implements DateTimeParser {
     @Override
     public DateTimeParser withLocale(Locale locale) {
         return new JavaTimeDateTimeParser(formatter.withLocale(locale));
-    }
-
-    @Override
-    public void applyToBuilder(DateTimeFormatterBuilder builder) {
-        builder.append(formatter);
     }
 
     @Override


### PR DESCRIPTION
Refactor roundup parsers to remove the requirement for additional methods on `DateTimeParser`, and to allow other implementations of `DateTimeParser`

This is not a perfect solution, as `DateTimeParser` then knows about all its implementations. But it's the least worst option here.