### PR TITLE
Refactor GetApiKeyResponse and QueryApiKeyResponse to return List instead of arrays

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/GetApiKeyResponse.java
@@ -31,21 +31,21 @@ public final class GetApiKeyResponse extends ActionResponse implements ToXConten
 
     public static final GetApiKeyResponse EMPTY = new GetApiKeyResponse(List.of());
 
-    private final List<Item> foundApiKeysInfo;
+    private final List<Item> foundApiKeyInfoList;
 
-    public GetApiKeyResponse(Collection<ApiKey> foundApiKeysInfo) {
-        Objects.requireNonNull(foundApiKeysInfo, "found_api_keys_info must be provided");
-        this.foundApiKeysInfo = foundApiKeysInfo.stream().map(Item::new).toList();
+    public GetApiKeyResponse(Collection<ApiKey> foundApiKeyInfos) {
+        Objects.requireNonNull(foundApiKeyInfos, "found_api_keys_info must be provided");
+        this.foundApiKeyInfoList = foundApiKeyInfos.stream().map(Item::new).toList();
     }
 
-    public List<Item> getApiKeyInfos() {
-        return foundApiKeysInfo;
+    public List<Item> getApiKeyInfoList() {
+        return foundApiKeyInfoList;
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("api_keys", foundApiKeysInfo);
+        builder.field("api_keys", foundApiKeyInfoList);
         builder.endObject();
         return builder;
     }
@@ -56,8 +56,21 @@ public final class GetApiKeyResponse extends ActionResponse implements ToXConten
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GetApiKeyResponse that = (GetApiKeyResponse) o;
+        return Objects.equals(foundApiKeyInfoList, that.foundApiKeyInfoList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(foundApiKeyInfoList);
+    }
+
+    @Override
     public String toString() {
-        return "GetApiKeyResponse [foundApiKeysInfo=" + foundApiKeysInfo + "]";
+        return "GetApiKeyResponse{foundApiKeysInfo=" + foundApiKeyInfoList + "}";
     }
 
     public record Item(ApiKey apiKeyInfo) implements ToXContentObject {
@@ -71,7 +84,7 @@ public final class GetApiKeyResponse extends ActionResponse implements ToXConten
 
         @Override
         public String toString() {
-            return "Item [apiKeyInfo=" + apiKeyInfo + "]";
+            return "Item{apiKeyInfo=" + apiKeyInfo + "}";
         }
     }
 

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
@@ -1824,9 +1824,12 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
         assertOK(response);
         try (XContentParser parser = responseAsParser(response)) {
             final var apiKeyResponse = GetApiKeyResponse.fromXContent(parser);
-            assertThat(apiKeyResponse.getApiKeyInfos().length, equalTo(1));
+            assertThat(apiKeyResponse.getApiKeyInfos().size(), equalTo(1));
             // ApiKey metadata is set to empty Map if null
-            assertThat(apiKeyResponse.getApiKeyInfos()[0].getMetadata(), equalTo(expectedMetadata == null ? Map.of() : expectedMetadata));
+            assertThat(
+                apiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getMetadata(),
+                equalTo(expectedMetadata == null ? Map.of() : expectedMetadata)
+            );
         }
     }
 

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/ApiKeyRestIT.java
@@ -1824,10 +1824,10 @@ public class ApiKeyRestIT extends SecurityOnTrialLicenseRestTestCase {
         assertOK(response);
         try (XContentParser parser = responseAsParser(response)) {
             final var apiKeyResponse = GetApiKeyResponse.fromXContent(parser);
-            assertThat(apiKeyResponse.getApiKeyInfos().size(), equalTo(1));
+            assertThat(apiKeyResponse.getApiKeyInfoList().size(), equalTo(1));
             // ApiKey metadata is set to empty Map if null
             assertThat(
-                apiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getMetadata(),
+                apiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getMetadata(),
                 equalTo(expectedMetadata == null ? Map.of() : expectedMetadata)
             );
         }

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/GetApiKeysRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/GetApiKeysRestIT.java
@@ -27,18 +27,17 @@ import org.elasticsearch.xpack.security.SecurityOnTrialLicenseRestTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -103,7 +102,7 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
 
         // We get an empty result when no API keys active
         getSecurityClient().invalidateApiKeys(apiKeyId1);
-        assertThat(getApiKeysWithRequestParams(Map.of("active_only", "true")).getApiKeyInfos(), emptyArray());
+        assertThat(getApiKeysWithRequestParams(Map.of("active_only", "true")).getApiKeyInfos(), emptyIterable());
 
         {
             // Using together with id parameter, returns 404 for inactive key
@@ -167,11 +166,11 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
         );
         assertThat(
             getApiKeysWithRequestParams(Map.of("active_only", "true", "username", MANAGE_OWN_API_KEY_USER)).getApiKeyInfos(),
-            emptyArray()
+            emptyIterable()
         );
         assertThat(
             getApiKeysWithRequestParams(MANAGE_OWN_API_KEY_USER, Map.of("active_only", "true", "owner", "true")).getApiKeyInfos(),
-            emptyArray()
+            emptyIterable()
         );
 
         // No more active API keys
@@ -181,14 +180,14 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
             getApiKeysWithRequestParams(
                 Map.of("active_only", "true", "username", randomFrom(MANAGE_SECURITY_USER, MANAGE_OWN_API_KEY_USER))
             ).getApiKeyInfos(),
-            emptyArray()
+            emptyIterable()
         );
         assertThat(
             getApiKeysWithRequestParams(
                 randomFrom(MANAGE_SECURITY_USER, MANAGE_OWN_API_KEY_USER),
                 Map.of("active_only", "true", "owner", "true")
             ).getApiKeyInfos(),
-            emptyArray()
+            emptyIterable()
         );
         // With flag set to false, we get both inactive keys
         assertResponseContainsApiKeyIds(
@@ -205,8 +204,8 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
         setUserForRequest(request, MANAGE_SECURITY_USER);
         GetApiKeyResponse getApiKeyResponse = GetApiKeyResponse.fromXContent(getParser(client().performRequest(request)));
 
-        assertThat(getApiKeyResponse.getApiKeyInfos().length, equalTo(1));
-        ApiKey apiKey = getApiKeyResponse.getApiKeyInfos()[0];
+        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
+        ApiKey apiKey = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
         assertThat(apiKey.isInvalidated(), equalTo(false));
         assertThat(apiKey.getInvalidation(), nullValue());
         assertThat(apiKey.getId(), equalTo(apiKeyId0));
@@ -226,8 +225,8 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
         setUserForRequest(request, MANAGE_SECURITY_USER);
         getApiKeyResponse = GetApiKeyResponse.fromXContent(getParser(client().performRequest(request)));
 
-        assertThat(getApiKeyResponse.getApiKeyInfos().length, equalTo(1));
-        apiKey = getApiKeyResponse.getApiKeyInfos()[0];
+        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
+        apiKey = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
         assertThat(apiKey.isInvalidated(), equalTo(true));
         assertThat(apiKey.getInvalidation(), notNullValue());
         assertThat(apiKey.getId(), equalTo(apiKeyId0));
@@ -245,7 +244,10 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
     }
 
     private static void assertResponseContainsApiKeyIds(GetApiKeyResponse response, String... ids) {
-        assertThat(Arrays.stream(response.getApiKeyInfos()).map(ApiKey::getId).collect(Collectors.toList()), containsInAnyOrder(ids));
+        assertThat(
+            response.getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).map(ApiKey::getId).toList(),
+            containsInAnyOrder(ids)
+        );
     }
 
     private static XContentParser getParser(Response response) throws IOException {

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/GetApiKeysRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/apikey/GetApiKeysRestIT.java
@@ -102,7 +102,7 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
 
         // We get an empty result when no API keys active
         getSecurityClient().invalidateApiKeys(apiKeyId1);
-        assertThat(getApiKeysWithRequestParams(Map.of("active_only", "true")).getApiKeyInfos(), emptyIterable());
+        assertThat(getApiKeysWithRequestParams(Map.of("active_only", "true")).getApiKeyInfoList(), emptyIterable());
 
         {
             // Using together with id parameter, returns 404 for inactive key
@@ -165,11 +165,11 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
             manageApiKeyUserApiKeyId
         );
         assertThat(
-            getApiKeysWithRequestParams(Map.of("active_only", "true", "username", MANAGE_OWN_API_KEY_USER)).getApiKeyInfos(),
+            getApiKeysWithRequestParams(Map.of("active_only", "true", "username", MANAGE_OWN_API_KEY_USER)).getApiKeyInfoList(),
             emptyIterable()
         );
         assertThat(
-            getApiKeysWithRequestParams(MANAGE_OWN_API_KEY_USER, Map.of("active_only", "true", "owner", "true")).getApiKeyInfos(),
+            getApiKeysWithRequestParams(MANAGE_OWN_API_KEY_USER, Map.of("active_only", "true", "owner", "true")).getApiKeyInfoList(),
             emptyIterable()
         );
 
@@ -179,14 +179,14 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
         assertThat(
             getApiKeysWithRequestParams(
                 Map.of("active_only", "true", "username", randomFrom(MANAGE_SECURITY_USER, MANAGE_OWN_API_KEY_USER))
-            ).getApiKeyInfos(),
+            ).getApiKeyInfoList(),
             emptyIterable()
         );
         assertThat(
             getApiKeysWithRequestParams(
                 randomFrom(MANAGE_SECURITY_USER, MANAGE_OWN_API_KEY_USER),
                 Map.of("active_only", "true", "owner", "true")
-            ).getApiKeyInfos(),
+            ).getApiKeyInfoList(),
             emptyIterable()
         );
         // With flag set to false, we get both inactive keys
