### PR TITLE
[8.12] Unmute {p0=data_stream/10_basic/Delete data stream with failure stores} (#106865)

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -540,10 +540,8 @@ setup:
 ---
 "Delete data stream with failure stores":
   - skip:
-      # version: " - 8.11.99"
-      # reason: "data streams only supported in 8.12+"
-      version: all
-      reason: AwaitsFix https://github.com/elastic/elasticsearch/issues/104348
+       version: " - 8.11.99"
+       reason: "data stream failure stores only supported in 8.12+"
 
   - do:
       allowed_warnings:


### PR DESCRIPTION
Backports the following commits to 8.12:
 - Unmute {p0=data_stream/10_basic/Delete data stream with failure stores} (#106865)