### PR TITLE
Harden new tsid hashing transport version

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -120,6 +120,7 @@ public class TransportVersions {
     public static final TransportVersion DESIRED_NODE_VERSION_OPTIONAL_STRING = def(8_580_00_0);
     public static final TransportVersion ML_INFERENCE_REQUEST_INPUT_TYPE_UNSPECIFIED_ADDED = def(8_581_00_0);
     public static final TransportVersion ASYNC_SEARCH_STATUS_SUPPORTS_KEEP_ALIVE = def(8_582_00_0);
+    public static final TransportVersion TIME_SERIES_ID_HASHING = def(8_582_10_0);
     public static final TransportVersion KNN_QUERY_NUMCANDS_AS_OPTIONAL_PARAM = def(8_583_00_0);
     public static final TransportVersion TRANSFORM_GET_BASIC_STATS = def(8_584_00_0);
     public static final TransportVersion NLP_DOCUMENT_CHUNKING_ADDED = def(8_585_00_0);
@@ -133,7 +134,6 @@ public class TransportVersions {
     public static final TransportVersion INDEX_REQUEST_NORMALIZED_BYTES_PARSED = def(8_593_00_0);
     public static final TransportVersion INGEST_GRAPH_STRUCTURE_EXCEPTION = def(8_594_00_0);
     public static final TransportVersion ML_MODEL_IN_SERVICE_SETTINGS = def(8_595_00_0);
-    // 8.14.0+
     public static final TransportVersion RANDOM_AGG_SHARD_SEED = def(8_596_00_0);
     public static final TransportVersion ESQL_TIMINGS = def(8_597_00_0);
     public static final TransportVersion DATA_STREAM_AUTO_SHARDING_EVENT = def(8_598_00_0);

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardTaskParams.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardTaskParams.java
@@ -37,7 +37,6 @@ public record DownsampleShardTaskParams(
     String[] dimensions
 ) implements PersistentTaskParams {
 
-    private static final TransportVersion V_8_13_0 = TransportVersions.ML_MODEL_IN_SERVICE_SETTINGS;
     public static final String NAME = DownsampleShardTask.TASK_NAME;
     private static final ParseField DOWNSAMPLE_CONFIG = new ParseField("downsample_config");
     private static final ParseField DOWNSAMPLE_INDEX = new ParseField("rollup_index");
@@ -73,7 +72,7 @@ public record DownsampleShardTaskParams(
             new ShardId(in),
             in.readStringArray(),
             in.readStringArray(),
-            in.getTransportVersion().onOrAfter(V_8_13_0) ? in.readOptionalStringArray() : new String[] {}
+            in.getTransportVersion().onOrAfter(TransportVersions.TIME_SERIES_ID_HASHING) ? in.readOptionalStringArray() : new String[] {}
         );
     }
 
@@ -112,7 +111,7 @@ public record DownsampleShardTaskParams(
         shardId.writeTo(out);
         out.writeStringArray(metrics);
         out.writeStringArray(labels);
-        if (out.getTransportVersion().onOrAfter(V_8_13_0)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.TIME_SERIES_ID_HASHING)) {
             out.writeOptionalStringArray(dimensions);
         }
     }


### PR DESCRIPTION
This commit introduced a transport version for the new tsid hash, which was missing in #98023. At the time, the latest version was `ASYNC_SEARCH_STATUS_SUPPORTS_KEEP_ALIVE = def(8_582_00_0)`. Therefore, I introduced a new version: `TransportVersion TIME_SERIES_ID_HASHING = def(8_582_10_0)`. This change aims to minimize potential issues during upgrades from 8.13.0 to later versions in serverless.

https://github.com/elastic/elasticsearch/blob/bdd3a4ffbe299b0325723a37f08c5e7c573291cc/server/src/main/java/org/elasticsearch/TransportVersions.java#L169

Relates #98023
Relates #106878