@@ -204,8 +204,8 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
         setUserForRequest(request, MANAGE_SECURITY_USER);
         GetApiKeyResponse getApiKeyResponse = GetApiKeyResponse.fromXContent(getParser(client().performRequest(request)));
 
-        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
-        ApiKey apiKey = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
+        assertThat(getApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        ApiKey apiKey = getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         assertThat(apiKey.isInvalidated(), equalTo(false));
         assertThat(apiKey.getInvalidation(), nullValue());
         assertThat(apiKey.getId(), equalTo(apiKeyId0));
@@ -225,8 +225,8 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
         setUserForRequest(request, MANAGE_SECURITY_USER);
         getApiKeyResponse = GetApiKeyResponse.fromXContent(getParser(client().performRequest(request)));
 
-        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
-        apiKey = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
+        assertThat(getApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        apiKey = getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         assertThat(apiKey.isInvalidated(), equalTo(true));
         assertThat(apiKey.getInvalidation(), notNullValue());
         assertThat(apiKey.getId(), equalTo(apiKeyId0));
@@ -245,7 +245,7 @@ public class GetApiKeysRestIT extends SecurityOnTrialLicenseRestTestCase {
 
     private static void assertResponseContainsApiKeyIds(GetApiKeyResponse response, String... ids) {
         assertThat(
-            response.getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).map(ApiKey::getId).toList(),
+            response.getApiKeyInfoList().stream().map(GetApiKeyResponse.Item::apiKeyInfo).map(ApiKey::getId).toList(),
             containsInAnyOrder(ids)
         );
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -137,7 +137,6 @@ import static org.elasticsearch.xpack.security.Security.SECURITY_CRYPTO_THREAD_P
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_ALIAS;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -589,7 +588,11 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         // The first API key with 1ms expiration should already be deleted
         Set<String> expectedKeyIds = Sets.newHashSet(nonExpiringKey.getId(), createdApiKeys.get(0).getId(), createdApiKeys.get(1).getId());
         boolean apiKeyInvalidatedButNotYetDeletedByExpiredApiKeysRemover = false;
-        for (ApiKey apiKey : getApiKeyResponseListener.get().getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList()) {
+        for (ApiKey apiKey : getApiKeyResponseListener.get()
+            .getApiKeyInfoList()
+            .stream()
+            .map(GetApiKeyResponse.Item::apiKeyInfo)
+            .toList()) {
             assertThat(apiKey.getId(), is(in(expectedKeyIds)));
             if (apiKey.getId().equals(nonExpiringKey.getId())) {
                 assertThat(apiKey.isInvalidated(), is(false));
@@ -604,7 +607,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             }
         }
         assertThat(
-            getApiKeyResponseListener.get().getApiKeyInfos().size(),
+            getApiKeyResponseListener.get().getApiKeyInfoList().size(),
             is((apiKeyInvalidatedButNotYetDeletedByExpiredApiKeysRemover) ? 3 : 2)
         );
 
@@ -634,7 +637,11 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         );
         expectedKeyIds = Sets.newHashSet(nonExpiringKey.getId(), createdApiKeys.get(1).getId());
         apiKeyInvalidatedButNotYetDeletedByExpiredApiKeysRemover = false;
-        for (ApiKey apiKey : getApiKeyResponseListener.get().getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList()) {
+        for (ApiKey apiKey : getApiKeyResponseListener.get()
+            .getApiKeyInfoList()
+            .stream()
+            .map(GetApiKeyResponse.Item::apiKeyInfo)
+            .toList()) {
             assertThat(apiKey.getId(), is(in(expectedKeyIds)));
             if (apiKey.getId().equals(nonExpiringKey.getId())) {
                 assertThat(apiKey.isInvalidated(), is(false));
@@ -646,7 +653,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             }
         }
         assertThat(
-            getApiKeyResponseListener.get().getApiKeyInfos().size(),
+            getApiKeyResponseListener.get().getApiKeyInfoList().size(),
             is((apiKeyInvalidatedButNotYetDeletedByExpiredApiKeysRemover) ? 2 : 1)
         );
     }
@@ -685,7 +692,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             GetApiKeyRequest.builder().apiKeyName(namePrefix + "*").build(),
             getApiKeyResponseListener
         );
-        assertThat(getApiKeyResponseListener.get().getApiKeyInfos().size(), is(noOfKeys));
+        assertThat(getApiKeyResponseListener.get().getApiKeyInfoList().size(), is(noOfKeys));
 
         // Expire the 1st key such that it cannot be deleted by the remover
         // hack doc to modify the expiration time
@@ -784,7 +791,11 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             createdApiKeys.get(7).getId(),
             createdApiKeys.get(8).getId()
         );
-        for (ApiKey apiKey : getApiKeyResponseListener.get().getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList()) {
+        for (ApiKey apiKey : getApiKeyResponseListener.get()
+            .getApiKeyInfoList()
+            .stream()
+            .map(GetApiKeyResponse.Item::apiKeyInfo)
+            .toList()) {
             assertThat(apiKey.getId(), is(in(expectedKeyIds)));
             if (apiKey.getId().equals(createdApiKeys.get(0).getId())) {
                 // has been expired, not invalidated
@@ -806,7 +817,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
                 fail("unexpected API key " + apiKey);
             }
         }
-        assertThat(getApiKeyResponseListener.get().getApiKeyInfos().size(), is(4));
+        assertThat(getApiKeyResponseListener.get().getApiKeyInfoList().size(), is(4));
     }
 
     private void refreshSecurityIndex() throws Exception {
@@ -843,7 +854,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple.v2(),
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            response.getApiKeyInfos(),
+            response.getApiKeyInfoList(),
             Collections.singleton(responses.get(0).getId()),
             Collections.singletonList(responses.get(1).getId())
         );
@@ -889,7 +900,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple.v2(),
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            response.getApiKeyInfos(),
+            response.getApiKeyInfoList(),
             expectedValidKeyIds,
             invalidatedApiKeyIds
         );
