### PR TITLE
Add an index option recording the highest index version that has read an index

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -39,6 +39,7 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.UpdateForV9;
 import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
@@ -350,7 +351,17 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Property.PrivateIndex
     );
 
+    public static final String SETTING_VERSION_UPDATED = "index.version.updated";
+
+    public static final Setting<IndexVersion> SETTING_INDEX_VERSION_UPDATED = Setting.versionIdSetting(
+        SETTING_VERSION_UPDATED,
+        SETTING_INDEX_VERSION_CREATED,
+        Property.IndexScope,
+        Property.PrivateIndex
+    );
+
     public static final String SETTING_VERSION_CREATED_STRING = "index.version.created_string";
+    public static final String SETTING_VERSION_UPDATED_STRING = "index.version.updated_string";
     public static final String SETTING_CREATION_DATE = "index.creation_date";
 
     /**
@@ -358,8 +369,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      * to retain compatibility with old indexes. TODO: remove in 9.0.
      */
     @Deprecated
+    @UpdateForV9
     public static final String SETTING_VERSION_UPGRADED = "index.version.upgraded";
     @Deprecated
+    @UpdateForV9
     public static final String SETTING_VERSION_UPGRADED_STRING = "index.version.upgraded_string";
 
     public static final String SETTING_VERSION_COMPATIBILITY = "index.version.compatibility";
@@ -2680,9 +2693,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
      */
     public static Settings addHumanReadableSettings(Settings settings) {
         Settings.Builder builder = Settings.builder().put(settings);
-        IndexVersion version = SETTING_INDEX_VERSION_CREATED.get(settings);
-        if (version.equals(IndexVersions.ZERO) == false) {
-            builder.put(SETTING_VERSION_CREATED_STRING, version.toString());
+        IndexVersion createdVersion = SETTING_INDEX_VERSION_CREATED.get(settings);
+        if (createdVersion.equals(IndexVersions.ZERO) == false) {
+            builder.put(SETTING_VERSION_CREATED_STRING, createdVersion.toString());
+        }
+        IndexVersion updatedVersion = SETTING_INDEX_VERSION_UPDATED.get(settings);
+        if (updatedVersion.equals(IndexVersions.ZERO) == false) {
+            builder.put(SETTING_VERSION_UPDATED_STRING, updatedVersion.toString());
         }
         Long creationDate = settings.getAsLong(SETTING_CREATION_DATE, null);
         if (creationDate != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -1125,6 +1125,13 @@ public class MetadataIndexStateService {
                 final Index index = indexMetadata.getIndex();
                 if (indexMetadata.getState() != IndexMetadata.State.OPEN) {
                     final Settings.Builder updatedSettings = Settings.builder().put(indexMetadata.getSettings());
+
+                    // record the highest version to read this index
+                    IndexVersion version = IndexMetadata.SETTING_INDEX_VERSION_UPDATED.get(indexMetadata.getSettings());
+                    if (version.before(IndexVersion.current())) {
+                        updatedSettings.put(IndexMetadata.SETTING_INDEX_VERSION_UPDATED.getKey(), IndexVersion.current());
+                    }
+
                     updatedSettings.remove(VERIFIED_BEFORE_CLOSE_SETTING.getKey());
 
                     IndexMetadata newIndexMetadata = IndexMetadata.builder(indexMetadata)

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1311,6 +1311,10 @@ public class Setting<T> implements ToXContentObject {
         return new Setting<>(key, Integer.toString(defaultValue.id()), s -> parseVersion.apply(Integer.parseInt(s)), properties);
     }
 
+    public static <T extends VersionId<T>> Setting<T> versionIdSetting(String key, Setting<T> fallbackSetting, Property... properties) {
+        return new Setting<>(key, fallbackSetting, fallbackSetting.parser, properties);
+    }
+
     public static <T extends VersionId<T>> Setting<T> versionIdSetting(
         final String key,
         Setting<T> fallbackSetting,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/HumanReadableIndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/HumanReadableIndexSettingsTests.java
@@ -22,16 +22,19 @@ import static org.hamcrest.Matchers.equalTo;
 public class HumanReadableIndexSettingsTests extends ESTestCase {
     public void testHumanReadableSettings() {
         IndexVersion versionCreated = randomVersion(random());
+        IndexVersion versionUpdated = randomVersion(random());
         long created = System.currentTimeMillis();
         Settings testSettings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, versionCreated)
+            .put(IndexMetadata.SETTING_VERSION_UPDATED, versionUpdated)
             .put(IndexMetadata.SETTING_CREATION_DATE, created)
             .build();
 
         Settings humanSettings = IndexMetadata.addHumanReadableSettings(testSettings);
-        assertThat(humanSettings.size(), equalTo(4));
-        assertEquals(versionCreated.toString(), humanSettings.get(IndexMetadata.SETTING_VERSION_CREATED_STRING, null));
+        assertThat(humanSettings.size(), equalTo(6));
+        assertThat(humanSettings.get(IndexMetadata.SETTING_VERSION_CREATED_STRING, null), equalTo(versionCreated.toString()));
+        assertThat(humanSettings.get(IndexMetadata.SETTING_VERSION_UPDATED_STRING, null), equalTo(versionUpdated.toString()));
         ZonedDateTime creationDate = ZonedDateTime.ofInstant(Instant.ofEpochMilli(created), ZoneOffset.UTC);
-        assertEquals(creationDate.toString(), humanSettings.get(IndexMetadata.SETTING_CREATION_DATE_STRING, null));
+        assertThat(humanSettings.get(IndexMetadata.SETTING_CREATION_DATE_STRING, null), equalTo(creationDate.toString()));
     }
 }


### PR DESCRIPTION
This option will be needed to decide index shard allocations in an updated https://github.com/elastic/elasticsearch/pull/102708