### PR TITLE
[Transform] Fix `_reset` API when called with `force=true` on a failed transform

### DIFF
--- a/docs/changelog/106574.yaml
+++ b/docs/changelog/106574.yaml
@@ -1,0 +1,5 @@
+pr: 106574
+summary: Fix `_reset` API when called with `force=true`
+area: Transform
+type: bug
+issues: []

--- a/docs/changelog/106574.yaml
+++ b/docs/changelog/106574.yaml
@@ -1,5 +1,5 @@
 pr: 106574
-summary: Fix `_reset` API when called with `force=true`
+summary: Fix `_reset` API when called with `force=true` on a failed transform
 area: Transform
 type: bug
 issues:

--- a/docs/changelog/106574.yaml
+++ b/docs/changelog/106574.yaml
@@ -2,4 +2,5 @@ pr: 106574
 summary: Fix `_reset` API when called with `force=true`
 area: Transform
 type: bug
-issues: []
+issues:
+ - 106573

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformResetIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformResetIT.java
@@ -32,6 +32,13 @@ public class TransformResetIT extends TransformRestTestCase {
         TEST_PASSWORD_SECURE_STRING
     );
     private static final String DATA_ACCESS_ROLE = "test_data_access";
+    private static final String SYNC_CONFIG = """
+          "sync": {
+            "time": {
+              "field": "timestamp"
+            }
+          },
+        """;
 
     private static boolean indicesCreated = false;
 
@@ -132,6 +139,7 @@ public class TransformResetIT extends TransformRestTestCase {
     }
 
     private static String createConfig(String transformDestIndex) {
+        boolean isContinuous = randomBoolean();
         return Strings.format("""
             {
               "dest": {
@@ -140,6 +148,7 @@ public class TransformResetIT extends TransformRestTestCase {
               "source": {
                 "index": "%s"
               },
+              %s
               "pivot": {
                 "group_by": {
                   "reviewer": {
@@ -156,6 +165,6 @@ public class TransformResetIT extends TransformRestTestCase {
                   }
                 }
               }
-            }""", transformDestIndex, REVIEWS_INDEX_NAME);
+            }""", transformDestIndex, REVIEWS_INDEX_NAME, isContinuous ? SYNC_CONFIG : "");
     }
 }

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -31,6 +31,7 @@ import org.junit.AfterClass;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -733,5 +734,27 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
                 throw new AssertionError("Failed to retrieve audit logs", e);
             }
         }, 5, TimeUnit.SECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected List<String> getTransformTasks() throws IOException {
+        final Request tasksRequest = new Request("GET", "/_tasks");
+        tasksRequest.addParameter("actions", TransformField.TASK_NAME + "*");
+        Map<String, Object> tasksResponse = entityAsMap(client().performRequest(tasksRequest));
+
+        Map<String, Object> nodes = (Map<String, Object>) tasksResponse.get("nodes");
+        if (nodes == null) {
+            return List.of();
+        }
+
+        List<String> foundTasks = new ArrayList<>();
+        for (Map.Entry<String, Object> node : nodes.entrySet()) {
+            Map<String, Object> nodeInfo = (Map<String, Object>) node.getValue();
+            Map<String, Object> tasks = (Map<String, Object>) nodeInfo.get("tasks");
+            if (tasks != null) {
+                foundTasks.addAll(tasks.keySet());
+            }
+        }
+        return foundTasks;
     }
 }

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
@@ -15,10 +15,8 @@ import org.elasticsearch.xpack.core.transform.TransformField;
 import org.elasticsearch.xpack.core.transform.transforms.persistence.TransformInternalIndexConstants;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.containsString;
@@ -148,28 +146,6 @@ public class TransformRobustnessIT extends TransformRestTestCase {
 
         // Verify that there is no transform task left.
         assertThat(getTransformTasks(), is(empty()));
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<String> getTransformTasks() throws IOException {
-        final Request tasksRequest = new Request("GET", "/_tasks");
-        tasksRequest.addParameter("actions", TransformField.TASK_NAME + "*");
-        Map<String, Object> tasksResponse = entityAsMap(client().performRequest(tasksRequest));
-
-        Map<String, Object> nodes = (Map<String, Object>) tasksResponse.get("nodes");
-        if (nodes == null) {
-            return List.of();
-        }
-
-        List<String> foundTasks = new ArrayList<>();
-        for (Entry<String, Object> node : nodes.entrySet()) {
-            Map<String, Object> nodeInfo = (Map<String, Object>) node.getValue();
-            Map<String, Object> tasks = (Map<String, Object>) nodeInfo.get("tasks");
-            if (tasks != null) {
-                foundTasks.addAll(tasks.keySet());
-            }
-        }
-        return foundTasks;
     }
 
     private void beEvilAndDeleteTheTransformIndex() throws IOException {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
@@ -154,7 +154,14 @@ public class TransportResetTransformAction extends AcknowledgedTransportMasterNo
             stopTransformActionListener.onResponse(null);
             return;
         }
-        StopTransformAction.Request stopTransformRequest = new StopTransformAction.Request(request.getId(), true, false, null, true, false);
+        StopTransformAction.Request stopTransformRequest = new StopTransformAction.Request(
+            request.getId(),
+            true,
+            request.isForce(),
+            null,
+            true,
+            false
+        );
         executeAsyncWithOrigin(client, TRANSFORM_ORIGIN, StopTransformAction.INSTANCE, stopTransformRequest, stopTransformActionListener);
     }
 


### PR DESCRIPTION
The [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/reset-transform.html#_description_21) of `_reset` API states:
```
Before you can reset the transform, you must stop it; alternatively, use the force query parameter.
```
Unfortunately, for a failed transform this is not true. The `force` parameter does not do anything and the `_reset` API fails anyway.

This PR fixes this by passing the value of `force` parameter from `_reset` request to `_stop` request.

Additionally, this PR moves the `getTransformTasks()` method to a common `TransformRestTestCase` class from where it can be used by multiple tests.

Fixes https://github.com/elastic/elasticsearch/issues/106573