### PR TITLE
Fix106475 where we have a new test that should not run in older versions

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/61_enrich_ip.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/61_enrich_ip.yml
@@ -106,6 +106,10 @@ teardown:
 
 ---
 "Invalid IP strings":
+  - skip:
+      version: " - 8.13.99"
+      reason: "IP range ENRICH support was added in 8.14.0"
+
   - do:
       catch: /'invalid_[\d\.]+' is not an IP string literal/
       esql.query:


### PR DESCRIPTION
This error message only works in 8.14

Fixes #106475 
