### PR TITLE
Move SearchHit parsing to test codebase

### DIFF
--- a/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedSearchHitTests.java
+++ b/modules/rank-eval/src/test/java/org/elasticsearch/index/rankeval/RatedSearchHitTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.rankeval;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -34,7 +35,11 @@ public class RatedSearchHitTests extends ESTestCase {
     );
 
     static {
-        PARSER.declareObject(ConstructingObjectParser.constructorArg(), (p, c) -> SearchHit.fromXContent(p), new ParseField("hit"));
+        PARSER.declareObject(
+            ConstructingObjectParser.constructorArg(),
+            (p, c) -> SearchResponseUtils.parseSearchHit(p),
+            new ParseField("hit")
+        );
         PARSER.declareField(
             ConstructingObjectParser.constructorArg(),
             (p) -> p.currentToken() == XContentParser.Token.VALUE_NULL ? OptionalInt.empty() : OptionalInt.of(p.intValue()),

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search;
 import org.apache.lucene.search.Explanation;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -33,22 +32,15 @@ import org.elasticsearch.index.mapper.IgnoredFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.seqno.SequenceNumbers;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.search.fetch.subphase.LookupField;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.transport.LeakTracker;
 import org.elasticsearch.transport.RemoteClusterAware;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.ObjectParser.ValueType;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentParser.Token;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -56,7 +48,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -66,10 +57,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 import static org.elasticsearch.common.lucene.Lucene.readExplanation;
 import static org.elasticsearch.common.lucene.Lucene.writeExplanation;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * A single search hit.
@@ -80,10 +67,10 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
 
     private final transient int docId;
 
-    private static final float DEFAULT_SCORE = Float.NaN;
+    static final float DEFAULT_SCORE = Float.NaN;
     private float score;
 
-    private static final int NO_RANK = -1;
+    static final int NO_RANK = -1;
     private int rank;
 
     private final Text id;
@@ -935,258 +922,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
         return builder;
     }
 
-    // All fields on the root level of the parsed SearhHit are interpreted as metadata fields
-    // public because we use it in a completion suggestion option
-    @SuppressWarnings("unchecked")
-    public static final ObjectParser.UnknownFieldConsumer<Map<String, Object>> unknownMetaFieldConsumer = (map, fieldName, fieldValue) -> {
-        Map<String, DocumentField> fieldMap = (Map<String, DocumentField>) map.computeIfAbsent(
-            METADATA_FIELDS,
-            v -> new HashMap<String, DocumentField>()
-        );
-        if (fieldName.equals(IgnoredFieldMapper.NAME)) {
-            fieldMap.put(fieldName, new DocumentField(fieldName, (List<Object>) fieldValue));
-        } else {
-            fieldMap.put(fieldName, new DocumentField(fieldName, Collections.singletonList(fieldValue)));
-        }
-    };
-
-    /**
-     * This parser outputs a temporary map of the objects needed to create the
-     * SearchHit instead of directly creating the SearchHit. The reason for this
-     * is that this way we can reuse the parser when parsing xContent from
-     * {@link org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry.Option} which unfortunately inlines
-     * the output of
-     * {@link #toInnerXContent(XContentBuilder, org.elasticsearch.xcontent.ToXContent.Params)}
-     * of the included search hit. The output of the map is used to create the
-     * actual SearchHit instance via {@link #createFromMap(Map)}
-     */
-    private static final ObjectParser<Map<String, Object>, Void> MAP_PARSER = new ObjectParser<>(
-        "innerHitParser",
-        unknownMetaFieldConsumer,
-        HashMap::new
-    );
-
-    static {
-        declareInnerHitsParseFields(MAP_PARSER);
-    }
-
-    public static SearchHit fromXContent(XContentParser parser) {
-        return createFromMap(MAP_PARSER.apply(parser, null));
-    }
-
-    public static void declareInnerHitsParseFields(ObjectParser<Map<String, Object>, Void> parser) {
-        parser.declareString((map, value) -> map.put(Fields._INDEX, value), new ParseField(Fields._INDEX));
-        parser.declareString((map, value) -> map.put(Fields._ID, value), new ParseField(Fields._ID));
-        parser.declareString((map, value) -> map.put(Fields._NODE, value), new ParseField(Fields._NODE));
-        parser.declareField(
-            (map, value) -> map.put(Fields._SCORE, value),
-            SearchHit::parseScore,
-            new ParseField(Fields._SCORE),
-            ValueType.FLOAT_OR_NULL
-        );
-        parser.declareInt((map, value) -> map.put(Fields._RANK, value), new ParseField(Fields._RANK));
-
-        parser.declareLong((map, value) -> map.put(Fields._VERSION, value), new ParseField(Fields._VERSION));
-        parser.declareLong((map, value) -> map.put(Fields._SEQ_NO, value), new ParseField(Fields._SEQ_NO));
-        parser.declareLong((map, value) -> map.put(Fields._PRIMARY_TERM, value), new ParseField(Fields._PRIMARY_TERM));
-        parser.declareField(
-            (map, value) -> map.put(Fields._SHARD, value),
-            (p, c) -> ShardId.fromString(p.text()),
-            new ParseField(Fields._SHARD),
-            ValueType.STRING
-        );
-        parser.declareObject(
-            (map, value) -> map.put(SourceFieldMapper.NAME, value),
-            (p, c) -> parseSourceBytes(p),
-            new ParseField(SourceFieldMapper.NAME)
-        );
-        parser.declareObject(
-            (map, value) -> map.put(Fields.HIGHLIGHT, value),
-            (p, c) -> parseHighlightFields(p),
-            new ParseField(Fields.HIGHLIGHT)
-        );
-        parser.declareObject((map, value) -> {
-            Map<String, DocumentField> fieldMap = get(Fields.FIELDS, map, new HashMap<String, DocumentField>());
-            fieldMap.putAll(value);
-            map.put(DOCUMENT_FIELDS, fieldMap);
-        }, (p, c) -> parseFields(p), new ParseField(Fields.FIELDS));
-        parser.declareObject(
-            (map, value) -> map.put(Fields._EXPLANATION, value),
-            (p, c) -> parseExplanation(p),
-            new ParseField(Fields._EXPLANATION)
-        );
-        parser.declareObject(
-            (map, value) -> map.put(NestedIdentity._NESTED, value),
-            NestedIdentity::fromXContent,
-            new ParseField(NestedIdentity._NESTED)
-        );
-        parser.declareObject(
-            (map, value) -> map.put(Fields.INNER_HITS, value),
-            (p, c) -> parseInnerHits(p),
-            new ParseField(Fields.INNER_HITS)
-        );
-
-        parser.declareField((p, map, context) -> {
-            XContentParser.Token token = p.currentToken();
-            Map<String, Float> matchedQueries = new LinkedHashMap<>();
-            if (token == XContentParser.Token.START_OBJECT) {
-                String fieldName = null;
-                while ((token = p.nextToken()) != XContentParser.Token.END_OBJECT) {
-                    if (token == XContentParser.Token.FIELD_NAME) {
-                        fieldName = p.currentName();
-                    } else if (token.isValue()) {
-                        matchedQueries.put(fieldName, p.floatValue());
-                    }
-                }
-            } else if (token == XContentParser.Token.START_ARRAY) {
-                while (p.nextToken() != XContentParser.Token.END_ARRAY) {
-                    matchedQueries.put(p.text(), Float.NaN);
-                }
-            }
-            map.put(Fields.MATCHED_QUERIES, matchedQueries);
-        }, new ParseField(Fields.MATCHED_QUERIES), ObjectParser.ValueType.OBJECT_ARRAY);
-
-        parser.declareField(
-            (map, list) -> map.put(Fields.SORT, list),
-            SearchSortValues::fromXContent,
-            new ParseField(Fields.SORT),
-            ValueType.OBJECT_ARRAY
-        );
-    }
-
-    public static SearchHit createFromMap(Map<String, Object> values) {
-        String id = get(Fields._ID, values, null);
-        String index = get(Fields._INDEX, values, null);
-        String clusterAlias = null;
-        if (index != null) {
-            int indexOf = index.indexOf(RemoteClusterAware.REMOTE_CLUSTER_INDEX_SEPARATOR);
-            if (indexOf > 0) {
-                clusterAlias = index.substring(0, indexOf);
-                index = index.substring(indexOf + 1);
-            }
-        }
-        ShardId shardId = get(Fields._SHARD, values, null);
-        String nodeId = get(Fields._NODE, values, null);
-        final SearchShardTarget shardTarget;
-        if (shardId != null && nodeId != null) {
-            assert shardId.getIndexName().equals(index);
-            shardTarget = new SearchShardTarget(nodeId, shardId, clusterAlias);
-            index = shardTarget.getIndex();
-            clusterAlias = shardTarget.getClusterAlias();
-        } else {
-            shardTarget = null;
-        }
-        return new SearchHit(
-            -1,
-            get(Fields._SCORE, values, DEFAULT_SCORE),
-            get(Fields._RANK, values, NO_RANK),
-            id == null ? null : new Text(id),
-            get(NestedIdentity._NESTED, values, null),
-            get(Fields._VERSION, values, -1L),
-            get(Fields._SEQ_NO, values, SequenceNumbers.UNASSIGNED_SEQ_NO),
-            get(Fields._PRIMARY_TERM, values, SequenceNumbers.UNASSIGNED_PRIMARY_TERM),
-            get(SourceFieldMapper.NAME, values, null),
-            get(Fields.HIGHLIGHT, values, null),
-            get(Fields.SORT, values, SearchSortValues.EMPTY),
-            get(Fields.MATCHED_QUERIES, values, null),
-            get(Fields._EXPLANATION, values, null),
-            shardTarget,
-            index,
-            clusterAlias,
-            null,
-            get(Fields.INNER_HITS, values, null),
-            get(DOCUMENT_FIELDS, values, Collections.emptyMap()),
-            get(METADATA_FIELDS, values, Collections.emptyMap()),
-            ALWAYS_REFERENCED // TODO: do we ever want pooling here?
-        );
-    }
-
-    @SuppressWarnings("unchecked")
-    private static <T> T get(String key, Map<String, Object> map, T defaultValue) {
-        return (T) map.getOrDefault(key, defaultValue);
-    }
-
-    private static float parseScore(XContentParser parser) throws IOException {
-        if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER || parser.currentToken() == XContentParser.Token.VALUE_STRING) {
-            return parser.floatValue();
-        } else {
-            return Float.NaN;
-        }
-    }
-
-    private static BytesReference parseSourceBytes(XContentParser parser) throws IOException {
-        try (XContentBuilder builder = XContentBuilder.builder(parser.contentType().xContent())) {
-            // the original document gets slightly modified: whitespaces or
-            // pretty printing are not preserved,
-            // it all depends on the current builder settings
-            builder.copyCurrentStructure(parser);
-            return BytesReference.bytes(builder);
-        }
-    }
-
-    private static Map<String, DocumentField> parseFields(XContentParser parser) throws IOException {
-        Map<String, DocumentField> fields = new HashMap<>();
-        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
-            DocumentField field = DocumentField.fromXContent(parser);
-            fields.put(field.getName(), field);
-        }
-        return fields;
-    }
-
-    private static Map<String, SearchHits> parseInnerHits(XContentParser parser) throws IOException {
-        Map<String, SearchHits> innerHits = new HashMap<>();
-        while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
-            String name = parser.currentName();
-            ensureExpectedToken(Token.START_OBJECT, parser.nextToken(), parser);
-            ensureFieldName(parser, parser.nextToken(), SearchHits.Fields.HITS);
-            innerHits.put(name, SearchHits.fromXContent(parser));
-            ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
-        }
-        return innerHits;
-    }
-
-    private static Map<String, HighlightField> parseHighlightFields(XContentParser parser) throws IOException {
-        Map<String, HighlightField> highlightFields = new HashMap<>();
-        while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            HighlightField highlightField = HighlightField.fromXContent(parser);
-            highlightFields.put(highlightField.name(), highlightField);
-        }
-        return highlightFields;
-    }
-
-    private static Explanation parseExplanation(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-        XContentParser.Token token;
-        Float value = null;
-        String description = null;
-        List<Explanation> details = new ArrayList<>();
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
-            String currentFieldName = parser.currentName();
-            token = parser.nextToken();
-            if (Fields.VALUE.equals(currentFieldName)) {
-                value = parser.floatValue();
-            } else if (Fields.DESCRIPTION.equals(currentFieldName)) {
-                description = parser.textOrNull();
-            } else if (Fields.DETAILS.equals(currentFieldName)) {
-                ensureExpectedToken(XContentParser.Token.START_ARRAY, token, parser);
-                while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                    details.add(parseExplanation(parser));
-                }
-            } else {
-                parser.skipChildren();
-            }
-        }
-        if (value == null) {
-            throw new ParsingException(parser.getTokenLocation(), "missing explanation value");
-        }
-        if (description == null) {
-            throw new ParsingException(parser.getTokenLocation(), "missing explanation description");
-        }
-        return Explanation.match(value, description, details);
-    }
-
     private static void buildExplanation(XContentBuilder builder, Explanation explanation) throws IOException {
         builder.startObject();
         builder.field(Fields.VALUE, explanation.getValue());
@@ -1251,9 +986,9 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
      */
     public static final class NestedIdentity implements Writeable, ToXContentFragment {
 
-        private static final String _NESTED = "_nested";
-        private static final String FIELD = "field";
-        private static final String OFFSET = "offset";
+        static final String _NESTED = "_nested";
+        static final String FIELD = "field";
+        static final String OFFSET = "offset";
 
         private final Text field;
         private final int offset;
@@ -1377,25 +1112,6 @@ public final class SearchHit implements Writeable, ToXContentObject, RefCounted 
             }
             builder.endObject();
             return builder;
-        }
-
-        private static final ConstructingObjectParser<NestedIdentity, Void> PARSER = new ConstructingObjectParser<>(
-            "nested_identity",
-            true,
-            ctorArgs -> new NestedIdentity((String) ctorArgs[0], (int) ctorArgs[1], (NestedIdentity) ctorArgs[2])
-        );
-        static {
-            PARSER.declareString(constructorArg(), new ParseField(FIELD));
-            PARSER.declareInt(constructorArg(), new ParseField(OFFSET));
-            PARSER.declareObject(optionalConstructorArg(), PARSER, new ParseField(_NESTED));
-        }
-
-        static NestedIdentity fromXContent(XContentParser parser, Void context) {
-            return fromXContent(parser);
-        }
-
-        public static NestedIdentity fromXContent(XContentParser parser) {
-            return PARSER.apply(parser, null);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/Suggest.java
@@ -8,26 +8,20 @@
 package org.elasticsearch.search.suggest;
 
 import org.apache.lucene.util.CollectionUtil;
-import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.common.xcontent.XContentParserUtils;
-import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
-import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,11 +29,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 
 /**
  * Top level suggest result, containing the result for each suggestion.
@@ -123,29 +114,6 @@ public final class Suggest implements Iterable<Suggest.Suggestion<? extends Entr
         }
         builder.endObject();
         return builder;
-    }
-
-    /**
-     * this parsing method assumes that the leading "suggest" field name has already been parsed by the caller
-     */
-    public static Suggest fromXContent(XContentParser parser) throws IOException {
-        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
-        List<Suggestion<? extends Entry<? extends Option>>> suggestions = new ArrayList<>();
-        while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
-            String currentField = parser.currentName();
-            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
-            Suggestion<? extends Entry<? extends Option>> suggestion = Suggestion.fromXContent(parser);
-            if (suggestion != null) {
-                suggestions.add(suggestion);
-            } else {
-                throw new ParsingException(
-                    parser.getTokenLocation(),
-                    String.format(Locale.ROOT, "Could not parse suggestion keyed as [%s]", currentField)
-                );
-            }
-        }
-        return new Suggest(suggestions);
     }
 
     public static List<Suggestion<? extends Entry<? extends Option>>> reduce(Map<String, List<Suggest.Suggestion<?>>> groupedSuggestions) {
@@ -362,33 +330,14 @@ public final class Suggest implements Iterable<Suggest.Suggestion<? extends Entr
             return Objects.hash(name, size, entries);
         }
 
