### PR TITLE
Re-mute SimpleThreadPoolIT.testThreadPoolMetrics

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
@@ -117,8 +117,7 @@ public class SimpleThreadPoolIT extends ESIntegTestCase {
         }
     }
 
-    // temporarily re-enable to gather more data on test failures likely caused by diverging thread pool stats
-    // at the time stats are collected vs when measurements are taken.
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104652")
     public void testThreadPoolMetrics() throws Exception {
         internalCluster().startNode();
 


### PR DESCRIPTION
Mute test until remaining races are addressed.
(related to #104652)