### PR TITLE
Different string allocation on jdk 21/22

### DIFF
--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkSystemdLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkSystemdLibrary.java
@@ -58,7 +58,7 @@ class JdkSystemdLibrary implements SystemdLibrary {
     @Override
     public int sd_notify(int unset_environment, String state) {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment nativeState = arena.allocateUtf8String(state);
+            MemorySegment nativeState = MemorySegmentUtil.allocateString(arena, state);
             return (int) sd_notify$mh.invokeExact(unset_environment, nativeState);
         } catch (Throwable t) {
             throw new AssertionError(t);

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.nativeaccess.jdk;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 /**
@@ -17,6 +18,10 @@ class MemorySegmentUtil {
 
     static String getString(MemorySegment segment, long offset) {
         return segment.getUtf8String(offset);
+    }
+
+    static MemorySegment allocateString(Arena arena, String s) {
+        return arena.allocateUtf8String(s);
     }
 
     private MemorySegmentUtil() {}

--- a/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -8,12 +8,17 @@
 
 package org.elasticsearch.nativeaccess.jdk;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 
 public class MemorySegmentUtil {
 
     static String getString(MemorySegment segment, long offset) {
         return segment.getString(offset);
+    }
+
+    static MemorySegment allocateString(Arena arena, String s) {
+        return arena.allocateFrom(s);
     }
 
     private MemorySegmentUtil() {}


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/106360, the methods for allocating a native string changed between Java 21 and 22. This commit adds another util method to handle the differences and uses it in the jdk systemd impl.