### PR TITLE
Fix testScheduledFixedDelayRejection

### DIFF
--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -465,7 +465,6 @@ public class ThreadPoolTests extends ESTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106618")
     public void testScheduledFixedDelayRejection() {
         final var name = "fixed-bounded";
         final var threadPool = new TestThreadPool(
@@ -476,17 +475,14 @@ public class ThreadPoolTests extends ESTestCase {
         final var future = new PlainActionFuture<Void>();
         final var latch = new CountDownLatch(1);
         try {
+            blockExecution(threadPool.executor(name), latch);
             threadPool.scheduleWithFixedDelay(
-                ActionRunnable.wrap(future, ignored -> Thread.yield()),
+                ActionRunnable.wrap(future, ignored -> fail("should not execute")),
                 TimeValue.timeValueMillis(between(1, 100)),
                 threadPool.executor(name)
             );
 
-            while (future.isDone() == false) {
-                // might not block all threads the first time round if the scheduled runnable is running, so must keep trying
-                blockExecution(threadPool.executor(name), latch);
-            }
-            expectThrows(EsRejectedExecutionException.class, () -> FutureUtils.get(future));
+            expectThrows(EsRejectedExecutionException.class, () -> FutureUtils.get(future, 10, TimeUnit.SECONDS));
         } finally {
             latch.countDown();
             assertTrue(terminate(threadPool));


### PR DESCRIPTION
Not really necessary to allow the scheduled task to race against the
blocks, and this race is a source of test flakiness. Fixed by imposing
the blocks first.

Closes #106618