### PR TITLE
[Transform] Raise loglevel of events related to transform lifecycle from DEBUG to INFO

### DIFF
--- a/docs/changelog/106602.yaml
+++ b/docs/changelog/106602.yaml
@@ -1,0 +1,5 @@
+pr: 106602
+summary: Raise loglevel of events related to transform lifecycle from DEBUG to INFO
+area: Transform
+type: enhancement
+issues: []

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportDeleteTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportDeleteTransformAction.java
@@ -95,7 +95,7 @@ public class TransportDeleteTransformAction extends AcknowledgedTransportMasterN
         // <3> Delete transform config
         ActionListener<AcknowledgedResponse> deleteDestIndexListener = ActionListener.wrap(
             unusedAcknowledgedResponse -> transformConfigManager.deleteTransform(request.getId(), ActionListener.wrap(r -> {
-                logger.debug("[{}] deleted transform", request.getId());
+                logger.info("[{}] deleted transform", request.getId());
                 auditor.info(request.getId(), "Deleted transform.");
                 listener.onResponse(AcknowledgedResponse.of(r));
             }, listener::onFailure)),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -168,7 +168,7 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
         var config = request.getConfig();
         transformConfigManager.putTransformConfiguration(config, listener.delegateFailureAndWrap((l, unused) -> {
             var transformId = config.getId();
-            logger.debug("[{}] created transform", transformId);
+            logger.info("[{}] created transform", transformId);
             auditor.info(transformId, "Created transform.");
 
             var validationFunc = FunctionFactory.create(config);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportResetTransformAction.java
@@ -110,7 +110,7 @@ public class TransportResetTransformAction extends AcknowledgedTransportMasterNo
         // <4> Reset transform
         ActionListener<TransformUpdater.UpdateResult> updateTransformListener = ActionListener.wrap(
             unusedUpdateResult -> transformConfigManager.resetTransform(request.getId(), ActionListener.wrap(resetResponse -> {
-                logger.debug("[{}] reset transform", request.getId());
+                logger.info("[{}] reset transform", request.getId());
                 auditor.info(request.getId(), "Reset transform.");
                 listener.onResponse(AcknowledgedResponse.of(resetResponse));
             }, listener::onFailure)),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -154,7 +154,7 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
                         TransformConfig updatedConfig = updateResult.getConfig();
                         AuthorizationState authState = updateResult.getAuthState();
                         auditor.info(updatedConfig.getId(), "Updated transform.");
-                        logger.debug("[{}] Updated transform [{}]", updatedConfig.getId(), updateResult.getStatus());
+                        logger.info("[{}] Updated transform [{}]", updatedConfig.getId(), updateResult.getStatus());
 
                         checkTransformConfigAndLogWarnings(updatedConfig);
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
@@ -199,7 +199,7 @@ public class TransportUpgradeTransformsAction extends TransportMasterNodeAction<
         updateOneTransform(next, dryRun, timeout, ActionListener.wrap(updateResponse -> {
             if (UpdateResult.Status.DELETED.equals(updateResponse.getStatus()) == false) {
                 auditor.info(next, "Updated transform.");
-                logger.debug("[{}] Updated transform [{}]", next, updateResponse.getStatus());
+                logger.info("[{}] Updated transform [{}]", next, updateResponse.getStatus());
                 updatesByStatus.compute(updateResponse.getStatus(), (k, v) -> (v == null) ? 1 : v + 1L);
             }
             if (transformsToUpgrade.isEmpty() == false) {


### PR DESCRIPTION
This PR raises loglevel of events related to transform lifecycle from `DEBUG` to `INFO` in order to ease debugging.
