### PR TITLE
Fix field caps and field level security

### DIFF
--- a/docs/changelog/106731.yaml
+++ b/docs/changelog/106731.yaml
@@ -1,0 +1,5 @@
+pr: 106731
+summary: Fix field caps and field level security
+area: Security
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -48,6 +48,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SearchPlugin;
@@ -78,7 +79,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static java.util.Collections.singletonList;
@@ -809,8 +809,23 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         }
 
         @Override
-        public Function<String, Predicate<String>> getFieldFilter() {
-            return index -> field -> field.equals("playlist") == false;
+        public Function<String, FieldPredicate> getFieldFilter() {
+            return index -> new FieldPredicate() {
+                @Override
+                public boolean test(String field) {
+                    return field.equals("playlist") == false;
+                }
+
+                @Override
+                public String modifyHash(String hash) {
+                    return "not-playlist:" + hash;
+                }
+
+                @Override
+                public long ramBytesUsed() {
+                    return 0;
+                }
+            };
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -127,6 +127,7 @@ class FieldCapabilitiesFetcher {
         FieldPredicate fieldPredicate = indicesService.getFieldFilter().apply(shardId.getIndexName());
         if (indexMappingHash != null) {
             indexMappingHash = fieldPredicate.modifyHash(indexMappingHash);
+            System.err.println(shardId.getIndex() + " " + indexMappingHash);
             final Map<String, IndexFieldCapabilities> existing = indexMappingHashToResponses.get(indexMappingHash);
             if (existing != null) {
                 return new FieldCapabilitiesIndexResponse(shardId.getIndexName(), indexMappingHash, existing, true);

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -127,7 +127,6 @@ class FieldCapabilitiesFetcher {
         FieldPredicate fieldPredicate = indicesService.getFieldFilter().apply(shardId.getIndexName());
         if (indexMappingHash != null) {
             indexMappingHash = fieldPredicate.modifyHash(indexMappingHash);
-            System.err.println(shardId.getIndex() + " " + indexMappingHash);
             final Map<String, IndexFieldCapabilities> existing = indexMappingHashToResponses.get(indexMappingHash);
             if (existing != null) {
                 return new FieldCapabilitiesIndexResponse(shardId.getIndexName(), indexMappingHash, existing, true);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -51,6 +51,7 @@ import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.Transports;
@@ -921,7 +922,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, Ch
      */
     public Map<String, MappingMetadata> findMappings(
         String[] concreteIndices,
-        Function<String, Predicate<String>> fieldFilter,
+        Function<String, ? extends Predicate<String>> fieldFilter,
         Runnable onNextIndex
     ) {
         assert Transports.assertNotTransportThread("decompressing mappings is too expensive for a transport thread");
@@ -974,7 +975,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, Ch
         if (mappingMetadata == null) {
             return MappingMetadata.EMPTY_MAPPINGS;
         }
-        if (fieldPredicate == MapperPlugin.NOOP_FIELD_PREDICATE) {
+        if (fieldPredicate == FieldPredicate.ACCEPT_ALL) {
             return mappingMetadata;
         }
         Map<String, Object> sourceAsMap = XContentHelper.convertToMap(mappingMetadata.source().compressedReference(), true).v2();
@@ -997,7 +998,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, Ch
 
     @SuppressWarnings("unchecked")
     private static boolean filterFields(String currentPath, Map<String, Object> fields, Predicate<String> fieldPredicate) {
-        assert fieldPredicate != MapperPlugin.NOOP_FIELD_PREDICATE;
+        assert fieldPredicate != FieldPredicate.ACCEPT_ALL;
         Iterator<Map.Entry<String, Object>> entryIterator = fields.entrySet().iterator();
         while (entryIterator.hasNext()) {
             Map.Entry<String, Object> entry = entryIterator.next();

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperRegistry.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperRegistry.java
@@ -10,13 +10,13 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * A registry for all field mappers.
@@ -29,13 +29,13 @@ public final class MapperRegistry {
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers7x;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers6x;
     private final Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers5x;
-    private final Function<String, Predicate<String>> fieldFilter;
+    private final Function<String, FieldPredicate> fieldFilter;
 
     public MapperRegistry(
         Map<String, Mapper.TypeParser> mapperParsers,
         Map<String, RuntimeField.Parser> runtimeFieldParsers,
         Map<String, MetadataFieldMapper.TypeParser> metadataMapperParsers,
-        Function<String, Predicate<String>> fieldFilter
+        Function<String, FieldPredicate> fieldFilter
     ) {
         this.mapperParsers = Collections.unmodifiableMap(new LinkedHashMap<>(mapperParsers));
         this.runtimeFieldParsers = runtimeFieldParsers;
@@ -92,7 +92,7 @@ public final class MapperRegistry {
      * {@link MapperPlugin#getFieldFilter()}, only fields that match all the registered filters will be returned by get mappings,
      * get index, get field mappings and field capabilities API.
      */
-    public Function<String, Predicate<String>> getFieldFilter() {
+    public Function<String, FieldPredicate> getFieldFilter() {
         return fieldFilter;
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -128,6 +128,7 @@ import org.elasticsearch.indices.recovery.PeerRecoveryTargetService;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.indices.store.CompositeIndexFoldersDeletionListener;
 import org.elasticsearch.node.Node;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -168,7 +169,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongSupplier;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
@@ -1756,7 +1756,7 @@ public class IndicesService extends AbstractLifecycleComponent
      * {@link org.elasticsearch.plugins.MapperPlugin#getFieldFilter()}, only fields that match all the registered filters will be
      * returned by get mappings, get index, get field mappings and field capabilities API.
      */
-    public Function<String, Predicate<String>> getFieldFilter() {
+    public Function<String, FieldPredicate> getFieldFilter() {
         return mapperRegistry.getFieldFilter();
     }
 

--- a/server/src/main/java/org/elasticsearch/plugins/FieldPredicate.java
+++ b/server/src/main/java/org/elasticsearch/plugins/FieldPredicate.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.apache.lucene.util.Accountable;
+import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+
+import java.util.function.Predicate;
+
+/**
+ * Filter for visible fields.
+ */
+public interface FieldPredicate extends Accountable, Predicate<String> {
+    /**
+     * The default field predicate applied, which doesn't filter anything. That means that by default get mappings, get index
+     * get field mappings and field capabilities API will return every field that's present in the mappings.
+     */
+    FieldPredicate ACCEPT_ALL = new FieldPredicate() {
+        @Override
+        public boolean test(String field) {
+            return true;
+        }
+
+        @Override
+        public String modifyHash(String hash) {
+            return hash;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return 0; // Shared
+        }
+
+        @Override
+        public String toString() {
+            return "accept all";
+        }
+    };
+
+    /**
+     * Should this field be included?
+     */
+    @Override
+    boolean test(String field);
+
+    /**
+     * Modify the {@link MappingMetadata#getSha256} to track any filtering this predicate
+     * has performed on the list of fields.
+     */
+    String modifyHash(String hash);
+
+    class And implements FieldPredicate {
+        private static final long SHALLOW_RAM_BYTES_USED = RamUsageEstimator.shallowSizeOfInstance(And.class);
+
+        private final FieldPredicate first;
+        private final FieldPredicate second;
+
+        public And(FieldPredicate first, FieldPredicate second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public boolean test(String field) {
+            return first.test(field) && second.test(field);
+        }
+
+        @Override
+        public String modifyHash(String hash) {
+            return second.modifyHash(first.modifyHash(hash));
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return SHALLOW_RAM_BYTES_USED + first.ramBytesUsed() + second.ramBytesUsed();
+        }
+
+        @Override
+        public String toString() {
+            return first + " then " + second;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/MapperPlugin.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.plugins;
 
-import org.elasticsearch.core.Predicates;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.RuntimeField;
@@ -16,7 +15,6 @@ import org.elasticsearch.index.mapper.RuntimeField;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 /**
  * An extension point for {@link Plugin} implementations to add custom mappers
@@ -62,19 +60,23 @@ public interface MapperPlugin {
      * get index, get field mappings and field capabilities API. Useful to filter the fields that such API return. The predicate receives
      * the field name as input argument and should return true to show the field and false to hide it.
      */
-    default Function<String, Predicate<String>> getFieldFilter() {
+    default Function<String, FieldPredicate> getFieldFilter() {
         return NOOP_FIELD_FILTER;
     }
-
-    /**
-     * The default field predicate applied, which doesn't filter anything. That means that by default get mappings, get index
-     * get field mappings and field capabilities API will return every field that's present in the mappings.
-     */
-    Predicate<String> NOOP_FIELD_PREDICATE = Predicates.always();
 
     /**
      * The default field filter applied, which doesn't filter anything. That means that by default get mappings, get index
      * get field mappings and field capabilities API will return every field that's present in the mappings.
      */
-    Function<String, Predicate<String>> NOOP_FIELD_FILTER = index -> NOOP_FIELD_PREDICATE;
+    Function<String, FieldPredicate> NOOP_FIELD_FILTER = new Function<>() {
+        @Override
+        public FieldPredicate apply(String index) {
+            return FieldPredicate.ACCEPT_ALL;
+        }
+
+        @Override
+        public String toString() {
+            return "accept all";
+        }
+    };
 }

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFilterTests.java
@@ -14,10 +14,10 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.plugins.FieldPredicate;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.function.Predicate;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,7 +46,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
             s -> true,
             new String[] { "-nested" },
             Strings.EMPTY_ARRAY,
-            f -> true,
+            FieldPredicate.ACCEPT_ALL,
             getMockIndexShard(),
             true
         );
@@ -74,7 +74,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
                 s -> true,
                 new String[] { "+metadata" },
                 Strings.EMPTY_ARRAY,
-                f -> true,
+                FieldPredicate.ACCEPT_ALL,
                 getMockIndexShard(),
                 true
             );
@@ -87,7 +87,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
                 s -> true,
                 new String[] { "-metadata" },
                 Strings.EMPTY_ARRAY,
-                f -> true,
+                FieldPredicate.ACCEPT_ALL,
                 getMockIndexShard(),
                 true
             );
@@ -120,7 +120,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
             s -> true,
             new String[] { "-multifield" },
             Strings.EMPTY_ARRAY,
-            f -> true,
+            FieldPredicate.ACCEPT_ALL,
             getMockIndexShard(),
             true
         );
@@ -151,7 +151,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
             s -> true,
             new String[] { "-parent" },
             Strings.EMPTY_ARRAY,
-            f -> true,
+            FieldPredicate.ACCEPT_ALL,
             getMockIndexShard(),
             true
         );
@@ -171,7 +171,22 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
             } }
             """);
         SearchExecutionContext sec = createSearchExecutionContext(mapperService);
-        Predicate<String> securityFilter = f -> f.startsWith("permitted");
+        FieldPredicate securityFilter = new FieldPredicate() {
+            @Override
+            public boolean test(String field) {
+                return field.startsWith("permitted");
+            }
+
+            @Override
+            public String modifyHash(String hash) {
+                return "only-permitted:" + hash;
+            }
+
+            @Override
+            public long ramBytesUsed() {
+                return 0;
+            }
+        };
 
         {
             Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
@@ -223,7 +238,7 @@ public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
             s -> true,
             Strings.EMPTY_ARRAY,
             new String[] { "text", "keyword" },
-            f -> true,
+            FieldPredicate.ACCEPT_ALL,
             getMockIndexShard(),
             true
         );

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.index.alias.RandomAliasActionsGenerator;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
@@ -786,7 +787,7 @@ public class MetadataTests extends ESTestCase {
                 if (index.equals("index2")) {
                     return Predicates.never();
                 }
-                return MapperPlugin.NOOP_FIELD_PREDICATE;
+                return FieldPredicate.ACCEPT_ALL;
             }, Metadata.ON_NEXT_INDEX_FIND_MAPPINGS_NOOP);
 
             assertIndexMappingsNoFields(mappings, "index2");

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldFilterMapperPluginTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldFilterMapperPluginTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.indices.IndicesModule;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
@@ -32,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static org.elasticsearch.cluster.metadata.MetadataTests.assertLeafs;
 import static org.elasticsearch.cluster.metadata.MetadataTests.assertMultiField;
@@ -246,8 +246,23 @@ public class FieldFilterMapperPluginTests extends ESSingleNodeTestCase {
     public static class FieldFilterPlugin extends Plugin implements MapperPlugin {
 
         @Override
-        public Function<String, Predicate<String>> getFieldFilter() {
-            return index -> index.equals("filtered") ? field -> field.endsWith("visible") : MapperPlugin.NOOP_FIELD_PREDICATE;
+        public Function<String, FieldPredicate> getFieldFilter() {
+            return index -> false == index.equals("filtered") ? FieldPredicate.ACCEPT_ALL : new FieldPredicate() {
+                @Override
+                public boolean test(String field) {
+                    return field.endsWith("visible");
+                }
+
+                @Override
+                public String modifyHash(String hash) {
+                    return "only-visible:" + hash;
+                }
+
+                @Override
+                public long ramBytesUsed() {
+                    return 0;
+                }
+            };
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesModuleTests.java
@@ -32,6 +32,7 @@ import org.elasticsearch.index.mapper.TextFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesRoutingHashFieldMapper;
 import org.elasticsearch.index.mapper.VersionFieldMapper;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.index.IndexVersionUtils;
@@ -44,11 +45,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static org.elasticsearch.test.LambdaMatchers.falseWith;
 import static org.elasticsearch.test.LambdaMatchers.trueWith;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -246,24 +247,24 @@ public class IndicesModuleTests extends ESTestCase {
         List<MapperPlugin> mapperPlugins = List.of(new MapperPlugin() {
         }, new MapperPlugin() {
             @Override
-            public Function<String, Predicate<String>> getFieldFilter() {
-                return index -> index.equals("hidden_index") ? field -> false : MapperPlugin.NOOP_FIELD_PREDICATE;
+            public Function<String, FieldPredicate> getFieldFilter() {
+                return index -> index.equals("hidden_index") ? HIDDEN_INDEX : FieldPredicate.ACCEPT_ALL;
             }
         }, new MapperPlugin() {
             @Override
-            public Function<String, Predicate<String>> getFieldFilter() {
-                return index -> field -> field.equals("hidden_field") == false;
+            public Function<String, FieldPredicate> getFieldFilter() {
+                return index -> HIDDEN_FIELD;
             }
         }, new MapperPlugin() {
             @Override
-            public Function<String, Predicate<String>> getFieldFilter() {
-                return index -> index.equals("filtered") ? field -> field.equals("visible") : MapperPlugin.NOOP_FIELD_PREDICATE;
+            public Function<String, FieldPredicate> getFieldFilter() {
+                return index -> index.equals("filtered") ? ONLY_VISIBLE : FieldPredicate.ACCEPT_ALL;
             }
         });
 
         IndicesModule indicesModule = new IndicesModule(mapperPlugins);
         MapperRegistry mapperRegistry = indicesModule.getMapperRegistry();
-        Function<String, Predicate<String>> fieldFilter = mapperRegistry.getFieldFilter();
+        Function<String, FieldPredicate> fieldFilter = mapperRegistry.getFieldFilter();
         assertNotSame(MapperPlugin.NOOP_FIELD_FILTER, fieldFilter);
 
         assertThat(fieldFilter.apply("hidden_index"), falseWith(randomAlphaOfLengthBetween(3, 5)));
@@ -276,6 +277,10 @@ public class IndicesModuleTests extends ESTestCase {
         assertThat(fieldFilter.apply("hidden_index"), falseWith("visible"));
         assertThat(fieldFilter.apply(randomAlphaOfLengthBetween(3, 5)), trueWith("visible"));
         assertThat(fieldFilter.apply("hidden_index"), falseWith("hidden_field"));
+
+        assertThat(fieldFilter.apply("filtered").modifyHash("hash"), equalTo("only-visible:hide-field:hash"));
+        assertThat(fieldFilter.apply(randomAlphaOfLengthBetween(3, 5)).modifyHash("hash"), equalTo("hide-field:hash"));
+        assertThat(fieldFilter.apply("hidden_index").modifyHash("hash"), equalTo("hide-field:hidden:hash"));
     }
 
     public void testDefaultFieldFilterIsNoOp() {
@@ -286,7 +291,7 @@ public class IndicesModuleTests extends ESTestCase {
             });
         }
         IndicesModule indicesModule = new IndicesModule(mapperPlugins);
-        Function<String, Predicate<String>> fieldFilter = indicesModule.getMapperRegistry().getFieldFilter();
+        Function<String, FieldPredicate> fieldFilter = indicesModule.getMapperRegistry().getFieldFilter();
         assertSame(MapperPlugin.NOOP_FIELD_FILTER, fieldFilter);
     }
 
@@ -294,21 +299,72 @@ public class IndicesModuleTests extends ESTestCase {
         List<MapperPlugin> mapperPlugins = Arrays.asList(new MapperPlugin() {
         }, new MapperPlugin() {
             @Override
-            public Function<String, Predicate<String>> getFieldFilter() {
-                return index -> index.equals("hidden_index") ? field -> false : MapperPlugin.NOOP_FIELD_PREDICATE;
+            public Function<String, FieldPredicate> getFieldFilter() {
+                return index -> index.equals("hidden_index") ? HIDDEN_INDEX : FieldPredicate.ACCEPT_ALL;
             }
         }, new MapperPlugin() {
             @Override
-            public Function<String, Predicate<String>> getFieldFilter() {
-                return index -> index.equals("filtered") ? field -> field.equals("visible") : MapperPlugin.NOOP_FIELD_PREDICATE;
+            public Function<String, FieldPredicate> getFieldFilter() {
+                return index -> index.equals("filtered") ? ONLY_VISIBLE : FieldPredicate.ACCEPT_ALL;
             }
         });
 
         IndicesModule indicesModule = new IndicesModule(mapperPlugins);
         MapperRegistry mapperRegistry = indicesModule.getMapperRegistry();
-        Function<String, Predicate<String>> fieldFilter = mapperRegistry.getFieldFilter();
-        assertSame(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply(randomAlphaOfLengthBetween(3, 7)));
-        assertNotSame(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply("hidden_index"));
-        assertNotSame(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply("filtered"));
+        Function<String, FieldPredicate> fieldFilter = mapperRegistry.getFieldFilter();
+        assertSame(FieldPredicate.ACCEPT_ALL, fieldFilter.apply(randomAlphaOfLengthBetween(3, 7)));
+        assertNotSame(FieldPredicate.ACCEPT_ALL, fieldFilter.apply("hidden_index"));
+        assertNotSame(FieldPredicate.ACCEPT_ALL, fieldFilter.apply("filtered"));
     }
+
+    private static final FieldPredicate HIDDEN_INDEX = new FieldPredicate() {
+        @Override
+        public boolean test(String field) {
+            return false;
+        }
+
+        @Override
+        public String modifyHash(String hash) {
+            return "hidden:" + hash;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return 0;
+        }
+    };
+
+    private static final FieldPredicate HIDDEN_FIELD = new FieldPredicate() {
+        @Override
+        public boolean test(String field) {
+            return false == field.equals("hidden_field");
+        }
+
+        @Override
+        public String modifyHash(String hash) {
+            return "hide-field:" + hash;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return 0;
+        }
+    };
+
+    private static final FieldPredicate ONLY_VISIBLE = new FieldPredicate() {
+        @Override
+        public boolean test(String field) {
+            return field.equals("visible");
+        }
+
+        @Override
+        public String modifyHash(String hash) {
+            return "only-visible:" + hash;
+        }
+
+        @Override
+        public long ramBytesUsed() {
+            return 0;
+        }
+    };
 }

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -101,7 +101,7 @@ public class BootstrapForTesting {
         // check for jar hell
         try {
             final Logger logger = LogManager.getLogger(JarHell.class);
-            JarHell.checkJarHell(logger::debug);
+            // JarHell.checkJarHell(logger::debug);
         } catch (Exception e) {
             throw new RuntimeException("found jar hell in test classpath", e);
         }

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -101,7 +101,7 @@ public class BootstrapForTesting {
         // check for jar hell
         try {
             final Logger logger = LogManager.getLogger(JarHell.class);
-            // JarHell.checkJarHell(logger::debug);
+            JarHell.checkJarHell(logger::debug);
         } catch (Exception e) {
             throw new RuntimeException("found jar hell in test classpath", e);
         }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldFilterPlugin.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldFilterPlugin.java
@@ -8,18 +8,32 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.elasticsearch.core.Predicates;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 public class MockFieldFilterPlugin extends Plugin implements MapperPlugin {
 
     @Override
-    public Function<String, Predicate<String>> getFieldFilter() {
+    public Function<String, FieldPredicate> getFieldFilter() {
         // this filter doesn't filter any field out, but it's used to exercise the code path executed when the filter is not no-op
-        return index -> Predicates.always();
+        return index -> new FieldPredicate() {
+            @Override
+            public boolean test(String field) {
+                return true;
+            }
+
+            @Override
+            public String modifyHash(String hash) {
+                return hash + ":includeall";
+            }
+
+            @Override
+            public long ramBytesUsed() {
+                return 0;
+            }
+        };
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/AutomatonFieldPredicate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/AutomatonFieldPredicate.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.authz.permission;
+
+import org.apache.lucene.util.RamUsageEstimator;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.apache.lucene.util.automaton.Transition;
+import org.elasticsearch.common.hash.MessageDigests;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.plugins.FieldPredicate;
+
+import java.io.IOException;
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+/**
+ * Build a SHA256 of the contents of an {@link Automaton}.
+ */
+class AutomatonFieldPredicate implements FieldPredicate {
+    private final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(AutomatonFieldPredicate.class);
+
+    private final String automatonHash;
+    private final CharacterRunAutomaton automaton;
+
+    AutomatonFieldPredicate(Automaton originalAutomaton, CharacterRunAutomaton automaton) {
+        this.automatonHash = sha256(originalAutomaton);
+        this.automaton = automaton;
+    }
+
+    @Override
+    public boolean test(String field) {
+        return automaton.run(field);
+    }
+
+    @Override
+    public String modifyHash(String hash) {
+        return hash + ":" + automatonHash;
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return SHALLOW_SIZE + RamUsageEstimator.sizeOf(automatonHash); // automaton itself is a shallow copy so not counted here
+    }
+
+    private static String sha256(Automaton automaton) {
+        MessageDigest messageDigest = MessageDigests.sha256();
+        try {
+            StreamOutput out = new OutputStreamStreamOutput(new DigestOutputStream(Streams.NULL_OUTPUT_STREAM, messageDigest));
+            Transition t = new Transition();
+            for (int state = 0; state < automaton.getNumStates(); state++) {
+                out.writeInt(state);
+                out.writeBoolean(automaton.isAccept(state));
+
+                int numTransitions = automaton.initTransition(state, t);
+                for (int i = 0; i < numTransitions; ++i) {
+                    automaton.getNextTransition(t);
+                    out.writeInt(t.dest);
+                    out.writeInt(t.min);
+                    out.writeInt(t.max);
+                }
+            }
+        } catch (IOException bogus) {
+            // cannot happen
+            throw new Error(bogus);
+        }
+        return Base64.getEncoder().encodeToString(messageDigest.digest());
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/AutomatonFieldPredicate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/AutomatonFieldPredicate.java
@@ -23,7 +23,8 @@ import java.security.MessageDigest;
 import java.util.Base64;
 
 /**
- * Build a SHA256 of the contents of an {@link Automaton}.
+ * An implementation of {@link FieldPredicate} which matches fields
+ * against an {@link Automaton}.
  */
 class AutomatonFieldPredicate implements FieldPredicate {
     private final long SHALLOW_SIZE = RamUsageEstimator.shallowSizeOfInstance(AutomatonFieldPredicate.class);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
@@ -67,6 +67,7 @@ import org.elasticsearch.plugins.ClusterCoordinationPlugin;
 import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.EnginePlugin;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
@@ -454,8 +455,8 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin
     }
 
     @Override
-    public Function<String, Predicate<String>> getFieldFilter() {
-        List<Function<String, Predicate<String>>> items = filterPlugins(MapperPlugin.class).stream()
+    public Function<String, FieldPredicate> getFieldFilter() {
+        List<Function<String, FieldPredicate>> items = filterPlugins(MapperPlugin.class).stream()
             .map(p -> p.getFieldFilter())
             .filter(p -> p.equals(NOOP_FIELD_FILTER) == false)
             .toList();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/AutomatonFieldPredicateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/AutomatonFieldPredicateTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.authz.permission;
+
+import org.apache.lucene.util.automaton.Automata;
+import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+public class AutomatonFieldPredicateTests extends ESTestCase {
+    public void testMatching() {
+        String str = randomAlphaOfLength(10);
+        Automaton a = Automata.makeString(str);
+        AutomatonFieldPredicate pred = new AutomatonFieldPredicate(a, new CharacterRunAutomaton(a));
+        assertTrue(pred.test(str));
+        assertFalse(pred.test(str + randomAlphaOfLength(1)));
+    }
+
+    public void testHash() {
+        Automaton a = Automata.makeString("a");
+        AutomatonFieldPredicate predA = new AutomatonFieldPredicate(a, new CharacterRunAutomaton(a));
+
+        Automaton b = Automata.makeString("b");
+        AutomatonFieldPredicate predB = new AutomatonFieldPredicate(b, new CharacterRunAutomaton(b));
+
+        assertThat(predA.modifyHash("a"), not(equalTo(predB.modifyHash("a"))));
+    }
+}

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql;
 
 import org.apache.http.HttpStatus;
+import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Build;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -31,6 +32,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import static org.elasticsearch.test.MapMatcher.assertMap;
+import static org.elasticsearch.test.MapMatcher.matchesMap;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class EsqlSecurityIT extends ESRestTestCase {
@@ -47,6 +51,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         .user("user3", "x-pack-test-password", "user3", false)
         .user("user4", "x-pack-test-password", "user4", false)
         .user("user5", "x-pack-test-password", "user5", false)
+        .user("fls_user", "x-pack-test-password", "fls_user", false)
         .build();
 
     @Override
@@ -62,7 +67,11 @@ public class EsqlSecurityIT extends ESRestTestCase {
 
     private void indexDocument(String index, int id, double value, String org) throws IOException {
         Request indexDoc = new Request("PUT", index + "/_doc/" + id);
-        indexDoc.setJsonEntity("{\"value\":" + value + ",\"org\":\"" + org + "\"}");
+        XContentBuilder builder = JsonXContent.contentBuilder().startObject();
+        builder.field("value", value);
+        builder.field("org", org);
+        builder.field("partial", org + value);
+        indexDoc.setJsonEntity(Strings.toString(builder.endObject()));
         client().performRequest(indexDoc);
     }
 
@@ -85,6 +94,11 @@ public class EsqlSecurityIT extends ESRestTestCase {
         indexDocument("index-user2", 1, 32.0, "marketing");
         indexDocument("index-user2", 2, 40.0, "sales");
         refresh("index-user2");
+
+        createIndex("indexpartial", Settings.EMPTY, mapping);
+        indexDocument("indexpartial", 1, 32.0, "marketing");
+        indexDocument("indexpartial", 2, 40.0, "sales");
+        refresh("indexpartial");
     }
 
     public void testAllowedIndices() throws Exception {
@@ -122,12 +136,75 @@ public class EsqlSecurityIT extends ESRestTestCase {
         assertThat(error.getResponse().getStatusLine().getStatusCode(), equalTo(400));
     }
 
-    public void testDLS() throws Exception {
+    public void testDocumentLevelSecurity() throws Exception {
         Response resp = runESQLCommand("user3", "from index | stats sum=sum(value)");
         assertOK(resp);
         Map<String, Object> respMap = entityAsMap(resp);
         assertThat(respMap.get("columns"), equalTo(List.of(Map.of("name", "sum", "type", "double"))));
         assertThat(respMap.get("values"), equalTo(List.of(List.of(10.0))));
+    }
+
+    public void testFieldLevelSecurityAllow() throws Exception {
+        Response resp = runESQLCommand("fls_user", "FROM index* | SORT value | LIMIT 1");
+        assertOK(resp);
+        assertMap(
+            entityAsMap(resp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "partial").entry("type", "text"),
+                        matchesMap().entry("name", "value").entry("type", "double")
+                    )
+                )
+                .entry("values", List.of(List.of("sales10.0", 10.0)))
+        );
+    }
+
+    public void testFieldLevelSecurityAllowPartial() throws Exception {
+        Request request = new Request("GET", "/index*/_field_caps");
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("es-security-runas-user", "fls_user"));
+        request.addParameter("error_trace", "true");
+        request.addParameter("pretty", "true");
+        request.addParameter("fields", "*");
+
+        request = new Request("GET", "/index*/_search");
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("es-security-runas-user", "fls_user"));
+        request.addParameter("error_trace", "true");
+        request.addParameter("pretty", "true");
+
+        Response resp = runESQLCommand("fls_user", "FROM index* | SORT partial | LIMIT 1");
+        assertOK(resp);
+        assertMap(
+            entityAsMap(resp),
+            matchesMap().extraOk()
+                .entry(
+                    "columns",
+                    List.of(
+                        matchesMap().entry("name", "partial").entry("type", "text"),
+                        matchesMap().entry("name", "value").entry("type", "double")
+                    )
+                )
+                .entry("values", List.of(List.of("engineering20.0", 20.0)))
+        );
+    }
+
+    public void testFieldLevelSecuritySpellingMistake() throws Exception {
+        ResponseException e = expectThrows(
+            ResponseException.class,
+            () -> runESQLCommand("fls_user", "FROM index* | SORT parial | LIMIT 1")
+        );
+        assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(EntityUtils.toString(e.getResponse().getEntity()), containsString("Unknown column [parial]"));
+    }
+
+    public void testFieldLevelSecurityNotAllowed() throws Exception {
+        ResponseException e = expectThrows(
+            ResponseException.class,
+            () -> runESQLCommand("fls_user", "FROM index* | SORT org DESC | LIMIT 1")
+        );
+        assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        assertThat(EntityUtils.toString(e.getResponse().getEntity()), containsString("Unknown column [org]"));
     }
 
     public void testRowCommand() throws Exception {
@@ -283,6 +360,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         Request request = new Request("POST", "_query");
         request.setJsonEntity(Strings.toString(json));
         request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("es-security-runas-user", user));
+        request.addParameter("error_trace", "true");
         return client().performRequest(request);
     }
 

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
@@ -51,9 +51,22 @@ user4:
     - names: ['index-user1', 'index', "test-enrich" ]
       privileges:
         - read
+
 user5:
   cluster: []
   indices:
     - names: ['index-user1', 'index', "test-enrich" ]
       privileges:
         - read
+
+fls_user:
+  cluster: []
+  indices:
+    - names: [ 'index' ]
+      privileges: [ 'read' ]
+      field_security:
+        grant: [ value, partial ]
+    - names: [ 'indexpartial' ]
+      privileges: [ 'read' ]
+      field_security:
+        grant: [ value ]

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -2356,8 +2356,8 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testSearchDifferentFieldsVisible() {
-        String firstName = "partial1*" + randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-        String secondName = "partial2*" + randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        String firstName = "partial1" + randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        String secondName = "partial2" + randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         indexPartial(firstName, secondName);
         SearchResponse response = client().filterWithHeader(
             Map.of(BASIC_AUTH_HEADER, basicAuthHeaderValue("user_different_fields", USERS_PASSWD))

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -52,6 +52,7 @@ import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.internal.XPackLicenseStatus;
 import org.elasticsearch.plugins.ExtensiblePlugin;
+import org.elasticsearch.plugins.FieldPredicate;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.internal.RestExtension;
 import org.elasticsearch.rest.RestHandler;
@@ -120,7 +121,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
@@ -469,7 +469,7 @@ public class SecurityTests extends ESTestCase {
 
     public void testGetFieldFilterSecurityEnabled() throws Exception {
         createComponents(Settings.EMPTY);
-        Function<String, Predicate<String>> fieldFilter = security.getFieldFilter();
+        Function<String, FieldPredicate> fieldFilter = security.getFieldFilter();
         assertNotSame(MapperPlugin.NOOP_FIELD_FILTER, fieldFilter);
         Map<String, IndicesAccessControl.IndexAccessControl> permissionsMap = new HashMap<>();
 
@@ -491,9 +491,9 @@ public class SecurityTests extends ESTestCase {
 
         assertThat(fieldFilter.apply("index_granted"), trueWith("field_granted"));
         assertThat(fieldFilter.apply("index_granted"), falseWith(randomAlphaOfLengthBetween(3, 10)));
-        assertEquals(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply("index_granted_all_permissions"));
+        assertEquals(FieldPredicate.ACCEPT_ALL, fieldFilter.apply("index_granted_all_permissions"));
         assertThat(fieldFilter.apply("index_granted_all_permissions"), trueWith(randomAlphaOfLengthBetween(3, 10)));
-        assertEquals(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply("index_other"));
+        assertEquals(FieldPredicate.ACCEPT_ALL, fieldFilter.apply("index_other"));
     }
 
     public void testGetFieldFilterSecurityDisabled() throws Exception {
@@ -503,7 +503,7 @@ public class SecurityTests extends ESTestCase {
 
     public void testGetFieldFilterSecurityEnabledLicenseNoFLS() throws Exception {
         createComponents(Settings.EMPTY);
-        Function<String, Predicate<String>> fieldFilter = security.getFieldFilter();
+        Function<String, FieldPredicate> fieldFilter = security.getFieldFilter();
         assertNotSame(MapperPlugin.NOOP_FIELD_FILTER, fieldFilter);
         licenseState.update(
             new XPackLicenseStatus(
@@ -513,7 +513,7 @@ public class SecurityTests extends ESTestCase {
             )
         );
         assertNotSame(MapperPlugin.NOOP_FIELD_FILTER, fieldFilter);
-        assertSame(MapperPlugin.NOOP_FIELD_PREDICATE, fieldFilter.apply(randomAlphaOfLengthBetween(3, 6)));
+        assertSame(FieldPredicate.ACCEPT_ALL, fieldFilter.apply(randomAlphaOfLengthBetween(3, 6)));
     }
 
     public void testValidateRealmsWhenSettingsAreInvalid() {


### PR DESCRIPTION
If you perform a `_field_caps` request on two indices with the same mapping but *different* field level security settings we were returning incorrect results. In particular, we'd return return whatever fields were visible in one of the indices. It's random which one we'd return.
