### PR TITLE
Mute "Test vector search with query_vector_builder" (AwaitsFix #106535)

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/search_knn_query_vector_builder.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/search_knn_query_vector_builder.yml
@@ -106,8 +106,11 @@ setup:
 ---
 "Test vector search with query_vector_builder":
   - skip:
-      version: " - 8.13.99"
-      reason: "introduced after 8.13"
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/106535"
+  #    version: " - 8.13.99"
+  #    reason: "introduced after 8.13"
+
   - do:
       search:
         index: index-with-embedded-text


### PR DESCRIPTION
Ref: https://github.com/elastic/elasticsearch/issues/106535