### PR TITLE
Add PersistentTask exceptions

### DIFF
--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -32,6 +32,8 @@ import org.elasticsearch.indices.AutoscalingMissedIndicesUpdateException;
 import org.elasticsearch.indices.FailureIndexNotSupportedException;
 import org.elasticsearch.indices.recovery.RecoveryCommitTooNewException;
 import org.elasticsearch.ingest.GraphStructureException;
+import org.elasticsearch.persistent.NotPersistentTaskNodeException;
+import org.elasticsearch.persistent.PersistentTaskNodeNotAssignedException;
 import org.elasticsearch.rest.ApiNotAvailableException;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchException;
@@ -1917,6 +1919,18 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             FailureIndexNotSupportedException::new,
             178,
             TransportVersions.ADD_FAILURE_STORE_INDICES_OPTIONS
+        ),
+        NOT_PERSISTENT_TASK_NODE_EXCEPTION(
+            NotPersistentTaskNodeException.class,
+            NotPersistentTaskNodeException::new,
+            179,
+            TransportVersions.ADD_PERSISTENT_TASK_EXCEPTIONS
+        ),
+        PERSISTENT_TASK_NODE_NOT_ASSIGNED_EXCEPTION(
+            PersistentTaskNodeNotAssignedException.class,
+            PersistentTaskNodeNotAssignedException::new,
+            180,
+            TransportVersions.ADD_PERSISTENT_TASK_EXCEPTIONS
         );
 
         final Class<? extends ElasticsearchException> exceptionClass;

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -156,6 +156,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_L2_NORM_SIMILARITY_ADDED = def(8_616_00_0);
     public static final TransportVersion SEARCH_NODE_LOAD_AUTOSCALING = def(8_617_00_0);
     public static final TransportVersion ESQL_ES_SOURCE_OPTIONS = def(8_618_00_0);
+    public static final TransportVersion ADD_PERSISTENT_TASK_EXCEPTIONS = def(8_619_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/persistent/NotPersistentTaskNodeException.java
+++ b/server/src/main/java/org/elasticsearch/persistent/NotPersistentTaskNodeException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.persistent;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+
+/**
+ * Exception which indicates that an operation failed because the node stopped being the node on which the PersistentTask is allocated.
+ */
+public class NotPersistentTaskNodeException extends ElasticsearchException {
+
+    public NotPersistentTaskNodeException(String nodeId, String persistentTaskName) {
+        super("Node [{}] is not hosting PersistentTask [{}]", nodeId, persistentTaskName);
+    }
+
+    public NotPersistentTaskNodeException(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.SERVICE_UNAVAILABLE;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTaskNodeNotAssignedException.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTaskNodeNotAssignedException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.persistent;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.rest.RestStatus;
+
+import java.io.IOException;
+
+/**
+ * Exception which indicates that the PersistentTask node has not been assigned yet.
+ */
+public class PersistentTaskNodeNotAssignedException extends ElasticsearchException {
+
+    public PersistentTaskNodeNotAssignedException(String persistentTaskName) {
+        super("PersistentTask [{}] has not been yet assigned to a node on this cluster", persistentTaskName);
+    }
+
+    public PersistentTaskNodeNotAssignedException(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.SERVICE_UNAVAILABLE;
+    }
+}

--- a/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/ExceptionSerializationTests.java
@@ -68,6 +68,8 @@ import org.elasticsearch.indices.recovery.RecoverFilesRecoveryException;
 import org.elasticsearch.indices.recovery.RecoveryCommitTooNewException;
 import org.elasticsearch.ingest.GraphStructureException;
 import org.elasticsearch.ingest.IngestProcessorException;
+import org.elasticsearch.persistent.NotPersistentTaskNodeException;
+import org.elasticsearch.persistent.PersistentTaskNodeNotAssignedException;
 import org.elasticsearch.repositories.RepositoryConflictException;
 import org.elasticsearch.repositories.RepositoryException;
 import org.elasticsearch.rest.ApiNotAvailableException;
@@ -829,6 +831,8 @@ public class ExceptionSerializationTests extends ESTestCase {
         ids.put(176, SearchTimeoutException.class);
         ids.put(177, GraphStructureException.class);
         ids.put(178, FailureIndexNotSupportedException.class);
+        ids.put(179, NotPersistentTaskNodeException.class);
+        ids.put(180, PersistentTaskNodeNotAssignedException.class);
 
         Map<Class<? extends ElasticsearchException>, Integer> reverse = new HashMap<>();
         for (Map.Entry<Integer, Class<? extends ElasticsearchException>> entry : ids.entrySet()) {


### PR DESCRIPTION
Add a couple of exceptions that can be used in TransportActions to check/raise error if specific conditions on PersistentTasks (and the node they are allocated to) are not met.
