### PR TITLE
Refactor MultiBucketAggregatorsReducer and DelayedMultiBucketAggregatorsReducer

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
@@ -11,20 +11,20 @@ package org.elasticsearch.aggregations.bucket.adjacency;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.common.util.ObjectObjectPagedHashMap;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.bucket.MultiBucketAggregatorsReducer;
+import org.elasticsearch.search.aggregations.bucket.BucketReducer;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -180,28 +180,40 @@ public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<Inte
     @Override
     protected AggregatorReducer getLeaderReducer(AggregationReduceContext reduceContext, int size) {
         return new AggregatorReducer() {
-            final Map<String, MultiBucketAggregatorsReducer> bucketsReducer = new HashMap<>(getBuckets().size());
+            final ObjectObjectPagedHashMap<String, BucketReducer<InternalBucket>> bucketsReducer = new ObjectObjectPagedHashMap<>(
+                getBuckets().size(),
+                reduceContext.bigArrays()
+            );
 
             @Override
             public void accept(InternalAggregation aggregation) {
                 final InternalAdjacencyMatrix filters = (InternalAdjacencyMatrix) aggregation;
                 for (InternalBucket bucket : filters.buckets) {
-                    MultiBucketAggregatorsReducer reducer = bucketsReducer.computeIfAbsent(
-                        bucket.key,
-                        k -> new MultiBucketAggregatorsReducer(reduceContext, size)
-                    );
+                    BucketReducer<InternalBucket> reducer = bucketsReducer.get(bucket.key);
+                    if (reducer == null) {
+                        reducer = new BucketReducer<>(bucket, reduceContext, size);
+                        boolean success = false;
+                        try {
+                            bucketsReducer.put(bucket.key, reducer);
+                            success = true;
+                        } finally {
+                            if (success == false) {
+                                Releasables.close(reducer);
+                            }
+                        }
+                    }
                     reducer.accept(bucket);
                 }
             }
 
             @Override
             public InternalAggregation get() {
-                List<InternalBucket> reducedBuckets = new ArrayList<>(bucketsReducer.size());
-                for (Map.Entry<String, MultiBucketAggregatorsReducer> entry : bucketsReducer.entrySet()) {
-                    if (entry.getValue().getDocCount() >= 1) {
-                        reducedBuckets.add(new InternalBucket(entry.getKey(), entry.getValue().getDocCount(), entry.getValue().get()));
+                List<InternalBucket> reducedBuckets = new ArrayList<>((int) bucketsReducer.size());
+                bucketsReducer.forEach(entry -> {
+                    if (entry.value.getDocCount() >= 1) {
+                        reducedBuckets.add(new InternalBucket(entry.key, entry.value.getDocCount(), entry.value.getAggregations()));
                     }
-                }
+                });
                 reduceContext.consumeBucketsAndMaybeBreak(reducedBuckets.size());
                 reducedBuckets.sort(Comparator.comparing(InternalBucket::getKey));
                 return new InternalAdjacencyMatrix(name, reducedBuckets, getMetadata());
@@ -209,7 +221,8 @@ public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<Inte
 
             @Override
             public void close() {
-                Releasables.close(bucketsReducer.values());
+                bucketsReducer.forEach(entry -> Releasables.close(entry.value));
+                Releasables.close(bucketsReducer);
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketReducer.java
@@ -15,32 +15,42 @@ import org.elasticsearch.search.aggregations.AggregatorsReducer;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 
 /**
- *  Class for reducing a list of {@link MultiBucketsAggregation.Bucket} to a single
- *  {@link InternalAggregations} and the number of documents.
+ *  Class for reducing a list of {@link B} to a single {@link InternalAggregations}
+ *  and the number of documents.
  */
-public final class MultiBucketAggregatorsReducer implements Releasable {
+public final class BucketReducer<B extends MultiBucketsAggregation.Bucket> implements Releasable {
 
     private final AggregatorsReducer aggregatorsReducer;
+    private final B proto;
     private long count = 0;
 
-    public MultiBucketAggregatorsReducer(AggregationReduceContext context, int size) {
+    public BucketReducer(B proto, AggregationReduceContext context, int size) {
         this.aggregatorsReducer = new AggregatorsReducer(context, size);
+        this.proto = proto;
     }
 
     /**
-     * Adds a {@link MultiBucketsAggregation.Bucket} for reduction.
+     * Adds a {@link B} for reduction.
      */
-    public void accept(MultiBucketsAggregation.Bucket bucket) {
+    public void accept(B bucket) {
+        assert bucket.getKey().equals(proto.getKey())
+            : "expected bucket with key [" + proto.getKeyAsString() + "], got [" + bucket.getKeyAsString() + "]";
         count += bucket.getDocCount();
         aggregatorsReducer.accept(bucket.getAggregations());
     }
 
     /**
+     * returns the bucket prototype.
+     */
+    public B getProto() {
+        return proto;
+    }
+
+    /**
      * returns the reduced {@link InternalAggregations}.
      */
-    public InternalAggregations get() {
+    public InternalAggregations getAggregations() {
         return aggregatorsReducer.get();
-
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketReducer.java
@@ -33,8 +33,6 @@ public final class BucketReducer<B extends MultiBucketsAggregation.Bucket> imple
      * Adds a {@link B} for reduction.
      */
     public void accept(B bucket) {
-        assert bucket.getKey().equals(proto.getKey())
-            : "expected bucket with key [" + proto.getKeyAsString() + "], got [" + bucket.getKeyAsString() + "]";
         count += bucket.getDocCount();
         aggregatorsReducer.accept(bucket.getAggregations());
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DelayedBucketReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DelayedBucketReducer.java
@@ -43,8 +43,6 @@ public final class DelayedBucketReducer<B extends MultiBucketsAggregation.Bucket
      * Adds a {@link B} for reduction.
      */
     public void accept(B bucket) {
-        assert bucket.getKey().equals(proto.getKey())
-            : "expected bucket with key [" + proto.getKeyAsString() + "], got [" + bucket.getKeyAsString() + "]";
         count += bucket.getDocCount();
         internalAggregations.add(bucket.getAggregations());
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DelayedBucketReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DelayedBucketReducer.java
@@ -19,14 +19,15 @@ import java.util.List;
  *  Class for reducing a list of {@link B} to a single {@link InternalAggregations}
  *  and the number of documents in a delayable fashion.
  *
- *  This class can be reused by calling {@link #reset()}.
+ *  This class can be reused by calling {@link #reset(B)}.
  *
  * @see BucketReducer
  */
 public final class DelayedBucketReducer<B extends MultiBucketsAggregation.Bucket> {
 
     private final AggregationReduceContext context;
-    private final B proto;
+    // changes at reset time
+    private B proto;
     // the maximum size of this array is the number of shards to be reduced. We currently do it in a batches of 256
     // by default. if we expect bigger batches, we might consider to use ObjectArray.
     private final List<InternalAggregations> internalAggregations;
@@ -58,7 +59,8 @@ public final class DelayedBucketReducer<B extends MultiBucketsAggregation.Bucket
     /**
      * Reset the content of this reducer.
      */
-    public void reset() {
+    public void reset(B proto) {
+        this.proto = proto;
         count = 0L;
         internalAggregations.clear();
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DelayedBucketReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DelayedBucketReducer.java
@@ -16,32 +16,43 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- *  Class for reducing a list of {@link MultiBucketsAggregation.Bucket} to a single
- *  {@link InternalAggregations} and the number of documents in a delayable fashion.
+ *  Class for reducing a list of {@link B} to a single {@link InternalAggregations}
+ *  and the number of documents in a delayable fashion.
  *
  *  This class can be reused by calling {@link #reset()}.
  *
- * @see MultiBucketAggregatorsReducer
+ * @see BucketReducer
  */
-public final class DelayedMultiBucketAggregatorsReducer {
+public final class DelayedBucketReducer<B extends MultiBucketsAggregation.Bucket> {
 
     private final AggregationReduceContext context;
+    private final B proto;
     // the maximum size of this array is the number of shards to be reduced. We currently do it in a batches of 256
-    // if we expect bigger batches, we might consider to use ObjectArray.
+    // by default. if we expect bigger batches, we might consider to use ObjectArray.
     private final List<InternalAggregations> internalAggregations;
     private long count = 0;
 
-    public DelayedMultiBucketAggregatorsReducer(AggregationReduceContext context) {
+    public DelayedBucketReducer(B proto, AggregationReduceContext context) {
+        this.proto = proto;
         this.context = context;
         this.internalAggregations = new ArrayList<>();
     }
 
     /**
-     * Adds a {@link MultiBucketsAggregation.Bucket} for reduction.
+     * Adds a {@link B} for reduction.
      */
-    public void accept(MultiBucketsAggregation.Bucket bucket) {
+    public void accept(B bucket) {
+        assert bucket.getKey().equals(proto.getKey())
+            : "expected bucket with key [" + proto.getKeyAsString() + "], got [" + bucket.getKeyAsString() + "]";
         count += bucket.getDocCount();
         internalAggregations.add(bucket.getAggregations());
+    }
+
+    /**
+     * returns the bucket prototype.
+     */
+    public B getProto() {
+        return proto;
     }
 
     /**
@@ -55,7 +66,7 @@ public final class DelayedMultiBucketAggregatorsReducer {
     /**
      * returns the reduced {@link InternalAggregations}.
      */
-    public InternalAggregations get() {
+    public InternalAggregations getAggregations() {
         try (AggregatorsReducer aggregatorsReducer = new AggregatorsReducer(context, internalAggregations.size())) {
             for (InternalAggregations agg : internalAggregations) {
                 aggregatorsReducer.accept(agg);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/FixedMultiBucketAggregatorsReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/FixedMultiBucketAggregatorsReducer.java
@@ -23,15 +23,13 @@ import java.util.List;
 public abstract class FixedMultiBucketAggregatorsReducer<B extends MultiBucketsAggregation.Bucket> implements Releasable {
 
     // we could use an ObjectArray here but these arrays are in normally small, so it is not worthy
-    private final MultiBucketAggregatorsReducer[] bucketsReducer;
-    private final List<B> protoList;
+    private final List<BucketReducer<B>> bucketReducer;
 
     public FixedMultiBucketAggregatorsReducer(AggregationReduceContext reduceContext, int size, List<B> protoList) {
         reduceContext.consumeBucketsAndMaybeBreak(protoList.size());
-        this.protoList = protoList;
-        this.bucketsReducer = new MultiBucketAggregatorsReducer[protoList.size()];
+        this.bucketReducer = new ArrayList<>(protoList.size());
         for (int i = 0; i < protoList.size(); ++i) {
-            bucketsReducer[i] = new MultiBucketAggregatorsReducer(reduceContext, size);
+            bucketReducer.add(new BucketReducer<>(protoList.get(i), reduceContext, size));
         }
     }
 
@@ -40,10 +38,10 @@ public abstract class FixedMultiBucketAggregatorsReducer<B extends MultiBucketsA
      * of the list passed on the constructor
      */
     public final void accept(List<B> buckets) {
-        assert buckets.size() == protoList.size();
-        int i = 0;
-        for (B bucket : buckets) {
-            bucketsReducer[i++].accept(bucket);
+        assert buckets.size() == bucketReducer.size();
+        for (int i = 0; i < buckets.size(); i++) {
+            assert bucketReducer.get(i).getProto().getKey().equals(buckets.get(i).getKey());
+            bucketReducer.get(i).accept(buckets.get(i));
         }
     }
 
@@ -51,19 +49,17 @@ public abstract class FixedMultiBucketAggregatorsReducer<B extends MultiBucketsA
      * returns the reduced buckets.
      */
     public final List<B> get() {
-        final List<B> reduceBuckets = new ArrayList<>(protoList.size());
-        for (int i = 0; i < protoList.size(); i++) {
-            final B proto = protoList.get(i);
-            final MultiBucketAggregatorsReducer reducer = bucketsReducer[i];
-            reduceBuckets.add(createBucket(proto, reducer.getDocCount(), reducer.get()));
+        final List<B> reduceBuckets = new ArrayList<>(bucketReducer.size());
+        for (final BucketReducer<B> reducer : bucketReducer) {
+            reduceBuckets.add(createBucket(reducer.getProto(), reducer.getDocCount(), reducer.getAggregations()));
         }
         return reduceBuckets;
     }
 
-    protected abstract B createBucket(B proto, long focCount, InternalAggregations aggregations);
+    protected abstract B createBucket(B proto, long docCount, InternalAggregations aggregations);
 
     @Override
     public final void close() {
-        Releasables.close(bucketsReducer);
+        Releasables.close(bucketReducer);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/FixedMultiBucketAggregatorsReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/FixedMultiBucketAggregatorsReducer.java
@@ -40,7 +40,6 @@ public abstract class FixedMultiBucketAggregatorsReducer<B extends MultiBucketsA
     public final void accept(List<B> buckets) {
         assert buckets.size() == bucketReducer.size();
         for (int i = 0; i < buckets.size(); i++) {
-            assert bucketReducer.get(i).getProto().getKey().equals(buckets.get(i).getKey());
             bucketReducer.get(i).accept(buckets.get(i));
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -22,7 +22,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.KeyComparable;
-import org.elasticsearch.search.aggregations.bucket.DelayedMultiBucketAggregatorsReducer;
+import org.elasticsearch.search.aggregations.bucket.DelayedBucketReducer;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -257,7 +257,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
     }
 
     private class BucketsQueue implements Releasable {
-        private final ObjectObjectPagedHashMap<Object, DelayedMultiBucketAggregatorsReducer> bucketReducers;
+        private final ObjectObjectPagedHashMap<Object, DelayedBucketReducer<InternalBucket>> bucketReducers;
         private final ObjectArrayPriorityQueue<InternalBucket> queue;
         private final AggregationReduceContext reduceContext;
 
@@ -274,12 +274,12 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
 
         /** adds a bucket to the queue. Return false if the bucket is not competitive, otherwise true.*/
         boolean add(InternalBucket bucket) {
-            DelayedMultiBucketAggregatorsReducer delayed = bucketReducers.get(bucket.key);
+            DelayedBucketReducer<InternalBucket> delayed = bucketReducers.get(bucket.key);
             if (delayed == null) {
                 final InternalBucket out = queue.insertWithOverflow(bucket);
                 if (out == null) {
                     // bucket is added
-                    delayed = new DelayedMultiBucketAggregatorsReducer(reduceContext);
+                    delayed = new DelayedBucketReducer<>(bucket, reduceContext);
                 } else if (out == bucket) {
                     // bucket is not competitive
                     return false;
@@ -307,7 +307,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
                  * just whatever formats make sense for *its* index. This can be real
                  * trouble when the index doing the reducing is unmapped. */
                 final var reducedFormats = bucket.formats;
-                final DelayedMultiBucketAggregatorsReducer reducer = Objects.requireNonNull(bucketReducers.get(bucket.key));
+                final DelayedBucketReducer<InternalBucket> reducer = Objects.requireNonNull(bucketReducers.get(bucket.key));
                 result[i] = new InternalBucket(
                     sourceNames,
                     reducedFormats,
@@ -315,7 +315,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
                     reverseMuls,
                     missingOrders,
                     reducer.getDocCount(),
-                    reducer.get()
+                    reducer.getAggregations()
                 );
             }
             return List.of(result);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -287,7 +287,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
                     // bucket replaces existing bucket
                     delayed = bucketReducers.remove(out.key);
                     assert delayed != null;
-                    delayed.reset();
+                    delayed.reset(bucket);
                 }
                 bucketReducers.put(bucket.key, delayed);
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/LongKeyedMultiBucketsAggregatorReducer.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/LongKeyedMultiBucketsAggregatorReducer.java
@@ -13,7 +13,7 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
-import org.elasticsearch.search.aggregations.bucket.MultiBucketAggregatorsReducer;
+import org.elasticsearch.search.aggregations.bucket.BucketReducer;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ abstract class LongKeyedMultiBucketsAggregatorReducer<B extends MultiBucketsAggr
     private final AggregationReduceContext reduceContext;
     private final int size;
     private final long minDocCount;
-    private final LongObjectPagedHashMap<MultiBucketAggregatorsReducer> bucketsReducer;
+    private final LongObjectPagedHashMap<BucketReducer<B>> bucketsReducer;
     int consumeBucketCount = 0;
 
     LongKeyedMultiBucketsAggregatorReducer(AggregationReduceContext reduceContext, int size, long minDocCount) {
@@ -42,16 +42,16 @@ abstract class LongKeyedMultiBucketsAggregatorReducer<B extends MultiBucketsAggr
      * The bucket to reduce with its corresponding long key.
      */
     public final void accept(long key, B bucket) {
-        MultiBucketAggregatorsReducer reducer = bucketsReducer.get(key);
+        BucketReducer<B> reducer = bucketsReducer.get(key);
         if (reducer == null) {
-            reducer = new MultiBucketAggregatorsReducer(reduceContext, size);
+            reducer = new BucketReducer<>(bucket, reduceContext, size);
             bucketsReducer.put(key, reducer);
         }
         consumeBucketsAndMaybeBreak(reducer, bucket);
         reducer.accept(bucket);
     }
 
-    private void consumeBucketsAndMaybeBreak(MultiBucketAggregatorsReducer reducer, B bucket) {
+    private void consumeBucketsAndMaybeBreak(BucketReducer<B> reducer, B bucket) {
         if (reduceContext.isFinalReduce() == false || minDocCount == 0) {
             if (reducer.getDocCount() == 0 && bucket.getDocCount() > 0) {
                 consumeBucketsAndMaybeBreak();
@@ -76,9 +76,9 @@ abstract class LongKeyedMultiBucketsAggregatorReducer<B extends MultiBucketsAggr
     public final List<B> get() {
         reduceContext.consumeBucketsAndMaybeBreak(consumeBucketCount);
         final List<B> reducedBuckets = new ArrayList<>((int) bucketsReducer.size());
-        bucketsReducer.iterator().forEachRemaining(entry -> {
+        bucketsReducer.forEach(entry -> {
             if (reduceContext.isFinalReduce() == false || entry.value.getDocCount() >= minDocCount) {
-                reducedBuckets.add(createBucket(entry.key, entry.value.getDocCount(), entry.value.get()));
+                reducedBuckets.add(createBucket(entry.key, entry.value.getDocCount(), entry.value.getAggregations()));
             }
         });
         return reducedBuckets;
@@ -91,7 +91,7 @@ abstract class LongKeyedMultiBucketsAggregatorReducer<B extends MultiBucketsAggr
 
     @Override
     public final void close() {
-        bucketsReducer.iterator().forEachRemaining(r -> Releasables.close(r.value));
+        bucketsReducer.forEach(r -> Releasables.close(r.value));
         Releasables.close(bucketsReducer);
     }
 }


### PR DESCRIPTION
Small refactor of those classes. They are renamed to BucketReducer DelayedBucketReducer and they have a new property containing the prototype bucket. This is useful because it allows us to check we are doing the right thing with asserting the incoming buckets and it is useful most of the times to create the reduced bucket. Later, it might hekp us giving those object the capability of using Bucket ordering.

There are other small improvements,  in particular InternalAdjacencyMatrix uses a ObjectObjectPagedHashMap instead of a java hashmap.