### PR TITLE
Added content_type to profiling for rest-api-spec

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.flamegraph.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.flamegraph.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"private",
     "headers":{
-      "accept": ["application/json"]
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.stacktraces.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.stacktraces.json
@@ -7,7 +7,8 @@
     "stability":"stable",
     "visibility":"private",
     "headers":{
-      "accept": ["application/json"]
+      "accept": ["application/json"],
+      "content_type": ["application/json"]
     },
     "url":{
       "paths":[


### PR DESCRIPTION
The `content_type` is missing in the rest-api-spec of [profiling.flamegraph](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.flamegraph.json) and [profiling.stacktraces](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/main/resources/rest-api-spec/api/profiling.stacktraces.json). This PR adds it.