### PR TITLE
Track memory in rate aggregation function

### DIFF
--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/GroupingAggregatorImplementer.java
@@ -100,7 +100,7 @@ public class GroupingAggregatorImplementer {
         this.createParameters = init.getParameters()
             .stream()
             .map(Parameter::from)
-            .filter(f -> false == f.type().equals(BIG_ARRAYS))
+            .filter(f -> false == f.type().equals(BIG_ARRAYS) && false == f.type().equals(DRIVER_CONTEXT))
             .collect(Collectors.toList());
 
         this.implementation = ClassName.get(

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongAggregator.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/RateLongAggregator.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.ann.GroupingAggregator;
@@ -35,9 +36,9 @@ import org.elasticsearch.core.Releasables;
         @IntermediateState(name = "resets", type = "DOUBLE") }
 )
 public class RateLongAggregator {
-    public static LongRateGroupingState initGrouping(BigArrays bigArrays, long unitInMillis) {
-        // TODO: pass BlockFactory instead bigArrays so we can use the breaker
-        return new LongRateGroupingState(bigArrays, unitInMillis);
+
+    public static LongRateGroupingState initGrouping(DriverContext driverContext, long unitInMillis) {
+        return new LongRateGroupingState(driverContext.bigArrays(), driverContext.breaker(), unitInMillis);
     }
 
     public static void combine(LongRateGroupingState current, int groupId, long timestamp, long value) {
@@ -68,7 +69,7 @@ public class RateLongAggregator {
         return state.evaluateFinal(selected, driverContext.blockFactory());
     }
 
-    private static class LongRateState implements Accountable {
+    private static class LongRateState {
         static final long BASE_RAM_USAGE = RamUsageEstimator.sizeOfObject(LongRateState.class);
         final long[] timestamps; // descending order
         final long[] values;
@@ -101,9 +102,10 @@ public class RateLongAggregator {
             return timestamps.length;
         }
 
-        @Override
-        public long ramBytesUsed() {
-            return BASE_RAM_USAGE;
+        static long bytesUsed(int entries) {
+            var ts = RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * entries);
+            var vs = RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * entries);
+            return BASE_RAM_USAGE + ts + vs;
         }
     }
 
@@ -111,9 +113,12 @@ public class RateLongAggregator {
         private ObjectArray<LongRateState> states;
         private final long unitInMillis;
         private final BigArrays bigArrays;
+        private final CircuitBreaker breaker;
+        private long stateBytes; // for individual states
 
-        LongRateGroupingState(BigArrays bigArrays, long unitInMillis) {
+        LongRateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, long unitInMillis) {
             this.bigArrays = bigArrays;
+            this.breaker = breaker;
             this.states = bigArrays.newObjectArray(1);
             this.unitInMillis = unitInMillis;
         }
@@ -122,16 +127,25 @@ public class RateLongAggregator {
             states = bigArrays.grow(states, groupId + 1);
         }
 
+        void adjustBreaker(long bytes) {
+            breaker.addEstimateBytesAndMaybeBreak(bytes, "<<rate aggregation>>");
+            stateBytes += bytes;
+            assert stateBytes >= 0 : stateBytes;
+        }
+
         void append(int groupId, long timestamp, long value) {
             ensureCapacity(groupId);
             var state = states.get(groupId);
             if (state == null) {
+                adjustBreaker(LongRateState.bytesUsed(1));
                 state = new LongRateState(new long[] { timestamp }, new long[] { value });
                 states.set(groupId, state);
             } else {
                 if (state.entries() == 1) {
+                    adjustBreaker(LongRateState.bytesUsed(2));
                     state = new LongRateState(new long[] { state.timestamps[0], timestamp }, new long[] { state.values[0], value });
                     states.set(groupId, state);
+                    adjustBreaker(-LongRateState.bytesUsed(1)); // old state
                 } else {
                     state.append(timestamp, value);
                 }
@@ -147,6 +161,7 @@ public class RateLongAggregator {
             ensureCapacity(groupId);
             var state = states.get(groupId);
             if (state == null) {
+                adjustBreaker(LongRateState.bytesUsed(valueCount));
                 state = new LongRateState(valueCount);
                 states.set(groupId, state);
                 // TODO: add bulk_copy to Block
@@ -155,9 +170,11 @@ public class RateLongAggregator {
                     state.values[i] = values.getLong(firstIndex + i);
                 }
             } else {
+                adjustBreaker(LongRateState.bytesUsed(state.entries() + valueCount));
                 var newState = new LongRateState(state.entries() + valueCount);
                 states.set(groupId, newState);
                 merge(state, newState, firstIndex, valueCount, timestamps, values);
+                adjustBreaker(-LongRateState.bytesUsed(state.entries())); // old state
             }
             state.reset += reset;
         }
@@ -193,12 +210,12 @@ public class RateLongAggregator {
 
         @Override
         public long ramBytesUsed() {
-            return states.ramBytesUsed();
+            return states.ramBytesUsed() + stateBytes;
         }
 
         @Override
         public void close() {
-            Releasables.close(states);
+            Releasables.close(states, () -> adjustBreaker(-stateBytes));
         }
 
         @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateDoubleGroupingAggregatorFunction.java
@@ -49,7 +49,7 @@ public final class RateDoubleGroupingAggregatorFunction implements GroupingAggre
 
   public static RateDoubleGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, long unitInMillis) {
-    return new RateDoubleGroupingAggregatorFunction(channels, RateDoubleAggregator.initGrouping(driverContext.bigArrays(), unitInMillis), driverContext, unitInMillis);
+    return new RateDoubleGroupingAggregatorFunction(channels, RateDoubleAggregator.initGrouping(driverContext, unitInMillis), driverContext, unitInMillis);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateIntGroupingAggregatorFunction.java
@@ -49,7 +49,7 @@ public final class RateIntGroupingAggregatorFunction implements GroupingAggregat
 
   public static RateIntGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, long unitInMillis) {
-    return new RateIntGroupingAggregatorFunction(channels, RateIntAggregator.initGrouping(driverContext.bigArrays(), unitInMillis), driverContext, unitInMillis);
+    return new RateIntGroupingAggregatorFunction(channels, RateIntAggregator.initGrouping(driverContext, unitInMillis), driverContext, unitInMillis);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/RateLongGroupingAggregatorFunction.java
@@ -49,7 +49,7 @@ public final class RateLongGroupingAggregatorFunction implements GroupingAggrega
 
   public static RateLongGroupingAggregatorFunction create(List<Integer> channels,
       DriverContext driverContext, long unitInMillis) {
-    return new RateLongGroupingAggregatorFunction(channels, RateLongAggregator.initGrouping(driverContext.bigArrays(), unitInMillis), driverContext, unitInMillis);
+    return new RateLongGroupingAggregatorFunction(channels, RateLongAggregator.initGrouping(driverContext, unitInMillis), driverContext, unitInMillis);
   }
 
   public static List<IntermediateStateDesc> intermediateStateDesc() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateAggregator.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/X-RateAggregator.java.st
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.aggregation;
 
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.compute.ann.GroupingAggregator;
@@ -38,9 +39,9 @@ import org.elasticsearch.core.Releasables;
         @IntermediateState(name = "resets", type = "DOUBLE") }
 )
 public class Rate$Type$Aggregator {
-    public static $Type$RateGroupingState initGrouping(BigArrays bigArrays, long unitInMillis) {
-        // TODO: pass BlockFactory instead bigArrays so we can use the breaker
-        return new $Type$RateGroupingState(bigArrays, unitInMillis);
+
+    public static $Type$RateGroupingState initGrouping(DriverContext driverContext, long unitInMillis) {
+        return new $Type$RateGroupingState(driverContext.bigArrays(), driverContext.breaker(), unitInMillis);
     }
 
     public static void combine($Type$RateGroupingState current, int groupId, long timestamp, $type$ value) {
@@ -71,7 +72,7 @@ public class Rate$Type$Aggregator {
         return state.evaluateFinal(selected, driverContext.blockFactory());
     }
 
-    private static class $Type$RateState implements Accountable {
+    private static class $Type$RateState {
         static final long BASE_RAM_USAGE = RamUsageEstimator.sizeOfObject($Type$RateState.class);
         final long[] timestamps; // descending order
         final $type$[] values;
@@ -104,9 +105,10 @@ public class Rate$Type$Aggregator {
             return timestamps.length;
         }
 
-        @Override
-        public long ramBytesUsed() {
-            return BASE_RAM_USAGE;
+        static long bytesUsed(int entries) {
+            var ts = RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) Long.BYTES * entries);
+            var vs = RamUsageEstimator.alignObjectSize(RamUsageEstimator.NUM_BYTES_ARRAY_HEADER + (long) $BYTES$ * entries);
+            return BASE_RAM_USAGE + ts + vs;
         }
     }
 
@@ -114,9 +116,12 @@ public class Rate$Type$Aggregator {
         private ObjectArray<$Type$RateState> states;
         private final long unitInMillis;
         private final BigArrays bigArrays;
+        private final CircuitBreaker breaker;
+        private long stateBytes; // for individual states
 
-        $Type$RateGroupingState(BigArrays bigArrays, long unitInMillis) {
+        $Type$RateGroupingState(BigArrays bigArrays, CircuitBreaker breaker, long unitInMillis) {
             this.bigArrays = bigArrays;
+            this.breaker = breaker;
             this.states = bigArrays.newObjectArray(1);
             this.unitInMillis = unitInMillis;
         }
@@ -125,16 +130,25 @@ public class Rate$Type$Aggregator {
             states = bigArrays.grow(states, groupId + 1);
         }
 
+        void adjustBreaker(long bytes) {
+            breaker.addEstimateBytesAndMaybeBreak(bytes, "<<rate aggregation>>");
+            stateBytes += bytes;
+            assert stateBytes >= 0 : stateBytes;
+        }
+
         void append(int groupId, long timestamp, $type$ value) {
             ensureCapacity(groupId);
             var state = states.get(groupId);
             if (state == null) {
+                adjustBreaker($Type$RateState.bytesUsed(1));
                 state = new $Type$RateState(new long[] { timestamp }, new $type$[] { value });
                 states.set(groupId, state);
             } else {
                 if (state.entries() == 1) {
+                    adjustBreaker($Type$RateState.bytesUsed(2));
                     state = new $Type$RateState(new long[] { state.timestamps[0], timestamp }, new $type$[] { state.values[0], value });
                     states.set(groupId, state);
+                    adjustBreaker(-$Type$RateState.bytesUsed(1)); // old state
                 } else {
                     state.append(timestamp, value);
                 }
@@ -150,6 +164,7 @@ public class Rate$Type$Aggregator {
             ensureCapacity(groupId);
             var state = states.get(groupId);
             if (state == null) {
+                adjustBreaker($Type$RateState.bytesUsed(valueCount));
                 state = new $Type$RateState(valueCount);
                 states.set(groupId, state);
                 // TODO: add bulk_copy to Block
@@ -158,9 +173,11 @@ public class Rate$Type$Aggregator {
                     state.values[i] = values.get$Type$(firstIndex + i);
                 }
             } else {
+                adjustBreaker($Type$RateState.bytesUsed(state.entries() + valueCount));
                 var newState = new $Type$RateState(state.entries() + valueCount);
                 states.set(groupId, newState);
                 merge(state, newState, firstIndex, valueCount, timestamps, values);
+                adjustBreaker(-$Type$RateState.bytesUsed(state.entries())); // old state
             }
             state.reset += reset;
         }
@@ -196,12 +213,12 @@ public class Rate$Type$Aggregator {
 
         @Override
         public long ramBytesUsed() {
-            return states.ramBytesUsed();
+            return states.ramBytesUsed() + stateBytes;
         }
 
         @Override
         public void close() {
-            Releasables.close(states);
+            Releasables.close(states, () -> adjustBreaker(-stateBytes));
         }
 
         @Override


### PR DESCRIPTION
We should track the memory usage of the individual state in the rate aggregation function.

Relates #106703