### PR TITLE
Make testXContentSerializationWithRolloverAndEffectiveRetention take into consideration a disabled lifecycle

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
@@ -132,7 +132,11 @@ public class DataStreamLifecycleTests extends AbstractXContentSerializingTestCas
             } else {
                 assertThat(serialized, containsString("data_retention"));
             }
-            assertThat(serialized, containsString("effective_retention"));
+            if (lifecycle.isEnabled()) {
+                assertThat(serialized, containsString("effective_retention"));
+            } else {
+                assertThat(serialized, not(containsString("effective_retention")));
+            }
         }
     }
 


### PR DESCRIPTION
When a random lifecycle is disabled then the effective retention should not be in the response.

Fixes: https://github.com/elastic/elasticsearch/issues/106608