### PR TITLE
[Profiling] Accept OTEL host architecture values

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/CO2Calculator.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/CO2Calculator.java
@@ -53,14 +53,13 @@ final class CO2Calculator {
     }
 
     private double getKiloWattsPerCore(HostMetadata host) {
-        if ("aarch64".equals(host.profilingHostMachine)) {
-            // Assume that AARCH64 (aka ARM64) machines are more energy efficient than x86_64 machines.
-            return customKilowattsPerCoreARM64;
-        }
-        if ("x86_64".equals(host.profilingHostMachine)) {
-            return customKilowattsPerCoreX86;
-        }
-        return DEFAULT_KILOWATTS_PER_CORE;
+        return switch (host.profilingHostMachine) {
+            // For the OTEL donation of the profiling agent, we switch to OTEL semantic conventions,
+            // which require "arm64" and "amd64" to be reported as the host architecture.
+            case "arm64", "aarch64" -> customKilowattsPerCoreARM64;
+            case "amd64", "x86_64" -> customKilowattsPerCoreX86;
+            default -> DEFAULT_KILOWATTS_PER_CORE;
+        };
     }
 
     private double getCO2TonsPerKWH(HostMetadata host) {


### PR DESCRIPTION
Due to the OTEL donation of the Universal Profiling agent, we switch the agent to use the [OTEL semantic conventions for the host architecture](https://opentelemetry.io/docs/specs/semconv/attributes-registry/host/).

These require us to support "amd64" and "arm64" values in the CO2 calculations.

I'd like to get this in rather sooner than later to achieve highest possible backwards compatibility when future agents send to older ES backends.

Fixes #106410