### PR TITLE
Small cleanup in `FollowersChecker`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionRunnable.java
@@ -36,6 +36,11 @@ public abstract class ActionRunnable<Response> extends AbstractRunnable {
                 runnable.run();
                 listener.onResponse(null);
             }
+
+            @Override
+            public String toString() {
+                return runnable.toString();
+            }
         };
     }
 


### PR DESCRIPTION
Replaces a call to `ActionRunnable#<Void>supply` with the more
appropriate `ActionRunnable#run`, and extracts the executor constant.