### PR TITLE
[main] Update discovery.asciidoc (#106541)

### DIFF
--- a/docs/reference/modules/discovery/discovery.asciidoc
+++ b/docs/reference/modules/discovery/discovery.asciidoc
@@ -115,7 +115,7 @@ supplied in `unicast_hosts.txt`.
 
 The `unicast_hosts.txt` file contains one node entry per line. Each node entry
 consists of the host (host name or IP address) and an optional transport port
-number. If the port number is specified, is must come immediately after the
+number. If the port number is specified, it must come immediately after the
 host (on the same line) separated by a `:`. If the port number is not
 specified, {es} will implicitly use the first port in the port range given by
 `transport.profiles.default.port`, or by `transport.port` if


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.12` to `main`:
 - [Update discovery.asciidoc (#106541)](https://github.com/elastic/elasticsearch/pull/106541)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)