### PR TITLE
[DOCS] Adds note to inference tutorial about similarity

### DIFF
--- a/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
@@ -22,6 +22,13 @@ key.
 <3> The name of the embedding model to use. You can find the list of Cohere
 embedding models https://docs.cohere.com/reference/embed[here].
 
+NOTE: The default `similarity` for the service is `dot_product` while the
+default `similarity` of a `dense_vector` field of an index is `cosine`. In the
+case of the Cohere service models, you can use the two `symilarity` types
+interchangeably.
+
+
+
 // end::cohere[]
 
 
@@ -50,5 +57,10 @@ key.
 <3> The name of the embedding model to use. You can find the list of OpenAI
 embedding models
 https://platform.openai.com/docs/guides/embeddings/embedding-models[here].
+
+NOTE: The default `similarity` for the service is `dot_product` while the
+default `similarity` of a `dense_vector` field of an index is `cosine`. In the
+case of the OpenAI service models, you can use the two `symilarity` types
+interchangeably.
 
 // end::openai[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
@@ -22,10 +22,10 @@ key.
 <3> The name of the embedding model to use. You can find the list of Cohere
 embedding models https://docs.cohere.com/reference/embed[here].
 
-NOTE: The default `similarity` for the service is `dot_product` while the
-default `similarity` of a `dense_vector` field of an index is `cosine`. In the
-case of the Cohere service models, you can use the two `symilarity` types
-interchangeably.
+NOTE: When using this model the recommended similarity measure to use in the
+`dense_vector` field mapping is `dot_product`. In the case of Cohere models, the
+embeddings are normalized to unit length in which case the `dot_product` and
+the `cosine` measures are equivalent.
 
 
 
@@ -42,8 +42,6 @@ PUT _inference/text_embedding/openai_embeddings <1>
     "service_settings": {
         "api_key": "<api_key>", <2>
         "model_id": "text-embedding-ada-002" <3>
-    },
-    "task_settings": {
     }
 }
 ------------------------------------------------------------
@@ -58,9 +56,9 @@ key.
 embedding models
 https://platform.openai.com/docs/guides/embeddings/embedding-models[here].
 
-NOTE: The default `similarity` for the service is `dot_product` while the
-default `similarity` of a `dense_vector` field of an index is `cosine`. In the
-case of the OpenAI service models, you can use the two `symilarity` types
-interchangeably.
+NOTE: When using this model the recommended similarity measure to use in the
+`dense_vector` field mapping is `dot_product`. In the case of OpenAI models, the
+embeddings are normalized to unit length in which case the `dot_product` and
+the `cosine` measures are equivalent.
 
 // end::openai[]


### PR DESCRIPTION
## Overview

This PR adds a note to the inference API tutorial that explains that the inference service and ES mappings have different defaults for `similarity` but they can used interchangeably in the case of Cohere and OpenAI models.