### PR TITLE
ES|QL: Refactor HeapAttackIT to run on Serverless

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/Clusters.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/Clusters.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xpack.esql.heap_attack;
+
+import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+
+public class Clusters {
+    static ElasticsearchCluster buildCluster() {
+        var spec = ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .nodes(2)
+            .module("test-esql-heap-attack")
+            .setting("xpack.security.enabled", "false")
+            .setting("xpack.license.self_generated.type", "trial");
+        String javaVersion = JvmInfo.jvmInfo().version();
+        if (javaVersion.equals("20") || javaVersion.equals("21")) {
+            // see https://github.com/elastic/elasticsearch/issues/99592
+            spec.jvmArg("-XX:+UnlockDiagnosticVMOptions -XX:+G1UsePreventiveGC");
+        }
+        return spec.build();
+    }
+}

--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -21,10 +21,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.test.ListMatcher;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -60,24 +58,9 @@ import static org.hamcrest.Matchers.hasSize;
 public class HeapAttackIT extends ESRestTestCase {
 
     @ClassRule
-    public static ElasticsearchCluster cluster = buildCluster();
+    public static ElasticsearchCluster cluster = Clusters.buildCluster();
 
     static volatile boolean SUITE_ABORTED = false;
-
-    static ElasticsearchCluster buildCluster() {
-        var spec = ElasticsearchCluster.local()
-            .distribution(DistributionType.DEFAULT)
-            .nodes(2)
-            .module("test-esql-heap-attack")
-            .setting("xpack.security.enabled", "false")
-            .setting("xpack.license.self_generated.type", "trial");
-        String javaVersion = JvmInfo.jvmInfo().version();
-        if (javaVersion.equals("20") || javaVersion.equals("21")) {
-            // see https://github.com/elastic/elasticsearch/issues/99592
-            spec.jvmArg("-XX:+UnlockDiagnosticVMOptions -XX:+G1UsePreventiveGC");
-        }
-        return spec.build();
-    }
 
     @Override
     protected String getTestRestCluster() {

--- a/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/RestTriggerOutOfMemoryAction.java
+++ b/test/external-modules/esql-heap-attack/src/main/java/org/elasticsearch/test/esql/heap_attack/RestTriggerOutOfMemoryAction.java
@@ -20,12 +20,15 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
+@ServerlessScope(Scope.PUBLIC)
 public class RestTriggerOutOfMemoryAction extends BaseRestHandler {
     private static final Logger LOGGER = LogManager.getLogger(RestTriggerOutOfMemoryAction.class);
 


### PR DESCRIPTION
Small refactoring to allow running HeapAttackIT on Serverless