### PR TITLE
[8.13] [Connectors API] Add missing `_api_key_id` docs (#106469)

### DIFF
--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -33,6 +33,7 @@ Use the following APIs to manage connectors:
 * <<get-connector-api>>
 * <<list-connector-api>>
 * <<check-in-connector-api>>
+* <<update-connector-api-key-id-api>>
 * <<update-connector-configuration-api>>
 * <<update-connector-error-api>>
 * <<update-connector-filtering-api>>
@@ -77,6 +78,7 @@ include::list-connectors-api.asciidoc[]
 include::list-connector-sync-jobs-api.asciidoc[]
 include::set-connector-sync-job-error-api.asciidoc[]
 include::set-connector-sync-job-stats-api.asciidoc[]
+include::update-connector-api-key-id-api.asciidoc[]
 include::update-connector-configuration-api.asciidoc[]
 include::update-connector-error-api.asciidoc[]
 include::update-connector-filtering-api.asciidoc[]

--- a/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
@@ -1,0 +1,97 @@
+[[update-connector-api-key-id-api]]
+=== Update connector API key ID API
+++++
+<titleabbrev>Update connector API key id</titleabbrev>
+++++
+
+preview::[]
+
+Updates the `api_key_id` and/or `api_key_secret_id` field(s) of a connector, specifying:
+
+. The ID of the API key used for authorization
+. The ID of the Connector Secret where the API key is stored
+
+The Connector Secret ID is only required for native connectors.
+Connector clients do not use this field.
+See the documentation for {enterprise-search-ref}/native-connectors.html#native-connectors-manage-API-keys-programmatically[managing native connector API keys programmatically^] for more details.
+
+[[update-connector-api-key-id-api-request]]
+==== {api-request-title}
+
+`PUT _connector/<connector_id>/_api_key_id`
+
+[[update-connector-api-key-id-api-prereq]]
+==== {api-prereq-title}
+
+* To sync data using connectors, it's essential to have the Elastic connectors service running.
+* The `connector_id` parameter should reference an existing connector.
+* The `api_key_id` parameter should reference an existing API key.
+* The `api_key_secret_id` parameter should reference an existing Connector Secret containing an encoded API key value.
+
+[[update-connector-api-key-id-api-path-params]]
+==== {api-path-parms-title}
+
+`<connector_id>`::
+(Required, string)
+
+[role="child_attributes"]
+[[update-connector-api-key-id-api-request-body]]
+==== {api-request-body-title}
+
+`api_key_id`::
+(Optional, string) ID of the API key that the connector will use to authorize access to required indices. Each connector can be associated with at most one API key.
+
+`api_key_secret_id`::
+(Optional, string) ID of the Connector Secret that contains the encoded API key. This should be the same API key as `api_key_id` references. This is only required for native connectors.
+
+[[update-connector-api-key-id-api-response-codes]]
+==== {api-response-codes-title}
+
+`200`::
+Connector `api_key_id` and/or `api_key_secret_id` field(s) successfully updated.
+
+`400`::
+The `connector_id` was not provided or the request payload was malformed.
+
+`404` (Missing resources)::
+No connector matching `connector_id` could be found.
+
+[[update-connector-api-key-id-api-example]]
+==== {api-examples-title}
+
+The following example updates the `api_key_id` and `api_key_secret_id` field(s) for the connector with ID `my-connector`:
+
+////
+[source, console]
+--------------------------------------------------
+PUT _connector/my-connector
+{
+  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "service_type": "google_drive"
+}
+--------------------------------------------------
+// TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE _connector/my-connector
+--------------------------------------------------
+// TEARDOWN
+////
+
+[source,console]
+----
+PUT _connector/my-connector/_api_key_id
+{
+    "api_key_id": "my-api-key-id",
+    "api_key_secret_id": "my-connector-secret-id"
+}
+----
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_api_key_id.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/connector.update_api_key_id.json
@@ -1,7 +1,7 @@
 {
   "connector.update_api_key_id": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/connector-apis.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/update-connector-api-key-id-api.html",
       "description": "Updates the API key id and/or API key secret id fields in the connector document."
     },
     "stability": "experimental",


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Connectors API] Add missing `_api_key_id` docs (#106469)