-        @SuppressWarnings("unchecked")
-        public static Suggestion<? extends Entry<? extends Option>> fromXContent(XContentParser parser) throws IOException {
-            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
-            SetOnce<Suggestion> suggestion = new SetOnce<>();
-            XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggestion.class, suggestion::set);
-            return suggestion.get();
-        }
-
-        protected static <E extends Suggestion.Entry<?>> void parseEntries(
-            XContentParser parser,
-            Suggestion<E> suggestion,
-            CheckedFunction<XContentParser, E, IOException> entryParser
-        ) throws IOException {
-            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
-            while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                suggestion.addTerm(entryParser.apply(parser));
-            }
-        }
-
         /**
          * Represents a part from the suggest text with suggested options.
          */
         public abstract static class Entry<O extends Option> implements Iterable<O>, Writeable, ToXContentFragment {
 
-            private static final String TEXT = "text";
-            private static final String OFFSET = "offset";
-            private static final String LENGTH = "length";
+            static final String TEXT = "text";
+            static final String OFFSET = "offset";
+            static final String LENGTH = "length";
             protected static final String OPTIONS = "options";
 
             protected Text text;
@@ -559,12 +508,6 @@ public final class Suggest implements Iterable<Suggest.Suggestion<? extends Entr
                 }
                 builder.endArray();
                 return builder;
