### PR TITLE
Reproduce testRestoredIndexManagedByLocalPolicySkipsIllegalActions

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/SearchableSnapshotActionIT.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.ilm.actions;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.elasticsearch.client.Request;
@@ -342,6 +344,7 @@ public class SearchableSnapshotActionIT extends ESRestTestCase {
         }, 30, TimeUnit.SECONDS);
     }
 
+    @Repeat(iterations = 100)
     public void testRestoredIndexManagedByLocalPolicySkipsIllegalActions() throws Exception {
         // let's create a data stream, rollover it and convert the first generation backing index into a searchable snapshot
         createSnapshotRepo(client(), snapshotRepo, randomBoolean());


### PR DESCRIPTION
For now just a draft PR to try and reproduce #106706. The linked build scan in that issue doesn't have any artifacts which means we have very limited logging (as this is a Java REST IT test).