### PR TITLE
Release `TranslogSnapshot` buffer after iteration

### DIFF
--- a/docs/changelog/106398.yaml
+++ b/docs/changelog/106398.yaml
@@ -1,0 +1,6 @@
+pr: 106398
+summary: Release `TranslogSnapshot` buffer after iteration
+area: Engine
+type: bug
+issues:
+ - 106390

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogSnapshot.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogSnapshot.java
@@ -62,6 +62,7 @@ final class TranslogSnapshot extends BaseTranslogReader {
             }
             skippedOperations++;
         }
+        reuse = null; // release buffer, it may be large and is no longer needed
         return null;
     }
 


### PR DESCRIPTION
Closes #106390