### PR TITLE
[8.10] [ML] Document wait_for_completion parameter to PUT trained models (#106769)

### DIFF
--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -50,6 +50,10 @@ definition decompression and skips relevant validations.
 This deferral is useful for systems or users that know a good byte size estimate for their
 model and know that their model is valid and likely won't fail during inference.
 
+`wait_for_completion`::
+(Optional, boolean)
+Whether to wait for all child operations such as model download
+to complete, before returning or not. Defaults to `false`.
 
 [role="child_attributes"]
 [[ml-put-trained-models-request-body]]


### PR DESCRIPTION
Backports the following commits to 8.10:
 - [ML] Document wait_for_completion parameter to PUT trained models (#106769)