@@ -914,7 +925,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple.v2(),
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            response.getApiKeyInfos(),
+            response.getApiKeyInfoList(),
             responses.stream().map(o -> o.getId()).collect(Collectors.toSet()),
             null
         );
@@ -938,7 +949,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple.v2(),
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            response.getApiKeyInfos(),
+            response.getApiKeyInfoList(),
             Collections.singleton(responses.get(0).getId()),
             null
         );
@@ -962,7 +973,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple.v2(),
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            response.getApiKeyInfos(),
+            response.getApiKeyInfoList(),
             Collections.singleton(responses.get(0).getId()),
             null
         );
@@ -1004,7 +1015,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             metadatas,
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            listener.get().getApiKeyInfos(),
+            listener.get().getApiKeyInfoList(),
             Collections.singleton(responses.get(0).getId()),
             null
         );
@@ -1021,7 +1032,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple1.v2(),
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            listener2.get().getApiKeyInfos(),
+            listener2.get().getApiKeyInfoList(),
             createApiKeyResponses1.stream().map(CreateApiKeyResponse::getId).collect(Collectors.toSet()),
             null
         );
@@ -1044,7 +1055,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             metadatas,
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            listener3.get().getApiKeyInfos(),
+            listener3.get().getApiKeyInfoList(),
             responses.stream().map(CreateApiKeyResponse::getId).collect(Collectors.toSet()),
             null
         );
