### PR TITLE
[ML] Fix the position of spike, dip and distribution changes bucket when the sibling aggregation includes empty buckets

### DIFF
--- a/docs/changelog/106472.yaml
+++ b/docs/changelog/106472.yaml
@@ -1,0 +1,6 @@
+pr: 106472
+summary: "Fix the position of spike, dip and distribution changes bucket when the\
+  \ sibling aggregation includes empty buckets"
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
There was a bug in our indexing of the spike, dip and distribution change bucket. Specifically, we were not mapping the index in the values array, which skips empty buckets, back to the aggregation bucket index. The effect was that the reported buckets were offset to the left when the spike, dip or distribution change occurred after one or more empty buckets.