### PR TITLE
Clarify docs about the flood-stage index block

### DIFF
--- a/docs/reference/index-modules/blocks.asciidoc
+++ b/docs/reference/index-modules/blocks.asciidoc
@@ -25,17 +25,18 @@ index:
 
 `index.blocks.read_only_allow_delete`::
 
-    Similar to `index.blocks.write`, but also allows deleting the index to
-    make more resources available. The <<disk-based-shard-allocation,disk-based shard
-    allocator>> adds and removes this block automatically according to the available
-    disk space.
+    Similar to `index.blocks.write`, except that you can delete the index when
+    this block is in place. Do not set or remove this block yourself. The
+    <<disk-based-shard-allocation,disk-based shard allocator>> sets and removes
+    this block automatically according to the available disk space.
 +
 Deleting documents from an index to release resources - rather than deleting
-the index itself - increases the index size temporarily, and may not succeed
-when nodes are low on disk space. When `index.blocks.read_only_allow_delete` is
-set to `true`, deleting documents is not permitted. However, deleting the index
-entirely requires very little extra disk space and frees up the disk space
-consumed by the index almost immediately.
+the index itself - increases the index size temporarily, and therefore may not
+be possible when nodes are low on disk space. When
+`index.blocks.read_only_allow_delete` is set to `true`, deleting documents is
+not permitted. However, deleting the index entirely requires very little extra
+disk space and frees up the disk space consumed by the index almost immediately
+so this is still permitted.
 +
 IMPORTANT: {es} adds the read-only-allow-delete index block automatically when
 the disk utilization exceeds the flood stage watermark, and removes this block

--- a/docs/reference/index-modules/blocks.asciidoc
+++ b/docs/reference/index-modules/blocks.asciidoc
@@ -27,24 +27,22 @@ index:
 
     Similar to `index.blocks.write`, but also allows deleting the index to
     make more resources available. The <<disk-based-shard-allocation,disk-based shard
-    allocator>> may add and remove this block automatically.
+    allocator>> adds and removes this block automatically according to the available
+    disk space.
 +
 Deleting documents from an index to release resources - rather than deleting
-the index itself - can increase the index size over time. When
-`index.blocks.read_only_allow_delete` is set to `true`, deleting documents is
-not permitted. However, deleting the index itself releases the read-only index
-block and makes resources available almost immediately.
+the index itself - increases the index size temporarily, and may not succeed
+when nodes are low on disk space. When `index.blocks.read_only_allow_delete` is
+set to `true`, deleting documents is not permitted. However, deleting the index
+entirely requires very little extra disk space and frees up the disk space
+consumed by the index almost immediately.
 +
-IMPORTANT: {es} adds the read-only index block automatically when the disk
-utilization exceeds the flood stage watermark, controlled by the
-<<cluster-routing-flood-stage,cluster.routing.allocation.disk.watermark.flood_stage>>
-and <<cluster-routing-flood-stage,cluster.routing.allocation.disk.watermark.flood_stage.max_headroom>>
-settings, and removes the block automatically when the disk utilization falls
-under the high watermark, controlled by the
-<<cluster-routing-flood-stage,cluster.routing.allocation.disk.watermark.high>>
-and <<cluster-routing-flood-stage,cluster.routing.allocation.disk.watermark.high.max_headroom>>
-settings. Refer to <<fix-watermark-errors,Fix watermark errors>> to resolve 
-watermark issues.
+IMPORTANT: {es} adds the read-only-allow-delete index block automatically when
+the disk utilization exceeds the flood stage watermark, and removes this block
+automatically when the disk utilization falls under the high watermark. See
+<<disk-based-shard-allocation,Disk-based shard allocation>> for more
+information about watermarks, and <<fix-watermark-errors,Fix watermark errors>>
+for help with resolving watermark issues.
 
 `index.blocks.read`::
 


### PR DESCRIPTION
The docs here are a little inaccurate, and link to several individual
settings (incorrectly in some cases) in a paragraph that's pretty hard
to read. This commit fixes the inaccuracies and replaces the links to
individual settings with one to all the docs about the disk-based shard
allocator.