### PR TITLE
[ESQL] Migrate PropagateEquals optimization

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -82,7 +82,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.elasticsearch.xpack.esql.expression.NamedExpressions.mergeOutputExpressions;
 import static org.elasticsearch.xpack.ql.expression.Expressions.asAttributes;
-import static org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PropagateEquals;
 import static org.elasticsearch.xpack.ql.optimizer.OptimizerRules.TransformDirection;
 import static org.elasticsearch.xpack.ql.optimizer.OptimizerRules.TransformDirection.DOWN;
 
@@ -126,7 +125,7 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
             new BooleanSimplification(),
             new LiteralsOnTheRight(),
             // needs to occur before BinaryComparison combinations (see class)
-            new PropagateEquals(),
+            new org.elasticsearch.xpack.esql.optimizer.OptimizerRules.PropagateEquals(),
             new PropagateNullable(),
             new BooleanFunctionEqualsElimination(),
             new org.elasticsearch.xpack.esql.optimizer.OptimizerRules.CombineDisjunctionsToIn(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRules.java
@@ -8,7 +8,13 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.GreaterThanOrEqual;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NullEquals;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
 import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
@@ -34,14 +40,23 @@ import org.elasticsearch.xpack.ql.common.Failures;
 import org.elasticsearch.xpack.ql.expression.AttributeSet;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Expressions;
+import org.elasticsearch.xpack.ql.expression.Literal;
+import org.elasticsearch.xpack.ql.expression.predicate.Predicates;
+import org.elasticsearch.xpack.ql.expression.predicate.Range;
+import org.elasticsearch.xpack.ql.expression.predicate.logical.And;
+import org.elasticsearch.xpack.ql.expression.predicate.logical.BinaryLogic;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.ql.plan.QueryPlan;
 import org.elasticsearch.xpack.ql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.ql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.ql.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.elasticsearch.xpack.ql.util.CollectionUtils;
 
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -50,6 +65,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.elasticsearch.xpack.ql.common.Failure.fail;
+import static org.elasticsearch.xpack.ql.expression.Literal.TRUE;
 import static org.elasticsearch.xpack.ql.expression.predicate.Predicates.combineOr;
 import static org.elasticsearch.xpack.ql.expression.predicate.Predicates.splitOr;
 
@@ -231,7 +247,329 @@ class OptimizerRules {
         }
     }
 
