### PR TITLE
Add isPatchFrom method to check for future patch versions

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -104,10 +104,10 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     /**
      * Returns {@code true} if this version is a patch version at or after {@code version}.
      * <p>
-     * This should not be used normally. It is used for matching patch versions in the same patch group,
+     * This should not be used normally. It is used for matching patch versions of the same base version,
      * using the standard version number format specified in {@link TransportVersions}.
      * When a patch version of an existing transport version is created, {@code transportVersion.isPatchFrom(patchVersion)}
-     * will match any transport version at or above {@code patchVersion} that is also of the same patch group.
+     * will match any transport version at or above {@code patchVersion} that is also of the same base version.
      * <p>
      * For example, {@code version.isPatchFrom(8_800_00_4)} will return the following for the given {@code version}:
      * <ul>

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -102,6 +102,30 @@ public record TransportVersion(int id) implements VersionId<TransportVersion> {
     }
 
     /**
+     * Returns {@code true} if this version is a patch version at or after {@code version}.
+     * <p>
+     * This should not be used normally. It is used for matching patch versions in the same patch group,
+     * using the standard version number format specified in {@link TransportVersions}.
+     * When a patch version of an existing transport version is created, {@code transportVersion.isPatchFrom(patchVersion)}
+     * will match any transport version at or above {@code patchVersion} that is also of the same patch group.
+     * <p>
+     * For example, {@code version.isPatchFrom(8_800_00_4)} will return the following for the given {@code version}:
+     * <ul>
+     *     <li>{@code 8_799_00_0.isPatchFrom(8_800_00_4)}: {@code false}</li>
+     *     <li>{@code 8_799_00_9.isPatchFrom(8_800_00_4)}: {@code false}</li>
+     *     <li>{@code 8_800_00_0.isPatchFrom(8_800_00_4)}: {@code false}</li>
+     *     <li>{@code 8_800_00_3.isPatchFrom(8_800_00_4)}: {@code false}</li>
+     *     <li>{@code 8_800_00_4.isPatchFrom(8_800_00_4)}: {@code true}</li>
+     *     <li>{@code 8_800_00_9.isPatchFrom(8_800_00_4)}: {@code true}</li>
+     *     <li>{@code 8_800_01_0.isPatchFrom(8_800_00_4)}: {@code false}</li>
+     *     <li>{@code 8_801_00_0.isPatchFrom(8_800_00_4)}: {@code false}</li>
+     * </ul>
+     */
+    public boolean isPatchFrom(TransportVersion version) {
+        return onOrAfter(version) && id < version.id + 10 - (version.id % 10);
+    }
+
+    /**
      * Returns a string representing the Elasticsearch release version of this transport version,
      * if applicable for this deployment, otherwise the raw version number.
      */

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -159,6 +159,18 @@ public class TransportVersionTests extends ESTestCase {
         }
     }
 
+    public void testIsPatchFrom() {
+        TransportVersion patchVersion = TransportVersion.fromId(8_800_00_4);
+        assertThat(TransportVersion.fromId(8_799_00_0).isPatchFrom(patchVersion), is(false));
+        assertThat(TransportVersion.fromId(8_799_00_9).isPatchFrom(patchVersion), is(false));
+        assertThat(TransportVersion.fromId(8_800_00_0).isPatchFrom(patchVersion), is(false));
+        assertThat(TransportVersion.fromId(8_800_00_3).isPatchFrom(patchVersion), is(false));
+        assertThat(TransportVersion.fromId(8_800_00_4).isPatchFrom(patchVersion), is(true));
+        assertThat(TransportVersion.fromId(8_800_00_9).isPatchFrom(patchVersion), is(true));
+        assertThat(TransportVersion.fromId(8_800_01_0).isPatchFrom(patchVersion), is(false));
+        assertThat(TransportVersion.fromId(8_801_00_0).isPatchFrom(patchVersion), is(false));
+    }
+
     public void testVersionConstantPresent() {
         Set<TransportVersion> ignore = Set.of(TransportVersions.ZERO, TransportVersion.current(), TransportVersions.MINIMUM_COMPATIBLE);
         assertThat(TransportVersion.current(), sameInstance(TransportVersion.fromId(TransportVersion.current().id())));


### PR DESCRIPTION
Following from internal discussions, this is a method to use when we're creating patch versions of previous transport versions (eg when patching a minor release). `isPatchFrom` will match this and future patch versions of the same base version, and no others.