### PR TITLE
[DOCS] Creates a semantic_text field type docs page

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -75,6 +75,7 @@ markup. Used for identifying named entities.
 <<completion-suggester,`completion`>>:: Used for auto-complete suggestions.
 <<search-as-you-type,`search_as_you_type`>>:: `text`-like type for
 as-you-type completion.
+<<semantic-text, `semantic_text`>>:: 
 <<token-count,`token_count`>>:: A count of tokens in a text.
 
 
@@ -177,6 +178,8 @@ include::types/rank-feature.asciidoc[]
 include::types/rank-features.asciidoc[]
 
 include::types/search-as-you-type.asciidoc[]
+
+include::types/semantic-text.asciidoc[]
 
 include::types/shape.asciidoc[]
 

--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -1,0 +1,8 @@
+[role="xpack"]
+[[semantic-text]]
+=== Semantic text field type
+++++
+<titleabbrev>Semantic text</titleabbrev>
+++++
+
+The documentation page for the `semantic_text` field type.


### PR DESCRIPTION
## Overview

This PR creates a placeholder page for the `semantic_text` field type docs and adds it to the TOC.