### PR TITLE
Fix missing docs in time series source reader

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
@@ -228,15 +228,10 @@ public record TimeSeriesSortedSourceOperatorFactory(int limit, int maxPageSize, 
             void consume() throws IOException {
                 if (queue != null) {
                     currentTsid = BytesRef.deepCopyOf(queue.top().timeSeriesHash);
-                    boolean breakOnNextTsidChange = false;
                     while (queue.size() > 0) {
-                        if (remainingDocs <= 0) {
+                        if (remainingDocs <= 0 || currentPagePos >= maxPageSize) {
                             break;
                         }
-                        if (currentPagePos > maxPageSize) {
-                            breakOnNextTsidChange = true;
-                        }
-
                         currentPagePos++;
                         remainingDocs--;
                         Leaf leaf = queue.top();
@@ -244,46 +239,32 @@ public record TimeSeriesSortedSourceOperatorFactory(int limit, int maxPageSize, 
                         docsBuilder.appendInt(leaf.iterator.docID());
                         timestampIntervalBuilder.appendLong(leaf.timestamp);
                         tsOrdBuilder.appendInt(globalTsidOrd);
+                        final Leaf newTop;
                         if (leaf.nextDoc()) {
                             // TODO: updating the top is one of the most expensive parts of this operation.
                             // Ideally we would do this a less as possible. Maybe the top can be updated every N docs?
-                            Leaf newTop = queue.updateTop();
-                            if (newTop.timeSeriesHash.equals(currentTsid) == false) {
-                                globalTsidOrd++;
-                                currentTsid = BytesRef.deepCopyOf(newTop.timeSeriesHash);
-                                if (breakOnNextTsidChange) {
-                                    break;
-                                }
-                            }
+                            newTop = queue.updateTop();
                         } else {
                             queue.pop();
+                            newTop = queue.size() > 0 ? queue.top() : null;
+                        }
+                        if (newTop != null && newTop.timeSeriesHash.equals(currentTsid) == false) {
+                            globalTsidOrd++;
+                            currentTsid = BytesRef.deepCopyOf(newTop.timeSeriesHash);
                         }
                     }
                 } else {
-                    int previousTsidOrd = leaf.timeSeriesHashOrd;
-                    boolean breakOnNextTsidChange = false;
                     // Only one segment, so no need to use priority queue and use segment ordinals as tsid ord.
                     while (leaf.nextDoc()) {
-                        if (remainingDocs <= 0) {
-                            break;
-                        }
-                        if (currentPagePos > maxPageSize) {
-                            breakOnNextTsidChange = true;
-                        }
-                        if (breakOnNextTsidChange) {
-                            if (previousTsidOrd != leaf.timeSeriesHashOrd) {
-                                break;
-                            }
-                        }
-
-                        currentPagePos++;
-                        remainingDocs--;
-
                         tsOrdBuilder.appendInt(leaf.timeSeriesHashOrd);
                         timestampIntervalBuilder.appendLong(leaf.timestamp);
                         // Don't append segment ord, because there is only one segment.
                         docsBuilder.appendInt(leaf.iterator.docID());
-                        previousTsidOrd = leaf.timeSeriesHashOrd;
+                        currentPagePos++;
+                        remainingDocs--;
+                        if (remainingDocs <= 0 || currentPagePos >= maxPageSize) {
+                            break;
+                        }
                     }
                 }
             }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorTests.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.SortedNumericSortField;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Randomness;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.data.ElementType;
@@ -33,6 +34,7 @@ import org.elasticsearch.compute.data.LongVector;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.AnyOperatorTestCase;
 import org.elasticsearch.compute.operator.Driver;
+import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.OperatorTestCase;
 import org.elasticsearch.compute.operator.TestResultPageSinkOperator;
@@ -48,15 +50,15 @@ import org.junit.After;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 
-import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
@@ -73,81 +75,28 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         int numTimeSeries = 3;
         int numSamplesPerTS = 10;
         long timestampStart = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-01-01T00:00:00Z");
-        List<Page> results = runDriver(1024, 1024, randomBoolean(), numTimeSeries, numSamplesPerTS, timestampStart);
-        assertThat(results, hasSize(1));
-        Page page = results.get(0);
-        assertThat(page.getBlockCount(), equalTo(5));
-
-        DocVector docVector = (DocVector) page.getBlock(0).asVector();
-        assertThat(docVector.getPositionCount(), equalTo(numTimeSeries * numSamplesPerTS));
-
-        IntVector tsidVector = (IntVector) page.getBlock(1).asVector();
-        assertThat(tsidVector.getPositionCount(), equalTo(numTimeSeries * numSamplesPerTS));
-
-        LongVector timestampVector = (LongVector) page.getBlock(2).asVector();
-        assertThat(timestampVector.getPositionCount(), equalTo(numTimeSeries * numSamplesPerTS));
-
-        LongVector voltageVector = (LongVector) page.getBlock(3).asVector();
-        assertThat(voltageVector.getPositionCount(), equalTo(numTimeSeries * numSamplesPerTS));
-
-        BytesRefVector hostnameVector = (BytesRefVector) page.getBlock(4).asVector();
-        assertThat(hostnameVector.getPositionCount(), equalTo(numTimeSeries * numSamplesPerTS));
-
+        int maxPageSize = between(1, 1024);
+        List<Page> results = runDriver(1024, maxPageSize, randomBoolean(), numTimeSeries, numSamplesPerTS, timestampStart);
+        // for now we emit at most one time series each page
         int offset = 0;
-        for (int expectedTsidOrd = 0; expectedTsidOrd < numTimeSeries; expectedTsidOrd++) {
-            String expectedHostname = String.format(Locale.ROOT, "host-%02d", expectedTsidOrd);
-            long expectedVoltage = 5L + expectedTsidOrd;
-            for (int j = 0; j < numSamplesPerTS; j++) {
-                long expectedTimestamp = timestampStart + ((numSamplesPerTS - j - 1) * 10_000L);
-
-                assertThat(docVector.shards().getInt(offset), equalTo(0));
-                assertThat(voltageVector.getLong(offset), equalTo(expectedVoltage));
-                assertThat(hostnameVector.getBytesRef(offset, new BytesRef()).utf8ToString(), equalTo(expectedHostname));
-                assertThat(tsidVector.getInt(offset), equalTo(expectedTsidOrd));
-                assertThat(timestampVector.getLong(offset), equalTo(expectedTimestamp));
-                offset++;
-            }
-        }
-    }
-
-    public void testMaxPageSize() {
-        int numTimeSeries = 3;
-        int numSamplesPerTS = 10;
-        long timestampStart = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-01-01T00:00:00Z");
-        List<Page> results = runDriver(1024, 1, randomBoolean(), numTimeSeries, numSamplesPerTS, timestampStart);
-        // A time series shouldn't be split over multiple pages.
-        assertThat(results, hasSize(numTimeSeries));
-        for (int i = 0; i < numTimeSeries; i++) {
-            Page page = results.get(i);
+        for (Page page : results) {
             assertThat(page.getBlockCount(), equalTo(5));
-
             DocVector docVector = (DocVector) page.getBlock(0).asVector();
-            assertThat(docVector.getPositionCount(), equalTo(numSamplesPerTS));
-
             IntVector tsidVector = (IntVector) page.getBlock(1).asVector();
-            assertThat(tsidVector.getPositionCount(), equalTo(numSamplesPerTS));
-
             LongVector timestampVector = (LongVector) page.getBlock(2).asVector();
-            assertThat(timestampVector.getPositionCount(), equalTo(numSamplesPerTS));
-
             LongVector voltageVector = (LongVector) page.getBlock(3).asVector();
-            assertThat(voltageVector.getPositionCount(), equalTo(numSamplesPerTS));
-
             BytesRefVector hostnameVector = (BytesRefVector) page.getBlock(4).asVector();
-            assertThat(hostnameVector.getPositionCount(), equalTo(numSamplesPerTS));
-
-            int offset = 0;
-            int expectedTsidOrd = i;
-            String expectedHostname = String.format(Locale.ROOT, "host-%02d", expectedTsidOrd);
-            long expectedVoltage = 5L + expectedTsidOrd;
-            for (int j = 0; j < numSamplesPerTS; j++) {
-                long expectedTimestamp = timestampStart + ((numSamplesPerTS - j - 1) * 10_000L);
-
-                assertThat(docVector.shards().getInt(offset), equalTo(0));
-                assertThat(voltageVector.getLong(offset), equalTo(expectedVoltage));
-                assertThat(hostnameVector.getBytesRef(offset, new BytesRef()).utf8ToString(), equalTo(expectedHostname));
-                assertThat(tsidVector.getInt(offset), equalTo(expectedTsidOrd));
-                assertThat(timestampVector.getLong(offset), equalTo(expectedTimestamp));
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                int expectedTsidOrd = offset / numSamplesPerTS;
+                String expectedHostname = String.format(Locale.ROOT, "host-%02d", expectedTsidOrd);
+                long expectedVoltage = 5L + expectedTsidOrd;
+                int sampleIndex = offset - expectedTsidOrd * numSamplesPerTS;
+                long expectedTimestamp = timestampStart + ((numSamplesPerTS - sampleIndex - 1) * 10_000L);
+                assertThat(docVector.shards().getInt(i), equalTo(0));
+                assertThat(voltageVector.getLong(i), equalTo(expectedVoltage));
+                assertThat(hostnameVector.getBytesRef(i, new BytesRef()).utf8ToString(), equalTo(expectedHostname));
+                assertThat(tsidVector.getInt(i), equalTo(expectedTsidOrd));
+                assertThat(timestampVector.getLong(i), equalTo(expectedTimestamp));
                 offset++;
             }
         }
@@ -158,7 +107,7 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         int numSamplesPerTS = 10;
         int limit = 1;
         long timestampStart = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-01-01T00:00:00Z");
-        List<Page> results = runDriver(limit, 1024, randomBoolean(), numTimeSeries, numSamplesPerTS, timestampStart);
+        List<Page> results = runDriver(limit, randomIntBetween(1, 1024), randomBoolean(), numTimeSeries, numSamplesPerTS, timestampStart);
         assertThat(results, hasSize(1));
         Page page = results.get(0);
         assertThat(page.getBlockCount(), equalTo(5));
@@ -186,57 +135,67 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
     }
 
     public void testRandom() {
-        int numDocs = 1024;
-        var ctx = driverContext();
-        long timestampStart = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-01-01T00:00:00Z");
-        var timeSeriesFactory = createTimeSeriesSourceOperator(Integer.MAX_VALUE, Integer.MAX_VALUE, randomBoolean(), writer -> {
-            int commitEvery = 64;
-            long timestamp = timestampStart;
-            for (int i = 0; i < numDocs; i++) {
-                String hostname = String.format(Locale.ROOT, "host-%02d", i % 20);
-                int voltage = i % 5;
-                writeTS(writer, timestamp, new Object[] { "hostname", hostname }, new Object[] { "voltage", voltage });
-                if (i % commitEvery == 0) {
-                    writer.commit();
-                }
-                timestamp += 10_000;
+        record Doc(int host, long timestamp, long metric) {}
+        int numDocs = between(1, 1000);
+        List<Doc> docs = new ArrayList<>();
+        Map<Integer, Long> timestamps = new HashMap<>();
+        long t0 = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-01-01T00:00:00Z");
+        for (int i = 0; i < numDocs; i++) {
+            int tsid = randomIntBetween(0, 9);
+            long timestamp = timestamps.compute(tsid, (k, curr) -> {
+                long t = curr != null ? curr : t0;
+                return t + randomIntBetween(1, 5000);
+            });
+            docs.add(new Doc(tsid, timestamp, randomIntBetween(1, 10000)));
+        }
+        int maxPageSize = between(1, 1024);
+        int limit = randomBoolean() ? between(1, 100000) : Integer.MAX_VALUE;
+        var timeSeriesFactory = createTimeSeriesSourceOperator(limit, maxPageSize, randomBoolean(), writer -> {
+            Randomness.shuffle(docs);
+            for (Doc doc : docs) {
+                writeTS(writer, doc.timestamp, new Object[] { "hostname", "h" + doc.host }, new Object[] { "metric", doc.metric });
             }
-            return numDocs;
+            return docs.size();
         });
+        DriverContext driverContext = driverContext();
         List<Page> results = new ArrayList<>();
-
-        var voltageField = new NumberFieldMapper.NumberFieldType("voltage", NumberFieldMapper.NumberType.LONG);
+        var metricField = new NumberFieldMapper.NumberFieldType("metric", NumberFieldMapper.NumberType.LONG);
         OperatorTestCase.runDriver(
             new Driver(
-                ctx,
-                timeSeriesFactory.get(ctx),
-                List.of(ValuesSourceReaderOperatorTests.factory(reader, voltageField, ElementType.LONG).get(ctx)),
+                driverContext,
+                timeSeriesFactory.get(driverContext),
+                List.of(ValuesSourceReaderOperatorTests.factory(reader, metricField, ElementType.LONG).get(driverContext)),
                 new TestResultPageSinkOperator(results::add),
                 () -> {}
             )
         );
-        OperatorTestCase.assertDriverContext(ctx);
-        assertThat(results, hasSize(1));
-        Page page = results.get(0);
-        assertThat(page.getBlockCount(), equalTo(4));
-
-        DocVector docVector = (DocVector) page.getBlock(0).asVector();
-        assertThat(docVector.getPositionCount(), equalTo(numDocs));
-
-        IntVector tsidVector = (IntVector) page.getBlock(1).asVector();
-        assertThat(tsidVector.getPositionCount(), equalTo(numDocs));
-
-        LongVector timestampVector = (LongVector) page.getBlock(2).asVector();
-        assertThat(timestampVector.getPositionCount(), equalTo(numDocs));
-
-        LongVector voltageVector = (LongVector) page.getBlock(3).asVector();
-        assertThat(voltageVector.getPositionCount(), equalTo(numDocs));
-        for (int i = 0; i < page.getBlockCount(); i++) {
-            assertThat(docVector.shards().getInt(0), equalTo(0));
-            assertThat(voltageVector.getLong(i), either(greaterThanOrEqualTo(0L)).or(lessThanOrEqualTo(4L)));
-            assertThat(tsidVector.getInt(i), either(greaterThanOrEqualTo(0)).or(lessThan(20)));
-            assertThat(timestampVector.getLong(i), greaterThanOrEqualTo(timestampStart));
+        docs.sort(Comparator.comparing(Doc::host).thenComparing(Comparator.comparingLong(Doc::timestamp).reversed()));
+        Map<Integer, Integer> hostToTsidOrd = new HashMap<>();
+        timestamps.keySet().stream().sorted().forEach(n -> hostToTsidOrd.put(n, hostToTsidOrd.size()));
+        int offset = 0;
+        for (int p = 0; p < results.size(); p++) {
+            Page page = results.get(p);
+            if (p < results.size() - 1) {
+                assertThat(page.getPositionCount(), equalTo(maxPageSize));
+            } else {
+                assertThat(page.getPositionCount(), lessThanOrEqualTo(limit));
+                assertThat(page.getPositionCount(), lessThanOrEqualTo(maxPageSize));
+            }
+            assertThat(page.getBlockCount(), equalTo(4));
+            DocVector docVector = (DocVector) page.getBlock(0).asVector();
+            IntVector tsidVector = (IntVector) page.getBlock(1).asVector();
+            LongVector timestampVector = (LongVector) page.getBlock(2).asVector();
+            LongVector metricVector = (LongVector) page.getBlock(3).asVector();
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                Doc doc = docs.get(offset);
+                offset++;
+                assertThat(docVector.shards().getInt(0), equalTo(0));
+                assertThat(tsidVector.getInt(i), equalTo(hostToTsidOrd.get(doc.host)));
+                assertThat(timestampVector.getLong(i), equalTo(doc.timestamp));
+                assertThat(metricVector.getLong(i), equalTo(doc.metric));
+            }
         }
+        assertThat(offset, equalTo(Math.min(limit, numDocs)));
     }
 
     @Override
@@ -289,6 +248,10 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
             )
         );
         OperatorTestCase.assertDriverContext(ctx);
+        for (Page result : results) {
+            assertThat(result.getPositionCount(), lessThanOrEqualTo(maxPageSize));
+            assertThat(result.getPositionCount(), lessThanOrEqualTo(limit));
+        }
         return results;
     }
 
@@ -298,7 +261,6 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         boolean forceMerge,
         CheckedFunction<RandomIndexWriter, Integer, IOException> indexingLogic
     ) {
-        int numDocs;
         Sort sort = new Sort(
             new SortField(TimeSeriesIdFieldMapper.NAME, SortField.Type.STRING, false),
             new SortedNumericSortField(DataStreamTimestampFieldMapper.DEFAULT_PATH, SortField.Type.LONG, true)
@@ -311,23 +273,18 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
             )
         ) {
 
-            numDocs = indexingLogic.apply(writer);
+            int numDocs = indexingLogic.apply(writer);
             if (forceMerge) {
                 writer.forceMerge(1);
             }
             reader = writer.getReader();
+            assertThat(reader.numDocs(), equalTo(numDocs));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
         var ctx = new LuceneSourceOperatorTests.MockShardContext(reader, 0);
         Function<ShardContext, Query> queryFunction = c -> new MatchAllDocsQuery();
-        return TimeSeriesSortedSourceOperatorFactory.create(
-            Math.min(numDocs, limit),
-            Math.min(numDocs, maxPageSize),
-            1,
-            List.of(ctx),
-            queryFunction
-        );
+        return TimeSeriesSortedSourceOperatorFactory.create(limit, maxPageSize, 1, List.of(ctx), queryFunction);
     }
 
     static void writeTS(RandomIndexWriter iw, long timestamp, Object[] dimensions, Object[] metrics) throws IOException {


### PR DESCRIPTION
While working on rate aggregation, I noticed that the time series source might miss documents. Specifically, when we reach the [max_page_size](https://github.com/elastic/elasticsearch/pull/106705/files#diff-8bb21ea96e1c7ab1c4e97c1ad295414b084f9703c335962e740ddff28ff00c72L271)  limit and the tsid [changes](https://github.com/elastic/elasticsearch/pull/106705/files#diff-8bb21ea96e1c7ab1c4e97c1ad295414b084f9703c335962e740ddff28ff00c72L274), we skip that document because we call  [nextDoc](https://github.com/elastic/elasticsearch/pull/106705/files#diff-8bb21ea96e1c7ab1c4e97c1ad295414b084f9703c335962e740ddff28ff00c72L266) again when resuming reading. Also, I think this operator should honor the max_page_size limit and avoid emitting pages that exceed this threshold.

Labelled this non-issue for an unreleased bug.