### PR TITLE
[DOCS] Recommend a better installation directory for Windows

### DIFF
--- a/docs/reference/setup/install/zip-windows.asciidoc
+++ b/docs/reference/setup/install/zip-windows.asciidoc
@@ -41,7 +41,7 @@ window, `cd` to the `%ES_HOME%` directory, for instance:
 
 ["source","sh",subs="attributes"]
 ----------------------------
-cd C:\elasticsearch-{version}
+cd C:\Program Files\elasticsearch-{version}
 ----------------------------
 
 ifdef::include-xpack[]
@@ -93,7 +93,7 @@ automatically at boot time without user interaction.
 +
 ["source","sh",subs="attributes"]
 ----
-C:\elasticsearch-{version}{backslash}bin>elasticsearch-service.bat install
+C:\Program Files\elasticsearch-{version}{backslash}bin>elasticsearch-service.bat install
 Installing service      :  "elasticsearch-service-x64"
 Using ES_JAVA_HOME (64-bit):  "C:\jvm\jdk1.8"
 The service 'elasticsearch-service-x64' has been installed.
@@ -104,7 +104,7 @@ default:
 +
 ["source","sh",subs="attributes"]
 ----
-C:\elasticsearch-{version}{backslash}bin>bin\elasticsearch-service.bat start
+C:\Program Files\elasticsearch-{version}{backslash}bin>bin\elasticsearch-service.bat start
 ----
 +
 NOTE: TLS is not enabled or configured when you start {es} as a service.
@@ -115,7 +115,7 @@ to the command line.
 +
 ["source","sh",subs="attributes"]
 ----
-C:\elasticsearch-{version}{backslash}bin>\bin\elasticsearch-reset-password -u elastic
+C:\Program Files\elasticsearch-{version}{backslash}bin>\bin\elasticsearch-reset-password -u elastic
 ----
 
 NOTE: While a JRE can be used for the {es} service, due to its use of a client
@@ -138,7 +138,7 @@ service from the command line.
 
 ["source","sh",subs="attributes,callouts"]
 ----
-C:\elasticsearch-{version}{backslash}bin>elasticsearch-service.bat
+C:\Program Files\elasticsearch-{version}{backslash}bin>elasticsearch-service.bat
 
 Usage: elasticsearch-service.bat install|remove|start|stop|manager [SERVICE_ID]
 ----


### PR DESCRIPTION
It's not very realistic to install something straight to `C:\` on Windows. While this is an arbitrary example, we should use something that would make sense if users copy it directly.