### PR TITLE
Fix range queries for float/half_float fields when bounds are out of type's range

### DIFF
--- a/docs/changelog/106691.yaml
+++ b/docs/changelog/106691.yaml
@@ -1,0 +1,6 @@
+pr: 106691
+summary: Fix range queries for float/half_float fields when bounds are out of type's
+  range
+area: Search
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/510_range_query_out_of_bounds.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/510_range_query_out_of_bounds.yml
@@ -1,0 +1,199 @@
+setup:
+  - skip:
+      version: " - 8.13.99"
+      reason: fixed in 8.14.0
+  - do:
+      indices.create:
+        index: range_query_test_index
+        body:
+          mappings:
+            properties:
+              half_float_field:
+                type: half_float
+              float_field:
+                type: float
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "1" } }'
+          - '{"half_float_field" : -65504, "float_field" : -3.4028235E38 }'
+          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "2" } }'
+          - '{"half_float_field" : 65504, "float_field" : 3.4028235E38 }'
+
+---
+"Test range query for half_float field with out of bounds upper limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              half_float_field:
+                lte: 1e+300
+                gt: 1
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "2" }
+
+---
+"Test range query for float field with out of bounds upper limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              float_field:
+                lte: 1e+300
+                gt: 1
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "2" }
+
+---
+"Test range query for half_float field with out of bounds lower limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              half_float_field:
+                gte: -1e+300
+                lt: 1
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+---
+"Test range query for float field with out of bounds lower limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              float_field:
+                gte: -1e+300
+                lt: 1
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+---
+"Test range query for float field with greater or equal than half float min value limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              half_float_field:
+                gte: -65504
+                lt: 1
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+---
+"Test range query for float field with greater or equal than float min value limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              float_field:
+                gte: -3.4028235E38
+                lt: 1
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "1" }
+
+---
+"Test range query for float field with greater than half float min value limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              half_float_field:
+                gt: -65504
+                lt: 1
+
+  - length: { hits.hits: 0 }
+
+---
+"Test range query for float field with greater than float min value limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              float_field:
+                gt: -3.4028235E38
+                lt: 1
+
+  - length: { hits.hits: 0 }
+
+---
+"Test range query for half_float field with lower or equal than half float max value limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              half_float_field:
+                lte: 65504
+                gt: 1
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "2" }
+
+---
+"Test range query for float field with lower or equal than float max value limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              float_field:
+                lte: 3.4028235E38
+                gt: 1
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "2" }
+
+---
+"Test range query for half_float field with lower than half float max value limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              half_float_field:
+                lt: 65504
+                gt: 1
+
+  - length: { hits.hits: 0 }
+
+---
+"Test range query for float field with lower than float max value limit":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              float_field:
+                lt: 3.4028235E38
+                gt: 1
+
+  - length: { hits.hits: 0 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/510_range_query_out_of_bounds.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/510_range_query_out_of_bounds.yml
@@ -12,15 +12,23 @@ setup:
                 type: half_float
               float_field:
                 type: float
+              keyword_field:
+                type: keyword
 
   - do:
       bulk:
         refresh: true
         body:
-          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "1" } }'
+          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "min_boundary_doc" } }'
           - '{"half_float_field" : -65504, "float_field" : -3.4028235E38 }'
-          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "2" } }'
+          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "max_boundary_doc" } }'
           - '{"half_float_field" : 65504, "float_field" : 3.4028235E38 }'
+          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "1" } }'
+          - '{"half_float_field" : -1, "float_field" : -1 }'
+          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "2" } }'
+          - '{"half_float_field" : 1, "float_field" : 1 }'
+          - '{ "index" : { "_index" : "range_query_test_index", "_id" : "3" } }'
+          - '{"keyword": "I am missing the half_float/float fields and should not be part of the results" }'
 
 ---
 "Test range query for half_float field with out of bounds upper limit":
@@ -32,10 +40,12 @@ setup:
             range:
               half_float_field:
                 lte: 1e+300
-                gt: 1
+                gt: 0
+          sort: half_float_field
 
-  - length: { hits.hits: 1 }
+  - length: { hits.hits: 2 }
   - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "max_boundary_doc" }
 
 ---
 "Test range query for float field with out of bounds upper limit":
@@ -47,10 +57,12 @@ setup:
             range:
               float_field:
                 lte: 1e+300
-                gt: 1
+                gt: 0
+          sort: half_float_field
 
