### PR TITLE
Print out state of index if didn't recover from the snapshot

### DIFF
--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -986,7 +986,11 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         if (waitForSnapshotDownloadToStart) {
             // must complete using snapshots alone.
             RecoveryState recoveryState = getLatestPeerRecoveryStateForShard(indexName, 0);
-            assertThat(recoveryState.getIndex().recoveredFromSnapshotBytes(), equalTo(snapshotSizeForIndex));
+            assertThat(
+                "Index " + recoveryState.getIndex() + " should be completely recovered from the snapshot",
+                recoveryState.getIndex().recoveredFromSnapshotBytes(),
+                equalTo(snapshotSizeForIndex)
+            );
         }
 
         assertDocumentsAreEqual(indexName, numDocs.get());


### PR DESCRIPTION
Add additional debug information about the index and its recovery state if the assertion for `recoveredFromSnapshotBytes` fails

See #87568