-            }
-
-            protected static void declareCommonFields(ObjectParser<? extends Entry<? extends Option>, Void> parser) {
-                parser.declareString((entry, text) -> entry.text = new Text(text), new ParseField(TEXT));
-                parser.declareInt((entry, offset) -> entry.offset = offset, new ParseField(OFFSET));
-                parser.declareInt((entry, length) -> entry.length = length, new ParseField(LENGTH));
             }
 
             /**

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/CompletionSuggestion.java
@@ -18,24 +18,17 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.suggest.Suggest;
-import org.elasticsearch.search.suggest.Suggest.Suggestion;
-import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.elasticsearch.search.SearchHit.unknownMetaFieldConsumer;
 import static org.elasticsearch.search.suggest.Suggest.COMPARATOR;
 
 /**
@@ -112,12 +105,6 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), skipDuplicates);
-    }
-
-    public static CompletionSuggestion fromXContent(XContentParser parser, String name) throws IOException {
-        CompletionSuggestion suggestion = new CompletionSuggestion(name, -1, false);
-        parseEntries(parser, suggestion, CompletionSuggestion.Entry::fromXContent);
-        return suggestion;
     }
 
     private static final class OptionPriorityQueue extends PriorityQueue<ShardOptions> {
@@ -230,7 +217,7 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
             super(text, offset, length);
         }
 
-        private Entry() {}
+        public Entry() {}
 
         public Entry(StreamInput in) throws IOException {
             super(in);
@@ -239,20 +226,6 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
         @Override
         protected Option newOption(StreamInput in) throws IOException {
             return new Option(in);
-        }
-
-        private static final ObjectParser<Entry, Void> PARSER = new ObjectParser<>("CompletionSuggestionEntryParser", true, Entry::new);
-        static {
-            declareCommonFields(PARSER);
-            /*
-             * The use of a lambda expression instead of the method reference Entry::addOptions is a workaround for a JDK 14 compiler bug.
-             * The bug is: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8242214
-             */
-            PARSER.declareObjectArray((e, o) -> e.addOptions(o), (p, c) -> Option.fromXContent(p), new ParseField(OPTIONS));
-        }
-
-        public static Entry fromXContent(XContentParser parser) {
-            return PARSER.apply(parser, null);
         }
 
         public static class Option extends Suggest.Suggestion.Entry.Option {
@@ -334,69 +307,6 @@ public final class CompletionSuggestion extends Suggest.Suggestion<CompletionSug
                     builder.endObject();
                 }
                 return builder;
-            }
-
-            private static final ObjectParser<Map<String, Object>, Void> PARSER = new ObjectParser<>(
-                "CompletionOptionParser",
-                unknownMetaFieldConsumer,
-                HashMap::new
-            );
-
-            static {
-                SearchHit.declareInnerHitsParseFields(PARSER);
-                PARSER.declareString(
-                    (map, value) -> map.put(Suggestion.Entry.Option.TEXT.getPreferredName(), value),
-                    Suggestion.Entry.Option.TEXT
-                );
-                PARSER.declareFloat(
-                    (map, value) -> map.put(Suggestion.Entry.Option.SCORE.getPreferredName(), value),
-                    Suggestion.Entry.Option.SCORE
-                );
-                PARSER.declareObject(
-                    (map, value) -> map.put(CompletionSuggestion.Entry.Option.CONTEXTS.getPreferredName(), value),
-                    (p, c) -> parseContexts(p),
-                    CompletionSuggestion.Entry.Option.CONTEXTS
-                );
-            }
-
-            private static Map<String, Set<String>> parseContexts(XContentParser parser) throws IOException {
-                Map<String, Set<String>> contexts = new HashMap<>();
-                while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-                    ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
-                    String key = parser.currentName();
-                    ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
-                    Set<String> values = new HashSet<>();
-                    while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
-                        ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.currentToken(), parser);
-                        values.add(parser.text());
-                    }
-                    contexts.put(key, values);
-                }
-                return contexts;
-            }
-
-            public static Option fromXContent(XContentParser parser) {
-                Map<String, Object> values = PARSER.apply(parser, null);
-
-                Text text = new Text((String) values.get(Suggestion.Entry.Option.TEXT.getPreferredName()));
-                Float score = (Float) values.get(Suggestion.Entry.Option.SCORE.getPreferredName());
-                @SuppressWarnings("unchecked")
-                Map<String, Set<String>> contexts = (Map<String, Set<String>>) values.get(
-                    CompletionSuggestion.Entry.Option.CONTEXTS.getPreferredName()
-                );
-                if (contexts == null) {
-                    contexts = Collections.emptyMap();
-                }
-
-                SearchHit hit = null;
-                // the option either prints SCORE or inlines the search hit
-                if (score == null) {
-                    hit = SearchHit.createFromMap(values);
-                    score = hit.getScore();
-                }
-                CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(-1, text, score, contexts);
-                option.setHit(hit);
-                return option;
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/plugins/spi/NamedXContentProviderTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/spi/NamedXContentProviderTests.java
@@ -10,8 +10,7 @@ package org.elasticsearch.plugins.spi;
 
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.search.suggest.Suggest;
-import org.elasticsearch.search.suggest.phrase.PhraseSuggestion;
-import org.elasticsearch.search.suggest.term.TermSuggestion;
+import org.elasticsearch.search.suggest.SuggestTests;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ParseField;
@@ -61,12 +60,12 @@ public class NamedXContentProviderTests extends ESTestCase {
                 new NamedXContentRegistry.Entry(
                     Suggest.Suggestion.class,
                     new ParseField("phrase_aggregation"),
-                    (parser, context) -> PhraseSuggestion.fromXContent(parser, (String) context)
+                    (parser, context) -> SuggestTests.parsePhraseSuggestion(parser, (String) context)
                 ),
                 new NamedXContentRegistry.Entry(
                     Suggest.Suggestion.class,
                     new ParseField("test_suggestion"),
-                    (parser, context) -> TermSuggestion.fromXContent(parser, (String) context)
+                    (parser, context) -> SuggestTests.parseTermSuggestion(parser, (String) context)
                 )
             );
         }