-    static class PropagateEquals extends org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PropagateEquals {
-       // TODO: clone the QL version
+    /**
+     * Propagate Equals to eliminate conjuncted Ranges or BinaryComparisons.
+     * When encountering a different Equals, non-containing {@link Range} or {@link BinaryComparison}, the conjunction becomes false.
+     * When encountering a containing {@link Range}, {@link BinaryComparison} or {@link NotEquals}, these get eliminated by the equality.
+     *
+     * Since this rule can eliminate Ranges and BinaryComparisons, it should be applied before
+     * {@link org.elasticsearch.xpack.ql.optimizer.OptimizerRules.CombineBinaryComparisons}.
+     *
+     * This rule doesn't perform any promotion of {@link BinaryComparison}s, that is handled by
+     * {@link org.elasticsearch.xpack.ql.optimizer.OptimizerRules.CombineBinaryComparisons} on purpose as the resulting Range might be
+     * foldable (which is picked by the folding rule on the next run).
+     */
+    public static final class PropagateEquals extends org.elasticsearch.xpack.ql.optimizer.OptimizerRules.OptimizerExpressionRule<
+        BinaryLogic> {
+
+        PropagateEquals() {
+            super(org.elasticsearch.xpack.ql.optimizer.OptimizerRules.TransformDirection.DOWN);
+        }
+
+        public Expression rule(BinaryLogic e) {
+            if (e instanceof And) {
+                return propagate((And) e);
+            } else if (e instanceof Or) {
+                return propagate((Or) e);
+            }
+            return e;
+        }
+
+        // combine conjunction
+        private static Expression propagate(And and) {
+            List<Range> ranges = new ArrayList<>();
+            // Only equalities, not-equalities and inequalities with a foldable .right are extracted separately;
+            // the others go into the general 'exps'.
+            // TODO: In 105217, this should change to EsqlBinaryComparison, but it doesn't exist in this branch yet
+            List<BinaryComparison> equals = new ArrayList<>();
+            List<NotEquals> notEquals = new ArrayList<>();
+            List<BinaryComparison> inequalities = new ArrayList<>();
+            List<Expression> exps = new ArrayList<>();
+
+            boolean changed = false;
+
+            for (Expression ex : Predicates.splitAnd(and)) {
+                if (ex instanceof Range) {
+                    ranges.add((Range) ex);
+                } else if (ex instanceof Equals || ex instanceof NullEquals) {
+                    BinaryComparison otherEq = (BinaryComparison) ex;
+                    // equals on different values evaluate to FALSE
+                    // ignore date/time fields as equality comparison might actually be a range check
+                    if (otherEq.right().foldable() && DataTypes.isDateTime(otherEq.left().dataType()) == false) {
+                        for (BinaryComparison eq : equals) {
+                            if (otherEq.left().semanticEquals(eq.left())) {
+                                Integer comp = BinaryComparison.compare(eq.right().fold(), otherEq.right().fold());
+                                if (comp != null) {
+                                    // var cannot be equal to two different values at the same time
+                                    if (comp != 0) {
+                                        return new Literal(and.source(), Boolean.FALSE, DataTypes.BOOLEAN);
+                                    }
+                                }
+                            }
+                        }
+                        equals.add(otherEq);
+                    } else {
+                        exps.add(otherEq);
+                    }
+                } else if (ex instanceof GreaterThan
+                    || ex instanceof GreaterThanOrEqual
+                    || ex instanceof LessThan
+                    || ex instanceof LessThanOrEqual) {
+                        BinaryComparison bc = (BinaryComparison) ex;
+                        if (bc.right().foldable()) {
+                            inequalities.add(bc);
+                        } else {
+                            exps.add(ex);
+                        }
+                    } else if (ex instanceof NotEquals otherNotEq) {
+                        if (otherNotEq.right().foldable()) {
+                            notEquals.add(otherNotEq);
+                        } else {
+                            exps.add(ex);
+                        }
+                    } else {
+                        exps.add(ex);
+                    }
+            }
+
+            // check
+            for (BinaryComparison eq : equals) {
+                Object eqValue = eq.right().fold();
+
+                for (Iterator<Range> iterator = ranges.iterator(); iterator.hasNext();) {
+                    Range range = iterator.next();
+
+                    if (range.value().semanticEquals(eq.left())) {
+                        // if equals is outside the interval, evaluate the whole expression to FALSE
+                        if (range.lower().foldable()) {
+                            Integer compare = BinaryComparison.compare(range.lower().fold(), eqValue);
+                            if (compare != null && (
+                            // eq outside the lower boundary
+                            compare > 0 ||
+                            // eq matches the boundary but should not be included
+                                (compare == 0 && range.includeLower() == false))) {
+                                return new Literal(and.source(), Boolean.FALSE, DataTypes.BOOLEAN);
+                            }
+                        }
+                        if (range.upper().foldable()) {
+                            Integer compare = BinaryComparison.compare(range.upper().fold(), eqValue);
+                            if (compare != null && (
+                            // eq outside the upper boundary
+                            compare < 0 ||
+                            // eq matches the boundary but should not be included
+                                (compare == 0 && range.includeUpper() == false))) {
+                                return new Literal(and.source(), Boolean.FALSE, DataTypes.BOOLEAN);
+                            }
+                        }
+
+                        // it's in the range and thus, remove it
+                        iterator.remove();
+                        changed = true;
+                    }
+                }
+
+                // evaluate all NotEquals against the Equal
+                for (Iterator<NotEquals> iter = notEquals.iterator(); iter.hasNext();) {
+                    NotEquals neq = iter.next();
+                    if (eq.left().semanticEquals(neq.left())) {
+                        Integer comp = BinaryComparison.compare(eqValue, neq.right().fold());
+                        if (comp != null) {
+                            if (comp == 0) { // clashing and conflicting: a = 1 AND a != 1
+                                return new Literal(and.source(), Boolean.FALSE, DataTypes.BOOLEAN);
+                            } else { // clashing and redundant: a = 1 AND a != 2
+                                iter.remove();
+                                changed = true;
+                            }
+                        }
+                    }
+                }
+
+                // evaluate all inequalities against the Equal
+                for (Iterator<BinaryComparison> iter = inequalities.iterator(); iter.hasNext();) {
+                    BinaryComparison bc = iter.next();
+                    if (eq.left().semanticEquals(bc.left())) {
+                        Integer compare = BinaryComparison.compare(eqValue, bc.right().fold());
+                        if (compare != null) {
+                            if (bc instanceof LessThan || bc instanceof LessThanOrEqual) { // a = 2 AND a </<= ?
+                                if ((compare == 0 && bc instanceof LessThan) || // a = 2 AND a < 2
+                                    0 < compare) { // a = 2 AND a </<= 1
+                                    return new Literal(and.source(), Boolean.FALSE, DataTypes.BOOLEAN);
+                                }
+                            } else if (bc instanceof GreaterThan || bc instanceof GreaterThanOrEqual) { // a = 2 AND a >/>= ?
+                                if ((compare == 0 && bc instanceof GreaterThan) || // a = 2 AND a > 2
+                                    compare < 0) { // a = 2 AND a >/>= 3
+                                    return new Literal(and.source(), Boolean.FALSE, DataTypes.BOOLEAN);
+                                }
+                            }
+
+                            iter.remove();
+                            changed = true;
+                        }
+                    }
+                }
+            }
+
+            return changed ? Predicates.combineAnd(CollectionUtils.combine(exps, equals, notEquals, inequalities, ranges)) : and;
+        }
+
+        // combine disjunction:
+        // a = 2 OR a > 3 -> nop; a = 2 OR a > 1 -> a > 1
+        // a = 2 OR a < 3 -> a < 3; a = 2 OR a < 1 -> nop
+        // a = 2 OR 3 < a < 5 -> nop; a = 2 OR 1 < a < 3 -> 1 < a < 3; a = 2 OR 0 < a < 1 -> nop
+        // a = 2 OR a != 2 -> TRUE; a = 2 OR a = 5 -> nop; a = 2 OR a != 5 -> a != 5
+        private static Expression propagate(Or or) {
+            List<Expression> exps = new ArrayList<>();
+            List<Equals> equals = new ArrayList<>(); // foldable right term Equals
+            List<NotEquals> notEquals = new ArrayList<>(); // foldable right term NotEquals
+            List<Range> ranges = new ArrayList<>();
+            List<BinaryComparison> inequalities = new ArrayList<>(); // foldable right term (=limit) BinaryComparision
+
+            // split expressions by type
+            for (Expression ex : Predicates.splitOr(or)) {
+                if (ex instanceof Equals eq) {
+                    if (eq.right().foldable()) {
+                        equals.add(eq);
+                    } else {
+                        exps.add(ex);
+                    }
+                } else if (ex instanceof NotEquals neq) {
+                    if (neq.right().foldable()) {
+                        notEquals.add(neq);
+                    } else {
+                        exps.add(ex);
+                    }
+                } else if (ex instanceof Range) {
+                    ranges.add((Range) ex);
+                } else if (ex instanceof BinaryComparison bc) {
+                    if (bc.right().foldable()) {
+                        inequalities.add(bc);
+                    } else {
+                        exps.add(ex);
+                    }
+                } else {
+                    exps.add(ex);
+                }
+            }
+
+            boolean updated = false; // has the expression been modified?
+
+            // evaluate the impact of each Equal over the different types of Expressions
+            for (Iterator<Equals> iterEq = equals.iterator(); iterEq.hasNext();) {
+                Equals eq = iterEq.next();
+                Object eqValue = eq.right().fold();
+                boolean removeEquals = false;
+
+                // Equals OR NotEquals
+                for (NotEquals neq : notEquals) {
+                    if (eq.left().semanticEquals(neq.left())) { // a = 2 OR a != ? -> ...
+                        Integer comp = BinaryComparison.compare(eqValue, neq.right().fold());
+                        if (comp != null) {
+                            if (comp == 0) { // a = 2 OR a != 2 -> TRUE
+                                return TRUE;
+                            } else { // a = 2 OR a != 5 -> a != 5
+                                removeEquals = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (removeEquals) {
+                    iterEq.remove();
+                    updated = true;
+                    continue;
+                }
+
+                // Equals OR Range
+                for (int i = 0; i < ranges.size(); i++) { // might modify list, so use index loop
+                    Range range = ranges.get(i);
+                    if (eq.left().semanticEquals(range.value())) {
+                        Integer lowerComp = range.lower().foldable() ? BinaryComparison.compare(eqValue, range.lower().fold()) : null;
+                        Integer upperComp = range.upper().foldable() ? BinaryComparison.compare(eqValue, range.upper().fold()) : null;
+
+                        if (lowerComp != null && lowerComp == 0) {
+                            if (range.includeLower() == false) { // a = 2 OR 2 < a < ? -> 2 <= a < ?
+                                ranges.set(
+                                    i,
+                                    new Range(
+                                        range.source(),
+                                        range.value(),
+                                        range.lower(),
+                                        true,
+                                        range.upper(),
+                                        range.includeUpper(),
+                                        range.zoneId()
+                                    )
+                                );
+                            } // else : a = 2 OR 2 <= a < ? -> 2 <= a < ?
+                            removeEquals = true; // update range with lower equality instead or simply superfluous
+                            break;
+                        } else if (upperComp != null && upperComp == 0) {
+                            if (range.includeUpper() == false) { // a = 2 OR ? < a < 2 -> ? < a <= 2
+                                ranges.set(
+                                    i,
+                                    new Range(
+                                        range.source(),
+                                        range.value(),
+                                        range.lower(),
+                                        range.includeLower(),
+                                        range.upper(),
+                                        true,
+                                        range.zoneId()
+                                    )
+                                );
+                            } // else : a = 2 OR ? < a <= 2 -> ? < a <= 2
+                            removeEquals = true; // update range with upper equality instead
+                            break;
+                        } else if (lowerComp != null && upperComp != null) {
+                            if (0 < lowerComp && upperComp < 0) { // a = 2 OR 1 < a < 3
+                                removeEquals = true; // equality is superfluous
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (removeEquals) {
+                    iterEq.remove();
+                    updated = true;
+                    continue;
+                }
+
+                // Equals OR Inequality
+                for (int i = 0; i < inequalities.size(); i++) {
+                    BinaryComparison bc = inequalities.get(i);
+                    if (eq.left().semanticEquals(bc.left())) {
+                        Integer comp = BinaryComparison.compare(eqValue, bc.right().fold());
+                        if (comp != null) {
+                            if (bc instanceof GreaterThan || bc instanceof GreaterThanOrEqual) {
+                                if (comp < 0) { // a = 1 OR a > 2 -> nop
+                                    continue;
+                                } else if (comp == 0 && bc instanceof GreaterThan) { // a = 2 OR a > 2 -> a >= 2
+                                    inequalities.set(i, new GreaterThanOrEqual(bc.source(), bc.left(), bc.right(), bc.zoneId()));
+                                } // else (0 < comp || bc instanceof GreaterThanOrEqual) :
+                                  // a = 3 OR a > 2 -> a > 2; a = 2 OR a => 2 -> a => 2
+
+                                removeEquals = true; // update range with equality instead or simply superfluous
+                                break;
+                            } else if (bc instanceof LessThan || bc instanceof LessThanOrEqual) {
+                                if (comp > 0) { // a = 2 OR a < 1 -> nop
+                                    continue;
+                                }
+                                if (comp == 0 && bc instanceof LessThan) { // a = 2 OR a < 2 -> a <= 2
+                                    inequalities.set(i, new LessThanOrEqual(bc.source(), bc.left(), bc.right(), bc.zoneId()));
+                                } // else (comp < 0 || bc instanceof LessThanOrEqual) : a = 2 OR a < 3 -> a < 3; a = 2 OR a <= 2 -> a <= 2
+                                removeEquals = true; // update range with equality instead or simply superfluous
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (removeEquals) {
+                    iterEq.remove();
+                    updated = true;
+                }
+            }
+
+            return updated ? Predicates.combineOr(CollectionUtils.combine(exps, equals, notEquals, inequalities, ranges)) : or;
+        }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRules.java
@@ -230,4 +230,8 @@ class OptimizerRules {
             return e;
         }
     }
+
+    static class PropagateEquals extends org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PropagateEquals {
+       // TODO: clone the QL version
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRulesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRulesTests.java
@@ -292,7 +292,7 @@ public class OptimizerRulesTests extends ESTestCase {
         Equals eq = equalsOf(fa, TWO);
         GreaterThanOrEqual gte = greaterThanOrEqualOf(fa, TWO);
 
-        org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
         Expression exp = rule.rule(new And(EMPTY, eq, gte));
         assertEquals(eq, exp);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRulesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRulesTests.java
@@ -9,11 +9,19 @@ package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.GreaterThan;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.LessThan;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.LessThanOrEqual;
+import org.elasticsearch.xpack.esql.evaluator.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NullEquals;
+import org.elasticsearch.xpack.ql.TestUtils;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.FieldAttribute;
 import org.elasticsearch.xpack.ql.expression.Literal;
+import org.elasticsearch.xpack.ql.expression.predicate.Predicates;
+import org.elasticsearch.xpack.ql.expression.predicate.Range;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.And;
 import org.elasticsearch.xpack.ql.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.ql.plan.logical.Filter;
@@ -24,8 +32,10 @@ import org.elasticsearch.xpack.ql.type.DataTypes;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.elasticsearch.xpack.ql.TestUtils.getFieldAttribute;
+import static org.elasticsearch.xpack.ql.TestUtils.rangeOf;
 import static org.elasticsearch.xpack.ql.TestUtils.relation;
+import static org.elasticsearch.xpack.ql.expression.Literal.FALSE;
+import static org.elasticsearch.xpack.ql.expression.Literal.TRUE;
 import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 import static org.hamcrest.Matchers.contains;
 
@@ -33,6 +43,8 @@ public class OptimizerRulesTests extends ESTestCase {
     private static final Literal ONE = new Literal(Source.EMPTY, 1, DataTypes.INTEGER);
     private static final Literal TWO = new Literal(Source.EMPTY, 2, DataTypes.INTEGER);
     private static final Literal THREE = new Literal(Source.EMPTY, 3, DataTypes.INTEGER);
+    private static final Literal FOUR = new Literal(Source.EMPTY, 4, DataTypes.INTEGER);
+    private static final Literal FIVE = new Literal(Source.EMPTY, 5, DataTypes.INTEGER);
 
     private static Equals equalsOf(Expression left, Expression right) {
         return new Equals(EMPTY, left, right, null);
@@ -41,12 +53,33 @@ public class OptimizerRulesTests extends ESTestCase {
     private static LessThan lessThanOf(Expression left, Expression right) {
         return new LessThan(EMPTY, left, right, null);
     }
+    public static GreaterThan greaterThanOf(Expression left, Expression right) {
+        return new GreaterThan(EMPTY, left, right, randomZone());
+    }
 
+    public static NotEquals notEqualsOf(Expression left, Expression right) {
+        return new NotEquals(EMPTY, left, right, randomZone());
+    }
+
+    public static NullEquals nullEqualsOf(Expression left, Expression right) {
+        return new NullEquals(EMPTY, left, right, randomZone());
+    }
+
+    public static LessThanOrEqual lessThanOrEqualOf(Expression left, Expression right) {
+        return new LessThanOrEqual(EMPTY, left, right, randomZone());
+    }
+    public static GreaterThanOrEqual greaterThanOrEqualOf(Expression left, Expression right) {
+        return new GreaterThanOrEqual(EMPTY, left, right, randomZone());
+    }
+
+    private static FieldAttribute getFieldAttribute() {
+        return TestUtils.getFieldAttribute("a");
+    }
     //
     // CombineDisjunction in Equals
     //
     public void testTwoEqualsWithOr() {
-        FieldAttribute fa = getFieldAttribute("a");
+        FieldAttribute fa = getFieldAttribute();
 
         Or or = new Or(EMPTY, equalsOf(fa, ONE), equalsOf(fa, TWO));
         Expression e = new OptimizerRules.CombineDisjunctionsToIn().rule(or);
@@ -57,7 +90,7 @@ public class OptimizerRulesTests extends ESTestCase {
     }
 
     public void testTwoEqualsWithSameValue() {
-        FieldAttribute fa = getFieldAttribute("a");
+        FieldAttribute fa = getFieldAttribute();
 
         Or or = new Or(EMPTY, equalsOf(fa, ONE), equalsOf(fa, ONE));
         Expression e = new OptimizerRules.CombineDisjunctionsToIn().rule(or);
@@ -68,7 +101,7 @@ public class OptimizerRulesTests extends ESTestCase {
     }
 
     public void testOneEqualsOneIn() {
-        FieldAttribute fa = getFieldAttribute("a");
+        FieldAttribute fa = getFieldAttribute();
 
         Or or = new Or(EMPTY, equalsOf(fa, ONE), new In(EMPTY, fa, List.of(TWO)));
         Expression e = new OptimizerRules.CombineDisjunctionsToIn().rule(or);
@@ -79,7 +112,7 @@ public class OptimizerRulesTests extends ESTestCase {
     }
 
     public void testOneEqualsOneInWithSameValue() {
-        FieldAttribute fa = getFieldAttribute("a");
+        FieldAttribute fa = getFieldAttribute();
 
         Or or = new Or(EMPTY, equalsOf(fa, ONE), new In(EMPTY, fa, asList(ONE, TWO)));
         Expression e = new OptimizerRules.CombineDisjunctionsToIn().rule(or);
@@ -90,7 +123,7 @@ public class OptimizerRulesTests extends ESTestCase {
     }
 
     public void testSingleValueInToEquals() {
-        FieldAttribute fa = getFieldAttribute("a");
+        FieldAttribute fa = getFieldAttribute();
 
         Equals equals = equalsOf(fa, ONE);
         Or or = new Or(EMPTY, equals, new In(EMPTY, fa, List.of(ONE)));
@@ -99,7 +132,7 @@ public class OptimizerRulesTests extends ESTestCase {
     }
 
     public void testEqualsBehindAnd() {
-        FieldAttribute fa = getFieldAttribute("a");
+        FieldAttribute fa = getFieldAttribute();
 
         And and = new And(EMPTY, equalsOf(fa, ONE), equalsOf(fa, TWO));
         Filter dummy = new Filter(EMPTY, relation(), and);
@@ -109,8 +142,8 @@ public class OptimizerRulesTests extends ESTestCase {
     }
 
     public void testTwoEqualsDifferentFields() {
-        FieldAttribute fieldOne = getFieldAttribute("ONE");
-        FieldAttribute fieldTwo = getFieldAttribute("TWO");
+        FieldAttribute fieldOne = TestUtils.getFieldAttribute("ONE");
+        FieldAttribute fieldTwo = TestUtils.getFieldAttribute("TWO");
 
         Or or = new Or(EMPTY, equalsOf(fieldOne, ONE), equalsOf(fieldTwo, TWO));
         Expression e = new OptimizerRules.CombineDisjunctionsToIn().rule(or);
@@ -118,7 +151,7 @@ public class OptimizerRulesTests extends ESTestCase {
     }
 
     public void testMultipleIn() {
-        FieldAttribute fa = getFieldAttribute("a");
+        FieldAttribute fa = getFieldAttribute();
 
         Or firstOr = new Or(EMPTY, new In(EMPTY, fa, List.of(ONE)), new In(EMPTY, fa, List.of(TWO)));
         Or secondOr = new Or(EMPTY, firstOr, new In(EMPTY, fa, List.of(THREE)));
@@ -130,7 +163,7 @@ public class OptimizerRulesTests extends ESTestCase {
     }
 
     public void testOrWithNonCombinableExpressions() {
-        FieldAttribute fa = getFieldAttribute("a");
+        FieldAttribute fa = getFieldAttribute();
 
         Or firstOr = new Or(EMPTY, new In(EMPTY, fa, List.of(ONE)), lessThanOf(fa, TWO));
         Or secondOr = new Or(EMPTY, firstOr, new In(EMPTY, fa, List.of(THREE)));
@@ -143,4 +176,304 @@ public class OptimizerRulesTests extends ESTestCase {
         assertEquals(fa, in.value());
         assertThat(in.list(), contains(ONE, THREE));
     }
+    // a == 1 AND a == 2 -> FALSE
+    public void testDualEqualsConjunction() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq1 = equalsOf(fa, ONE);
+        Equals eq2 = equalsOf(fa, TWO);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq1, eq2));
+        assertEquals(FALSE, exp);
+    }
+    // a <=> 1 AND a <=> 2 -> FALSE
+    public void testDualNullEqualsConjunction() {
+        FieldAttribute fa = getFieldAttribute();
+        NullEquals eq1 = nullEqualsOf(fa, ONE);
+        NullEquals eq2 = nullEqualsOf(fa, TWO);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq1, eq2));
+        assertEquals(FALSE, exp);
+    }
+
+    // 1 < a < 10 AND a == 10 -> FALSE
+    public void testEliminateRangeByEqualsOutsideInterval() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq1 = equalsOf(fa, new Literal(EMPTY, 10, DataTypes.INTEGER));
+        Range r = rangeOf(fa, ONE, false, new Literal(EMPTY, 10, DataTypes.INTEGER), false);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq1, r));
+        assertEquals(FALSE, exp);
+    }
+
+    // 1 < a < 10 AND a <=> 10 -> FALSE
+    public void testEliminateRangeByNullEqualsOutsideInterval() {
+        FieldAttribute fa = getFieldAttribute();
+        NullEquals eq1 = nullEqualsOf(fa, new Literal(EMPTY, 10, DataTypes.INTEGER));
+        Range r = rangeOf(fa, ONE, false, new Literal(EMPTY, 10, DataTypes.INTEGER), false);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq1, r));
+        assertEquals(FALSE, exp);
+    }
+
+    // a != 3 AND a = 3 -> FALSE
+    public void testPropagateEquals_VarNeq3AndVarEq3() {
+        FieldAttribute fa = getFieldAttribute();
+        NotEquals neq = notEqualsOf(fa, THREE);
+        Equals eq = equalsOf(fa, THREE);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, neq, eq));
+        assertEquals(FALSE, exp);
+    }
+
+    // a != 4 AND a = 3 -> a = 3
+    public void testPropagateEquals_VarNeq4AndVarEq3() {
+        FieldAttribute fa = getFieldAttribute();
+        NotEquals neq = notEqualsOf(fa, FOUR);
+        Equals eq = equalsOf(fa, THREE);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, neq, eq));
+        assertEquals(Equals.class, exp.getClass());
+        assertEquals(eq, exp);
+    }
+
+    // a = 2 AND a < 2 -> FALSE
+    public void testPropagateEquals_VarEq2AndVarLt2() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        LessThan lt = lessThanOf(fa, TWO);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq, lt));
+        assertEquals(FALSE, exp);
+    }
+
+    // a = 2 AND a <= 2 -> a = 2
+    public void testPropagateEquals_VarEq2AndVarLte2() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        LessThanOrEqual lt = lessThanOrEqualOf(fa, TWO);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq, lt));
+        assertEquals(eq, exp);
+    }
+
+    // a = 2 AND a <= 1 -> FALSE
+    public void testPropagateEquals_VarEq2AndVarLte1() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        LessThanOrEqual lt = lessThanOrEqualOf(fa, ONE);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq, lt));
+        assertEquals(FALSE, exp);
+    }
+
+    // a = 2 AND a > 2 -> FALSE
+    public void testPropagateEquals_VarEq2AndVarGt2() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        GreaterThan gt = greaterThanOf(fa, TWO);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq, gt));
+        assertEquals(FALSE, exp);
+    }
+
+    // a = 2 AND a >= 2 -> a = 2
+    public void testPropagateEquals_VarEq2AndVarGte2() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        GreaterThanOrEqual gte = greaterThanOrEqualOf(fa, TWO);
+
+        org.elasticsearch.xpack.ql.optimizer.OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq, gte));
+        assertEquals(eq, exp);
+    }
+
+    // a = 2 AND a > 3 -> FALSE
+    public void testPropagateEquals_VarEq2AndVarLt3() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        GreaterThan gt = greaterThanOf(fa, THREE);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq, gt));
+        assertEquals(FALSE, exp);
+    }
+
+    // a = 2 AND a < 3 AND a > 1 AND a != 4 -> a = 2
+    public void testPropagateEquals_VarEq2AndVarLt3AndVarGt1AndVarNeq4() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        LessThan lt = lessThanOf(fa, THREE);
+        GreaterThan gt = greaterThanOf(fa, ONE);
+        NotEquals neq = notEqualsOf(fa, FOUR);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression and = Predicates.combineAnd(asList(eq, lt, gt, neq));
+        Expression exp = rule.rule((And) and);
+        assertEquals(eq, exp);
+    }
+
+    // a = 2 AND 1 < a < 3 AND a > 0 AND a != 4 -> a = 2
+    public void testPropagateEquals_VarEq2AndVarRangeGt1Lt3AndVarGt0AndVarNeq4() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        Range range = rangeOf(fa, ONE, false, THREE, false);
+        GreaterThan gt = greaterThanOf(fa, new Literal(EMPTY, 0, DataTypes.INTEGER));
+        NotEquals neq = notEqualsOf(fa, FOUR);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression and = Predicates.combineAnd(asList(eq, range, gt, neq));
+        Expression exp = rule.rule((And) and);
+        assertEquals(eq, exp);
+    }
+
+    // a = 2 OR a > 1 -> a > 1
+    public void testPropagateEquals_VarEq2OrVarGt1() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        GreaterThan gt = greaterThanOf(fa, ONE);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, gt));
+        assertEquals(gt, exp);
+    }
+
+    // a = 2 OR a > 2 -> a >= 2
+    public void testPropagateEquals_VarEq2OrVarGte2() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        GreaterThan gt = greaterThanOf(fa, TWO);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, gt));
+        assertEquals(GreaterThanOrEqual.class, exp.getClass());
+        GreaterThanOrEqual gte = (GreaterThanOrEqual) exp;
+        assertEquals(TWO, gte.right());
+    }
+
+    // a = 2 OR a < 3 -> a < 3
+    public void testPropagateEquals_VarEq2OrVarLt3() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        LessThan lt = lessThanOf(fa, THREE);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, lt));
+        assertEquals(lt, exp);
+    }
+
+    // a = 3 OR a < 3 -> a <= 3
+    public void testPropagateEquals_VarEq3OrVarLt3() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, THREE);
+        LessThan lt = lessThanOf(fa, THREE);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, lt));
+        assertEquals(LessThanOrEqual.class, exp.getClass());
+        LessThanOrEqual lte = (LessThanOrEqual) exp;
+        assertEquals(THREE, lte.right());
+    }
+
+    // a = 2 OR 1 < a < 3 -> 1 < a < 3
+    public void testPropagateEquals_VarEq2OrVarRangeGt1Lt3() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        Range range = rangeOf(fa, ONE, false, THREE, false);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, range));
+        assertEquals(range, exp);
+    }
+
+    // a = 2 OR 2 < a < 3 -> 2 <= a < 3
+    public void testPropagateEquals_VarEq2OrVarRangeGt2Lt3() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        Range range = rangeOf(fa, TWO, false, THREE, false);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, range));
+        assertEquals(Range.class, exp.getClass());
+        Range r = (Range) exp;
+        assertEquals(TWO, r.lower());
+        assertTrue(r.includeLower());
+        assertEquals(THREE, r.upper());
+        assertFalse(r.includeUpper());
+    }
+
+    // a = 3 OR 2 < a < 3 -> 2 < a <= 3
+    public void testPropagateEquals_VarEq3OrVarRangeGt2Lt3() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, THREE);
+        Range range = rangeOf(fa, TWO, false, THREE, false);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, range));
+        assertEquals(Range.class, exp.getClass());
+        Range r = (Range) exp;
+        assertEquals(TWO, r.lower());
+        assertFalse(r.includeLower());
+        assertEquals(THREE, r.upper());
+        assertTrue(r.includeUpper());
+    }
+
+    // a = 2 OR a != 2 -> TRUE
+    public void testPropagateEquals_VarEq2OrVarNeq2() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        NotEquals neq = notEqualsOf(fa, TWO);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, neq));
+        assertEquals(TRUE, exp);
+    }
+
+    // a = 2 OR a != 5 -> a != 5
+    public void testPropagateEquals_VarEq2OrVarNeq5() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq = equalsOf(fa, TWO);
+        NotEquals neq = notEqualsOf(fa, FIVE);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new Or(EMPTY, eq, neq));
+        assertEquals(NotEquals.class, exp.getClass());
+        NotEquals ne = (NotEquals) exp;
+        assertEquals(FIVE, ne.right());
+    }
+
+    // a = 2 OR 3 < a < 4 OR a > 2 OR a!= 2 -> TRUE
+    public void testPropagateEquals_VarEq2OrVarRangeGt3Lt4OrVarGt2OrVarNe2() {
+        FieldAttribute fa = getFieldAttribute();
+        org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.Equals eq = equalsOf(fa, TWO);
+        Range range = rangeOf(fa, THREE, false, FOUR, false);
+        GreaterThan gt = greaterThanOf(fa, TWO);
+        NotEquals neq = notEqualsOf(fa, TWO);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule((Or) Predicates.combineOr(asList(eq, range, neq, gt)));
+        assertEquals(TRUE, exp);
+    }
+
+    // a == 1 AND a == 2 -> nop for date/time fields
+    public void testPropagateEquals_ignoreDateTimeFields() {
+        FieldAttribute fa = TestUtils.getFieldAttribute("a", DataTypes.DATETIME);
+        Equals eq1 = equalsOf(fa, ONE);
+        Equals eq2 = equalsOf(fa, TWO);
+        And and = new And(EMPTY, eq1, eq2);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(and);
+        assertEquals(and, exp);
+    }
+
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRulesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRulesTests.java
@@ -32,6 +32,8 @@ import org.elasticsearch.xpack.ql.type.DataTypes;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.elasticsearch.xpack.ql.TestUtils.equalsOf;
+import static org.elasticsearch.xpack.ql.TestUtils.nullEqualsOf;
 import static org.elasticsearch.xpack.ql.TestUtils.rangeOf;
 import static org.elasticsearch.xpack.ql.TestUtils.relation;
 import static org.elasticsearch.xpack.ql.expression.Literal.FALSE;