@@ -1061,7 +1072,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             null,
             List.of(),
             List.of(),
-            listener4.get().getApiKeyInfos(),
+            listener4.get().getApiKeyInfoList(),
             Collections.emptySet(),
             null
         );
@@ -1078,7 +1089,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple2.v2(),
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             withLimitedBy ? List.of(ES_TEST_ROOT_ROLE_DESCRIPTOR) : null,
-            listener5.get().getApiKeyInfos(),
+            listener5.get().getApiKeyInfoList(),
             createApiKeyResponses2.stream().map(CreateApiKeyResponse::getId).collect(Collectors.toSet()),
             null
         );
@@ -1129,7 +1140,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple.v2(),
             List.of(DEFAULT_API_KEY_ROLE_DESCRIPTOR),
             expectedLimitedByRoleDescriptors,
-            listener.get().getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(),
+            listener.get().getApiKeyInfoList().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(),
             userWithManageApiKeyRoleApiKeys.stream().map(o -> o.getId()).collect(Collectors.toSet()),
             null
         );
@@ -1164,7 +1175,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             withLimitedBy
                 ? List.of(new RoleDescriptor("manage_own_api_key_role", new String[] { "manage_own_api_key" }, null, null))
                 : null,
-            listener.get().getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(),
+            listener.get().getApiKeyInfoList().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(),
             userWithManageOwnApiKeyRoleApiKeys.stream().map(o -> o.getId()).collect(Collectors.toSet()),
             null
         );
@@ -1199,7 +1210,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             withLimitedBy
                 ? List.of(new RoleDescriptor("manage_own_api_key_role", new String[] { "manage_own_api_key" }, null, null))
                 : null,
-            listener.get().getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(),
+            listener.get().getApiKeyInfoList().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(),
             userWithManageOwnApiKeyRoleApiKeys.stream().map(o -> o.getId()).collect(Collectors.toSet()),
             null
         );
@@ -1449,7 +1460,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             tuple.v2(),
             List.of(new RoleDescriptor(DEFAULT_API_KEY_ROLE_DESCRIPTOR.getName(), Strings.EMPTY_ARRAY, null, null)),
             null,
-            response.getApiKeyInfos(),
+            response.getApiKeyInfoList(),
             Collections.singleton(responses.get(0).getId()),
             null
         );
@@ -1722,8 +1733,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             GetApiKeyRequest.builder().apiKeyId(key100Response.getId()).withLimitedBy().build(),
             future
         );
-        assertThat(future.actionGet().getApiKeyInfos().size(), equalTo(1));
-        RoleDescriptorsIntersection limitedBy = future.actionGet().getApiKeyInfos().get(0).apiKeyInfo().getLimitedBy();
+        assertThat(future.actionGet().getApiKeyInfoList().size(), equalTo(1));
+        RoleDescriptorsIntersection limitedBy = future.actionGet().getApiKeyInfoList().get(0).apiKeyInfo().getLimitedBy();
         assertThat(limitedBy.roleDescriptorsList().size(), equalTo(1));
         assertThat(limitedBy.roleDescriptorsList().iterator().next(), emptyIterable());
 
@@ -1762,8 +1773,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             GetApiKeyAction.INSTANCE,
             GetApiKeyRequest.builder().apiKeyId(response2.getId()).ownedByAuthenticatedUser(true).build()
         ).actionGet();
-        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
-        ApiKey apiKeyInfo = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
+        assertThat(getApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        ApiKey apiKeyInfo = getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         assertThat(apiKeyInfo.getId(), equalTo(response2.getId()));
         assertThat(apiKeyInfo.getUsername(), equalTo(ES_TEST_ROOT_USER));
         assertThat(apiKeyInfo.getRealm(), equalTo("file"));
@@ -2886,8 +2897,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
                 future
             );
             final GetApiKeyResponse getApiKeyResponse = future.actionGet();
-            assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
-            return getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
+            assertThat(getApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+            return getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         } else {
             final PlainActionFuture<QueryApiKeyResponse> future = new PlainActionFuture<>();
             client.execute(
@@ -2896,8 +2907,8 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
                 future
             );
             final QueryApiKeyResponse queryApiKeyResponse = future.actionGet();
-            assertThat(queryApiKeyResponse.getItems(), arrayWithSize(1));
-            return queryApiKeyResponse.getItems()[0].getApiKey();
+            assertThat(queryApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+            return queryApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         }
     }
 