--- a/server/src/test/java/org/elasticsearch/search/NestedIdentityTests.java
+++ b/server/src/test/java/org/elasticsearch/search/NestedIdentityTests.java
@@ -48,7 +48,7 @@ public class NestedIdentityTests extends ESTestCase {
         }
         builder = nestedIdentity.innerToXContent(builder, ToXContent.EMPTY_PARAMS);
         try (XContentParser parser = createParser(builder)) {
-            NestedIdentity parsedNestedIdentity = NestedIdentity.fromXContent(parser);
+            NestedIdentity parsedNestedIdentity = SearchResponseUtils.parseNestedIdentity(parser);
             assertEquals(nestedIdentity, parsedNestedIdentity);
             assertNull(parser.nextToken());
         }

--- a/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitTests.java
@@ -166,7 +166,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
             SearchHit parsed;
             try (XContentParser parser = createParser(xContentType.xContent(), originalBytes)) {
                 parser.nextToken(); // jump to first START_OBJECT
-                parsed = SearchHit.fromXContent(parser);
+                parsed = SearchResponseUtils.parseSearchHit(parser);
                 assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
                 assertNull(parser.nextToken());
             }
@@ -201,7 +201,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
             SearchHit parsed;
             try (XContentParser parser = createParser(xContentType.xContent(), withRandomFields)) {
                 parser.nextToken(); // jump to first START_OBJECT
-                parsed = SearchHit.fromXContent(parser);
+                parsed = SearchResponseUtils.parseSearchHit(parser);
                 assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
                 assertNull(parser.nextToken());
             }
@@ -219,7 +219,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
         SearchHit parsed;
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, hit)) {
             parser.nextToken(); // jump to first START_OBJECT
-            parsed = SearchHit.fromXContent(parser);
+            parsed = SearchResponseUtils.parseSearchHit(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertNull(parser.nextToken());
         }
@@ -341,7 +341,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
                     "result": [null]
                   }
                 }""");
-            SearchHit searchHit = SearchHit.fromXContent(parser);
+            SearchHit searchHit = SearchResponseUtils.parseSearchHit(parser);
             Map<String, DocumentField> fields = searchHit.getFields();
             assertEquals(1, fields.size());
             DocumentField result = fields.get("result");
@@ -360,7 +360,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
                   }
                 }""");
 
-            SearchHit searchHit = SearchHit.fromXContent(parser);
+            SearchHit searchHit = SearchResponseUtils.parseSearchHit(parser);
             Map<String, DocumentField> fields = searchHit.getFields();
             assertEquals(1, fields.size());
             DocumentField result = fields.get("result");
