### PR TITLE
[Transform] Rearrange failure reason

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -37,8 +37,8 @@ public class TransformMessages {
 
     public static final String CANNOT_STOP_SINGLE_FAILED_TRANSFORM = "Unable to stop transform [{0}] as it is in a failed state. "
         + "Use force stop to stop the transform. More details: [{1}]";
-    public static final String CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM = "Unable to stop transforms. The following transforms are in a failed"
-        + " state [{0}]. Use force stop to stop the transform. More details: [{1}]";
+    public static final String CANNOT_STOP_MULTIPLE_FAILED_TRANSFORMS = "Unable to stop transforms. The following transforms are in a "
+        + "failed state [{0}]. Use force stop to stop the transforms. More details: [{1}]";
     public static final String CANNOT_START_FAILED_TRANSFORM = "Unable to start transform [{0}] as it is in a failed state. "
         + "Use force stop and then restart the transform once error is resolved. More details: [{1}]";
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -35,11 +35,12 @@ public class TransformMessages {
     public static final String REST_WARN_NO_TRANSFORM_NODES =
         "Transform requires the transform node role for at least 1 node, found no transform nodes";
 
-    public static final String CANNOT_STOP_FAILED_TRANSFORM = "Unable to stop transform [{0}] as it is in a failed state with reason [{1}]."
-        + " Use force stop to stop the transform.";
-    public static final String CANNOT_START_FAILED_TRANSFORM =
-        "Unable to start transform [{0}] as it is in a failed state with failure: [{1}]. "
-            + "Use force stop and then restart the transform once error is resolved.";
+    public static final String CANNOT_STOP_SINGLE_FAILED_TRANSFORM = "Unable to stop transform [{0}] as it is in a failed state. "
+        + "Use force stop to stop the transform. More details: [{1}]";
+    public static final String CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM = "Unable to stop transforms. The following transforms are in a failed"
+        + " state [{0}]. Use force stop to stop the transform. More details: [{1}]";
+    public static final String CANNOT_START_FAILED_TRANSFORM = "Unable to start transform [{0}] as it is in a failed state. "
+        + "Use force stop and then restart the transform once error is resolved. More details: [{1}]";
 
     public static final String FAILED_TO_CREATE_DESTINATION_INDEX = "Could not create destination index [{0}] for transform [{1}]";
     public static final String FAILED_TO_SET_UP_DESTINATION_ALIASES =

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -116,8 +116,8 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                     ? TransformMessages.getMessage(CANNOT_STOP_SINGLE_FAILED_TRANSFORM, failedTasks.get(0), failedReasons.get(0))
                     : TransformMessages.getMessage(
                         CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM,
-                        String.join(",", failedTasks),
-                        String.join(",", failedReasons)
+                        String.join(", ", failedTasks),
+                        String.join(", ", failedReasons)
                     );
                 throw new ElasticsearchStatusException(msg, RestStatus.CONFLICT);
             }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -61,7 +61,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM;
+import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_MULTIPLE_FAILED_TRANSFORMS;
 import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_SINGLE_FAILED_TRANSFORM;
 
 public class TransportStopTransformAction extends TransportTasksAction<TransformTask, Request, Response, Response> {
@@ -115,7 +115,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                 String msg = failedTasks.size() == 1
                     ? TransformMessages.getMessage(CANNOT_STOP_SINGLE_FAILED_TRANSFORM, failedTasks.get(0), failedReasons.get(0))
                     : TransformMessages.getMessage(
-                        CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM,
+                        CANNOT_STOP_MULTIPLE_FAILED_TRANSFORMS,
                         String.join(", ", failedTasks),
                         String.join(", ", failedReasons)
                     );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -61,7 +61,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_FAILED_TRANSFORM;
+import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM;
+import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_SINGLE_FAILED_TRANSFORM;
 
 public class TransportStopTransformAction extends TransportTasksAction<TransformTask, Request, Response, Response> {
 
@@ -112,12 +113,12 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
             }
             if (failedTasks.isEmpty() == false) {
                 String msg = failedTasks.size() == 1
-                    ? TransformMessages.getMessage(CANNOT_STOP_FAILED_TRANSFORM, failedTasks.get(0), failedReasons.get(0))
-                    : "Unable to stop transforms. The following transforms are in a failed state "
-                        + failedTasks
-                        + " with reasons "
-                        + failedReasons
-                        + ". Use force stop to stop the transforms.";
+                    ? TransformMessages.getMessage(CANNOT_STOP_SINGLE_FAILED_TRANSFORM, failedTasks.get(0), failedReasons.get(0))
+                    : TransformMessages.getMessage(
+                        CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM,
+                        String.join(",", failedTasks),
+                        String.join(",", failedReasons)
+                    );
                 throw new ElasticsearchStatusException(msg, RestStatus.CONFLICT);
             }
         }
@@ -409,7 +410,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                     exceptions.put(
                         persistentTaskId,
                         new ElasticsearchStatusException(
-                            TransformMessages.getMessage(CANNOT_STOP_FAILED_TRANSFORM, persistentTaskId, taskState.getReason()),
+                            TransformMessages.getMessage(CANNOT_STOP_SINGLE_FAILED_TRANSFORM, persistentTaskId, taskState.getReason()),
                             RestStatus.CONFLICT
                         )
                     );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -53,7 +53,7 @@ import java.util.function.Predicate;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_START_FAILED_TRANSFORM;
-import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_FAILED_TRANSFORM;
+import static org.elasticsearch.xpack.core.transform.TransformMessages.CANNOT_STOP_SINGLE_FAILED_TRANSFORM;
 
 public class TransformTask extends AllocatedPersistentTask implements TransformScheduler.Listener, TransformContext.Listener {
 
@@ -359,7 +359,7 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
         synchronized (context) {
             if (context.getTaskState() == TransformTaskState.FAILED && force == false) {
                 throw new ElasticsearchStatusException(
-                    TransformMessages.getMessage(CANNOT_STOP_FAILED_TRANSFORM, getTransformId(), context.getStateReason()),
+                    TransformMessages.getMessage(CANNOT_STOP_SINGLE_FAILED_TRANSFORM, getTransformId(), context.getStateReason()),
                     RestStatus.CONFLICT
                 );
             }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.transform.TransformConfigVersion;
-import org.elasticsearch.xpack.core.transform.TransformMessages;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
@@ -92,7 +91,10 @@ public class TransportStopTransformActionTests extends ESTestCase {
         assertThat(ex.status(), equalTo(CONFLICT));
         assertThat(
             ex.getMessage(),
-            equalTo(TransformMessages.getMessage(TransformMessages.CANNOT_STOP_SINGLE_FAILED_TRANSFORM, "failed-task", "task has failed"))
+            equalTo(
+                "Unable to stop transform [failed-task] as it is in a failed state. Use force stop to stop the transform. "
+                    + "More details: [task has failed]"
+            )
         );
 
         // test again with two failed tasks
@@ -127,11 +129,8 @@ public class TransportStopTransformActionTests extends ESTestCase {
         assertThat(
             ex.getMessage(),
             equalTo(
-                TransformMessages.getMessage(
-                    TransformMessages.CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM,
-                    "failed-task, failed-task-2",
-                    "task has failed, task has also failed"
-                )
+                "Unable to stop transforms. The following transforms are in a failed state [failed-task, failed-task-2]. Use force "
+                    + "stop to stop the transforms. More details: [task has failed, task has also failed]"
             )
         );
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
@@ -93,7 +93,7 @@ public class TransportStopTransformActionTests extends ESTestCase {
         assertThat(ex.status(), equalTo(CONFLICT));
         assertThat(
             ex.getMessage(),
-            equalTo(TransformMessages.getMessage(TransformMessages.CANNOT_STOP_FAILED_TRANSFORM, "failed-task", "task has failed"))
+            equalTo(TransformMessages.getMessage(TransformMessages.CANNOT_STOP_SINGLE_FAILED_TRANSFORM, "failed-task", "task has failed"))
         );
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
@@ -23,8 +23,6 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestStatus.CONFLICT;
@@ -39,11 +37,11 @@ public class TransportStopTransformActionTests extends ESTestCase {
     public void testTaskStateValidationWithNoTasks() {
         Metadata.Builder metadata = Metadata.builder();
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name")).metadata(metadata);
-        TransportStopTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+        TransportStopTransformAction.validateTaskState(csBuilder.build(), List.of("non-failed-task"), false);
 
         PersistentTasksCustomMetadata.Builder pTasksBuilder = PersistentTasksCustomMetadata.builder();
         csBuilder = ClusterState.builder(new ClusterName("_name")).metadata(buildMetadata(pTasksBuilder.build()));
-        TransportStopTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+        TransportStopTransformAction.validateTaskState(csBuilder.build(), List.of("non-failed-task"), false);
     }
 
     public void testTaskStateValidationWithTransformTasks() {
@@ -57,7 +55,7 @@ public class TransportStopTransformActionTests extends ESTestCase {
             );
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name")).metadata(buildMetadata(pTasksBuilder.build()));
 
-        TransportStopTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+        TransportStopTransformAction.validateTaskState(csBuilder.build(), List.of("non-failed-task"), false);
 
         // test again with a non failed task but this time it has internal state
         pTasksBuilder.updateTaskState(
@@ -66,8 +64,9 @@ public class TransportStopTransformActionTests extends ESTestCase {
         );
         csBuilder = ClusterState.builder(new ClusterName("_name")).metadata(buildMetadata(pTasksBuilder.build()));
 
-        TransportStopTransformAction.validateTaskState(csBuilder.build(), Collections.singletonList("non-failed-task"), false);
+        TransportStopTransformAction.validateTaskState(csBuilder.build(), List.of("non-failed-task"), false);
 
+        // test again with one failed task
         pTasksBuilder.addTask(
             "failed-task",
             TransformTaskParams.NAME,
@@ -80,20 +79,60 @@ public class TransportStopTransformActionTests extends ESTestCase {
             );
         final ClusterState cs = ClusterState.builder(new ClusterName("_name")).metadata(buildMetadata(pTasksBuilder.build())).build();
 
-        TransportStopTransformAction.validateTaskState(cs, Arrays.asList("non-failed-task", "failed-task"), true);
+        TransportStopTransformAction.validateTaskState(cs, List.of("non-failed-task", "failed-task"), true);
 
-        TransportStopTransformAction.validateTaskState(cs, Collections.singletonList("non-failed-task"), false);
+        TransportStopTransformAction.validateTaskState(cs, List.of("non-failed-task"), false);
 
         ClusterState.Builder csBuilderFinal = ClusterState.builder(new ClusterName("_name")).metadata(buildMetadata(pTasksBuilder.build()));
         ElasticsearchStatusException ex = expectThrows(
             ElasticsearchStatusException.class,
-            () -> TransportStopTransformAction.validateTaskState(csBuilderFinal.build(), Collections.singletonList("failed-task"), false)
+            () -> TransportStopTransformAction.validateTaskState(csBuilderFinal.build(), List.of("failed-task"), false)
         );
 
         assertThat(ex.status(), equalTo(CONFLICT));
         assertThat(
             ex.getMessage(),
             equalTo(TransformMessages.getMessage(TransformMessages.CANNOT_STOP_SINGLE_FAILED_TRANSFORM, "failed-task", "task has failed"))
+        );
+
+        // test again with two failed tasks
+        pTasksBuilder.addTask(
+            "failed-task-2",
+            TransformTaskParams.NAME,
+            new TransformTaskParams("transform-task-2", TransformConfigVersion.CURRENT, null, false),
+            new PersistentTasksCustomMetadata.Assignment("current-data-node-with-2-tasks", "")
+        )
+            .updateTaskState(
+                "failed-task-2",
+                new TransformState(
+                    TransformTaskState.FAILED,
+                    IndexerState.STOPPED,
+                    null,
+                    0L,
+                    "task has also failed",
+                    null,
+                    null,
+                    false,
+                    null
+                )
+            );
+
+        var csBuilderMultiTask = ClusterState.builder(new ClusterName("_name")).metadata(buildMetadata(pTasksBuilder.build()));
+        ex = expectThrows(
+            ElasticsearchStatusException.class,
+            () -> TransportStopTransformAction.validateTaskState(csBuilderMultiTask.build(), List.of("failed-task", "failed-task-2"), false)
+        );
+
+        assertThat(ex.status(), equalTo(CONFLICT));
+        assertThat(
+            ex.getMessage(),
+            equalTo(
+                TransformMessages.getMessage(
+                    TransformMessages.CANNOT_STOP_MULTIPLE_FAILED_TRANSFORM,
+                    "failed-task, failed-task-2",
+                    "task has failed, task has also failed"
+                )
+            )
         );
     }
 
@@ -106,38 +145,27 @@ public class TransportStopTransformActionTests extends ESTestCase {
         );
         taskOperationFailures.add(new TaskOperationFailure("node", 1, new ElasticsearchStatusException("failure", RestStatus.BAD_REQUEST)));
 
-        assertThat(
-            TransportStopTransformAction.firstNotOKStatus(Collections.emptyList(), Collections.emptyList()),
-            equalTo(RestStatus.INTERNAL_SERVER_ERROR)
-        );
+        assertThat(TransportStopTransformAction.firstNotOKStatus(List.of(), List.of()), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
 
-        assertThat(
-            TransportStopTransformAction.firstNotOKStatus(taskOperationFailures, Collections.emptyList()),
-            equalTo(RestStatus.BAD_REQUEST)
-        );
+        assertThat(TransportStopTransformAction.firstNotOKStatus(taskOperationFailures, List.of()), equalTo(RestStatus.BAD_REQUEST));
         assertThat(TransportStopTransformAction.firstNotOKStatus(taskOperationFailures, nodeFailures), equalTo(RestStatus.BAD_REQUEST));
         assertThat(
             TransportStopTransformAction.firstNotOKStatus(
                 taskOperationFailures,
-                Collections.singletonList(new ElasticsearchException(new ElasticsearchStatusException("not failure", RestStatus.OK)))
+                List.of(new ElasticsearchException(new ElasticsearchStatusException("not failure", RestStatus.OK)))
             ),
             equalTo(RestStatus.BAD_REQUEST)
         );
 
         assertThat(
             TransportStopTransformAction.firstNotOKStatus(
-                Collections.singletonList(
-                    new TaskOperationFailure("node", 1, new ElasticsearchStatusException("not failure", RestStatus.OK))
-                ),
+                List.of(new TaskOperationFailure("node", 1, new ElasticsearchStatusException("not failure", RestStatus.OK))),
                 nodeFailures
             ),
             equalTo(RestStatus.INTERNAL_SERVER_ERROR)
         );
 
-        assertThat(
-            TransportStopTransformAction.firstNotOKStatus(Collections.emptyList(), nodeFailures),
-            equalTo(RestStatus.INTERNAL_SERVER_ERROR)
-        );
+        assertThat(TransportStopTransformAction.firstNotOKStatus(List.of(), nodeFailures), equalTo(RestStatus.INTERNAL_SERVER_ERROR));
     }
 
     public void testBuildException() {
@@ -160,12 +188,12 @@ public class TransportStopTransformActionTests extends ESTestCase {
         assertThat(statusException.getMessage(), equalTo(taskOperationFailures.get(0).getCause().getMessage()));
         assertThat(statusException.getSuppressed().length, equalTo(1));
 
-        statusException = TransportStopTransformAction.buildException(Collections.emptyList(), nodeFailures, status);
+        statusException = TransportStopTransformAction.buildException(List.of(), nodeFailures, status);
         assertThat(statusException.status(), equalTo(status));
         assertThat(statusException.getMessage(), equalTo(nodeFailures.get(0).getMessage()));
         assertThat(statusException.getSuppressed().length, equalTo(0));
 
-        statusException = TransportStopTransformAction.buildException(taskOperationFailures, Collections.emptyList(), status);
+        statusException = TransportStopTransformAction.buildException(taskOperationFailures, List.of(), status);
         assertThat(statusException.status(), equalTo(status));
         assertThat(statusException.getMessage(), equalTo(taskOperationFailures.get(0).getCause().getMessage()));
         assertThat(statusException.getSuppressed().length, equalTo(0));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -151,7 +151,7 @@ public class TransformTaskTests extends ESTestCase {
             equalTo(
                 "Unable to stop transform ["
                     + transformConfig.getId()
-                    + "] as it is in a failed state with reason [because]. Use force stop to stop the transform."
+                    + "] as it is in a failed state. Use force stop to stop the transform. More details: [because]"
             )
         );
 
@@ -256,7 +256,7 @@ public class TransformTaskTests extends ESTestCase {
             equalTo(
                 "Unable to stop transform ["
                     + transformConfig.getId()
-                    + "] as it is in a failed state with reason [because]. Use force stop to stop the transform."
+                    + "] as it is in a failed state. Use force stop to stop the transform. More details: [because]"
             )
         );
 


### PR DESCRIPTION
Stop and Start error messages include the reason for the error followed by the suggestion to use force=true.  This may cause the suggestion to be hidden by the reason, so we will move the reason after the suggestion.

Close #106819 
