### PR TITLE
Allow users with read role to use the async_search/status endpoint

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -75,14 +75,20 @@ import static org.elasticsearch.xpack.core.security.support.Automatons.unionAndM
 public final class IndexPrivilege extends Privilege {
     private static final Logger logger = LogManager.getLogger(IndexPrivilege.class);
 
-    private static final Automaton ALL_AUTOMATON = patterns("indices:*", "internal:transport/proxy/indices:*");
+    private static final Automaton ALL_AUTOMATON = patterns(
+        "indices:*",
+        "internal:transport/proxy/indices:*",
+        "cluster:monitor/async_search/status"
+    );
     private static final Automaton READ_AUTOMATON = patterns(
         "indices:data/read/*",
+        "cluster:monitor/async_search/status",
         ResolveIndexAction.NAME,
         TransportResolveClusterAction.NAME
     );
     private static final Automaton READ_CROSS_CLUSTER_AUTOMATON = patterns(
         "internal:transport/proxy/indices:data/read/*",
+        "cluster:monitor/async_search/status",
         ClusterSearchShardsAction.NAME,
         TransportSearchShardsAction.TYPE.name(),
         TransportResolveClusterAction.NAME,


### PR DESCRIPTION
# Summary of issue

Currently, the `async_search` action and `async_search/status` actions have radically different action names:

GetAsyncStatusAction has `cluster:monitor/async_search/status`
GetAsyncSearchAction has `indices:data/read/async_search/get`

The status endpoint requires the monitor, manage or all privileges, which is not something all Kibana users will have, which results in this error on a secured cluster:

```
action [cluster:monitor/async_search/status] is unauthorized for user [my_kibana_user] with effective roles [my_kibana_role], this action is granted by the cluster privileges [monitor,manage,all]
```

The async_search/status endpoint was added in this PR: https://github.com/elastic/elasticsearch/pull/62947

The original request for this endpoint came from Kibana (https://github.com/elastic/elasticsearch/issues/57537) and their scope was to have background jobs running to check on status, using the kibana_admin user, so that is likely why a `cluster:monitor` action name was chosen rather than `indices:data`.

However, there are two arguments for changing this:

1. If you have the privilege to start an async search and retrieve its results, you should also have the permissions to check its status.

2. Cross-cluster async search has recently made a change to do [incremental merges of search results](https://github.com/elastic/elasticsearch/pull/105781) whenever a user requests them via the `GET _async_search/:id` endpoint. This will have CPU cost, and since Kibana regularly polls this endpoint to check for status, we (Elasticsearch) have asked Kibana to move to polling status via `_async_search/status`. The current permissions settings on the status endpoint now blocks that move.

## Options for changing

1) I tried the simplest change I could think of, which is to add `cluster:monitor/async_search/status` to the IndexPrivilege.READ_AUTOMATON, but that does not work. It still fails with the same security error mentioned above. See the details section below.

I also tried adding that to IndexPrivilege.ALL and it also still fails with the same error message. So my guess is that the cluster:monitor prefix is causing some issue.

2) Change the GetAsyncStatusAction to have the same action name as GetAsyncSearchAction, namely: `indices:data/read/async_search/get`

Is this allowed? Is there a way to make this backwards compatible? We'd need roles with only `manage` or `monitor` and not `read` roles to still have access to async-search-status so as not to break existing functionality.

3) Other options?


### Attempt 1: add `cluster:monitor/async_search/status` to the IndexPrivilege.READ_AUTOMATON

With a user having the following privileges:

```
{
  "mp_role": {
    "cluster": [],
    "indices": [
      {
        "names": [
          "blogs"
        ],
        "privileges": [
          "read"
        ],
        "allow_restricted_indices": false
      },
```

I can start an async-search no problem (not shown), but when I query for status I get an error, even with the code changes in this first commit where I added `cluster:monitor/async_search/status` to the IndexPrivilege.READ_AUTOMATON.

<details><summary>(toggle for error info and stack trace)</summary>

```
{"error":{"root_cause":[{"type":"security_exception","reason":"action [cluster:monitor/async_search/status] is unauthorized for user [mp_user] with effective roles [mp_role], this action is granted by the cluster privileges [monitor,manage,all]","stack_trace":"org.elasticsearch.ElasticsearchSecurityException: action [cluster:monitor/async_search/status] is unauthorized for user [mp_user] with effective roles [mp_role], this action is granted by the cluster privileges [monitor,manage,all]
	at org.elasticsearch.xcore@8.14.0-SNAPSHOT/org.elasticsearch.xpack.core.security.support.Exceptions.authorizationError(Exceptions.java:36)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.denialException(AuthorizationService.java:993)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.actionDenied(AuthorizationService.java:970)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService$AuthorizationResultListener.handleFailure(AuthorizationService.java:1049)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService$AuthorizationResultListener.onResponse(AuthorizationService.java:1035)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService$AuthorizationResultListener.onResponse(AuthorizationService.java:996)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:32)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorizeAction$9(AuthorizationService.java:473)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.RBACEngine.authorizeClusterAction(RBACEngine.java:192)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.authorizeAction(AuthorizationService.java:463)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.maybeAuthorizeRunAs(AuthorizationService.java:439)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorize$3(AuthorizationService.java:326)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:171)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:32)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.RBACEngine.lambda$resolveAuthorizationInfo$0(RBACEngine.java:153)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.lambda$getRoles$4(CompositeRolesStore.java:193)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.lambda$getRole$5(CompositeRolesStore.java:211)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.xcore@8.14.0-SNAPSHOT/org.elasticsearch.xpack.core.security.authz.store.RoleReferenceIntersection.lambda$buildRole$0(RoleReferenceIntersection.java:49)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.GroupedActionListener.onResponse(GroupedActionListener.java:56)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.buildRoleFromRoleReference(CompositeRolesStore.java:291)
	at org.elasticsearch.xcore@8.14.0-SNAPSHOT/org.elasticsearch.xpack.core.security.authz.store.RoleReferenceIntersection.lambda$buildRole$1(RoleReferenceIntersection.java:53)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.elasticsearch.xcore@8.14.0-SNAPSHOT/org.elasticsearch.xpack.core.security.authz.store.RoleReferenceIntersection.buildRole(RoleReferenceIntersection.java:53)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.getRole(CompositeRolesStore.java:209)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.getRoles(CompositeRolesStore.java:186)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.RBACEngine.resolveAuthorizationInfo(RBACEngine.java:149)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.authorize(AuthorizationService.java:342)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.action.filter.SecurityActionFilter.lambda$applyInternal$4(SecurityActionFilter.java:161)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:95)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.AuthenticatorChain.authenticate(AuthenticatorChain.java:93)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.AuthenticationService.authenticate(AuthenticationService.java:264)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.AuthenticationService.authenticate(AuthenticationService.java:173)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.action.filter.SecurityActionFilter.applyInternal(SecurityActionFilter.java:157)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.action.filter.SecurityActionFilter.apply(SecurityActionFilter.java:114)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:93)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:68)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.tasks.TaskManager.registerAndExecute(TaskManager.java:196)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.client.internal.node.NodeClient.executeLocally(NodeClient.java:105)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.client.internal.node.NodeClient.doExecute(NodeClient.java:83)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.client.internal.support.AbstractClient.execute(AbstractClient.java:356)
	at org.elasticsearch.xpack.search.RestGetAsyncStatusAction.lambda$prepareRequest$0(RestGetAsyncStatusAction.java:40)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:106)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:452)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:446)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.rest.SecurityRestFilter.doHandleRequest(SecurityRestFilter.java:89)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$0(SecurityRestFilter.java:81)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:171)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.lambda$authenticateAndAttachToContext$3(SecondaryAuthenticator.java:99)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticate(SecondaryAuthenticator.java:109)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticateAndAttachToContext(SecondaryAuthenticator.java:90)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.rest.SecurityRestFilter.intercept(SecurityRestFilter.java:75)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:446)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController.tryAllHandlers(RestController.java:606)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:329)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.http.AbstractHttpServerTransport.dispatchRequest(AbstractHttpServerTransport.java:465)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.http.AbstractHttpServerTransport.handleIncomingRequest(AbstractHttpServerTransport.java:561)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.http.AbstractHttpServerTransport.incomingRequest(AbstractHttpServerTransport.java:438)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpPipeliningHandler.handlePipelinedRequest(Netty4HttpPipeliningHandler.java:126)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:116)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.codec@4.1.107.Final/io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.codec@4.1.107.Final/io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpHeaderValidator.forwardData(Netty4HttpHeaderValidator.java:194)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpHeaderValidator.forwardFullRequest(Netty4HttpHeaderValidator.java:137)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpHeaderValidator.lambda$requestStart$1(Netty4HttpHeaderValidator.java:120)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.PromiseTask.run(PromiseTask.java:106)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.transport@4.1.107.Final/io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.common@4.1.107.Final/io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1570)
"}],"type":"security_exception","reason":"action [cluster:monitor/async_search/status] is unauthorized for user [mp_user] with effective roles [mp_role], this action is granted by the cluster privileges [monitor,manage,all]","stack_trace":"org.elasticsearch.ElasticsearchSecurityException: action [cluster:monitor/async_search/status] is unauthorized for user [mp_user] with effective roles [mp_role], this action is granted by the cluster privileges [monitor,manage,all]
	at org.elasticsearch.xcore@8.14.0-SNAPSHOT/org.elasticsearch.xpack.core.security.support.Exceptions.authorizationError(Exceptions.java:36)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.denialException(AuthorizationService.java:993)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.actionDenied(AuthorizationService.java:970)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService$AuthorizationResultListener.handleFailure(AuthorizationService.java:1049)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService$AuthorizationResultListener.onResponse(AuthorizationService.java:1035)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService$AuthorizationResultListener.onResponse(AuthorizationService.java:996)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:32)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorizeAction$9(AuthorizationService.java:473)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.RBACEngine.authorizeClusterAction(RBACEngine.java:192)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.authorizeAction(AuthorizationService.java:463)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.maybeAuthorizeRunAs(AuthorizationService.java:439)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.lambda$authorize$3(AuthorizationService.java:326)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:171)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.ContextPreservingActionListener.onResponse(ContextPreservingActionListener.java:32)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.RBACEngine.lambda$resolveAuthorizationInfo$0(RBACEngine.java:153)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.lambda$getRoles$4(CompositeRolesStore.java:193)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.lambda$getRole$5(CompositeRolesStore.java:211)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.xcore@8.14.0-SNAPSHOT/org.elasticsearch.xpack.core.security.authz.store.RoleReferenceIntersection.lambda$buildRole$0(RoleReferenceIntersection.java:49)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.GroupedActionListener.onResponse(GroupedActionListener.java:56)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.buildRoleFromRoleReference(CompositeRolesStore.java:291)
	at org.elasticsearch.xcore@8.14.0-SNAPSHOT/org.elasticsearch.xpack.core.security.authz.store.RoleReferenceIntersection.lambda$buildRole$1(RoleReferenceIntersection.java:53)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at org.elasticsearch.xcore@8.14.0-SNAPSHOT/org.elasticsearch.xpack.core.security.authz.store.RoleReferenceIntersection.buildRole(RoleReferenceIntersection.java:53)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.getRole(CompositeRolesStore.java:209)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.store.CompositeRolesStore.getRoles(CompositeRolesStore.java:186)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.RBACEngine.resolveAuthorizationInfo(RBACEngine.java:149)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authz.AuthorizationService.authorize(AuthorizationService.java:342)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.action.filter.SecurityActionFilter.lambda$applyInternal$4(SecurityActionFilter.java:161)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$MappedActionListener.onResponse(ActionListenerImplementations.java:95)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.AuthenticatorChain.authenticate(AuthenticatorChain.java:93)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.AuthenticationService.authenticate(AuthenticationService.java:264)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.AuthenticationService.authenticate(AuthenticationService.java:173)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.action.filter.SecurityActionFilter.applyInternal(SecurityActionFilter.java:157)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.action.filter.SecurityActionFilter.apply(SecurityActionFilter.java:114)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:93)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:68)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.tasks.TaskManager.registerAndExecute(TaskManager.java:196)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.client.internal.node.NodeClient.executeLocally(NodeClient.java:105)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.client.internal.node.NodeClient.doExecute(NodeClient.java:83)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.client.internal.support.AbstractClient.execute(AbstractClient.java:356)
	at org.elasticsearch.xpack.search.RestGetAsyncStatusAction.lambda$prepareRequest$0(RestGetAsyncStatusAction.java:40)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:106)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:452)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController$1.onResponse(RestController.java:446)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.rest.SecurityRestFilter.doHandleRequest(SecurityRestFilter.java:89)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.rest.SecurityRestFilter.lambda$intercept$0(SecurityRestFilter.java:81)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListener$2.onResponse(ActionListener.java:171)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.lambda$authenticateAndAttachToContext$3(SecondaryAuthenticator.java:99)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.action.ActionListenerImplementations$ResponseWrappingActionListener.onResponse(ActionListenerImplementations.java:245)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticate(SecondaryAuthenticator.java:109)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator.authenticateAndAttachToContext(SecondaryAuthenticator.java:90)
	at org.elasticsearch.security@8.14.0-SNAPSHOT/org.elasticsearch.xpack.security.rest.SecurityRestFilter.intercept(SecurityRestFilter.java:75)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:446)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController.tryAllHandlers(RestController.java:606)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.rest.RestController.dispatchRequest(RestController.java:329)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.http.AbstractHttpServerTransport.dispatchRequest(AbstractHttpServerTransport.java:465)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.http.AbstractHttpServerTransport.handleIncomingRequest(AbstractHttpServerTransport.java:561)
	at org.elasticsearch.server@8.14.0-SNAPSHOT/org.elasticsearch.http.AbstractHttpServerTransport.incomingRequest(AbstractHttpServerTransport.java:438)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpPipeliningHandler.handlePipelinedRequest(Netty4HttpPipeliningHandler.java:126)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:116)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.codec@4.1.107.Final/io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.codec@4.1.107.Final/io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.transport@4.1.107.Final/io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpHeaderValidator.forwardData(Netty4HttpHeaderValidator.java:194)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpHeaderValidator.forwardFullRequest(Netty4HttpHeaderValidator.java:137)
	at org.elasticsearch.transport.netty4@8.14.0-SNAPSHOT/org.elasticsearch.http.netty4.Netty4HttpHeaderValidator.lambda$requestStart$1(Netty4HttpHeaderValidator.java:120)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.PromiseTask.run(PromiseTask.java:106)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:173)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:166)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470)
	at io.netty.transport@4.1.107.Final/io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:566)
	at io.netty.common@4.1.107.Final/io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.common@4.1.107.Final/io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1570)
"},"status":403}
```

</details>


What is the best way forward on this issue?