### PR TITLE
Move more XContent parsing to test codebase

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -12,13 +12,11 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.support.WriteResponse;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
-import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.seqno.SequenceNumbers;
@@ -26,7 +24,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -34,7 +31,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Objects;
 
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 
@@ -43,14 +39,14 @@ import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
  */
 public abstract class DocWriteResponse extends ReplicationResponse implements WriteResponse, ToXContentObject {
 
-    private static final String _SHARDS = "_shards";
-    private static final String _INDEX = "_index";
-    private static final String _ID = "_id";
-    private static final String _VERSION = "_version";
-    private static final String _SEQ_NO = "_seq_no";
-    private static final String _PRIMARY_TERM = "_primary_term";
-    private static final String RESULT = "result";
-    private static final String FORCED_REFRESH = "forced_refresh";
+    public static final String _SHARDS = "_shards";
+    public static final String _INDEX = "_index";
+    public static final String _ID = "_id";
+    public static final String _VERSION = "_version";
+    public static final String _SEQ_NO = "_seq_no";
+    public static final String _PRIMARY_TERM = "_primary_term";
+    public static final String RESULT = "result";
+    public static final String FORCED_REFRESH = "forced_refresh";
 
     /**
      * An enum that represents the results of CRUD operations, primarily used to communicate the type of
@@ -300,54 +296,6 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
             builder.field(MapperService.TYPE_FIELD_NAME, MapperService.SINGLE_MAPPING_NAME);
         }
         return builder;
-    }
-
-    /**
-     * Parse the output of the {@link #innerToXContent(XContentBuilder, Params)} method.
-     *
-     * This method is intended to be called by subclasses and must be called multiple times to parse all the information concerning
-     * {@link DocWriteResponse} objects. It always parses the current token, updates the given parsing context accordingly
-     * if needed and then immediately returns.
-     */
-    public static void parseInnerToXContent(XContentParser parser, Builder context) throws IOException {
-        XContentParser.Token token = parser.currentToken();
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
-
-        String currentFieldName = parser.currentName();
-        token = parser.nextToken();
-
-        if (token.isValue()) {
-            if (_INDEX.equals(currentFieldName)) {
-                // index uuid and shard id are unknown and can't be parsed back for now.
-                context.setShardId(new ShardId(new Index(parser.text(), IndexMetadata.INDEX_UUID_NA_VALUE), -1));
-            } else if (_ID.equals(currentFieldName)) {
-                context.setId(parser.text());
-            } else if (_VERSION.equals(currentFieldName)) {
-                context.setVersion(parser.longValue());
-            } else if (RESULT.equals(currentFieldName)) {
-                String result = parser.text();
-                for (Result r : Result.values()) {
-                    if (r.getLowercase().equals(result)) {
-                        context.setResult(r);
-                        break;
-                    }
-                }
-            } else if (FORCED_REFRESH.equals(currentFieldName)) {
-                context.setForcedRefresh(parser.booleanValue());
-            } else if (_SEQ_NO.equals(currentFieldName)) {
-                context.setSeqNo(parser.longValue());
-            } else if (_PRIMARY_TERM.equals(currentFieldName)) {
-                context.setPrimaryTerm(parser.longValue());
-            }
-        } else if (token == XContentParser.Token.START_OBJECT) {
-            if (_SHARDS.equals(currentFieldName)) {
-                context.setShardInfo(ShardInfo.fromXContent(parser));
-            } else {
-                parser.skipChildren(); // skip potential inner objects for forward compatibility
-            }
-        } else if (token == XContentParser.Token.START_ARRAY) {
-            parser.skipChildren(); // skip potential inner arrays for forward compatibility
-        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexStatus.java
@@ -8,26 +8,17 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
-import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * Represents snapshot status of all shards in the index
@@ -116,45 +107,6 @@ public class SnapshotIndexStatus implements Iterable<SnapshotIndexShardStatus>, 
         builder.endObject();
         builder.endObject();
         return builder;
-    }
-
-    static final ObjectParser.NamedObjectParser<SnapshotIndexStatus, Void> PARSER;
-    static {
-        ConstructingObjectParser<SnapshotIndexStatus, String> innerParser = new ConstructingObjectParser<>(
-            "snapshot_index_status",
-            true,
-            (Object[] parsedObjects, String index) -> {
-                int i = 0;
-                SnapshotShardsStats shardsStats = ((SnapshotShardsStats) parsedObjects[i++]);
-                SnapshotStats stats = ((SnapshotStats) parsedObjects[i++]);
-                @SuppressWarnings("unchecked")
-                List<SnapshotIndexShardStatus> shardStatuses = (List<SnapshotIndexShardStatus>) parsedObjects[i];
-
-                final Map<Integer, SnapshotIndexShardStatus> indexShards;
-                if (shardStatuses == null || shardStatuses.isEmpty()) {
-                    indexShards = emptyMap();
-                } else {
-                    indexShards = Maps.newMapWithExpectedSize(shardStatuses.size());
-                    for (SnapshotIndexShardStatus shardStatus : shardStatuses) {
-                        indexShards.put(shardStatus.getShardId().getId(), shardStatus);
-                    }
-                }
-                return new SnapshotIndexStatus(index, indexShards, shardsStats, stats);
-            }
-        );
-        innerParser.declareObject(
-            constructorArg(),
-            (p, c) -> SnapshotShardsStats.PARSER.apply(p, null),
-            new ParseField(SnapshotShardsStats.Fields.SHARDS_STATS)
-        );
-        innerParser.declareObject(constructorArg(), (p, c) -> SnapshotStats.fromXContent(p), new ParseField(SnapshotStats.Fields.STATS));
-        innerParser.declareNamedObjects(constructorArg(), SnapshotIndexShardStatus.PARSER, new ParseField(Fields.SHARDS));
-        PARSER = ((p, c, name) -> innerParser.apply(p, name));
-    }
-
-    public static SnapshotIndexStatus fromXContent(XContentParser parser) throws IOException {
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
-        return PARSER.parse(parser, null, parser.currentName());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotShardsStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotShardsStats.java
@@ -8,17 +8,12 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collection;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * Status of a snapshot shards
@@ -127,33 +122,6 @@ public class SnapshotShardsStats implements ToXContentObject {
         }
         builder.endObject();
         return builder;
-    }
-
-    static final ConstructingObjectParser<SnapshotShardsStats, Void> PARSER = new ConstructingObjectParser<>(
-        Fields.SHARDS_STATS,
-        true,
-        (Object[] parsedObjects) -> {
-            int i = 0;
-            int initializingShards = (int) parsedObjects[i++];
-            int startedShards = (int) parsedObjects[i++];
-            int finalizingShards = (int) parsedObjects[i++];
-            int doneShards = (int) parsedObjects[i++];
-            int failedShards = (int) parsedObjects[i++];
-            int totalShards = (int) parsedObjects[i];
-            return new SnapshotShardsStats(initializingShards, startedShards, finalizingShards, doneShards, failedShards, totalShards);
-        }
-    );
-    static {
-        PARSER.declareInt(constructorArg(), new ParseField(Fields.INITIALIZING));
-        PARSER.declareInt(constructorArg(), new ParseField(Fields.STARTED));
-        PARSER.declareInt(constructorArg(), new ParseField(Fields.FINALIZING));
-        PARSER.declareInt(constructorArg(), new ParseField(Fields.DONE));
-        PARSER.declareInt(constructorArg(), new ParseField(Fields.FAILED));
-        PARSER.declareInt(constructorArg(), new ParseField(Fields.TOTAL));
-    }
-
-    public static SnapshotShardsStats fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
-import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.cluster.SnapshotsInProgress.State;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
@@ -19,12 +18,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.snapshots.Snapshot;
-import org.elasticsearch.snapshots.SnapshotId;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,11 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * Status of a snapshot
@@ -87,7 +77,7 @@ public class SnapshotStatus implements ChunkedToXContentObject, Writeable {
         updateShardStats(startTime, time);
     }
 
-    private SnapshotStatus(
+    SnapshotStatus(
         Snapshot snapshot,
         State state,
         List<SnapshotIndexShardStatus> shards,
@@ -182,12 +172,12 @@ public class SnapshotStatus implements ChunkedToXContentObject, Writeable {
         return stats;
     }
 
-    private static final String SNAPSHOT = "snapshot";
-    private static final String REPOSITORY = "repository";
-    private static final String UUID = "uuid";
-    private static final String STATE = "state";
-    private static final String INDICES = "indices";
-    private static final String INCLUDE_GLOBAL_STATE = "include_global_state";
+    static final String SNAPSHOT = "snapshot";
+    static final String REPOSITORY = "repository";
+    static final String UUID = "uuid";
+    static final String STATE = "state";
+    static final String INDICES = "indices";
+    static final String INCLUDE_GLOBAL_STATE = "include_global_state";
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
@@ -204,59 +194,6 @@ public class SnapshotStatus implements ChunkedToXContentObject, Writeable {
                 .field(SnapshotStats.Fields.STATS, stats, p)
                 .startObject(INDICES);
         }), getIndices().values().iterator(), Iterators.single((b, p) -> b.endObject().endObject()));
-    }
-
-    static final ConstructingObjectParser<SnapshotStatus, Void> PARSER = new ConstructingObjectParser<>(
-        "snapshot_status",
-        true,
-        (Object[] parsedObjects) -> {
-            int i = 0;
-            String name = (String) parsedObjects[i++];
-            String repository = (String) parsedObjects[i++];
-            String uuid = (String) parsedObjects[i++];
-            String rawState = (String) parsedObjects[i++];
-            Boolean includeGlobalState = (Boolean) parsedObjects[i++];
-            SnapshotStats stats = ((SnapshotStats) parsedObjects[i++]);
-            SnapshotShardsStats shardsStats = ((SnapshotShardsStats) parsedObjects[i++]);
-            @SuppressWarnings("unchecked")
-            List<SnapshotIndexStatus> indices = ((List<SnapshotIndexStatus>) parsedObjects[i]);
-
-            Snapshot snapshot = new Snapshot(repository, new SnapshotId(name, uuid));
-            SnapshotsInProgress.State state = SnapshotsInProgress.State.valueOf(rawState);
-            Map<String, SnapshotIndexStatus> indicesStatus;
-            List<SnapshotIndexShardStatus> shards;
-            if (indices == null || indices.isEmpty()) {
-                indicesStatus = emptyMap();
-                shards = emptyList();
-            } else {
-                indicesStatus = Maps.newMapWithExpectedSize(indices.size());
-                shards = new ArrayList<>();
-                for (SnapshotIndexStatus index : indices) {
-                    indicesStatus.put(index.getIndex(), index);
-                    shards.addAll(index.getShards().values());
-                }
-            }
-            return new SnapshotStatus(snapshot, state, shards, indicesStatus, shardsStats, stats, includeGlobalState);
-        }
-    );
-    static {
-        PARSER.declareString(constructorArg(), new ParseField(SNAPSHOT));
-        PARSER.declareString(constructorArg(), new ParseField(REPOSITORY));
-        PARSER.declareString(constructorArg(), new ParseField(UUID));
-        PARSER.declareString(constructorArg(), new ParseField(STATE));
-        PARSER.declareBoolean(optionalConstructorArg(), new ParseField(INCLUDE_GLOBAL_STATE));
-        PARSER.declareField(
-            constructorArg(),
-            SnapshotStats::fromXContent,
-            new ParseField(SnapshotStats.Fields.STATS),
-            ObjectParser.ValueType.OBJECT
-        );
-        PARSER.declareObject(constructorArg(), SnapshotShardsStats.PARSER, new ParseField(SnapshotShardsStats.Fields.SHARDS_STATS));
-        PARSER.declareNamedObjects(constructorArg(), SnapshotIndexStatus.PARSER, new ParseField(INDICES));
-    }
-
-    public static SnapshotStatus fromXContent(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
     }
 
     private void updateShardStats(long startTime, long time) {

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/BaseBroadcastResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/BaseBroadcastResponse.java
@@ -13,15 +13,11 @@ import org.elasticsearch.action.support.DefaultShardOperationFailedException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.action.support.DefaultShardOperationFailedException.readShardOperationFailed;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * Base class for all broadcast operation based responses.
@@ -30,34 +26,10 @@ public class BaseBroadcastResponse extends ActionResponse {
 
     public static final DefaultShardOperationFailedException[] EMPTY = new DefaultShardOperationFailedException[0];
 
-    private static final ParseField _SHARDS_FIELD = new ParseField("_shards");
-    private static final ParseField TOTAL_FIELD = new ParseField("total");
-    private static final ParseField SUCCESSFUL_FIELD = new ParseField("successful");
-    private static final ParseField FAILED_FIELD = new ParseField("failed");
-    private static final ParseField FAILURES_FIELD = new ParseField("failures");
-
     private final int totalShards;
     private final int successfulShards;
     private final int failedShards;
     private final DefaultShardOperationFailedException[] shardFailures;
-
-    @SuppressWarnings("unchecked")
-    public static <T extends BaseBroadcastResponse> void declareBroadcastFields(ConstructingObjectParser<T, Void> PARSER) {
-        ConstructingObjectParser<BaseBroadcastResponse, Void> shardsParser = new ConstructingObjectParser<>(
-            "_shards",
-            true,
-            arg -> new BaseBroadcastResponse((int) arg[0], (int) arg[1], (int) arg[2], (List<DefaultShardOperationFailedException>) arg[3])
-        );
-        shardsParser.declareInt(constructorArg(), TOTAL_FIELD);
-        shardsParser.declareInt(constructorArg(), SUCCESSFUL_FIELD);
-        shardsParser.declareInt(constructorArg(), FAILED_FIELD);
-        shardsParser.declareObjectArray(
-            optionalConstructorArg(),
-            (p, c) -> DefaultShardOperationFailedException.fromXContent(p),
-            FAILURES_FIELD
-        );
-        PARSER.declareObject(constructorArg(), shardsParser, _SHARDS_FIELD);
-    }
 
     public BaseBroadcastResponse(StreamInput in) throws IOException {
         totalShards = in.readVInt();

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterIndexHealth.java
@@ -15,93 +15,25 @@ import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.Collections.emptyMap;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
-
 public final class ClusterIndexHealth implements Writeable, ToXContentFragment {
-    private static final String STATUS = "status";
-    private static final String NUMBER_OF_SHARDS = "number_of_shards";
-    private static final String NUMBER_OF_REPLICAS = "number_of_replicas";
-    private static final String ACTIVE_PRIMARY_SHARDS = "active_primary_shards";
-    private static final String ACTIVE_SHARDS = "active_shards";
-    private static final String RELOCATING_SHARDS = "relocating_shards";
-    private static final String INITIALIZING_SHARDS = "initializing_shards";
-    private static final String UNASSIGNED_SHARDS = "unassigned_shards";
-    private static final String SHARDS = "shards";
-
-    private static final ConstructingObjectParser<ClusterIndexHealth, String> PARSER = new ConstructingObjectParser<>(
-        "cluster_index_health",
-        true,
-        (parsedObjects, index) -> {
-            int i = 0;
-            int numberOfShards = (int) parsedObjects[i++];
-            int numberOfReplicas = (int) parsedObjects[i++];
-            int activeShards = (int) parsedObjects[i++];
-            int relocatingShards = (int) parsedObjects[i++];
-            int initializingShards = (int) parsedObjects[i++];
-            int unassignedShards = (int) parsedObjects[i++];
-            int activePrimaryShards = (int) parsedObjects[i++];
-            String statusStr = (String) parsedObjects[i++];
-            ClusterHealthStatus status = ClusterHealthStatus.fromString(statusStr);
-            @SuppressWarnings("unchecked")
-            List<ClusterShardHealth> shardList = (List<ClusterShardHealth>) parsedObjects[i];
-            final Map<Integer, ClusterShardHealth> shards;
-            if (shardList == null || shardList.isEmpty()) {
-                shards = emptyMap();
-            } else {
-                shards = Maps.newMapWithExpectedSize(shardList.size());
-                for (ClusterShardHealth shardHealth : shardList) {
-                    shards.put(shardHealth.getShardId(), shardHealth);
-                }
-            }
-            return new ClusterIndexHealth(
-                index,
-                numberOfShards,
-                numberOfReplicas,
-                activeShards,
-                relocatingShards,
-                initializingShards,
-                unassignedShards,
-                activePrimaryShards,
-                status,
-                shards
-            );
-        }
-    );
-
-    public static final ObjectParser.NamedObjectParser<ClusterShardHealth, String> SHARD_PARSER = (
-        XContentParser p,
-        String indexIgnored,
-        String shardId) -> ClusterShardHealth.innerFromXContent(p, Integer.valueOf(shardId));
-
-    static {
-        PARSER.declareInt(constructorArg(), new ParseField(NUMBER_OF_SHARDS));
-        PARSER.declareInt(constructorArg(), new ParseField(NUMBER_OF_REPLICAS));
-        PARSER.declareInt(constructorArg(), new ParseField(ACTIVE_SHARDS));
-        PARSER.declareInt(constructorArg(), new ParseField(RELOCATING_SHARDS));
-        PARSER.declareInt(constructorArg(), new ParseField(INITIALIZING_SHARDS));
-        PARSER.declareInt(constructorArg(), new ParseField(UNASSIGNED_SHARDS));
-        PARSER.declareInt(constructorArg(), new ParseField(ACTIVE_PRIMARY_SHARDS));
-        PARSER.declareString(constructorArg(), new ParseField(STATUS));
-        // Can be absent if LEVEL == 'indices' or 'cluster'
-        PARSER.declareNamedObjects(optionalConstructorArg(), SHARD_PARSER, new ParseField(SHARDS));
-    }
+    static final String STATUS = "status";
+    static final String NUMBER_OF_SHARDS = "number_of_shards";
+    static final String NUMBER_OF_REPLICAS = "number_of_replicas";
+    static final String ACTIVE_PRIMARY_SHARDS = "active_primary_shards";
+    static final String ACTIVE_SHARDS = "active_shards";
+    static final String RELOCATING_SHARDS = "relocating_shards";
+    static final String INITIALIZING_SHARDS = "initializing_shards";
+    static final String UNASSIGNED_SHARDS = "unassigned_shards";
+    static final String SHARDS = "shards";
 
     private final String index;
     private final int numberOfShards;
@@ -277,10 +209,6 @@ public final class ClusterIndexHealth implements Writeable, ToXContentFragment {
         }
         builder.endObject();
         return builder;
-    }
-
-    public static ClusterIndexHealth innerFromXContent(XContentParser parser, String index) {
-        return PARSER.apply(parser, index);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -17,59 +17,20 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
 
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
-
 public final class ClusterShardHealth implements Writeable, ToXContentFragment {
-    private static final String STATUS = "status";
-    private static final String ACTIVE_SHARDS = "active_shards";
-    private static final String RELOCATING_SHARDS = "relocating_shards";
-    private static final String INITIALIZING_SHARDS = "initializing_shards";
-    private static final String UNASSIGNED_SHARDS = "unassigned_shards";
-    private static final String PRIMARY_ACTIVE = "primary_active";
-
-    public static final ConstructingObjectParser<ClusterShardHealth, Integer> PARSER = new ConstructingObjectParser<>(
-        "cluster_shard_health",
-        true,
-        (parsedObjects, shardId) -> {
-            int i = 0;
-            boolean primaryActive = (boolean) parsedObjects[i++];
-            int activeShards = (int) parsedObjects[i++];
-            int relocatingShards = (int) parsedObjects[i++];
-            int initializingShards = (int) parsedObjects[i++];
-            int unassignedShards = (int) parsedObjects[i++];
-            String statusStr = (String) parsedObjects[i];
-            ClusterHealthStatus status = ClusterHealthStatus.fromString(statusStr);
-            return new ClusterShardHealth(
-                shardId,
-                status,
-                activeShards,
-                relocatingShards,
-                initializingShards,
-                unassignedShards,
-                primaryActive
-            );
-        }
-    );
-
-    static {
-        PARSER.declareBoolean(constructorArg(), new ParseField(PRIMARY_ACTIVE));
-        PARSER.declareInt(constructorArg(), new ParseField(ACTIVE_SHARDS));
-        PARSER.declareInt(constructorArg(), new ParseField(RELOCATING_SHARDS));
-        PARSER.declareInt(constructorArg(), new ParseField(INITIALIZING_SHARDS));
-        PARSER.declareInt(constructorArg(), new ParseField(UNASSIGNED_SHARDS));
-        PARSER.declareString(constructorArg(), new ParseField(STATUS));
-    }
+    static final String STATUS = "status";
+    static final String ACTIVE_SHARDS = "active_shards";
+    static final String RELOCATING_SHARDS = "relocating_shards";
+    static final String INITIALIZING_SHARDS = "initializing_shards";
+    static final String UNASSIGNED_SHARDS = "unassigned_shards";
+    static final String PRIMARY_ACTIVE = "primary_active";
 
     private final int shardId;
     private final ClusterHealthStatus status;
@@ -228,20 +189,6 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
         builder.field(UNASSIGNED_SHARDS, getUnassignedShards());
         builder.endObject();
         return builder;
-    }
-
-    static ClusterShardHealth innerFromXContent(XContentParser parser, Integer shardId) {
-        return PARSER.apply(parser, shardId);
-    }
-
-    public static ClusterShardHealth fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-        XContentParser.Token token = parser.nextToken();
-        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
-        String shardIdStr = parser.currentName();
-        ClusterShardHealth parsed = innerFromXContent(parser, Integer.valueOf(shardIdStr));
-        ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
-        return parsed;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
@@ -11,23 +11,16 @@ package org.elasticsearch.script;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.Tuple;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * The allowable types, languages and their corresponding contexts.  When serialized there is a top level <code>types_allowed</code> list,
@@ -68,10 +61,10 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
  * </code>
  */
 public class ScriptLanguagesInfo implements ToXContentObject, Writeable {
-    private static final ParseField TYPES_ALLOWED = new ParseField("types_allowed");
-    private static final ParseField LANGUAGE_CONTEXTS = new ParseField("language_contexts");
-    private static final ParseField LANGUAGE = new ParseField("language");
-    private static final ParseField CONTEXTS = new ParseField("contexts");
+    public static final ParseField TYPES_ALLOWED = new ParseField("types_allowed");
+    public static final ParseField LANGUAGE_CONTEXTS = new ParseField("language_contexts");
+    public static final ParseField LANGUAGE = new ParseField("language");
+    public static final ParseField CONTEXTS = new ParseField("contexts");
 
     public final Set<String> typesAllowed;
     public final Map<String, Set<String>> languageContexts;
@@ -84,31 +77,6 @@ public class ScriptLanguagesInfo implements ToXContentObject, Writeable {
     public ScriptLanguagesInfo(StreamInput in) throws IOException {
         typesAllowed = in.readCollectionAsImmutableSet(StreamInput::readString);
         languageContexts = in.readImmutableMap(sin -> sin.readCollectionAsImmutableSet(StreamInput::readString));
-    }
-
-    @SuppressWarnings("unchecked")
-    public static final ConstructingObjectParser<ScriptLanguagesInfo, Void> PARSER = new ConstructingObjectParser<>(
-        "script_languages_info",
-        true,
-        (a) -> new ScriptLanguagesInfo(
-            new HashSet<>((List<String>) a[0]),
-            ((List<Tuple<String, Set<String>>>) a[1]).stream().collect(Collectors.toMap(Tuple::v1, Tuple::v2))
-        )
-    );
-
-    @SuppressWarnings("unchecked")
-    private static final ConstructingObjectParser<Tuple<String, Set<String>>, Void> LANGUAGE_CONTEXT_PARSER =
-        new ConstructingObjectParser<>("language_contexts", true, (m, name) -> new Tuple<>((String) m[0], Set.copyOf((List<String>) m[1])));
-
-    static {
-        PARSER.declareStringArray(constructorArg(), TYPES_ALLOWED);
-        PARSER.declareObjectArray(constructorArg(), LANGUAGE_CONTEXT_PARSER, LANGUAGE_CONTEXTS);
-        LANGUAGE_CONTEXT_PARSER.declareString(constructorArg(), LANGUAGE);
-        LANGUAGE_CONTEXT_PARSER.declareStringArray(constructorArg(), CONTEXTS);
-    }
-
-    public static ScriptLanguagesInfo fromXContent(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileDfsPhaseResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileDfsPhaseResult.java
@@ -15,19 +15,15 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.search.profile.query.CollectorResult;
 import org.elasticsearch.search.profile.query.QueryProfileShardResult;
-import org.elasticsearch.xcontent.InstantiatingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ParserConstructor;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class SearchProfileDfsPhaseResult implements Writeable, ToXContentObject {
 
@@ -63,24 +59,8 @@ public class SearchProfileDfsPhaseResult implements Writeable, ToXContentObject 
         }
     }
 
-    private static final ParseField STATISTICS = new ParseField("statistics");
-    private static final ParseField KNN = new ParseField("knn");
-    private static final InstantiatingObjectParser<SearchProfileDfsPhaseResult, Void> PARSER;
-
-    static {
-        InstantiatingObjectParser.Builder<SearchProfileDfsPhaseResult, Void> parser = InstantiatingObjectParser.builder(
-            "search_profile_dfs_phase_result",
-            true,
-            SearchProfileDfsPhaseResult.class
-        );
-        parser.declareObject(optionalConstructorArg(), (p, c) -> ProfileResult.fromXContent(p), STATISTICS);
-        parser.declareObjectArray(optionalConstructorArg(), (p, c) -> QueryProfileShardResult.fromXContent(p), KNN);
-        PARSER = parser.build();
-    }
-
-    public static SearchProfileDfsPhaseResult fromXContent(XContentParser parser) throws IOException {
-        return PARSER.parse(parser, null);
-    }
+    public static final ParseField STATISTICS = new ParseField("statistics");
+    public static final ParseField KNN = new ParseField("knn");
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/QueryProfileShardResult.java
@@ -17,15 +17,12 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * A container class to hold the profile results for a single shard in the request.
@@ -138,43 +135,5 @@ public final class QueryProfileShardResult implements Writeable, ToXContentObjec
     @Override
     public String toString() {
         return Strings.toString(this);
-    }
-
-    public static QueryProfileShardResult fromXContent(XContentParser parser) throws IOException {
-        XContentParser.Token token = parser.currentToken();
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, token, parser);
-        String currentFieldName = null;
-        List<ProfileResult> queryProfileResults = new ArrayList<>();
-        long rewriteTime = 0;
-        Long vectorOperationsCount = null;
-        CollectorResult collector = null;
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else if (token.isValue()) {
-                if (REWRITE_TIME.equals(currentFieldName)) {
-                    rewriteTime = parser.longValue();
-                } else if (VECTOR_OPERATIONS_COUNT.equals(currentFieldName)) {
-                    vectorOperationsCount = parser.longValue();
-                } else {
-                    parser.skipChildren();
-                }
-            } else if (token == XContentParser.Token.START_ARRAY) {
-                if (QUERY_ARRAY.equals(currentFieldName)) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        queryProfileResults.add(ProfileResult.fromXContent(parser));
-                    }
-                } else if (COLLECTOR.equals(currentFieldName)) {
-                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        collector = CollectorResult.fromXContent(parser);
-                    }
-                } else {
-                    parser.skipChildren();
-                }
-            } else {
-                parser.skipChildren();
-            }
-        }
-        return new QueryProfileShardResult(queryProfileResults, rewriteTime, collector, vectorOperationsCount);
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthResponsesTests.java
@@ -110,7 +110,7 @@ public class ClusterHealthResponsesTests extends AbstractXContentSerializingTest
     private static final ObjectParser.NamedObjectParser<ClusterIndexHealth, Void> INDEX_PARSER = (
         XContentParser parser,
         Void context,
-        String index) -> ClusterIndexHealth.innerFromXContent(parser, index);
+        String index) -> ClusterIndexHealthTests.parseInstance(parser, index);
 
     static {
         // ClusterStateHealth fields

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotIndexStatusTests.java
@@ -8,16 +8,62 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
+import static java.util.Collections.emptyMap;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
 public class SnapshotIndexStatusTests extends AbstractXContentTestCase<SnapshotIndexStatus> {
+
+    static final ObjectParser.NamedObjectParser<SnapshotIndexStatus, Void> PARSER;
+    static {
+        ConstructingObjectParser<SnapshotIndexStatus, String> innerParser = new ConstructingObjectParser<>(
+            "snapshot_index_status",
+            true,
+            (Object[] parsedObjects, String index) -> {
+                int i = 0;
+                SnapshotShardsStats shardsStats = ((SnapshotShardsStats) parsedObjects[i++]);
+                SnapshotStats stats = ((SnapshotStats) parsedObjects[i++]);
+                @SuppressWarnings("unchecked")
+                List<SnapshotIndexShardStatus> shardStatuses = (List<SnapshotIndexShardStatus>) parsedObjects[i];
+
+                final Map<Integer, SnapshotIndexShardStatus> indexShards;
+                if (shardStatuses == null || shardStatuses.isEmpty()) {
+                    indexShards = emptyMap();
+                } else {
+                    indexShards = Maps.newMapWithExpectedSize(shardStatuses.size());
+                    for (SnapshotIndexShardStatus shardStatus : shardStatuses) {
+                        indexShards.put(shardStatus.getShardId().getId(), shardStatus);
+                    }
+                }
+                return new SnapshotIndexStatus(index, indexShards, shardsStats, stats);
+            }
+        );
+        innerParser.declareObject(
+            constructorArg(),
+            (p, c) -> SnapshotShardsStatsTests.PARSER.apply(p, null),
+            new ParseField(SnapshotShardsStats.Fields.SHARDS_STATS)
+        );
+        innerParser.declareObject(constructorArg(), (p, c) -> SnapshotStats.fromXContent(p), new ParseField(SnapshotStats.Fields.STATS));
+        innerParser.declareNamedObjects(
+            constructorArg(),
+            SnapshotIndexShardStatus.PARSER,
+            new ParseField(SnapshotIndexStatus.Fields.SHARDS)
+        );
+        PARSER = ((p, c, name) -> innerParser.apply(p, name));
+    }
 
     @Override
     protected SnapshotIndexStatus createTestInstance() {
@@ -40,7 +86,8 @@ public class SnapshotIndexStatusTests extends AbstractXContentTestCase<SnapshotI
     protected SnapshotIndexStatus doParseInstance(XContentParser parser) throws IOException {
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser);
-        SnapshotIndexStatus status = SnapshotIndexStatus.fromXContent(parser);
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+        SnapshotIndexStatus status = PARSER.parse(parser, null, parser.currentName());
         XContentParserUtils.ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
         return status;
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotShardsStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotShardsStatsTests.java
@@ -9,11 +9,38 @@
 package org.elasticsearch.action.admin.cluster.snapshots.status;
 
 import org.elasticsearch.test.AbstractXContentTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+
 public class SnapshotShardsStatsTests extends AbstractXContentTestCase<SnapshotShardsStats> {
+
+    static final ConstructingObjectParser<SnapshotShardsStats, Void> PARSER = new ConstructingObjectParser<>(
+        SnapshotShardsStats.Fields.SHARDS_STATS,
+        true,
+        (Object[] parsedObjects) -> {
+            int i = 0;
+            int initializingShards = (int) parsedObjects[i++];
+            int startedShards = (int) parsedObjects[i++];
+            int finalizingShards = (int) parsedObjects[i++];
+            int doneShards = (int) parsedObjects[i++];
+            int failedShards = (int) parsedObjects[i++];
+            int totalShards = (int) parsedObjects[i];
+            return new SnapshotShardsStats(initializingShards, startedShards, finalizingShards, doneShards, failedShards, totalShards);
+        }
+    );
+    static {
+        PARSER.declareInt(constructorArg(), new ParseField(SnapshotShardsStats.Fields.INITIALIZING));
+        PARSER.declareInt(constructorArg(), new ParseField(SnapshotShardsStats.Fields.STARTED));
+        PARSER.declareInt(constructorArg(), new ParseField(SnapshotShardsStats.Fields.FINALIZING));
+        PARSER.declareInt(constructorArg(), new ParseField(SnapshotShardsStats.Fields.DONE));
+        PARSER.declareInt(constructorArg(), new ParseField(SnapshotShardsStats.Fields.FAILED));
+        PARSER.declareInt(constructorArg(), new ParseField(SnapshotShardsStats.Fields.TOTAL));
+    }
 
     @Override
     protected SnapshotShardsStats createTestInstance() {
@@ -28,7 +55,7 @@ public class SnapshotShardsStatsTests extends AbstractXContentTestCase<SnapshotS
 
     @Override
     protected SnapshotShardsStats doParseInstance(XContentParser parser) throws IOException {
-        return SnapshotShardsStats.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponseTests.java
@@ -33,7 +33,7 @@ public class SnapshotsStatusResponseTests extends AbstractChunkedSerializingTest
         }
     );
     static {
-        PARSER.declareObjectArray(constructorArg(), SnapshotStatus.PARSER, new ParseField("snapshots"));
+        PARSER.declareObjectArray(constructorArg(), SnapshotStatusTests.PARSER, new ParseField("snapshots"));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptLanguageResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/storedscripts/GetScriptLanguageResponseTests.java
@@ -10,8 +10,10 @@ package org.elasticsearch.action.admin.cluster.storedscripts;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.script.ScriptLanguagesInfo;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
@@ -22,8 +24,33 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 public class GetScriptLanguageResponseTests extends AbstractXContentSerializingTestCase<GetScriptLanguageResponse> {
+
+    @SuppressWarnings("unchecked")
+    public static final ConstructingObjectParser<ScriptLanguagesInfo, Void> PARSER = new ConstructingObjectParser<>(
+        "script_languages_info",
+        true,
+        (a) -> new ScriptLanguagesInfo(
+            new HashSet<>((List<String>) a[0]),
+            ((List<Tuple<String, Set<String>>>) a[1]).stream().collect(Collectors.toMap(Tuple::v1, Tuple::v2))
+        )
+    );
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<Tuple<String, Set<String>>, Void> LANGUAGE_CONTEXT_PARSER =
+        new ConstructingObjectParser<>("language_contexts", true, (m, name) -> new Tuple<>((String) m[0], Set.copyOf((List<String>) m[1])));
+
+    static {
+        PARSER.declareStringArray(constructorArg(), ScriptLanguagesInfo.TYPES_ALLOWED);
+        PARSER.declareObjectArray(constructorArg(), LANGUAGE_CONTEXT_PARSER, ScriptLanguagesInfo.LANGUAGE_CONTEXTS);
+        LANGUAGE_CONTEXT_PARSER.declareString(constructorArg(), ScriptLanguagesInfo.LANGUAGE);
+        LANGUAGE_CONTEXT_PARSER.declareStringArray(constructorArg(), ScriptLanguagesInfo.CONTEXTS);
+    }
+
     private static int MAX_VALUES = 4;
     private static final int MIN_LENGTH = 1;
     private static final int MAX_LENGTH = 16;
@@ -38,7 +65,7 @@ public class GetScriptLanguageResponseTests extends AbstractXContentSerializingT
 
     @Override
     protected GetScriptLanguageResponse doParseInstance(XContentParser parser) throws IOException {
-        return new GetScriptLanguageResponse(ScriptLanguagesInfo.fromXContent(parser));
+        return new GetScriptLanguageResponse(PARSER.parse(parser, null));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponseTests.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.action.support.broadcast.BaseBroadcastResponse.declareBroadcastFields;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 public class ReloadAnalyzersResponseTests extends AbstractBroadcastResponseTestCase<ReloadAnalyzersResponse> {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/validate/query/ValidateQueryResponseTests.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.elasticsearch.action.support.broadcast.BaseBroadcastResponse.declareBroadcastFields;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/BulkItemResponseTests.java
@@ -17,12 +17,15 @@ import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.delete.DeleteResponseTests;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.index.IndexResponseTests;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.action.update.UpdateResponseTests;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
@@ -42,6 +45,54 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.throwUnknown
 import static org.hamcrest.Matchers.containsString;
 
 public class BulkItemResponseTests extends ESTestCase {
+
+    /**
+     * Parse the output of the {@link DocWriteResponse#innerToXContent(XContentBuilder, ToXContent.Params)} method.
+     *
+     * This method is intended to be called by subclasses and must be called multiple times to parse all the information concerning
+     * {@link DocWriteResponse} objects. It always parses the current token, updates the given parsing context accordingly
+     * if needed and then immediately returns.
+     */
+    public static void parseInnerToXContent(XContentParser parser, DocWriteResponse.Builder context) throws IOException {
+        XContentParser.Token token = parser.currentToken();
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
+
+        String currentFieldName = parser.currentName();
+        token = parser.nextToken();
+
+        if (token.isValue()) {
+            if (DocWriteResponse._INDEX.equals(currentFieldName)) {
+                // index uuid and shard id are unknown and can't be parsed back for now.
+                context.setShardId(new ShardId(new Index(parser.text(), IndexMetadata.INDEX_UUID_NA_VALUE), -1));
+            } else if (DocWriteResponse._ID.equals(currentFieldName)) {
+                context.setId(parser.text());
+            } else if (DocWriteResponse._VERSION.equals(currentFieldName)) {
+                context.setVersion(parser.longValue());
+            } else if (DocWriteResponse.RESULT.equals(currentFieldName)) {
+                String result = parser.text();
+                for (DocWriteResponse.Result r : DocWriteResponse.Result.values()) {
+                    if (r.getLowercase().equals(result)) {
+                        context.setResult(r);
+                        break;
+                    }
+                }
+            } else if (DocWriteResponse.FORCED_REFRESH.equals(currentFieldName)) {
+                context.setForcedRefresh(parser.booleanValue());
+            } else if (DocWriteResponse._SEQ_NO.equals(currentFieldName)) {
+                context.setSeqNo(parser.longValue());
+            } else if (DocWriteResponse._PRIMARY_TERM.equals(currentFieldName)) {
+                context.setPrimaryTerm(parser.longValue());
+            }
+        } else if (token == XContentParser.Token.START_OBJECT) {
+            if (DocWriteResponse._SHARDS.equals(currentFieldName)) {
+                context.setShardInfo(ReplicationResponse.ShardInfo.fromXContent(parser));
+            } else {
+                parser.skipChildren(); // skip potential inner objects for forward compatibility
+            }
+        } else if (token == XContentParser.Token.START_ARRAY) {
+            parser.skipChildren(); // skip potential inner arrays for forward compatibility
+        }
+    }
 
     public void testBulkItemResponseShouldContainTypeInV7CompatibilityMode() throws IOException {
         BulkItemResponse bulkItemResponse = BulkItemResponse.success(
@@ -192,7 +243,7 @@ public class BulkItemResponseTests extends ESTestCase {
         if (opType == DocWriteRequest.OpType.INDEX || opType == DocWriteRequest.OpType.CREATE) {
             final IndexResponse.Builder indexResponseBuilder = new IndexResponse.Builder();
             builder = indexResponseBuilder;
-            itemParser = indexParser -> DocWriteResponse.parseInnerToXContent(indexParser, indexResponseBuilder);
+            itemParser = indexParser -> parseInnerToXContent(indexParser, indexResponseBuilder);
         } else if (opType == DocWriteRequest.OpType.UPDATE) {
             final UpdateResponse.Builder updateResponseBuilder = new UpdateResponse.Builder();
             builder = updateResponseBuilder;
@@ -201,7 +252,7 @@ public class BulkItemResponseTests extends ESTestCase {
         } else if (opType == DocWriteRequest.OpType.DELETE) {
             final DeleteResponse.Builder deleteResponseBuilder = new DeleteResponse.Builder();
             builder = deleteResponseBuilder;
-            itemParser = deleteParser -> DocWriteResponse.parseInnerToXContent(deleteParser, deleteResponseBuilder);
+            itemParser = deleteParser -> parseInnerToXContent(deleteParser, deleteResponseBuilder);
         } else {
             throwUnknownField(currentFieldName, parser);
         }

--- a/server/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.action.delete;
 
-import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.bulk.BulkItemResponseTests;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -119,7 +119,7 @@ public class DeleteResponseTests extends ESTestCase {
 
         DeleteResponse.Builder context = new DeleteResponse.Builder();
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            DocWriteResponse.parseInnerToXContent(parser, context);
+            BulkItemResponseTests.parseInnerToXContent(parser, context);
         }
         return context.build();
     }

--- a/server/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.index;
 
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.bulk.BulkItemResponseTests;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -126,7 +127,7 @@ public class IndexResponseTests extends ESTestCase {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
         IndexResponse.Builder context = new IndexResponse.Builder();
         while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            DocWriteResponse.parseInnerToXContent(parser, context);
+            BulkItemResponseTests.parseInnerToXContent(parser, context);
         }
         return context.build();
     }

--- a/server/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.update;
 
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.bulk.BulkItemResponseTests;
 import org.elasticsearch.action.index.IndexResponseTests;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.Strings;
@@ -214,7 +215,7 @@ public class UpdateResponseTests extends ESTestCase {
                 context.setGetResult(GetResult.fromXContentEmbedded(parser));
             }
         } else {
-            DocWriteResponse.parseInnerToXContent(parser, context);
+            BulkItemResponseTests.parseInnerToXContent(parser, context);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterIndexHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterIndexHealthTests.java
@@ -12,8 +12,12 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTableGenerator;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 
@@ -21,12 +25,16 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
+import static java.util.Collections.emptyMap;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class ClusterIndexHealthTests extends AbstractXContentSerializingTestCase<ClusterIndexHealth> {
@@ -106,7 +114,7 @@ public class ClusterIndexHealthTests extends AbstractXContentSerializingTestCase
         XContentParser.Token token = parser.nextToken();
         ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
         String index = parser.currentName();
-        ClusterIndexHealth parsed = ClusterIndexHealth.innerFromXContent(parser, index);
+        ClusterIndexHealth parsed = parseInstance(parser, index);
         ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
         return parsed;
     }
@@ -287,5 +295,67 @@ public class ClusterIndexHealthTests extends AbstractXContentSerializingTestCase
             default:
                 throw new UnsupportedOperationException();
         }
+    }
+
+    private static final ConstructingObjectParser<ClusterIndexHealth, String> PARSER = new ConstructingObjectParser<>(
+        "cluster_index_health",
+        true,
+        (parsedObjects, index) -> {
+            int i = 0;
+            int numberOfShards = (int) parsedObjects[i++];
+            int numberOfReplicas = (int) parsedObjects[i++];
+            int activeShards = (int) parsedObjects[i++];
+            int relocatingShards = (int) parsedObjects[i++];
+            int initializingShards = (int) parsedObjects[i++];
+            int unassignedShards = (int) parsedObjects[i++];
+            int activePrimaryShards = (int) parsedObjects[i++];
+            String statusStr = (String) parsedObjects[i++];
+            ClusterHealthStatus status = ClusterHealthStatus.fromString(statusStr);
+            @SuppressWarnings("unchecked")
+            List<ClusterShardHealth> shardList = (List<ClusterShardHealth>) parsedObjects[i];
+            final Map<Integer, ClusterShardHealth> shards;
+            if (shardList == null || shardList.isEmpty()) {
+                shards = emptyMap();
+            } else {
+                shards = Maps.newMapWithExpectedSize(shardList.size());
+                for (ClusterShardHealth shardHealth : shardList) {
+                    shards.put(shardHealth.getShardId(), shardHealth);
+                }
+            }
+            return new ClusterIndexHealth(
+                index,
+                numberOfShards,
+                numberOfReplicas,
+                activeShards,
+                relocatingShards,
+                initializingShards,
+                unassignedShards,
+                activePrimaryShards,
+                status,
+                shards
+            );
+        }
+    );
+
+    public static final ObjectParser.NamedObjectParser<ClusterShardHealth, String> SHARD_PARSER = (
+        XContentParser p,
+        String indexIgnored,
+        String shardId) -> ClusterShardHealthTests.PARSER.apply(p, Integer.valueOf(shardId));
+
+    static {
+        PARSER.declareInt(constructorArg(), new ParseField(ClusterIndexHealth.NUMBER_OF_SHARDS));
+        PARSER.declareInt(constructorArg(), new ParseField(ClusterIndexHealth.NUMBER_OF_REPLICAS));
+        PARSER.declareInt(constructorArg(), new ParseField(ClusterIndexHealth.ACTIVE_SHARDS));
+        PARSER.declareInt(constructorArg(), new ParseField(ClusterIndexHealth.RELOCATING_SHARDS));
+        PARSER.declareInt(constructorArg(), new ParseField(ClusterIndexHealth.INITIALIZING_SHARDS));
+        PARSER.declareInt(constructorArg(), new ParseField(ClusterIndexHealth.UNASSIGNED_SHARDS));
+        PARSER.declareInt(constructorArg(), new ParseField(ClusterIndexHealth.ACTIVE_PRIMARY_SHARDS));
+        PARSER.declareString(constructorArg(), new ParseField(ClusterIndexHealth.STATUS));
+        // Can be absent if LEVEL == 'indices' or 'cluster'
+        PARSER.declareNamedObjects(optionalConstructorArg(), SHARD_PARSER, new ParseField(ClusterIndexHealth.SHARDS));
+    }
+
+    public static ClusterIndexHealth parseInstance(XContentParser parser, String index) {
+        return PARSER.apply(parser, index);
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/profile/SearchProfileDfsPhaseResultTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/SearchProfileDfsPhaseResultTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.profile;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.search.profile.query.CollectorResult;
 import org.elasticsearch.search.profile.query.QueryProfileShardResult;
 import org.elasticsearch.search.profile.query.QueryProfileShardResultTests;
@@ -48,7 +49,7 @@ public class SearchProfileDfsPhaseResultTests extends AbstractXContentSerializin
 
     @Override
     protected SearchProfileDfsPhaseResult doParseInstance(XContentParser parser) throws IOException {
-        return SearchProfileDfsPhaseResult.fromXContent(parser);
+        return SearchResponseUtils.parseProfileDfsPhaseResult(parser);
     }
 
     public void testCombineQueryProfileShardResults() {

--- a/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/query/QueryProfileShardResultTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.search.profile.query;
 
 import org.elasticsearch.common.io.stream.Writeable.Reader;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.search.profile.ProfileResultTests;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
@@ -51,7 +52,7 @@ public class QueryProfileShardResultTests extends AbstractXContentSerializingTes
     @Override
     protected QueryProfileShardResult doParseInstance(XContentParser parser) throws IOException {
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-        QueryProfileShardResult result = QueryProfileShardResult.fromXContent(parser);
+        QueryProfileShardResult result = SearchResponseUtils.parseQueryProfileShardResult(parser);
         ensureExpectedToken(null, parser.nextToken(), parser);
         return result;
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBroadcastResponseTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBroadcastResponseTestCase.java
@@ -10,12 +10,15 @@ package org.elasticsearch.test;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BaseBroadcastResponse;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
@@ -24,11 +27,37 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public abstract class AbstractBroadcastResponseTestCase<T extends BroadcastResponse> extends AbstractXContentTestCase<T> {
+
+    private static final ParseField _SHARDS_FIELD = new ParseField("_shards");
+    private static final ParseField TOTAL_FIELD = new ParseField("total");
+    private static final ParseField SUCCESSFUL_FIELD = new ParseField("successful");
+    private static final ParseField FAILED_FIELD = new ParseField("failed");
+    private static final ParseField FAILURES_FIELD = new ParseField("failures");
+
+    @SuppressWarnings("unchecked")
+    public static <T extends BaseBroadcastResponse> void declareBroadcastFields(ConstructingObjectParser<T, Void> PARSER) {
+        ConstructingObjectParser<BaseBroadcastResponse, Void> shardsParser = new ConstructingObjectParser<>(
+            "_shards",
+            true,
+            arg -> new BaseBroadcastResponse((int) arg[0], (int) arg[1], (int) arg[2], (List<DefaultShardOperationFailedException>) arg[3])
+        );
+        shardsParser.declareInt(constructorArg(), TOTAL_FIELD);
+        shardsParser.declareInt(constructorArg(), SUCCESSFUL_FIELD);
+        shardsParser.declareInt(constructorArg(), FAILED_FIELD);
+        shardsParser.declareObjectArray(
+            optionalConstructorArg(),
+            (p, c) -> DefaultShardOperationFailedException.fromXContent(p),
+            FAILURES_FIELD
+        );
+        PARSER.declareObject(constructorArg(), shardsParser, _SHARDS_FIELD);
+    }
 
     @Override
     protected T createTestInstance() {

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -72,6 +72,7 @@ import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.AbstractBroadcastResponseTestCase;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.DeprecationHandler;
@@ -1312,7 +1313,7 @@ public abstract class ESRestTestCase extends ESTestCase {
     );
 
     static {
-        BaseBroadcastResponse.declareBroadcastFields(BROADCAST_RESPONSE_PARSER);
+        AbstractBroadcastResponseTestCase.declareBroadcastFields(BROADCAST_RESPONSE_PARSER);
     }
 
     protected static BroadcastResponse refresh(RestClient client, String index) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TermsEnumResponse.java
@@ -7,21 +7,14 @@
 package org.elasticsearch.xpack.core.termsenum.action;
 
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
-import org.elasticsearch.action.support.broadcast.BaseBroadcastResponse;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * The response of the _terms_enum action.
@@ -30,28 +23,6 @@ public class TermsEnumResponse extends BroadcastResponse {
 
     public static final String TERMS_FIELD = "terms";
     public static final String COMPLETE_FIELD = "complete";
-
-    @SuppressWarnings("unchecked")
-    static final ConstructingObjectParser<TermsEnumResponse, Void> PARSER = new ConstructingObjectParser<>(
-        "term_enum_results",
-        true,
-        arg -> {
-            BaseBroadcastResponse response = (BaseBroadcastResponse) arg[0];
-            return new TermsEnumResponse(
-                (List<String>) arg[1],
-                response.getTotalShards(),
-                response.getSuccessfulShards(),
-                response.getFailedShards(),
-                Arrays.asList(response.getShardFailures()),
-                (Boolean) arg[2]
-            );
-        }
-    );
-    static {
-        declareBroadcastFields(PARSER);
-        PARSER.declareStringArray(optionalConstructorArg(), new ParseField(TERMS_FIELD));
-        PARSER.declareBoolean(optionalConstructorArg(), new ParseField(COMPLETE_FIELD));
-    }
 
     private final List<String> terms;
 
@@ -106,7 +77,4 @@ public class TermsEnumResponse extends BroadcastResponse {
         builder.field(COMPLETE_FIELD, complete);
     }
 
-    public static TermsEnumResponse fromXContent(XContentParser parser) {
-        return PARSER.apply(parser, null);
-    }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumResponseTests.java
@@ -8,18 +8,47 @@ package org.elasticsearch.xpack.core.termsenum;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.DefaultShardOperationFailedException;
+import org.elasticsearch.action.support.broadcast.BaseBroadcastResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.AbstractBroadcastResponseTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.termsenum.action.TermsEnumResponse;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+
 public class TermsEnumResponseTests extends AbstractBroadcastResponseTestCase<TermsEnumResponse> {
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<TermsEnumResponse, Void> PARSER = new ConstructingObjectParser<>(
+        "term_enum_results",
+        true,
+        arg -> {
+            BaseBroadcastResponse response = (BaseBroadcastResponse) arg[0];
+            return new TermsEnumResponse(
+                (List<String>) arg[1],
+                response.getTotalShards(),
+                response.getSuccessfulShards(),
+                response.getFailedShards(),
+                Arrays.asList(response.getShardFailures()),
+                (Boolean) arg[2]
+            );
+        }
+    );
+
+    static {
+        AbstractBroadcastResponseTestCase.declareBroadcastFields(PARSER);
+        PARSER.declareStringArray(optionalConstructorArg(), new ParseField(TermsEnumResponse.TERMS_FIELD));
+        PARSER.declareBoolean(optionalConstructorArg(), new ParseField(TermsEnumResponse.COMPLETE_FIELD));
+    }
 
     protected static List<String> getRandomTerms() {
         int termCount = randomIntBetween(0, 100);
@@ -48,7 +77,7 @@ public class TermsEnumResponseTests extends AbstractBroadcastResponseTestCase<Te
 
     @Override
     protected TermsEnumResponse doParseInstance(XContentParser parser) throws IOException {
-        return TermsEnumResponse.fromXContent(parser);
+        return PARSER.apply(parser, null);
     }
 
     @Override


### PR DESCRIPTION
Follow up to #105801 moving more parsers that are test-only over to the test codebase.