@@ -2906,7 +2917,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             final PlainActionFuture<GetApiKeyResponse> future = new PlainActionFuture<>();
             client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.builder().withLimitedBy(withLimitedBy).build(), future);
             final GetApiKeyResponse getApiKeyResponse = future.actionGet();
-            return getApiKeyResponse.getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList();
+            return getApiKeyResponse.getApiKeyInfoList().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList();
         } else {
             final PlainActionFuture<QueryApiKeyResponse> future = new PlainActionFuture<>();
             client.execute(
@@ -2915,7 +2926,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
                 future
             );
             final QueryApiKeyResponse queryApiKeyResponse = future.actionGet();
-            return Arrays.stream(queryApiKeyResponse.getItems()).map(QueryApiKeyResponse.Item::getApiKey).toList();
+            return queryApiKeyResponse.getApiKeyInfoList().stream().map(QueryApiKeyResponse.Item::apiKeyInfo).toList();
         }
     }
 
@@ -2968,7 +2979,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
             0,
             client.execute(GetApiKeyAction.INSTANCE, GetApiKeyRequest.builder().apiKeyName(keyName).ownedByAuthenticatedUser(false).build())
                 .get()
-                .getApiKeyInfos()
+                .getApiKeyInfoList()
                 .size()
         );
     }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
@@ -101,6 +101,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -286,8 +287,8 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             GetApiKeyAction.INSTANCE,
             GetApiKeyRequest.builder().apiKeyId(apiKeyId).ownedByAuthenticatedUser(randomBoolean()).build()
         ).actionGet();
-        assertThat(getApiKeyResponse.getApiKeyInfos().length, equalTo(1));
-        assertThat(getApiKeyResponse.getApiKeyInfos()[0].getId(), equalTo(apiKeyId));
+        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
+        assertThat(getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getId(), is(apiKeyId));
 
         // Cannot get any other keys
         final ElasticsearchSecurityException e = expectThrows(
@@ -613,8 +614,8 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             GetApiKeyAction.INSTANCE,
             GetApiKeyRequest.builder().apiKeyId(apiKeyId).withLimitedBy(randomBoolean()).build()
         ).actionGet();
-        assertThat(getApiKeyResponse.getApiKeyInfos(), arrayWithSize(1));
-        final ApiKey getApiKeyInfo = getApiKeyResponse.getApiKeyInfos()[0];
+        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
+        ApiKey getApiKeyInfo = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
         assertThat(getApiKeyInfo.getType(), is(ApiKey.Type.CROSS_CLUSTER));
         assertThat(getApiKeyInfo.getRoleDescriptors(), contains(expectedRoleDescriptor));
         assertThat(getApiKeyInfo.getLimitedBy(), nullValue());
@@ -669,8 +670,8 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             GetApiKeyAction.INSTANCE,
             GetApiKeyRequest.builder().apiKeyId(apiKeyId).withLimitedBy(randomBoolean()).build()
         ).actionGet();
-        assertThat(getApiKeyResponse.getApiKeyInfos(), arrayWithSize(1));
-        final ApiKey getApiKeyInfo = getApiKeyResponse.getApiKeyInfos()[0];
+        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
+        ApiKey getApiKeyInfo = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
         assertThat(getApiKeyInfo.getType(), is(ApiKey.Type.CROSS_CLUSTER));
         assertThat(getApiKeyInfo.getRoleDescriptors(), contains(originalRoleDescriptor));
         assertThat(getApiKeyInfo.getLimitedBy(), nullValue());

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/apikey/ApiKeySingleNodeTests.java
@@ -92,7 +92,6 @@ import static org.elasticsearch.test.SecuritySettingsSourceField.TEST_PASSWORD;
 import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_ALIAS;
 import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
@@ -149,10 +148,10 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
                 .filter(QueryBuilders.rangeQuery("expiration").from(Instant.now().toEpochMilli()))
         );
         final QueryApiKeyResponse queryApiKeyResponse = client().execute(QueryApiKeyAction.INSTANCE, queryApiKeyRequest).actionGet();
-        assertThat(queryApiKeyResponse.getItems().length, equalTo(1));
-        assertThat(queryApiKeyResponse.getItems()[0].getApiKey().getId(), equalTo(id2));
-        assertThat(queryApiKeyResponse.getItems()[0].getApiKey().getName(), equalTo("long-lived"));
-        assertThat(queryApiKeyResponse.getItems()[0].getSortValues(), emptyArray());
+        assertThat(queryApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        assertThat(queryApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getId(), equalTo(id2));
+        assertThat(queryApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getName(), equalTo("long-lived"));
+        assertThat(queryApiKeyResponse.getApiKeyInfoList().get(0).sortValues(), emptyArray());
     }
 
     public void testCreatingApiKeyWithNoAccess() {
@@ -287,8 +286,8 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             GetApiKeyAction.INSTANCE,
             GetApiKeyRequest.builder().apiKeyId(apiKeyId).ownedByAuthenticatedUser(randomBoolean()).build()
         ).actionGet();