@@ -384,7 +384,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
                   }
                 }""");
 
-            SearchHit searchHit = SearchHit.fromXContent(parser);
+            SearchHit searchHit = SearchResponseUtils.parseSearchHit(parser);
             Map<String, DocumentField> fields = searchHit.getFields();
             assertEquals(1, fields.size());
             DocumentField result = fields.get("result");
@@ -410,7 +410,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
             final SearchHit parsed;
             try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
                 parser.nextToken(); // jump to first START_OBJECT
-                parsed = SearchHit.fromXContent(parser);
+                parsed = SearchResponseUtils.parseSearchHit(parser);
                 assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
                 assertNull(parser.nextToken());
             }
@@ -431,7 +431,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
             final SearchHit parsed;
             try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
                 parser.nextToken(); // jump to first START_OBJECT
-                parsed = SearchHit.fromXContent(parser);
+                parsed = SearchResponseUtils.parseSearchHit(parser);
                 assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
                 assertNull(parser.nextToken());
             }
@@ -448,7 +448,7 @@ public class SearchHitTests extends AbstractWireSerializingTestCase<SearchHit> {
             final SearchHit parsed;
             try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
                 parser.nextToken(); // jump to first START_OBJECT
-                parsed = SearchHit.fromXContent(parser);
+                parsed = SearchResponseUtils.parseSearchHit(parser);
                 assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
                 assertNull(parser.nextToken());
             }

--- a/server/src/test/java/org/elasticsearch/search/SearchHitsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchHitsTests.java
@@ -225,7 +225,7 @@ public class SearchHitsTests extends AbstractChunkedSerializingTestCase<SearchHi
         assertEquals(XContentParser.Token.FIELD_NAME, parser.nextToken());
         assertEquals(SearchHits.Fields.HITS, parser.currentName());
         assertEquals(XContentParser.Token.START_OBJECT, parser.nextToken());
-        SearchHits searchHits = SearchHits.fromXContent(parser);
+        SearchHits searchHits = SearchResponseUtils.parseSearchHits(parser);
         assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
         assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
         try {

--- a/server/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestionOptionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/CompletionSuggestionOptionTests.java
@@ -12,9 +12,11 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHitTests;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion;
 import org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry.Option;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
@@ -28,10 +30,74 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
 
 public class CompletionSuggestionOptionTests extends ESTestCase {
+
+    private static final ObjectParser<Map<String, Object>, Void> PARSER = new ObjectParser<>(
+        "CompletionOptionParser",
+        SearchResponseUtils.unknownMetaFieldConsumer,
+        HashMap::new
+    );
+
+    static {
+        SearchResponseUtils.declareInnerHitsParseFields(PARSER);
+        PARSER.declareString(
+            (map, value) -> map.put(Suggest.Suggestion.Entry.Option.TEXT.getPreferredName(), value),
+            Suggest.Suggestion.Entry.Option.TEXT
+        );
+        PARSER.declareFloat(
+            (map, value) -> map.put(Suggest.Suggestion.Entry.Option.SCORE.getPreferredName(), value),
+            Suggest.Suggestion.Entry.Option.SCORE
+        );
+        PARSER.declareObject(
+            (map, value) -> map.put(CompletionSuggestion.Entry.Option.CONTEXTS.getPreferredName(), value),
+            (p, c) -> parseContexts(p),
+            CompletionSuggestion.Entry.Option.CONTEXTS
+        );
+    }
+
+    private static Map<String, Set<String>> parseContexts(XContentParser parser) throws IOException {
+        Map<String, Set<String>> contexts = new HashMap<>();
+        while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+            String key = parser.currentName();
+            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
+            Set<String> values = new HashSet<>();
+            while ((parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                ensureExpectedToken(XContentParser.Token.VALUE_STRING, parser.currentToken(), parser);
+                values.add(parser.text());
+            }
+            contexts.put(key, values);
+        }
+        return contexts;
+    }
+
+    public static Option parseOption(XContentParser parser) {
+        Map<String, Object> values = PARSER.apply(parser, null);
+
+        Text text = new Text((String) values.get(Suggest.Suggestion.Entry.Option.TEXT.getPreferredName()));
+        Float score = (Float) values.get(Suggest.Suggestion.Entry.Option.SCORE.getPreferredName());
+        @SuppressWarnings("unchecked")
+        Map<String, Set<String>> contexts = (Map<String, Set<String>>) values.get(
+            CompletionSuggestion.Entry.Option.CONTEXTS.getPreferredName()
+        );
+        if (contexts == null) {
+            contexts = Collections.emptyMap();
+        }
+
+        SearchHit hit = null;
+        // the option either prints SCORE or inlines the search hit
+        if (score == null) {
+            hit = SearchResponseUtils.searchHitFromMap(values);
+            score = hit.getScore();
+        }
+        CompletionSuggestion.Entry.Option option = new CompletionSuggestion.Entry.Option(-1, text, score, contexts);
+        option.setHit(hit);
+        return option;
+    }
 
     public static Option createTestItem() {
         Text text = new Text(randomAlphaOfLengthBetween(5, 15));
@@ -91,7 +157,7 @@ public class CompletionSuggestionOptionTests extends ESTestCase {
         }
         Option parsed;
         try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
-            parsed = Option.fromXContent(parser);
+            parsed = parseOption(parser);
             assertNull(parser.nextToken());
         }
         assertEquals(option.getText(), parsed.getText());

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestionOptionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestionOptionTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.text.Text;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
 import org.elasticsearch.search.suggest.phrase.PhraseSuggestion;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
@@ -21,10 +22,37 @@ import java.io.IOException;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option.COLLATE_MATCH;
+import static org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option.HIGHLIGHTED;
+import static org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option.SCORE;
+import static org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option.TEXT;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class SuggestionOptionTests extends ESTestCase {
+
+    private static final ConstructingObjectParser<PhraseSuggestion.Entry.Option, Void> PHRASE_OPTION_PARSER =
+        new ConstructingObjectParser<>("PhraseOptionParser", true, args -> {
+            Text text = new Text((String) args[0]);
+            float score = (Float) args[1];
+            String highlighted = (String) args[2];
+            Text highlightedText = highlighted == null ? null : new Text(highlighted);
+            Boolean collateMatch = (Boolean) args[3];
+            return new PhraseSuggestion.Entry.Option(text, highlightedText, score, collateMatch);
+        });
+
+    static {
+        PHRASE_OPTION_PARSER.declareString(constructorArg(), TEXT);
+        PHRASE_OPTION_PARSER.declareFloat(constructorArg(), SCORE);
+        PHRASE_OPTION_PARSER.declareString(optionalConstructorArg(), HIGHLIGHTED);
+        PHRASE_OPTION_PARSER.declareBoolean(optionalConstructorArg(), COLLATE_MATCH);
+    }
+
+    public static PhraseSuggestion.Entry.Option parsePhraseSuggestionOption(XContentParser parser) {
+        return PHRASE_OPTION_PARSER.apply(parser, null);
+    }
 
     public static Option createTestItem() {
         Text text = new Text(randomAlphaOfLengthBetween(5, 15));
@@ -56,7 +84,7 @@ public class SuggestionOptionTests extends ESTestCase {
         Option parsed;
         try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-            parsed = PhraseSuggestion.Entry.Option.fromXContent(parser);
+            parsed = parsePhraseSuggestionOption(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertNull(parser.nextToken());
         }

--- a/server/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/SuggestionTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.suggest;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.rest.action.search.RestSearchAction;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.search.suggest.Suggest.Suggestion;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry;
 import org.elasticsearch.search.suggest.Suggest.Suggestion.Entry.Option;
@@ -130,7 +131,7 @@ public class SuggestionTests extends ESTestCase {
                 ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
                 ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser);
                 ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
-                parsed = Suggestion.fromXContent(parser);
+                parsed = SearchResponseUtils.parseSuggestion(parser);
                 assertEquals(XContentParser.Token.END_OBJECT, parser.nextToken());
                 assertNull(parser.nextToken());
             }
@@ -153,7 +154,7 @@ public class SuggestionTests extends ESTestCase {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser);
             ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
-            assertNull(Suggestion.fromXContent(parser));
+            assertNull(SearchResponseUtils.parseSuggestion(parser));
             ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
         }
     }
@@ -187,7 +188,10 @@ public class SuggestionTests extends ESTestCase {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
             ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser);
             ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
-            NamedObjectNotFoundException e = expectThrows(NamedObjectNotFoundException.class, () -> Suggestion.fromXContent(parser));
+            NamedObjectNotFoundException e = expectThrows(
+                NamedObjectNotFoundException.class,
+                () -> SearchResponseUtils.parseSuggestion(parser)
+            );
             assertEquals("[1:31] unknown field [unknownType]", e.getMessage());
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/suggest/TermSuggestionOptionTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/TermSuggestionOptionTests.java
@@ -10,8 +10,10 @@ package org.elasticsearch.search.suggest;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.text.Text;
+import org.elasticsearch.search.suggest.term.TermSuggestion;
 import org.elasticsearch.search.suggest.term.TermSuggestion.Entry.Option;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
@@ -22,6 +24,7 @@ import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 public class TermSuggestionOptionTests extends ESTestCase {
 
@@ -54,7 +57,7 @@ public class TermSuggestionOptionTests extends ESTestCase {
         Option parsed;
         try (XContentParser parser = createParser(xContentType.xContent(), mutated)) {
             ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
-            parsed = Option.fromXContent(parser);
+            parsed = parseEntryOption(parser);
             assertEquals(XContentParser.Token.END_OBJECT, parser.currentToken());
             assertNull(parser.nextToken());
         }
@@ -71,4 +74,24 @@ public class TermSuggestionOptionTests extends ESTestCase {
             {"text":"someText","score":1.3,"freq":100}""", xContent.utf8ToString());
     }
 
