### PR TITLE
Make ENRICH-MV test less flaky

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich-IT_tests_only.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich-IT_tests_only.csv-spec
@@ -161,13 +161,13 @@ FROM sample_data
 ;
 
 client_ip:ip | count_env:i | max_env:keyword
-172.21.3.15  | 2           | Production
-172.21.3.15  | 2           | Production
-172.21.3.15  | 2           | Production
-172.21.3.15  | 2           | Production
 172.21.0.5   | 1           | Development
 172.21.2.113 | 2           | QA
 172.21.2.162 | 2           | QA
+172.21.3.15  | 2           | Production
+172.21.3.15  | 2           | Production
+172.21.3.15  | 2           | Production
+172.21.3.15  | 2           | Production
 ;
 
 enrichCidr2#[skip:-8.99.99, reason:ip_range support not added yet]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich-IT_tests_only.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich-IT_tests_only.csv-spec
@@ -155,17 +155,19 @@ a:keyword   | a_lang:keyword
 enrichCidr#[skip:-8.13.99, reason:enrich for cidr added in 8.14.0]
 FROM sample_data
 | ENRICH client_cidr_policy ON client_ip WITH env
-| KEEP client_ip, env
+| EVAL max_env = MV_MAX(env), count_env = MV_COUNT(env)
+| KEEP client_ip, count_env, max_env
+| SORT client_ip
 ;
 
-client_ip:ip | env:keyword
-172.21.3.15  | [Development, Production]
-172.21.3.15  | [Development, Production]
-172.21.3.15  | [Development, Production]
-172.21.3.15  | [Development, Production]
-172.21.0.5   | Development
-172.21.2.113 | [Development, QA]
-172.21.2.162 | [Development, QA]
+client_ip:ip | count_env:i | max_env:keyword
+172.21.3.15  | 2           | Production
+172.21.3.15  | 2           | Production
+172.21.3.15  | 2           | Production
+172.21.3.15  | 2           | Production
+172.21.0.5   | 1           | Development
+172.21.2.113 | 2           | QA
+172.21.2.162 | 2           | QA
 ;
 
 enrichCidr2#[skip:-8.99.99, reason:ip_range support not added yet]


### PR DESCRIPTION
ENRICH with multiple results can lead to MV fields with non-deterministic ordering.

Fixes #106433