### PR TITLE
Allow different aggregator function for each mode

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorFunctionSupplierImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/AggregatorFunctionSupplierImplementer.java
@@ -80,7 +80,7 @@ public class AggregatorFunctionSupplierImplementer {
         builder.addJavadoc("{@link $T} implementation for {@link $T}.\n", AGGREGATOR_FUNCTION_SUPPLIER, declarationType);
         builder.addJavadoc("This class is generated. Do not edit it.");
         builder.addModifiers(Modifier.PUBLIC, Modifier.FINAL);
-        builder.addSuperinterface(AGGREGATOR_FUNCTION_SUPPLIER);
+        builder.superclass(AGGREGATOR_FUNCTION_SUPPLIER);
 
         createParameters.stream().forEach(p -> p.declareField(builder));
         builder.addMethod(ctor());
@@ -100,7 +100,7 @@ public class AggregatorFunctionSupplierImplementer {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("aggregator")
             .addParameter(DRIVER_CONTEXT, "driverContext")
             .returns(aggregatorImplementer.implementation());
-        builder.addAnnotation(Override.class).addModifiers(Modifier.PUBLIC);
+        builder.addAnnotation(Override.class).addModifiers(Modifier.PROTECTED);
         builder.addStatement(
             "return $T.create($L)",
             aggregatorImplementer.implementation(),
@@ -115,7 +115,7 @@ public class AggregatorFunctionSupplierImplementer {
         MethodSpec.Builder builder = MethodSpec.methodBuilder("groupingAggregator")
             .addParameter(DRIVER_CONTEXT, "driverContext")
             .returns(groupingAggregatorImplementer.implementation());
-        builder.addAnnotation(Override.class).addModifiers(Modifier.PUBLIC);
+        builder.addAnnotation(Override.class).addModifiers(Modifier.PROTECTED);
         builder.addStatement(
             "return $T.create($L)",
             groupingAggregatorImplementer.implementation(),

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctBooleanAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class CountDistinctBooleanAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class CountDistinctBooleanAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public CountDistinctBooleanAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class CountDistinctBooleanAggregatorFunctionSupplier implements Agg
   }
 
   @Override
-  public CountDistinctBooleanAggregatorFunction aggregator(DriverContext driverContext) {
+  protected CountDistinctBooleanAggregatorFunction aggregator(DriverContext driverContext) {
     return CountDistinctBooleanAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public CountDistinctBooleanGroupingAggregatorFunction groupingAggregator(
+  protected CountDistinctBooleanGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return CountDistinctBooleanGroupingAggregatorFunction.create(channels, driverContext);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctBytesRefAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class CountDistinctBytesRefAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class CountDistinctBytesRefAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   private final int precision;
@@ -25,12 +25,12 @@ public final class CountDistinctBytesRefAggregatorFunctionSupplier implements Ag
   }
 
   @Override
-  public CountDistinctBytesRefAggregatorFunction aggregator(DriverContext driverContext) {
+  protected CountDistinctBytesRefAggregatorFunction aggregator(DriverContext driverContext) {
     return CountDistinctBytesRefAggregatorFunction.create(driverContext, channels, precision);
   }
 
   @Override
-  public CountDistinctBytesRefGroupingAggregatorFunction groupingAggregator(
+  protected CountDistinctBytesRefGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return CountDistinctBytesRefGroupingAggregatorFunction.create(channels, driverContext, precision);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class CountDistinctDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class CountDistinctDoubleAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   private final int precision;
@@ -25,12 +25,12 @@ public final class CountDistinctDoubleAggregatorFunctionSupplier implements Aggr
   }
 
   @Override
-  public CountDistinctDoubleAggregatorFunction aggregator(DriverContext driverContext) {
+  protected CountDistinctDoubleAggregatorFunction aggregator(DriverContext driverContext) {
     return CountDistinctDoubleAggregatorFunction.create(driverContext, channels, precision);
   }
 
   @Override
-  public CountDistinctDoubleGroupingAggregatorFunction groupingAggregator(
+  protected CountDistinctDoubleGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return CountDistinctDoubleGroupingAggregatorFunction.create(channels, driverContext, precision);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctIntAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class CountDistinctIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class CountDistinctIntAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   private final int precision;
@@ -25,12 +25,12 @@ public final class CountDistinctIntAggregatorFunctionSupplier implements Aggrega
   }
 
   @Override
-  public CountDistinctIntAggregatorFunction aggregator(DriverContext driverContext) {
+  protected CountDistinctIntAggregatorFunction aggregator(DriverContext driverContext) {
     return CountDistinctIntAggregatorFunction.create(driverContext, channels, precision);
   }
 
   @Override
-  public CountDistinctIntGroupingAggregatorFunction groupingAggregator(
+  protected CountDistinctIntGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return CountDistinctIntGroupingAggregatorFunction.create(channels, driverContext, precision);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link CountDistinctLongAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class CountDistinctLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class CountDistinctLongAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   private final int precision;
@@ -25,12 +25,12 @@ public final class CountDistinctLongAggregatorFunctionSupplier implements Aggreg
   }
 
   @Override
-  public CountDistinctLongAggregatorFunction aggregator(DriverContext driverContext) {
+  protected CountDistinctLongAggregatorFunction aggregator(DriverContext driverContext) {
     return CountDistinctLongAggregatorFunction.create(driverContext, channels, precision);
   }
 
   @Override
-  public CountDistinctLongGroupingAggregatorFunction groupingAggregator(
+  protected CountDistinctLongGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return CountDistinctLongGroupingAggregatorFunction.create(channels, driverContext, precision);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MaxDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MaxDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MaxDoubleAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MaxDoubleAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class MaxDoubleAggregatorFunctionSupplier implements AggregatorFunc
   }
 
   @Override
-  public MaxDoubleAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MaxDoubleAggregatorFunction aggregator(DriverContext driverContext) {
     return MaxDoubleAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MaxDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected MaxDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return MaxDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MaxIntAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MaxIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MaxIntAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MaxIntAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class MaxIntAggregatorFunctionSupplier implements AggregatorFunctio
   }
 
   @Override
-  public MaxIntAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MaxIntAggregatorFunction aggregator(DriverContext driverContext) {
     return MaxIntAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MaxIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected MaxIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return MaxIntGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MaxLongAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MaxLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MaxLongAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MaxLongAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class MaxLongAggregatorFunctionSupplier implements AggregatorFuncti
   }
 
   @Override
-  public MaxLongAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MaxLongAggregatorFunction aggregator(DriverContext driverContext) {
     return MaxLongAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MaxLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected MaxLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return MaxLongGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MedianAbsoluteDeviationDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,13 @@ public final class MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier imple
   }
 
   @Override
-  public MedianAbsoluteDeviationDoubleAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MedianAbsoluteDeviationDoubleAggregatorFunction aggregator(
+      DriverContext driverContext) {
     return MedianAbsoluteDeviationDoubleAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MedianAbsoluteDeviationDoubleGroupingAggregatorFunction groupingAggregator(
+  protected MedianAbsoluteDeviationDoubleGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return MedianAbsoluteDeviationDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MedianAbsoluteDeviationIntAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MedianAbsoluteDeviationIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MedianAbsoluteDeviationIntAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MedianAbsoluteDeviationIntAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class MedianAbsoluteDeviationIntAggregatorFunctionSupplier implemen
   }
 
   @Override
-  public MedianAbsoluteDeviationIntAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MedianAbsoluteDeviationIntAggregatorFunction aggregator(DriverContext driverContext) {
     return MedianAbsoluteDeviationIntAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MedianAbsoluteDeviationIntGroupingAggregatorFunction groupingAggregator(
+  protected MedianAbsoluteDeviationIntGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return MedianAbsoluteDeviationIntGroupingAggregatorFunction.create(channels, driverContext);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MedianAbsoluteDeviationLongAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MedianAbsoluteDeviationLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MedianAbsoluteDeviationLongAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MedianAbsoluteDeviationLongAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class MedianAbsoluteDeviationLongAggregatorFunctionSupplier impleme
   }
 
   @Override
-  public MedianAbsoluteDeviationLongAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MedianAbsoluteDeviationLongAggregatorFunction aggregator(DriverContext driverContext) {
     return MedianAbsoluteDeviationLongAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MedianAbsoluteDeviationLongGroupingAggregatorFunction groupingAggregator(
+  protected MedianAbsoluteDeviationLongGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return MedianAbsoluteDeviationLongGroupingAggregatorFunction.create(channels, driverContext);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MinDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MinDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MinDoubleAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MinDoubleAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class MinDoubleAggregatorFunctionSupplier implements AggregatorFunc
   }
 
   @Override
-  public MinDoubleAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MinDoubleAggregatorFunction aggregator(DriverContext driverContext) {
     return MinDoubleAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MinDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected MinDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return MinDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinIntAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MinIntAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MinIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MinIntAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MinIntAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class MinIntAggregatorFunctionSupplier implements AggregatorFunctio
   }
 
   @Override
-  public MinIntAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MinIntAggregatorFunction aggregator(DriverContext driverContext) {
     return MinIntAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MinIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected MinIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return MinIntGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/MinLongAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link MinLongAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class MinLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class MinLongAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public MinLongAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class MinLongAggregatorFunctionSupplier implements AggregatorFuncti
   }
 
   @Override
-  public MinLongAggregatorFunction aggregator(DriverContext driverContext) {
+  protected MinLongAggregatorFunction aggregator(DriverContext driverContext) {
     return MinLongAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public MinLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected MinLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return MinLongGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link PercentileDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class PercentileDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class PercentileDoubleAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   private final double percentile;
@@ -25,12 +25,12 @@ public final class PercentileDoubleAggregatorFunctionSupplier implements Aggrega
   }
 
   @Override
-  public PercentileDoubleAggregatorFunction aggregator(DriverContext driverContext) {
+  protected PercentileDoubleAggregatorFunction aggregator(DriverContext driverContext) {
     return PercentileDoubleAggregatorFunction.create(driverContext, channels, percentile);
   }
 
   @Override
-  public PercentileDoubleGroupingAggregatorFunction groupingAggregator(
+  protected PercentileDoubleGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return PercentileDoubleGroupingAggregatorFunction.create(channels, driverContext, percentile);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link PercentileIntAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class PercentileIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class PercentileIntAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   private final double percentile;
@@ -25,12 +25,13 @@ public final class PercentileIntAggregatorFunctionSupplier implements Aggregator
   }
 
   @Override
-  public PercentileIntAggregatorFunction aggregator(DriverContext driverContext) {
+  protected PercentileIntAggregatorFunction aggregator(DriverContext driverContext) {
     return PercentileIntAggregatorFunction.create(driverContext, channels, percentile);
   }
 
   @Override
-  public PercentileIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected PercentileIntGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext) {
     return PercentileIntGroupingAggregatorFunction.create(channels, driverContext, percentile);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link PercentileLongAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class PercentileLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class PercentileLongAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   private final double percentile;
@@ -25,12 +25,13 @@ public final class PercentileLongAggregatorFunctionSupplier implements Aggregato
   }
 
   @Override
-  public PercentileLongAggregatorFunction aggregator(DriverContext driverContext) {
+  protected PercentileLongAggregatorFunction aggregator(DriverContext driverContext) {
     return PercentileLongAggregatorFunction.create(driverContext, channels, percentile);
   }
 
   @Override
-  public PercentileLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected PercentileLongGroupingAggregatorFunction groupingAggregator(
+      DriverContext driverContext) {
     return PercentileLongGroupingAggregatorFunction.create(channels, driverContext, percentile);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link SumDoubleAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class SumDoubleAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class SumDoubleAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public SumDoubleAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class SumDoubleAggregatorFunctionSupplier implements AggregatorFunc
   }
 
   @Override
-  public SumDoubleAggregatorFunction aggregator(DriverContext driverContext) {
+  protected SumDoubleAggregatorFunction aggregator(DriverContext driverContext) {
     return SumDoubleAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public SumDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected SumDoubleGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return SumDoubleGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link SumIntAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class SumIntAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class SumIntAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public SumIntAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class SumIntAggregatorFunctionSupplier implements AggregatorFunctio
   }
 
   @Override
-  public SumIntAggregatorFunction aggregator(DriverContext driverContext) {
+  protected SumIntAggregatorFunction aggregator(DriverContext driverContext) {
     return SumIntAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public SumIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected SumIntGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return SumIntGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link SumLongAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class SumLongAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class SumLongAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public SumLongAggregatorFunctionSupplier(List<Integer> channels) {
@@ -22,12 +22,12 @@ public final class SumLongAggregatorFunctionSupplier implements AggregatorFuncti
   }
 
   @Override
-  public SumLongAggregatorFunction aggregator(DriverContext driverContext) {
+  protected SumLongAggregatorFunction aggregator(DriverContext driverContext) {
     return SumLongAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public SumLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+  protected SumLongGroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
     return SumLongGroupingAggregatorFunction.create(channels, driverContext);
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointDocValuesAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointDocValuesAggregatorFunctionSupplier.java
@@ -15,7 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link SpatialCentroidCartesianPointDocValuesAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class SpatialCentroidCartesianPointDocValuesAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class SpatialCentroidCartesianPointDocValuesAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public SpatialCentroidCartesianPointDocValuesAggregatorFunctionSupplier(List<Integer> channels) {
@@ -23,13 +23,13 @@ public final class SpatialCentroidCartesianPointDocValuesAggregatorFunctionSuppl
   }
 
   @Override
-  public SpatialCentroidCartesianPointDocValuesAggregatorFunction aggregator(
+  protected SpatialCentroidCartesianPointDocValuesAggregatorFunction aggregator(
       DriverContext driverContext) {
     return SpatialCentroidCartesianPointDocValuesAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public SpatialCentroidCartesianPointDocValuesGroupingAggregatorFunction groupingAggregator(
+  protected SpatialCentroidCartesianPointDocValuesGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return SpatialCentroidCartesianPointDocValuesGroupingAggregatorFunction.create(channels, driverContext);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointSourceValuesAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidCartesianPointSourceValuesAggregatorFunctionSupplier.java
@@ -15,7 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link SpatialCentroidCartesianPointSourceValuesAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class SpatialCentroidCartesianPointSourceValuesAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class SpatialCentroidCartesianPointSourceValuesAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public SpatialCentroidCartesianPointSourceValuesAggregatorFunctionSupplier(
@@ -24,13 +24,13 @@ public final class SpatialCentroidCartesianPointSourceValuesAggregatorFunctionSu
   }
 
   @Override
-  public SpatialCentroidCartesianPointSourceValuesAggregatorFunction aggregator(
+  protected SpatialCentroidCartesianPointSourceValuesAggregatorFunction aggregator(
       DriverContext driverContext) {
     return SpatialCentroidCartesianPointSourceValuesAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public SpatialCentroidCartesianPointSourceValuesGroupingAggregatorFunction groupingAggregator(
+  protected SpatialCentroidCartesianPointSourceValuesGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return SpatialCentroidCartesianPointSourceValuesGroupingAggregatorFunction.create(channels, driverContext);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointDocValuesAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointDocValuesAggregatorFunctionSupplier.java
@@ -15,7 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link SpatialCentroidGeoPointDocValuesAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class SpatialCentroidGeoPointDocValuesAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class SpatialCentroidGeoPointDocValuesAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public SpatialCentroidGeoPointDocValuesAggregatorFunctionSupplier(List<Integer> channels) {
@@ -23,13 +23,13 @@ public final class SpatialCentroidGeoPointDocValuesAggregatorFunctionSupplier im
   }
 
   @Override
-  public SpatialCentroidGeoPointDocValuesAggregatorFunction aggregator(
+  protected SpatialCentroidGeoPointDocValuesAggregatorFunction aggregator(
       DriverContext driverContext) {
     return SpatialCentroidGeoPointDocValuesAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public SpatialCentroidGeoPointDocValuesGroupingAggregatorFunction groupingAggregator(
+  protected SpatialCentroidGeoPointDocValuesGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return SpatialCentroidGeoPointDocValuesGroupingAggregatorFunction.create(channels, driverContext);
   }

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointSourceValuesAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/spatial/SpatialCentroidGeoPointSourceValuesAggregatorFunctionSupplier.java
@@ -15,7 +15,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * {@link AggregatorFunctionSupplier} implementation for {@link SpatialCentroidGeoPointSourceValuesAggregator}.
  * This class is generated. Do not edit it.
  */
-public final class SpatialCentroidGeoPointSourceValuesAggregatorFunctionSupplier implements AggregatorFunctionSupplier {
+public final class SpatialCentroidGeoPointSourceValuesAggregatorFunctionSupplier extends AggregatorFunctionSupplier {
   private final List<Integer> channels;
 
   public SpatialCentroidGeoPointSourceValuesAggregatorFunctionSupplier(List<Integer> channels) {
@@ -23,13 +23,13 @@ public final class SpatialCentroidGeoPointSourceValuesAggregatorFunctionSupplier
   }
 
   @Override
-  public SpatialCentroidGeoPointSourceValuesAggregatorFunction aggregator(
+  protected SpatialCentroidGeoPointSourceValuesAggregatorFunction aggregator(
       DriverContext driverContext) {
     return SpatialCentroidGeoPointSourceValuesAggregatorFunction.create(driverContext, channels);
   }
 
   @Override
-  public SpatialCentroidGeoPointSourceValuesGroupingAggregatorFunction groupingAggregator(
+  protected SpatialCentroidGeoPointSourceValuesGroupingAggregatorFunction groupingAggregator(
       DriverContext driverContext) {
     return SpatialCentroidGeoPointSourceValuesGroupingAggregatorFunction.create(channels, driverContext);
   }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunctionSupplier.java
@@ -13,12 +13,13 @@ import org.elasticsearch.compute.operator.DriverContext;
 /**
  * Builds aggregation implementations, closing over any state required to do so.
  */
-public interface AggregatorFunctionSupplier extends Describable {
-    AggregatorFunction aggregator(DriverContext driverContext);
+public abstract class AggregatorFunctionSupplier implements Describable {
+    
+    protected abstract AggregatorFunction aggregator(DriverContext driverContext);
 
-    GroupingAggregatorFunction groupingAggregator(DriverContext driverContext);
+    protected abstract GroupingAggregatorFunction groupingAggregator(DriverContext driverContext);
 
-    default Aggregator.Factory aggregatorFactory(AggregatorMode mode) {
+    public Aggregator.Factory aggregatorFactory(AggregatorMode mode) {
         return new Aggregator.Factory() {
             @Override
             public Aggregator apply(DriverContext driverContext) {
@@ -32,7 +33,7 @@ public interface AggregatorFunctionSupplier extends Describable {
         };
     }
 
-    default GroupingAggregator.Factory groupingAggregatorFactory(AggregatorMode mode) {
+    public GroupingAggregator.Factory groupingAggregatorFactory(AggregatorMode mode) {
         return new GroupingAggregator.Factory() {
             @Override
             public GroupingAggregator apply(DriverContext driverContext) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/AggregatorFunctionSupplier.java
@@ -14,7 +14,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  * Builds aggregation implementations, closing over any state required to do so.
  */
 public abstract class AggregatorFunctionSupplier implements Describable {
-    
+
     protected abstract AggregatorFunction aggregator(DriverContext driverContext);
 
     protected abstract GroupingAggregatorFunction groupingAggregator(DriverContext driverContext);

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/AggregatorFunctionTestCase.java
@@ -58,7 +58,8 @@ public abstract class AggregatorFunctionTestCase extends ForkingOperatorTestCase
     @Override
     protected Operator.OperatorFactory simpleWithMode(AggregatorMode mode) {
         List<Integer> channels = mode.isInputPartial() ? range(0, aggregatorIntermediateBlockCount()).boxed().toList() : List.of(0);
-        return new AggregationOperator.AggregationOperatorFactory(List.of(aggregatorFunction(mode, channels).aggregatorFactory(mode)), mode);
+        List<Aggregator.Factory> aggregators = List.of(aggregatorFunction(mode, channels).aggregatorFactory(mode));
+        return new AggregationOperator.AggregationOperatorFactory(aggregators, mode);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountAggregatorFunctionTests.java
@@ -26,7 +26,7 @@ public class CountAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return CountAggregatorFunction.supplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctBooleanAggregatorFunctionTests.java
@@ -26,7 +26,7 @@ public class CountDistinctBooleanAggregatorFunctionTests extends AggregatorFunct
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new CountDistinctBooleanAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctBytesRefAggregatorFunctionTests.java
@@ -32,7 +32,7 @@ public class CountDistinctBytesRefAggregatorFunctionTests extends AggregatorFunc
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new CountDistinctBytesRefAggregatorFunctionSupplier(inputChannels, 40000);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctDoubleAggregatorFunctionTests.java
@@ -28,7 +28,7 @@ public class CountDistinctDoubleAggregatorFunctionTests extends AggregatorFuncti
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new CountDistinctDoubleAggregatorFunctionSupplier(inputChannels, 40000);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctIntAggregatorFunctionTests.java
@@ -34,7 +34,7 @@ public class CountDistinctIntAggregatorFunctionTests extends AggregatorFunctionT
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new CountDistinctIntAggregatorFunctionSupplier(inputChannels, 40000);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/CountDistinctLongAggregatorFunctionTests.java
@@ -35,7 +35,7 @@ public class CountDistinctLongAggregatorFunctionTests extends AggregatorFunction
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new CountDistinctLongAggregatorFunctionSupplier(inputChannels, 40000);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxDoubleAggregatorFunctionTests.java
@@ -26,7 +26,7 @@ public class MaxDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MaxDoubleAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxIntAggregatorFunctionTests.java
@@ -25,7 +25,7 @@ public class MaxIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MaxIntAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MaxLongAggregatorFunctionTests.java
@@ -26,7 +26,7 @@ public class MaxLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MaxLongAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleAggregatorFunctionTests.java
@@ -29,7 +29,7 @@ public class MedianAbsoluteDeviationDoubleAggregatorFunctionTests extends Aggreg
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MedianAbsoluteDeviationDoubleAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationIntAggregatorFunctionTests.java
@@ -29,7 +29,7 @@ public class MedianAbsoluteDeviationIntAggregatorFunctionTests extends Aggregato
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MedianAbsoluteDeviationIntAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationLongAggregatorFunctionTests.java
@@ -29,7 +29,7 @@ public class MedianAbsoluteDeviationLongAggregatorFunctionTests extends Aggregat
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MedianAbsoluteDeviationLongAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MinDoubleAggregatorFunctionTests.java
@@ -26,7 +26,7 @@ public class MinDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MinDoubleAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MinIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MinIntAggregatorFunctionTests.java
@@ -25,7 +25,7 @@ public class MinIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MinIntAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MinLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MinLongAggregatorFunctionTests.java
@@ -26,7 +26,7 @@ public class MinLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new MinLongAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileDoubleAggregatorFunctionTests.java
@@ -31,7 +31,7 @@ public class PercentileDoubleAggregatorFunctionTests extends AggregatorFunctionT
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new PercentileDoubleAggregatorFunctionSupplier(inputChannels, percentile);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileIntAggregatorFunctionTests.java
@@ -30,7 +30,7 @@ public class PercentileIntAggregatorFunctionTests extends AggregatorFunctionTest
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new PercentileIntAggregatorFunctionSupplier(inputChannels, percentile);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/PercentileLongAggregatorFunctionTests.java
@@ -30,7 +30,7 @@ public class PercentileLongAggregatorFunctionTests extends AggregatorFunctionTes
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new PercentileLongAggregatorFunctionSupplier(inputChannels, percentile);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumDoubleAggregatorFunctionTests.java
@@ -33,7 +33,7 @@ public class SumDoubleAggregatorFunctionTests extends AggregatorFunctionTestCase
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new SumDoubleAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumIntAggregatorFunctionTests.java
@@ -32,7 +32,7 @@ public class SumIntAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new SumIntAggregatorFunctionSupplier(inputChannels);
     }
 

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/SumLongAggregatorFunctionTests.java
@@ -32,7 +32,7 @@ public class SumLongAggregatorFunctionTests extends AggregatorFunctionTestCase {
     }
 
     @Override
-    protected AggregatorFunctionSupplier aggregatorFunction(List<Integer> inputChannels) {
+    protected AggregatorFunctionSupplier aggregatorFunction(AggregatorMode mode, List<Integer> inputChannels) {
         return new SumLongAggregatorFunctionSupplier(inputChannels);
     }
 


### PR DESCRIPTION
We will implement two distinct aggregator functions for the rate function: one for raw input and another for partial input. The raw input assumes documents arrive in order without gaps, enabling intermediate reduction without buffering. While our production code supports this, our tests currently do not. This change enables us to plug in different aggregator functions for each mode in our tests.