### PR TITLE
ES|QL: expose the query transport action to improve usage

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/esql/action/EsqlQueryRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/esql/action/EsqlQueryRequestBuilder.java
@@ -16,6 +16,8 @@ import org.elasticsearch.xpack.core.esql.action.internal.SharedSecrets;
 public abstract class EsqlQueryRequestBuilder<Request extends EsqlQueryRequest, Response extends EsqlQueryResponse> extends
     ActionRequestBuilder<Request, Response> {
 
+    private final ActionType<Response> action;
+
     /** Creates a new ES|QL query request builder. */
     public static EsqlQueryRequestBuilder<? extends EsqlQueryRequest, ? extends EsqlQueryResponse> newRequestBuilder(
         ElasticsearchClient client
@@ -26,6 +28,11 @@ public abstract class EsqlQueryRequestBuilder<Request extends EsqlQueryRequest, 
     // not for direct use
     protected EsqlQueryRequestBuilder(ElasticsearchClient client, ActionType<Response> action, Request request) {
         super(client, action, request);
+        this.action = action;
+    }
+
+    public final ActionType<Response> action() {
+        return action;
     }
 
     public abstract EsqlQueryRequestBuilder<Request, Response> query(String query);

--- a/x-pack/plugin/esql/qa/action/src/internalClusterTest/java/org/elasticsearch/test/esql/qa/action/CoreEsqlActionIT.java
+++ b/x-pack/plugin/esql/qa/action/src/internalClusterTest/java/org/elasticsearch/test/esql/qa/action/CoreEsqlActionIT.java
@@ -129,8 +129,11 @@ public class CoreEsqlActionIT extends ESIntegTestCase {
 
     protected EsqlQueryResponse run(EsqlQueryRequestBuilder<? extends EsqlQueryRequest, ? extends EsqlQueryResponse> request) {
         try {
+            // The variants here ensure API usage patterns
             if (randomBoolean()) {
                 return request.execute().actionGet(30, SECONDS);
+            } else if (randomBoolean()) {
+                return client().execute(request.action(), request.request()).actionGet(30, SECONDS);
             } else {
                 return ClientHelper.executeWithHeaders(
                     Map.of("Foo", "bar"),


### PR DESCRIPTION
This commits exposes the query transport action to improve usage. While one can perform all operations prior to this change, it has been suggested that adding the `action` would improve the symmetry of the API by allowing e.g. 

```
client().execute(builder.action(), builder.request()).actionGet(30, SECONDS);
```