### PR TITLE
[Inference API] Move organization constant to OpenAiServiceFields and use OpenAiServiceFields in inference module

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceFields.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceFields.java
@@ -11,4 +11,6 @@ public class OpenAiServiceFields {
 
     public static final String USER = "user";
 
+    public static final String ORGANIZATION = "organization_id";
+
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionServiceSettings.java
@@ -31,6 +31,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.createOpti
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeAsType;
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.ORGANIZATION;
 
 /**
  * Defines the service settings for interacting with OpenAI's chat completion models.
@@ -38,8 +39,6 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeAsTy
 public class OpenAiChatCompletionServiceSettings implements ServiceSettings {
 
     public static final String NAME = "openai_completion_service_settings";
-
-    static final String ORGANIZATION = "organization_id";
 
     public static OpenAiChatCompletionServiceSettings fromMap(Map<String, Object> map) {
         ValidationException validationException = new ValidationException();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionTaskSettings.java
@@ -22,12 +22,11 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.USER;
 
 public class OpenAiChatCompletionTaskSettings implements TaskSettings {
 
     public static final String NAME = "openai_completion_task_settings";
-
-    public static final String USER = "user";
 
     public static OpenAiChatCompletionTaskSettings fromMap(Map<String, Object> map) {
         ValidationException validationException = new ValidationException();

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
@@ -16,7 +16,7 @@ import org.elasticsearch.inference.ModelConfigurations;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
-import static org.elasticsearch.xpack.inference.services.openai.embeddings.OpenAiEmbeddingsTaskSettings.USER;
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.USER;
 
 /**
  * This class handles extracting OpenAI task settings from a request. The difference between this class and

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettings.java
@@ -37,6 +37,7 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractSimilarity;
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.removeAsType;
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.ORGANIZATION;
 
 /**
  * Defines the service settings for interacting with OpenAI's text embedding models.
@@ -45,7 +46,6 @@ public class OpenAiEmbeddingsServiceSettings implements ServiceSettings {
 
     public static final String NAME = "openai_service_settings";
 
-    static final String ORGANIZATION = "organization_id";
     static final String DIMENSIONS_SET_BY_USER = "dimensions_set_by_user";
 
     public static OpenAiEmbeddingsServiceSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettings.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.USER;
 
 /**
  * Defines the task settings for the openai service.
@@ -33,7 +34,6 @@ import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOpt
 public class OpenAiEmbeddingsTaskSettings implements TaskSettings {
 
     public static final String NAME = "openai_embeddings_task_settings";
-    public static final String USER = "user";
 
     public static OpenAiEmbeddingsTaskSettings fromMap(Map<String, Object> map, ConfigurationParseContext context) {
         ValidationException validationException = new ValidationException();

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionRequestTaskSettingsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.services.openai.completion;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,9 +29,7 @@ public class OpenAiChatCompletionRequestTaskSettingsTests extends ESTestCase {
     }
 
     public void testFromMap_ReturnsUser() {
-        var settings = OpenAiChatCompletionRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiChatCompletionTaskSettings.USER, "user"))
-        );
+        var settings = OpenAiChatCompletionRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "user")));
         assertThat(settings.user(), is("user"));
     }
 
@@ -38,7 +37,7 @@ public class OpenAiChatCompletionRequestTaskSettingsTests extends ESTestCase {
         var map = new HashMap<String, Object>();
 
         if (user != null) {
-            map.put(OpenAiChatCompletionTaskSettings.USER, user);
+            map.put(OpenAiServiceFields.USER, user);
         }
 
         return map;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionServiceSettingsTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields;
 
 import java.io.IOException;
 import java.net.URI;
@@ -40,7 +41,7 @@ public class OpenAiChatCompletionServiceSettingsTests extends AbstractWireSerial
                     modelId,
                     ServiceFields.URL,
                     url,
-                    OpenAiChatCompletionServiceSettings.ORGANIZATION,
+                    OpenAiServiceFields.ORGANIZATION,
                     org,
                     ServiceFields.MAX_INPUT_TOKENS,
                     maxInputTokens
@@ -61,7 +62,7 @@ public class OpenAiChatCompletionServiceSettingsTests extends AbstractWireSerial
                 Map.of(
                     ServiceFields.MODEL_ID,
                     modelId,
-                    OpenAiChatCompletionServiceSettings.ORGANIZATION,
+                    OpenAiServiceFields.ORGANIZATION,
                     organization,
                     ServiceFields.MAX_INPUT_TOKENS,
                     maxInputTokens
@@ -109,7 +110,7 @@ public class OpenAiChatCompletionServiceSettingsTests extends AbstractWireSerial
         var thrownException = expectThrows(
             ValidationException.class,
             () -> OpenAiChatCompletionServiceSettings.fromMap(
-                new HashMap<>(Map.of(OpenAiChatCompletionServiceSettings.ORGANIZATION, "", ServiceFields.MODEL_ID, "model"))
+                new HashMap<>(Map.of(OpenAiServiceFields.ORGANIZATION, "", ServiceFields.MODEL_ID, "model"))
             )
         );
 
@@ -118,7 +119,7 @@ public class OpenAiChatCompletionServiceSettingsTests extends AbstractWireSerial
             containsString(
                 org.elasticsearch.common.Strings.format(
                     "Validation Failed: 1: [service_settings] Invalid value empty string. [%s] must be a non-empty string;",
-                    OpenAiChatCompletionServiceSettings.ORGANIZATION
+                    OpenAiServiceFields.ORGANIZATION
                 )
             )
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionTaskSettingsTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -27,14 +28,14 @@ public class OpenAiChatCompletionTaskSettingsTests extends AbstractWireSerializi
     public void testFromMap_WithUser() {
         assertEquals(
             new OpenAiChatCompletionTaskSettings("user"),
-            OpenAiChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiChatCompletionTaskSettings.USER, "user")))
+            OpenAiChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "user")))
         );
     }
 
     public void testFromMap_UserIsEmptyString() {
         var thrownException = expectThrows(
             ValidationException.class,
-            () -> OpenAiChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiChatCompletionTaskSettings.USER, "")))
+            () -> OpenAiChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "")))
         );
 
         assertThat(
@@ -49,7 +50,7 @@ public class OpenAiChatCompletionTaskSettingsTests extends AbstractWireSerializi
     }
 
     public void testOverrideWith_KeepsOriginalValuesWithOverridesAreNull() {
-        var taskSettings = OpenAiChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiChatCompletionTaskSettings.USER, "user")));
+        var taskSettings = OpenAiChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "user")));
 
         var overriddenTaskSettings = OpenAiChatCompletionTaskSettings.of(
             taskSettings,
@@ -59,11 +60,9 @@ public class OpenAiChatCompletionTaskSettingsTests extends AbstractWireSerializi
     }
 
     public void testOverrideWith_UsesOverriddenSettings() {
-        var taskSettings = OpenAiChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiChatCompletionTaskSettings.USER, "user")));
+        var taskSettings = OpenAiChatCompletionTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "user")));
 
-        var requestTaskSettings = OpenAiChatCompletionRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiChatCompletionTaskSettings.USER, "user2"))
-        );
+        var requestTaskSettings = OpenAiChatCompletionRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "user2")));
 
         var overriddenTaskSettings = OpenAiChatCompletionTaskSettings.of(taskSettings, requestTaskSettings);
         assertThat(overriddenTaskSettings, is(new OpenAiChatCompletionTaskSettings("user2")));

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettingsTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.inference.services.openai.embeddings;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,7 +28,7 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
     }
 
     public void testFromMap_ReturnsUser() {
-        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")));
+        var settings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "user")));
         assertThat(settings.user(), is("user"));
     }
 
@@ -35,7 +36,7 @@ public class OpenAiEmbeddingsRequestTaskSettingsTests extends ESTestCase {
         var map = new HashMap<String, Object>();
 
         if (user != null) {
-            map.put(OpenAiEmbeddingsTaskSettings.USER, user);
+            map.put(OpenAiServiceFields.USER, user);
         }
 
         return map;

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsServiceSettingsTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.ServiceFields;
 import org.elasticsearch.xpack.inference.services.ServiceUtils;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields;
 import org.hamcrest.CoreMatchers;
 
 import java.io.IOException;
@@ -79,7 +80,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     modelId,
                     ServiceFields.URL,
                     url,
-                    OpenAiEmbeddingsServiceSettings.ORGANIZATION,
+                    OpenAiServiceFields.ORGANIZATION,
                     org,
                     ServiceFields.SIMILARITY,
                     similarity,
@@ -121,7 +122,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     modelId,
                     ServiceFields.URL,
                     url,
-                    OpenAiEmbeddingsServiceSettings.ORGANIZATION,
+                    OpenAiServiceFields.ORGANIZATION,
                     org,
                     ServiceFields.SIMILARITY,
                     similarity,
@@ -162,7 +163,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
                     modelId,
                     ServiceFields.URL,
                     url,
-                    OpenAiEmbeddingsServiceSettings.ORGANIZATION,
+                    OpenAiServiceFields.ORGANIZATION,
                     org,
                     ServiceFields.SIMILARITY,
                     similarity,
@@ -219,7 +220,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
 
     public void testFromMap_MissingUrl_DoesNotThrowException() {
         var serviceSettings = OpenAiEmbeddingsServiceSettings.fromMap(
-            new HashMap<>(Map.of(ServiceFields.MODEL_ID, "m", OpenAiEmbeddingsServiceSettings.ORGANIZATION, "org")),
+            new HashMap<>(Map.of(ServiceFields.MODEL_ID, "m", OpenAiServiceFields.ORGANIZATION, "org")),
             ConfigurationParseContext.REQUEST
         );
         assertNull(serviceSettings.uri());
@@ -260,7 +261,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
         var thrownException = expectThrows(
             ValidationException.class,
             () -> OpenAiEmbeddingsServiceSettings.fromMap(
-                new HashMap<>(Map.of(OpenAiEmbeddingsServiceSettings.ORGANIZATION, "", ServiceFields.MODEL_ID, "m")),
+                new HashMap<>(Map.of(OpenAiServiceFields.ORGANIZATION, "", ServiceFields.MODEL_ID, "m")),
                 ConfigurationParseContext.REQUEST
             )
         );
@@ -270,7 +271,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
             containsString(
                 Strings.format(
                     "Validation Failed: 1: [service_settings] Invalid value empty string. [%s] must be a non-empty string;",
-                    OpenAiEmbeddingsServiceSettings.ORGANIZATION
+                    OpenAiServiceFields.ORGANIZATION
                 )
             )
         );
@@ -375,7 +376,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
         }
 
         if (org != null) {
-            map.put(OpenAiEmbeddingsServiceSettings.ORGANIZATION, org);
+            map.put(OpenAiServiceFields.ORGANIZATION, org);
         }
         return map;
     }
@@ -395,7 +396,7 @@ public class OpenAiEmbeddingsServiceSettingsTests extends AbstractWireSerializin
         }
 
         if (org != null) {
-            map.put(OpenAiEmbeddingsServiceSettings.ORGANIZATION, org);
+            map.put(OpenAiServiceFields.ORGANIZATION, org);
         }
 
         if (dimensions != null) {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsTaskSettingsTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -38,10 +39,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
     public void testFromMap_WithUser() {
         assertEquals(
             new OpenAiEmbeddingsTaskSettings("user"),
-            OpenAiEmbeddingsTaskSettings.fromMap(
-                new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
-                ConfigurationParseContext.REQUEST
-            )
+            OpenAiEmbeddingsTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "user")), ConfigurationParseContext.REQUEST)
         );
     }
 
@@ -49,7 +47,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
         var thrownException = expectThrows(
             ValidationException.class,
             () -> OpenAiEmbeddingsTaskSettings.fromMap(
-                new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "")),
+                new HashMap<>(Map.of(OpenAiServiceFields.USER, "")),
                 ConfigurationParseContext.REQUEST
             )
         );
@@ -67,7 +65,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
 
     public void testOverrideWith_KeepsOriginalValuesWithOverridesAreNull() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiServiceFields.USER, "user")),
             ConfigurationParseContext.PERSISTENT
         );
 
@@ -77,13 +75,11 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
 
     public void testOverrideWith_UsesOverriddenSettings() {
         var taskSettings = OpenAiEmbeddingsTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user")),
+            new HashMap<>(Map.of(OpenAiServiceFields.USER, "user")),
             ConfigurationParseContext.PERSISTENT
         );
 
-        var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(
-            new HashMap<>(Map.of(OpenAiEmbeddingsTaskSettings.USER, "user2"))
-        );
+        var requestTaskSettings = OpenAiEmbeddingsRequestTaskSettings.fromMap(new HashMap<>(Map.of(OpenAiServiceFields.USER, "user2")));
 
         var overriddenTaskSettings = OpenAiEmbeddingsTaskSettings.of(taskSettings, requestTaskSettings);
         MatcherAssert.assertThat(overriddenTaskSettings, is(new OpenAiEmbeddingsTaskSettings("user2")));
@@ -108,7 +104,7 @@ public class OpenAiEmbeddingsTaskSettingsTests extends AbstractWireSerializingTe
         var map = new HashMap<String, Object>();
 
         if (user != null) {
-            map.put(OpenAiEmbeddingsTaskSettings.USER, user);
+            map.put(OpenAiServiceFields.USER, user);
         }
 
         return map;


### PR DESCRIPTION
Follow-up for https://github.com/elastic/elasticsearch/pull/106476#discussion_r1530505586:
- Use `OpenAiServiceFields` constants in the codebase
- Moved `ORGANIZATION` constant also to `OpenAiServiceFields` as it's common for embeddings and completions