### PR TITLE
[8.13] Fix Search Applications bug where deleting an alias before deleting an application intermittently caused errors (#106329)

### DIFF
--- a/docs/changelog/106329.yaml
+++ b/docs/changelog/106329.yaml
@@ -1,0 +1,5 @@
+pr: 106329
+summary: Fix Search Applications bug where deleting an alias before deleting an application intermittently caused errors
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_search_application_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_search_application_delete.yml
@@ -77,3 +77,18 @@ teardown:
         name: test-search-application-to-delete
 
   - match: { acknowledged: true }
+
+---
+"Delete Search Application - Alias does not exist as alias was explicitly removed":
+  - do:
+      indices.update_aliases:
+        body:
+          actions:
+            - remove:
+                index: test-index
+                alias: test-search-application-to-delete
+
+      search_application.delete:
+        name: test-search-application-to-delete
+
+  - match: { acknowledged: true }


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Fix Search Applications bug where deleting an alias before deleting an application intermittently caused errors (#106329)