### PR TITLE
Fix AffixSetting.exists to include secure settings

### DIFF
--- a/docs/changelog/106745.yaml
+++ b/docs/changelog/106745.yaml
@@ -1,0 +1,5 @@
+pr: 106745
+summary: Fix `AffixSetting.exists` to include secure settings
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -888,6 +888,18 @@ public class Setting<T> implements ToXContentObject {
             return settings.keySet().stream().filter(this::match).map(key::getConcreteString);
         }
 
+        @Override
+        public boolean exists(Settings settings) {
+            // concrete settings might be secure, so don't exclude these here
+            return key.exists(settings.keySet(), Collections.emptySet());
+        }
+
+        @Override
+        public boolean exists(Settings.Builder builder) {
+            // concrete settings might be secure, so don't exclude these here
+            return key.exists(builder.keys(), Collections.emptySet());
+        }
+
         /**
          * Get the raw list of dependencies. This method is exposed for testing purposes and {@link #getSettingsDependencies(String)}
          * should be preferred for most all cases.


### PR DESCRIPTION
I noticed this when looking into AffixSettings and fallbacks. 

The concrete settings of an affix setting might be secure, e.g. `AzureStorageSettings.KEY_SETTING`, though currently secure settings are excluded (introduced in #105652, my bad!). 

This fixes `AffixSetting.exists` to include secure settings.