### PR TITLE
Disable children aggregation concurrent execution

### DIFF
--- a/docs/changelog/106911.yaml
+++ b/docs/changelog/106911.yaml
@@ -1,0 +1,5 @@
+pr: 106911
+summary: Disable children aggregation concurrent execution
+area: "Search, Aggregations"
+type: bug
+issues: []

--- a/docs/changelog/106911.yaml
+++ b/docs/changelog/106911.yaml
@@ -1,5 +1,5 @@
 pr: 106911
 summary: Disable children aggregation concurrent execution
-area: "Search, Aggregations"
+area: "Aggregations"
 type: bug
 issues: []

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/aggregations/ChildrenAggregationBuilder.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.ToLongFunction;
 
 public class ChildrenAggregationBuilder extends ValuesSourceAggregationBuilder<ChildrenAggregationBuilder> {
 
@@ -177,5 +178,10 @@ public class ChildrenAggregationBuilder extends ValuesSourceAggregationBuilder<C
     @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.ZERO;
+    }
+
+    @Override
+    public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        return false;
     }
 }


### PR DESCRIPTION
Parent/children aggregations are used together but only the parent
disables concurrent execution by overriding `supportsParallelCollection`.
This is incorrect, so we here just make sure the children is not
executed concurrently too.

This is required for #106325.