### PR TITLE
[8.13] Validate that test cluster BWC nodes use the default distribution (#106559)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -71,6 +71,15 @@ public class LocalClusterSpec implements ClusterSpec {
         if (nodeNames.isEmpty() == false) {
             throw new IllegalArgumentException("Cluster cannot contain nodes with duplicates names: " + nodeNames);
         }
+
+        // Ensure we do not configure older version nodes with the integTest distribution
+        if (nodes.stream().anyMatch(n -> n.getVersion() != Version.CURRENT && n.getDistributionType() == DistributionType.INTEG_TEST)) {
+            throw new IllegalArgumentException(
+                "Error configuring test cluster '"
+                    + name
+                    + "'. When configuring a node for a prior Elasticsearch version, the default distribution type must be used."
+            );
+        }
     }
 
     public static class LocalNodeSpec {

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
@@ -49,7 +49,7 @@ public class RemoteClusterSecurityBwcRestIT extends AbstractRemoteClusterSecurit
     static {
         fulfillingCluster = ElasticsearchCluster.local()
             .version(OLD_CLUSTER_VERSION)
-            .distribution(DistributionType.INTEG_TEST)
+            .distribution(DistributionType.DEFAULT)
             .name("fulfilling-cluster")
             .apply(commonClusterConfig)
             .setting("xpack.ml.enabled", "false")


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Validate that test cluster BWC nodes use the default distribution (#106559)