### PR TITLE
Disable top hits concurrent execution

### DIFF
--- a/docs/changelog/106910.yaml
+++ b/docs/changelog/106910.yaml
@@ -1,5 +1,5 @@
 pr: 106910
 summary: Disable top hits concurrent execution
-area: "Search, Infra/Logging"
+area: "Aggregations"
 type: bug
 issues: []

--- a/docs/changelog/106910.yaml
+++ b/docs/changelog/106910.yaml
@@ -1,0 +1,5 @@
+pr: 106910
+summary: Disable top hits concurrent execution
+area: "Search, Infra/Logging"
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TopHitsAggregationBuilder.java
@@ -48,6 +48,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.ToLongFunction;
 
 public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHitsAggregationBuilder> {
     public static final String NAME = "top_hits";
@@ -820,5 +821,10 @@ public class TopHitsAggregationBuilder extends AbstractAggregationBuilder<TopHit
     @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.ZERO;
+    }
+
+    @Override
+    public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        return false;
     }
 }


### PR DESCRIPTION
This is required for #106325 whose debugging and further investigation revealed that
we can't use the fetch phase as it is at the moment as part of the top hits query execution
because it is not thread safe.
To be more precise `TopHits` executes the fetch phase as part of `TopHitsAggregator#buildAggregation`
whose query phase is executed concurrently by possibly more than one `search_worker` thread.
Anyway, the fetch phase is not thread safe and expected to be executed sequentially.
Here we disable parallel execution of the `TopHits` aggregator so to workaround the issue,
at least temporarily, so that in the meanwhile we can merge #106325 and re-enable concurrent
execution later on, once the fetch phase is adjusted to be executed concurrently.