### PR TITLE
Rename semantic_text field type

### DIFF
--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -75,7 +75,7 @@ markup. Used for identifying named entities.
 <<completion-suggester,`completion`>>:: Used for auto-complete suggestions.
 <<search-as-you-type,`search_as_you_type`>>:: `text`-like type for
 as-you-type completion.
-<<semantic-text, `semantic_text`>>:: 
+<<semantic-text, `semantic_text`>>::
 <<token-count,`token_count`>>:: A count of tokens in a text.
 
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilter.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
  * {@link SemanticTextFieldMapper} in the index mapping.
  * The source of each {@link BulkItemRequest} requiring inference is augmented with the results for each field
  * under the {@link InferenceMetadataFieldMapper#NAME} section.
- * For example, for an index with a semantic_text field named {@code my_semantic_field} the following source document:
+ * For example, for an index with a semantic field named {@code my_semantic_field} the following source document:
  * <br>
  * <pre>
  * {

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/InferenceMetadataFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/InferenceMetadataFieldMapper.java
@@ -59,8 +59,8 @@ import static org.elasticsearch.xpack.inference.mapper.SemanticTextFieldMapper.c
  * A mapper for the {@code _inference} field.
  * <br>
  * <br>
- * This mapper works in tandem with {@link SemanticTextFieldMapper semantic_text} fields to index inference results.
- * The inference results for {@code semantic_text} fields are written to {@code _source} by an upstream process like so:
+ * This mapper works in tandem with {@link SemanticTextFieldMapper semantic} fields to index inference results.
+ * The inference results for {@code semantic} fields are written to {@code _source} by an upstream process like so:
  * <br>
  * <br>
  * <pre>

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -58,7 +58,7 @@ import static org.elasticsearch.xpack.inference.mapper.InferenceMetadataFieldMap
 public class SemanticTextFieldMapper extends FieldMapper implements InferenceFieldMapper {
     private static final Logger logger = LogManager.getLogger(SemanticTextFieldMapper.class);
 
-    public static final String CONTENT_TYPE = "semantic_text";
+    public static final String CONTENT_TYPE = "semantic";
 
     private static SemanticTextFieldMapper toType(FieldMapper in) {
         return (SemanticTextFieldMapper) in;
@@ -276,7 +276,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
         @Override
         public IndexFieldData.Builder fielddataBuilder(FieldDataContext fieldDataContext) {
-            throw new IllegalArgumentException("[semantic_text] fields do not support sorting, scripting or aggregating");
+            throw new IllegalArgumentException("[" + CONTENT_TYPE + "] fields do not support sorting, scripting or aggregating");
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextModelSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextModelSettings.java
@@ -31,7 +31,7 @@ import static org.elasticsearch.inference.TaskType.SPARSE_EMBEDDING;
 import static org.elasticsearch.inference.TaskType.TEXT_EMBEDDING;
 
 /**
- * Serialization class for specifying the settings of a model from semantic_text inference to field mapper.
+ * Serialization class for specifying the settings of a model from semantic inference to field mapper.
  */
 public class SemanticTextModelSettings implements ToXContentObject {
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/cluster/metadata/SemanticTextClusterMetadataTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/cluster/metadata/SemanticTextClusterMetadataTests.java
@@ -31,7 +31,7 @@ public class SemanticTextClusterMetadataTests extends ESSingleNodeTestCase {
     public void testCreateIndexWithSemanticTextField() {
         final IndexService indexService = createIndex(
             "test",
-            client().admin().indices().prepareCreate("test").setMapping("field", "type=semantic_text,inference_id=test_model")
+            client().admin().indices().prepareCreate("test").setMapping("field", "type=semantic,inference_id=test_model")
         );
         assertEquals(indexService.getMetadata().getInferenceFields().get("field").getInferenceId(), "test_model");
     }
@@ -43,7 +43,7 @@ public class SemanticTextClusterMetadataTests extends ESSingleNodeTestCase {
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
 
         final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties": { "field": { "type": "semantic_text", "inference_id": "test_model" }}}""");
+            { "properties": { "field": { "type": "semantic", "inference_id": "test_model" }}}""");
         request.indices(new Index[] { indexService.index() });
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/InferenceMetadataFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/InferenceMetadataFieldMapperTests.java
@@ -442,7 +442,7 @@ public class InferenceMetadataFieldMapperTests extends MetadataMapperTestCase {
                 )
             )
         );
-        assertThat(ex.getMessage(), containsString("Missing required [model_settings] for field [field] of type [semantic_text]"));
+        assertThat(ex.getMessage(), containsString("Missing required [model_settings] for field [field] of type [semantic]"));
     }
 
     public void testMissingTaskType() throws IOException {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -45,7 +45,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected void minimalMapping(XContentBuilder b) throws IOException {
-        b.field("type", "semantic_text").field("inference_id", "test_model");
+        b.field("type", "semantic").field("inference_id", "test_model");
     }
 
     @Override
@@ -73,7 +73,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
 
     @Override
     protected Object generateRandomInputValue(MappedFieldType ft) {
-        assumeFalse("doc_values are not supported in semantic_text", true);
+        assumeFalse("doc_values are not supported in semantic", true);
         return null;
     }
 
@@ -101,7 +101,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
     public void testInferenceIdNotPresent() throws IOException {
         Exception e = expectThrows(
             MapperParsingException.class,
-            () -> createMapperService(fieldMapping(b -> b.field("type", "semantic_text")))
+            () -> createMapperService(fieldMapping(b -> b.field("type", "semantic")))
         );
         assertThat(e.getMessage(), containsString("field [inference_id] must be specified"));
     }
@@ -111,24 +111,24 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
             b.field("type", "text");
             b.startObject("fields");
             b.startObject("semantic");
-            b.field("type", "semantic_text");
+            b.field("type", "semantic");
             b.endObject();
             b.endObject();
         })));
-        assertThat(e.getMessage(), containsString("Field [semantic] of type [semantic_text] can't be used in multifields"));
+        assertThat(e.getMessage(), containsString("Field [semantic] of type [semantic] can't be used in multifields"));
     }
 
     public void testUpdatesToInferenceIdNotSupported() throws IOException {
         String fieldName = randomAlphaOfLengthBetween(5, 15);
         MapperService mapperService = createMapperService(
-            mapping(b -> b.startObject(fieldName).field("type", "semantic_text").field("inference_id", "test_model").endObject())
+            mapping(b -> b.startObject(fieldName).field("type", "semantic").field("inference_id", "test_model").endObject())
         );
         assertSemanticTextField(mapperService, fieldName, false);
         Exception e = expectThrows(
             IllegalArgumentException.class,
             () -> merge(
                 mapperService,
-                mapping(b -> b.startObject(fieldName).field("type", "semantic_text").field("inference_id", "another_model").endObject())
+                mapping(b -> b.startObject(fieldName).field("type", "semantic").field("inference_id", "another_model").endObject())
             )
         );
         assertThat(e.getMessage(), containsString("Cannot update parameter [inference_id] from [test_model] to [another_model]"));
@@ -138,7 +138,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
         for (int depth = 1; depth < 5; depth++) {
             String fieldName = InferenceMetadataFieldMapperTests.randomFieldName(depth);
             MapperService mapperService = createMapperService(
-                mapping(b -> b.startObject(fieldName).field("type", "semantic_text").field("inference_id", "test_model").endObject())
+                mapping(b -> b.startObject(fieldName).field("type", "semantic").field("inference_id", "test_model").endObject())
             );
             assertSemanticTextField(mapperService, fieldName, false);
             {
@@ -148,7 +148,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                         mapperService,
                         mapping(
                             b -> b.startObject(fieldName)
-                                .field("type", "semantic_text")
+                                .field("type", "semantic")
                                 .field("inference_id", "test_model")
                                 .startObject("model_settings")
                                 .field("inference_id", "test_model")
@@ -164,7 +164,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                     mapperService,
                     mapping(
                         b -> b.startObject(fieldName)
-                            .field("type", "semantic_text")
+                            .field("type", "semantic")
                             .field("inference_id", "test_model")
                             .startObject("model_settings")
                             .field("task_type", "sparse_embedding")
@@ -180,7 +180,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                     () -> merge(
                         mapperService,
                         mapping(
-                            b -> b.startObject(fieldName).field("type", "semantic_text").field("inference_id", "test_model").endObject()
+                            b -> b.startObject(fieldName).field("type", "semantic").field("inference_id", "test_model").endObject()
                         )
                     )
                 );
@@ -196,7 +196,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                         mapperService,
                         mapping(
                             b -> b.startObject(fieldName)
-                                .field("type", "semantic_text")
+                                .field("type", "semantic")
                                 .field("inference_id", "test_model")
                                 .startObject("model_settings")
                                 .field("task_type", "text_embedding")

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapperTests.java
@@ -99,10 +99,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
     }
 
     public void testInferenceIdNotPresent() throws IOException {
-        Exception e = expectThrows(
-            MapperParsingException.class,
-            () -> createMapperService(fieldMapping(b -> b.field("type", "semantic")))
-        );
+        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> b.field("type", "semantic"))));
         assertThat(e.getMessage(), containsString("field [inference_id] must be specified"));
     }
 
@@ -179,9 +176,7 @@ public class SemanticTextFieldMapperTests extends MapperTestCase {
                     IllegalArgumentException.class,
                     () -> merge(
                         mapperService,
-                        mapping(
-                            b -> b.startObject(fieldName).field("type", "semantic").field("inference_id", "test_model").endObject()
-                        )
+                        mapping(b -> b.startObject(fieldName).field("type", "semantic").field("inference_id", "test_model").endObject())
                     )
                 );
                 assertThat(

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_inference.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_inference.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
       version: " - 8.12.99"
-      reason: semantic_text introduced in 8.13.0 # TODO change when 8.13.0 is released
+      reason: semantic field type introduced in 8.13.0 # TODO change when 8.13.0 is released
 
   - do:
       inference.put_model:
@@ -41,10 +41,10 @@ setup:
           mappings:
             properties:
               inference_field:
-                type: semantic_text
+                type: semantic
                 inference_id: sparse-inference-id
               another_inference_field:
-                type: semantic_text
+                type: semantic
                 inference_id: sparse-inference-id
               non_inference_field:
                 type: text
@@ -56,10 +56,10 @@ setup:
           mappings:
             properties:
               inference_field:
-                type: semantic_text
+                type: semantic
                 inference_id: dense-inference-id
               another_inference_field:
-                type: semantic_text
+                type: semantic
                 inference_id: dense-inference-id
               non_inference_field:
                 type: text
@@ -96,8 +96,8 @@ setup:
       indices.get_mapping:
         index: test-sparse-index
 
-  - match: {test-sparse-index.mappings.properties.inference_field.type: semantic_text}
-  - match: {test-sparse-index.mappings.properties.another_inference_field.type: semantic_text}
+  - match: {test-sparse-index.mappings.properties.inference_field.type: semantic}
+  - match: {test-sparse-index.mappings.properties.another_inference_field.type: semantic}
   - match: {test-sparse-index.mappings.properties.non_inference_field.type: text}
   - length: {test-sparse-index.mappings.properties: 3}
 
@@ -134,13 +134,13 @@ setup:
       indices.get_mapping:
         index: test-dense-index
 
-  - match: {test-dense-index.mappings.properties.inference_field.type: semantic_text}
-  - match: {test-dense-index.mappings.properties.another_inference_field.type: semantic_text}
+  - match: {test-dense-index.mappings.properties.inference_field.type: semantic}
+  - match: {test-dense-index.mappings.properties.another_inference_field.type: semantic}
   - match: {test-dense-index.mappings.properties.non_inference_field.type: text}
   - length: {test-dense-index.mappings.properties: 3}
 
 ---
-"Updating non semantic_text fields does not recalculate embeddings":
+"Updating non semantic fields does not recalculate embeddings":
     - do:
         index:
           index: test-sparse-index
@@ -183,7 +183,7 @@ setup:
     - match:  { _source._inference.another_inference_field.chunks.0.inference: $another_inference_field_embedding }
 
 ---
-"Updating semantic_text fields recalculates embeddings":
+"Updating semantic fields recalculates embeddings":
     - do:
         index:
           index: test-sparse-index
@@ -265,7 +265,7 @@ setup:
     - match:  { _source._inference.another_inference_field.chunks.0.text: "bulk updated inference test" }
 
 ---
-"Reindex works for semantic_text fields":
+"Reindex works for semantic fields":
   - do:
       index:
         index: test-sparse-index
@@ -293,10 +293,10 @@ setup:
           mappings:
             properties:
               inference_field:
-                type: semantic_text
+                type: semantic
                 inference_id: sparse-inference-id
               another_inference_field:
-                type: semantic_text
+                type: semantic
                 inference_id: sparse-inference-id
               non_inference_field:
                 type: text
@@ -334,7 +334,7 @@ setup:
           mappings:
             properties:
               inference_field:
-                type: semantic_text
+                type: semantic
                 inference_id: non-existing-inference-id
               non_inference_field:
                 type: text
@@ -350,7 +350,7 @@ setup:
 
   - match: { error.reason: "Inference id [non-existing-inference-id] not found for field [inference_field]" }
 
-  # Succeeds when semantic_text field is not used
+  # Succeeds when semantic field is not used
   - do:
       index:
         index: incorrect-test-sparse-index
@@ -376,4 +376,4 @@ setup:
 
   - match: { errors: true }
   - match: { items.0.update.status: 400 }
-  - match: { items.0.update.error.reason: "Cannot apply update with a script on indices that contain [semantic_text] field(s)" }
+  - match: { items.0.update.error.reason: "Cannot apply update with a script on indices that contain [semantic] field(s)" }

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/20_semantic_text_field_mapper.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/20_semantic_text_field_mapper.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
       version: " - 8.12.99"
-      reason: semantic_text introduced in 8.13.0 # TODO change when 8.13.0 is released
+      reason: semantic field type introduced in 8.13.0 # TODO change when 8.13.0 is released
 
   - do:
       inference.put_model:
@@ -41,10 +41,10 @@ setup:
           mappings:
             properties:
               sparse_field:
-                type: semantic_text
+                type: semantic
                 inference_id: sparse-inference-id
               dense_field:
-                type: semantic_text
+                type: semantic
                 inference_id: dense-inference-id
               non_inference_field:
                 type: text
@@ -70,7 +70,7 @@ setup:
 ---
 "Inference section contains unreferenced fields":
   - do:
-      catch: /Field \[unknown_field\] is not registered as a \[semantic_text\] field type/
+      catch: /Field \[unknown_field\] is not registered as a \[semantic\] field type/
       index:
         index: test-index
         id: doc_1


### PR DESCRIPTION
Rename the `semantic_text` field type to `semantic`. This PR only changes the field type name, not any class names, which is good enough IMO.
