### PR TITLE
Abstract differences in the java.lang.foreign API between Java21 and Java 22.

### DIFF
--- a/libs/native/build.gradle
+++ b/libs/native/build.gradle
@@ -32,3 +32,7 @@ tasks.withType(CheckForbiddenApisTask).configureEach {
 tasks.named('forbiddenApisMain21').configure {
   ignoreMissingClasses = true
 }
+
+tasks.named('forbiddenApisMain22').configure {
+  ignoreMissingClasses = true
+}

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -72,7 +72,7 @@ class JdkZstdLibrary implements ZstdLibrary {
     public String getErrorName(long code) {
         try {
             MemorySegment str = (MemorySegment) getErrorName$mh.invokeExact(code);
-            return str.reinterpret(Long.MAX_VALUE).getUtf8String(0);
+            return Utils.getUtf8String(0, str.reinterpret(Long.MAX_VALUE));
         } catch (Throwable t) {
             throw new AssertionError(t);
         }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/Utils.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/Utils.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess.jdk;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Static utility methods that abstract parts of the java.lang.foreign API
+ * that has been modified between Java 21 and 22.
+ */
+final class Utils {
+
+    static String getUtf8String(long offset, MemorySegment memorySegment) {
+        return memorySegment.getUtf8String(offset);
+    }
+
+    private Utils() {} // no instances
+}

--- a/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/Utils.java
+++ b/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/Utils.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess.jdk;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Static utility methods that abstract parts of the java.lang.foreign API
+ * that has been modified between Java 21 and 22.
+ */
+final class Utils {
+
+    static String getUtf8String(long offset, MemorySegment memorySegment) {
+        return memorySegment.getString(offset);
+    }
+
+    private Utils() {} // no instances
+}

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/ZstdTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/ZstdTests.java
@@ -36,7 +36,7 @@ public class ZstdTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> zstd.compressBound(Integer.MIN_VALUE));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106347")
+    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106347")
     public void testCompressValidation() {
         try (var src = nativeAccess.newBuffer(1000); var dst = nativeAccess.newBuffer(500)) {
             var srcBuf = src.buffer();
@@ -56,7 +56,7 @@ public class ZstdTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106347")
+    // @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106347")
     public void testDecompressValidation() {
         try (
             var original = nativeAccess.newBuffer(1000);


### PR DESCRIPTION
This commit adds a utility class to abstract the differences in the java.lang.foreign API between Java21 and Java 22. 

For now, we're just using `getUtf8String`, which was renamed to `getString` in Java 22. Note: `getString` is specified to be UTF-8, other overloads allow to use a different charset.

closes #106347