### PR TITLE
[Transform] Fail requests to start a finished task

### DIFF
--- a/docs/changelog/106893.yaml
+++ b/docs/changelog/106893.yaml
@@ -1,0 +1,6 @@
+pr: 106893
+summary: Fail requests to start a finished task
+area: Transform
+type: enhancement
+issues:
+ - 46453

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -174,6 +174,12 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         assertAcknowledged(client().performRequest(startTransformRequest));
     }
 
+    protected void resetTransform(String id) throws IOException {
+        var resetTransformRequest = new Request("POST", TRANSFORM_ENDPOINT + id + "/_reset");
+        resetTransformRequest.setOptions(RequestOptions.DEFAULT);
+        assertAcknowledged(client().performRequest(resetTransformRequest));
+    }
+
     // workaround for https://github.com/elastic/elasticsearch/issues/62204
     protected void startTransformWithRetryOnConflict(String id, RequestOptions options) throws Exception {
         final int totalRetries = 10;

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/80_transform_jobs_crud.yml
@@ -8,11 +8,11 @@
 
   - do:
       transform.put_transform:
-        transform_id: "mixed-simple-transform"
+        transform_id: "mixed-simple-batch-transform"
         body: >
           {
             "source": { "index": "transform-airline-data" },
-            "dest": { "index": "mixed-simple-transform-idx" },
+            "dest": { "index": "mixed-simple-batch-transform-idx" },
             "pivot": {
               "group_by": { "airline": {"terms": {"field": "airline"}}},
               "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
@@ -22,31 +22,19 @@
 
   - do:
       transform.start_transform:
-        transform_id: "mixed-simple-transform"
+        transform_id: "mixed-simple-batch-transform"
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
-        transform_id: "mixed-simple-transform"
+        transform_id: "mixed-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-simple-transform" }
+  - match: { transforms.0.id: "mixed-simple-batch-transform" }
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
-      transform.stop_transform:
-        transform_id: "mixed-simple-transform"
-        wait_for_completion: true
-  - match: { acknowledged: true }
-
-  - do:
-      transform.get_transform_stats:
-        transform_id: "mixed-simple-transform"
-  - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-simple-transform" }
-  - match: { transforms.0.state: "stopped" }
-
-  - do:
       transform.put_transform:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
         body: >
           {
             "source": {
@@ -58,7 +46,7 @@
               }
             },
             "dest": {
-              "index": "mixed-complex-transform-idx",
+              "index": "mixed-complex-batch-transform-idx",
               "pipeline": "data_frame_simple_pipeline"
             },
             "pivot": {
@@ -74,35 +62,23 @@
 
   - do:
       transform.get_transform:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-complex-transform" }
+  - match: { transforms.0.id: "mixed-complex-batch-transform" }
   - is_true: transforms.0.version
   - is_true: transforms.0.create_time
 
   - do:
       transform.start_transform:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-complex-transform" }
+  - match: { transforms.0.id: "mixed-complex-batch-transform" }
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
-
-  - do:
-      transform.stop_transform:
-        transform_id: "mixed-complex-transform"
-        wait_for_completion: true
-  - match: { acknowledged: true }
-
-  - do:
-      transform.get_transform_stats:
-        transform_id: "mixed-complex-transform"
-  - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-complex-transform" }
-  - match: { transforms.0.state: "stopped" }
 
 ---
 "Test put continuous transform on mixed cluster":
@@ -146,6 +122,7 @@
       transform.start_transform:
         transform_id: "mixed-simple-continuous-transform"
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
         transform_id: "mixed-simple-continuous-transform"
@@ -165,6 +142,7 @@
   - match: { count: 1 }
   - match: { transforms.0.id: "mixed-simple-continuous-transform" }
   - match: { transforms.0.state: "stopped" }
+
   - do:
       transform.update_transform:
         transform_id: "mixed-simple-continuous-transform"
@@ -182,44 +160,28 @@
 
   - do:
       transform.get_transform:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
+  - match: { transforms.0.id: "old-simple-batch-transform" }
   - match: { transforms.0.source.index.0: "transform-airline-data" }
-  - match: { transforms.0.dest.index: "old-simple-transform-idx" }
+  - match: { transforms.0.dest.index: "old-simple-batch-transform-idx" }
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
-      transform.start_transform:
-        transform_id: "old-simple-transform"
-  - match: { acknowledged: true }
-  - do:
       transform.get_transform_stats:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
+  - match: { transforms.0.id: "old-simple-batch-transform" }
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
-      transform.stop_transform:
-        transform_id: "old-simple-transform"
-        wait_for_completion: true
-  - match: { acknowledged: true }
-  - do:
-      transform.get_transform_stats:
-        transform_id: "old-simple-transform"
-  - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
-  - match: { transforms.0.state: "stopped" }
-
-  - do:
       transform.get_transform:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
+  - match: { transforms.0.id: "old-complex-batch-transform" }
   - match: { transforms.0.source.index.0: "transform-airline-data" }
-  - match: { transforms.0.dest.index: "old-complex-transform-idx" }
+  - match: { transforms.0.dest.index: "old-complex-batch-transform-idx" }
   - match: { transforms.0.dest.pipeline: "data_frame_simple_pipeline" }
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
   - match: { transforms.0.pivot.group_by.day.date_histogram.field: "timestamp" }
@@ -227,33 +189,31 @@
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
-      transform.start_transform:
-        transform_id: "old-complex-transform"
-  - match: { acknowledged: true }
-  - do:
       transform.get_transform_stats:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
+  - match: { transforms.0.id: "old-complex-batch-transform" }
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       transform.stop_transform:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
+  - match: { transforms.0.id: "old-complex-batch-transform" }
   - match: { transforms.0.state: "stopped" }
+
   - do:
       transform.update_transform:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
         body: >
           {
-            "description": "old complex transform"
+            "description": "old complex batch transform"
           }
 ---
 "Test GET, stop, start, old continuous transforms":
@@ -277,6 +237,7 @@
       transform.start_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
@@ -296,6 +257,7 @@
   - match: { count: 1 }
   - match: { transforms.0.id: "old-simple-continuous-transform" }
   - match: { transforms.0.state: "stopped" }
+
   - do:
       transform.update_transform:
         transform_id: "old-simple-continuous-transform"

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/80_transform_jobs_crud.yml
@@ -36,11 +36,11 @@
           }
   - do:
       transform.put_transform:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
         body: >
           {
             "source": { "index": "transform-airline-data" },
-            "dest": { "index": "old-simple-transform-idx" },
+            "dest": { "index": "old-simple-batch-transform-idx" },
             "pivot": {
               "group_by": { "airline": {"terms": {"field": "airline"}}},
               "aggs": {"avg_response": {"avg": {"field": "responsetime"}}}
@@ -50,37 +50,27 @@
 
   - do:
       transform.get_transform:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
+  - match: { transforms.0.id: "old-simple-batch-transform" }
   - is_true: transforms.0.version
   - is_true: transforms.0.create_time
 
   - do:
       transform.start_transform:
-        transform_id: "old-simple-transform"
-  - match: { acknowledged: true }
-  - do:
-      transform.get_transform_stats:
-        transform_id: "old-simple-transform"
-  - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
-
-  - do:
-      transform.stop_transform:
-        transform_id: "old-simple-transform"
-        wait_for_completion: true
+        transform_id: "old-simple-batch-transform"
   - match: { acknowledged: true }
 
   - do:
       transform.get_transform_stats:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
+  - match: { transforms.0.id: "old-simple-batch-transform" }
+  - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       transform.put_transform:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
         body: >
           {
             "source": {
@@ -92,7 +82,7 @@
               }
             },
             "dest": {
-              "index": "old-complex-transform-idx",
+              "index": "old-complex-batch-transform-idx",
               "pipeline": "data_frame_simple_pipeline"
             },
             "pivot": {
@@ -108,31 +98,21 @@
 
   - do:
       transform.get_transform:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
+  - match: { transforms.0.id: "old-complex-batch-transform" }
 
   - do:
       transform.start_transform:
-        transform_id: "old-complex-transform"
-  - match: { acknowledged: true }
-  - do:
-      transform.get_transform_stats:
-        transform_id: "old-complex-transform"
-  - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
-
-  - do:
-      transform.stop_transform:
-        transform_id: "old-complex-transform"
-        wait_for_completion: true
+        transform_id: "old-complex-batch-transform"
   - match: { acknowledged: true }
 
   - do:
       transform.get_transform_stats:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
+  - match: { transforms.0.id: "old-complex-batch-transform" }
+  - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
 ---
 "Test put continuous transform on old cluster":

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_transform_jobs_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/80_transform_jobs_crud.yml
@@ -10,43 +10,41 @@ setup:
   # Simple and complex OLD transforms
   - do:
       transform.get_transform:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
+  - match: { transforms.0.id: "old-simple-batch-transform" }
   - match: { transforms.0.source.index.0: "transform-airline-data" }
-  - match: { transforms.0.dest.index: "old-simple-transform-idx" }
+  - match: { transforms.0.dest.index: "old-simple-batch-transform-idx" }
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
-      transform.start_transform:
-        transform_id: "old-simple-transform"
-  - match: { acknowledged: true }
-  - do:
       transform.get_transform_stats:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
+  - match: { transforms.0.id: "old-simple-batch-transform" }
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       transform.stop_transform:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-simple-transform" }
+  - match: { transforms.0.id: "old-simple-batch-transform" }
   - match: { transforms.0.state: "stopped" }
+
   - do:
       transform.get_transform:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
+  - match: { transforms.0.id: "old-complex-batch-transform" }
   - match: { transforms.0.source.index.0: "transform-airline-data" }
-  - match: { transforms.0.dest.index: "old-complex-transform-idx" }
+  - match: { transforms.0.dest.index: "old-complex-batch-transform-idx" }
   - match: { transforms.0.dest.pipeline: "data_frame_simple_pipeline" }
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
   - match: { transforms.0.pivot.group_by.day.date_histogram.field: "timestamp" }
@@ -54,26 +52,23 @@ setup:
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
-      transform.start_transform:
-        transform_id: "old-complex-transform"
-  - match: { acknowledged: true }
-  - do:
       transform.get_transform_stats:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
+  - match: { transforms.0.id: "old-complex-batch-transform" }
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       transform.stop_transform:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
-        transform_id: "old-complex-transform"
+        transform_id: "old-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "old-complex-transform" }
+  - match: { transforms.0.id: "old-complex-batch-transform" }
   - match: { transforms.0.state: "stopped" }
 
   # upgrade transform
@@ -85,10 +80,10 @@ setup:
   # Delete old transform
   - do:
       transform.delete_transform:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - do:
       transform.get_transform_stats:
-        transform_id: "old-simple-transform"
+        transform_id: "old-simple-batch-transform"
   - match: { count: 0 }
 
 ---
@@ -96,44 +91,41 @@ setup:
   # Simple and complex Mixed cluster transforms
   - do:
       transform.get_transform:
-        transform_id: "mixed-simple-transform"
+        transform_id: "mixed-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-simple-transform" }
+  - match: { transforms.0.id: "mixed-simple-batch-transform" }
   - match: { transforms.0.source.index.0: "transform-airline-data" }
-  - match: { transforms.0.dest.index: "mixed-simple-transform-idx" }
+  - match: { transforms.0.dest.index: "mixed-simple-batch-transform-idx" }
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
-      transform.start_transform:
-        transform_id: "mixed-simple-transform"
-  - match: { acknowledged: true }
-  - do:
       transform.get_transform_stats:
-        transform_id: "mixed-simple-transform"
+        transform_id: "mixed-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-simple-transform" }
+  - match: { transforms.0.id: "mixed-simple-batch-transform" }
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       transform.stop_transform:
-        transform_id: "mixed-simple-transform"
+        transform_id: "mixed-simple-batch-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
-        transform_id: "mixed-simple-transform"
+        transform_id: "mixed-simple-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-simple-transform" }
+  - match: { transforms.0.id: "mixed-simple-batch-transform" }
   - match: { transforms.0.state: "stopped" }
 
   - do:
       transform.get_transform:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-complex-transform" }
+  - match: { transforms.0.id: "mixed-complex-batch-transform" }
   - match: { transforms.0.source.index.0: "transform-airline-data" }
-  - match: { transforms.0.dest.index: "mixed-complex-transform-idx" }
+  - match: { transforms.0.dest.index: "mixed-complex-batch-transform-idx" }
   - match: { transforms.0.dest.pipeline: "data_frame_simple_pipeline" }
   - match: { transforms.0.pivot.group_by.airline.terms.field: "airline" }
   - match: { transforms.0.pivot.group_by.day.date_histogram.field: "timestamp" }
@@ -141,37 +133,35 @@ setup:
   - match: { transforms.0.pivot.aggregations.avg_response.avg.field: "responsetime" }
 
   - do:
-      transform.start_transform:
-        transform_id: "mixed-complex-transform"
-  - match: { acknowledged: true }
-  - do:
       transform.get_transform_stats:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-complex-transform" }
+  - match: { transforms.0.id: "mixed-complex-batch-transform" }
   - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
 
   - do:
       transform.stop_transform:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
         wait_for_completion: true
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
   - match: { count: 1 }
-  - match: { transforms.0.id: "mixed-complex-transform" }
+  - match: { transforms.0.id: "mixed-complex-batch-transform" }
   - match: { transforms.0.state: "stopped" }
+
   # Delete mixed transform
   - do:
       transform.delete_transform:
-        transform_id: "mixed-simple-transform"
+        transform_id: "mixed-simple-batch-transform"
   - do:
       transform.delete_transform:
-        transform_id: "mixed-complex-transform"
+        transform_id: "mixed-complex-batch-transform"
   - do:
       transform.get_transform_stats:
-        transform_id: "mixed-simple-transform,mixed-complex-transform"
+        transform_id: "mixed-simple-batch-transform,mixed-complex-batch-transform"
   - match: { count: 0 }
 
 ---
@@ -190,6 +180,7 @@ setup:
       transform.start_transform:
         transform_id: "old-simple-continuous-transform"
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
         transform_id: "old-simple-continuous-transform"
@@ -236,6 +227,7 @@ setup:
       transform.start_transform:
         transform_id: "mixed-simple-continuous-transform"
   - match: { acknowledged: true }
+
   - do:
       transform.get_transform_stats:
         transform_id: "mixed-simple-continuous-transform"


### PR DESCRIPTION
Batch transforms can be started after they have finished. The Indexer will not try to process any additional changes, so the Transform will be stuck in `started` until the stop API is called.

Now, the start API will check that the batch transform has not already finished before scheduling the transform to run again.  If the transform has already finished, the user will receive a 409 response.

Close #46453

