### PR TITLE
[Doc] Privileges required to retrieve the status of async searches

### DIFF
--- a/docs/reference/search/async-search.asciidoc
+++ b/docs/reference/search/async-search.asciidoc
@@ -143,8 +143,10 @@ allowed size for a stored async search response can be set by changing the
 ==== Get async search
 
 The get async search API retrieves the results of a previously submitted async
-search request given its id. If the {es} {security-features} are enabled, the
-access to the results of a specific async search is restricted to
+search request given its id.
+
+If the {es} {security-features} are enabled, the access to the results of a
+specific async search is restricted to only
 <<can-access-resources-check,the user or API key that submitted it>>.
 
 [source,console,id=get-async-search-date-histogram-example]
@@ -235,9 +237,13 @@ its saved results are deleted.
 ==== Get async search status
 
 The get async search status API, without retrieving search results, shows only
-the status of a previously submitted async search request given its `id`. If the
-{es} {security-features} are enabled, the access to the get async search status
-API is restricted to the <<built-in-roles, monitoring_user role>>.
+the status of a previously submitted async search request given its `id`.
+
+If the {es} {security-features} are enabled, the access to the status of a
+specific async search is restricted to:
+
+* The <<can-access-resources-check,user or API key that submitted>> the original async search request.
+* Users that have the `monitor` cluster privilege or higher.
 
 You can also specify how long the async search needs to be available through the
 `keep_alive` parameter, which defaults to `5d` (five days). Ongoing async
@@ -333,5 +339,5 @@ DELETE /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWH
 If the {es} {security-features} are enabled, the deletion of a specific async
 search is restricted to:
 
-  * The authenticated user that submitted the original search request.
-  * Users that have the `cancel_task` cluster privilege.
+  * The <<can-access-resources-check,user or API key that submitted>> the original async search request.
+  * Users that have the `cancel_task` cluster privilege or higher.


### PR DESCRIPTION
Doc changes associated to https://github.com/elastic/elasticsearch/pull/106638 .