### PR TITLE
Ensure ILM policy is installed before starting the tests.

### DIFF
--- a/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
+++ b/x-pack/plugin/ent-search/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/application/FullClusterRestartIT.java
@@ -172,7 +172,7 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
             assertOK(response);
 
             assertNotNull(ObjectPath.createFromResponse(response).evaluate(policyName));
-        }  catch (ResponseException e) {
+        } catch (ResponseException e) {
             int status = e.getResponse().getStatusLine().getStatusCode();
             if (status == 404) {
                 throw new AssertionError("Waiting for the policy to be created");


### PR DESCRIPTION
Fix for #106473 

Added a step to wait for the ILM policy to be installed before starting the tests.