### PR TITLE
Revert "Revert "Exclude internal fields from job APIs. (#106115)" (#106277)"

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -109,6 +109,8 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
   )
   task.skipTest("ml/jobs_crud/Test update job", "Behaviour change #89824 - added limit filter to categorization analyzer")
   task.skipTest("ml/jobs_crud/Test create job with delimited format", "removing undocumented functionality")
+  task.skipTest("ml/jobs_crud/Test cannot create job with model snapshot id set", "Exception type has changed.")
+  task.skipTest("ml/validate/Test job config is invalid because model snapshot id set", "Exception type has changed.")
   task.skipTest("ml/datafeeds_crud/Test update datafeed to point to missing job", "behaviour change #44752 - not allowing to update datafeed job_id")
   task.skipTest(
     "ml/datafeeds_crud/Test update datafeed to point to different job",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PreviewDatafeedAction.java
@@ -60,7 +60,7 @@ public class PreviewDatafeedAction extends ActionType<PreviewDatafeedAction.Resp
         private static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>("preview_datafeed_action", Request.Builder::new);
         static {
             PARSER.declareObject(Builder::setDatafeedBuilder, DatafeedConfig.STRICT_PARSER, DATAFEED_CONFIG);
-            PARSER.declareObject(Builder::setJobBuilder, Job.STRICT_PARSER, JOB_CONFIG);
+            PARSER.declareObject(Builder::setJobBuilder, Job.REST_REQUEST_PARSER, JOB_CONFIG);
             PARSER.declareString(Builder::setStart, START_TIME);
             PARSER.declareString(Builder::setEnd, END_TIME);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/PutJobAction.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.core.ml.job.config.Job;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
 
 public class PutJobAction extends ActionType<PutJobAction.Response> {
@@ -35,7 +34,7 @@ public class PutJobAction extends ActionType<PutJobAction.Response> {
     public static class Request extends AcknowledgedRequest<Request> {
 
         public static Request parseRequest(String jobId, XContentParser parser, IndicesOptions indicesOptions) {
-            Job.Builder jobBuilder = Job.STRICT_PARSER.apply(parser, null);
+            Job.Builder jobBuilder = Job.REST_REQUEST_PARSER.apply(parser, null);
             if (jobBuilder.getId() == null) {
                 jobBuilder.setId(jobId);
             } else if (Strings.isNullOrEmpty(jobId) == false && jobId.equals(jobBuilder.getId()) == false) {
@@ -57,14 +56,6 @@ public class PutJobAction extends ActionType<PutJobAction.Response> {
             // This validation logically belongs to validateInputFields call but we perform it only for PUT action to avoid BWC issues which
             // would occur when parsing an old job config that already had duplicate detectors.
             jobBuilder.validateDetectorsAreUnique();
-
-            // Some fields cannot be set at create time
-            List<String> invalidJobCreationSettings = jobBuilder.invalidCreateTimeSettings();
-            if (invalidJobCreationSettings.isEmpty() == false) {
-                throw new IllegalArgumentException(
-                    Messages.getMessage(Messages.JOB_CONFIG_INVALID_CREATE_SETTINGS, String.join(",", invalidJobCreationSettings))
-                );
-            }
 
             this.jobBuilder = jobBuilder;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -222,8 +222,6 @@ public final class Messages {
     public static final String JOB_CONFIG_FUNCTION_REQUIRES_OVERFIELD = "over_field_name must be set when the ''{0}'' function is used";
     public static final String JOB_CONFIG_ID_ALREADY_TAKEN = "The job cannot be created with the Id ''{0}''. The Id is already used.";
     public static final String JOB_CONFIG_ID_TOO_LONG = "The job id cannot contain more than {0,number,integer} characters.";
-    public static final String JOB_CONFIG_INVALID_CREATE_SETTINGS =
-        "The job is configured with fields [{0}] that are illegal to set at job creation";
     public static final String JOB_CONFIG_INVALID_FIELDNAME_CHARS =
         "Invalid field name ''{0}''. Field names including over, by and partition " + "fields cannot contain any of these characters: {1}";
     public static final String JOB_CONFIG_INVALID_FIELDNAME =

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/config/JobTests.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -101,7 +100,7 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
 
     @Override
     protected Job doParseInstance(XContentParser parser) {
-        return Job.STRICT_PARSER.apply(parser, null).build();
+        return Job.LENIENT_PARSER.apply(parser, null).build();
     }
 
     public void testToXContentForInternalStorage() throws IOException {
@@ -119,10 +118,10 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
         }
     }
 
-    public void testFutureConfigParse() throws IOException {
+    public void testRestRequestParser_DoesntAllowInternalFields() throws IOException {
         XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(XContentParserConfiguration.EMPTY, FUTURE_JOB);
-        XContentParseException e = expectThrows(XContentParseException.class, () -> Job.STRICT_PARSER.apply(parser, null).build());
-        assertEquals("[4:5] [job_details] unknown field [tomorrows_technology_today]", e.getMessage());
+        XContentParseException e = expectThrows(XContentParseException.class, () -> Job.REST_REQUEST_PARSER.apply(parser, null).build());
+        assertEquals("[3:5] [job_details] unknown field [create_time]", e.getMessage());
     }
 
     public void testFutureMetadataParse() throws IOException {
@@ -552,22 +551,6 @@ public class JobTests extends AbstractXContentSerializingTestCase<Job> {
 
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, jobBuilder::build);
         assertThat(e.getMessage(), equalTo(Messages.getMessage(Messages.JOB_CONFIG_TIME_FIELD_NOT_ALLOWED_IN_ANALYSIS_CONFIG)));
-    }
-
-    public void testInvalidCreateTimeSettings() {
-        Job.Builder builder = new Job.Builder("invalid-settings");
-        builder.setModelSnapshotId("snapshot-foo");
-        assertEquals(Collections.singletonList(Job.MODEL_SNAPSHOT_ID.getPreferredName()), builder.invalidCreateTimeSettings());
-
-        builder.setCreateTime(new Date());
-        builder.setFinishedTime(new Date());
-
-        Set<String> expected = new HashSet<>();
-        expected.add(Job.CREATE_TIME.getPreferredName());
-        expected.add(Job.FINISHED_TIME.getPreferredName());
-        expected.add(Job.MODEL_SNAPSHOT_ID.getPreferredName());
-
-        assertEquals(expected, new HashSet<>(builder.invalidCreateTimeSettings()));
     }
 
     public void testEmptyGroup() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -1130,7 +1130,7 @@
 "Test cannot create job with model snapshot id set":
 
   - do:
-      catch: /illegal_argument_exception/
+      catch: /x_content_parse_exception/
       ml.put_job:
         job_id: has-model-snapshot-id
         body:  >

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/validate.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/validate.yml
@@ -76,21 +76,7 @@
 "Test job config is invalid because model snapshot id set":
 
   - do:
-      catch: /illegal_argument_exception/
-      ml.validate:
-        body: >
-          {
-            "model_snapshot_id": "wont-create-with-this-setting",
-            "analysis_config" : {
-                "bucket_span": "1h",
-                "detectors" :[{"function":"metric","field_name":"responsetime","by_field_name":"airline"}]
-            },
-            "data_description" : {
-            }
-          }
-
-  - do:
-      catch: /The job is configured with fields \[model_snapshot_id\] that are illegal to set at job creation/
+      catch: /x_content_parse_exception/
       ml.validate:
         body: >
           {


### PR DESCRIPTION
The original PR caused the following Kibana test to break:
https://github.com/elastic/kibana/issues/178562

However, that turned out to be an issue with the Kibana tests, not with the production code. The test is fixed here:
https://github.com/elastic/kibana/pull/178715
(so don't merge this before that's merged)

I've confirmed with @jgowdyelastic that these fields are not used in the production code. They are never explicitly set and when cloning a job, the get job API is called with the query param `exclude_generated=true`.