### PR TITLE
Update MRJarPlugin to only create test tasks when runtime jdk supports the version

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/MrjarPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/MrjarPlugin.java
@@ -75,7 +75,11 @@ public class MrjarPlugin implements Plugin<Project> {
             String testSourceSetName = SourceSet.TEST_SOURCE_SET_NAME + javaVersion;
             SourceSet testSourceSet = addSourceSet(project, javaExtension, testSourceSetName, testSourceSets, javaVersion);
             testSourceSets.add(testSourceSetName);
-            createTestTask(project, testSourceSet, javaVersion, mainSourceSets);
+            var testTask = project.getTasks().withType(Test.class).iterator().next();
+            // only register a testTask if the runtime JDK is capable of running the test-specific java version
+            if (testTask.getJavaLauncher().get().getMetadata().getLanguageVersion().canCompileOrRun(JavaLanguageVersion.of(javaVersion))) {
+                createTestTask(project, testSourceSet, javaVersion, mainSourceSets);
+            }
         }
 
         configureMrjar(project);


### PR DESCRIPTION
This commit updates the MrJarPlugin to only create test tasks when the runtime jdk supports the version.

Prior to this change, running tests with a runtime prior to the test specific source will fail, e.g. passing`-Druntime.java=20` when the project contains a `test21` source set. Clearly we only want to run the tests from `test21` when the runtime tool chain supports it (so on JDK 21 and greater, not JDK 20).

Note: it's fine to continue to compile the test source, since the tool chain to compile the source is orthogonal to the runtime JDK.
