### PR TITLE
[ML] Fix Array out of bounds exception in the XLM Roberta tokenizer

### DIFF
--- a/docs/changelog/106655.yaml
+++ b/docs/changelog/106655.yaml
@@ -1,0 +1,5 @@
+pr: 106655
+summary: Fix Array out of bounds exception in the XLM Roberta tokenizer
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/PrecompiledCharMapNormalizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/PrecompiledCharMapNormalizer.java
@@ -73,10 +73,8 @@ public class PrecompiledCharMapNormalizer extends BaseCharFilter {
     private final int[] offsets;
     // The entire normalized bytes representations delimited by NULL
     private final byte[] normalizedStrUtf8Bytes;
-    // Continually reused to copy a single char into utf8 bytes
-    private final byte[] reusableCharByteBuffer = new byte[4];
     // reusable char buffer for decoding utf8 bytes to determine char offset corrections
-    private final char[] reusableCharDecodeBuffer = new char[8];
+    private final char[] reusableCharDecodeBuffer = new char[64];
     private Reader transformedInput;
 
     public PrecompiledCharMapNormalizer(int[] offsets, String normalizedStr, Reader in) {
@@ -172,7 +170,6 @@ public class PrecompiledCharMapNormalizer extends BaseCharFilter {
         ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(str));
         byte[] strBytes = new byte[byteBuffer.limit()];
         byteBuffer.get(strBytes);
-        int[] strCp = str.codePoints().toArray();
         BreakIterator b = BreakIterator.getCharacterInstance(Locale.ROOT);
         b.setText(str);
         // We iterate the whole string, so b.first() is always `0`

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/PrecompiledCharMapNormalizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/PrecompiledCharMapNormalizerTests.java
@@ -57,6 +57,11 @@ public class PrecompiledCharMapNormalizerTests extends ESTestCase {
         assertNormalization("😀", parsed, "😀");
     }
 
+    public void testCharThatNormalizesToLongText() throws IOException {
+        PrecompiledCharMapNormalizer.Config parsed = loadTestCharMap();
+        assertNormalization("ﷺ", parsed, "صلى الله عليه وسلم");
+    }
+
     private void assertNormalization(String input, PrecompiledCharMapNormalizer.Config config, String expected) throws IOException {
         PrecompiledCharMapNormalizer normalizer = new PrecompiledCharMapNormalizer(
             config.offsets(),


### PR DESCRIPTION
The following `ArrayIndexOutOfBoundsException` has been observed tokenising certain Unicode characters in the XLM Roberta tokenizer. The overflow comes from a fixed sized reusable buffer that holds the normalised form of a single unicode character encoded as UTF-8. The normalised form can be much longer than the allocated buffer size (8 chars), for example 'ﷺ' normalises to 33 characters. That is surprising so I compared the output to other SentencePiece  implementations and the results are in agreement. 

The fix here is to spend a few bytes increasing the buffer size.


```
java.lang.ArrayIndexOutOfBoundsException: Index 8 out of bounds for length 8
	at org.apache.lucene.util.UnicodeUtil.UTF8toUTF16(UnicodeUtil.java:650) ~[lucene-core-9.9.2.jar:?]
	at org.elasticsearch.xpack.ml.inference.nlp.tokenizers.PrecompiledCharMapNormalizer.normalize(PrecompiledCharMapNormalizer.java:194) ~[?:?]
	at org.elasticsearch.xpack.ml.inference.nlp.tokenizers.PrecompiledCharMapNormalizer.fill(PrecompiledCharMapNormalizer.java:263) ~[?:?]
	at org.elasticsearch.xpack.ml.inference.nlp.tokenizers.PrecompiledCharMapNormalizer.read(PrecompiledCharMapNormalizer.java:242) ~[?:?]
	at org.apache.lucene.analysis.CharacterUtils.readFully(CharacterUtils.java:183) ~[lucene-core-9.9.2.jar:?]
	at org.apache.lucene.analysis.CharacterUtils.fill(CharacterUtils.java:159) ~[lucene-core-9.9.2.jar:?]
	at org.apache.lucene.analysis.CharacterUtils.fill(CharacterUtils.java:177) ~[lucene-core-9.9.2.jar:?]
	at org.elasticsearch.xpack.ml.inference.nlp.tokenizers.UnigramTokenizer$SimpleWhitespaceTokenizer.next(UnigramTokenizer.java:464) ~[?:?]
	at org.elasticsearch.xpack.ml.inference.nlp.tokenizers.UnigramTokenizer.incrementToken(UnigramTokenizer.java:165) ~[?:?]
	at org.elasticsearch.xpack.ml.inference.nlp.tokenizers.XLMRobertaTokenizer.innerTokenize(XLMRobertaTokenizer.java:173) ~[?:?]
	at org.elasticsearch.xpack.ml.inference.nlp.tokenizers.NlpTokenizer.tokenize(NlpTokenizer.java:60) ~[?:?]
	at org.elasticsearch.xpack.ml.inference.nlp.tokenizers.XLMRobertaTokenizer.lambda$requestBuilder$0(XLMRobertaTokenizer.java:132) ~[?:?]
```

This PR also removes some unused fields. 