### PR TITLE
Fix default search timeout in watcher docs

### DIFF
--- a/docs/reference/watcher/input/search.asciidoc
+++ b/docs/reference/watcher/input/search.asciidoc
@@ -194,7 +194,7 @@ accurately.
                                                                                     When a search generates a large response, you can use `extract` to select the
                                                                                     relevant fields instead of loading the entire response.
 
-| `timeout`                                     | no        | 30s                 | The timeout for waiting for the search api call to return. If no response is
+| `timeout`                                     | no        | 1m                  | The timeout for waiting for the search api call to return. If no response is
                                                                                     returned within this time, the search input times out and fails. This setting
                                                                                     overrides the default search operations timeouts.
 |======


### PR DESCRIPTION
There are a couple of "default search timeout" settings:
- https://github.com/elastic/elasticsearch/blob/dceea6118c556e21ed7890644ce5cc893b7a9974/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/WatcherService.java#L99-L99
- https://github.com/elastic/elasticsearch/blob/dceea6118c556e21ed7890644ce5cc893b7a9974/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStore.java#L71-L71

These two do have a default of 30s, but they seem to be influencing other aspects of the watcher module.
The one that actually seems to be the [Watcher search input](https://www.elastic.co/guide/en/elasticsearch/reference/current/input-search.html#search-input-attributes) default timeout setting is: https://github.com/elastic/elasticsearch/blob/dceea6118c556e21ed7890644ce5cc893b7a9974/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/input/search/SearchInputFactory.java#L36-L36

This seems to have been the case for a while already (the docs line and the default in the code haven't changed since 2017), so then the question becomes until what version we want to backport this (provided that my conclusion above is actually correct).