-        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
-        assertThat(getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getId(), is(apiKeyId));
+        assertThat(getApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        assertThat(getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getId(), is(apiKeyId));
 
         // Cannot get any other keys
         final ElasticsearchSecurityException e = expectThrows(
@@ -614,8 +613,8 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             GetApiKeyAction.INSTANCE,
             GetApiKeyRequest.builder().apiKeyId(apiKeyId).withLimitedBy(randomBoolean()).build()
         ).actionGet();
-        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
-        ApiKey getApiKeyInfo = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
+        assertThat(getApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        ApiKey getApiKeyInfo = getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         assertThat(getApiKeyInfo.getType(), is(ApiKey.Type.CROSS_CLUSTER));
         assertThat(getApiKeyInfo.getRoleDescriptors(), contains(expectedRoleDescriptor));
         assertThat(getApiKeyInfo.getLimitedBy(), nullValue());
@@ -635,8 +634,8 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             randomBoolean()
         );
         final QueryApiKeyResponse queryApiKeyResponse = client().execute(QueryApiKeyAction.INSTANCE, queryApiKeyRequest).actionGet();
-        assertThat(queryApiKeyResponse.getItems(), arrayWithSize(1));
-        final ApiKey queryApiKeyInfo = queryApiKeyResponse.getItems()[0].getApiKey();
+        assertThat(queryApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        ApiKey queryApiKeyInfo = queryApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         assertThat(queryApiKeyInfo.getType(), is(ApiKey.Type.CROSS_CLUSTER));
         assertThat(queryApiKeyInfo.getRoleDescriptors(), contains(expectedRoleDescriptor));
         assertThat(queryApiKeyInfo.getLimitedBy(), nullValue());
@@ -670,8 +669,8 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             GetApiKeyAction.INSTANCE,
             GetApiKeyRequest.builder().apiKeyId(apiKeyId).withLimitedBy(randomBoolean()).build()
         ).actionGet();
-        assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(1));
-        ApiKey getApiKeyInfo = getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo();
+        assertThat(getApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        ApiKey getApiKeyInfo = getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         assertThat(getApiKeyInfo.getType(), is(ApiKey.Type.CROSS_CLUSTER));
         assertThat(getApiKeyInfo.getRoleDescriptors(), contains(originalRoleDescriptor));
         assertThat(getApiKeyInfo.getLimitedBy(), nullValue());
@@ -741,8 +740,8 @@ public class ApiKeySingleNodeTests extends SecuritySingleNodeTestCase {
             randomBoolean()
         );
         final QueryApiKeyResponse queryApiKeyResponse = client().execute(QueryApiKeyAction.INSTANCE, queryApiKeyRequest).actionGet();
-        assertThat(queryApiKeyResponse.getItems(), arrayWithSize(1));
-        final ApiKey queryApiKeyInfo = queryApiKeyResponse.getItems()[0].getApiKey();
+        assertThat(queryApiKeyResponse.getApiKeyInfoList(), iterableWithSize(1));
+        final ApiKey queryApiKeyInfo = queryApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo();
         assertThat(queryApiKeyInfo.getType(), is(ApiKey.Type.CROSS_CLUSTER));
         assertThat(
             queryApiKeyInfo.getRoleDescriptors(),

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -1940,7 +1940,7 @@ public class ApiKeyService {
         final SecurityIndexManager frozenSecurityIndex = securityIndex.defensiveCopy();
         if (frozenSecurityIndex.indexExists() == false) {
             logger.debug("security index does not exist");
-            listener.onResponse(QueryApiKeyResponse.emptyResponse());
+            listener.onResponse(QueryApiKeyResponse.EMPTY);
         } else if (frozenSecurityIndex.isAvailable(SEARCH_SHARDS) == false) {
             listener.onFailure(frozenSecurityIndex.getUnavailableReason(SEARCH_SHARDS));
         } else {
@@ -1955,7 +1955,7 @@ public class ApiKeyService {
                         final long total = searchResponse.getHits().getTotalHits().value;
                         if (total == 0) {
                             logger.debug("No api keys found for query [{}]", searchRequest.source().query());
-                            listener.onResponse(QueryApiKeyResponse.emptyResponse());
+                            listener.onResponse(QueryApiKeyResponse.EMPTY);
                             return;
                         }
                         final List<QueryApiKeyResponse.Item> apiKeyItem = Arrays.stream(searchResponse.getHits().getHits())

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -1927,7 +1927,7 @@ public class ApiKeyService {
                         Arrays.toString(apiKeyIds),
                         activeOnly
                     );
-                    listener.onResponse(GetApiKeyResponse.emptyResponse());
+                    listener.onResponse(GetApiKeyResponse.EMPTY);
                 } else {
                     listener.onResponse(new GetApiKeyResponse(apiKeyInfos));
                 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyAction.java
@@ -66,7 +66,7 @@ public final class RestGetApiKeyAction extends ApiKeyBaseRestHandler {
                 getApiKeyResponse.toXContent(builder, channel.request());
 
                 // return HTTP status 404 if no API key found for API key id
-                if (Strings.hasText(apiKeyId) && getApiKeyResponse.getApiKeyInfos().length == 0) {
+                if (Strings.hasText(apiKeyId) && getApiKeyResponse.getApiKeyInfos().isEmpty()) {
                     return new RestResponse(RestStatus.NOT_FOUND, builder);
                 }
                 return new RestResponse(RestStatus.OK, builder);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyAction.java
@@ -66,7 +66,7 @@ public final class RestGetApiKeyAction extends ApiKeyBaseRestHandler {
                 getApiKeyResponse.toXContent(builder, channel.request());
 
                 // return HTTP status 404 if no API key found for API key id
-                if (Strings.hasText(apiKeyId) && getApiKeyResponse.getApiKeyInfos().isEmpty()) {
+                if (Strings.hasText(apiKeyId) && getApiKeyResponse.getApiKeyInfoList().isEmpty()) {
                     return new RestResponse(RestStatus.NOT_FOUND, builder);
                 }
                 return new RestResponse(RestStatus.OK, builder);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -327,7 +327,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         verify(searchRequestBuilder).setFetchSource(eq(true));
         assertThat(searchRequest.get().source().query(), is(boolQuery));
         GetApiKeyResponse getApiKeyResponse = getApiKeyResponsePlainActionFuture.get();
-        assertThat(getApiKeyResponse.getApiKeyInfos(), emptyIterable());
+        assertThat(getApiKeyResponse.getApiKeyInfoList(), emptyIterable());
     }
 
     @SuppressWarnings("unchecked")
@@ -408,31 +408,31 @@ public class ApiKeyServiceTests extends ESTestCase {
                 getApiKeyResponsePlainActionFuture
             );
             GetApiKeyResponse getApiKeyResponse = getApiKeyResponsePlainActionFuture.get();
-            assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(2));
-            assertThat(getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getRealm(), is(realm1));
-            assertThat(getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getRealmType(), is(realm1Type));
+            assertThat(getApiKeyResponse.getApiKeyInfoList(), iterableWithSize(2));
+            assertThat(getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getRealm(), is(realm1));
+            assertThat(getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getRealmType(), is(realm1Type));
             assertThat(
-                getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getRealmIdentifier(),
+                getApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getRealmIdentifier(),
                 is(new RealmConfig.RealmIdentifier(realm1Type, realm1))
             );
-            assertThat(getApiKeyResponse.getApiKeyInfos().get(1).apiKeyInfo().getRealm(), is(realm2));
-            assertThat(getApiKeyResponse.getApiKeyInfos().get(1).apiKeyInfo().getRealmType(), nullValue());
-            assertThat(getApiKeyResponse.getApiKeyInfos().get(1).apiKeyInfo().getRealmIdentifier(), nullValue());
+            assertThat(getApiKeyResponse.getApiKeyInfoList().get(1).apiKeyInfo().getRealm(), is(realm2));
+            assertThat(getApiKeyResponse.getApiKeyInfoList().get(1).apiKeyInfo().getRealmType(), nullValue());
+            assertThat(getApiKeyResponse.getApiKeyInfoList().get(1).apiKeyInfo().getRealmIdentifier(), nullValue());
         }
         {
             PlainActionFuture<QueryApiKeyResponse> queryApiKeyResponsePlainActionFuture = new PlainActionFuture<>();
             service.queryApiKeys(new SearchRequest(".security"), false, queryApiKeyResponsePlainActionFuture);
             QueryApiKeyResponse queryApiKeyResponse = queryApiKeyResponsePlainActionFuture.get();
-            assertThat(queryApiKeyResponse.getItems().length, is(2));
-            assertThat(queryApiKeyResponse.getItems()[0].getApiKey().getRealm(), is(realm1));
-            assertThat(queryApiKeyResponse.getItems()[0].getApiKey().getRealmType(), is(realm1Type));
+            assertThat(queryApiKeyResponse.getApiKeyInfoList(), iterableWithSize(2));
+            assertThat(queryApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getRealm(), is(realm1));
+            assertThat(queryApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getRealmType(), is(realm1Type));
             assertThat(
-                queryApiKeyResponse.getItems()[0].getApiKey().getRealmIdentifier(),
+                queryApiKeyResponse.getApiKeyInfoList().get(0).apiKeyInfo().getRealmIdentifier(),
                 is(new RealmConfig.RealmIdentifier(realm1Type, realm1))
             );
-            assertThat(queryApiKeyResponse.getItems()[1].getApiKey().getRealm(), is(realm2));
-            assertThat(queryApiKeyResponse.getItems()[1].getApiKey().getRealmType(), nullValue());
-            assertThat(queryApiKeyResponse.getItems()[1].getApiKey().getRealmIdentifier(), nullValue());
+            assertThat(queryApiKeyResponse.getApiKeyInfoList().get(1).apiKeyInfo().getRealm(), is(realm2));
+            assertThat(queryApiKeyResponse.getApiKeyInfoList().get(1).apiKeyInfo().getRealmType(), nullValue());
+            assertThat(queryApiKeyResponse.getApiKeyInfoList().get(1).apiKeyInfo().getRealmIdentifier(), nullValue());
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -181,6 +181,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -326,7 +327,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         verify(searchRequestBuilder).setFetchSource(eq(true));
         assertThat(searchRequest.get().source().query(), is(boolQuery));
         GetApiKeyResponse getApiKeyResponse = getApiKeyResponsePlainActionFuture.get();
-        assertThat(getApiKeyResponse.getApiKeyInfos(), emptyArray());
+        assertThat(getApiKeyResponse.getApiKeyInfos(), emptyIterable());
     }
 
     @SuppressWarnings("unchecked")
@@ -407,13 +408,16 @@ public class ApiKeyServiceTests extends ESTestCase {
                 getApiKeyResponsePlainActionFuture
             );
             GetApiKeyResponse getApiKeyResponse = getApiKeyResponsePlainActionFuture.get();
-            assertThat(getApiKeyResponse.getApiKeyInfos().length, is(2));
-            assertThat(getApiKeyResponse.getApiKeyInfos()[0].getRealm(), is(realm1));
-            assertThat(getApiKeyResponse.getApiKeyInfos()[0].getRealmType(), is(realm1Type));
-            assertThat(getApiKeyResponse.getApiKeyInfos()[0].getRealmIdentifier(), is(new RealmConfig.RealmIdentifier(realm1Type, realm1)));
-            assertThat(getApiKeyResponse.getApiKeyInfos()[1].getRealm(), is(realm2));
-            assertThat(getApiKeyResponse.getApiKeyInfos()[1].getRealmType(), nullValue());
-            assertThat(getApiKeyResponse.getApiKeyInfos()[1].getRealmIdentifier(), nullValue());
+            assertThat(getApiKeyResponse.getApiKeyInfos(), iterableWithSize(2));
+            assertThat(getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getRealm(), is(realm1));
+            assertThat(getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getRealmType(), is(realm1Type));
+            assertThat(
+                getApiKeyResponse.getApiKeyInfos().get(0).apiKeyInfo().getRealmIdentifier(),
+                is(new RealmConfig.RealmIdentifier(realm1Type, realm1))
+            );
+            assertThat(getApiKeyResponse.getApiKeyInfos().get(1).apiKeyInfo().getRealm(), is(realm2));
+            assertThat(getApiKeyResponse.getApiKeyInfos().get(1).apiKeyInfo().getRealmType(), nullValue());
+            assertThat(getApiKeyResponse.getApiKeyInfos().get(1).apiKeyInfo().getRealmIdentifier(), nullValue());
         }
         {
             PlainActionFuture<QueryApiKeyResponse> queryApiKeyResponsePlainActionFuture = new PlainActionFuture<>();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestGetApiKeyActionTests.java
@@ -163,10 +163,10 @@ public class RestGetApiKeyActionTests extends ESTestCase {
         assertThat(restResponse.status(), (replyEmptyResponse && params.get("id") != null) ? is(RestStatus.NOT_FOUND) : is(RestStatus.OK));
         final GetApiKeyResponse actual = GetApiKeyResponse.fromXContent(createParser(XContentType.JSON.xContent(), restResponse.content()));
         if (replyEmptyResponse) {
-            assertThat(actual.getApiKeyInfos(), emptyIterable());
+            assertThat(actual.getApiKeyInfoList(), emptyIterable());
         } else {
             assertThat(
-                actual.getApiKeyInfos(),
+                actual.getApiKeyInfoList(),
                 contains(
                     new GetApiKeyResponse.Item(
                         new ApiKey(
@@ -289,9 +289,9 @@ public class RestGetApiKeyActionTests extends ESTestCase {
         assertThat(restResponse.status(), is(RestStatus.OK));
         final GetApiKeyResponse actual = GetApiKeyResponse.fromXContent(createParser(XContentType.JSON.xContent(), restResponse.content()));
         if (isGetRequestForOwnedKeysOnly) {
-            assertThat(actual.getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(), contains(apiKey1));
+            assertThat(actual.getApiKeyInfoList().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(), contains(apiKey1));
         } else {
-            assertThat(actual.getApiKeyInfos().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(), contains(apiKey1, apiKey2));
+            assertThat(actual.getApiKeyInfoList().stream().map(GetApiKeyResponse.Item::apiKeyInfo).toList(), contains(apiKey1, apiKey2));
         }
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyActionTests.java
@@ -126,7 +126,7 @@ public class RestQueryApiKeyActionTests extends ESTestCase {
                 final QueryBuilder shouldQueryBuilder = boolQueryBuilder.should().get(0);
                 assertThat(shouldQueryBuilder.getClass(), is(PrefixQueryBuilder.class));
                 assertThat(((PrefixQueryBuilder) shouldQueryBuilder).fieldName(), equalTo("metadata.environ"));
-                listener.onResponse((Response) QueryApiKeyResponse.emptyResponse());
+                listener.onResponse((Response) QueryApiKeyResponse.EMPTY);
             }
         };
         final RestQueryApiKeyAction restQueryApiKeyAction = new RestQueryApiKeyAction(Settings.EMPTY, mockLicenseState);
@@ -190,7 +190,7 @@ public class RestQueryApiKeyActionTests extends ESTestCase {
                     equalTo(new SearchAfterBuilder().setSortValues(new String[] { "key-2048", "2021-07-01T00:00:59.000Z" }))
                 );
 
-                listener.onResponse((Response) QueryApiKeyResponse.emptyResponse());
+                listener.onResponse((Response) QueryApiKeyResponse.EMPTY);
             }
         };
 


### PR DESCRIPTION
The plan is that `GetApiKeyResponse` and `QueryApiKeyResponse`
will be receiving collections of api key info, optional profile uids, and optional
sort values, that they will "zip" into a single list of records.
Array vs List is not important in this context, but we use collections in the
internal services and action handlers, so it is more consistent to also use them
in the responses.