### PR TITLE
Update field-usage-stats.asciidoc to clarify counter behaviour

### DIFF
--- a/docs/reference/indices/field-usage-stats.asciidoc
+++ b/docs/reference/indices/field-usage-stats.asciidoc
@@ -9,9 +9,12 @@ experimental[]
 Returns field usage information for each shard and field
 of an index.
 Field usage statistics are automatically captured when
-queries are running on a cluster. A shard-level search
+a shard starts running on a cluster node. A shard-level search
 request that accesses a given field, even if multiple times
-during that request, is counted as a single use.
+during that request, is counted as a single use. The counters 
+are cumulative and kept in memory. Upon node restart, or 
+when the shard is moved to a new node, the counters for 
+that shard will be reset.
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Added additional information to clarify that counter are kept in memory and reset on node restart or shard rellocation.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
