### PR TITLE
Set explicit directory and file permissions on native libraries

### DIFF
--- a/libs/native/libraries/build.gradle
+++ b/libs/native/libraries/build.gradle
@@ -57,6 +57,12 @@ def extractLibs = tasks.register('extractLibs', Copy) {
   filesMatching("win32*/*") {
     it.path = it.path.replace("win32", "windows")
   }
+  filePermissions {
+    unix("644")
+  }
+  dirPermissions {
+    unix("755")
+  }
 }
 
 artifacts {


### PR DESCRIPTION
The distributions already have correct permissions set on native libraries copied to them. However, the build itself to extract the native libs relies on the upstream file permissions. This commit sets explicit permissions on the copy task which extracts native libraries.