### PR TITLE
Move KeyComparable interface to AbstractInternalTerms.AbstractTermsBucket

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java
@@ -18,6 +18,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.InternalOrder;
+import org.elasticsearch.search.aggregations.KeyComparable;
 import org.elasticsearch.search.aggregations.TopBucketBuilder;
 import org.elasticsearch.search.aggregations.bucket.IteratorAndCurrent;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
@@ -40,7 +41,7 @@ import static org.elasticsearch.search.aggregations.bucket.terms.InternalTerms.S
 /**
  * Base class for terms and multi_terms aggregation that handles common reduce logic
  */
-public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B>, B extends AbstractInternalTerms.AbstractTermsBucket>
+public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B>, B extends AbstractInternalTerms.AbstractTermsBucket<B>>
     extends InternalMultiBucketAggregation<A, B> {
 
     public AbstractInternalTerms(String name, Map<String, Object> metadata) {
@@ -52,7 +53,9 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         super(in);
     }
 
-    public abstract static class AbstractTermsBucket extends InternalMultiBucketAggregation.InternalBucket {
+    public abstract static class AbstractTermsBucket<B extends AbstractTermsBucket<B>> extends InternalMultiBucketAggregation.InternalBucket
+        implements
+            KeyComparable<B> {
 
         protected abstract void updateDocCountError(long docCountErrorDiff);
 
@@ -361,12 +364,12 @@ public abstract class AbstractInternalTerms<A extends AbstractInternalTerms<A, B
         Params params,
         Long docCountError,
         long otherDocCount,
-        List<? extends AbstractTermsBucket> buckets
+        List<? extends AbstractTermsBucket<?>> buckets
     ) throws IOException {
         builder.field(DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME.getPreferredName(), docCountError);
         builder.field(SUM_OF_OTHER_DOC_COUNTS.getPreferredName(), otherDocCount);
         builder.startArray(CommonFields.BUCKETS.getPreferredName());
-        for (AbstractTermsBucket bucket : buckets) {
+        for (AbstractTermsBucket<?> bucket : buckets) {
             bucket.toXContent(builder, params);
         }
         builder.endArray();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalTerms.java
@@ -13,7 +13,6 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalOrder;
-import org.elasticsearch.search.aggregations.KeyComparable;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -29,7 +28,7 @@ public abstract class InternalTerms<A extends InternalTerms<A, B>, B extends Int
     public static final ParseField DOC_COUNT_ERROR_UPPER_BOUND_FIELD_NAME = new ParseField("doc_count_error_upper_bound");
     public static final ParseField SUM_OF_OTHER_DOC_COUNTS = new ParseField("sum_other_doc_count");
 
-    public abstract static class Bucket<B extends Bucket<B>> extends AbstractTermsBucket implements Terms.Bucket, KeyComparable<B> {
+    public abstract static class Bucket<B extends Bucket<B>> extends AbstractTermsBucket<B> implements Terms.Bucket {
         /**
          * Reads a bucket. Should be a constructor reference.
          */

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -19,7 +19,6 @@ import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.InternalOrder;
-import org.elasticsearch.search.aggregations.KeyComparable;
 import org.elasticsearch.search.aggregations.bucket.terms.AbstractInternalTerms;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -37,7 +36,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
 
     public static final TermsComparator TERMS_COMPARATOR = new TermsComparator();
 
-    public static class Bucket extends AbstractInternalTerms.AbstractTermsBucket implements KeyComparable<Bucket> {
+    public static class Bucket extends AbstractInternalTerms.AbstractTermsBucket<Bucket> {
 
         long bucketOrd;
 


### PR DESCRIPTION
Currently AbstractInternalTerms.AbstractTermsBucket has two implementations and both implement KeyComparable, therefore let's move the interface to the parent abstract class.