### PR TITLE
Wait in SimpleThreadPoolIT.testThreadPoolMetrics for threads to complete

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
@@ -39,7 +39,6 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertNoFa
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.matchesRegex;
@@ -184,9 +183,7 @@ public class SimpleThreadPoolIT extends ESIntegTestCase {
             logger.info("Stats of `{}`: {}", stats.name(), threadPoolStats);
             logger.info("Measurements of `{}`: {}", stats.name(), measurements);
 
-            threadPoolStats.forEach(
-                (metric, value) -> assertThat(measurements, hasEntry(equalTo(metric), contains(equalTo(value))))
-            );
+            threadPoolStats.forEach((metric, value) -> assertThat(measurements, hasEntry(equalTo(metric), contains(equalTo(value)))));
         });
     }
 


### PR DESCRIPTION
Apparently search threads might still be active even after returning a response.
This causes a race between threadpool stats and measurement collection.

```
[2024-03-21T03:18:15,736][INFO ][o.e.t.SimpleThreadPoolIT ] [testThreadPoolMetrics] Stats of `search`: {.threads.active.current=1, .threads.completed.total=196, .threads.count.current=2, .threads.largest.current=2, .threads.queue.size=0}
[2024-03-21T03:18:15,737][INFO ][o.e.t.SimpleThreadPoolIT ] [testThreadPoolMetrics] Measurements of `search`: {.threads.active.current=[0], .threads.completed.total=[197], .threads.count.current=[2], .threads.largest.current=[2], .threads.queue.size=[0]} 
```

Waiting for all threads to be completed should fix this and give deterministic results.