-  - length: { hits.hits: 1 }
+  - length: { hits.hits: 2 }
   - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "max_boundary_doc" }
 
 ---
 "Test range query for half_float field with out of bounds lower limit":
@@ -62,10 +74,12 @@ setup:
             range:
               half_float_field:
                 gte: -1e+300
-                lt: 1
+                lt: 0
+          sort: half_float_field
 
-  - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "1" }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "min_boundary_doc" }
+  - match: { hits.hits.1._id: "1" }
 
 ---
 "Test range query for float field with out of bounds lower limit":
@@ -77,10 +91,12 @@ setup:
             range:
               float_field:
                 gte: -1e+300
-                lt: 1
+                lt: 0
+          sort: float_field
 
-  - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "1" }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "min_boundary_doc" }
+  - match: { hits.hits.1._id: "1" }
 
 ---
 "Test range query for float field with greater or equal than half float min value limit":
@@ -92,10 +108,12 @@ setup:
             range:
               half_float_field:
                 gte: -65504
-                lt: 1
+                lt: 0
+          sort: half_float_field
 
-  - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "1" }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "min_boundary_doc" }
+  - match: { hits.hits.1._id: "1" }
 
 ---
 "Test range query for float field with greater or equal than float min value limit":
@@ -107,10 +125,12 @@ setup:
             range:
               float_field:
                 gte: -3.4028235E38
-                lt: 1
+                lt: 0
+          sort: float_field
 
-  - length: { hits.hits: 1 }
-  - match: { hits.hits.0._id: "1" }
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "min_boundary_doc" }
+  - match: { hits.hits.1._id: "1" }
 
 ---
 "Test range query for float field with greater than half float min value limit":
@@ -122,9 +142,10 @@ setup:
             range:
               half_float_field:
                 gt: -65504
-                lt: 1
+                lt: 0
 
-  - length: { hits.hits: 0 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "1" }
 
 ---
 "Test range query for float field with greater than float min value limit":
@@ -136,9 +157,11 @@ setup:
             range:
               float_field:
                 gt: -3.4028235E38
-                lt: 1
+                lt: 0
+          sort: float_field
 
-  - length: { hits.hits: 0 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "1" }
 
 ---
 "Test range query for half_float field with lower or equal than half float max value limit":
@@ -150,10 +173,12 @@ setup:
             range:
               half_float_field:
                 lte: 65504
-                gt: 1
+                gt: 0
+          sort: half_float_field
 
-  - length: { hits.hits: 1 }
+  - length: { hits.hits: 2 }
   - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "max_boundary_doc" }
 
 ---
 "Test range query for float field with lower or equal than float max value limit":
@@ -165,10 +190,12 @@ setup:
             range:
               float_field:
                 lte: 3.4028235E38
-                gt: 1
+                gt: 0
+          sort: float_field
 
-  - length: { hits.hits: 1 }
+  - length: { hits.hits: 2 }
   - match: { hits.hits.0._id: "2" }
+  - match: { hits.hits.1._id: "max_boundary_doc" }
 
 ---
 "Test range query for half_float field with lower than half float max value limit":
@@ -180,9 +207,10 @@ setup:
             range:
               half_float_field:
                 lt: 65504
-                gt: 1
+                gt: 0
 
-  - length: { hits.hits: 0 }
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "2" }
 
 ---
 "Test range query for float field with lower than float max value limit":
@@ -194,6 +222,69 @@ setup:
             range:
               float_field:
                 lt: 3.4028235E38
-                gt: 1
+                gt: 0
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._id: "2" }
+
+---
+"Test range query for half float field with lt and gt limits":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              half_float_field:
+                lt: 1
+                gt: -1
 
   - length: { hits.hits: 0 }
+
+---
+"Test range query for float field with lt and gt limits":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              float_field:
+                lt: 1
+                gt: -1
+
+  - length: { hits.hits: 0 }
+
+---
+"Test range query for half_float field with gte and lte limits":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              half_float_field:
+                lte: 1
+                gte: -1
+          sort: half_float_field
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }
+
+---
+"Test range query for float field with gte and lte limits":
+  - do:
+      search:
+        index: range_query_test_index
+        body:
+          query:
+            range:
+              float_field:
+                lte: 1
+                gte: -1
+          sort: float_field
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._id: "1" }
+  - match: { hits.hits.1._id: "2" }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -346,6 +346,55 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         );
     }
 
