### PR TITLE
Slightly better geoip databaseType validation

### DIFF
--- a/docs/changelog/106889.yaml
+++ b/docs/changelog/106889.yaml
@@ -1,0 +1,5 @@
+pr: 106889
+summary: Slightly better geoip `databaseType` validation
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -175,10 +175,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         } else if (databaseType.endsWith(ASN_DB_SUFFIX)) {
             geoData = retrieveAsnGeoData(geoIpDatabase, ipAddress);
         } else {
-            throw new ElasticsearchParseException(
-                "Unsupported database type [" + geoIpDatabase.getDatabaseType() + "]",
-                new IllegalStateException()
-            );
+            throw new ElasticsearchParseException("Unsupported database type [" + databaseType + "]", new IllegalStateException());
         }
         return geoData;
     }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -437,11 +437,18 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 // pipeline.
                 return new DatabaseUnavailableProcessor(processorTag, description, databaseFile);
             }
+
             final String databaseType;
             try {
                 databaseType = geoIpDatabase.getDatabaseType();
             } finally {
                 geoIpDatabase.release();
+            }
+            if (databaseType == null
+                || (databaseType.endsWith(CITY_DB_SUFFIX)
+                    || databaseType.endsWith(COUNTRY_DB_SUFFIX)
+                    || databaseType.endsWith(ASN_DB_SUFFIX)) == false) {
+                throw newConfigurationException(TYPE, processorTag, "database_file", "Unsupported database type [" + databaseType + "]");
             }
 
             final Set<Property> properties;
@@ -463,12 +470,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 } else if (databaseType.endsWith(ASN_DB_SUFFIX)) {
                     properties = DEFAULT_ASN_PROPERTIES;
                 } else {
-                    throw newConfigurationException(
-                        TYPE,
-                        processorTag,
-                        "database_file",
-                        "Unsupported database type [" + databaseType + "]"
-                    );
+                    assert false : "unsupported database type [" + databaseType + "]";
+                    properties = Set.of();
                 }
             }
             return new GeoIpProcessor(
@@ -542,6 +545,8 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 validProperties = ALL_COUNTRY_PROPERTIES;
             } else if (databaseType.endsWith(ASN_DB_SUFFIX)) {
                 validProperties = ALL_ASN_PROPERTIES;
+            } else {
+                assert false : "unsupported database type [" + databaseType + "]";
             }
 
             try {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -448,7 +448,12 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 || (databaseType.endsWith(CITY_DB_SUFFIX)
                     || databaseType.endsWith(COUNTRY_DB_SUFFIX)
                     || databaseType.endsWith(ASN_DB_SUFFIX)) == false) {
-                throw newConfigurationException(TYPE, processorTag, "database_file", "Unsupported database type [" + databaseType + "]");
+                throw newConfigurationException(
+                    TYPE,
+                    processorTag,
+                    "database_file",
+                    "Unsupported database type [" + databaseType + "] for file [" + databaseFile + "]"
+                );
             }
 
             final Set<Property> properties;

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -50,6 +50,7 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -285,6 +286,22 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         config2.put("properties", "invalid");
         e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, null, config2));
         assertThat(e.getMessage(), equalTo("[properties] property isn't a list, but of type [java.lang.String]"));
+    }
+
+    public void testBuildUnsupportedDatabase() throws Exception {
+        // mock up some unsupported database (it has a databaseType that we don't recognize)
+        GeoIpDatabase database = mock(GeoIpDatabase.class);
+        when(database.getDatabaseType()).thenReturn("some-unsupported-database");
+        GeoIpDatabaseProvider provider = mock(GeoIpDatabaseProvider.class);
+        when(provider.getDatabase(anyString())).thenReturn(database);
+
+        GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(provider);
+
+        Map<String, Object> config1 = new HashMap<>();
+        config1.put("field", "_field");
+        config1.put("properties", List.of("ip"));
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, null, config1));
+        assertThat(e.getMessage(), equalTo("[properties] illegal property value [ip]. valid values are []"));
     }
 
     @SuppressWarnings("HiddenField")

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -301,7 +301,10 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         config1.put("field", "_field");
         config1.put("properties", List.of("ip"));
         Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, null, config1));
-        assertThat(e.getMessage(), equalTo("[database_file] Unsupported database type [some-unsupported-database]"));
+        assertThat(
+            e.getMessage(),
+            equalTo("[database_file] Unsupported database type [some-unsupported-database] for file [GeoLite2-City.mmdb]")
+        );
     }
 
     public void testBuildNullDatabase() throws Exception {
@@ -317,7 +320,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         config1.put("field", "_field");
         config1.put("properties", List.of("ip"));
         Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, null, config1));
-        assertThat(e.getMessage(), equalTo("[database_file] Unsupported database type [null]"));
+        assertThat(e.getMessage(), equalTo("[database_file] Unsupported database type [null] for file [GeoLite2-City.mmdb]"));
     }
 
     @SuppressWarnings("HiddenField")

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -301,7 +301,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         config1.put("field", "_field");
         config1.put("properties", List.of("ip"));
         Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, null, config1));
-        assertThat(e.getMessage(), equalTo("[properties] illegal property value [ip]. valid values are []"));
+        assertThat(e.getMessage(), equalTo("[database_file] Unsupported database type [some-unsupported-database]"));
     }
 
     @SuppressWarnings("HiddenField")


### PR DESCRIPTION
We have some code that's intended to complain if you use an unsupported `databaseType`, but it never actually executes, instead we throw a configuration error earlier in the code and complain about unsupported fields. This PR fixes the code so that the intended validation actually runs.

My first commit is just a tidying commit. My second commit adds a test of the existing (unintended) behavior. My third commit corrects the behavior and updates the test.

