### PR TITLE
Use confined arena for CloseableByteBuffer

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/CloseableByteBuffer.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/CloseableByteBuffer.java
@@ -10,7 +10,16 @@ package org.elasticsearch.nativeaccess;
 
 import java.nio.ByteBuffer;
 
+/**
+ * A wrapper around a native {@link ByteBuffer} which allows that buffer to be
+ * closed synchronously. This is in contrast to JDK created native buffers
+ * which are deallocated only after GC has cleaned up references to
+ * the buffer.
+ */
 public interface CloseableByteBuffer extends AutoCloseable {
+    /**
+     * Returns the wrapped {@link ByteBuffer}.
+     */
     ByteBuffer buffer();
 
     @Override

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
@@ -35,5 +35,11 @@ public interface NativeAccess {
      */
     Zstd getZstd();
 
+    /**
+     * Creates a new {@link CloseableByteBuffer}. The buffer must be used within the same thread
+     * that it is created.
+     * @param len the number of bytes the buffer should allocate
+     * @return the buffer
+     */
     CloseableByteBuffer newBuffer(int len);
 }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkCloseableByteBuffer.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkCloseableByteBuffer.java
@@ -18,7 +18,7 @@ class JdkCloseableByteBuffer implements CloseableByteBuffer {
     private final ByteBuffer bufferView;
 
     JdkCloseableByteBuffer(int len) {
-        this.arena = Arena.ofShared();
+        this.arena = Arena.ofConfined();
         this.bufferView = this.arena.allocate(len).asByteBuffer();
     }
 


### PR DESCRIPTION
The jdk implementation of CloseableByteBuffer currently uses a shared arena. The assumption was that a buffer might be shared across threads. However, in practice for compression/decompression that is not true, and the shared arena has a noticeable impact on deallocation when the buffer is closed. This commit switches to a confined arena, limtting buffer creation and compress/decompress calls to a single thread.

relates #103374