### PR TITLE
[Transform] Fail checkpoint on missing clusters

### DIFF
--- a/docs/changelog/106793.yaml
+++ b/docs/changelog/106793.yaml
@@ -1,0 +1,7 @@
+pr: 106793
+summary: Fail checkpoint on missing clusters
+area: Transform
+type: bug
+issues:
+ - 104533
+ - 106790

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/CheckpointException.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/CheckpointException.java
@@ -10,6 +10,10 @@ package org.elasticsearch.xpack.transform.checkpoint;
 import org.elasticsearch.ElasticsearchException;
 
 class CheckpointException extends ElasticsearchException {
+    CheckpointException(String msg, Object... params) {
+        super(msg, params);
+    }
+
     CheckpointException(String msg, Throwable cause, Object... params) {
         super(msg, cause, params);
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProvider.java
@@ -116,6 +116,11 @@ class DefaultCheckpointProvider implements CheckpointProvider {
             ResolvedIndices resolvedIndexes = remoteClusterResolver.resolve(transformConfig.getSource().getIndex());
             ActionListener<Map<String, long[]>> groupedListener = listener;
 
+            if (resolvedIndexes.numClusters() == 0) {
+                var indices = String.join(",", transformConfig.getSource().getIndex());
+                listener.onFailure(new CheckpointException("No clusters exist for [{}]", indices));
+            }
+
             if (resolvedIndexes.numClusters() > 1) {
                 ActionListener<Collection<Map<String, long[]>>> mergeMapsListener = ActionListener.wrap(indexCheckpoints -> {
                     listener.onResponse(
@@ -234,10 +239,7 @@ class DefaultCheckpointProvider implements CheckpointProvider {
         );
         ActionListener<GetCheckpointAction.Response> checkpointListener;
         if (RemoteClusterService.LOCAL_CLUSTER_GROUP_KEY.equals(cluster)) {
-            checkpointListener = ActionListener.wrap(
-                checkpointResponse -> listener.onResponse(checkpointResponse.getCheckpoints()),
-                listener::onFailure
-            );
+            checkpointListener = listener.delegateFailure((l, r) -> l.onResponse(r.getCheckpoints()));
         } else {
             checkpointListener = ActionListener.wrap(
                 checkpointResponse -> listener.onResponse(
@@ -401,12 +403,12 @@ class DefaultCheckpointProvider implements CheckpointProvider {
 
         long timestamp = clock.millis();
 
-        getIndexCheckpoints(timeout, ActionListener.wrap(checkpointsByIndex -> {
-            TransformCheckpoint sourceCheckpoint = new TransformCheckpoint(transformConfig.getId(), timestamp, -1L, checkpointsByIndex, 0L);
+        getIndexCheckpoints(timeout, listener.delegateFailure((l, r) -> {
+            TransformCheckpoint sourceCheckpoint = new TransformCheckpoint(transformConfig.getId(), timestamp, -1L, r, 0L);
             checkpointingInfoBuilder.setSourceCheckpoint(sourceCheckpoint);
             checkpointingInfoBuilder.setOperationsBehind(TransformCheckpoint.getBehind(lastCheckpoint, sourceCheckpoint));
-            listener.onResponse(checkpointingInfoBuilder);
-        }, listener::onFailure));
+            l.onResponse(checkpointingInfoBuilder);
+        }));
     }
 
     @Override


### PR DESCRIPTION
When there are no remote or local clusters for a given source index, we call the listener's `onFailure` method with a `CheckpointException`. A running transform will fail and retry, eventually moving into an unhealthy and failed state.  Any call to the stats API will note the checkpoint failure and return.

This fixes a timeout issue calling the Transform stats API and prevents the Transform from being stuck in indexing.

Fix #106790
Fix #104533
