### PR TITLE
Set index mode earlier for new downsample index

### DIFF
--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -808,8 +808,14 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
             .put(IndexMetadata.INDEX_DOWNSAMPLE_INTERVAL.getKey(), downsampleInterval)
             .put(IndexSettings.MODE.getKey(), sourceIndexMetadata.getIndexMode())
             .putList(IndexMetadata.INDEX_ROUTING_PATH.getKey(), sourceIndexMetadata.getRoutingPaths())
-            .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), sourceIndexMetadata.getSettings().get(IndexSettings.TIME_SERIES_START_TIME.getKey()))
-            .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), sourceIndexMetadata.getSettings().get(IndexSettings.TIME_SERIES_END_TIME.getKey()));
+            .put(
+                IndexSettings.TIME_SERIES_START_TIME.getKey(),
+                sourceIndexMetadata.getSettings().get(IndexSettings.TIME_SERIES_START_TIME.getKey())
+            )
+            .put(
+                IndexSettings.TIME_SERIES_END_TIME.getKey(),
+                sourceIndexMetadata.getSettings().get(IndexSettings.TIME_SERIES_END_TIME.getKey())
+            );
         if (sourceIndexMetadata.getSettings().hasValue(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey())) {
             builder.put(
                 MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(),

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -805,7 +805,11 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
             .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, String.valueOf(numberOfReplicas))
             .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "-1")
             .put(IndexMetadata.INDEX_DOWNSAMPLE_STATUS.getKey(), DownsampleTaskStatus.STARTED)
-            .put(IndexMetadata.INDEX_DOWNSAMPLE_INTERVAL.getKey(), downsampleInterval);
+            .put(IndexMetadata.INDEX_DOWNSAMPLE_INTERVAL.getKey(), downsampleInterval)
+            .put(IndexSettings.MODE.getKey(), sourceIndexMetadata.getIndexMode())
+            .putList(IndexMetadata.INDEX_ROUTING_PATH.getKey(), sourceIndexMetadata.getRoutingPaths())
+            .put(IndexSettings.TIME_SERIES_START_TIME.getKey(), sourceIndexMetadata.getSettings().get(IndexSettings.TIME_SERIES_START_TIME.getKey()))
+            .put(IndexSettings.TIME_SERIES_END_TIME.getKey(), sourceIndexMetadata.getSettings().get(IndexSettings.TIME_SERIES_END_TIME.getKey()));
         if (sourceIndexMetadata.getSettings().hasValue(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey())) {
             builder.put(
                 MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(),


### PR DESCRIPTION
Downsample index is created using temporary index service using a 
static predefined subset of index settings. All other settings are later
 copied over from source index. As discovered in #106338 this causes 
 context like index mode to be missing during initial index creation 
 process. This PR adds index mode and related required settings to 
 initial set of index settings in order to have access to this 
 information during initial create index operation.