### PR TITLE
Re-enable the RemoteClusterSecurityBwcRestIT

### DIFF
--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityBwcRestIT.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.remotecluster;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -41,7 +40,6 @@ import static org.hamcrest.Matchers.notNullValue;
 /**
  * BWC test which ensures that users and API keys with defined {@code remote_indices} privileges can be used to query legacy remote clusters
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104858")
 public class RemoteClusterSecurityBwcRestIT extends AbstractRemoteClusterSecurityTestCase {
 
     private static final Version OLD_CLUSTER_VERSION = Version.fromString(System.getProperty("tests.old_cluster_version"));


### PR DESCRIPTION
The bwc test was fixed by https://github.com/elastic/elasticsearch/pull/106559.

Reverts elastic/elasticsearch#106534