### PR TITLE
[8.13] Force execution of `SearchService.Reaper` (#106544)

### DIFF
--- a/docs/changelog/106544.yaml
+++ b/docs/changelog/106544.yaml
@@ -1,0 +1,6 @@
+pr: 106544
+summary: Force execution of `SearchService.Reaper`
+area: Search
+type: bug
+issues:
+ - 106543


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Force execution of `SearchService.Reaper` (#106544)