### PR TITLE
[Refactoring] Rename DataStreamGlobalRetentionTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateResponseTests.java
@@ -12,7 +12,7 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverConfigurationTest
 import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComponentTemplateTests;
-import org.elasticsearch.cluster.metadata.DataStreamGlobalRetentionSerializationTests;
+import org.elasticsearch.cluster.metadata.DataStreamGlobalRetentionTests;
 import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.Strings;
@@ -47,7 +47,7 @@ public class GetComponentTemplateResponseTests extends AbstractWireSerializingTe
         return new GetComponentTemplateAction.Response(
             randomBoolean() ? Map.of() : randomTemplates(),
             RolloverConfigurationTests.randomRolloverConditions(),
-            DataStreamGlobalRetentionSerializationTests.randomGlobalRetention()
+            DataStreamGlobalRetentionTests.randomGlobalRetention()
         );
     }
 
@@ -59,10 +59,7 @@ public class GetComponentTemplateResponseTests extends AbstractWireSerializingTe
         switch (randomInt(2)) {
             case 0 -> templates = templates == null ? randomTemplates() : null;
             case 1 -> rolloverConditions = randomValueOtherThan(rolloverConditions, RolloverConfigurationTests::randomRolloverConditions);
-            case 2 -> globalRetention = randomValueOtherThan(
-                globalRetention,
-                DataStreamGlobalRetentionSerializationTests::randomGlobalRetention
-            );
+            case 2 -> globalRetention = randomValueOtherThan(globalRetention, DataStreamGlobalRetentionTests::randomGlobalRetention);
         }
         return new GetComponentTemplateAction.Response(templates, rolloverConditions, globalRetention);
     }
@@ -88,7 +85,7 @@ public class GetComponentTemplateResponseTests extends AbstractWireSerializingTe
             null,
             false
         );
-        var globalRetention = DataStreamGlobalRetentionSerializationTests.randomGlobalRetention();
+        var globalRetention = DataStreamGlobalRetentionTests.randomGlobalRetention();
         var rolloverConfiguration = RolloverConfigurationTests.randomRolloverConditions();
         var response = new GetComponentTemplateAction.Response(
             Map.of(randomAlphaOfLength(10), template),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
@@ -289,7 +289,7 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
             builder.humanReadable(true);
             RolloverConfiguration rolloverConfiguration = RolloverConfigurationTests.randomRolloverConditions();
-            DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionSerializationTests.randomGlobalRetention();
+            DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionTests.randomGlobalRetention();
             ToXContent.Params withEffectiveRetention = new ToXContent.MapParams(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAMS);
             template.toXContent(builder, withEffectiveRetention, rolloverConfiguration, globalRetention);
             String serialized = Strings.toString(builder);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
@@ -238,7 +238,7 @@ public class ComposableIndexTemplateTests extends SimpleDiffableSerializationTes
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
             builder.humanReadable(true);
             RolloverConfiguration rolloverConfiguration = RolloverConfigurationTests.randomRolloverConditions();
-            DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionSerializationTests.randomGlobalRetention();
+            DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionTests.randomGlobalRetention();
             ToXContent.Params withEffectiveRetention = new ToXContent.MapParams(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAMS);
             template.toXContent(builder, withEffectiveRetention, rolloverConfiguration, globalRetention);
             String serialized = Strings.toString(builder);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetentionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetentionTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.test.SimpleDiffableWireSerializationTestCase;
 
 import java.util.List;
 
-public class DataStreamGlobalRetentionSerializationTests extends SimpleDiffableWireSerializationTestCase<ClusterState.Custom> {
+public class DataStreamGlobalRetentionTests extends SimpleDiffableWireSerializationTestCase<ClusterState.Custom> {
 
     @Override
     protected ClusterState.Custom makeTestChanges(ClusterState.Custom testInstance) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
@@ -112,7 +112,7 @@ public class DataStreamLifecycleTests extends AbstractXContentSerializingTestCas
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
             builder.humanReadable(true);
             RolloverConfiguration rolloverConfiguration = RolloverConfigurationTests.randomRolloverConditions();
-            DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionSerializationTests.randomGlobalRetention();
+            DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionTests.randomGlobalRetention();
             ToXContent.Params withEffectiveRetention = new ToXContent.MapParams(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAMS);
             lifecycle.toXContent(builder, withEffectiveRetention, rolloverConfiguration, globalRetention);
             String serialized = Strings.toString(builder);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -1697,7 +1697,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
         try (XContentBuilder builder = XContentBuilder.builder(XContentType.JSON.xContent())) {
             builder.humanReadable(true);
             RolloverConfiguration rolloverConfiguration = RolloverConfigurationTests.randomRolloverConditions();
-            DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionSerializationTests.randomGlobalRetention();
+            DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionTests.randomGlobalRetention();
 
             ToXContent.Params withEffectiveRetention = new ToXContent.MapParams(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAMS);
             dataStream.toXContent(builder, withEffectiveRetention, rolloverConfiguration, globalRetention);


### PR DESCRIPTION
In this PR we just rename `DataStreamGlobalRetentionTests` to reduce a bit the size of https://github.com/elastic/elasticsearch/pull/105682.
