### PR TITLE
[DON'T MERGE] EsqlDataExtractor proof of concept v2

### DIFF
--- a/docs/changelog/106407.yaml
+++ b/docs/changelog/106407.yaml
@@ -1,0 +1,5 @@
+pr: 106407
+summary: "[DON'T MERGE] `EsqlDataExtractor` proof of concept v2"
+area: Machine Learning
+type: feature
+issues: []

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -149,6 +149,7 @@ public class TransportVersions {
     public static final TransportVersion AGGS_EXCLUDED_DELETED_DOCS = def(8_609_00_0);
     public static final TransportVersion ESQL_SERIALIZE_BIG_ARRAY = def(8_610_00_0);
     public static final TransportVersion AUTO_SHARDING_ROLLOVER_CONDITION = def(8_611_00_0);
+    public static final TransportVersion ESQL_IN_DATAFEEDS = def(8_612_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlConfigIndex.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlConfigIndex.java
@@ -20,7 +20,7 @@ public final class MlConfigIndex {
     private static final String MAPPINGS_VERSION_VARIABLE = "xpack.ml.version";
 
     public static final int CONFIG_INDEX_MAX_RESULTS_WINDOW = 10_000;
-    public static final int CONFIG_INDEX_MAPPINGS_VERSION = 1;
+    public static final int CONFIG_INDEX_MAPPINGS_VERSION = 2;
 
     /**
      * The name of the index where job, datafeed and analytics configuration is stored

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -30,7 +30,7 @@ public final class Messages {
         "delayed_data_check_config: check_window [{0}] must be less than 10,000x the bucket_span [{1}]";
     public static final String DATAFEED_CONFIG_QUERY_BAD_FORMAT = "Datafeed query is not parsable";
     public static final String DATAFEED_CONFIG_AGG_BAD_FORMAT = "Datafeed aggregations are not parsable";
-
+    public static final String DATAFEED_CONFIG_INCOMPATIBLE_WITH_ESQL = "[{0}] and [esql] are incompatible";
     public static final String DATAFEED_DOES_NOT_SUPPORT_JOB_WITH_LATENCY = "A job configured with datafeed cannot support latency";
     public static final String DATAFEED_NOT_FOUND = "No datafeed with id [{0}] exists";
     public static final String DATAFEED_AGGREGATIONS_REQUIRES_DATE_HISTOGRAM = "A date_histogram (or histogram) aggregation is required";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/messages/Messages.java
@@ -31,6 +31,7 @@ public final class Messages {
     public static final String DATAFEED_CONFIG_QUERY_BAD_FORMAT = "Datafeed query is not parsable";
     public static final String DATAFEED_CONFIG_AGG_BAD_FORMAT = "Datafeed aggregations are not parsable";
     public static final String DATAFEED_CONFIG_INCOMPATIBLE_WITH_ESQL = "[{0}] and [esql] are incompatible";
+    public static final String DATAFEED_CONFIG_ESQL_UNAVAILABLE = "[esql] not available on all nodes";
     public static final String DATAFEED_DOES_NOT_SUPPORT_JOB_WITH_LATENCY = "A job configured with datafeed cannot support latency";
     public static final String DATAFEED_NOT_FOUND = "No datafeed with id [{0}] exists";
     public static final String DATAFEED_AGGREGATIONS_REQUIRES_DATE_HISTOGRAM = "A date_histogram (or histogram) aggregation is required";

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/config_index_mappings.json
@@ -376,6 +376,9 @@
           }
         }
       },
+      "esql_query": {
+        "type": "keyword"
+      },
       "finished_time" : {
         "type" : "date"
       },

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -79,7 +79,6 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   compileOnly project(path: xpackModule('autoscaling'))
   compileOnly project(path: xpackModule('ml-package-loader'))
-  compileOnly project(path: xpackModule('ql'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(path: xpackModule('ilm'))
   testImplementation project(path: xpackModule('shutdown'))

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -79,6 +79,7 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   compileOnly project(path: xpackModule('autoscaling'))
   compileOnly project(path: xpackModule('ml-package-loader'))
+  compileOnly project(path: xpackModule('ql'))
   testImplementation(testArtifact(project(xpackModule('core'))))
   testImplementation project(path: xpackModule('ilm'))
   testImplementation project(path: xpackModule('shutdown'))

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedManager.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.datafeed;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -61,6 +62,7 @@ import java.util.stream.Collectors;
 import static java.util.function.Predicate.not;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+import static org.elasticsearch.xpack.core.ml.job.messages.Messages.DATAFEED_CONFIG_ESQL_UNAVAILABLE;
 import static org.elasticsearch.xpack.ml.utils.SecondaryAuthorizationUtils.useSecondaryAuthIfAvailable;
 
 /**
@@ -305,6 +307,11 @@ public final class DatafeedManager {
         ClusterState clusterState,
         ActionListener<PutDatafeedAction.Response> listener
     ) {
+        if (clusterState.getMinTransportVersion().before(TransportVersions.ESQL_IN_DATAFEEDS)
+            && request.getDatafeed().getEsqlQuery() != null) {
+            listener.onFailure(ExceptionsHelper.badRequestException(DATAFEED_CONFIG_ESQL_UNAVAILABLE));
+        }
+
         DatafeedConfig.validateAggregations(request.getDatafeed().getParsedAggregations(xContentRegistry));
 
         CheckedConsumer<Boolean, Exception> mappingsUpdated = ok -> datafeedConfigProvider.putDatafeedConfig(
@@ -313,22 +320,15 @@ public final class DatafeedManager {
             listener.delegateFailureAndWrap((l, response) -> l.onResponse(new PutDatafeedAction.Response(response.v1())))
         );
 
-        CheckedConsumer<Boolean, Exception> validationOk = ok -> {
-            if (clusterState == null) {
-                logger.warn("Cannot update doc mapping because clusterState == null");
-                mappingsUpdated.accept(false);
-                return;
-            }
-            ElasticsearchMappings.addDocMappingIfMissing(
-                MlConfigIndex.indexName(),
-                MlConfigIndex::mapping,
-                client,
-                clusterState,
-                request.masterNodeTimeout(),
-                ActionListener.wrap(mappingsUpdated, listener::onFailure),
-                MlConfigIndex.CONFIG_INDEX_MAPPINGS_VERSION
-            );
-        };
+        CheckedConsumer<Boolean, Exception> validationOk = ok -> ElasticsearchMappings.addDocMappingIfMissing(
+            MlConfigIndex.indexName(),
+            MlConfigIndex::mapping,
+            client,
+            clusterState,
+            request.masterNodeTimeout(),
+            ActionListener.wrap(mappingsUpdated, listener::onFailure),
+            MlConfigIndex.CONFIG_INDEX_MAPPINGS_VERSION
+        );
 
         CheckedConsumer<Boolean, Exception> jobOk = ok -> jobConfigProvider.validateDatafeedJob(
             request.getDatafeed(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/delayeddatacheck/DatafeedDelayedDataDetector.java
@@ -93,6 +93,12 @@ public class DatafeedDelayedDataDetector implements DelayedDataDetector {
             return Collections.emptyList();
         }
 
+        if (datafeedQuery == null) {
+            // In case of an ES|QL datafeed, the query is null and this will fail.
+            // TODO: implement DatafeedDelayedDataDetector for ES|QL datafeeds.
+            return Collections.emptyList();
+        }
+
         List<Bucket> finalizedBuckets = checkBucketEvents(start, end);
         Map<Long, Long> indexedData = checkCurrentBucketEventCount(start, end);
         return finalizedBuckets.stream()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactory.java
@@ -71,7 +71,7 @@ public interface DataExtractorFactory {
 
         ActionListener<GetRollupIndexCapsAction.Response> getRollupIndexCapsActionHandler = ActionListener.wrap(response -> {
             if (hasEsqlQuery) {
-                EsqlDataExtractorFactory.create(datafeed, factoryHandler);
+                EsqlDataExtractorFactory.create(client, datafeed, job.getDataDescription().getTimeField(), factoryHandler);
                 return;
             }
             final boolean hasRollup = response.getJobs().isEmpty() == false;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactory.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xpack.ml.datafeed.extractor.aggregation.AggregationData
 import org.elasticsearch.xpack.ml.datafeed.extractor.aggregation.CompositeAggregationDataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.extractor.aggregation.RollupDataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.extractor.chunked.ChunkedDataExtractorFactory;
+import org.elasticsearch.xpack.ml.datafeed.extractor.esql.EsqlDataExtractorFactory;
 import org.elasticsearch.xpack.ml.datafeed.extractor.scroll.ScrollDataExtractorFactory;
 
 public interface DataExtractorFactory {
@@ -59,6 +60,7 @@ public interface DataExtractorFactory {
     ) {
         final boolean hasAggs = datafeed.hasAggregations();
         final boolean isComposite = hasAggs && datafeed.hasCompositeAgg(xContentRegistry);
+        final boolean hasEsqlQuery = datafeed.getEsqlQuery() != null;
         ActionListener<DataExtractorFactory> factoryHandler = listener.delegateFailureAndWrap(
             (l, factory) -> l.onResponse(
                 datafeed.getChunkingConfig().isEnabled()
@@ -68,6 +70,10 @@ public interface DataExtractorFactory {
         );
 
         ActionListener<GetRollupIndexCapsAction.Response> getRollupIndexCapsActionHandler = ActionListener.wrap(response -> {
+            if (hasEsqlQuery) {
+                EsqlDataExtractorFactory.create(datafeed, factoryHandler);
+                return;
+            }
             final boolean hasRollup = response.getJobs().isEmpty() == false;
             if (hasRollup && hasAggs == false) {
                 listener.onFailure(new IllegalArgumentException("Aggregations are required when using Rollup indices"));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.datafeed.extractor.esql;
+
+import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractor;
+
+import java.io.IOException;
+
+public class EsqlDataExtractor implements DataExtractor {
+
+    @Override
+    public DataSummary getSummary() {
+        return null;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return false;
+    }
+
+    @Override
+    public Result next() throws IOException {
+        return null;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public void cancel() {
+
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+
+    @Override
+    public long getEndTime() {
+        return 0;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractor.java
@@ -105,7 +105,6 @@ public class EsqlDataExtractor implements DataExtractor {
             XContentBuilder jsonBuilder = new XContentBuilder(JsonXContent.jsonXContent, outputStream);
 
             List<? extends ColumnInfo> columns = response.response().columns();
-            int valueCount = 0;
             for (Iterable<Object> row : response.response().rows()) {
                 jsonBuilder.startObject();
                 int index = 0;
@@ -120,17 +119,8 @@ public class EsqlDataExtractor implements DataExtractor {
                     index++;
                 }
                 jsonBuilder.endObject();
-                valueCount++;
             }
             jsonBuilder.close();
-
-            logger.info(
-                "query interval: {} - {}, valueCount: {}",
-                DATE_TIME_FORMATTER.formatMillis(interval.startMs()),
-                DATE_TIME_FORMATTER.formatMillis(interval.endMs()),
-                valueCount
-            );
-
             return new Result(interval, Optional.of(outputStream.bytes().streamInput()));
         }
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractor.java
@@ -7,15 +7,86 @@
 
 package org.elasticsearch.xpack.ml.datafeed.extractor.esql;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.ClientHelper;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.core.ml.datafeed.SearchInterval;
+import org.elasticsearch.xpack.esql.action.ColumnInfo;
+import org.elasticsearch.xpack.esql.action.EsqlQueryAction;
+import org.elasticsearch.xpack.esql.action.EsqlQueryRequest;
+import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractor;
+import org.elasticsearch.xpack.ql.util.DateUtils;
 
 import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 public class EsqlDataExtractor implements DataExtractor {
 
+    private static final Logger logger = LogManager.getLogger(EsqlDataExtractor.class);
+
+    private final Client client;
+    private final DatafeedConfig datafeed;
+    private final String timeField;
+    private final SearchInterval interval;
+    private boolean isCancelled;
+
+    EsqlDataExtractor(Client client, DatafeedConfig datafeed, String timeField, long start, long end) {
+        this.client = Objects.requireNonNull(client);
+        this.datafeed = Objects.requireNonNull(datafeed);
+        this.timeField = timeField;
+        this.interval = new SearchInterval(start, end);
+        this.isCancelled = false;
+    }
+
+    // TODO: check whether these expressions facilitate injection attacks!
+    private String esqlTimeFilter() {
+        return Strings.format(
+            " | WHERE %s >= \"%s\" AND %s < \"%s\"",
+            timeField,
+            DateUtils.UTC_DATE_TIME_FORMATTER.formatMillis(
+                Math.min(interval.startMs(), org.elasticsearch.common.time.DateUtils.MAX_MILLIS_BEFORE_9999)
+            ),
+            timeField,
+            DateUtils.UTC_DATE_TIME_FORMATTER.formatMillis(
+                Math.min(interval.endMs(), org.elasticsearch.common.time.DateUtils.MAX_MILLIS_BEFORE_9999)
+            )
+        );
+    }
+
+    private String esqlSortByTime() {
+        return Strings.format(" | SORT %s", timeField);
+    }
+
+    private String esqlSummaryStats() {
+        return Strings.format(" | STATS earliest_time=MIN(%s), latest_time=MAX(%s), total_hits=COUNT(*)", timeField, timeField);
+    }
+
     @Override
     public DataSummary getSummary() {
-        return null;
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query(datafeed.getEsqlQuery() + esqlTimeFilter() + esqlSummaryStats());
+
+        try (EsqlQueryResponse response = execute(request)) {
+            Iterator<Object> values = response.values().next();
+            String earliestTime = (String) values.next();
+            String latestTime = (String) values.next();
+            long totalHits = (long) values.next();
+            return new DataSummary(
+                earliestTime == null ? null : DateUtils.UTC_DATE_TIME_FORMATTER.parseMillis(earliestTime),
+                latestTime == null ? null : DateUtils.UTC_DATE_TIME_FORMATTER.parseMillis(latestTime),
+                totalHits
+            );
+        }
     }
 
     @Override
@@ -25,26 +96,71 @@ public class EsqlDataExtractor implements DataExtractor {
 
     @Override
     public Result next() throws IOException {
-        return null;
+        EsqlQueryRequest request = new EsqlQueryRequest();
+        request.query(datafeed.getEsqlQuery() + esqlTimeFilter() + esqlSortByTime());
+
+        EsqlQueryResponse response = execute(request);
+
+        try (BytesStreamOutput outputStream = new BytesStreamOutput()) {
+            XContentBuilder jsonBuilder = new XContentBuilder(JsonXContent.jsonXContent, outputStream);
+
+            List<ColumnInfo> columns = response.columns();
+            int valueCount = 0;
+            for (Iterator<Iterator<Object>> itValues = response.values(); itValues.hasNext();) {
+                jsonBuilder.startObject();
+                int index = 0;
+                for (Iterator<Object> itValue = itValues.next(); itValue.hasNext();) {
+                    Object value = itValue.next();
+                    if ("date".equals(columns.get(index).type())) {
+                        if (value instanceof String && Strings.isNullOrEmpty((String) value) == false) {
+                            value = DateUtils.UTC_DATE_TIME_FORMATTER.parseMillis((String) value);
+                        }
+                        // TODO: something with arrays of dates? (e.g. kibana_sample_data_ecommerce -> products.created_on)
+                    }
+                    jsonBuilder.field(columns.get(index).name(), value);
+                    index++;
+                }
+                jsonBuilder.endObject();
+                valueCount++;
+            }
+            jsonBuilder.close();
+
+            logger.info(
+                "query interval: {} - {}, valueCount: {}",
+                DateUtils.UTC_DATE_TIME_FORMATTER.formatMillis(interval.startMs()),
+                DateUtils.UTC_DATE_TIME_FORMATTER.formatMillis(interval.endMs()),
+                valueCount
+            );
+
+            return new Result(interval, Optional.of(outputStream.bytes().streamInput()));
+        }
     }
 
     @Override
     public boolean isCancelled() {
-        return false;
+        return isCancelled;
     }
 
     @Override
     public void cancel() {
-
+        logger.trace("Data extractor received cancel request");
+        isCancelled = true;
     }
 
     @Override
-    public void destroy() {
-
-    }
+    public void destroy() {}
 
     @Override
     public long getEndTime() {
-        return 0;
+        return interval.endMs();
+    }
+
+    private EsqlQueryResponse execute(EsqlQueryRequest request) {
+        return ClientHelper.executeWithHeaders(
+            datafeed.getHeaders(),
+            ClientHelper.ML_ORIGIN,
+            client,
+            () -> client.execute(EsqlQueryAction.INSTANCE, request).actionGet()
+        );
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractorFactory.java
@@ -8,21 +8,37 @@
 package org.elasticsearch.xpack.ml.datafeed.extractor.esql;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractor;
 import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
-//
-//import java.time.ZoneOffset;
-//import java.util.List;
-//import java.util.Locale;
+
+import java.util.Objects;
 
 public class EsqlDataExtractorFactory implements DataExtractorFactory {
 
-    public static void create(DatafeedConfig datafeed, ActionListener<DataExtractorFactory> factoryHandler) {
+    private final Client client;
+    private final DatafeedConfig datafeed;
+    private final String timeField;
+
+    private EsqlDataExtractorFactory(Client client, DatafeedConfig datafeed, String timeField) {
+        this.client = Objects.requireNonNull(client);
+        this.datafeed = Objects.requireNonNull(datafeed);
+        this.timeField = timeField;
+    }
+
+    public static void create(
+        Client client,
+        DatafeedConfig datafeed,
+        String timeField,
+        ActionListener<DataExtractorFactory> factoryHandler
+    ) {
+        DataExtractorFactory factory = new EsqlDataExtractorFactory(client, datafeed, timeField);
+        factoryHandler.onResponse(factory);
     }
 
     @Override
     public DataExtractor newExtractor(long start, long end) {
-        return null;
+        return new EsqlDataExtractor(client, datafeed, timeField, start, end);
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractorFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/extractor/esql/EsqlDataExtractorFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.datafeed.extractor.esql;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.xpack.core.ml.datafeed.DatafeedConfig;
+import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractor;
+import org.elasticsearch.xpack.ml.datafeed.extractor.DataExtractorFactory;
+//
+//import java.time.ZoneOffset;
+//import java.util.List;
+//import java.util.Locale;
+
+public class EsqlDataExtractorFactory implements DataExtractorFactory {
+
+    public static void create(DatafeedConfig datafeed, ActionListener<DataExtractorFactory> factoryHandler) {
+    }
+
+    @Override
+    public DataExtractor newExtractor(long start, long end) {
+        return null;
+    }
+}


### PR DESCRIPTION
Proof of concept for the EsqlDataExtractor. This works end-to-end for datafeeds with and without aggregations.
This is the next iteration of #105337. This version calls the ES|QL cleanly.

Note that just one EsqlDataExtractor can handle both aggregated and non-aggregated data, contrary to the multiple implementations for the Query DSL data extractors.

One caveat: at the moment you have to manually set the chunking config / scroll size, to work around the ES|QL shortcoming of only returning a max number of results and providing no scroll functionality. (Alternatively, we should tweak our chunking in case the max number of results is hit.)

Example usage of ES|QL with and without aggregations and Query DSL for comparison (all four data extractors give the same anomaly detection results):

```
PUT _ml/anomaly_detectors/query-dsl-job
{
  "analysis_config": {
    "bucket_span": "1h",
    "detectors": [
      {
        "detector_description": "Total sales",
        "function": "sum",
        "field_name": "taxful_total_price"
      }
    ]
  },
  "data_description": {
    "time_field": "order_date"
  },
  "results_index_name": "query-dsl-job-output",
  "datafeed_config": {
    "indices": [
      "kibana_sample_data_ecommerce"
    ]
  }
}

PUT _ml/anomaly_detectors/esql-job
{
  "analysis_config": {
    "bucket_span": "1h",
    "detectors": [
      {
        "detector_description": "Total sales",
        "function": "sum",
        "field_name": "taxful_total_price"
      }
    ]
  },
  "data_description": {
    "time_field": "order_date"
  },
  "results_index_name": "esql-job-output",
  "datafeed_config": {
    "esql_query": """
      FROM kibana_sample_data_ecommerce | KEEP order_date, taxful_total_price
    """,
    "chunking_config": {
      "mode": "manual",
      "time_span": "1d"
    }
  }
}

PUT /_ml/anomaly_detectors/query-dsl-aggs-job
{
  "analysis_config": {
    "bucket_span": "1h",
    "summary_count_field_name": "doc_count",
    "detectors": [
      {
        "detector_description": "Total sales",
        "function": "sum",
        "field_name": "taxful_total_price"
      }
    ]
  },
  "data_description": {
    "time_field": "order_date"
  },
  "results_index_name": "query-dsl-aggs-job-output",
  "datafeed_config": {
    "indices": [
      "kibana_sample_data_ecommerce"
    ],
    "aggs": {
      "buckets": {
        "date_histogram": {
          "field": "order_date",
          "fixed_interval": "10m",
          "time_zone": "UTC"
        },
        "aggregations": {
          "order_date": {  
            "max": {"field": "order_date"}
          },
          "taxful_total_price": {  
            "sum": {
              "field": "taxful_total_price"
            }
          }
        }
      }   
    }
  }
}

PUT _ml/anomaly_detectors/esql-aggs-job
{
  "analysis_config": {
    "bucket_span": "1h",
    "summary_count_field_name": "doc_count",
    "detectors": [
      {
        "detector_description": "Total sales",
        "function": "sum",
        "field_name": "taxful_total_price"
      }
    ]
  },
  "data_description": {
    "time_field": "order_date"
  },
  "results_index_name": "esql-job-aggs-output",
  "datafeed_config": {
    "esql_query": """
      FROM kibana_sample_data_ecommerce
      | EVAL bucket = DATE_TRUNC(10 minute, order_date)
      | STATS order_date = MAX(order_date), taxful_total_price = SUM(taxful_total_price), doc_count = COUNT(*) BY bucket
    """,
    "chunking_config": {
      "mode": "manual",
      "time_span": "1d"
    }
  }
}
```