### PR TITLE
Remove row method from Vector

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVector.java
@@ -25,11 +25,6 @@ abstract class AbstractVector extends AbstractNonThreadSafeRefCounted implements
     }
 
     @Override
-    public final Vector getRow(int position) {
-        return filter(position);
-    }
-
-    @Override
     public BlockFactory blockFactory() {
         return blockFactory;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Vector.java
@@ -28,9 +28,6 @@ public interface Vector extends Accountable, RefCounted, Releasable {
      */
     int getPositionCount();
 
-    // TODO: improve implementation not to waste as much space
-    Vector getRow(int position);
-
     /**
      * Creates a new vector that only exposes the positions provided. Materialization of the selected positions is avoided.
      * @param positions the positions to retain


### PR DESCRIPTION
We previously introduced the row method for TopN. However, TopN no longer uses this method. We should remove it to prevent potential misuse.