### PR TITLE
WIP: Create new async-search-status endpoint accessible with read index permissions

### DIFF
--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearch.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/AsyncSearch.java
@@ -21,6 +21,7 @@ import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.xpack.core.search.action.GetAsyncMyStatusAction;
 import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
 import org.elasticsearch.xpack.core.search.action.GetAsyncStatusAction;
 import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
@@ -40,7 +41,8 @@ public final class AsyncSearch extends Plugin implements ActionPlugin {
         return Arrays.asList(
             new ActionHandler<>(SubmitAsyncSearchAction.INSTANCE, TransportSubmitAsyncSearchAction.class),
             new ActionHandler<>(GetAsyncSearchAction.INSTANCE, TransportGetAsyncSearchAction.class),
-            new ActionHandler<>(GetAsyncStatusAction.INSTANCE, TransportGetAsyncStatusAction.class)
+            new ActionHandler<>(GetAsyncStatusAction.INSTANCE, TransportGetAsyncStatusAction.class),
+            new ActionHandler<>(GetAsyncMyStatusAction.INSTANCE, TransportGetAsyncMyStatusAction.class)
         );
     }
 
@@ -60,6 +62,7 @@ public final class AsyncSearch extends Plugin implements ActionPlugin {
             new RestSubmitAsyncSearchAction(restController.getSearchUsageHolder(), namedWriteableRegistry, clusterSupportsFeature),
             new RestGetAsyncSearchAction(),
             new RestGetAsyncStatusAction(),
+            new RestGetAsyncMyStatusAction(),
             new RestDeleteAsyncSearchAction()
         );
     }

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestGetAsyncMyStatusAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/RestGetAsyncMyStatusAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.async.GetAsyncStatusRequest;
+import org.elasticsearch.xpack.core.search.action.GetAsyncMyStatusAction;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+@ServerlessScope(Scope.PUBLIC)
+public class RestGetAsyncMyStatusAction extends BaseRestHandler {
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(GET, "/_async_search_status/{id}"));
+    }
+
+    @Override
+    public String getName() {
+        return "async_search_my_status_action";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        GetAsyncStatusRequest statusRequest = new GetAsyncStatusRequest(request.param("id"));
+        if (request.hasParam("keep_alive")) {
+            statusRequest.setKeepAlive(request.paramAsTime("keep_alive", statusRequest.getKeepAlive()));
+        }
+        return channel -> client.execute(GetAsyncMyStatusAction.INSTANCE, statusRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncMyStatusAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncMyStatusAction.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.XPackPlugin;
+import org.elasticsearch.xpack.core.async.AsyncExecutionId;
+import org.elasticsearch.xpack.core.async.AsyncTaskIndexService;
+import org.elasticsearch.xpack.core.async.GetAsyncStatusRequest;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
+import org.elasticsearch.xpack.core.search.action.GetAsyncMyStatusAction;
+import org.elasticsearch.xpack.core.search.action.GetAsyncStatusAction;
+
+import java.util.Objects;
+
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
+
+public class TransportGetAsyncMyStatusAction extends HandledTransportAction<GetAsyncStatusRequest, AsyncStatusResponse> {
+    private final TransportService transportService;
+    private final ClusterService clusterService;
+    private final AsyncTaskIndexService<AsyncSearchResponse> store;
+
+    @Inject
+    public TransportGetAsyncMyStatusAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ClusterService clusterService,
+        NamedWriteableRegistry registry,
+        Client client,
+        ThreadPool threadPool,
+        BigArrays bigArrays
+    ) {
+        super(
+            GetAsyncMyStatusAction.NAME,
+            transportService,
+            actionFilters,
+            GetAsyncStatusRequest::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+        this.transportService = transportService;
+        this.clusterService = clusterService;
+        this.store = new AsyncTaskIndexService<>(
+            XPackPlugin.ASYNC_RESULTS_INDEX,
+            clusterService,
+            threadPool.getThreadContext(),
+            client,
+            ASYNC_SEARCH_ORIGIN,
+            AsyncSearchResponse::new,
+            registry,
+            bigArrays
+        );
+    }
+
+    /// MP TODO: this code is exactly the same as TransportGetAsyncStatusAction - can we just call it directly? (or move it shared code)
+    @Override
+    protected void doExecute(Task task, GetAsyncStatusRequest request, ActionListener<AsyncStatusResponse> listener) {
+        AsyncExecutionId searchId = AsyncExecutionId.decode(request.getId());
+        DiscoveryNode node = clusterService.state().nodes().get(searchId.getTaskId().getNodeId());
+        DiscoveryNode localNode = clusterService.state().getNodes().getLocalNode();
+
+        if (node == null || Objects.equals(node, localNode)) {
+            if (request.getKeepAlive() != null && request.getKeepAlive().getMillis() > 0) {
+                long expirationTime = System.currentTimeMillis() + request.getKeepAlive().getMillis();
+                store.updateExpirationTime(searchId.getDocId(), expirationTime, ActionListener.wrap(p -> {
+                    AsyncSearchTask asyncSearchTask = store.getTaskAndCheckAuthentication(taskManager, searchId, AsyncSearchTask.class);
+                    if (asyncSearchTask != null) {
+                        asyncSearchTask.setExpirationTime(expirationTime);
+                    }
+                    store.retrieveStatus(
+                        request,
+                        taskManager,
+                        AsyncSearchTask.class,
+                        AsyncSearchTask::getStatusResponse,
+                        AsyncStatusResponse::getStatusFromStoredSearch,
+                        listener
+                    );
+                }, exc -> {
+                    RestStatus status = ExceptionsHelper.status(ExceptionsHelper.unwrapCause(exc));
+                    if (status != RestStatus.NOT_FOUND) {
+                        logger.error(() -> format("failed to update expiration time for async-search [%s]", searchId.getEncoded()), exc);
+                        listener.onFailure(exc);
+                    } else {
+                        // the async search document or its index is not found.
+                        // That can happen if an invalid/deleted search id is provided.
+                        listener.onFailure(new ResourceNotFoundException(searchId.getEncoded()));
+                    }
+                }));
+            } else {
+                store.retrieveStatus(
+                    request,
+                    taskManager,
+                    AsyncSearchTask.class,
+                    AsyncSearchTask::getStatusResponse,
+                    AsyncStatusResponse::getStatusFromStoredSearch,
+                    listener
+                );
+            }
+        } else {
+            transportService.sendRequest(
+                node,
+                GetAsyncStatusAction.NAME,
+                request,
+                new ActionListenerResponseHandler<>(listener, AsyncStatusResponse::new, EsExecutors.DIRECT_EXECUTOR_SERVICE)
+            );
+        }
+    }
+}

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncMyStatusAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncMyStatusAction.java
@@ -74,7 +74,6 @@ public class TransportGetAsyncMyStatusAction extends HandledTransportAction<GetA
         );
     }
 
