### PR TITLE
Adjust randomization in ResolveClusterActionResponseTests (#105932)

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/resolve/ResolveClusterActionResponseTests.java
@@ -20,22 +20,39 @@ public class ResolveClusterActionResponseTests extends AbstractWireSerializingTe
 
     @Override
     protected ResolveClusterActionResponse createTestInstance() {
-        return new ResolveClusterActionResponse(randomResolveClusterInfoMap());
+        return new ResolveClusterActionResponse(randomResolveClusterInfoMap(null));
     }
 
-    private Map<String, ResolveClusterInfo> randomResolveClusterInfoMap() {
+    private ResolveClusterInfo randomResolveClusterInfo(ResolveClusterInfo existing) {
+        if (existing == null) {
+            return randomResolveClusterInfo();
+        } else {
+            return randomValueOtherThan(existing, () -> randomResolveClusterInfo());
+        }
+    }
+
+    private ResolveClusterInfo getResolveClusterInfoFromResponse(String key, ResolveClusterActionResponse response) {
+        if (response == null || response.getResolveClusterInfo() == null) {
+            return null;
+        }
+        return response.getResolveClusterInfo().get(key);
+    }
+
+    private Map<String, ResolveClusterInfo> randomResolveClusterInfoMap(ResolveClusterActionResponse existingResponse) {
         Map<String, ResolveClusterInfo> infoMap = new HashMap<>();
         int numClusters = randomIntBetween(0, 50);
         if (randomBoolean() || numClusters == 0) {
-            infoMap.put(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY, randomResolveClusterInfo());
+            String key = RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY;
+            infoMap.put(key, randomResolveClusterInfo(getResolveClusterInfoFromResponse(key, existingResponse)));
         }
         for (int i = 0; i < numClusters; i++) {
-            infoMap.put("remote_" + i, randomResolveClusterInfo());
+            String key = "remote_" + i;
+            infoMap.put(key, randomResolveClusterInfo(getResolveClusterInfoFromResponse(key, existingResponse)));
         }
         return infoMap;
     }
 
-    private ResolveClusterInfo randomResolveClusterInfo() {
+    static ResolveClusterInfo randomResolveClusterInfo() {
         int val = randomIntBetween(1, 3);
         return switch (val) {
             case 1 -> new ResolveClusterInfo(false, randomBoolean());
@@ -52,6 +69,6 @@ public class ResolveClusterActionResponseTests extends AbstractWireSerializingTe
 
     @Override
     protected ResolveClusterActionResponse mutateInstance(ResolveClusterActionResponse response) {
-        return new ResolveClusterActionResponse(randomResolveClusterInfoMap());
+        return new ResolveClusterActionResponse(randomResolveClusterInfoMap(response));
     }
 }


### PR DESCRIPTION
Adjust randomization in ResolveClusterActionResponseTests (#105932)
to avoid failures in `testEqualsAndHashcode` tests.
Backport of commit `f1035bba1ecf18181697a5ab6329c5c6c43a4c3b`

Fixes https://github.com/elastic/elasticsearch/issues/105898
