### PR TITLE
Fix potential BigArray leak in InternalAggregation#getReducer

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregation.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator;
 import org.elasticsearch.search.aggregations.pipeline.PipelineAggregator.PipelineTree;
@@ -138,6 +139,11 @@ public abstract class InternalAggregation implements Aggregation, NamedWriteable
             @Override
             public InternalAggregation get() {
                 return aggregatorReducer == null ? current : aggregatorReducer.get();
+            }
+
+            @Override
+            public void close() {
+                Releasables.close(aggregatorReducer);
             }
         };
     }


### PR DESCRIPTION
when the first InternalAggregation cannot lead reduction, we create an AggregatorReducer that waits until the first InternalAggregation that cal lead reduction is found. Then it uses that one to lead the reduction. The issue is that we are not closing this object so there is a possibility of a leak.

This change has not been released so set as non-issue.