### PR TITLE
[8.13] Improve error message when rolling over DS alias (#106708)

### DIFF
--- a/docs/changelog/106708.yaml
+++ b/docs/changelog/106708.yaml
@@ -1,0 +1,6 @@
+pr: 106708
+summary: Improve error message when rolling over DS alias
+area: Data streams
+type: bug
+issues:
+ - 106137

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -205,6 +205,16 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
             }
         }
 
+        final IndexAbstraction rolloverTargetAbstraction = clusterState.metadata()
+            .getIndicesLookup()
+            .get(rolloverRequest.getRolloverTarget());
+        if (rolloverTargetAbstraction.getType() == IndexAbstraction.Type.ALIAS && rolloverTargetAbstraction.isDataStreamRelated()) {
+            listener.onFailure(
+                new IllegalStateException("Aliases to data streams cannot be rolled over. Please rollover the data stream itself.")
+            );
+            return;
+        }
+
         IndicesStatsRequest statsRequest = new IndicesStatsRequest().indices(rolloverRequest.getRolloverTarget())
             .clear()
             .indicesOptions(IndicesOptions.fromOptions(true, false, true, true))

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -570,8 +570,7 @@ public class TransportRolloverActionTests extends ESTestCase {
             rolloverService,
             mockClient,
             mockAllocationService,
-            mockMetadataDataStreamService,
-            dataStreamAutoShardingService
+            mockMetadataDataStreamService
         );
 
         final PlainActionFuture<RolloverResponse> future = new PlainActionFuture<>();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -540,6 +540,47 @@ public class TransportRolloverActionTests extends ESTestCase {
         }
     }
 
+    public void testRolloverAliasToDataStreamFails() throws Exception {
+        final IndexMetadata backingIndexMetadata = IndexMetadata.builder(".ds-logs-ds-000001")
+            .settings(settings(IndexVersion.current()))
+            .numberOfShards(1)
+            .numberOfReplicas(1)
+            .build();
+        final DataStream dataStream = new DataStream(
+            "logs-ds",
+            List.of(backingIndexMetadata.getIndex()),
+            1,
+            Map.of(),
+            false,
+            false,
+            false,
+            false,
+            IndexMode.STANDARD
+        );
+        Metadata.Builder metadataBuilder = Metadata.builder().put(backingIndexMetadata, false).put(dataStream);
+        metadataBuilder.put("ds-alias", dataStream.getName(), true, null);
+        final ClusterState stateBefore = ClusterState.builder(ClusterName.DEFAULT).metadata(metadataBuilder).build();
+
+        final TransportRolloverAction transportRolloverAction = new TransportRolloverAction(
+            mock(TransportService.class),
+            mockClusterService,
+            mockThreadPool,
+            mockActionFilters,
+            mockIndexNameExpressionResolver,
+            rolloverService,
+            mockClient,
+            mockAllocationService,
+            mockMetadataDataStreamService,
+            dataStreamAutoShardingService
+        );
+
+        final PlainActionFuture<RolloverResponse> future = new PlainActionFuture<>();
+        RolloverRequest rolloverRequest = new RolloverRequest("ds-alias", null);
+        transportRolloverAction.masterOperation(mock(CancellableTask.class), rolloverRequest, stateBefore, future);
+        IllegalStateException illegalStateException = expectThrows(IllegalStateException.class, future::actionGet);
+        assertThat(illegalStateException.getMessage(), containsString("Aliases to data streams cannot be rolled over."));
+    }
+
     private IndicesStatsResponse createIndicesStatResponse(String indexName, long totalDocs, long primariesDocs) {
         final CommonStats primaryStats = mock(CommonStats.class);
         when(primaryStats.getDocs()).thenReturn(new DocsStats(primariesDocs, 0, between(1, 10000)));


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Improve error message when rolling over DS alias (#106708)