### PR TITLE
Fix byte array iterator

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/BigByteArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigByteArray.java
@@ -146,14 +146,17 @@ final class BigByteArray extends AbstractBigArray implements ByteArray {
     public BytesRefIterator iterator() {
         return new BytesRefIterator() {
             int i = 0;
+            long remained = size;
 
             @Override
             public BytesRef next() {
-                if (i >= pages.length) {
+                if (remained == 0) {
                     return null;
                 }
-                int len = i == pages.length - 1 ? Math.toIntExact(size - (pages.length - 1L) * PAGE_SIZE_IN_BYTES) : PAGE_SIZE_IN_BYTES;
-                return new BytesRef(pages[i++], 0, len);
+                byte[] page = pages[i++];
+                int len = Math.toIntExact(Math.min(page.length, remained));
+                remained -= len;
+                return new BytesRef(page, 0, len);
             }
         };
     }

--- a/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/BigArraysTests.java
@@ -371,6 +371,19 @@ public class BigArraysTests extends ESTestCase {
             }
         }
         assertThat(offset, equalTo(bytes.length));
+        int newLen = randomIntBetween(bytes.length, bytes.length + 100_000);
+        array = bigArrays.resize(array, newLen);
+        it = array.iterator();
+        offset = 0;
+        while ((ref = it.next()) != null) {
+            for (int i = 0; i < ref.length; i++) {
+                if (offset < bytes.length) {
+                    assertEquals(bytes[offset], ref.bytes[ref.offset + i]);
+                }
+                offset++;
+            }
+        }
+        assertThat(offset, equalTo(newLen));
         array.close();
     }
 


### PR DESCRIPTION
If ByteArray has been resized, the byte iterator can access null pages. When resizing a big array, we overly allocate the pages array and assign null to the extra pages.

Relates #106270