### PR TITLE
[8.13] Add test to exercise reduction of terms aggregation order by key and fix pruning bug (#106799)

### DIFF
--- a/docs/changelog/106799.yaml
+++ b/docs/changelog/106799.yaml
@@ -1,0 +1,5 @@
+pr: 106799
+summary: Add test to exercise reduction of terms aggregation order by key
+area: Aggregations
+type: bug
+issues: []


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Add test to exercise reduction of terms aggregation order by key and fix pruning bug (#106799)