### PR TITLE
ESQL: Fix count pushdown for unmapped fields

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1217,3 +1217,12 @@ FROM airports
 c:l
 891
 ;
+
+countMV#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS vals = COUNT(salary_change.int)
+;
+
+vals:l
+183
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/stats/SearchStats.java
@@ -195,7 +195,8 @@ public class SearchStats {
             if (exists(field) == false) {
                 stat.singleValue = true;
             } else {
-                var sv = new boolean[] { true };
+                // fields are MV per default
+                var sv = new boolean[] { false };
                 for (SearchContext context : contexts) {
                     var sec = context.getSearchExecutionContext();
                     MappedFieldType mappedType = sec.isFieldMapped(field) ? null : sec.getFieldType(field);


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/105400

Unmapped fields are multi-valued per default. We wrongly treat them as single-valued, though, when pushing `COUNT` down to Lucene. This leads to `COUNT(field)` returning the number docs with non-null `field`, rather than the total number of `field` values.