@@ -481,4 +483,25 @@ public class OptimizerRulesTests extends ESTestCase {
         assertEquals(and, exp);
     }
 
+    // 1 <= a < 10 AND a == 1 -> a == 1
+    public void testEliminateRangeByEqualsInInterval() {
+        FieldAttribute fa = getFieldAttribute();
+        Equals eq1 = equalsOf(fa, ONE);
+        Range r = rangeOf(fa, ONE, true, new Literal(EMPTY, 10, DataTypes.INTEGER), false);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq1, r));
+        assertEquals(eq1, exp);
+    }
+
+    // 1 <= a < 10 AND a <=> 1 -> a <=> 1
+    public void testEliminateRangeByNullEqualsInInterval() {
+        FieldAttribute fa = getFieldAttribute();
+        NullEquals eq1 = nullEqualsOf(fa, ONE);
+        Range r = rangeOf(fa, ONE, true, new Literal(EMPTY, 10, DataTypes.INTEGER), false);
+
+        OptimizerRules.PropagateEquals rule = new OptimizerRules.PropagateEquals();
+        Expression exp = rule.rule(new And(EMPTY, eq1, r));
+        assertEquals(eq1, exp);
+    }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRulesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRulesTests.java
@@ -53,6 +53,7 @@ public class OptimizerRulesTests extends ESTestCase {
     private static LessThan lessThanOf(Expression left, Expression right) {
         return new LessThan(EMPTY, left, right, null);
     }
+
     public static GreaterThan greaterThanOf(Expression left, Expression right) {
         return new GreaterThan(EMPTY, left, right, randomZone());
     }
@@ -68,6 +69,7 @@ public class OptimizerRulesTests extends ESTestCase {
     public static LessThanOrEqual lessThanOrEqualOf(Expression left, Expression right) {
         return new LessThanOrEqual(EMPTY, left, right, randomZone());
     }
+
     public static GreaterThanOrEqual greaterThanOrEqualOf(Expression left, Expression right) {
         return new GreaterThanOrEqual(EMPTY, left, right, randomZone());
     }
@@ -75,6 +77,7 @@ public class OptimizerRulesTests extends ESTestCase {
     private static FieldAttribute getFieldAttribute() {
         return TestUtils.getFieldAttribute("a");
     }
+
     //
     // CombineDisjunction in Equals
     //
@@ -176,6 +179,7 @@ public class OptimizerRulesTests extends ESTestCase {
         assertEquals(fa, in.value());
         assertThat(in.list(), contains(ONE, THREE));
     }
+
     // a == 1 AND a == 2 -> FALSE
     public void testDualEqualsConjunction() {
         FieldAttribute fa = getFieldAttribute();
@@ -186,6 +190,7 @@ public class OptimizerRulesTests extends ESTestCase {
         Expression exp = rule.rule(new And(EMPTY, eq1, eq2));
         assertEquals(FALSE, exp);
     }
+
     // a <=> 1 AND a <=> 2 -> FALSE
     public void testDualNullEqualsConjunction() {
         FieldAttribute fa = getFieldAttribute();

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
@@ -325,8 +325,7 @@ public final class OptimizerRules {
      * {@link CombineBinaryComparisons} on purpose as the resulting Range might be foldable
      * (which is picked by the folding rule on the next run).
      */
-    // NOCOMMIT - This should go back to being final once we finish copying it into ESQL
-    public static class PropagateEquals extends OptimizerExpressionRule<BinaryLogic> {
+    public static final class PropagateEquals extends OptimizerExpressionRule<BinaryLogic> {
 
         public PropagateEquals() {
             super(TransformDirection.DOWN);

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRules.java
@@ -325,7 +325,8 @@ public final class OptimizerRules {
      * {@link CombineBinaryComparisons} on purpose as the resulting Range might be foldable
      * (which is picked by the folding rule on the next run).
      */
-    public static final class PropagateEquals extends OptimizerExpressionRule<BinaryLogic> {
+    // NOCOMMIT - This should go back to being final once we finish copying it into ESQL
+    public static class PropagateEquals extends OptimizerExpressionRule<BinaryLogic> {
 
         public PropagateEquals() {
             super(TransformDirection.DOWN);


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/105217

This copies the PropagateEquals logical optimization into ESQL, following the pattern established in https://github.com/elastic/elasticsearch/pull/106499.  I've copied the optimization rule into the ESQL version of `OptimizerRules`, and the tests into `OpitmizerRulesTests`, and changed the imports &c to point to the appropriate ESQL classes instead of their QL counterparts.

I expect to have several more PRs following this pattern, for the remaining logical optimizations that touch the binary comparison logic.  I'm intending to make separate PRs for each, in the interest of making them easier to review.