### PR TITLE
Use CloseableByteBuffer in compress/decompress signatures

### DIFF
--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaCloseableByteBuffer.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaCloseableByteBuffer.java
@@ -15,7 +15,7 @@ import org.elasticsearch.nativeaccess.CloseableByteBuffer;
 import java.nio.ByteBuffer;
 
 class JnaCloseableByteBuffer implements CloseableByteBuffer {
-    private final Memory memory;
+    final Memory memory;
     private final ByteBuffer bufferView;
 
     JnaCloseableByteBuffer(int len) {

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaZstdLibrary.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaZstdLibrary.java
@@ -10,23 +10,23 @@ package org.elasticsearch.nativeaccess.jna;
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 
+import org.elasticsearch.nativeaccess.CloseableByteBuffer;
 import org.elasticsearch.nativeaccess.lib.ZstdLibrary;
-
-import java.nio.ByteBuffer;
 
 class JnaZstdLibrary implements ZstdLibrary {
 
     private interface NativeFunctions extends Library {
         long ZSTD_compressBound(int scrLen);
 
-        long ZSTD_compress(ByteBuffer dst, int dstLen, ByteBuffer src, int srcLen, int compressionLevel);
+        long ZSTD_compress(Pointer dst, int dstLen, Pointer src, int srcLen, int compressionLevel);
 
         boolean ZSTD_isError(long code);
 
         String ZSTD_getErrorName(long code);
 
-        long ZSTD_decompress(ByteBuffer dst, int dstLen, ByteBuffer src, int srcLen);
+        long ZSTD_decompress(Pointer dst, int dstLen, Pointer src, int srcLen);
     }
 
     private final NativeFunctions functions;
@@ -41,8 +41,18 @@ class JnaZstdLibrary implements ZstdLibrary {
     }
 
     @Override
-    public long compress(ByteBuffer dst, ByteBuffer src, int compressionLevel) {
-        return functions.ZSTD_compress(dst, dst.remaining(), src, src.remaining(), compressionLevel);
+    public long compress(CloseableByteBuffer dst, CloseableByteBuffer src, int compressionLevel) {
+        assert dst instanceof JnaCloseableByteBuffer;
+        assert src instanceof JnaCloseableByteBuffer;
+        var nativeDst = (JnaCloseableByteBuffer) dst;
+        var nativeSrc = (JnaCloseableByteBuffer) src;
+        return functions.ZSTD_compress(
+            nativeDst.memory.share(dst.buffer().position()),
+            dst.buffer().remaining(),
+            nativeSrc.memory.share(src.buffer().position()),
+            src.buffer().remaining(),
+            compressionLevel
+        );
     }
 
     @Override
@@ -56,7 +66,16 @@ class JnaZstdLibrary implements ZstdLibrary {
     }
 
     @Override
-    public long decompress(ByteBuffer dst, ByteBuffer src) {
-        return functions.ZSTD_decompress(dst, dst.remaining(), src, src.remaining());
+    public long decompress(CloseableByteBuffer dst, CloseableByteBuffer src) {
+        assert dst instanceof JnaCloseableByteBuffer;
+        assert src instanceof JnaCloseableByteBuffer;
+        var nativeDst = (JnaCloseableByteBuffer) dst;
+        var nativeSrc = (JnaCloseableByteBuffer) src;
+        return functions.ZSTD_decompress(
+            nativeDst.memory.share(dst.buffer().position()),
+            dst.buffer().remaining(),
+            nativeSrc.memory.share(src.buffer().position()),
+            src.buffer().remaining()
+        );
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/Zstd.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/Zstd.java
@@ -25,13 +25,13 @@ public final class Zstd {
      * Compress the content of {@code src} into {@code dst} at compression level {@code level}, and return the number of compressed bytes.
      * {@link ByteBuffer#position()} and {@link ByteBuffer#limit()} of both {@link ByteBuffer}s are left unmodified.
      */
-    public int compress(ByteBuffer dst, ByteBuffer src, int level) {
+    public int compress(CloseableByteBuffer dst, CloseableByteBuffer src, int level) {
         Objects.requireNonNull(dst, "Null destination buffer");
         Objects.requireNonNull(src, "Null source buffer");
-        assert dst.isDirect();
+        /*assert dst.isDirect();
         assert dst.isReadOnly() == false;
         assert src.isDirect();
-        assert src.isReadOnly() == false;
+        assert src.isReadOnly() == false;*/
         long ret = zstdLib.compress(dst, src, level);
         if (zstdLib.isError(ret)) {
             throw new IllegalArgumentException(zstdLib.getErrorName(ret));
@@ -45,13 +45,13 @@ public final class Zstd {
      * Compress the content of {@code src} into {@code dst}, and return the number of decompressed bytes. {@link ByteBuffer#position()} and
      * {@link ByteBuffer#limit()} of both {@link ByteBuffer}s are left unmodified.
      */
-    public int decompress(ByteBuffer dst, ByteBuffer src) {
+    public int decompress(CloseableByteBuffer dst, CloseableByteBuffer src) {
         Objects.requireNonNull(dst, "Null destination buffer");
         Objects.requireNonNull(src, "Null source buffer");
-        assert dst.isDirect();
+        /*assert dst.isDirect();
         assert dst.isReadOnly() == false;
         assert src.isDirect();
-        assert src.isReadOnly() == false;
+        assert src.isReadOnly() == false;*/
         long ret = zstdLib.decompress(dst, src);
         if (zstdLib.isError(ret)) {
             throw new IllegalArgumentException(zstdLib.getErrorName(ret));

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/Zstd.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/Zstd.java
@@ -28,10 +28,6 @@ public final class Zstd {
     public int compress(CloseableByteBuffer dst, CloseableByteBuffer src, int level) {
         Objects.requireNonNull(dst, "Null destination buffer");
         Objects.requireNonNull(src, "Null source buffer");
-        /*assert dst.isDirect();
-        assert dst.isReadOnly() == false;
-        assert src.isDirect();
-        assert src.isReadOnly() == false;*/
         long ret = zstdLib.compress(dst, src, level);
         if (zstdLib.isError(ret)) {
             throw new IllegalArgumentException(zstdLib.getErrorName(ret));
@@ -48,10 +44,6 @@ public final class Zstd {
     public int decompress(CloseableByteBuffer dst, CloseableByteBuffer src) {
         Objects.requireNonNull(dst, "Null destination buffer");
         Objects.requireNonNull(src, "Null source buffer");
-        /*assert dst.isDirect();
-        assert dst.isReadOnly() == false;
-        assert src.isDirect();
-        assert src.isReadOnly() == false;*/
         long ret = zstdLib.decompress(dst, src);
         if (zstdLib.isError(ret)) {
             throw new IllegalArgumentException(zstdLib.getErrorName(ret));

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/ZstdLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/ZstdLibrary.java
@@ -8,17 +8,17 @@
 
 package org.elasticsearch.nativeaccess.lib;
 
-import java.nio.ByteBuffer;
+import org.elasticsearch.nativeaccess.CloseableByteBuffer;
 
 public non-sealed interface ZstdLibrary extends NativeLibrary {
 
     long compressBound(int scrLen);
 
-    long compress(ByteBuffer dst, ByteBuffer src, int compressionLevel);
+    long compress(CloseableByteBuffer dst, CloseableByteBuffer src, int compressionLevel);
 
     boolean isError(long code);
 
     String getErrorName(long code);
 
-    long decompress(ByteBuffer dst, ByteBuffer src);
+    long decompress(CloseableByteBuffer dst, CloseableByteBuffer src);
 }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkCloseableByteBuffer.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkCloseableByteBuffer.java
@@ -11,15 +11,18 @@ package org.elasticsearch.nativeaccess.jdk;
 import org.elasticsearch.nativeaccess.CloseableByteBuffer;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
 import java.nio.ByteBuffer;
 
 class JdkCloseableByteBuffer implements CloseableByteBuffer {
     private final Arena arena;
+    final MemorySegment segment;
     private final ByteBuffer bufferView;
 
     JdkCloseableByteBuffer(int len) {
         this.arena = Arena.ofShared();
-        this.bufferView = this.arena.allocate(len).asByteBuffer();
+        this.segment = arena.allocate(len);
+        this.bufferView = segment.asByteBuffer();
     }
 
     @Override

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -8,12 +8,12 @@
 
 package org.elasticsearch.nativeaccess.jdk;
 
+import org.elasticsearch.nativeaccess.CloseableByteBuffer;
 import org.elasticsearch.nativeaccess.lib.ZstdLibrary;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
-import java.nio.ByteBuffer;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
@@ -49,11 +49,15 @@ class JdkZstdLibrary implements ZstdLibrary {
     }
 
     @Override
-    public long compress(ByteBuffer dst, ByteBuffer src, int compressionLevel) {
-        var nativeDst = MemorySegment.ofBuffer(dst);
-        var nativeSrc = MemorySegment.ofBuffer(src);
+    public long compress(CloseableByteBuffer dst, CloseableByteBuffer src, int compressionLevel) {
+        assert dst instanceof JdkCloseableByteBuffer;
+        assert src instanceof JdkCloseableByteBuffer;
+        var nativeDst = (JdkCloseableByteBuffer) dst;
+        var nativeSrc = (JdkCloseableByteBuffer) src;
+        var segmentDst = nativeDst.segment.asSlice(dst.buffer().position(), dst.buffer().remaining());
+        var segmentSrc = nativeSrc.segment.asSlice(src.buffer().position(), src.buffer().remaining());
         try {
-            return (long) compress$mh.invokeExact(nativeDst, dst.remaining(), nativeSrc, src.remaining(), compressionLevel);
+            return (long) compress$mh.invokeExact(segmentDst, segmentDst.byteSize(), segmentSrc, segmentSrc.byteSize(), compressionLevel);
         } catch (Throwable t) {
             throw new AssertionError(t);
         }
@@ -79,11 +83,15 @@ class JdkZstdLibrary implements ZstdLibrary {
     }
 
     @Override
-    public long decompress(ByteBuffer dst, ByteBuffer src) {
-        var nativeDst = MemorySegment.ofBuffer(dst);
-        var nativeSrc = MemorySegment.ofBuffer(src);
+    public long decompress(CloseableByteBuffer dst, CloseableByteBuffer src) {
+        assert dst instanceof JdkCloseableByteBuffer;
+        assert src instanceof JdkCloseableByteBuffer;
+        var nativeDst = (JdkCloseableByteBuffer) dst;
+        var nativeSrc = (JdkCloseableByteBuffer) src;
+        var segmentDst = nativeDst.segment.asSlice(dst.buffer().position(), dst.buffer().remaining());
+        var segmentSrc = nativeSrc.segment.asSlice(src.buffer().position(), src.buffer().remaining());
         try {
-            return (long) decompress$mh.invokeExact(nativeDst, dst.remaining(), nativeSrc, src.remaining());
+            return (long) decompress$mh.invokeExact(segmentDst, segmentDst.byteSize(), segmentSrc, segmentSrc.byteSize());
         } catch (Throwable t) {
             throw new AssertionError(t);
         }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkZstdLibrary.java
@@ -54,10 +54,12 @@ class JdkZstdLibrary implements ZstdLibrary {
         assert src instanceof JdkCloseableByteBuffer;
         var nativeDst = (JdkCloseableByteBuffer) dst;
         var nativeSrc = (JdkCloseableByteBuffer) src;
-        var segmentDst = nativeDst.segment.asSlice(dst.buffer().position(), dst.buffer().remaining());
-        var segmentSrc = nativeSrc.segment.asSlice(src.buffer().position(), src.buffer().remaining());
+        var dstSize = dst.buffer().remaining();
+        var srcSize = src.buffer().remaining();
+        var segmentDst = nativeDst.segment.asSlice(dst.buffer().position(), dstSize);
+        var segmentSrc = nativeSrc.segment.asSlice(src.buffer().position(), srcSize);
         try {
-            return (long) compress$mh.invokeExact(segmentDst, segmentDst.byteSize(), segmentSrc, segmentSrc.byteSize(), compressionLevel);
+            return (long) compress$mh.invokeExact(segmentDst, dstSize, segmentSrc, srcSize, compressionLevel);
         } catch (Throwable t) {
             throw new AssertionError(t);
         }
@@ -88,10 +90,12 @@ class JdkZstdLibrary implements ZstdLibrary {
         assert src instanceof JdkCloseableByteBuffer;
         var nativeDst = (JdkCloseableByteBuffer) dst;
         var nativeSrc = (JdkCloseableByteBuffer) src;
-        var segmentDst = nativeDst.segment.asSlice(dst.buffer().position(), dst.buffer().remaining());
-        var segmentSrc = nativeSrc.segment.asSlice(src.buffer().position(), src.buffer().remaining());
+        var dstSize = dst.buffer().remaining();
+        var srcSize = src.buffer().remaining();
+        var segmentDst = nativeDst.segment.asSlice(dst.buffer().position(), dstSize);
+        var segmentSrc = nativeSrc.segment.asSlice(src.buffer().position(), srcSize);
         try {
-            return (long) decompress$mh.invokeExact(segmentDst, segmentDst.byteSize(), segmentSrc, segmentSrc.byteSize());
+            return (long) decompress$mh.invokeExact(segmentDst, dstSize, segmentSrc, srcSize);
         } catch (Throwable t) {
             throw new AssertionError(t);
         }


### PR DESCRIPTION
CloseableByteBuffer is backed by native memory segments, but the interfaces for compress and decompress methods of zstd take ByteBuffer. Although both Jna and the Jdk can deal with turning the native ByteBuffer back into an address to pass to the native method, the jdk may have a more significant cost to that action.

This commit changes the signature of compress and decompress to take in CloseableByteBuffer so that each implementation can do its own unwrapping to get the appropriate native address.

relates #103374