### PR TITLE
Assert that FsBlobContainer.readBlob does not start reading after file length

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -197,6 +197,7 @@ public class FsBlobContainer extends AbstractBlobContainer {
         assert BlobContainer.assertPurposeConsistency(purpose, blobName);
         final SeekableByteChannel channel = Files.newByteChannel(path.resolve(blobName));
         if (position > 0L) {
+            assert position < channel.size() : "reading from " + position + " exceeds file length " + channel.size();
             channel.position(position);
         }
         assert channel.position() == position;


### PR DESCRIPTION
This change adds an assertion in the FsBlobContainer.readBlob to ensure we are not reading after the last byte of the file. 

While this is legal and documented in the `SeekableByteChannel.position()` API, having this assertion in place would have caught on CI some regression introduced recently and only caught on deployments where S3 rejects reads starting after blob length.