-    /// MP TODO: this code is exactly the same as TransportGetAsyncStatusAction - can we just call it directly? (or move it shared code)
     @Override
     protected void doExecute(Task task, GetAsyncStatusRequest request, ActionListener<AsyncStatusResponse> listener) {
         AsyncExecutionId searchId = AsyncExecutionId.decode(request.getId());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/GetAsyncMyStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/GetAsyncMyStatusAction.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.ActionType;
  */
 public class GetAsyncMyStatusAction extends ActionType<AsyncStatusResponse> {
     public static final GetAsyncMyStatusAction INSTANCE = new GetAsyncMyStatusAction();
-    public static final String NAME = "indices:data/read/async_search/status";
+    public static final String NAME = "indices:data/read/async_search_status";
 
     private GetAsyncMyStatusAction() {
         super(NAME);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/GetAsyncMyStatusAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/GetAsyncMyStatusAction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.core.search.action;
+
+import org.elasticsearch.action.ActionType;
+
+/**
+ * TODO: DOCUMENT ME
+ */
+public class GetAsyncMyStatusAction extends ActionType<AsyncStatusResponse> {
+    public static final GetAsyncMyStatusAction INSTANCE = new GetAsyncMyStatusAction();
+    public static final String NAME = "indices:data/read/async_search/status";
+
+    private GetAsyncMyStatusAction() {
+        super(NAME);
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -528,6 +528,7 @@ public class Constants {
         "indices:data/read/downsample_delegate",
         "indices:data/read/async_search/delete",
         "indices:data/read/async_search/get",
+        "indices:data/read/async_search_status",
         "indices:data/read/async_search/submit",
         "indices:data/read/close_point_in_time",
         "indices:data/read/eql",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/RBACEngine.java
@@ -45,6 +45,7 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.async.TransportDeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.eql.EqlAsyncActionNames;
 import org.elasticsearch.xpack.core.esql.EsqlAsyncActionNames;
+import org.elasticsearch.xpack.core.search.action.GetAsyncMyStatusAction;
 import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
 import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
 import org.elasticsearch.xpack.core.security.action.apikey.GetApiKeyAction;
@@ -998,6 +999,7 @@ public class RBACEngine implements AuthorizationEngine {
     private static boolean isAsyncRelatedAction(String action) {
         return action.equals(SubmitAsyncSearchAction.NAME)
             || action.equals(GetAsyncSearchAction.NAME)
+            || action.equals(GetAsyncMyStatusAction.NAME)
             || action.equals(TransportDeleteAsyncResultAction.TYPE.name())
             || action.equals(EqlAsyncActionNames.EQL_ASYNC_GET_RESULT_ACTION_NAME)
             || action.equals(EsqlAsyncActionNames.ESQL_ASYNC_GET_RESULT_ACTION_NAME)


### PR DESCRIPTION
This looks promising based on manual testing.

Against a secured cluster with a user having permissions set as:

```
{
  "mp_role": {
    "cluster": [],
    "indices": [
      {
        "names": [
          "blogs"
        ],
        "privileges": [
          "read"
        ],
        "allow_restricted_indices": false
      },
```

I can create an async-search and the query it via the new endpoint:

```
└─ $ ▶ curlhj -X GET "https://localhost:9200/_async_search_status/$SID?error_trace=false" --cacert primary-http_ca.crt -u mp_user:$MYPASS  | jq .
HTTP/1.1 200 OK
X-elastic-product: Elasticsearch
content-type: application/json
content-length: 253

{
  "id": "FjNVWFJVUktGVENpR05vdmxFc3ZXWVEbeXpsQTRkaTJUZGVudFF5SUFDS0YzUToxNzg3",
  "is_running": true,
  "is_partial": true,
  "start_time_in_millis": 1711046614126,
  "expiration_time_in_millis": 1711478614126,
  "_shards": {
    "total": 13,
    "successful": 9,
    "skipped": 0,
    "failed": 0
  }
}
```