### PR TITLE
[8.13] [DOCS] Add contextual info about connectors to API docs (#106420)

### DIFF
--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -3,7 +3,14 @@
 
 preview::[]
 
-The connector and sync jobs API provides a convenient way to create and manage Elastic {enterprise-search-ref}/connectors.html[connectors^] and sync jobs in an internal index.
+The connector and sync jobs APIs provide a convenient way to create and manage Elastic {enterprise-search-ref}/connectors.html[connectors^] and sync jobs in an internal index.
+
+Connectors are third-party {es} integrations which can be deployed on {ecloud} or hosted on your own infrastructure:
+
+* *Native connectors* are a managed service on {ecloud}
+* *Connector clients* are self-managed on your infrastructure
+
+Find a list of all supported service types in the {enterprise-search-ref}/connectors.html[connectors documentation^].
 
 This API provides an alternative to relying solely on {kib} UI for connector and sync job management. The API comes with a set of
 validations and assertions to ensure that the state representation in the internal index remains valid.

--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -6,8 +6,13 @@
 
 preview::[]
 
-Creates a connector.
+Creates an Elastic connector.
+Connectors are third-party {es} integrations which can be deployed on {ecloud} or hosted on your own infrastructure:
 
+* *Native connectors* are a managed service on {ecloud}
+* *Connector clients* are self-managed on your infrastructure
+
+Find a list of all supported service types in the {enterprise-search-ref}/connectors.html[connectors documentation^].
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [DOCS] Add contextual info about connectors to API docs (#106420)