### PR TITLE
[DOCS] Adjusts PUT inference API docs examples

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -165,7 +165,7 @@ the same name and the updated API key.
 
 `model_id`:::
 (Optional, string)
-The name of the model to use for the {infer} task. Referto the
+The name of the model to use for the {infer} task. Refer to the
 https://platform.openai.com/docs/guides/embeddings/what-are-embeddings[OpenAI documentation]
 for the list of available text embedding models.
 

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -396,7 +396,7 @@ PUT _inference/text_embedding/openai_embeddings
 {
     "service": "openai",
     "service_settings": {
-        "api_key": "<api_key>"
+        "api_key": "<api_key>",
         "model_id": "text-embedding-ada-002"
     }
 }

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -163,6 +163,12 @@ creating the {infer} model, you cannot change the associated API key. If you
 want to use a different API key, delete the {infer} model and recreate it with
 the same name and the updated API key.
 
+`model_id`:::
+(Optional, string)
+The name of the model to use for the {infer} task. Referto the
+https://platform.openai.com/docs/guides/embeddings/what-are-embeddings[OpenAI documentation]
+for the list of available text embedding models.
+
 `organization_id`:::
 (Optional, string)
 The unique identifier of your organization. You can find the Organization ID in
@@ -216,13 +222,6 @@ Valid values are:
   * `search`: use it for storing embeddings of search queries run against a
   vector data base to find relevant documents.
 
-`model`:::
-(Optional, string)
-For `openai` sevice only. The name of the model to use for the {infer} task. Refer
-to the
-https://platform.openai.com/docs/guides/embeddings/what-are-embeddings[OpenAI documentation]
-for the list of available text embedding models.
-
 `truncate`:::
 (Optional, string)
 For `cohere` service only. Specifies how the API handles inputs longer than the
@@ -257,7 +256,7 @@ PUT _inference/text_embedding/cohere-embeddings
     "service": "cohere",
     "service_settings": {
         "api_key": "<api_key>",
-        "model": "embed-english-light-v3.0",
+        "model_id": "embed-english-light-v3.0",
         "embedding_type": "byte"
     }
 }
@@ -305,8 +304,7 @@ PUT _inference/sparse_embedding/my-elser-model
   "service_settings": {
     "num_allocations": 1,
     "num_threads": 1
-  },
-  "task_settings": {}
+  }
 }
 ------------------------------------------------------------
 // TEST[skip:TBD]
@@ -399,9 +397,7 @@ PUT _inference/text_embedding/openai_embeddings
     "service": "openai",
     "service_settings": {
         "api_key": "<api_key>"
-    },
-    "task_settings": {
-       "model": "text-embedding-ada-002"
+        "model_id": "text-embedding-ada-002"
     }
 }
 ------------------------------------------------------------


### PR DESCRIPTION
## Overview

This PR adjusts the examples on the PUT inference API docs page:
* removes the `task_settings` object from the ELSER and the OpenAI examples,
* put the `model_id` parameter of the OpenAI example to the `service_settings` object,
* move the `model_id` parameter docs from `task_settings` under `service_settings`.