### PR TITLE
Fix rolling over aliases to data streams

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   api project(":libs:elasticsearch-tdigest")
 
   implementation project(':libs:elasticsearch-plugin-classloader')
-  testImplementation project(path: ':modules:data-streams')
+  testImplementation project(':modules:data-streams')
   // no compile dependency by server, but server defines security policy for this codebase so it i>
   runtimeOnly project(":libs:elasticsearch-preallocate")
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   api project(":libs:elasticsearch-tdigest")
 
   implementation project(':libs:elasticsearch-plugin-classloader')
+  testImplementation project(path: ':modules:data-streams')
   // no compile dependency by server, but server defines security policy for this codebase so it i>
   runtimeOnly project(":libs:elasticsearch-preallocate")
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -462,7 +462,8 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
 
                 final IndexAbstraction rolloverTargetAbstraction = currentState.metadata()
                     .getIndicesLookup()
-                    .get(rolloverRequest.getRolloverTarget());
+                    .get(rolloverRequest.getRolloverTarget())
+                    .resolveDataStreamAlias(currentState.metadata());
 
                 final IndexMetadataStats sourceIndexStats = rolloverTargetAbstraction.getType() == IndexAbstraction.Type.DATA_STREAM
                     ? IndexMetadataStats.fromStatsResponse(rolloverSourceIndex, rolloverTask.statsResponse())
@@ -471,7 +472,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                 // Perform the actual rollover
                 final var rolloverResult = rolloverService.rolloverClusterState(
                     currentState,
-                    rolloverRequest.getRolloverTarget(),
+                    rolloverTargetAbstraction.getName(),
                     rolloverRequest.getNewIndexName(),
                     rolloverRequest.getCreateIndexRequest(),
                     metConditions,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexAbstraction.java
@@ -78,6 +78,16 @@ public interface IndexAbstraction {
     }
 
     /**
+     * Resolves the data stream this alias points to.
+     * @param metadata The current metadata
+     * @return the data stream to which this alias points to or <code>this</code> if this is not an alias or if it
+     * is an alias that does not point to a data stream.
+     */
+    default IndexAbstraction resolveDataStreamAlias(Metadata metadata) {
+        return this;
+    }
+
+    /**
      * An index abstraction type.
      */
     enum Type {
@@ -283,6 +293,14 @@ public interface IndexAbstraction {
         @Override
         public boolean isDataStreamRelated() {
             return dataStreamAlias;
+        }
+
+        @Override
+        public IndexAbstraction resolveDataStreamAlias(Metadata metadata) {
+            if (dataStreamAlias) {
+                return metadata.getIndicesLookup().get(getWriteIndex().getName()).getParentDataStream();
+            }
+            return this;
         }
 
         @Override


### PR DESCRIPTION
Currently trying to rollover data streams via aliases fails. This commit fixes that by applying the rollover on the data stream directly.

Fixes #106137