### PR TITLE
Fix misspelled ESQL feature name from 'esql.value_agg' to 'esql.agg_values'

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
@@ -542,7 +542,7 @@ setup:
 ---
 values:
   - requires:
-      cluster_features: esql.value_agg
+      cluster_features: esql.agg_values
       reason: "values is available in 8.14+"
 
   - do:


### PR DESCRIPTION
Just a small catch, `esql.value_agg` doesn't exist, looks like this is meant to be `esql.agg_values`.

```java
/**
 * The introduction of the {@code VALUES} agg.
 */
private static final NodeFeature AGG_VALUES = new NodeFeature("esql.agg_values");
```