### PR TITLE
Validate that test cluster BWC nodes use the default distribution

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -71,6 +71,15 @@ public class LocalClusterSpec implements ClusterSpec {
         if (nodeNames.isEmpty() == false) {
             throw new IllegalArgumentException("Cluster cannot contain nodes with duplicates names: " + nodeNames);
         }
+
+        // Ensure we do not configure older version nodes with the integTest distribution
+        if (nodes.stream().anyMatch(n -> n.getVersion() != Version.CURRENT && n.getDistributionType() == DistributionType.INTEG_TEST)) {
+            throw new IllegalArgumentException(
+                "Error configuring test cluster '"
+                    + name
+                    + "'. When configuring a node for a prior Elasticsearch version, the default distribution type must be used."
+            );
+        }
     }
 
     public static class LocalNodeSpec {

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
@@ -49,7 +49,7 @@ public class RemoteClusterSecurityBwcRestIT extends AbstractRemoteClusterSecurit
     static {
         fulfillingCluster = ElasticsearchCluster.local()
             .version(OLD_CLUSTER_VERSION)
-            .distribution(DistributionType.INTEG_TEST)
+            .distribution(DistributionType.DEFAULT)
             .name("fulfilling-cluster")
             .apply(commonClusterConfig)
             .setting("xpack.ml.enabled", "false")


### PR DESCRIPTION
We have instances where BWC tests configure old ES version nodes with the integTest distribution. This isn't a valid configuration, and while we in reality resolve the default distribution artifact, we have other configuration logic that behaves differently based on whether the integTest distro was _requested_. Specifically, what to set ES_JAVA_HOME to. This bug resulted in us attempting to run old nodes using the current bundled JDK version, which may be incompatible with that older version of Elasticsearch.

Closes #104858