### PR TITLE
Preemptively create hdfs data folder in test fixture

### DIFF
--- a/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsFixture.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsFixture.java
@@ -197,7 +197,6 @@ public class HdfsFixture extends ExternalResource {
                 System.out.println("Attempt " + attempt + " failed with error: " + e.getMessage());
                 // If the maximum number of attempts is reached, rethrow the exception
                 FileUtils.deleteDirectory(baseDir.toFile());
-
                 if (attempt == maxAttempts) {
                     throw e;
                 }
@@ -213,7 +212,8 @@ public class HdfsFixture extends ExternalResource {
         }
         // hdfs-data/, where any data is going
         Path hdfsData = baseDir.resolve("hdfs-data");
-        Files.createDirectories(hdfsData);
+        Path data = hdfsData.resolve("data");
+        Files.createDirectories(data);
         return hdfsData;
     }
 


### PR DESCRIPTION
Potentially addresses flaky test as described here: https://github.com/elastic/elasticsearch/issues/106739
We see that the data folder sometimes is created with wrong permissions. Now we try to fix that by creating that folder preemptively as part of the fixture setup.