### PR TITLE
[8.13] Add gradle plugin for publishing docker based test fixtures (#106229)

### DIFF
--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -175,6 +175,10 @@ gradlePlugin {
       id = 'elasticsearch.test.fixtures'
       implementationClass = 'org.elasticsearch.gradle.internal.testfixtures.TestFixturesPlugin'
     }
+    deployTestFixtures {
+      id = 'elasticsearch.deploy-test-fixtures'
+      implementationClass = 'org.elasticsearch.gradle.internal.testfixtures.TestFixturesDeployPlugin'
+    }
     testBase {
       id = 'elasticsearch.test-base'
       implementationClass = 'org.elasticsearch.gradle.internal.ElasticsearchTestBasePlugin'

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixtureDeployment.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixtureDeployment.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.testfixtures;
+
+import org.gradle.api.Named;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+
+import java.io.File;
+
+public abstract class TestFixtureDeployment implements Named {
+
+    private final String name;
+
+    public TestFixtureDeployment(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public abstract Property<String> getDockerRegistry();
+
+    public abstract Property<File> getDockerContext();
+
+    public abstract Property<String> getVersion();
+
+    public abstract ListProperty<String> getBaseImages();
+}

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesDeployPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesDeployPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.gradle.internal.testfixtures;
+
+import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.gradle.Architecture;
+import org.elasticsearch.gradle.internal.docker.DockerBuildTask;
+import org.elasticsearch.gradle.internal.info.BuildParams;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TestFixturesDeployPlugin implements Plugin<Project> {
+
+    public static final String DEPLOY_FIXTURE_TASK_NAME = "deployFixtureDockerImages";
+    private static String DEFAULT_DOCKER_REGISTRY = "docker.elastic.co/elasticsearch-dev";
+
+    @Override
+    public void apply(Project project) {
+        NamedDomainObjectContainer<TestFixtureDeployment> fixtures = project.container(TestFixtureDeployment.class);
+        project.getExtensions().add("dockerFixtures", fixtures);
+        registerDeployTaskPerFixture(project, fixtures);
+        project.getTasks().register(DEPLOY_FIXTURE_TASK_NAME, task -> task.dependsOn(project.getTasks().withType(DockerBuildTask.class)));
+    }
+
+    private static void registerDeployTaskPerFixture(Project project, NamedDomainObjectContainer<TestFixtureDeployment> fixtures) {
+        fixtures.all(
+            fixture -> project.getTasks()
+                .register("deploy" + StringUtils.capitalize(fixture.getName()) + "DockerImage", DockerBuildTask.class, task -> {
+                    task.getDockerContext().fileValue(fixture.getDockerContext().get());
+                    List<String> baseImages = fixture.getBaseImages().get();
+                    if (baseImages.isEmpty() == false) {
+                        task.setBaseImages(baseImages.toArray(new String[baseImages.size()]));
+                    }
+                    task.setNoCache(BuildParams.isCi());
+                    task.setTags(
+                        new String[] {
+                            resolveTargetDockerRegistry(fixture) + "/" + fixture.getName() + "-fixture:" + fixture.getVersion().get() }
+                    );
+                    task.getPush().set(BuildParams.isCi());
+                    task.getPlatforms().addAll(Arrays.stream(Architecture.values()).map(a -> a.dockerPlatform).toList());
+                    task.setGroup("Deploy TestFixtures");
+                    task.setDescription("Deploys the " + fixture.getName() + " test fixture");
+                })
+        );
+    }
+
+    private static String resolveTargetDockerRegistry(TestFixtureDeployment fixture) {
+        return fixture.getDockerRegistry().getOrElse(DEFAULT_DOCKER_REGISTRY);
+    }
+}

--- a/test/fixtures/s3-fixture/build.gradle
+++ b/test/fixtures/s3-fixture/build.gradle
@@ -8,7 +8,6 @@
 apply plugin: 'elasticsearch.java'
 
 description = 'Fixture for S3 Storage service'
-//tasks.named("test").configure { enabled = false }
 
 dependencies {
   api project(':server')

--- a/x-pack/test/idp-fixture/build.gradle
+++ b/x-pack/test/idp-fixture/build.gradle
@@ -1,35 +1,22 @@
-import org.elasticsearch.gradle.Architecture
-import org.elasticsearch.gradle.internal.docker.DockerBuildTask
-import org.elasticsearch.gradle.internal.info.BuildParams
-
 apply plugin: 'elasticsearch.java'
 apply plugin: 'elasticsearch.cache-test-fixtures'
+apply plugin: 'elasticsearch.deploy-test-fixtures'
+
+dockerFixtures {
+  idp {
+    dockerContext = file("src/main/resources/idp")
+    version = "1.1"
+    baseImages = ["openjdk:11.0.16-jre"]
+  }
+  openldap {
+    dockerContext = file("src/main/resources/openldap")
+    version = "1.0"
+    baseImages = ["osixia/openldap:1.4.0"]
+  }
+}
 
 dependencies {
   testImplementation project(':test:framework')
-
   api project(':test:fixtures:testcontainer-utils')
   api "junit:junit:${versions.junit}"
-}
-
-tasks.withType(DockerBuildTask).configureEach {
-  noCache = BuildParams.isCi()
-  push = true //BuildParams.isCi()
-  getPlatforms().addAll( Architecture.values().collect{ it.dockerPlatform } )
-}
-
-tasks.register("deployIdpFixtureDockerImages", DockerBuildTask) {
-    dockerContext.fileValue(file("src/main/resources/idp"))
-    baseImages = ["openjdk:11.0.16-jre"]
-    tags = ["docker.elastic.co/elasticsearch-dev/idp-fixture:1.1"]
-}
-
-tasks.register("deployOpenLdapFixtureDockerImages", DockerBuildTask) {
-  dockerContext.fileValue(file("src/main/resources/openldap"))
-  baseImages = ["osixia/openldap:1.4.0"]
-  tags = ["docker.elastic.co/elasticsearch-dev/openldap-fixture:1.0"]
-}
-
-tasks.register("deployFixtureDockerImages") {
-  dependsOn tasks.withType(DockerBuildTask)
 }


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Add gradle plugin for publishing docker based test fixtures (#106229)