### PR TITLE
Check preTags and postTags params for empty values

### DIFF
--- a/docs/changelog/106396.yaml
+++ b/docs/changelog/106396.yaml
@@ -1,0 +1,6 @@
+pr: 106396
+summary: "fix check preTags and postTags with empty argument"
+area: search
+type: bug
+issues:
+  - 69009

--- a/docs/changelog/106396.yaml
+++ b/docs/changelog/106396.yaml
@@ -1,6 +1,6 @@
 pr: 106396
-summary: "fix check preTags and postTags with empty argument"
-area: search
+summary: "Check preTags and postTags params for empty values"
+area: Highlighting
 type: bug
 issues:
   - 69009

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/issue69009.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/issue69009.yml
@@ -1,4 +1,8 @@
 setup:
+  - skip:
+      version: ' - 8.13.99'
+      reason: 'check of preTags and postTags params for empty values was added in 8.14'
+
   - do:
       indices.create:
         index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/issue69009.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.highlight/issue69009.yml
@@ -1,0 +1,68 @@
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            "properties":
+              "text":
+                "type": "text"
+                "term_vector": "with_positions_offsets"
+
+  - do:
+      index:
+        index: test
+        id:    "1"
+        body:
+          "text" : "The quick brown fox is brown."
+  - do:
+      indices.refresh: {}
+
+---
+"Test with empty pre_tags or post_tags in query body with unified highlight type - should fail" :
+  - do:
+      catch: /pre_tags or post_tags must not be empty/
+      search:
+        index: test
+        body: {
+          "query": { "match": { "fox" } },
+          "highlight": {
+            "type": "unified",
+            "fields": { "*": { } },
+            "pre_tags": [ ],
+            "post_tags": [ ]
+          },
+        }
+
+---
+"Test with empty pre_tags or post_tags in query body with plain highlight type - should fail" :
+  - do:
+      catch: /pre_tags or post_tags must not be empty/
+      search:
+        index: test
+        body: {
+          "query": { "match": { "fox" } },
+          "highlight": {
+            "type": "plain",
+            "fields": { "*": { } },
+            "pre_tags": [ ],
+            "post_tags": [ ]
+          },
+        }
+
+---
+"Test with empty pre_tags or post_tags in query body with fvh highlight type - should fail" :
+  - do:
+      catch: /pre_tags or post_tags must not be empty/
+      search:
+        index: test
+        body: {
+          "query": { "match": { "fox" } },
+          "highlight": {
+            "type": "fvh",
+            "fields": { "*": { } },
+            "pre_tags": [ ],
+            "post_tags": [ ]
+          },
+        }
+

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
@@ -643,6 +643,9 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
                 if (hb.preTags() != null && hb.postTags() == null) {
                     throw new ParsingException(p.getTokenLocation(), "pre_tags are set but post_tags are not set");
                 }
+                if (hb.preTags() != null && hb.postTags() != null && (hb.preTags().length == 0 || hb.postTags().length == 0)) {
+                    throw new ParsingException(p.getTokenLocation(), "pre_tags or post_tags must not be empty");
+                }
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -610,8 +610,8 @@ public class HighlightBuilderTests extends ESTestCase {
     private static void setRandomCommonOptions(AbstractHighlighterBuilder highlightBuilder) {
         if (randomBoolean()) {
             // need to set this together, otherwise parsing will complain
-            highlightBuilder.preTags(randomStringArray(0, 3));
-            highlightBuilder.postTags(randomStringArray(0, 3));
+            highlightBuilder.preTags(randomStringArray(1, 3));
+            highlightBuilder.postTags(randomStringArray(1, 3));
         }
         if (randomBoolean()) {
             highlightBuilder.fragmentSize(randomIntBetween(0, 100));


### PR DESCRIPTION
Check `pre_tags` and `post_tags` params for empty values.

If empty throw `IllegalArgumentException`.

Closes #69009
