### PR TITLE
Check number of docs in search_knn_query_vector_builder test 

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/search_knn_query_vector_builder.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/search_knn_query_vector_builder.yml
@@ -121,7 +121,6 @@ setup:
                   model_id: text_embedding_model
                   model_text: "the octopus comforter smells"
   - length: { hits.hits: 3 }
-  - match: { hits.hits.0._id: "0" }
 
 ---
 "nested kNN search with inner_hits size":


### PR DESCRIPTION
Disable assertions on doc ids directly to avoid flakiness of nearest neighbor test results in `search_knn_query_vector_builder`.

closes #106740 