### PR TITLE
Ignore hdfs tests for searchable snapshots when fips enabled

### DIFF
--- a/x-pack/plugin/searchable-snapshots/qa/hdfs/build.gradle
+++ b/x-pack/plugin/searchable-snapshots/qa/hdfs/build.gradle
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 apply plugin: 'elasticsearch.internal-java-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
 apply plugin: 'elasticsearch.internal-available-ports'
@@ -26,5 +28,6 @@ restResources {
 
 tasks.named("javaRestTest").configure {
   usesDefaultDistribution()
+  BuildParams.withFipsEnabledOnly(it)
   jvmArgs '--add-exports', 'java.security.jgss/sun.security.krb5=ALL-UNNAMED'
 }


### PR DESCRIPTION
fixes https://github.com/elastic/elasticsearch/issues/106845.

When reworking hdfsfixtures and the according tests I missed that those tests where disabled for FIPS.