### PR TITLE
Force execution of `SearchService.Reaper`

### DIFF
--- a/docs/changelog/106544.yaml
+++ b/docs/changelog/106544.yaml
@@ -1,0 +1,6 @@
+pr: 106544
+summary: Force execution of `SearchService.Reaper`
+area: Search
+type: bug
+issues:
+ - 106543


### PR DESCRIPTION
If the search threadpool fills up then we may reject execution of
`SearchService.Reaper` which means it stops retrying. We must instead
force its execution so that it keeps on going.

With #106542, closes #106543
Backport of #106544 to 7.17