### PR TITLE
TransportMountSearchableSnapshotAction-set-parent-task-ID #105830

### DIFF
--- a/docs/changelog/106190.yaml
+++ b/docs/changelog/106190.yaml
@@ -1,0 +1,6 @@
+pr: 106190
+summary: TransportMountSearchableSnapshotAction-set-parentTaskId
+area: Snapshot/Restore
+type: enhancement
+issues:
+ - 105830

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/TransportMountSearchableSnapshotAction.java
@@ -39,6 +39,7 @@ import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotAction;
@@ -177,6 +178,7 @@ public class TransportMountSearchableSnapshotAction extends TransportMasterNodeA
             EsExecutors.DIRECT_EXECUTOR_SERVICE, // TODO fork to SNAPSHOT_META and drop the forking below, see #101445
             repositoryDataListener
         );
+        request.setParentTask(new TaskId(clusterService.localNode().getId(), task.getId()));
         repositoryDataListener.addListener(listener.delegateFailureAndWrap((delegate, repoData) -> {
             final Map<String, IndexId> indexIds = repoData.getIndices();
             if (indexIds.containsKey(indexName) == false) {


### PR DESCRIPTION
In the masterOperation method of TransportMountSearchableSnapshotAction, set the parentTaskId for MountSearchableSnapshotRequest.
https://github.com/elastic/elasticsearch/issues/105830
