### PR TITLE
SharedBlobCacheService.maybeFetchRegion should use computeCacheFileRegionSize

### DIFF
--- a/docs/changelog/106685.yaml
+++ b/docs/changelog/106685.yaml
@@ -1,0 +1,5 @@
+pr: 106685
+summary: '`SharedBlobCacheService.maybeFetchRegion` should use `computeCacheFileRegionSize`'
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -561,12 +561,8 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
             listener.onResponse(false);
             return;
         }
-        long regionLength = regionSize;
         try {
-            if (region == getEndingRegion(blobLength)) {
-                regionLength = blobLength - getRegionStart(region);
-            }
-            ByteRange regionRange = ByteRange.of(0, regionLength);
+            ByteRange regionRange = ByteRange.of(0, computeCacheFileRegionSize(blobLength, region));
             if (regionRange.isEmpty()) {
                 listener.onResponse(false);
                 return;


### PR DESCRIPTION
This method computes the exact ranges to fetch using the length of the blob, but that does not work for `SharedBlobCacheService` implementations that use a specific `computeCacheFileRegionSize` which is not based on blob length.

Note: I'll hold on merging this change until callers of `maybeFetchRegion` use the appropriate `copyToCacheFileAligned` method that fully consumes input streams.