### PR TITLE
Fix reading BytesRef in enrich

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/QueryList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/QueryList.java
@@ -131,7 +131,7 @@ abstract class QueryList {
                             final var bytes = bytesRefBlock.getBytesRef(offset, scratch);
                             if (ipBytes.length != bytes.length) {
                                 // Lucene only support 16-byte IP addresses, even IPv4 is encoded in 16 bytes
-                                throw new IllegalStateException("Cannot decode IP field from bytes of length " + scratch.length);
+                                throw new IllegalStateException("Cannot decode IP field from bytes of length " + bytes.length);
                             }
                             System.arraycopy(bytes.bytes, bytes.offset, ipBytes, 0, bytes.length);
                             return InetAddressPoint.decode(ipBytes);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/QueryList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/QueryList.java
@@ -29,7 +29,6 @@ import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes;
 
-import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.IntFunction;
@@ -129,14 +128,13 @@ abstract class QueryList {
                     BytesRefBlock bytesRefBlock = (BytesRefBlock) block;
                     if (inputDataType == IP) {
                         yield offset -> {
-                            bytesRefBlock.getBytesRef(offset, scratch);
-                            if (ipBytes.length != scratch.length) {
+                            final var bytes = bytesRefBlock.getBytesRef(offset, scratch);
+                            if (ipBytes.length != bytes.length) {
                                 // Lucene only support 16-byte IP addresses, even IPv4 is encoded in 16 bytes
                                 throw new IllegalStateException("Cannot decode IP field from bytes of length " + scratch.length);
                             }
-                            System.arraycopy(scratch.bytes, scratch.offset, ipBytes, 0, scratch.length);
-                            InetAddress ip = InetAddressPoint.decode(ipBytes);
-                            return ip;
+                            System.arraycopy(bytes.bytes, bytes.offset, ipBytes, 0, bytes.length);
+                            return InetAddressPoint.decode(ipBytes);
                         };
                     }
                     yield offset -> bytesRefBlock.getBytesRef(offset, new BytesRef());


### PR DESCRIPTION
We should use the returned value when reading BytesRef from a BytesRefBlock. However, we didn't follow this pattern when reading IP values in enrich. 

Labeled as a non-issue for a non-released bug we just introduced in #106186.

Relates #106186

Fixes #106430