### PR TITLE
[8.13] [DOCS] Changes Cohere inference examples in tutorial and API docs (#106524)

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -100,6 +100,7 @@ the same name and the updated API key.
 (Optional, string)
 Specifies the types of embeddings you want to get back. Defaults to `float`.
 Valid values are:
+  * `byte`: use it for signed int8 embeddings (this is a synonym of `int8`). 
   * `float`: use it for the default float embeddings.
   * `int8`: use it for signed int8 embeddings.
 
@@ -256,9 +257,7 @@ PUT _inference/text_embedding/cohere-embeddings
     "service_settings": {
         "api_key": "<api_key>",
         "model": "embed-english-light-v3.0",
-        "embedding_type": "int8"
-    },
-    "task_settings": {
+        "embedding_type": "byte"
     }
 }
 ------------------------------------------------------------

--- a/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
@@ -8,9 +8,7 @@ PUT _inference/text_embedding/cohere_embeddings <1>
     "service_settings": {
         "api_key": "<api_key>", <2>
         "model_id": "embed-english-v3.0", <3>
-        "embedding_type": "int8"
-    },
-    "task_settings": {
+        "embedding_type": "byte"
     }
 }
 ------------------------------------------------------------


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [DOCS] Changes Cohere inference examples in tutorial and API docs (#106524)