### PR TITLE
[DOCS] Adds disclaimer to semantic search tutorials

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -135,6 +135,10 @@ a list of relevant text passages. All unique passages, along with their IDs,
 have been extracted from that data set and compiled into a
 https://github.com/elastic/stack-docs/blob/main/docs/en/stack/ml/nlp/data/msmarco-passagetest2019-unique.tsv[tsv file].
 
+IMOPRTANT: The `msmarco-passagetest2019-top1000` data set was not used to train 
+the model. It is only utilized in this tutorial as sample data that is easily 
+accessible for demonstration purposes.
+
 Download the file and upload it to your cluster using the
 {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer]
 in the {ml-app} UI. Assign the name `id` to the first column and `content` to

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -135,9 +135,10 @@ a list of relevant text passages. All unique passages, along with their IDs,
 have been extracted from that data set and compiled into a
 https://github.com/elastic/stack-docs/blob/main/docs/en/stack/ml/nlp/data/msmarco-passagetest2019-unique.tsv[tsv file].
 
-IMOPRTANT: The `msmarco-passagetest2019-top1000` data set was not used to train 
-the model. It is only utilized in this tutorial as sample data that is easily 
-accessible for demonstration purposes.
+IMOPRTANT: The `msmarco-passagetest2019-top1000` dataset was not utilized to
+train the model. It is only used in this tutorial as a sample dataset that is
+easily accessible for demonstration purposes. You can use a different data set
+to test the workflow and become familiar with it.
 
 Download the file and upload it to your cluster using the
 {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer]

--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -66,10 +66,6 @@ a list of relevant text passages. All unique passages, along with their IDs,
 have been extracted from that data set and compiled into a
 https://github.com/elastic/stack-docs/blob/main/docs/en/stack/ml/nlp/data/msmarco-passagetest2019-unique.tsv[tsv file].
 
-IMOPRTANT: The `msmarco-passagetest2019-top1000` data set was not used to train 
-the models. It is only utilized in this tutorial as sample data that is easily 
-accessible for demonstration purposes.
-
 Download the file and upload it to your cluster using the
 {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer]
 in the {ml-app} UI. Assign the name `id` to the first column and `content` to

--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -66,6 +66,10 @@ a list of relevant text passages. All unique passages, along with their IDs,
 have been extracted from that data set and compiled into a
 https://github.com/elastic/stack-docs/blob/main/docs/en/stack/ml/nlp/data/msmarco-passagetest2019-unique.tsv[tsv file].
 
+IMOPRTANT: The `msmarco-passagetest2019-top1000` data set was not used to train 
+the models. It is only utilized in this tutorial as sample data that is easily 
+accessible for demonstration purposes.
+
 Download the file and upload it to your cluster using the
 {kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer]
 in the {ml-app} UI. Assign the name `id` to the first column and `content` to


### PR DESCRIPTION
## Overview

The semantic search tutorials for ELSER uses the `msmarco-passagetest2019-top1000` data set for demonstration. Some customers found it confusing and thought the model was trained on this data set. This disclaimer clarifies that the model wasn't trained on the mentioned data set, the tutorial utilizes it only for demonstration purposes.

### Preview

[Load data section in the tutorial]() --available soon