+    public void testHalfFloatRangeQueryWithOverflowingBounds() {
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.HALF_FLOAT, randomBoolean());
+        final float min_half_float = -65504;
+        final float max_half_float = 65504;
+        assertEquals(
+            ft.rangeQuery(min_half_float, 10, true, true, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(-1e+300, 10, true, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(min_half_float, 10, true, true, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(Float.NEGATIVE_INFINITY, 10, true, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(10, max_half_float, true, true, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(10, 1e+300, true, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(10, max_half_float, true, true, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(10, Float.POSITIVE_INFINITY, true, true, null, null, null, MOCK_CONTEXT)
+        );
+    }
+
+    public void testFloatRangeQueryWithOverflowingBounds() {
+        MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberType.FLOAT, randomBoolean());
+
+        assertEquals(
+            ft.rangeQuery(-Float.MAX_VALUE, 10.0, true, true, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(-1e+300, 10.0, true, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(-Float.MAX_VALUE, 10.0, true, true, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(Float.NEGATIVE_INFINITY, 10.0, true, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(10, Float.MAX_VALUE, true, true, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(10, 1e+300, true, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(10, Float.MAX_VALUE, true, true, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(10, Float.POSITIVE_INFINITY, true, true, null, null, null, MOCK_CONTEXT)
+        );
+    }
+
     public void testRangeQuery() {
         MappedFieldType ft = new NumberFieldMapper.NumberFieldType("field", NumberFieldMapper.NumberType.LONG);
         Query expected = new IndexOrDocValuesQuery(

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -369,6 +369,16 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             ft.rangeQuery(10, max_half_float, true, true, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(10, Float.POSITIVE_INFINITY, true, true, null, null, null, MOCK_CONTEXT)
         );
+
+        assertEquals(
+            ft.rangeQuery(10, 1e+300, false, false, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(10, Float.POSITIVE_INFINITY, false, false, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(-1e+300, 10, false, false, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(Float.NEGATIVE_INFINITY, 10, false, false, null, null, null, MOCK_CONTEXT)
+        );
     }
 
     public void testFloatRangeQueryWithOverflowingBounds() {
@@ -392,6 +402,16 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertEquals(
             ft.rangeQuery(10, Float.MAX_VALUE, true, true, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(10, Float.POSITIVE_INFINITY, true, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(10, 1e+300, false, false, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(10, Float.POSITIVE_INFINITY, false, false, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(-1e+300, 10, false, false, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(Float.NEGATIVE_INFINITY, 10, false, false, null, null, null, MOCK_CONTEXT)
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -379,6 +379,16 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
             ft.rangeQuery(-1e+300, 10, false, false, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(Float.NEGATIVE_INFINITY, 10, false, false, null, null, null, MOCK_CONTEXT)
         );
+
+        assertEquals(
+            ft.rangeQuery(10, 1e+300, false, false, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(10, max_half_float, false, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(-1e+300, 10, false, false, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(min_half_float, 10, true, false, null, null, null, MOCK_CONTEXT)
+        );
     }
 
     public void testFloatRangeQueryWithOverflowingBounds() {
@@ -412,6 +422,16 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         assertEquals(
             ft.rangeQuery(-1e+300, 10, false, false, null, null, null, MOCK_CONTEXT),
             ft.rangeQuery(Float.NEGATIVE_INFINITY, 10, false, false, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(10, 1e+300, false, false, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(10, Float.MAX_VALUE, false, true, null, null, null, MOCK_CONTEXT)
+        );
+
+        assertEquals(
+            ft.rangeQuery(-1e+300, 10, false, false, null, null, null, MOCK_CONTEXT),
+            ft.rangeQuery(-Float.MAX_VALUE, 10, true, false, null, null, null, MOCK_CONTEXT)
         );
     }
 


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/issues/105079

In the case of float/half_float types when the provided bounds for `range` are out of the type's range, we will no longer fail with a `supports only finite values, but got [Infinity]` error, but construct the range query such that the overflowing bound is the min/max values of that type's range.

For example:

```
POST /testidx/_search
{
  "query": {
    "range": {
      "half_float_field": {
        "lt": 1e+300
      }
    }
  }
}
```

will be equivalent to:
```
{
  "query": {
    "range": {
      "half_float_field": {
        "lt": 65504
      }
    }
  }
}
```
since `65504` is the largest positive value a `half_float` field can take.
