### PR TITLE
Move `XContent` -> `SnapshotInfo` parsing out of prod

### DIFF
--- a/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
+++ b/qa/smoke-test-http/src/javaRestTest/java/org/elasticsearch/http/snapshots/RestGetSnapshotsIT.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotInfoUtils;
 import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -524,7 +525,7 @@ public class RestGetSnapshotsIT extends AbstractSnapshotRestTestCase {
     static {
         GET_SNAPSHOT_PARSER.declareObjectArray(
             ConstructingObjectParser.constructorArg(),
-            (p, c) -> SnapshotInfo.SNAPSHOT_INFO_PARSER.apply(p, c).build(),
+            (p, c) -> SnapshotInfoUtils.snapshotInfoFromXContent(p),
             new ParseField("snapshots")
         );
         GET_SNAPSHOT_PARSER.declareObject(

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponse.java
@@ -14,12 +14,8 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.snapshots.SnapshotInfo;
-import org.elasticsearch.snapshots.SnapshotInfo.SnapshotInfoBuilder;
-import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -29,24 +25,8 @@ import java.util.Objects;
  */
 public class CreateSnapshotResponse extends ActionResponse implements ToXContentObject {
 
-    private static final ObjectParser<CreateSnapshotResponse, Void> PARSER = new ObjectParser<>(
-        CreateSnapshotResponse.class.getName(),
-        true,
-        CreateSnapshotResponse::new
-    );
-
-    static {
-        PARSER.declareObject(
-            CreateSnapshotResponse::setSnapshotInfoFromBuilder,
-            SnapshotInfo.SNAPSHOT_INFO_PARSER,
-            new ParseField("snapshot")
-        );
-    }
-
     @Nullable
-    private SnapshotInfo snapshotInfo;
-
-    CreateSnapshotResponse() {}
+    private final SnapshotInfo snapshotInfo;
 
     public CreateSnapshotResponse(@Nullable SnapshotInfo snapshotInfo) {
         this.snapshotInfo = snapshotInfo;
@@ -55,10 +35,6 @@ public class CreateSnapshotResponse extends ActionResponse implements ToXContent
     public CreateSnapshotResponse(StreamInput in) throws IOException {
         super(in);
         snapshotInfo = in.readOptionalWriteable(SnapshotInfo::readFrom);
-    }
-
-    private void setSnapshotInfoFromBuilder(SnapshotInfoBuilder snapshotInfoBuilder) {
-        this.snapshotInfo = snapshotInfoBuilder.build();
     }
 
     /**
@@ -101,10 +77,6 @@ public class CreateSnapshotResponse extends ActionResponse implements ToXContent
         }
         builder.endObject();
         return builder;
-    }
-
-    public static CreateSnapshotResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/create/TransportCreateSnapshotAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotsService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -68,7 +69,7 @@ public class TransportCreateSnapshotAction extends TransportMasterNodeAction<Cre
         if (request.waitForCompletion()) {
             snapshotsService.executeSnapshot(request, listener.map(CreateSnapshotResponse::new));
         } else {
-            snapshotsService.createSnapshot(request, listener.map(snapshot -> new CreateSnapshotResponse()));
+            snapshotsService.createSnapshot(request, listener.map(snapshot -> new CreateSnapshotResponse((SnapshotInfo) null)));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -23,7 +23,6 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.repositories.RepositoryShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentFragment;
@@ -53,236 +52,39 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
     public static final String INCLUDE_REPOSITORY_XCONTENT_PARAM = "include_repository";
 
     private static final DateFormatter DATE_TIME_FORMATTER = DateFormatter.forPattern("strict_date_optional_time");
-    private static final String SNAPSHOT = "snapshot";
-    private static final String UUID = "uuid";
-    private static final String REPOSITORY = "repository";
-    private static final String INDICES = "indices";
-    private static final String DATA_STREAMS = "data_streams";
-    private static final String STATE = "state";
-    private static final String REASON = "reason";
-    private static final String START_TIME = "start_time";
-    private static final String START_TIME_IN_MILLIS = "start_time_in_millis";
-    private static final String END_TIME = "end_time";
-    private static final String END_TIME_IN_MILLIS = "end_time_in_millis";
-    private static final String DURATION = "duration";
-    private static final String DURATION_IN_MILLIS = "duration_in_millis";
-    private static final String FAILURES = "failures";
-    private static final String SHARDS = "shards";
-    private static final String TOTAL = "total";
-    private static final String FAILED = "failed";
-    private static final String SUCCESSFUL = "successful";
-    private static final String VERSION_ID = "version_id";
-    private static final String VERSION = "version";
-    private static final String NAME = "name";
-    private static final String TOTAL_SHARDS = "total_shards";
-    private static final String SUCCESSFUL_SHARDS = "successful_shards";
-    private static final String INCLUDE_GLOBAL_STATE = "include_global_state";
-    private static final String USER_METADATA = "metadata";
-    private static final String FEATURE_STATES = "feature_states";
-    private static final String INDEX_DETAILS = "index_details";
 
-    private static final String UNKNOWN_REPO_NAME = "_na_";
+    static final String SNAPSHOT = "snapshot";
+    static final String UUID = "uuid";
+    static final String REPOSITORY = "repository";
+    static final String INDICES = "indices";
+    static final String DATA_STREAMS = "data_streams";
+    static final String STATE = "state";
+    static final String REASON = "reason";
+    static final String START_TIME = "start_time";
+    static final String START_TIME_IN_MILLIS = "start_time_in_millis";
+    static final String END_TIME = "end_time";
+    static final String END_TIME_IN_MILLIS = "end_time_in_millis";
+    static final String DURATION = "duration";
+    static final String DURATION_IN_MILLIS = "duration_in_millis";
+    static final String FAILURES = "failures";
+    static final String SHARDS = "shards";
+    static final String TOTAL = "total";
+    static final String FAILED = "failed";
+    static final String SUCCESSFUL = "successful";
+    static final String VERSION_ID = "version_id";
+    static final String VERSION = "version";
+    static final String NAME = "name";
+    static final String TOTAL_SHARDS = "total_shards";
+    static final String SUCCESSFUL_SHARDS = "successful_shards";
+    static final String INCLUDE_GLOBAL_STATE = "include_global_state";
+    static final String USER_METADATA = "metadata";
+    static final String FEATURE_STATES = "feature_states";
+    static final String INDEX_DETAILS = "index_details";
+
+    static final String UNKNOWN_REPO_NAME = "_na_";
 
     private static final Comparator<SnapshotInfo> COMPARATOR = Comparator.comparing(SnapshotInfo::startTime)
         .thenComparing(SnapshotInfo::snapshotId);
-
-    public static final class SnapshotInfoBuilder {
-        private String snapshotName = null;
-        private String snapshotUUID = null;
-        private String repository = UNKNOWN_REPO_NAME;
-        private String state = null;
-        private String reason = null;
-        private List<String> indices = null;
-        private List<String> dataStreams = null;
-        private List<SnapshotFeatureInfo> featureStates = null;
-        private Map<String, IndexSnapshotDetails> indexSnapshotDetails = null;
-        private long startTime = 0L;
-        private long endTime = 0L;
-        private ShardStatsBuilder shardStatsBuilder = null;
-        private Boolean includeGlobalState = null;
-        private Map<String, Object> userMetadata = null;
-        private int version = -1;
-        private List<SnapshotShardFailure> shardFailures = null;
-
-        private void setSnapshotName(String snapshotName) {
-            this.snapshotName = snapshotName;
-        }
-
-        private void setSnapshotUUID(String snapshotUUID) {
-            this.snapshotUUID = snapshotUUID;
-        }
-
-        private void setRepository(String repository) {
-            this.repository = repository;
-        }
-
-        private void setState(String state) {
-            this.state = state;
-        }
-
-        private void setReason(String reason) {
-            this.reason = reason;
-        }
-
-        private void setIndices(List<String> indices) {
-            this.indices = indices;
-        }
-
-        private void setDataStreams(List<String> dataStreams) {
-            this.dataStreams = dataStreams;
-        }
-
-        private void setFeatureStates(List<SnapshotFeatureInfo> featureStates) {
-            this.featureStates = featureStates;
-        }
-
-        private void setIndexSnapshotDetails(Map<String, IndexSnapshotDetails> indexSnapshotDetails) {
-            this.indexSnapshotDetails = indexSnapshotDetails;
-        }
-
-        private void setStartTime(long startTime) {
-            this.startTime = startTime;
-        }
-
-        private void setEndTime(long endTime) {
-            this.endTime = endTime;
-        }
-
-        private void setShardStatsBuilder(ShardStatsBuilder shardStatsBuilder) {
-            this.shardStatsBuilder = shardStatsBuilder;
-        }
-
-        private void setIncludeGlobalState(Boolean includeGlobalState) {
-            this.includeGlobalState = includeGlobalState;
-        }
-
-        private void setUserMetadata(Map<String, Object> userMetadata) {
-            this.userMetadata = userMetadata;
-        }
-
-        private void setVersion(int version) {
-            this.version = version;
-        }
-
-        private void setShardFailures(List<SnapshotShardFailure> shardFailures) {
-            this.shardFailures = shardFailures;
-        }
-
-        public SnapshotInfo build() {
-            final Snapshot snapshot = new Snapshot(repository, new SnapshotId(snapshotName, snapshotUUID));
-
-            if (indices == null) {
-                indices = Collections.emptyList();
-            }
-
-            if (dataStreams == null) {
-                dataStreams = Collections.emptyList();
-            }
-
-            if (featureStates == null) {
-                featureStates = Collections.emptyList();
-            }
-
-            if (indexSnapshotDetails == null) {
-                indexSnapshotDetails = Collections.emptyMap();
-            }
-
-            SnapshotState snapshotState = state == null ? null : SnapshotState.valueOf(state);
-            IndexVersion version = this.version == -1 ? IndexVersion.current() : IndexVersion.fromId(this.version);
-
-            int totalShards = shardStatsBuilder == null ? 0 : shardStatsBuilder.getTotalShards();
-            int successfulShards = shardStatsBuilder == null ? 0 : shardStatsBuilder.getSuccessfulShards();
-
-            if (shardFailures == null) {
-                shardFailures = new ArrayList<>();
-            }
-
-            return new SnapshotInfo(
-                snapshot,
-                indices,
-                dataStreams,
-                featureStates,
-                reason,
-                version,
-                startTime,
-                endTime,
-                totalShards,
-                successfulShards,
-                shardFailures,
-                includeGlobalState,
-                userMetadata,
-                snapshotState,
-                indexSnapshotDetails
-            );
-        }
-    }
-
-    private static final class ShardStatsBuilder {
-        private int totalShards;
-        private int successfulShards;
-
-        private void setTotalShards(int totalShards) {
-            this.totalShards = totalShards;
-        }
-
-        int getTotalShards() {
-            return totalShards;
-        }
-
-        private void setSuccessfulShards(int successfulShards) {
-            this.successfulShards = successfulShards;
-        }
-
-        int getSuccessfulShards() {
-            return successfulShards;
-        }
-    }
-
-    public static final ObjectParser<SnapshotInfoBuilder, Void> SNAPSHOT_INFO_PARSER = new ObjectParser<>(
-        SnapshotInfoBuilder.class.getName(),
-        true,
-        SnapshotInfoBuilder::new
-    );
-
-    private static final ObjectParser<ShardStatsBuilder, Void> SHARD_STATS_PARSER = new ObjectParser<>(
-        ShardStatsBuilder.class.getName(),
-        true,
-        ShardStatsBuilder::new
-    );
-
-    static {
-        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setSnapshotName, new ParseField(SNAPSHOT));
-        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setSnapshotUUID, new ParseField(UUID));
-        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setRepository, new ParseField(REPOSITORY));
-        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setState, new ParseField(STATE));
-        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setReason, new ParseField(REASON));
-        SNAPSHOT_INFO_PARSER.declareStringArray(SnapshotInfoBuilder::setIndices, new ParseField(INDICES));
-        SNAPSHOT_INFO_PARSER.declareStringArray(SnapshotInfoBuilder::setDataStreams, new ParseField(DATA_STREAMS));
-        SNAPSHOT_INFO_PARSER.declareObjectArray(
-            SnapshotInfoBuilder::setFeatureStates,
-            SnapshotFeatureInfo.SNAPSHOT_FEATURE_INFO_PARSER,
-            new ParseField(FEATURE_STATES)
-        );
-        SNAPSHOT_INFO_PARSER.declareObject(
-            SnapshotInfoBuilder::setIndexSnapshotDetails,
-            (p, c) -> p.map(HashMap::new, p2 -> IndexSnapshotDetails.PARSER.parse(p2, c)),
-            new ParseField(INDEX_DETAILS)
-        );
-        SNAPSHOT_INFO_PARSER.declareLong(SnapshotInfoBuilder::setStartTime, new ParseField(START_TIME_IN_MILLIS));
-        SNAPSHOT_INFO_PARSER.declareLong(SnapshotInfoBuilder::setEndTime, new ParseField(END_TIME_IN_MILLIS));
-        SNAPSHOT_INFO_PARSER.declareObject(SnapshotInfoBuilder::setShardStatsBuilder, SHARD_STATS_PARSER, new ParseField(SHARDS));
-        SNAPSHOT_INFO_PARSER.declareBoolean(SnapshotInfoBuilder::setIncludeGlobalState, new ParseField(INCLUDE_GLOBAL_STATE));
-        SNAPSHOT_INFO_PARSER.declareObject(SnapshotInfoBuilder::setUserMetadata, (p, c) -> p.map(), new ParseField(USER_METADATA));
-        SNAPSHOT_INFO_PARSER.declareInt(SnapshotInfoBuilder::setVersion, new ParseField(VERSION_ID));
-        SNAPSHOT_INFO_PARSER.declareObjectArray(
-            SnapshotInfoBuilder::setShardFailures,
-            SnapshotShardFailure.SNAPSHOT_SHARD_FAILURE_PARSER,
-            new ParseField(FAILURES)
-        );
-
-        SHARD_STATS_PARSER.declareInt(ShardStatsBuilder::setTotalShards, new ParseField(TOTAL));
-        SHARD_STATS_PARSER.declareInt(ShardStatsBuilder::setSuccessfulShards, new ParseField(SUCCESSFUL));
-    }
 
     private final Snapshot snapshot;
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotResponseTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.snapshots.SnapshotFeatureInfoTests;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotInfoTestUtils;
+import org.elasticsearch.snapshots.SnapshotInfoUtils;
 import org.elasticsearch.snapshots.SnapshotShardFailure;
 import org.elasticsearch.test.AbstractXContentTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -30,7 +31,7 @@ public class CreateSnapshotResponseTests extends AbstractXContentTestCase<Create
 
     @Override
     protected CreateSnapshotResponse doParseInstance(XContentParser parser) throws IOException {
-        return CreateSnapshotResponse.fromXContent(parser);
+        return SnapshotInfoUtils.createSnapshotResponseFromXContent(parser);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/SnapshotInfoUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/SnapshotInfoUtils.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.snapshots;
+
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
+import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.snapshots.SnapshotInfo.DATA_STREAMS;
+import static org.elasticsearch.snapshots.SnapshotInfo.END_TIME_IN_MILLIS;
+import static org.elasticsearch.snapshots.SnapshotInfo.FAILURES;
+import static org.elasticsearch.snapshots.SnapshotInfo.FEATURE_STATES;
+import static org.elasticsearch.snapshots.SnapshotInfo.INCLUDE_GLOBAL_STATE;
+import static org.elasticsearch.snapshots.SnapshotInfo.INDEX_DETAILS;
+import static org.elasticsearch.snapshots.SnapshotInfo.INDICES;
+import static org.elasticsearch.snapshots.SnapshotInfo.REASON;
+import static org.elasticsearch.snapshots.SnapshotInfo.REPOSITORY;
+import static org.elasticsearch.snapshots.SnapshotInfo.SHARDS;
+import static org.elasticsearch.snapshots.SnapshotInfo.START_TIME_IN_MILLIS;
+import static org.elasticsearch.snapshots.SnapshotInfo.STATE;
+import static org.elasticsearch.snapshots.SnapshotInfo.SUCCESSFUL;
+import static org.elasticsearch.snapshots.SnapshotInfo.TOTAL;
+import static org.elasticsearch.snapshots.SnapshotInfo.UNKNOWN_REPO_NAME;
+import static org.elasticsearch.snapshots.SnapshotInfo.USER_METADATA;
+import static org.elasticsearch.snapshots.SnapshotInfo.UUID;
+import static org.elasticsearch.snapshots.SnapshotInfo.VERSION_ID;
+import static org.elasticsearch.threadpool.ThreadPool.Names.SNAPSHOT;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
+public class SnapshotInfoUtils {
+
+    private SnapshotInfoUtils() {/* no instances */}
+
+    static final ConstructingObjectParser<CreateSnapshotResponse, Void> CREATE_SNAPSHOT_RESPONSE_PARSER = new ConstructingObjectParser<>(
+        CreateSnapshotResponse.class.getName(),
+        true,
+        args -> new CreateSnapshotResponse(((SnapshotInfoBuilder) args[0]).build())
+    );
+
+    static final ObjectParser<SnapshotInfoBuilder, Void> SNAPSHOT_INFO_PARSER = new ObjectParser<>(
+        SnapshotInfoBuilder.class.getName(),
+        true,
+        SnapshotInfoBuilder::new
+    );
+
+    static final ConstructingObjectParser<ShardStatsBuilder, Void> SHARD_STATS_PARSER = new ConstructingObjectParser<>(
+        ShardStatsBuilder.class.getName(),
+        true,
+        args -> new ShardStatsBuilder((int) Objects.requireNonNullElse(args[0], 0), (int) Objects.requireNonNullElse(args[1], 0))
+    );
+
+    static {
+        SHARD_STATS_PARSER.declareInt(optionalConstructorArg(), new ParseField(TOTAL));
+        SHARD_STATS_PARSER.declareInt(optionalConstructorArg(), new ParseField(SUCCESSFUL));
+
+        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setSnapshotName, new ParseField(SNAPSHOT));
+        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setSnapshotUUID, new ParseField(UUID));
+        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setRepository, new ParseField(REPOSITORY));
+        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setState, new ParseField(STATE));
+        SNAPSHOT_INFO_PARSER.declareString(SnapshotInfoBuilder::setReason, new ParseField(REASON));
+        SNAPSHOT_INFO_PARSER.declareStringArray(SnapshotInfoBuilder::setIndices, new ParseField(INDICES));
+        SNAPSHOT_INFO_PARSER.declareStringArray(SnapshotInfoBuilder::setDataStreams, new ParseField(DATA_STREAMS));
+        SNAPSHOT_INFO_PARSER.declareObjectArray(
+            SnapshotInfoBuilder::setFeatureStates,
+            SnapshotFeatureInfo.SNAPSHOT_FEATURE_INFO_PARSER,
+            new ParseField(FEATURE_STATES)
+        );
+        SNAPSHOT_INFO_PARSER.declareObject(
+            SnapshotInfoBuilder::setIndexSnapshotDetails,
+            (p, c) -> p.map(HashMap::new, p2 -> SnapshotInfo.IndexSnapshotDetails.PARSER.parse(p2, c)),
+            new ParseField(INDEX_DETAILS)
+        );
+        SNAPSHOT_INFO_PARSER.declareLong(SnapshotInfoBuilder::setStartTime, new ParseField(START_TIME_IN_MILLIS));
+        SNAPSHOT_INFO_PARSER.declareLong(SnapshotInfoBuilder::setEndTime, new ParseField(END_TIME_IN_MILLIS));
+        SNAPSHOT_INFO_PARSER.declareObject(SnapshotInfoBuilder::setShardStatsBuilder, SHARD_STATS_PARSER, new ParseField(SHARDS));
+        SNAPSHOT_INFO_PARSER.declareBoolean(SnapshotInfoBuilder::setIncludeGlobalState, new ParseField(INCLUDE_GLOBAL_STATE));
+        SNAPSHOT_INFO_PARSER.declareObject(SnapshotInfoBuilder::setUserMetadata, (p, c) -> p.map(), new ParseField(USER_METADATA));
+        SNAPSHOT_INFO_PARSER.declareInt(SnapshotInfoBuilder::setVersion, new ParseField(VERSION_ID));
+        SNAPSHOT_INFO_PARSER.declareObjectArray(
+            SnapshotInfoBuilder::setShardFailures,
+            SnapshotShardFailure.SNAPSHOT_SHARD_FAILURE_PARSER,
+            new ParseField(FAILURES)
+        );
+
+        CREATE_SNAPSHOT_RESPONSE_PARSER.declareObject(optionalConstructorArg(), SNAPSHOT_INFO_PARSER, new ParseField("snapshot"));
+    }
+
+    private record ShardStatsBuilder(int totalShards, int successfulShards) {}
+
+    public static final class SnapshotInfoBuilder {
+        private String snapshotName = null;
+        private String snapshotUUID = null;
+        private String repository = UNKNOWN_REPO_NAME;
+        private String state = null;
+        private String reason = null;
+        private List<String> indices = null;
+        private List<String> dataStreams = null;
+        private List<SnapshotFeatureInfo> featureStates = null;
+        private Map<String, SnapshotInfo.IndexSnapshotDetails> indexSnapshotDetails = null;
+        private long startTime = 0L;
+        private long endTime = 0L;
+        private ShardStatsBuilder shardStatsBuilder = null;
+        private Boolean includeGlobalState = null;
+        private Map<String, Object> userMetadata = null;
+        private int version = -1;
+        private List<SnapshotShardFailure> shardFailures = null;
+
+        private void setSnapshotName(String snapshotName) {
+            this.snapshotName = snapshotName;
+        }
+
+        private void setSnapshotUUID(String snapshotUUID) {
+            this.snapshotUUID = snapshotUUID;
+        }
+
+        private void setRepository(String repository) {
+            this.repository = repository;
+        }
+
+        private void setState(String state) {
+            this.state = state;
+        }
+
+        private void setReason(String reason) {
+            this.reason = reason;
+        }
+
+        private void setIndices(List<String> indices) {
+            this.indices = indices;
+        }
+
+        private void setDataStreams(List<String> dataStreams) {
+            this.dataStreams = dataStreams;
+        }
+
+        private void setFeatureStates(List<SnapshotFeatureInfo> featureStates) {
+            this.featureStates = featureStates;
+        }
+
+        private void setIndexSnapshotDetails(Map<String, SnapshotInfo.IndexSnapshotDetails> indexSnapshotDetails) {
+            this.indexSnapshotDetails = indexSnapshotDetails;
+        }
+
+        private void setStartTime(long startTime) {
+            this.startTime = startTime;
+        }
+
+        private void setEndTime(long endTime) {
+            this.endTime = endTime;
+        }
+
+        private void setShardStatsBuilder(ShardStatsBuilder shardStatsBuilder) {
+            this.shardStatsBuilder = shardStatsBuilder;
+        }
+
+        private void setIncludeGlobalState(Boolean includeGlobalState) {
+            this.includeGlobalState = includeGlobalState;
+        }
+
+        private void setUserMetadata(Map<String, Object> userMetadata) {
+            this.userMetadata = userMetadata;
+        }
+
+        private void setVersion(int version) {
+            this.version = version;
+        }
+
+        private void setShardFailures(List<SnapshotShardFailure> shardFailures) {
+            this.shardFailures = shardFailures;
+        }
+
+        public SnapshotInfo build() {
+            final Snapshot snapshot = new Snapshot(repository, new SnapshotId(snapshotName, snapshotUUID));
+
+            if (indices == null) {
+                indices = Collections.emptyList();
+            }
+
+            if (dataStreams == null) {
+                dataStreams = Collections.emptyList();
+            }
+
+            if (featureStates == null) {
+                featureStates = Collections.emptyList();
+            }
+
+            if (indexSnapshotDetails == null) {
+                indexSnapshotDetails = Collections.emptyMap();
+            }
+
+            SnapshotState snapshotState = state == null ? null : SnapshotState.valueOf(state);
+            IndexVersion version = this.version == -1 ? IndexVersion.current() : IndexVersion.fromId(this.version);
+
+            int totalShards = shardStatsBuilder == null ? 0 : shardStatsBuilder.totalShards();
+            int successfulShards = shardStatsBuilder == null ? 0 : shardStatsBuilder.successfulShards();
+
+            if (shardFailures == null) {
+                shardFailures = new ArrayList<>();
+            }
+
+            return new SnapshotInfo(
+                snapshot,
+                indices,
+                dataStreams,
+                featureStates,
+                reason,
+                version,
+                startTime,
+                endTime,
+                totalShards,
+                successfulShards,
+                shardFailures,
+                includeGlobalState,
+                userMetadata,
+                snapshotState,
+                indexSnapshotDetails
+            );
+        }
+    }
+
+    public static CreateSnapshotResponse createSnapshotResponseFromXContent(XContentParser parser) {
+        return CREATE_SNAPSHOT_RESPONSE_PARSER.apply(parser, null);
+    }
+
+    public static SnapshotInfo snapshotInfoFromXContent(XContentParser parser) {
+        return SNAPSHOT_INFO_PARSER.apply(parser, null).build();
+    }
+}

--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotInfoUtils;
 import org.elasticsearch.snapshots.SnapshotShardFailure;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
@@ -194,7 +195,9 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
                 assertThat(req.includeGlobalState(), equalTo(globalState));
 
                 try {
-                    return CreateSnapshotResponse.fromXContent(createParser(JsonXContent.jsonXContent, createSnapResponse));
+                    return SnapshotInfoUtils.createSnapshotResponseFromXContent(
+                        createParser(JsonXContent.jsonXContent, createSnapResponse)
+                    );
                 } catch (IOException e) {
                     fail("failed to parse snapshot response");
                     return null;


### PR DESCRIPTION
The code to parse a `SnapshotInfo` object out of an `XContent` response
body is only used in tests, so this commit moves it out of the
production codebase and into the test framework.