### PR TITLE
Enable data-streams module in REST tests

### DIFF
--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   clusterModules project(":modules:reindex")
   clusterModules project(":modules:analysis-common")
   clusterModules project(":modules:health-shards-availability")
+  clusterModules project(":modules:data-streams")
 }
 
 tasks.named("yamlRestTest").configure {

--- a/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
+++ b/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
@@ -30,6 +30,7 @@ public class SmokeTestMultiNodeClientYamlTestSuiteIT extends ESClientYamlSuiteTe
         .module("reindex")
         .module("analysis-common")
         .module("health-shards-availability")
+        .module("data-streams")
         // The first node does not have the ingest role so we're sure ingest requests are forwarded:
         .node(0, n -> n.setting("node.roles", "[master,data,ml,remote_cluster_client,transform]"))
         .feature(FeatureFlag.TIME_SERIES_MODE)

--- a/rest-api-spec/build.gradle
+++ b/rest-api-spec/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   clusterModules project(":modules:reindex")
   clusterModules project(':modules:analysis-common')
   clusterModules project(':modules:health-shards-availability')
+  clusterModules project(':modules:data-streams')
 }
 
 tasks.named("yamlRestTestV7CompatTransform").configure { task ->

--- a/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
+++ b/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
@@ -33,6 +33,7 @@ public class ClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         .module("reindex")
         .module("analysis-common")
         .module("health-shards-availability")
+        .module("data-streams")
         .feature(FeatureFlag.TIME_SERIES_MODE)
         .build();
 

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   clusterModules project(':modules:reindex')
   clusterModules project(':modules:analysis-common')
   clusterModules project(':modules:health-shards-availability')
+  clusterModules project(':modules:data-streams')
   clusterModules project(xpackModule('stack'))
   clusterModules project(xpackModule('ilm'))
   clusterModules project(xpackModule('mapper-constant-keyword'))

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
@@ -40,6 +40,7 @@ public class CoreWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteTest
         .module("wildcard")
         .module("analysis-common")
         .module("health-shards-availability")
+        .module("data-streams")
         .setting("xpack.security.enabled", "true")
         .setting("xpack.watcher.enabled", "false")
         .setting("xpack.ml.enabled", "false")


### PR DESCRIPTION
Previously the `data-streams` module wasn't ever present in the general REST specs.
Because of that the respective feature wasn't available causing the tests added in https://github.com/elastic/elasticsearch/pull/105682 to be silently ignored.

We've added some validation today to make sure features are known to most recent code base (vs supported by the code running) to prevent exactly such issues.