### PR TITLE
[8.13] (DOC+) Version API page for ES API Base URL (#105845)

### DIFF
--- a/docs/reference/rest-api/index.asciidoc
+++ b/docs/reference/rest-api/index.asciidoc
@@ -44,6 +44,7 @@ not be included yet.
 * <<indices-reload-analyzers,Reload search analyzers API>>
 * <<repositories-metering-apis,Repositories metering APIs>>
 * <<rollup-apis,Rollup APIs>>
+* <<rest-api-root,Root API>>
 * <<script-apis,Script APIs>>
 * <<search, Search APIs>>
 * <<search-application-apis, Search Application APIs>>
@@ -93,6 +94,7 @@ include::{es-repo-dir}/query-rules/apis/index.asciidoc[]
 include::{es-repo-dir}/indices/apis/reload-analyzers.asciidoc[]
 include::{es-repo-dir}/repositories-metering-api/repositories-metering-apis.asciidoc[]
 include::{es-repo-dir}/rollup/rollup-apis.asciidoc[]
+include::{es-repo-dir}/rest-api/root.asciidoc[]
 include::{es-repo-dir}/scripting/apis/script-apis.asciidoc[]
 include::{es-repo-dir}/search.asciidoc[]
 include::{es-repo-dir}/search-application/apis/index.asciidoc[]

--- a/docs/reference/rest-api/root.asciidoc
+++ b/docs/reference/rest-api/root.asciidoc
@@ -1,0 +1,117 @@
+[[rest-api-root]]
+== Root API
+++++
+<titleabbrev>Root API</titleabbrev>
+++++
+
+The Elasticsearch API's base url returns its basic build, 
+version, and cluster information. 
+
+[source,console]
+--------------------------------------------------
+GET /
+--------------------------------------------------
+
+[discrete]
+[[rest-api-root-prereq]]
+=== {api-prereq-title}
+
+* If the {es} {security-features} are enabled, you must have the
+`monitor`, `manage`, or `all`
+<<privileges-list-cluster,cluster privilege>> to use this API.
+
+[role="child_attributes"]
+[discrete]
+[[rest-api-root-response-body]]
+=== {api-response-body-title}
+
+
+`name` ::
+The responding <<node-name,Node's `name`>>.
+
+`cluster_name` ::
+The responding <<cluster-name,Cluster's `name`>>.
+
+`cluster_uuid` ::
+The responding Cluster's `uuid` as confirmed by 
+<<cluster-state,Cluster State>>.
+
+`version` ::
+(object) 
+Contains information about the running version of Elasticsearch.
++ properties of `version`
+[%collapsible%open]
+====
+`number` ::
+Version number of responding 
+https://www.elastic.co/downloads/past-releases#elasticsearch[Elasticsearch release].
+
+`build_flavor` ::
+Build flavor, e.g. `default`.
+
+`build_type` ::
+Build type corresponding to how 
+<<install-elasticsearch,Elasticsearch was installed>, 
+e.g. `docker`, `rpm`, `tar`.
+
+`build_hash` ::
+Elasticsearch's Git commit's SHA hash.
+
+`build_date` ::
+Elasticsearch's Git commit's date.
+
+`build_snapshot` ::
+If Elasticsearch's build was from a snapshot.
+
+`lucene_version` ::
+Version number of Elasticsearch's 
+<<https://archive.apache.org/dist/lucene/java/,underlying Lucene software>>.
+
+`minimum_wire_compatibility_version` ::
+Minimum node version with which the responding node can 
+communicate. Also minimum  version from which you can perform 
+a <<rolling-upgrades,Rolling Upgrade>>.
+
+`minimum_index_compatibility_version` ::
+Minimum index version with which the responding node can read 
+from disk.
+====
+
+[discrete]
+[[rest-api-root-response-example]]
+=== {api-examples-title}
+
+The API returns the following response: 
+
+[source,console-result]
+----
+{
+  "name": "instance-0000000000",
+  "cluster_name": "my_test_cluster",
+  "cluster_uuid": "5QaxoN0pRZuOmWSxstBBwQ",
+  "version": {
+    "build_date": "2024-02-01T13:07:13.727175297Z",
+    "minimum_wire_compatibility_version": "7.17.0",
+    "build_hash": "6185ba65d27469afabc9bc951cded6c17c21e3f3",
+    "number": "8.12.1",
+    "lucene_version": "9.9.2",
+    "minimum_index_compatibility_version": "7.0.0",
+    "build_flavor": "default",
+    "build_snapshot": false,
+    "build_type": "docker"
+  },
+  "tagline": "You Know, for Search"
+}
+----
+// TESTRESPONSE[s/"name": "instance-0000000000"/"name": "$body.name"/]
+// TESTRESPONSE[s/"cluster_name": "my_test_cluster"/"cluster_name": "$body.cluster_name"/]
+// TESTRESPONSE[s/"cluster_uuid": "5QaxoN0pRZuOmWSxstBBwQ"/"cluster_uuid": "$body.cluster_uuid"/]
+// TESTRESPONSE[s/"build_date": "2024-02-01T13:07:13.727175297Z"/"build_date": "$body.version.build_date"/]
+// TESTRESPONSE[s/"minimum_wire_compatibility_version": "7.17.0"/"minimum_wire_compatibility_version": "$body.version.minimum_wire_compatibility_version"/]
+// TESTRESPONSE[s/"build_hash": "6185ba65d27469afabc9bc951cded6c17c21e3f3"/"build_hash": "$body.version.build_hash"/]
+// TESTRESPONSE[s/"number": "8.12.1"/"number": "$body.version.number"/]
+// TESTRESPONSE[s/"lucene_version": "9.9.2"/"lucene_version": "$body.version.lucene_version"/]
+// TESTRESPONSE[s/"minimum_index_compatibility_version": "7.0.0"/"minimum_index_compatibility_version": "$body.version.minimum_index_compatibility_version"/]
+// TESTRESPONSE[s/"build_flavor": "default"/"build_flavor": "$body.version.build_flavor"/]
+// TESTRESPONSE[s/"build_snapshot": false/"build_snapshot": "$body.version.build_snapshot"/]
+// TESTRESPONSE[s/"build_type": "docker"/"build_type": "$body.version.build_type"/]

--- a/docs/reference/rest-api/root.asciidoc
+++ b/docs/reference/rest-api/root.asciidoc
@@ -65,7 +65,7 @@ If Elasticsearch's build was from a snapshot.
 
 `lucene_version` ::
 Version number of Elasticsearch's 
-<<https://archive.apache.org/dist/lucene/java/,underlying Lucene software>>.
+https://archive.apache.org/dist/lucene/java/[underlying Lucene software].
 
 `minimum_wire_compatibility_version` ::
 Minimum node version with which the responding node can 
@@ -81,7 +81,7 @@ from disk.
 [[rest-api-root-response-example]]
 === {api-examples-title}
 
-The API returns the following response: 
+The API returns a response like the following: 
 
 [source,console-result]
 ----


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [(DOC+) Version API page for ES API Base URL (#105845)](https://github.com/elastic/elasticsearch/pull/105845)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)