### PR TITLE
[DOCS] Clarify closed index setting warning

### DIFF
--- a/docs/reference/index-modules.asciidoc
+++ b/docs/reference/index-modules.asciidoc
@@ -7,7 +7,7 @@ an index.
 
 [discrete]
 [[index-modules-settings]]
-== Index Settings
+== Index settings
 
 [[index-modules-settings-description]]
 // tag::index-modules-settings-description-tag[]
@@ -27,9 +27,7 @@ They can be changed on a live index using the
 <<indices-update-settings,update-index-settings>> API.
 // end::index-modules-settings-description-tag[]
 
-WARNING: Changing static or dynamic index settings on a closed index could
-result in incorrect settings that are impossible to rectify without deleting
-and recreating the index.
+CAUTION: You can change any documented index settings on closed indices. However, changing undocumented index settings on closed indices is unsupported and might result in errors.
 
 [discrete]
 === Static index settings


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/101851

Clarifies that any _documented_ setting can be updated on a closed index, but updating undocumented settings might cause issues. This warning can be removed when the undocumented setting that could cause issues, `index.data_path`, is [removed in the next major release](https://github.com/elastic/elasticsearch/issues/73168).

Also downgraded the scary `warning` to a gentler `caution`

<img width="738" alt="image" src="https://github.com/elastic/elasticsearch/assets/58563081/a8893eb1-0d02-41cc-85ad-67540051874f">