### PR TITLE
Draft: Combine @timestamp, event.ingested and event.created into single timestamp range in cluster state

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/TimestampFieldMapperServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/TimestampFieldMapperServiceTests.java
@@ -31,6 +31,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
+/// MP TODO: probably need more tests here also?
 public class TimestampFieldMapperServiceTests extends ESSingleNodeTestCase {
 
     private static final String DOC = """
@@ -61,7 +62,7 @@ public class TimestampFieldMapperServiceTests extends ESSingleNodeTestCase {
         DocWriteResponse indexResponse = indexDoc();
 
         var indicesService = getInstanceFromNode(IndicesService.class);
-        var result = indicesService.getTimestampFieldType(indexResponse.getShardId().getIndex());
+        var result = indicesService.getTimestampFieldTypeMap(indexResponse.getShardId().getIndex());
         assertThat(result, notNullValue());
     }
 
@@ -70,7 +71,7 @@ public class TimestampFieldMapperServiceTests extends ESSingleNodeTestCase {
         DocWriteResponse indexResponse = indexDoc();
 
         var indicesService = getInstanceFromNode(IndicesService.class);
-        var result = indicesService.getTimestampFieldType(indexResponse.getShardId().getIndex());
+        var result = indicesService.getTimestampFieldTypeMap(indexResponse.getShardId().getIndex());
         assertThat(result, nullValue());
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/action/shard/ShardStateAction.java
@@ -552,7 +552,7 @@ public class ShardStateAction {
         final ShardRouting shardRouting,
         final long primaryTerm,
         final String message,
-        final ShardLongFieldRange timestampRange,
+        final ShardLongFieldRange timestampRange,  // from IndexShard.getTimestampRange (checks @timestamp, event.created, event.timestamp)
         final ActionListener<Void> listener,
         final ClusterState currentState
     ) {
@@ -747,7 +747,7 @@ public class ShardStateAction {
         final String allocationId;
         final long primaryTerm;
         final String message;
-        final ShardLongFieldRange timestampRange;
+        final ShardLongFieldRange timestampRange;  // TODO: how is this set? -> via the ctor below
 
         StartedShardEntry(StreamInput in) throws IOException {
             super(in);
@@ -758,6 +758,9 @@ public class ShardStateAction {
             this.timestampRange = ShardLongFieldRange.readFrom(in);
         }
 
+        /// MP TODO: called from two (prod) places:
+        /// MP TODO: ShardStateAction - ts range comes from IndexShard.getTimestampRange using event.created, event.ingested and @timestamp
+        /// MP TODO: ClusterStateChanges - timestamp is UNKNOWN
         public StartedShardEntry(
             final ShardId shardId,
             final String allocationId,

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
@@ -17,6 +17,7 @@ import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.function.LongSupplier;
 
 /**
@@ -28,14 +29,14 @@ import java.util.function.LongSupplier;
  */
 public class CoordinatorRewriteContext extends QueryRewriteContext {
     private final IndexLongFieldRange indexLongFieldRange;
-    private final DateFieldMapper.DateFieldType timestampFieldType;
+    private final Map<String, DateFieldMapper.DateFieldType> timestampFieldTypes;
 
     public CoordinatorRewriteContext(
         XContentParserConfiguration parserConfig,
         Client client,
         LongSupplier nowInMillis,
         IndexLongFieldRange indexLongFieldRange,
-        DateFieldMapper.DateFieldType timestampFieldType
+        Map<String, DateFieldMapper.DateFieldType> timestampFieldTypes
     ) {
         super(
             parserConfig,
@@ -54,7 +55,7 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
             null
         );
         this.indexLongFieldRange = indexLongFieldRange;
-        this.timestampFieldType = timestampFieldType;
+        this.timestampFieldTypes = timestampFieldTypes;
     }
 
     long getMinTimestamp() {
@@ -71,11 +72,7 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
 
     @Nullable
     public MappedFieldType getFieldType(String fieldName) {
-        if (fieldName.equals(timestampFieldType.name()) == false) {
-            return null;
-        }
-
-        return timestampFieldType;
+        return timestampFieldTypes.get(fieldName);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2195,6 +2195,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return this.recoveryState;
     }
 
+    /**
+     * @return the min and max timestamp range combined across 3 possible fields: '@timestamp', 'event.created' and
+     *         'event.ingested'. The minimum min and the maximum max across all 3 fields are used.
+     *         Can also return ShardLongFieldRange.UNKNOWN or ShardLongFieldRange.EMPTY.
+     */
     @Override
     public ShardLongFieldRange getTimestampRange() {
         if (mapperService() == null) {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1732,7 +1732,13 @@ public class IndicesService extends AbstractLifecycleComponent
     }
 
     public CoordinatorRewriteContextProvider getCoordinatorRewriteContextProvider(LongSupplier nowInMillis) {
-        return new CoordinatorRewriteContextProvider(parserConfig, client, nowInMillis, clusterService::state, this::getTimestampFieldType);
+        return new CoordinatorRewriteContextProvider(
+            parserConfig,
+            client,
+            nowInMillis,
+            clusterService::state,
+            this::getTimestampFieldTypeMap
+        );
     }
 
     /**
@@ -1821,6 +1827,7 @@ public class IndicesService extends AbstractLifecycleComponent
             || (danglingIndicesToWrite.isEmpty() && danglingIndicesThreadPoolExecutor.getActiveCount() == 0);
     }
 
+    /// MP TODO Update javadoc here
     /**
      * @return the field type of the {@code @timestamp} field of the given index, or {@code null} if:
      * - the index is not found,
@@ -1828,8 +1835,8 @@ public class IndicesService extends AbstractLifecycleComponent
      * - the field is not a timestamp field.
      */
     @Nullable
-    public DateFieldMapper.DateFieldType getTimestampFieldType(Index index) {
-        return timestampFieldMapperService.getTimestampFieldType(index);
+    public Map<String, DateFieldMapper.DateFieldType> getTimestampFieldTypeMap(Index index) {
+        return timestampFieldMapperService.getTimestampFieldTypeMap(index);
     }
 
     public IndexScopedSettings getIndexScopedSettings() {

--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -166,6 +166,10 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
         if (eventIngestedFieldType instanceof DateFieldMapper.DateFieldType dateFieldType) {
             fieldToType.put("event.ingested", dateFieldType);
         }
+        final MappedFieldType eventCreatedFieldType = mapperService.fieldType("event.created");
+        if (eventCreatedFieldType instanceof DateFieldMapper.DateFieldType dateFieldType) {
+            fieldToType.put("event.created", dateFieldType);
+        }
         if (fieldToType.isEmpty()) {
             return null;
         }

--- a/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
+++ b/server/src/main/java/org/elasticsearch/indices/TimestampFieldMapperService.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
@@ -51,10 +52,12 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
     private final ExecutorService executor; // single thread to construct mapper services async as needed
 
     /**
-     * The type of the {@code @timestamp} field keyed by index. Futures may be completed with {@code null} to indicate that there is
-     * no usable {@code @timestamp} field.
+     * The type of the field keyed by index for 'event.ingested' and/or '@timestamp'.
+     * Futures may be completed with {@code null} to indicate that there is no usable timestamp field.
      */
-    private final Map<Index, PlainActionFuture<DateFieldMapper.DateFieldType>> fieldTypesByIndex = ConcurrentCollections.newConcurrentMap();
+    // key to the inner map held by the Future is the fieldName ('@timestamp' or 'event.ingested')
+    private final Map<Index, PlainActionFuture<Map<String, DateFieldMapper.DateFieldType>>> fieldTypesByIndex = ConcurrentCollections
+        .newConcurrentMap();
 
     public TimestampFieldMapperService(Settings settings, ThreadPool threadPool, IndicesService indicesService) {
         this.indicesService = indicesService;
@@ -100,8 +103,8 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
             final Index index = indexMetadata.getIndex();
 
             if (hasUsefulTimestampField(indexMetadata) && fieldTypesByIndex.containsKey(index) == false) {
-                logger.trace("computing timestamp mapping for {}", index);
-                final PlainActionFuture<DateFieldMapper.DateFieldType> future = new PlainActionFuture<>();
+                logger.trace("computing timestamp mapping or mappings for {}", index);
+                final PlainActionFuture<Map<String, DateFieldMapper.DateFieldType>> future = new PlainActionFuture<>();
                 fieldTypesByIndex.put(index, future);
 
                 final IndexService indexService = indicesService.indexService(index);
@@ -146,19 +149,30 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
             return true;
         }
 
+        // the timestamp range is combined across any entry from event.created, event.ingested and @timestamp, so we don't
+        // so there is only one single range to lookup (could be from any combination of the above time fields)
         final IndexLongFieldRange timestampRange = indexMetadata.getTimestampRange();
         return timestampRange.isComplete() && timestampRange != IndexLongFieldRange.UNKNOWN;
     }
 
-    private static DateFieldMapper.DateFieldType fromMapperService(MapperService mapperService) {
-        final MappedFieldType mappedFieldType = mapperService.fieldType(DataStream.TIMESTAMP_FIELD_NAME);
-        if (mappedFieldType instanceof DateFieldMapper.DateFieldType) {
-            return (DateFieldMapper.DateFieldType) mappedFieldType;
-        } else {
+    private static Map<String, DateFieldMapper.DateFieldType> fromMapperService(MapperService mapperService) {
+        Map<String, DateFieldMapper.DateFieldType> fieldToType = new HashMap<>();
+
+        final MappedFieldType timestampFieldType = mapperService.fieldType(DataStream.TIMESTAMP_FIELD_NAME);
+        if (timestampFieldType instanceof DateFieldMapper.DateFieldType dateFieldType) {
+            fieldToType.put(DataStream.TIMESTAMP_FIELD_NAME, dateFieldType);
+        }
+        final MappedFieldType eventIngestedFieldType = mapperService.fieldType("event.ingested");
+        if (eventIngestedFieldType instanceof DateFieldMapper.DateFieldType dateFieldType) {
+            fieldToType.put("event.ingested", dateFieldType);
+        }
+        if (fieldToType.isEmpty()) {
             return null;
         }
+        return fieldToType;
     }
 
+    /// MP TODO: update the javadoc
     /**
      * @return the field type of the {@code @timestamp} field of the given index, or {@code null} if:
      * - the index is not found,
@@ -167,13 +181,12 @@ public class TimestampFieldMapperService extends AbstractLifecycleComponent impl
      * - the field is not a timestamp field.
      */
     @Nullable
-    public DateFieldMapper.DateFieldType getTimestampFieldType(Index index) {
-        final PlainActionFuture<DateFieldMapper.DateFieldType> future = fieldTypesByIndex.get(index);
+    public Map<String, DateFieldMapper.DateFieldType> getTimestampFieldTypeMap(Index index) {
+        final PlainActionFuture<Map<String, DateFieldMapper.DateFieldType>> future = fieldTypesByIndex.get(index);
         if (future == null || future.isDone() == false) {
             return null;
         }
         // call non-blocking actionResult() as we could be on a network or scheduler thread which we must not block
         return future.actionResult();
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -853,6 +853,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             this.primaryTerm = primaryTerm;
         }
 
+        /// MP TODO: where is this called from - who creates and passes in the timestamp range?
         @Override
         public void onRecoveryDone(final RecoveryState state, ShardLongFieldRange timestampMillisFieldRange) {
             shardStateAction.shardStarted(

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -848,7 +848,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
 
     private static class StaticCoordinatorRewriteContextProviderBuilder {
         private ClusterState clusterState = ClusterState.EMPTY_STATE;
-        private final Map<Index, DateFieldMapper.DateFieldType> fields = new HashMap<>();
+        private final Map<Index, Map<String, DateFieldMapper.DateFieldType>> fields = new HashMap<>();
 
         private void addIndexMinMaxTimestamps(Index index, String fieldName, long minTimeStamp, long maxTimestamp) {
             if (clusterState.metadata().index(index) != null) {
@@ -873,7 +873,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
 
             clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();
 
-            fields.put(index, new DateFieldMapper.DateFieldType(fieldName));
+            // MP TODO: we need to have more than one entry in this inner map for some tests
+            fields.put(index, Map.of(fieldName, new DateFieldMapper.DateFieldType(fieldName)));
         }
 
         private void addIndexMinMaxTimestamps(Index index, long minTimestamp, long maxTimestamp) {
@@ -894,7 +895,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
 
             Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata()).put(indexMetadataBuilder);
             clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();
-            fields.put(index, new DateFieldMapper.DateFieldType("@timestamp"));
+            fields.put(index, Map.of(DataStream.TIMESTAMP_FIELD_NAME, new DateFieldMapper.DateFieldType(DataStream.TIMESTAMP_FIELD_NAME)));
         }
 
         private void addIndex(Index index) {
@@ -910,7 +911,7 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
 
             Metadata.Builder metadataBuilder = Metadata.builder(clusterState.metadata()).put(indexMetadataBuilder);
             clusterState = ClusterState.builder(clusterState).metadata(metadataBuilder).build();
-            fields.put(index, new DateFieldMapper.DateFieldType("@timestamp"));
+            fields.put(index, Map.of(DataStream.TIMESTAMP_FIELD_NAME, new DateFieldMapper.DateFieldType(DataStream.TIMESTAMP_FIELD_NAME)));
         }
 
         public CoordinatorRewriteContextProvider build() {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
 import org.elasticsearch.action.termvectors.MultiTermVectorsResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -611,7 +612,8 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 this.client,
                 () -> nowInMillis,
                 IndexLongFieldRange.NO_SHARDS.extendWithShardRange(0, 1, ShardLongFieldRange.of(min, max)),
-                dateFieldType
+                /// MP TODO: find a way to not hardcod this list in tests?
+                Map.of(DataStream.TIMESTAMP_FIELD_NAME, dateFieldType, "event.ingested", dateFieldType, "event.created", dateFieldType)
             );
         }
 

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
@@ -169,9 +169,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
             default -> throw new AssertionError("impossible");
         }
 
-        /// MP TODO: this fails when run with event.created - why?
-        // String timeField = randomFrom("event.ingested", "event.created", DataStream.TIMESTAMP_FIELD_NAME);
-        String timeField = randomFrom("event.ingested", DataStream.TIMESTAMP_FIELD_NAME);
+        String timeField = randomFrom("event.created", "event.ingested", DataStream.TIMESTAMP_FIELD_NAME);
 
         assertAcked(
             prepareCreate("index").setSettings(

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING;
@@ -166,8 +167,8 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
         final IndexMetadata indexMetadata = getIndexMetadata(searchableSnapshotIndexOutsideSearchRange);
         assertThat(indexMetadata.getTimestampRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
 
-        DateFieldMapper.DateFieldType timestampFieldType = indicesService.getTimestampFieldType(indexMetadata.getIndex());
-        assertThat(timestampFieldType, nullValue());
+        Map<String, DateFieldMapper.DateFieldType> timestampFieldMap = indicesService.getTimestampFieldTypeMap(indexMetadata.getIndex());
+        assertThat(timestampFieldMap, nullValue());
 
         final boolean includeIndexCoveringSearchRangeInSearchRequest = randomBoolean();
         List<String> indicesToSearch = new ArrayList<>();
@@ -250,9 +251,10 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
 
         final IndexMetadata updatedIndexMetadata = getIndexMetadata(searchableSnapshotIndexOutsideSearchRange);
         final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampRange();
-        final DateFieldMapper.DateFieldType dateFieldType = indicesService.getTimestampFieldType(updatedIndexMetadata.getIndex());
-        assertThat(dateFieldType, notNullValue());
-        final DateFieldMapper.Resolution resolution = dateFieldType.resolution();
+        Map<String, DateFieldMapper.DateFieldType> dateFieldMap = indicesService.getTimestampFieldTypeMap(updatedIndexMetadata.getIndex());
+        assertThat(dateFieldMap, notNullValue());
+        /// MP TODO: add tests that use other timestamp fields (event.ingested, etc)
+        final DateFieldMapper.Resolution resolution = dateFieldMap.get(DataStream.TIMESTAMP_FIELD_NAME).resolution();
         assertThat(updatedTimestampMillisRange.isComplete(), equalTo(true));
         if (indexDataWithTimestamp) {
             assertThat(updatedTimestampMillisRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
@@ -437,8 +439,8 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
         final IndexMetadata indexMetadata = getIndexMetadata(searchableSnapshotIndexOutsideSearchRange);
         assertThat(indexMetadata.getTimestampRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
 
-        DateFieldMapper.DateFieldType timestampFieldType = indicesService.getTimestampFieldType(indexMetadata.getIndex());
-        assertThat(timestampFieldType, nullValue());
+        Map<String, DateFieldMapper.DateFieldType> timestampFieldMap = indicesService.getTimestampFieldTypeMap(indexMetadata.getIndex());
+        assertThat(timestampFieldMap, nullValue());
 
         RangeQueryBuilder rangeQuery = QueryBuilders.rangeQuery(DataStream.TIMESTAMP_FIELD_NAME)
             .from("2020-11-28T00:00:00.000000000Z", true)
@@ -499,9 +501,10 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
 
         final IndexMetadata updatedIndexMetadata = getIndexMetadata(searchableSnapshotIndexOutsideSearchRange);
         final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampRange();
-        final DateFieldMapper.DateFieldType dateFieldType = indicesService.getTimestampFieldType(updatedIndexMetadata.getIndex());
-        assertThat(dateFieldType, notNullValue());
-        final DateFieldMapper.Resolution resolution = dateFieldType.resolution();
+        Map<String, DateFieldMapper.DateFieldType> dateFieldMap = indicesService.getTimestampFieldTypeMap(updatedIndexMetadata.getIndex());
+        assertThat(dateFieldMap, notNullValue());
+        /// MP TODO: other time fields here too?
+        final DateFieldMapper.Resolution resolution = dateFieldMap.get(DataStream.TIMESTAMP_FIELD_NAME).resolution();
         assertThat(updatedTimestampMillisRange.isComplete(), equalTo(true));
         assertThat(updatedTimestampMillisRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
         assertThat(updatedTimestampMillisRange.getMin(), greaterThanOrEqualTo(resolution.convert(Instant.parse("2020-11-26T00:00:00Z"))));
@@ -619,8 +622,8 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
         final IndexMetadata indexMetadata = getIndexMetadata(searchableSnapshotIndexWithinSearchRange);
         assertThat(indexMetadata.getTimestampRange(), equalTo(IndexLongFieldRange.NO_SHARDS));
 
-        DateFieldMapper.DateFieldType timestampFieldType = indicesService.getTimestampFieldType(indexMetadata.getIndex());
-        assertThat(timestampFieldType, nullValue());
+        Map<String, DateFieldMapper.DateFieldType> timestampFieldMap = indicesService.getTimestampFieldTypeMap(indexMetadata.getIndex());
+        assertThat(timestampFieldMap, nullValue());
 
         RangeQueryBuilder rangeQuery = QueryBuilders.rangeQuery(DataStream.TIMESTAMP_FIELD_NAME)
             .from("2020-11-28T00:00:00.000000000Z", true)
@@ -677,9 +680,9 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
 
         final IndexMetadata updatedIndexMetadata = getIndexMetadata(searchableSnapshotIndexWithinSearchRange);
         final IndexLongFieldRange updatedTimestampMillisRange = updatedIndexMetadata.getTimestampRange();
-        final DateFieldMapper.DateFieldType dateFieldType = indicesService.getTimestampFieldType(updatedIndexMetadata.getIndex());
-        assertThat(dateFieldType, notNullValue());
-        final DateFieldMapper.Resolution resolution = dateFieldType.resolution();
+        Map<String, DateFieldMapper.DateFieldType> dateFieldMap = indicesService.getTimestampFieldTypeMap(updatedIndexMetadata.getIndex());
+        assertThat(dateFieldMap, notNullValue());
+        final DateFieldMapper.Resolution resolution = dateFieldMap.get(DataStream.TIMESTAMP_FIELD_NAME).resolution();
         assertThat(updatedTimestampMillisRange.isComplete(), equalTo(true));
         assertThat(updatedTimestampMillisRange, not(sameInstance(IndexLongFieldRange.EMPTY)));
         assertThat(updatedTimestampMillisRange.getMin(), greaterThanOrEqualTo(resolution.convert(Instant.parse("2020-11-28T00:00:00Z"))));


### PR DESCRIPTION
IndexShard changed - created new allTimestampFieldsMissingOrNotIndexed method…; seeing if all tests pass

Exploratory coding. No new tests have been added on testing event.ingested in cluster state. Before I do that I'd like feedback on whether this is the right approach structurally.
