### PR TITLE
Skip rest tests when hdfs cluster setup fails

### DIFF
--- a/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsFixture.java
+++ b/test/fixtures/hdfs-fixture/src/main/java/org/elasticsearch/test/fixtures/hdfs/HdfsFixture.java
@@ -198,7 +198,7 @@ public class HdfsFixture extends ExternalResource {
                 // If the maximum number of attempts is reached, rethrow the exception
                 FileUtils.deleteDirectory(baseDir.toFile());
                 if (attempt == maxAttempts) {
-                    throw e;
+                    Assume.assumeTrue("Unable to start HDFS cluster", false);
                 }
             }
         }


### PR DESCRIPTION
For now skip tests when flaky hdfs cluster cannot be started. Investigating further without
bothering others and keeping pipeline green.

Related to https://github.com/elastic/elasticsearch/issues/106739