### PR TITLE
Add security index metadata -> metadata_flattened field migration

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -192,6 +192,7 @@ public class TransportVersions {
     public static final TransportVersion ROLE_REMOTE_CLUSTER_PRIVS = def(8_649_00_0);
     public static final TransportVersion NO_GLOBAL_RETENTION_FOR_SYSTEM_DATA_STREAMS = def(8_650_00_0);
     public static final TransportVersion SHUTDOWN_REQUEST_TIMEOUTS_FIX = def(8_651_00_0);
+    public static final TransportVersion ADD_METADATA_FLATTENED_TO_ROLES = def(8_652_00_0);
     /*
      * STOP! READ THIS FIRST! No, really,
      *        ____ _____ ___  ____  _        ____  _____    _    ____    _____ _   _ ___ ____    _____ ___ ____  ____ _____ _

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -86,6 +86,7 @@ import org.elasticsearch.xpack.core.security.authz.permission.RemoteClusterPermi
 import org.elasticsearch.xpack.core.security.authz.permission.RemoteClusterPermissions;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivilege;
 import org.elasticsearch.xpack.core.security.authz.privilege.ConfigurableClusterPrivileges;
+import org.elasticsearch.xpack.core.security.support.MigrateSecurityIndexFieldTaskParams;
 import org.elasticsearch.xpack.core.slm.SLMFeatureSetUsage;
 import org.elasticsearch.xpack.core.slm.SnapshotLifecycleMetadata;
 import org.elasticsearch.xpack.core.spatial.SpatialFeatureSetUsage;
@@ -295,7 +296,12 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 XPackField.ENTERPRISE_SEARCH,
                 EnterpriseSearchFeatureSetUsage::new
             ),
-            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.UNIVERSAL_PROFILING, ProfilingUsage::new)
+            new NamedWriteableRegistry.Entry(XPackFeatureSet.Usage.class, XPackField.UNIVERSAL_PROFILING, ProfilingUsage::new),
+            new NamedWriteableRegistry.Entry(
+                PersistentTaskParams.class,
+                MigrateSecurityIndexFieldTaskParams.TASK_NAME,
+                MigrateSecurityIndexFieldTaskParams::new
+            )
         ).filter(Objects::nonNull).toList();
     }
 
@@ -366,6 +372,11 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
                 Metadata.Custom.class,
                 new ParseField(TransformMetadata.TYPE),
                 parser -> TransformMetadata.LENIENT_PARSER.parse(parser, null).build()
+            ),
+            new NamedXContentRegistry.Entry(
+                PersistentTaskParams.class,
+                new ParseField(MigrateSecurityIndexFieldTaskParams.TASK_NAME),
+                MigrateSecurityIndexFieldTaskParams::fromXContent
             )
         );
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/ExpressionRoleMapping.java
@@ -67,6 +67,7 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
         PARSER.declareObjectArray(Builder::roleTemplates, (parser, ctx) -> TemplateRoleName.parse(parser), Fields.ROLE_TEMPLATES);
         PARSER.declareField(Builder::rules, ExpressionParser::parseObject, Fields.RULES, ValueType.OBJECT);
         PARSER.declareField(Builder::metadata, XContentParser::map, Fields.METADATA, ValueType.OBJECT);
+        PARSER.declareField(Builder::metadata, XContentParser::map, Fields.METADATA_FLATTENED, ValueType.OBJECT);
         PARSER.declareBoolean(Builder::enabled, Fields.ENABLED);
         BiConsumer<Builder, String> ignored = (b, v) -> {};
         // skip the doc_type and type fields in case we're parsing directly from the index
@@ -263,6 +264,11 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
     }
 
     public XContentBuilder toXContent(XContentBuilder builder, Params params, boolean indexFormat) throws IOException {
+        return this.toXContent(builder, params, indexFormat, false);
+    }
+
+    public XContentBuilder toXContent(XContentBuilder builder, Params params, boolean indexFormat, boolean includeMetadataFlattened)
+        throws IOException {
         builder.startObject();
         builder.field(Fields.ENABLED.getPreferredName(), enabled);
         if (roles.isEmpty() == false) {
@@ -286,6 +292,9 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
 
         if (indexFormat) {
             builder.field(NativeRoleMappingStoreField.DOC_TYPE_FIELD, NativeRoleMappingStoreField.DOC_TYPE_ROLE_MAPPING);
+        }
+        if (includeMetadataFlattened) {
+            builder.field(NativeRoleMappingStoreField.METADATA_FLATTENED, metadata);
         }
         return builder.endObject();
     }
@@ -354,5 +363,6 @@ public class ExpressionRoleMapping implements ToXContentObject, Writeable {
         ParseField ENABLED = new ParseField("enabled");
         ParseField RULES = new ParseField("rules");
         ParseField METADATA = new ParseField("metadata");
+        ParseField METADATA_FLATTENED = new ParseField("metadata_flattened");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/NativeRoleMappingStoreField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/NativeRoleMappingStoreField.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.core.security.authc.support.mapper;
 public final class NativeRoleMappingStoreField {
 
     public static final String DOC_TYPE_FIELD = "doc_type";
+
+    public static final String METADATA_FLATTENED = "metadata_flattened";
     public static final String DOC_TYPE_ROLE_MAPPING = "role-mapping";
     public static final String ID_PREFIX = DOC_TYPE_ROLE_MAPPING + "_";
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
@@ -390,6 +390,10 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
         return toXContent(builder, params, false);
     }
 
+    public XContentBuilder toXContent(XContentBuilder builder, Params params, boolean docCreation) throws IOException {
+        return toXContent(builder, params, docCreation, false);
+    }
+
     /**
      * Generates x-content for this {@link RoleDescriptor} instance.
      *
@@ -398,10 +402,12 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
      * @param docCreation {@code true} if the x-content is being generated for creating a document
      *                    in the security index, {@code false} if the x-content being generated
      *                    is for API display purposes
+     * @param includeMetadataFlattened {@code true} if the metadataFlattened field should be included in doc
      * @return x-content builder
      * @throws IOException if there was an error writing the x-content to the builder
      */
-    public XContentBuilder toXContent(XContentBuilder builder, Params params, boolean docCreation) throws IOException {
+    public XContentBuilder toXContent(XContentBuilder builder, Params params, boolean docCreation, boolean includeMetadataFlattened)
+        throws IOException {
         builder.startObject();
         builder.array(Fields.CLUSTER.getPreferredName(), clusterPrivileges);
         if (configurableClusterPrivileges.length != 0) {
@@ -414,6 +420,9 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
             builder.array(Fields.RUN_AS.getPreferredName(), runAs);
         }
         builder.field(Fields.METADATA.getPreferredName(), metadata);
+        if (includeMetadataFlattened) {
+            builder.field(Fields.METADATA_FLATTENED.getPreferredName(), metadata);
+        }
         if (docCreation) {
             builder.field(Fields.TYPE.getPreferredName(), ROLE_TYPE);
         } else {
@@ -545,6 +554,16 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
                                 );
                             }
                             metadata = parser.map();
+                        } else if (Fields.METADATA_FLATTENED.match(currentFieldName, parser.getDeprecationHandler())) {
+                            if (token != XContentParser.Token.START_OBJECT) {
+                                throw new ElasticsearchParseException(
+                                    "expected field [{}] to be of type object, but found [{}] instead",
+                                    currentFieldName,
+                                    token
+                                );
+                            }
+                            // consume object but just drop
+                            parser.map();
                         } else if (Fields.TRANSIENT_METADATA.match(currentFieldName, parser.getDeprecationHandler())) {
                             if (token == XContentParser.Token.START_OBJECT) {
                                 // consume object but just drop
@@ -1814,6 +1833,8 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
         ParseField GRANT_FIELDS = new ParseField("grant");
         ParseField EXCEPT_FIELDS = new ParseField("except");
         ParseField METADATA = new ParseField("metadata");
+
+        ParseField METADATA_FLATTENED = new ParseField("metadata_flattened");
         ParseField TRANSIENT_METADATA = new ParseField("transient_metadata");
         ParseField TYPE = new ParseField("type");
         ParseField RESTRICTION = new ParseField("restriction");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptor.java
@@ -43,6 +43,7 @@ public class ApplicationPrivilegeDescriptor implements ToXContentObject, Writeab
         PARSER.declareString(Builder::privilegeName, Fields.NAME);
         PARSER.declareStringArray(Builder::actions, Fields.ACTIONS);
         PARSER.declareObject(Builder::metadata, (parser, context) -> parser.map(), Fields.METADATA);
+        PARSER.declareObject(Builder::metadata, (parser, context) -> parser.map(), Fields.METADATA_FLATTENED);
         PARSER.declareField(
             (parser, builder, allowType) -> builder.type(parser.text(), allowType),
             Fields.TYPE,
@@ -98,14 +99,21 @@ public class ApplicationPrivilegeDescriptor implements ToXContentObject, Writeab
         return toXContent(builder, false);
     }
 
-    public XContentBuilder toXContent(XContentBuilder builder, boolean includeTypeField) throws IOException {
+    public XContentBuilder toXContent(XContentBuilder builder, boolean indexFormat) throws IOException {
+        return toXContent(builder, indexFormat, false);
+    }
+
+    public XContentBuilder toXContent(XContentBuilder builder, boolean indexFormat, boolean includeMetadataFlattened) throws IOException {
         builder.startObject()
             .field(Fields.APPLICATION.getPreferredName(), application)
             .field(Fields.NAME.getPreferredName(), name)
             .field(Fields.ACTIONS.getPreferredName(), actions)
             .field(Fields.METADATA.getPreferredName(), metadata);
-        if (includeTypeField) {
+        if (indexFormat) {
             builder.field(Fields.TYPE.getPreferredName(), DOC_TYPE_VALUE);
+        }
+        if (includeMetadataFlattened) {
+            builder.field(Fields.METADATA_FLATTENED.getPreferredName(), metadata);
         }
         return builder.endObject();
     }
@@ -204,6 +212,7 @@ public class ApplicationPrivilegeDescriptor implements ToXContentObject, Writeab
         ParseField NAME = new ParseField("name");
         ParseField ACTIONS = new ParseField("actions");
         ParseField METADATA = new ParseField("metadata");
+        ParseField METADATA_FLATTENED = new ParseField("metadata_flattened");
         ParseField TYPE = new ParseField("type");
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/MigrateSecurityIndexFieldTaskParams.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/support/MigrateSecurityIndexFieldTaskParams.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.support;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.persistent.PersistentTaskParams;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+
+public class MigrateSecurityIndexFieldTaskParams implements PersistentTaskParams {
+    public static final String TASK_NAME = "migrate-security-index-field";
+    private final Boolean migrationNeeded;
+
+    public static final ConstructingObjectParser<MigrateSecurityIndexFieldTaskParams, Void> PARSER = new ConstructingObjectParser<>(
+        TASK_NAME,
+        true,
+        a -> new MigrateSecurityIndexFieldTaskParams((Boolean) a[0])
+    );
+
+    static {
+        PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), new ParseField("migrationNeeded"));
+    }
+
+    public MigrateSecurityIndexFieldTaskParams(Boolean migrationNeeded) {
+        this.migrationNeeded = migrationNeeded;
+    }
+
+    public MigrateSecurityIndexFieldTaskParams(StreamInput in) throws IOException {
+        this.migrationNeeded = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeBoolean(migrationNeeded);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return TASK_NAME;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersions.V_8_12_0;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        builder.startObject();
+        builder.field("migrationNeeded", this.migrationNeeded);
+        builder.endObject();
+        return builder;
+    }
+
+    public static MigrateSecurityIndexFieldTaskParams fromXContent(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+
+    public Boolean getMigrationNeeded() {
+        return migrationNeeded;
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/User.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/user/User.java
@@ -167,6 +167,7 @@ public class User implements ToXContentObject {
         ParseField FULL_NAME = new ParseField("full_name");
         ParseField EMAIL = new ParseField("email");
         ParseField METADATA = new ParseField("metadata");
+        ParseField METADATA_FLATTENED = new ParseField("metadata_flattened");
         ParseField ENABLED = new ParseField("enabled");
         ParseField TYPE = new ParseField("type");
         ParseField AUTHENTICATION_REALM = new ParseField("authentication_realm");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ApplicationPrivilegeDescriptorTests.java
@@ -80,7 +80,7 @@ public class ApplicationPrivilegeDescriptorTests extends ESTestCase {
 
             final ApplicationPrivilegeDescriptor original = randomPrivilege();
             if (includeTypeField) {
-                original.toXContent(builder, true);
+                original.toXContent(builder, true, true);
             } else if (randomBoolean()) {
                 original.toXContent(builder, false);
             } else {

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryUserIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/QueryUserIT.java
@@ -209,6 +209,19 @@ public class QueryUserIT extends SecurityInBasicRestTestCase {
             {"query":{"term":{"username":"%s"}}}""", reservedUsername), users -> assertTrue(users.isEmpty()));
     }
 
+    public void testQueryOnMetadata() throws IOException {
+        User user = createUser(
+            randomValueOtherThanMany(reservedUsers::contains, () -> randomAlphaOfLengthBetween(3, 8)) + "-random",
+            randomArray(1, 3, String[]::new, () -> randomAlphaOfLengthBetween(3, 8)),
+            randomAlphaOfLengthBetween(3, 8),
+            randomAlphaOfLengthBetween(3, 8),
+            Map.of("test_key", "test_value"),
+            randomBoolean()
+        );
+        assertQuery("""
+            {"query":{"term":{"metadata.test_key":"test_value"}}}""", users -> assertUser(user, users.get(0)));
+    }
+
     public void testPagination() throws IOException {
         final List<User> users = createRandomUsers();
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/SecurityFeatures.java
@@ -13,8 +13,15 @@ import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.xpack.security.support.SecuritySystemIndices;
 
 import java.util.Map;
+import java.util.Set;
 
 public class SecurityFeatures implements FeatureSpecification {
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(SecuritySystemIndices.SECURITY_METADATA_MIGRATED);
+    }
+
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
         return Map.of(SecuritySystemIndices.SECURITY_PROFILE_ORIGIN_FEATURE, SecuritySystemIndices.VERSION_SECURITY_PROFILE_ORIGIN);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStore.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.license.LicenseUtils;
@@ -73,6 +74,7 @@ import static org.elasticsearch.xpack.core.security.authz.RoleDescriptor.ROLE_TY
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.Availability.PRIMARY_SHARDS;
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.Availability.SEARCH_SHARDS;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_ALIAS;
+import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_METADATA_MIGRATED;
 
 /**
  * NativeRolesStore is a {@code RolesStore} that, instead of reading from a
@@ -109,18 +111,22 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
 
     private final ClusterService clusterService;
 
+    private final FeatureService featureService;
+
     public NativeRolesStore(
         Settings settings,
         Client client,
         XPackLicenseState licenseState,
         SecurityIndexManager securityIndex,
-        ClusterService clusterService
+        ClusterService clusterService,
+        FeatureService featureService
     ) {
         this.settings = settings;
         this.client = client;
         this.licenseState = licenseState;
         this.securityIndex = securityIndex;
         this.clusterService = clusterService;
+        this.featureService = featureService;
         this.enabled = settings.getAsBoolean(NATIVE_ROLES_ENABLED, true);
     }
 
@@ -286,7 +292,12 @@ public class NativeRolesStore implements BiConsumer<Set<String>, ActionListener<
         securityIndex.prepareIndexIfNeededThenExecute(listener::onFailure, () -> {
             final XContentBuilder xContentBuilder;
             try {
-                xContentBuilder = role.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS, true);
+                xContentBuilder = role.toXContent(
+                    jsonBuilder(),
+                    ToXContent.EMPTY_PARAMS,
+                    true,
+                    featureService.clusterHasFeature(clusterService.state(), SECURITY_METADATA_MIGRATED)
+                );
             } catch (IOException e) {
                 listener.onFailure(e);
                 return;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexFieldMigrationExecutor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexFieldMigrationExecutor.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.support;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.SimpleBatchedExecutor;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.UpdateByQueryAction;
+import org.elasticsearch.index.reindex.UpdateByQueryRequestBuilder;
+import org.elasticsearch.persistent.AllocatedPersistentTask;
+import org.elasticsearch.persistent.PersistentTaskState;
+import org.elasticsearch.persistent.PersistentTasksExecutor;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
+import org.elasticsearch.xpack.core.security.support.MigrateSecurityIndexFieldTaskParams;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+import static org.elasticsearch.xpack.security.support.SecurityIndexManager.Availability.PRIMARY_SHARDS;
+import static org.elasticsearch.xpack.security.support.SecurityIndexManager.Availability.SEARCH_SHARDS;
+
+public class SecurityIndexFieldMigrationExecutor extends PersistentTasksExecutor<MigrateSecurityIndexFieldTaskParams> {
+    private static final Logger logger = LogManager.getLogger(SecurityIndexFieldMigrationExecutor.class);
+    private final SecuritySystemIndices securitySystemIndices;
+    private final Client client;
+
+    private static final String MIGRATE_SECURITY_INDEX_FIELD_COMPLETED_META_KEY = "security-index-field-migration-completed";
+
+    // Queue for posting tasks to update the migration status in cluster state on the master node
+    private final MasterServiceTaskQueue<UpdateSecurityIndexFieldMigrationCompleteTask> migrateSecurityIndexFieldCompletedTaskQueue;
+
+    public SecurityIndexFieldMigrationExecutor(
+        ClusterService clusterService,
+        String taskName,
+        Executor executor,
+        SecuritySystemIndices securitySystemIndices,
+        Client client
+    ) {
+        super(taskName, executor);
+        this.securitySystemIndices = securitySystemIndices;
+        this.client = client;
+        this.migrateSecurityIndexFieldCompletedTaskQueue = clusterService.createTaskQueue(
+            "security-index-field-migration-completed-queue",
+            Priority.LOW,
+            MIGRATE_SECURITY_INDEX_FIELD_COMPLETED_TASK_EXECUTOR
+        );
+    }
+
+    @Override
+    protected void nodeOperation(AllocatedPersistentTask task, MigrateSecurityIndexFieldTaskParams params, PersistentTaskState state) {
+        ActionListener<Void> listener = ActionListener.wrap((res) -> {
+            logger.info("Security Index Field Migration complete - written to cluster state");
+            task.markAsCompleted();
+        }, (exception) -> {
+            logger.warn("Security Index Field Migration failed: " + exception);
+            task.markAsFailed(exception);
+        });
+
+        SecurityIndexManager securityIndex = securitySystemIndices.getMainIndexManager();
+
+        if (params.getMigrationNeeded() == false) {
+            this.writeMetadataMigrated(listener);
+        } else if (securityIndex.isAvailable(PRIMARY_SHARDS) == false || securityIndex.isAvailable(SEARCH_SHARDS) == false) {
+            listener.onFailure(new IllegalStateException("Security index not available"));
+        } else {
+            UpdateByQueryRequestBuilder updateByQueryRequestBuilder = new UpdateByQueryRequestBuilder(client);
+            updateByQueryRequestBuilder.filter(
+                // Skipping api key since already migrated
+                new BoolQueryBuilder().should(QueryBuilders.termQuery("type", "user"))
+                    .should(QueryBuilders.termQuery("type", "role"))
+                    .should(QueryBuilders.termQuery("type", "role-mapping"))
+                    .should(QueryBuilders.termQuery("type", "application-privilege"))
+                    .should(QueryBuilders.termQuery("doc_type", "role-mapping"))
+            );
+            updateByQueryRequestBuilder.source(securitySystemIndices.getMainIndexManager().aliasName());
+            updateByQueryRequestBuilder.script(
+                new Script(ScriptType.INLINE, "painless", "ctx._source.metadata_flattened = ctx._source.metadata", Collections.emptyMap())
+            );
+
+            securityIndex.checkIndexVersionThenExecute(
+                listener::onFailure,
+                () -> executeAsyncWithOrigin(
+                    client,
+                    SECURITY_ORIGIN,
+                    UpdateByQueryAction.INSTANCE,
+                    updateByQueryRequestBuilder.request(),
+                    ActionListener.wrap(bulkByScrollResponse -> {
+                        logger.info("Migrated [{}] security index documents", bulkByScrollResponse.getUpdated());
+                        this.writeMetadataMigrated(listener);
+                    }, listener::onFailure)
+                )
+            );
+        }
+    }
+
+    /**
+     * Batch executor responsible for updating the cluster state using {@link UpdateSecurityIndexFieldMigrationCompleteTask}
+     */
+    private static final SimpleBatchedExecutor<
+        UpdateSecurityIndexFieldMigrationCompleteTask,
+        Void> MIGRATE_SECURITY_INDEX_FIELD_COMPLETED_TASK_EXECUTOR = new SimpleBatchedExecutor<>() {
+            @Override
+            public Tuple<ClusterState, Void> executeTask(UpdateSecurityIndexFieldMigrationCompleteTask task, ClusterState clusterState) {
+                return Tuple.tuple(task.execute(clusterState), null);
+            }
+
+            @Override
+            public void taskSucceeded(UpdateSecurityIndexFieldMigrationCompleteTask task, Void unused) {
+                task.listener.onResponse(null);
+            }
+        };
+
+    /**
+     * Task to update the {@link IndexMetadata} for the .security index in cluster state with the completion status for an index field
+     * migration.
+     */
+    public static class UpdateSecurityIndexFieldMigrationCompleteTask implements ClusterStateTaskListener {
+        private final ActionListener<Void> listener;
+
+        UpdateSecurityIndexFieldMigrationCompleteTask(ActionListener<Void> listener) {
+            this.listener = listener;
+        }
+
+        ClusterState execute(ClusterState currentState) {
+            IndexMetadata indexMetadata = SecurityIndexManager.resolveConcreteIndex(
+                SecuritySystemIndices.SECURITY_MAIN_ALIAS,
+                currentState.metadata()
+            );
+            if (indexMetadata != null) {
+                IndexMetadata updatededIndexMetadata = new IndexMetadata.Builder(indexMetadata).putCustom(
+                    MIGRATE_SECURITY_INDEX_FIELD_COMPLETED_META_KEY,
+                    Map.of("completed", "true")
+                ).build();
+                Metadata metadata = Metadata.builder(currentState.metadata()).put(updatededIndexMetadata, true).build();
+                return ClusterState.builder(currentState).metadata(metadata).build();
+            }
+
+            return currentState;
+        }
+
+        @Override
+        public void onFailure(Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    public boolean shouldStartMetadataMigration(ClusterState clusterState) {
+        IndexMetadata indexMetadata = SecurityIndexManager.resolveConcreteIndex(
+            SecuritySystemIndices.SECURITY_MAIN_ALIAS,
+            clusterState.metadata()
+        );
+        if (indexMetadata != null) {
+            Map<String, String> customMetadata = indexMetadata.getCustomData(MIGRATE_SECURITY_INDEX_FIELD_COMPLETED_META_KEY);
+            if (customMetadata != null) {
+                String result = customMetadata.get("completed");
+                return result == null || Boolean.parseBoolean(result) == false;
+            }
+        }
+
+        return true;
+    }
+
+    public void writeMetadataMigrated(ActionListener<Void> listener) {
+        this.migrateSecurityIndexFieldCompletedTaskQueue.submitTask(
+            "Updating cluster state to show that the security index field migration has been completed",
+            new UpdateSecurityIndexFieldMigrationCompleteTask(listener),
+            null
+        );
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -364,7 +364,7 @@ public class SecurityIndexManager implements ClusterStateListener {
      * Resolves a concrete index name or alias to a {@link IndexMetadata} instance.  Requires
      * that if supplied with an alias, the alias resolves to at most one concrete index.
      */
-    private static IndexMetadata resolveConcreteIndex(final String indexOrAliasName, final Metadata metadata) {
+    public static IndexMetadata resolveConcreteIndex(final String indexOrAliasName, final Metadata metadata) {
         final IndexAbstraction indexAbstraction = metadata.getIndicesLookup().get(indexOrAliasName);
         if (indexAbstraction != null) {
             final List<Index> indices = indexAbstraction.getIndices();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -53,6 +53,7 @@ public class SecuritySystemIndices {
     public static final String SECURITY_PROFILE_ALIAS = ".security-profile";
     public static final Version VERSION_SECURITY_PROFILE_ORIGIN = Version.V_8_3_0;
     public static final NodeFeature SECURITY_PROFILE_ORIGIN_FEATURE = new NodeFeature("security.security_profile_origin");
+    public static final NodeFeature SECURITY_METADATA_MIGRATED = new NodeFeature("security.metadata_migrated");
 
     /**
      * Security managed index mappings used to be updated based on the product version. They are now updated based on per-index mappings

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/UserBoolQueryBuilder.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/UserBoolQueryBuilder.java
@@ -24,10 +24,18 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.xpack.security.support.SecurityIndexFieldNameTranslator.exact;
+import static org.elasticsearch.xpack.security.support.SecurityIndexFieldNameTranslator.prefix;
 
 public class UserBoolQueryBuilder extends BoolQueryBuilder {
     public static final SecurityIndexFieldNameTranslator USER_FIELD_NAME_TRANSLATOR = new SecurityIndexFieldNameTranslator(
-        List.of(exact("username"), exact("roles"), exact("full_name"), exact("email"), exact("enabled"))
+        List.of(
+            exact("username"),
+            exact("roles"),
+            exact("full_name"),
+            exact("email"),
+            exact("enabled"),
+            prefix("metadata", "metadata_flattened")
+        )
     );
 
     private UserBoolQueryBuilder() {}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityContextTests.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.TransportVersions.ADD_METADATA_FLATTENED_TO_ROLES;
 import static org.elasticsearch.xpack.core.security.authc.Authentication.VERSION_API_KEY_ROLES_AS_BYTES;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -227,7 +228,7 @@ public class SecurityContextTests extends ESTestCase {
         securityContext.executeAfterRewritingAuthentication(originalCtx -> {
             Authentication authentication = securityContext.getAuthentication();
             assertSame(original.getAuthenticatingSubject().getMetadata(), authentication.getAuthenticatingSubject().getMetadata());
-        }, TransportVersionUtils.randomVersionBetween(random(), VERSION_API_KEY_ROLES_AS_BYTES, TransportVersion.current()));
+        }, TransportVersionUtils.randomVersionBetween(random(), ADD_METADATA_FLATTENED_TO_ROLES, TransportVersion.current()));
     }
 
     public void testExecuteAfterRewritingAuthenticationWillConditionallyRewriteOldApiKeyMetadata() throws IOException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -51,6 +51,7 @@ import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.internal.XPackLicenseStatus;
+import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
@@ -228,7 +229,8 @@ public class SecurityTests extends ESTestCase {
             env,
             nodeMetadata,
             TestIndexNameExpressionResolver.newInstance(threadContext),
-            TelemetryProvider.NOOP
+            TelemetryProvider.NOOP,
+            mock(PersistentTasksService.class)
         );
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailFilterTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.http.HttpRequest;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -124,7 +125,8 @@ public class LoggingAuditTrailFilterTests extends ESTestCase {
             mock(SecurityIndexManager.class),
             clusterService,
             mock(CacheInvalidatorRegistry.class),
-            mock(ThreadPool.class)
+            mock(ThreadPool.class),
+            mock(FeatureService.class)
         );
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
@@ -360,7 +361,8 @@ public class LoggingAuditTrailTests extends ESTestCase {
             securityIndexManager,
             clusterService,
             mock(CacheInvalidatorRegistry.class),
-            mock(ThreadPool.class)
+            mock(ThreadPool.class),
+            mock(FeatureService.class)
         );
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -57,6 +57,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -1164,7 +1165,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             keyRoles,
             type,
             ApiKey.CURRENT_API_KEY_VERSION,
-            metadataMap
+            metadataMap,
+            false
         );
         Map<String, Object> keyMap = XContentHelper.convertToMap(BytesReference.bytes(docSource), true, XContentType.JSON).v2();
         if (invalidated) {
@@ -2373,7 +2375,8 @@ public class ApiKeyServiceTests extends ESTestCase {
                         oldKeyRoles,
                         type,
                         oldVersion,
-                        oldMetadata
+                        oldMetadata,
+                        false
                     )
                 ),
                 XContentType.JSON
@@ -2437,7 +2440,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             newAuthentication,
             request,
             newUserRoles,
-            clock
+            clock,
+            true
         );
 
         final boolean noop = (changeCreator
@@ -2718,7 +2722,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             securityIndex,
             clusterService,
             cacheInvalidatorRegistry,
-            threadPool
+            threadPool,
+            mock(FeatureService.class)
         );
 
         final PlainActionFuture<CreateApiKeyResponse> future = new PlainActionFuture<>();
@@ -2855,7 +2860,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             securityIndex,
             clusterService,
             cacheInvalidatorRegistry,
-            threadPool
+            threadPool,
+            mock(FeatureService.class)
         );
 
         final List<RoleDescriptor> roleDescriptorsWithWorkflowsRestriction = randomList(
@@ -2920,7 +2926,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             securityIndex,
             clusterService,
             cacheInvalidatorRegistry,
-            threadPool
+            threadPool,
+            mock(FeatureService.class)
         );
 
         final Set<RoleDescriptor> userRoleDescriptorsWithWorkflowsRestriction = randomSet(
@@ -3014,7 +3021,8 @@ public class ApiKeyServiceTests extends ESTestCase {
                 keyRoles,
                 ApiKey.Type.REST,
                 ApiKey.CURRENT_API_KEY_VERSION,
-                randomBoolean() ? null : Map.of(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8))
+                randomBoolean() ? null : Map.of(randomAlphaOfLengthBetween(3, 8), randomAlphaOfLengthBetween(3, 8)),
+                false
             );
             final ApiKeyDoc apiKeyDoc = ApiKeyDoc.fromXContent(
                 XContentHelper.createParser(
@@ -3101,7 +3109,8 @@ public class ApiKeyServiceTests extends ESTestCase {
             securityIndex,
             ClusterServiceUtils.createClusterService(threadPool, clusterSettings),
             cacheInvalidatorRegistry,
-            threadPool
+            threadPool,
+            mock(FeatureService.class)
         );
         if ("0s".equals(settings.get(ApiKeyService.CACHE_TTL_SETTING.getKey()))) {
             verify(cacheInvalidatorRegistry, never()).registerCacheInvalidator(eq("api_key"), any());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -41,6 +41,7 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.ShardId;
@@ -332,7 +333,8 @@ public class AuthenticationServiceTests extends ESTestCase {
             securityIndex,
             clusterService,
             mock(CacheInvalidatorRegistry.class),
-            threadPool
+            threadPool,
+            mock(FeatureService.class)
         );
         tokenService = new TokenService(
             settings,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStoreTests.java
@@ -20,11 +20,13 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.FilterClient;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -332,7 +334,7 @@ public class NativeUsersStoreTests extends ESTestCase {
             action.run();
             return null;
         }).when(securityIndex).checkIndexVersionThenExecute(any(Consumer.class), any(Runnable.class));
-        return new NativeUsersStore(Settings.EMPTY, client, securityIndex);
+        return new NativeUsersStore(Settings.EMPTY, client, securityIndex, mock(ClusterService.class), mock(FeatureService.class));
     }
 
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTestCase.java
@@ -9,12 +9,14 @@ package org.elasticsearch.xpack.security.authc.kerberos;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTestCase;
@@ -182,7 +184,9 @@ public abstract class KerberosRealmTestCase extends ESTestCase {
             Settings.EMPTY,
             mockClient,
             mock(SecurityIndexManager.class),
-            mock(ScriptService.class)
+            mock(ScriptService.class),
+            mock(FeatureService.class),
+            mock(ClusterService.class)
         );
         final NativeRoleMappingStore roleMapper = spy(store);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
@@ -18,6 +18,7 @@ import com.unboundid.ldap.sdk.schema.Schema;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.MockSecureSettings;
@@ -27,6 +28,7 @@ import org.elasticsearch.common.ssl.SslVerificationMode;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.script.ScriptModule;
@@ -438,7 +440,14 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
             ScriptModule.CORE_CONTEXTS,
             () -> 1L
         );
-        NativeRoleMappingStore roleMapper = new NativeRoleMappingStore(settings, mockClient, mockSecurityIndex, scriptService) {
+        NativeRoleMappingStore roleMapper = new NativeRoleMappingStore(
+            settings,
+            mockClient,
+            mockSecurityIndex,
+            scriptService,
+            mock(FeatureService.class),
+            mock(ClusterService.class)
+        ) {
             @Override
             protected void loadMappings(ActionListener<List<ExpressionRoleMapping>> listener) {
                 listener.onResponse(Arrays.asList(NativeRoleMappingStore.buildMapping("m1", new BytesArray("""

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -11,6 +11,7 @@ import com.unboundid.ldap.sdk.LDAPURL;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureSettings;
@@ -21,6 +22,7 @@ import org.elasticsearch.common.ssl.SslVerificationMode;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
@@ -541,7 +543,9 @@ public class LdapRealmTests extends LdapTestCase {
             defaultGlobalSettings,
             mockClient,
             mockSecurityIndex,
-            scriptService
+            scriptService,
+            mock(FeatureService.class),
+            mock(ClusterService.class)
         ) {
             @Override
             protected void loadMappings(ActionListener<List<ExpressionRoleMapping>> listener) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/SecondaryAuthenticatorTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.license.License;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.internal.XPackLicenseStatus;
@@ -138,7 +139,8 @@ public class SecondaryAuthenticatorTests extends ESTestCase {
             securityIndex,
             clusterService,
             mock(CacheInvalidatorRegistry.class),
-            threadPool
+            threadPool,
+            mock(FeatureService.class)
         );
         final ServiceAccountService serviceAccountService = mock(ServiceAccountService.class);
         doAnswer(invocationOnMock -> {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ExpressionRoleMappingTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ExpressionRoleMappingTests.java
@@ -374,7 +374,7 @@ public class ExpressionRoleMappingTests extends ESTestCase {
         final ExpressionRoleMapping mapping = parse(source, getTestName());
         assertThat(mapping.getRoleTemplates(), iterableWithSize(2));
 
-        final String xcontent = Strings.toString(mapping.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS, true));
+        final String xcontent = Strings.toString(mapping.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS, true, true));
         assertThat(xcontent, equalTo(XContentHelper.stripWhitespace("""
             {
               "enabled": false,
@@ -396,7 +396,10 @@ public class ExpressionRoleMappingTests extends ESTestCase {
               "metadata": {
                 "answer": 42
               },
-              "doc_type": "role-mapping"
+              "doc_type": "role-mapping",
+              "metadata_flattened": {
+                "answer": 42
+              }
             }""")));
 
         final ExpressionRoleMapping parsed = parse(xcontent, getTestName(), true);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.license.LicenseStateListener;
@@ -1906,7 +1907,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 mock(SecurityIndexManager.class),
                 clusterService,
                 mock(CacheInvalidatorRegistry.class),
-                mock(ThreadPool.class)
+                mock(ThreadPool.class),
+                mock(FeatureService.class)
             )
         );
         NativePrivilegeStore nativePrivStore = mock(NativePrivilegeStore.class);
@@ -1989,7 +1991,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 mock(SecurityIndexManager.class),
                 clusterService,
                 mock(CacheInvalidatorRegistry.class),
-                mock(ThreadPool.class)
+                mock(ThreadPool.class),
+                mock(FeatureService.class)
             )
         );
         NativePrivilegeStore nativePrivStore = mock(NativePrivilegeStore.class);
@@ -2089,7 +2092,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
                 mock(SecurityIndexManager.class),
                 clusterService,
                 mock(CacheInvalidatorRegistry.class),
-                mock(ThreadPool.class)
+                mock(ThreadPool.class),
+                mock(FeatureService.class)
             )
         );
         final NativePrivilegeStore nativePrivStore = mock(NativePrivilegeStore.class);
@@ -2246,7 +2250,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
             mock(SecurityIndexManager.class),
             clusterService,
             mock(CacheInvalidatorRegistry.class),
-            mock(ThreadPool.class)
+            mock(ThreadPool.class),
+            mock(FeatureService.class)
         );
         final NativePrivilegeStore privilegeStore = mock(NativePrivilegeStore.class);
         doAnswer((invocationOnMock) -> {
@@ -2358,7 +2363,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
             mock(SecurityIndexManager.class),
             clusterService,
             mock(CacheInvalidatorRegistry.class),
-            mock(ThreadPool.class)
+            mock(ThreadPool.class),
+            mock(FeatureService.class)
         );
         final NativePrivilegeStore privilegeStore = mock(NativePrivilegeStore.class);
         doAnswer((invocationOnMock) -> {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -163,7 +164,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             client,
             securityIndex,
             cacheInvalidatorRegistry,
-            clusterService
+            clusterService,
+            mock(FeatureService.class)
         );
     }
 
@@ -526,7 +528,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             client,
             securityIndex,
             new CacheInvalidatorRegistry(),
-            clusterService
+            clusterService,
+            mock(FeatureService.class)
         ) {
             @Override
             protected void cacheFetchedDescriptors(
@@ -648,7 +651,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
                 mockClient,
                 mockSecurityIndexManager,
                 new CacheInvalidatorRegistry(),
-                clusterService
+                clusterService,
+                mock(FeatureService.class)
             );
             store1.getPrivileges(applications, actions, future);
             assertResult(emptyList(), future);
@@ -754,7 +758,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             client,
             securityIndex,
             new CacheInvalidatorRegistry(),
-            clusterService
+            clusterService,
+            mock(FeatureService.class)
         );
         assertNull(store1.getApplicationNamesCache());
         assertNull(store1.getDescriptorsCache());
@@ -767,7 +772,8 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             client,
             securityIndex,
             new CacheInvalidatorRegistry(),
-            clusterService
+            clusterService,
+            mock(FeatureService.class)
         );
         assertNull(store1.getDescriptorsAndApplicationNamesCache());
         final List<ApplicationPrivilegeDescriptor> sourcePrivileges = Arrays.asList(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -325,7 +326,14 @@ public class NativeRolesStoreTests extends ESTestCase {
         systemIndices.init(client, clusterService);
         final SecurityIndexManager securityIndex = systemIndices.getMainIndexManager();
 
-        final NativeRolesStore rolesStore = new NativeRolesStore(Settings.EMPTY, client, licenseState, securityIndex, clusterService) {
+        final NativeRolesStore rolesStore = new NativeRolesStore(
+            Settings.EMPTY,
+            client,
+            licenseState,
+            securityIndex,
+            clusterService,
+            mock(FeatureService.class)
+        ) {
             @Override
             void innerPutRole(final PutRoleRequest request, final RoleDescriptor role, final ActionListener<Boolean> listener) {
                 if (methodCalled.compareAndSet(false, true)) {
@@ -438,7 +446,14 @@ public class NativeRolesStoreTests extends ESTestCase {
             systemIndices.init(client, clusterService);
             final SecurityIndexManager securityIndex = systemIndices.getMainIndexManager();
 
-            final NativeRolesStore rolesStore = new NativeRolesStore(Settings.EMPTY, client, licenseState, securityIndex, clusterService) {
+            final NativeRolesStore rolesStore = new NativeRolesStore(
+                Settings.EMPTY,
+                client,
+                licenseState,
+                securityIndex,
+                clusterService,
+                mock(FeatureService.class)
+            ) {
                 @Override
                 void innerPutRole(final PutRoleRequest request, final RoleDescriptor role, final ActionListener<Boolean> listener) {
                     if (methodCalled.compareAndSet(false, true)) {
@@ -496,7 +511,14 @@ public class NativeRolesStoreTests extends ESTestCase {
         systemIndices.init(client, clusterService);
         final SecurityIndexManager securityIndex = systemIndices.getMainIndexManager();
 
-        final NativeRolesStore store = new NativeRolesStore(settings, client, licenseState, securityIndex, clusterService);
+        final NativeRolesStore store = new NativeRolesStore(
+            settings,
+            client,
+            licenseState,
+            securityIndex,
+            clusterService,
+            mock(FeatureService.class)
+        );
 
         final PlainActionFuture<RoleRetrievalResult> future = new PlainActionFuture<>();
         store.getRoleDescriptors(Set.of(randomAlphaOfLengthBetween(4, 12)), future);

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SecurityIndexFieldMigrationIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SecurityIndexFieldMigrationIT.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.upgrades;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+import org.elasticsearch.xpack.core.security.user.User;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+
+public class SecurityIndexFieldMigrationIT extends AbstractUpgradeTestCase {
+
+    public void testMetadataCanBeQueriedThroughUserAPIInUpgradedCluster() throws Exception {
+        if (CLUSTER_TYPE == ClusterType.OLD) {
+            createUser(
+                "test-user",
+                "100%-security-guaranteed",
+                new String[] { "master-of-the-world", "some-other-role" },
+                Map.of("test_key", "test_value")
+            );
+        } else if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+            final Request request = new Request(randomFrom("POST", "GET"), "/_security/_query/user");
+            request.setJsonEntity("""
+                {"query":{"term":{"metadata.test_key":"test_value"}}}""");
+            final Response response = client().performRequest(request);
+            assertOK(response);
+            final Map<String, Object> responseMap = responseAsMap(response);
+            @SuppressWarnings("unchecked")
+            final List<Map<String, Object>> users = (List<Map<String, Object>>) responseMap.get("users");
+
+            assertEquals(1, users.size());
+        }
+    }
+
+    public void testMetadataMigratedAfterUpgrade() throws IOException {
+        String testUser = "test-user";
+        String testRole = "test-role";
+        String metaKey = "test_key";
+        String metaValue = "test_value";
+        // TODO Add test for role mapping and privilege
+        Map<String, Object> testMetadata = Map.of(metaKey, metaValue);
+        if (CLUSTER_TYPE == ClusterType.OLD) {
+            createUser(testUser, "100%-security-guaranteed", new String[] { "superuser" }, testMetadata);
+            assertEntityInSecurityIndex("user", testUser);
+            createRole(testRole, testMetadata);
+            assertEntityInSecurityIndex("role", testRole);
+        }
+        if (CLUSTER_TYPE == ClusterType.UPGRADED) {
+            assertEntityInSecurityIndex("user", testUser, metaKey, metaValue);
+            assertEntityInSecurityIndex("role", testRole, metaKey, metaValue);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertEntityInSecurityIndex(String type, String value, String metaKey, String metaValue) throws IOException {
+        final Request request = new Request("POST", "/.security/_search");
+        RequestOptions.Builder options = request.getOptions().toBuilder();
+        request.setJsonEntity(
+            String.format(
+                Locale.ROOT,
+                """
+                    {"query":{"bool":{"must":[{"term":{"_id":"%s-%s"}},{"term":{"metadata_flattened.%s":"%s"}}]}}""",
+                type,
+                value,
+                metaKey,
+                metaValue
+            )
+        );
+        addExpectWarningOption(options);
+        request.setOptions(options);
+
+        Response response = adminClient().performRequest(request);
+        assertOK(response);
+        final Map<String, Object> responseMap = responseAsMap(response);
+
+        Map<String, Object> hits = ((Map<String, Object>) responseMap.get("hits"));
+        assertEquals(1, ((List<Object>) hits.get("hits")).size());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertEntityInSecurityIndex(String type, String id) throws IOException {
+        final Request request = new Request("POST", "/.security/_search");
+        RequestOptions.Builder options = request.getOptions().toBuilder();
+        request.setJsonEntity(String.format(Locale.ROOT, """
+            {"query":{"term":{"_id":"%s-%s"}}}""", type, id));
+        addExpectWarningOption(options);
+        request.setOptions(options);
+        Response response = adminClient().performRequest(request);
+        assertOK(response);
+        final Map<String, Object> responseMap = responseAsMap(response);
+
+        Map<String, Object> hits = ((Map<String, Object>) responseMap.get("hits"));
+        assertEquals(1, ((List<Object>) hits.get("hits")).size());
+    }
+
+    private void addExpectWarningOption(RequestOptions.Builder options) {
+        Set<String> expectedWarnings = Set.of(
+            "this request accesses system indices: [.security-7],"
+                + " but in a future major version, direct access to system indices will be prevented by default"
+        );
+
+        options.setWarningsHandler(warnings -> {
+            final Set<String> actual = Set.copyOf(warnings);
+            // Return true if the warnings aren't what we expected; the client will treat them as a fatal error.
+            return actual.equals(expectedWarnings) == false;
+        });
+
+    }
+
+    private void createUser(String username, String password, String[] roles, Map<String, Object> metadata) throws IOException {
+        final Request request = new Request("POST", "/_security/user/" + username);
+        BytesReference source = BytesReference.bytes(
+            jsonBuilder().map(
+                Map.of(
+                    User.Fields.USERNAME.getPreferredName(),
+                    username,
+                    User.Fields.ROLES.getPreferredName(),
+                    roles,
+                    User.Fields.FULL_NAME.getPreferredName(),
+                    "Mr User Usersson",
+                    User.Fields.EMAIL.getPreferredName(),
+                    "user@user.com",
+                    User.Fields.METADATA.getPreferredName(),
+                    metadata,
+                    User.Fields.PASSWORD.getPreferredName(),
+                    password,
+                    User.Fields.ENABLED.getPreferredName(),
+                    true
+                )
+            )
+        );
+        request.setJsonEntity(source.utf8ToString());
+        assertOK(adminClient().performRequest(request));
+        refreshSecurityIndex();
+    }
+
+    private void createRole(String roleName, Map<String, Object> metadata) throws IOException {
+        final Request request = new Request("POST", "/_security/role/" + roleName);
+        BytesReference source = BytesReference.bytes(
+            jsonBuilder().map(
+                Map.of(
+                    RoleDescriptor.Fields.CLUSTER.getPreferredName(),
+                    List.of("cluster:monitor/xpack/license/get"),
+                    RoleDescriptor.Fields.METADATA.getPreferredName(),
+                    metadata
+                )
+            )
+        );
+        request.setJsonEntity(source.utf8ToString());
+        assertOK(adminClient().performRequest(request));
+        refreshSecurityIndex();
+    }
+
+    private void refreshSecurityIndex() throws IOException {
+        Request request = new Request("POST", "/.security-7/_refresh");
+        RequestOptions.Builder options = request.getOptions().toBuilder();
+        addExpectWarningOption(options);
+        request.setOptions(options);
+        assertOK(adminClient().performRequest(request));
+    }
+}

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SecurityIndexFieldMigrationIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SecurityIndexFieldMigrationIT.java
@@ -72,7 +72,7 @@ public class SecurityIndexFieldMigrationIT extends AbstractUpgradeTestCase {
             String.format(
                 Locale.ROOT,
                 """
-                    {"query":{"bool":{"must":[{"term":{"_id":"%s-%s"}},{"term":{"metadata_flattened.%s":"%s"}}]}}""",
+                    {"query":{"bool":{"must":[{"term":{"_id":"%s-%s"}},{"term":{"metadata_flattened.%s":"%s"}}]}}}""",
                 type,
                 value,
                 metaKey,


### PR DESCRIPTION
This PR adds code to migrate the `metadata` field to the `metadata_flattened` field in the main security index. `metadata_flattened` is of type `flattened` and already exists to enable [queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-query-api-key.html#security-api-query-api-key-request-body) against `metadata` for api keys. After this PR has been merged `metadata` will be indexed in the `metadata_flattened` field for `privilege`, `user`, `apikey` (already available), `role-mappings` and `roles`. 

To migrate the field the [PersistentTasksExecutor](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/persistent/PersistentTasksExecutor.java) is used, which is responsible for executing restartable tasks that can survive disappearance of a coordinating and executor nodes. It also gives us guarantees that only a single instance of a task with the same id will run concurrently.

The migration is triggered by a security index state change and therefore the cluster state will be checked for if the migration has happened or not on every security index state change. If a new security index is created, the migration is skipped and cluster state will be populated with the migration status as completed. 

The migration status is stored in [IndexMetadata](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java) in cluster state as a custom metadata. 

After this has been merged, the APIs that write to `privilege`, `user`, `role-mappings` and `roles` have been updated to dual-write the `metadata` field to `metadata_flattened`. This means that we also have to check that the new metadata flattened node feature exists so the new field is not written to a mixed cluster, causing old nodes to crash. 

The PR also adds: 
- A new node feature: `security.metadata_migrated` to prevent the migration from running in mixed clusters.
- A new transport version `ADD_METADATA_FLATTENED_TO_ROLES` to control the serialization of role descriptors. 
- A new field in the query `user` api allow queries against `metadata` for verification purposes. 

## Notes
- I investigated if the status of the migration job (completed or not) could be kept in the `_meta` field in the security index mapping. After some testing, I don't think that is a pattern we want to use, primarily because of how the `_meta` field [is updated](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/mapper/Mapping.java#L143-L145). It's a full replace of the object field, which means that first the mappings has to be read followed by an update/merge with the new properties and then written. This whole process is not atomic, so it's not a good place to track the status of a job due to risk of race conditions. It's also not a great place to keep metadata because of how the mappings are currently handled by the [SystemIndexMappingUpdateService](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/indices/SystemIndexMappingUpdateService.java), where the mapping is overwritten (including `_meta`) with the full mapping from the `SystemIndexDescriptor`. If the long term goal is to move over to only using the `SystemIndexMappingUpdateService`, it's better to not try to hack around its implementation in my opinion. 
- Logic could be added to the query metadata apis (query user, query roles) to check if the migration has happened and throw an error if the field is used in a query to prevent confusion for customers running mixed clusters or where the migration failed for some reason. I have not added this to the query users API. 

## Future Work
- When doing the next major upgrade this approach would allow us to drop the `metadata` field in favour of the `metadata_flattened` field.
- Add query roles API that uses the new field
- Remove usage of `metadata` entirely. 

## TODO 
- Add BWC test that checks the security index directly for models without query api 
- Add unit test for new executor class
- Update user docs to include metadata
- Add and describe the info logs added to track the status of this job.
- Mark metadata as remove in 9.x
