### PR TITLE
Remove unused code from example plugin

### DIFF
--- a/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestion.java
+++ b/plugins/examples/custom-suggester/src/main/java/org/elasticsearch/example/customsuggester/CustomSuggestion.java
@@ -8,19 +8,14 @@
 
 package org.elasticsearch.example.customsuggester;
 
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.text.Text;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.search.suggest.Suggest;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 public class CustomSuggestion extends Suggest.Suggestion<CustomSuggestion.Entry> {
 
@@ -64,25 +59,7 @@ public class CustomSuggestion extends Suggest.Suggestion<CustomSuggestion.Entry>
         return new Entry(in);
     }
 
-    public static CustomSuggestion fromXContent(XContentParser parser, String name) throws IOException {
-        CustomSuggestion suggestion = new CustomSuggestion(name, -1, null);
-        parseEntries(parser, suggestion, Entry::fromXContent);
-        return suggestion;
-    }
-
     public static class Entry extends Suggest.Suggestion.Entry<CustomSuggestion.Entry.Option> {
-
-        private static final ObjectParser<Entry, Void> PARSER = new ObjectParser<>("CustomSuggestionEntryParser", true, Entry::new);
-
-        static {
-            declareCommonFields(PARSER);
-            PARSER.declareString((entry, dummy) -> entry.dummy = dummy, DUMMY);
-            /*
-             * The use of a lambda expression instead of the method reference Entry::addOptions is a workaround for a JDK 14 compiler bug.
-             * The bug is: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8242214
-             */
-            PARSER.declareObjectArray((e, o) -> e.addOptions(o), (p, c) -> Option.fromXContent(p), new ParseField(OPTIONS));
-        }
 
         private String dummy;
 
@@ -131,26 +108,7 @@ public class CustomSuggestion extends Suggest.Suggestion<CustomSuggestion.Entry>
             return builder;
         }
 
-        public static Entry fromXContent(XContentParser parser) {
-            return PARSER.apply(parser, null);
-        }
-
         public static class Option extends Suggest.Suggestion.Entry.Option {
-
-            private static final ConstructingObjectParser<Option, Void> PARSER = new ConstructingObjectParser<>(
-                "CustomSuggestionObjectParser", true,
-                args -> {
-                    Text text = new Text((String) args[0]);
-                    float score = (float) args[1];
-                    String dummy = (String) args[2];
-                    return new Option(text, score, dummy);
-                });
-
-            static {
-                PARSER.declareString(constructorArg(), TEXT);
-                PARSER.declareFloat(constructorArg(), SCORE);
-                PARSER.declareString(constructorArg(), DUMMY);
-            }
 
             private String dummy;
 
@@ -191,10 +149,6 @@ public class CustomSuggestion extends Suggest.Suggestion<CustomSuggestion.Entry>
                 builder = super.toXContent(builder, params);
                 builder.field(DUMMY.getPreferredName(), dummy);
                 return builder;
-            }
-
-            public static Option fromXContent(XContentParser parser) {
-                return PARSER.apply(parser, null);
             }
         }
     }


### PR DESCRIPTION
Remove unnecessary code from example plugin as a follow up to #106787.