### PR TITLE
[8.11] [Doc] Remove invalid watcher ssl enabled settings (#106901)

### DIFF
--- a/docs/reference/settings/notification-settings.asciidoc
+++ b/docs/reference/settings/notification-settings.asciidoc
@@ -95,6 +95,7 @@ corresponding endpoints are explicitly allowed as well.
 :verifies:
 :server!:
 :ssl-context:            watcher
+:no-enabled-setting:
 
 include::ssl-settings.asciidoc[]
 
@@ -284,6 +285,7 @@ Defaults to `Warning: The attachment [%s] contains characters which spreadsheet 
 :verifies:
 :server!:
 :ssl-context:            watcher-email
+:no-enabled-setting:
 
 include::ssl-settings.asciidoc[]
 

--- a/docs/reference/settings/ssl-settings.asciidoc
+++ b/docs/reference/settings/ssl-settings.asciidoc
@@ -1,6 +1,7 @@
 ==== {component} TLS/SSL settings
 You can configure the following TLS/SSL settings.
 
+ifndef::no-enabled-setting[]
 +{ssl-prefix}.ssl.enabled+::
 (<<static-cluster-setting,Static>>)
 Used to enable or disable TLS/SSL on the {ssl-layer}.
@@ -10,6 +11,7 @@ endif::enabled-by-default[]
 ifndef::enabled-by-default[]
 The default is `false`.
 endif::enabled-by-default[]
+endif::no-enabled-setting[]
 
 +{ssl-prefix}.ssl.supported_protocols+::
 (<<static-cluster-setting,Static>>)


### PR DESCRIPTION
Backports the following commits to 8.11:
 - [Doc] Remove invalid watcher ssl enabled settings (#106901)