### PR TITLE
Fix 60_enrich/Enrich on keyword (fixes 106507)

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -39,10 +39,6 @@ BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseN
   def yamlRestTest = tasks.register("v${bwcVersion}#yamlRestTest", StandaloneRestIntegTestTask) {
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
-    systemProperty("tests.rest.blacklist", [
-      // https://github.com/elastic/elasticsearch/issues/106507
-      "esql/60_enrich/Enrich on keyword"
-    ].join(','))
     testClassesDirs = sourceSets.yamlRestTest.output.classesDirs
     classpath = sourceSets.yamlRestTest.runtimeClasspath
   }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_enrich.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_enrich.yml
@@ -94,7 +94,7 @@ teardown:
 "Enrich on keyword":
   - skip:
       version: " - 8.12.99"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/106507"
+      reason: "Enriching with text field in the enrich fields list involves reading text from source, not supported before 8.13.0"
       features: allowed_warnings_regex
 
   - do:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_enrich.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_enrich.yml
@@ -92,6 +92,11 @@ teardown:
 
 ---
 "Enrich on keyword":
+  - skip:
+      version: " - 8.12.99"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/106507"
+      features: allowed_warnings_regex
+
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"


### PR DESCRIPTION
This test used to work, but now is failing in BWC against 8.12.3. It appears the difference that caused the problem is that the query now returns a field that used to be a keyword, but is now a text field, provided by the enrich lookup. So even though the enrich is still based on a keyword, this query now accesses code paths it did not before, and those have issues before 8.13.0 related to reading text from source.

Fixes #106507 
