### PR TITLE
Use LogDocMergePolicy in GeoPointScriptFieldDistanceFeatureQueryTests#testMatches

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/runtime/GeoPointScriptFieldDistanceFeatureQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/runtime/GeoPointScriptFieldDistanceFeatureQueryTests.java
@@ -10,13 +10,17 @@ package org.elasticsearch.search.runtime;
 
 import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.LogDocMergePolicy;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.apache.lucene.tests.index.RandomIndexWriter;
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.geo.GeoUtils;
@@ -79,9 +83,13 @@ public class GeoPointScriptFieldDistanceFeatureQueryTests extends AbstractScript
 
     @Override
     public void testMatches() throws IOException {
-        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory)) {
+        IndexWriterConfig config = LuceneTestCase.newIndexWriterConfig(random(), new MockAnalyzer(random()));
+        // Use LogDocMergePolicy to avoid randomization issues with the doc retrieval order.
+        config.setMergePolicy(new LogDocMergePolicy());
+        try (Directory directory = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), directory, config)) {
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"location\": [34, 6]}"))));
             iw.addDocument(List.of(new StoredField("_source", new BytesRef("{\"location\": [-3.56, -45.98]}"))));
+
             try (DirectoryReader reader = iw.getReader()) {
                 IndexSearcher searcher = newSearcher(reader);
                 SearchLookup searchLookup = new SearchLookup(null, null, SourceProvider.fromStoredFields());


### PR DESCRIPTION
The latest lucene upgrade adds a new merge policy that reverse the order of the documents. To avoid randomisation we hardcode the merge policy to LogDocMergePolicy.

relates https://github.com/elastic/elasticsearch/pull/103040

fixes https://github.com/elastic/elasticsearch/issues/106549