+    private static final ConstructingObjectParser<Option, Void> PARSER = new ConstructingObjectParser<>(
+        "TermSuggestionOptionParser",
+        true,
+        args -> {
+            Text text = new Text((String) args[0]);
+            int freq = (Integer) args[1];
+            float score = (Float) args[2];
+            return new Option(text, freq, score);
+        }
+    );
+
+    static {
+        PARSER.declareString(constructorArg(), Suggest.Suggestion.Entry.Option.TEXT);
+        PARSER.declareInt(constructorArg(), TermSuggestion.Entry.Option.FREQ);
+        PARSER.declareFloat(constructorArg(), Suggest.Suggestion.Entry.Option.SCORE);
+    }
+
+    public static Option parseEntryOption(XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
@@ -7,17 +7,31 @@
  */
 package org.elasticsearch.search;
 
+import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.xcontent.XContentParserUtils;
+import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.mapper.IgnoredFieldMapper;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
+import org.elasticsearch.index.seqno.SequenceNumbers;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.action.RestActions;
+import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.fetch.subphase.highlight.HighlightField;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.search.profile.SearchProfileDfsPhaseResult;
 import org.elasticsearch.search.profile.SearchProfileQueryPhaseResult;
@@ -28,24 +42,45 @@ import org.elasticsearch.search.profile.query.CollectorResult;
 import org.elasticsearch.search.profile.query.QueryProfileShardResult;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.transport.RemoteClusterAware;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.InstantiatingObjectParser;
+import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureFieldName;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public enum SearchResponseUtils {
     ;
+
+    // All fields on the root level of the parsed SearchHit are interpreted as metadata fields
+    // public because we use it in a completion suggestion option
+    @SuppressWarnings("unchecked")
+    public static final ObjectParser.UnknownFieldConsumer<Map<String, Object>> unknownMetaFieldConsumer = (map, fieldName, fieldValue) -> {
+        Map<String, DocumentField> fieldMap = (Map<String, DocumentField>) map.computeIfAbsent(
+            SearchHit.METADATA_FIELDS,
+            v -> new HashMap<String, DocumentField>()
+        );
+        if (fieldName.equals(IgnoredFieldMapper.NAME)) {
+            fieldMap.put(fieldName, new DocumentField(fieldName, (List<Object>) fieldValue));
+        } else {
+            fieldMap.put(fieldName, new DocumentField(fieldName, Collections.singletonList(fieldValue)));
+        }
+    };
 
     public static TotalHits getTotalHits(SearchRequestBuilder request) {
         var resp = request.get();
@@ -190,11 +225,11 @@ public enum SearchResponseUtils {
                 }
             } else if (token == XContentParser.Token.START_OBJECT) {
                 if (SearchHits.Fields.HITS.equals(currentFieldName)) {
-                    hits = SearchHits.fromXContent(parser);
+                    hits = parseSearchHits(parser);
                 } else if (InternalAggregations.AGGREGATIONS_FIELD.equals(currentFieldName)) {
                     aggs = InternalAggregations.fromXContent(parser);
                 } else if (Suggest.NAME.equals(currentFieldName)) {
-                    suggest = Suggest.fromXContent(parser);
+                    suggest = parseSuggest(parser);
                 } else if (SearchProfileResults.PROFILE_FIELD.equals(currentFieldName)) {
                     profile = parseSearchProfileResults(parser);
                 } else if (RestActions._SHARDS_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
@@ -523,4 +558,341 @@ public enum SearchResponseUtils {
         }
         return new QueryProfileShardResult(queryProfileResults, rewriteTime, collector, vectorOperationsCount);
     }
+
+    public static SearchHits parseSearchHits(XContentParser parser) throws IOException {
+        if (parser.currentToken() != XContentParser.Token.START_OBJECT) {
+            parser.nextToken();
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        }
+        XContentParser.Token token = parser.currentToken();
+        String currentFieldName = null;
+        List<SearchHit> hits = new ArrayList<>();
+        TotalHits totalHits = null;
+        float maxScore = 0f;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token.isValue()) {
+                if (SearchHits.Fields.TOTAL.equals(currentFieldName)) {
+                    // For BWC with nodes pre 7.0
+                    long value = parser.longValue();
+                    totalHits = value == -1 ? null : new TotalHits(value, TotalHits.Relation.EQUAL_TO);
+                } else if (SearchHits.Fields.MAX_SCORE.equals(currentFieldName)) {
+                    maxScore = parser.floatValue();
+                }
+            } else if (token == XContentParser.Token.VALUE_NULL) {
+                if (SearchHits.Fields.MAX_SCORE.equals(currentFieldName)) {
+                    maxScore = Float.NaN; // NaN gets rendered as null-field
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                if (SearchHits.Fields.HITS.equals(currentFieldName)) {
+                    while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                        hits.add(parseSearchHit(parser));
+                    }
+                } else {
+                    parser.skipChildren();
+                }
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                if (SearchHits.Fields.TOTAL.equals(currentFieldName)) {
+                    totalHits = SearchHits.parseTotalHitsFragment(parser);
+                } else {
+                    parser.skipChildren();
+                }
+            }
+        }
+        return SearchHits.unpooled(hits.toArray(SearchHits.EMPTY), totalHits, maxScore);
+    }
+
+    /**
+     * This parser outputs a temporary map of the objects needed to create the
+     * SearchHit instead of directly creating the SearchHit. The reason for this
+     * is that this way we can reuse the parser when parsing xContent from
+     * {@link org.elasticsearch.search.suggest.completion.CompletionSuggestion.Entry.Option} which unfortunately inlines
+     * the output of
+     * {@link SearchHit#toInnerXContent(XContentBuilder, org.elasticsearch.xcontent.ToXContent.Params)}
+     * of the included search hit. The output of the map is used to create the
+     * actual SearchHit instance via {@link SearchResponseUtils#searchHitFromMap(Map)}
+     */
+    static final ObjectParser<Map<String, Object>, Void> MAP_PARSER = new ObjectParser<>(
+        "innerHitParser",
+        unknownMetaFieldConsumer,
+        HashMap::new
+    );
+
+    static {
+        declareInnerHitsParseFields(MAP_PARSER);
+    }
+
+    public static SearchHit parseSearchHit(XContentParser parser) {
+        return searchHitFromMap(MAP_PARSER.apply(parser, null));
+    }
+
+    public static void declareInnerHitsParseFields(ObjectParser<Map<String, Object>, Void> parser) {
+        parser.declareString((map, value) -> map.put(SearchHit.Fields._INDEX, value), new ParseField(SearchHit.Fields._INDEX));
+        parser.declareString((map, value) -> map.put(SearchHit.Fields._ID, value), new ParseField(SearchHit.Fields._ID));
+        parser.declareString((map, value) -> map.put(SearchHit.Fields._NODE, value), new ParseField(SearchHit.Fields._NODE));
+        parser.declareField(
+            (map, value) -> map.put(SearchHit.Fields._SCORE, value),
+            SearchResponseUtils::parseScore,
+            new ParseField(SearchHit.Fields._SCORE),
+            ObjectParser.ValueType.FLOAT_OR_NULL
+        );
+        parser.declareInt((map, value) -> map.put(SearchHit.Fields._RANK, value), new ParseField(SearchHit.Fields._RANK));
+
+        parser.declareLong((map, value) -> map.put(SearchHit.Fields._VERSION, value), new ParseField(SearchHit.Fields._VERSION));
+        parser.declareLong((map, value) -> map.put(SearchHit.Fields._SEQ_NO, value), new ParseField(SearchHit.Fields._SEQ_NO));
+        parser.declareLong((map, value) -> map.put(SearchHit.Fields._PRIMARY_TERM, value), new ParseField(SearchHit.Fields._PRIMARY_TERM));
+        parser.declareField(
+            (map, value) -> map.put(SearchHit.Fields._SHARD, value),
+            (p, c) -> ShardId.fromString(p.text()),
+            new ParseField(SearchHit.Fields._SHARD),
+            ObjectParser.ValueType.STRING
+        );
+        parser.declareObject(
+            (map, value) -> map.put(SourceFieldMapper.NAME, value),
+            (p, c) -> parseSourceBytes(p),
+            new ParseField(SourceFieldMapper.NAME)
+        );
+        parser.declareObject(
+            (map, value) -> map.put(SearchHit.Fields.HIGHLIGHT, value),
+            (p, c) -> parseHighlightFields(p),
+            new ParseField(SearchHit.Fields.HIGHLIGHT)
+        );
+        parser.declareObject((map, value) -> {
+            Map<String, DocumentField> fieldMap = get(SearchHit.Fields.FIELDS, map, new HashMap<>());
+            fieldMap.putAll(value);
+            map.put(SearchHit.DOCUMENT_FIELDS, fieldMap);
+        }, (p, c) -> parseFields(p), new ParseField(SearchHit.Fields.FIELDS));
+        parser.declareObject(
+            (map, value) -> map.put(SearchHit.Fields._EXPLANATION, value),
+            (p, c) -> parseExplanation(p),
+            new ParseField(SearchHit.Fields._EXPLANATION)
+        );
+        parser.declareObject(
+            (map, value) -> map.put(SearchHit.NestedIdentity._NESTED, value),
+            (p, ignored) -> parseNestedIdentity(p),
+            new ParseField(SearchHit.NestedIdentity._NESTED)
+        );
+        parser.declareObject(
+            (map, value) -> map.put(SearchHit.Fields.INNER_HITS, value),
+            (p, c) -> parseInnerHits(p),
+            new ParseField(SearchHit.Fields.INNER_HITS)
+        );
+
+        parser.declareField((p, map, context) -> {
+            XContentParser.Token token = p.currentToken();
+            Map<String, Float> matchedQueries = new LinkedHashMap<>();
+            if (token == XContentParser.Token.START_OBJECT) {
+                String fieldName = null;
+                while ((token = p.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token == XContentParser.Token.FIELD_NAME) {
+                        fieldName = p.currentName();
+                    } else if (token.isValue()) {
+                        matchedQueries.put(fieldName, p.floatValue());
+                    }
+                }
+            } else if (token == XContentParser.Token.START_ARRAY) {
+                while (p.nextToken() != XContentParser.Token.END_ARRAY) {
+                    matchedQueries.put(p.text(), Float.NaN);
+                }
+            }
+            map.put(SearchHit.Fields.MATCHED_QUERIES, matchedQueries);
+        }, new ParseField(SearchHit.Fields.MATCHED_QUERIES), ObjectParser.ValueType.OBJECT_ARRAY);
+
+        parser.declareField(
+            (map, list) -> map.put(SearchHit.Fields.SORT, list),
+            SearchSortValues::fromXContent,
+            new ParseField(SearchHit.Fields.SORT),
+            ObjectParser.ValueType.OBJECT_ARRAY
+        );
+    }
+
+    private static float parseScore(XContentParser parser) throws IOException {
+        if (parser.currentToken() == XContentParser.Token.VALUE_NUMBER || parser.currentToken() == XContentParser.Token.VALUE_STRING) {
+            return parser.floatValue();
+        } else {
+            return Float.NaN;
+        }
+    }
+
+    private static BytesReference parseSourceBytes(XContentParser parser) throws IOException {
+        try (XContentBuilder builder = XContentBuilder.builder(parser.contentType().xContent())) {
+            // the original document gets slightly modified: whitespaces or
+            // pretty printing are not preserved,
+            // it all depends on the current builder settings
+            builder.copyCurrentStructure(parser);
+            return BytesReference.bytes(builder);
+        }
+    }
+
+    private static Map<String, DocumentField> parseFields(XContentParser parser) throws IOException {
+        Map<String, DocumentField> fields = new HashMap<>();
+        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            DocumentField field = DocumentField.fromXContent(parser);
+            fields.put(field.getName(), field);
+        }
+        return fields;
+    }
+
+    private static Map<String, SearchHits> parseInnerHits(XContentParser parser) throws IOException {
+        Map<String, SearchHits> innerHits = new HashMap<>();
+        while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+            String name = parser.currentName();
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+            ensureFieldName(parser, parser.nextToken(), SearchHits.Fields.HITS);
+            innerHits.put(name, parseSearchHits(parser));
+            ensureExpectedToken(XContentParser.Token.END_OBJECT, parser.nextToken(), parser);
+        }
+        return innerHits;
+    }
+
+    private static Map<String, HighlightField> parseHighlightFields(XContentParser parser) throws IOException {
+        Map<String, HighlightField> highlightFields = new HashMap<>();
+        while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            HighlightField highlightField = HighlightField.fromXContent(parser);
+            highlightFields.put(highlightField.name(), highlightField);
+        }
+        return highlightFields;
+    }
+
+    private static Explanation parseExplanation(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        XContentParser.Token token;
+        Float value = null;
+        String description = null;
+        List<Explanation> details = new ArrayList<>();
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, token, parser);
+            String currentFieldName = parser.currentName();
+            token = parser.nextToken();
+            if (SearchHit.Fields.VALUE.equals(currentFieldName)) {
+                value = parser.floatValue();
+            } else if (SearchHit.Fields.DESCRIPTION.equals(currentFieldName)) {
+                description = parser.textOrNull();
+            } else if (SearchHit.Fields.DETAILS.equals(currentFieldName)) {
+                ensureExpectedToken(XContentParser.Token.START_ARRAY, token, parser);
+                while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY) {
+                    details.add(parseExplanation(parser));
+                }
+            } else {
+                parser.skipChildren();
+            }
+        }
+        if (value == null) {
+            throw new ParsingException(parser.getTokenLocation(), "missing explanation value");
+        }
+        if (description == null) {
+            throw new ParsingException(parser.getTokenLocation(), "missing explanation description");
+        }
+        return Explanation.match(value, description, details);
+    }
+
+    /**
+     * this parsing method assumes that the leading "suggest" field name has already been parsed by the caller
+     */
+    public static Suggest parseSuggest(XContentParser parser) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.currentToken(), parser);
+        List<Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>>> suggestions =
+            new ArrayList<>();
+        while ((parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.currentToken(), parser);
+            String currentField = parser.currentName();
+            ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.nextToken(), parser);
+            Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>> suggestion = parseSuggestion(
+                parser
+            );
+            if (suggestion != null) {
+                suggestions.add(suggestion);
+            } else {
+                throw new ParsingException(
+                    parser.getTokenLocation(),
+                    String.format(Locale.ROOT, "Could not parse suggestion keyed as [%s]", currentField)
+                );
+            }
+        }
+        return new Suggest(suggestions);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static Suggest.Suggestion<? extends Suggest.Suggestion.Entry<? extends Suggest.Suggestion.Entry.Option>> parseSuggestion(
+        XContentParser parser
+    ) throws IOException {
+        ensureExpectedToken(XContentParser.Token.START_ARRAY, parser.currentToken(), parser);
+        SetOnce<Suggest.Suggestion> suggestion = new SetOnce<>();
+        XContentParserUtils.parseTypedKeysObject(parser, Aggregation.TYPED_KEYS_DELIMITER, Suggest.Suggestion.class, suggestion::set);
+        return suggestion.get();
+    }
+
+    private static final ConstructingObjectParser<SearchHit.NestedIdentity, Void> NESTED_IDENTITY_PARSER = new ConstructingObjectParser<>(
+        "nested_identity",
+        true,
+        ctorArgs -> new SearchHit.NestedIdentity((String) ctorArgs[0], (int) ctorArgs[1], (SearchHit.NestedIdentity) ctorArgs[2])
+    );
+    static {
+        NESTED_IDENTITY_PARSER.declareString(constructorArg(), new ParseField(SearchHit.NestedIdentity.FIELD));
+        NESTED_IDENTITY_PARSER.declareInt(constructorArg(), new ParseField(SearchHit.NestedIdentity.OFFSET));
+        NESTED_IDENTITY_PARSER.declareObject(
+            optionalConstructorArg(),
+            NESTED_IDENTITY_PARSER,
+            new ParseField(SearchHit.NestedIdentity._NESTED)
+        );
+    }
+
+    public static SearchHit.NestedIdentity parseNestedIdentity(XContentParser parser) {
+        return NESTED_IDENTITY_PARSER.apply(parser, null);
+    }
+
+    public static SearchHit searchHitFromMap(Map<String, Object> values) {
+        String id = get(SearchHit.Fields._ID, values, null);
+        String index = get(SearchHit.Fields._INDEX, values, null);
+        String clusterAlias = null;
+        if (index != null) {
+            int indexOf = index.indexOf(RemoteClusterAware.REMOTE_CLUSTER_INDEX_SEPARATOR);
+            if (indexOf > 0) {
+                clusterAlias = index.substring(0, indexOf);
+                index = index.substring(indexOf + 1);
+            }
+        }
+        ShardId shardId = get(SearchHit.Fields._SHARD, values, null);
+        String nodeId = get(SearchHit.Fields._NODE, values, null);
+        final SearchShardTarget shardTarget;
+        if (shardId != null && nodeId != null) {
+            assert shardId.getIndexName().equals(index);
+            shardTarget = new SearchShardTarget(nodeId, shardId, clusterAlias);
+            index = shardTarget.getIndex();
+            clusterAlias = shardTarget.getClusterAlias();
+        } else {
+            shardTarget = null;
+        }
+        return new SearchHit(
+            -1,
+            get(SearchHit.Fields._SCORE, values, SearchHit.DEFAULT_SCORE),
+            get(SearchHit.Fields._RANK, values, SearchHit.NO_RANK),
+            id == null ? null : new Text(id),
+            get(SearchHit.NestedIdentity._NESTED, values, null),
+            get(SearchHit.Fields._VERSION, values, -1L),
+            get(SearchHit.Fields._SEQ_NO, values, SequenceNumbers.UNASSIGNED_SEQ_NO),
+            get(SearchHit.Fields._PRIMARY_TERM, values, SequenceNumbers.UNASSIGNED_PRIMARY_TERM),
+            get(SourceFieldMapper.NAME, values, null),
+            get(SearchHit.Fields.HIGHLIGHT, values, null),
+            get(SearchHit.Fields.SORT, values, SearchSortValues.EMPTY),
+            get(SearchHit.Fields.MATCHED_QUERIES, values, null),
+            get(SearchHit.Fields._EXPLANATION, values, null),
+            shardTarget,
+            index,
+            clusterAlias,
+            null,
+            get(SearchHit.Fields.INNER_HITS, values, null),
+            get(SearchHit.DOCUMENT_FIELDS, values, Collections.emptyMap()),
+            get(SearchHit.METADATA_FIELDS, values, Collections.emptyMap()),
+            RefCounted.ALWAYS_REFERENCED // TODO: do we ever want pooling here?
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T get(String key, Map<String, Object> map, T defaultValue) {
+        return (T) map.getOrDefault(key, defaultValue);
+    }
+
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryImplTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/registry/ModelRegistryImplTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -76,7 +77,7 @@ public class ModelRegistryImplTests extends ESTestCase {
 
     public void testGetUnparsedModelMap_ThrowsIllegalArgumentException_WhenInvalidIndexReceived() {
         var client = mockClient();
-        var unknownIndexHit = SearchHit.createFromMap(Map.of("_index", "unknown_index"));
+        var unknownIndexHit = SearchResponseUtils.searchHitFromMap(Map.of("_index", "unknown_index"));
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { unknownIndexHit }));
 
         var registry = new ModelRegistryImpl(client);
@@ -93,7 +94,7 @@ public class ModelRegistryImplTests extends ESTestCase {
 
     public void testGetUnparsedModelMap_ThrowsIllegalStateException_WhenUnableToFindInferenceEntry() {
         var client = mockClient();
-        var inferenceSecretsHit = SearchHit.createFromMap(Map.of("_index", ".secrets-inference"));
+        var inferenceSecretsHit = SearchResponseUtils.searchHitFromMap(Map.of("_index", ".secrets-inference"));
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceSecretsHit }));
 
         var registry = new ModelRegistryImpl(client);
@@ -110,7 +111,7 @@ public class ModelRegistryImplTests extends ESTestCase {
 
     public void testGetUnparsedModelMap_ThrowsIllegalStateException_WhenUnableToFindInferenceSecretsEntry() {
         var client = mockClient();
-        var inferenceHit = SearchHit.createFromMap(Map.of("_index", ".inference"));
+        var inferenceHit = SearchResponseUtils.searchHitFromMap(Map.of("_index", ".inference"));
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceHit }));
 
         var registry = new ModelRegistryImpl(client);
