### PR TITLE
Remove `rank` and `sub_searches` elements from documentation

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -564,28 +564,6 @@ preview:[]
 (Optional, <<retriever, retriever object>>) Defines a top-level retriever to specify
 a desired set of top documents instead of a standard query or knn search.
 
-[[request-body-rank]]
-`rank`::
-preview:[]
-This param is in technical preview and may change in the future. The syntax will
-likely change before GA.
-+
-This parameter is deprecated and will be removed. Use <<retriever, retriever>> instead.
-+
-(Optional, object)
-Defines a method for combining and ranking result sets from
-a combination of <<request-body-search-query, query>>,
-<<request-body-sub-searches, sub searches>>, and/or
-<<search-api-knn, knn searches>>. Requires a minimum of 2 results sets for
-ranking from the specified sources.
-+
-.Ranking methods
-[%collapsible%open]
-====
-`rrf`::
-(Optional, object) Sets the ranking method to <<rrf, reciprocal rank fusion (RRF)>>.
-====
-
 [[search-api-body-runtime]]
 // tag::runtime-mappings-def[]
 `runtime_mappings`::
@@ -732,35 +710,6 @@ exclude fields from this subset using the `excludes` property.
 Stats groups to associate with the search. Each group maintains a statistics
 aggregation for its associated searches. You can retrieve these stats using the
 <<indices-stats,indices stats API>>.
-
-[[request-body-sub-searches]]
-`sub_searches`::
-preview:[]
-This param is in technical preview and may change in the future. The syntax will
-likely change before GA.
-+
-This parameter is deprecated and will be removed. Use <<retriever, retriever>> instead.
-+
-(Optional, array of objects)
-An array of `sub_search` objects where each `sub_search` is evaluated
-independently, and their result sets are later combined as part of
-<<request-body-rank, ranking>>. Each `sub_search` object is required to
-contain a single `query`. `sub_searches` is only allowed with the
-<<request-body-rank,`rank`>> element, and is not allowed in conjunction
-with a top-level <<request-body-search-query, `query`>> element.
-+
-`sub_searches` as part of a search:
-[source,js]
-----
-{
-  "sub_searches": [
-    { "query": {...} },
-    { "query": {...} }
-  ]
-  ...
-}
-----
-// NOTCONSOLE
 
 [[request-body-search-terminate-after]]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=terminate_after]


### PR DESCRIPTION
This change removes the technical preview elements `rank` and `sub_searches` from the search API documentation now that retrievers are available.