### PR TITLE
Retrieve routing hash from id when missing

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -329,7 +329,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
      */
     @Override
     public IndexRequest routing(String routing) {
-        if (routing != null && routing.length() == 0) {
+        if (routing != null && routing.isEmpty()) {
             this.routing = null;
         } else {
             this.routing = routing;

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
@@ -720,38 +720,4 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
         });
         assertThat(failure.getMessage(), equalTo("[5:1] failed to parse: Illegal base64 character 20"));
     }
-
-    public void testParseWithDynamicMappingNullId() {
-        Settings indexSettings = Settings.builder()
-            .put(IndexSettings.MODE.getKey(), "time_series")
-            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dim")
-            .build();
-        MapperService mapper = createMapperService(IndexVersion.current(), indexSettings, () -> false);
-        SourceToParse source = new SourceToParse(null, new BytesArray("""
-            {
-                "@timestamp": 1609459200000,
-                "dim": "6a841a21",
-                "value": 100
-            }"""), XContentType.JSON);
-        var failure = expectThrows(DocumentParsingException.class, () -> {
-            IndexShard.prepareIndex(
-                mapper,
-                source,
-                UNASSIGNED_SEQ_NO,
-                randomNonNegativeLong(),
-                Versions.MATCH_ANY,
-                VersionType.INTERNAL,
-                Engine.Operation.Origin.PRIMARY,
-                -1,
-                false,
-                UNASSIGNED_SEQ_NO,
-                0,
-                System.nanoTime()
-            );
-        });
-        assertThat(
-            failure.getMessage(),
-            equalTo("[5:1] failed to parse: _ts_routing_hash was null but must be set because index [index] is in time_series mode")
-        );
-    }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
@@ -720,34 +720,4 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
         });
         assertThat(failure.getMessage(), equalTo("[5:1] failed to parse: Illegal base64 character 20"));
     }
-
-    public void testParseWithDynamicMappingNullRoutingId() {
-        Settings indexSettings = Settings.builder()
-            .put(IndexSettings.MODE.getKey(), "time_series")
-            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dim")
-            .build();
-        MapperService mapper = createMapperService(IndexVersion.current(), indexSettings, () -> false);
-        SourceToParse source = new SourceToParse(TimeSeriesRoutingHashFieldMapper.DUMMY_ENCODED_VALUE, new BytesArray("""
-            {
-                "@timestamp": 1609459200000,
-                "dim": "6a841a21",
-                "value": 100
-            }"""), XContentType.JSON);
-
-        Engine.Index index = IndexShard.prepareIndex(
-            mapper,
-            source,
-            UNASSIGNED_SEQ_NO,
-            randomNonNegativeLong(),
-            Versions.MATCH_ANY,
-            VersionType.INTERNAL,
-            Engine.Operation.Origin.PRIMARY,
-            -1,
-            false,
-            UNASSIGNED_SEQ_NO,
-            0,
-            System.nanoTime()
-        );
-        assertNotNull(index.parsedDoc().dynamicMappingsUpdate());
-    }
 }


### PR DESCRIPTION
In `applyTranslogOperation`, the routing field in the `DocumentParserContext`'s `SourceToParse` is not set, while the id is. Post parsing in `TimeSeriesRoutingHashFieldMapper` should retrieve the routing hash from the id prefix in this case.

Fixes #106550