### PR TITLE
Support jdk22 in zstd bindings

### DIFF
--- a/libs/native/build.gradle
+++ b/libs/native/build.gradle
@@ -32,3 +32,7 @@ tasks.withType(CheckForbiddenApisTask).configureEach {
 tasks.named('forbiddenApisMain21').configure {
   ignoreMissingClasses = true
 }
+
+tasks.named('forbiddenApisMain22').configure {
+  ignoreMissingClasses = true
+}

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -72,7 +72,7 @@ class JdkZstdLibrary implements ZstdLibrary {
     public String getErrorName(long code) {
         try {
             MemorySegment str = (MemorySegment) getErrorName$mh.invokeExact(code);
-            return MemorySegmentUtil.getString(str.reinterpret(Long.MAX_VALUE));
+            return MemorySegmentUtil.getString(str.reinterpret(Long.MAX_VALUE), 0);
         } catch (Throwable t) {
             throw new AssertionError(t);
         }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -72,7 +72,7 @@ class JdkZstdLibrary implements ZstdLibrary {
     public String getErrorName(long code) {
         try {
             MemorySegment str = (MemorySegment) getErrorName$mh.invokeExact(code);
-            return str.reinterpret(Long.MAX_VALUE).getUtf8String(0);
+            return MemorySegmentUtil.getString(str.reinterpret(Long.MAX_VALUE));
         } catch (Throwable t) {
             throw new AssertionError(t);
         }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess.jdk;
+
+import java.lang.foreign.MemorySegment;
+
+/**
+ * Utility methods to act on MemorySegment apis which have changed in subsequent JDK releases.
+ */
+class MemorySegmentUtil {
+
+    static String getString(MemorySegment segment) {
+        return segment.getUtf8String(0);
+    }
+}

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -15,7 +15,9 @@ import java.lang.foreign.MemorySegment;
  */
 class MemorySegmentUtil {
 
-    static String getString(MemorySegment segment) {
-        return segment.getUtf8String(0);
+    static String getString(MemorySegment segment, long offset) {
+        return segment.getUtf8String(offset);
     }
+
+    private MemorySegmentUtil() {}
 }

--- a/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess.jdk;
+
+import java.lang.foreign.MemorySegment;
+
+public class MemorySegmentUtil {
+
+    static String getString(MemorySegment segment) {
+        return segment.getString(0);
+    }
+}

--- a/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -12,7 +12,9 @@ import java.lang.foreign.MemorySegment;
 
 public class MemorySegmentUtil {
 
-    static String getString(MemorySegment segment) {
-        return segment.getString(0);
+    static String getString(MemorySegment segment, long offset) {
+        return segment.getString(offset);
     }
+
+    private MemorySegmentUtil() {}
 }

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/ZstdTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/ZstdTests.java
@@ -36,7 +36,6 @@ public class ZstdTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> zstd.compressBound(Integer.MIN_VALUE));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106347")
     public void testCompressValidation() {
         try (var src = nativeAccess.newBuffer(1000); var dst = nativeAccess.newBuffer(500)) {
             var srcBuf = src.buffer();
@@ -56,7 +55,6 @@ public class ZstdTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106347")
     public void testDecompressValidation() {
         try (
             var original = nativeAccess.newBuffer(1000);


### PR DESCRIPTION
The foreign memory API changed between Java 21 and 22 in how to decode a string from native memory. This commit adds an multi-release class to handle the two different methods on MemorySegment to decode a string.