### PR TITLE
Add getter for global retention GetComposableIndexTemplateAction.Response

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -158,6 +158,10 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
             return indexTemplates;
         }
 
+        public DataStreamGlobalRetention getGlobalRetention() {
+            return globalRetention;
+        }
+
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeMap(indexTemplates, StreamOutput::writeWriteable);


### PR DESCRIPTION
Add missing getter