### PR TITLE
Add total size in bytes to doc stats

### DIFF
--- a/docs/changelog/106840.yaml
+++ b/docs/changelog/106840.yaml
@@ -1,0 +1,6 @@
+pr: 106840
+summary: Add total size in bytes to doc stats
+area: Stats
+type: enhancement
+issues:
+ - 97670

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -223,6 +223,10 @@ selected nodes.
 +
 This number is based on documents in Lucene segments. {es} reclaims the disk
 space of deleted Lucene documents when a segment is merged.
+
+`total_size_in_bytes`::
+(integer)
+Total size in bytes across all primary shards assigned to selected nodes.
 =====
 
 `store`::
@@ -1594,7 +1598,8 @@ The API returns the following response:
       },
       "docs": {
          "count": 10,
-         "deleted": 0
+         "deleted": 0,
+         "total_size_in_bytes": 8833
       },
       "store": {
          "size": "16.2kb",

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -508,7 +508,7 @@ Return all statistics.
 <<completion-suggester,Completion suggester>> statistics.
 
 `docs`::
-Number of documents and deleted docs, which have not yet merged out.
+Number of documents, number of deleted docs which have not yet merged out, and total size in bytes.
 <<indices-refresh,Index refreshes>> can affect this statistic.
 
 `fielddata`::

--- a/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
@@ -81,6 +81,7 @@ public class DocsStats implements Writeable, ToXContentFragment {
         builder.startObject(Fields.DOCS);
         builder.field(Fields.COUNT, count);
         builder.field(Fields.DELETED, deleted);
+        builder.field(Fields.TOTAL_SIZE_IN_BYTES, totalSizeInBytes);
         builder.endObject();
         return builder;
     }
@@ -102,5 +103,6 @@ public class DocsStats implements Writeable, ToXContentFragment {
         static final String DOCS = "docs";
         static final String COUNT = "count";
         static final String DELETED = "deleted";
+        static final String TOTAL_SIZE_IN_BYTES = "total_size_in_bytes";
     }
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -522,7 +522,8 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
                   },
                   "docs": {
                     "count": 0,
-                    "deleted": 0
+                    "deleted": 0,
+                    "total_size_in_bytes": 0
                   },
                   "store": {
                     "size_in_bytes": 0,


### PR DESCRIPTION
Add a total_size_in_bytes field to the docs object returned by the [index stats api](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html)

Fixes #97670 