@@ -140,9 +141,9 @@ public class ModelRegistryImplTests extends ESTestCase {
             }
             """;
 
-        var inferenceHit = SearchHit.createFromMap(Map.of("_index", ".inference"));
+        var inferenceHit = SearchResponseUtils.searchHitFromMap(Map.of("_index", ".inference"));
         inferenceHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(config))));
-        var inferenceSecretsHit = SearchHit.createFromMap(Map.of("_index", ".secrets-inference"));
+        var inferenceSecretsHit = SearchResponseUtils.searchHitFromMap(Map.of("_index", ".secrets-inference"));
         inferenceSecretsHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(secrets))));
 
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceHit, inferenceSecretsHit }));
@@ -171,7 +172,7 @@ public class ModelRegistryImplTests extends ESTestCase {
             }
             """;
 
-        var inferenceHit = SearchHit.createFromMap(Map.of("_index", ".inference"));
+        var inferenceHit = SearchResponseUtils.searchHitFromMap(Map.of("_index", ".inference"));
         inferenceHit.sourceRef(BytesReference.fromByteBuffer(ByteBuffer.wrap(Strings.toUTF8Bytes(config))));
 
         mockClientExecuteSearch(client, mockSearchResponse(new SearchHit[] { inferenceHit }));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DataFrameAnalyticsTaskTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.persistent.UpdatePersistentTaskStatusAction;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -243,7 +244,11 @@ public class DataFrameAnalyticsTaskTests extends ESTestCase {
     }
 
     public void testPersistProgress_ProgressDocumentUpdated() throws IOException {
-        var hits = new SearchHits(new SearchHit[] { SearchHit.createFromMap(Map.of("_index", ".ml-state-dummy")) }, null, 0.0f);
+        var hits = new SearchHits(
+            new SearchHit[] { SearchResponseUtils.searchHitFromMap(Map.of("_index", ".ml-state-dummy")) },
+            null,
+            0.0f
+        );
         try {
             testPersistProgress(hits, ".ml-state-dummy");
         } finally {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunnerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/inference/InferenceRunnerTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -151,7 +152,7 @@ public class InferenceRunnerTests extends ESTestCase {
 
     private static Deque<SearchHit> buildSearchHits(List<Map<String, Object>> vals) {
         return vals.stream().map(InferenceRunnerTests::fromMap).map(reference -> {
-            var pooled = SearchHit.createFromMap(Collections.singletonMap("_source", reference));
+            var pooled = SearchResponseUtils.searchHitFromMap(Collections.singletonMap("_source", reference));
             try {
                 return pooled.asUnpooled();
             } finally {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ClientHelper;
@@ -358,7 +359,11 @@ public class JobResultsPersisterTests extends ESTestCase {
     }
 
     public void testPersistQuantilesSync_QuantilesDocumentUpdated() {
-        var hits = new SearchHits(new SearchHit[] { SearchHit.createFromMap(Map.of("_index", ".ml-state-dummy")) }, null, 0.0f);
+        var hits = new SearchHits(
+            new SearchHit[] { SearchResponseUtils.searchHitFromMap(Map.of("_index", ".ml-state-dummy")) },
+            null,
+            0.0f
+        );
         try {
             testPersistQuantilesSync(hits, ".ml-state-dummy");
         } finally {
@@ -399,7 +404,11 @@ public class JobResultsPersisterTests extends ESTestCase {
     }
 
     public void testPersistQuantilesAsync_QuantilesDocumentUpdated() {
-        var hits = new SearchHits(new SearchHit[] { SearchHit.createFromMap(Map.of("_index", ".ml-state-dummy")) }, null, 0.0f);
+        var hits = new SearchHits(
+            new SearchHit[] { SearchResponseUtils.searchHitFromMap(Map.of("_index", ".ml-state-dummy")) },
+            null,
+            0.0f
+        );
         try {
             testPersistQuantilesAsync(hits, ".ml-state-dummy");
         } finally {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/IndexingStateProcessorTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
+import org.elasticsearch.search.SearchResponseUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ml.notifications.AnomalyDetectionAuditor;
 import org.elasticsearch.xpack.ml.utils.persistence.ResultsPersisterService;
@@ -124,7 +125,7 @@ public class IndexingStateProcessorTests extends ESTestCase {
 
     public void testStateRead_StateDocumentUpdated() throws IOException {
         testStateRead(
-            SearchHits.unpooled(new SearchHit[] { SearchHit.createFromMap(Map.of("_index", ".ml-state-dummy")) }, null, 0.0f),
+            SearchHits.unpooled(new SearchHit[] { SearchResponseUtils.searchHitFromMap(Map.of("_index", ".ml-state-dummy")) }, null, 0.0f),
             ".ml-state-dummy"
         );
     }


### PR DESCRIPTION
Same as the other moves of parser code (e.g. #106704), this is only used in tests, no need to have all of this code loaded in production => just moving parser code to either `SearchResponseUtils` or to a test class that seemed natural(ish) with any other adjustments.