### PR TITLE
Add more debugging to 25_id_generation/generates a consistent id test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/25_id_generation.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/25_id_generation.yml
@@ -110,10 +110,13 @@ generates a consistent id:
           query:
             match_all: {}
           sort: ["@timestamp"]
+          _source: true
+          docvalue_fields: [_ts_routing_hash]
 
   - match: {hits.total.value: 9}
 
   - match: { hits.hits.0._id: cn4excfoxSs_KdA5AAABeRnRFAY }
+  - match: { hits.hits.0.fields._ts_routing_hash: [ cn4exQ ] }
   - match: { hits.hits.0._source.@timestamp: 2021-04-28T18:50:03.142Z }
   - match: { hits.hits.0._source.k8s.pod.uid: df3145b3-0563-4d3b-a0f7-897eb2876ea9 }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesRoutingHashFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesRoutingHashFieldMapper.java
@@ -25,7 +25,6 @@ import org.elasticsearch.script.field.DelegateDocValuesField;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 
-import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Collections;
@@ -56,8 +55,7 @@ public class TimeSeriesRoutingHashFieldMapper extends MetadataFieldMapper {
             }
 
             @Override
-            public void writeTo(StreamOutput out) {
-            }
+            public void writeTo(StreamOutput out) {}
 
             @Override
             public Object format(BytesRef value) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesRoutingHashFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesRoutingHashFieldMapper.java
@@ -10,6 +10,8 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.ByteUtils;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexVersions;
@@ -20,8 +22,11 @@ import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.fielddata.plain.SortedOrdinalsIndexFieldData;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.script.field.DelegateDocValuesField;
+import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 
+import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Base64;
 import java.util.Collections;
 
@@ -43,6 +48,23 @@ public class TimeSeriesRoutingHashFieldMapper extends MetadataFieldMapper {
     static final class TimeSeriesRoutingHashFieldType extends MappedFieldType {
 
         private static final TimeSeriesRoutingHashFieldType INSTANCE = new TimeSeriesRoutingHashFieldType();
+        private static final DocValueFormat DOC_VALUE_FORMAT = new DocValueFormat() {
+
+            @Override
+            public String getWriteableName() {
+                return NAME;
+            }
+
+            @Override
+            public void writeTo(StreamOutput out) {
+            }
+
+            @Override
+            public Object format(BytesRef value) {
+                return Uid.decodeId(value.bytes, value.offset, value.length);
+            }
+
+        };
 
         private TimeSeriesRoutingHashFieldType() {
             super(NAME, false, false, true, TextSearchInfo.NONE, Collections.emptyMap());
@@ -74,6 +96,11 @@ public class TimeSeriesRoutingHashFieldMapper extends MetadataFieldMapper {
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
             throw new IllegalArgumentException("[" + NAME + "] is not searchable");
+        }
+
+        @Override
+        public DocValueFormat docValueFormat(String format, ZoneId timeZone) {
+            return DOC_VALUE_FORMAT;
         }
     }
 


### PR DESCRIPTION
Include the _ts_routing_hash field in the search response for more debugging. In order to add support for docvalue_fields feature for this field type, a custom DOC_VALUE_FORMAT is needed in order to decode to valid utf8 string.

Relates #106550
