### PR TITLE
Fix AsyncSearchSecurityIT testStatusWithUsersWhileSearchIsRunning failing

### DIFF
--- a/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
+++ b/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.search;
 
 import org.apache.http.util.EntityUtils;
+import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Request;
@@ -177,6 +178,7 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
      * @throws IOException
      */
     public void testStatusWithUsersWhileSearchIsRunning() throws IOException {
+        assumeTrue("[error_query] is only available in snapshot builds", Build.current().isSnapshot());
         String user = randomFrom("user1", "user2");
         String other = user.equals("user1") ? "user2" : "user1";
         String indexName = "index-" + user;


### PR DESCRIPTION
The error_query is only available in snapshot builds.
All [test failures](https://es-delivery-stats.elastic.dev/app/dashboards#/view/dcec9e60-72ac-11ee-8f39-55975ded9e63?_g=(refreshInterval:(pause:!t,value:60000),time:(from:now-7d%2Fd,to:now))) have the `release-tests` tag.

Closes https://github.com/elastic/elasticsearch/issues/106871