### PR TITLE
Explicitly set number_of_shards to 1 in tests

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
@@ -9,6 +9,7 @@ setup:
         index: tsdb
         body:
           settings:
+            number_of_shards: 1
             mode: time_series
             routing_path: [key]
             time_series:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/count/30_min_score.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/count/30_min_score.yml
@@ -3,6 +3,9 @@
   - do:
       indices.create:
           index:  test_count_min_score
+          body:
+            settings:
+              number_of_shards: 1
 
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/160_knn_query_missing_params.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/160_knn_query_missing_params.yml
@@ -6,6 +6,8 @@ setup:
       indices.create:
         index: knn_query_test_index
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
                   vector:


### PR DESCRIPTION
Some tests rely on the default number_of_shards to be 1. This may not hold if the default number_of_shards changes. This PR removes that assumption in the tests by explicitly configuring the number_of_shards to 1 at index creation time.

Relates: #100171
Relates: ES-7911
