### PR TITLE
Add method to get the highest indexversion used to write to a shard

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -245,6 +245,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     private final RetentionLeaseSyncer retentionLeaseSyncer;
 
+    private IndexVersion lastModificationIndexVersion;
+
     @Nullable
     private volatile RecoveryState recoveryState;
 
@@ -1418,6 +1420,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     public BulkStats bulkStats() {
         return bulkOperationListener.stats();
+    }
+
+    /**
+     * Returns the highest IndexVersion that has been used to write segments to this shard
+     */
+    public IndexVersion getMaxCommitIndexVersion() {
+        return Engine.readIndexVersion(getEngine().getLastCommittedSegmentInfos().userData.get(Engine.ES_VERSION));
     }
 
     /**


### PR DESCRIPTION
Strawman implementation - need some confirmation that this is, in fact, the correct thing to do. Which I don't think it is...

This method will be used in a future IndexVersionAllocationDecider to get the indexversion required to read an index shard