### PR TITLE
[8.12] Switching evictor tests to use a deterministic queue (#105151)

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/IdleConnectionEvictorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/http/IdleConnectionEvictorTests.java
@@ -10,17 +10,16 @@ package org.elasticsearch.xpack.inference.external.http;
 import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
 import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
 import org.apache.http.nio.reactor.IOReactorException;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.After;
 import org.junit.Before;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.elasticsearch.xpack.inference.Utils.inferenceUtilityPool;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
@@ -32,16 +31,11 @@ import static org.mockito.Mockito.when;
 public class IdleConnectionEvictorTests extends ESTestCase {
 
     private static final TimeValue TIMEOUT = new TimeValue(30, TimeUnit.SECONDS);
-    private ThreadPool threadPool;
+    private DeterministicTaskQueue taskQueue;
 
     @Before
     public void init() {
-        threadPool = createThreadPool(inferenceUtilityPool());
-    }
-
-    @After
-    public void shutdown() {
-        terminate(threadPool);
+        taskQueue = new DeterministicTaskQueue();
     }
 
     public void testStart_CallsExecutorSubmit() throws IOReactorException {
@@ -87,7 +81,7 @@ public class IdleConnectionEvictorTests extends ESTestCase {
         var manager = mock(PoolingNHttpClientConnectionManager.class);
 
         var evictor = new IdleConnectionEvictor(
-            threadPool,
+            taskQueue.getThreadPool(),
             manager,
             new TimeValue(1, TimeUnit.NANOSECONDS),
             new TimeValue(1, TimeUnit.NANOSECONDS)
@@ -100,7 +94,8 @@ public class IdleConnectionEvictorTests extends ESTestCase {
             return Void.TYPE;
         }).when(manager).closeExpiredConnections();
 
-        evictor.start();
+        startEvictor(evictor);
+
         runLatch.await(TIMEOUT.getSeconds(), TimeUnit.SECONDS);
 
         verify(manager, times(1)).closeExpiredConnections();
@@ -110,7 +105,7 @@ public class IdleConnectionEvictorTests extends ESTestCase {
         var manager = mock(PoolingNHttpClientConnectionManager.class);
 
         var evictor = new IdleConnectionEvictor(
-            threadPool,
+            taskQueue.getThreadPool(),
             manager,
             new TimeValue(1, TimeUnit.NANOSECONDS),
             new TimeValue(1, TimeUnit.NANOSECONDS)
@@ -123,7 +118,8 @@ public class IdleConnectionEvictorTests extends ESTestCase {
             return Void.TYPE;
         }).when(manager).closeIdleConnections(anyLong(), any());
 
-        evictor.start();
+        startEvictor(evictor);
+
         runLatch.await(TIMEOUT.getSeconds(), TimeUnit.SECONDS);
 
         verify(manager, times(1)).closeIdleConnections(anyLong(), any());
@@ -131,30 +127,36 @@ public class IdleConnectionEvictorTests extends ESTestCase {
 
     public void testIsRunning_ReturnsTrue() throws IOReactorException {
         var evictor = new IdleConnectionEvictor(
-            threadPool,
+            taskQueue.getThreadPool(),
             createConnectionManager(),
             new TimeValue(1, TimeUnit.SECONDS),
             new TimeValue(1, TimeUnit.SECONDS)
         );
 
-        evictor.start();
+        startEvictor(evictor);
+
         assertTrue(evictor.isRunning());
         evictor.close();
     }
 
     public void testIsRunning_ReturnsFalse() throws IOReactorException {
         var evictor = new IdleConnectionEvictor(
-            threadPool,
+            taskQueue.getThreadPool(),
             createConnectionManager(),
             new TimeValue(1, TimeUnit.SECONDS),
             new TimeValue(1, TimeUnit.SECONDS)
         );
 
-        evictor.start();
+        startEvictor(evictor);
         assertTrue(evictor.isRunning());
 
         evictor.close();
         assertFalse(evictor.isRunning());
+    }
+
+    private void startEvictor(IdleConnectionEvictor evictor) {
+        taskQueue.scheduleNow(evictor::start);
+        taskQueue.runAllRunnableTasks();
     }
 
     private static PoolingNHttpClientConnectionManager createConnectionManager() throws IOReactorException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [Switching evictor tests to use a deterministic queue (#105151)](https://github.com/elastic/elasticsearch/pull/105151)

<!--- Backport version: 9.2.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)