### PR TITLE
Updating FullClusterRestartIT.testWatcher to account for watcher running

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -731,7 +731,7 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
 
         Map<String, Object> updateWatch = entityAsMap(client().performRequest(createWatchRequest));
         assertThat(updateWatch.get("created"), equalTo(false));
-        assertThat(updateWatch.get("_version"), equalTo(2));
+        assertThat((int) updateWatch.get("_version"), greaterThanOrEqualTo(2));
 
         Map<String, Object> get = entityAsMap(client().performRequest(new Request("GET", "_watcher/watch/new_watch")));
         assertThat(get.get("found"), equalTo(true));


### PR DESCRIPTION
FullClusterRestartIT.testWatcher calls `_watcher/watch/new_watch` twice and asserts that the version of the watch is then 2. However, when the watch is executed every 500ms, the watch document is updated with status information. If that happens in between calls to `_watcher/watch/new_watch`, then the version will be 3 rather than 2. This PR changes the assertion to make sure that the version is 2 or greater.
This is part of #48381, but not the whole thing.