### PR TITLE
Skip logging when no existing autosharding event

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -293,11 +293,13 @@ public class MetadataRolloverService {
             ? dataStream.getAutoShardingEvent()
             : switch (autoShardingResult.type()) {
                 case NO_CHANGE_REQUIRED -> {
-                    logger.info(
-                        "Rolling over data stream [{}] using existing auto-sharding recommendation [{}]",
-                        dataStreamName,
-                        dataStream.getAutoShardingEvent()
-                    );
+                    if (dataStream.getAutoShardingEvent() != null) {
+                        logger.info(
+                            "Rolling over data stream [{}] using existing auto-sharding recommendation [{}]",
+                            dataStreamName,
+                            dataStream.getAutoShardingEvent()
+                        );
+                    }
                     yield dataStream.getAutoShardingEvent();
                 }
                 case INCREASE_SHARDS, DECREASE_SHARDS -> {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/MetadataRolloverService.java
@@ -292,7 +292,7 @@ public class MetadataRolloverService {
         DataStreamAutoShardingEvent dataStreamAutoShardingEvent = autoShardingResult == null
             ? dataStream.getAutoShardingEvent()
             : switch (autoShardingResult.type()) {
-                case NO_CHANGE_REQUIRED -> {
+                case NO_CHANGE_REQUIRED, COOLDOWN_PREVENTED_INCREASE, COOLDOWN_PREVENTED_DECREASE -> {
                     if (dataStream.getAutoShardingEvent() != null) {
                         logger.info(
                             "Rolling over data stream [{}] using existing auto-sharding recommendation [{}]",
@@ -309,18 +309,6 @@ public class MetadataRolloverService {
                         autoShardingResult.targetNumberOfShards(),
                         now.toEpochMilli()
                     );
-                }
-                case COOLDOWN_PREVENTED_INCREASE, COOLDOWN_PREVENTED_DECREASE -> {
-                    // we're in the cooldown period for this particular recommendation so perhaps use a previous autosharding
-                    // recommendation (or the value configured in the backing index template otherwise)
-                    if (dataStream.getAutoShardingEvent() != null) {
-                        logger.info(
-                            "Rolling over data stream [{}] using existing auto-sharding recommendation [{}]",
-                            dataStreamName,
-                            dataStream.getAutoShardingEvent()
-                        );
-                    }
-                    yield dataStream.getAutoShardingEvent();
                 }
                 // data sharding might not be available due to the feature not being available/enabled or due to cluster level excludes
                 // being configured. the index template will dictate the number of shards as usual


### PR DESCRIPTION
This skips rather confusing logging like 
```
 Rolling over data stream [logs-mysql.error-default] using existing auto-sharding recommendation [null]
```

Will only log this statement when there actually is an active auto sharding event that's being used
in the rollover process.