### PR TITLE
Tidy up the geoip Property enum

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -382,23 +382,21 @@ public final class GeoIpProcessor extends AbstractProcessor {
     }
 
     public static final class Factory implements Processor.Factory {
-        static final Set<Property> DEFAULT_CITY_PROPERTIES = Set.copyOf(
-            EnumSet.of(
-                Property.CONTINENT_NAME,
-                Property.COUNTRY_NAME,
-                Property.COUNTRY_ISO_CODE,
-                Property.REGION_ISO_CODE,
-                Property.REGION_NAME,
-                Property.CITY_NAME,
-                Property.LOCATION
-            )
+        static final Set<Property> DEFAULT_CITY_PROPERTIES = Set.of(
+            Property.CONTINENT_NAME,
+            Property.COUNTRY_NAME,
+            Property.COUNTRY_ISO_CODE,
+            Property.REGION_ISO_CODE,
+            Property.REGION_NAME,
+            Property.CITY_NAME,
+            Property.LOCATION
         );
-        static final Set<Property> DEFAULT_COUNTRY_PROPERTIES = Set.copyOf(
-            EnumSet.of(Property.CONTINENT_NAME, Property.COUNTRY_NAME, Property.COUNTRY_ISO_CODE)
+        static final Set<Property> DEFAULT_COUNTRY_PROPERTIES = Set.of(
+            Property.CONTINENT_NAME,
+            Property.COUNTRY_NAME,
+            Property.COUNTRY_ISO_CODE
         );
-        static final Set<Property> DEFAULT_ASN_PROPERTIES = Set.copyOf(
-            EnumSet.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK)
-        );
+        static final Set<Property> DEFAULT_ASN_PROPERTIES = Set.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK);
 
         private final GeoIpDatabaseProvider geoIpDatabaseProvider;
 
@@ -502,7 +500,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
         ORGANIZATION_NAME,
         NETWORK;
 
-        static final EnumSet<Property> ALL_CITY_PROPERTIES = EnumSet.of(
+        static final Set<Property> ALL_CITY_PROPERTIES = Set.of(
             Property.IP,
             Property.COUNTRY_ISO_CODE,
             Property.COUNTRY_NAME,
@@ -513,18 +511,13 @@ public final class GeoIpProcessor extends AbstractProcessor {
             Property.TIMEZONE,
             Property.LOCATION
         );
-        static final EnumSet<Property> ALL_COUNTRY_PROPERTIES = EnumSet.of(
+        static final Set<Property> ALL_COUNTRY_PROPERTIES = Set.of(
             Property.IP,
             Property.CONTINENT_NAME,
             Property.COUNTRY_NAME,
             Property.COUNTRY_ISO_CODE
         );
-        static final EnumSet<Property> ALL_ASN_PROPERTIES = EnumSet.of(
-            Property.IP,
-            Property.ASN,
-            Property.ORGANIZATION_NAME,
-            Property.NETWORK
-        );
+        static final Set<Property> ALL_ASN_PROPERTIES = Set.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK);
 
         private static Property parseProperty(Set<Property> validProperties, String value) {
             try {
@@ -534,8 +527,12 @@ public final class GeoIpProcessor extends AbstractProcessor {
                 }
                 return property;
             } catch (IllegalArgumentException e) {
+                // put the properties in natural order before throwing so that we have reliable error messages -- this is a little
+                // bit inefficient, but we only do this validation at processor construction time so the cost is practically immaterial
+                Property[] properties = validProperties.toArray(new Property[0]);
+                Arrays.sort(properties);
                 throw new IllegalArgumentException(
-                    "illegal property value [" + value + "]. valid values are " + Arrays.toString(validProperties.toArray())
+                    "illegal property value [" + value + "]. valid values are " + Arrays.toString(properties)
                 );
             }
         }
@@ -568,7 +565,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
             final Set<Property> properties;
             if (propertyNames != null) {
-                Set<Property> modifiableProperties = EnumSet.noneOf(Property.class);
+                Set<Property> modifiableProperties = new HashSet<>();
                 for (String propertyName : propertyNames) {
                     modifiableProperties.add(parseProperty(validProperties, propertyName)); // n.b. this throws if a property is invalid
                 }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.RandomDocumentPicks;
+import org.elasticsearch.ingest.geoip.GeoIpProcessor.Property;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;
@@ -185,8 +186,8 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-Country.mmdb");
-        EnumSet<GeoIpProcessor.Property> asnOnlyProperties = EnumSet.copyOf(GeoIpProcessor.Property.ALL_ASN_PROPERTIES);
-        asnOnlyProperties.remove(GeoIpProcessor.Property.IP);
+        EnumSet<Property> asnOnlyProperties = EnumSet.copyOf(Property.ALL_ASN_PROPERTIES);
+        asnOnlyProperties.remove(Property.IP);
         String asnProperty = RandomPicks.randomFrom(Randomness.get(), asnOnlyProperties).toString();
         config.put("properties", List.of(asnProperty));
         Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, null, config));
@@ -205,8 +206,8 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-ASN.mmdb");
-        EnumSet<GeoIpProcessor.Property> cityOnlyProperties = EnumSet.copyOf(GeoIpProcessor.Property.ALL_CITY_PROPERTIES);
-        cityOnlyProperties.remove(GeoIpProcessor.Property.IP);
+        EnumSet<Property> cityOnlyProperties = EnumSet.copyOf(Property.ALL_CITY_PROPERTIES);
+        cityOnlyProperties.remove(Property.IP);
         String cityProperty = RandomPicks.randomFrom(Randomness.get(), cityOnlyProperties).toString();
         config.put("properties", List.of(cityProperty));
         Exception e = expectThrows(ElasticsearchParseException.class, () -> factory.create(null, null, null, config));
@@ -245,12 +246,12 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     public void testBuildFields() throws Exception {
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
 
-        Set<GeoIpProcessor.Property> properties = EnumSet.noneOf(GeoIpProcessor.Property.class);
+        Set<Property> properties = EnumSet.noneOf(Property.class);
         List<String> fieldNames = new ArrayList<>();
 
         int counter = 0;
-        int numFields = scaledRandomIntBetween(1, GeoIpProcessor.Property.values().length);
-        for (GeoIpProcessor.Property property : GeoIpProcessor.Property.ALL_CITY_PROPERTIES) {
+        int numFields = scaledRandomIntBetween(1, Property.values().length);
+        for (Property property : Property.ALL_CITY_PROPERTIES) {
             properties.add(property);
             fieldNames.add(property.name().toLowerCase(Locale.ROOT));
             if (++counter >= numFields) {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -38,8 +38,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -186,7 +186,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-Country.mmdb");
-        EnumSet<Property> asnOnlyProperties = EnumSet.copyOf(Property.ALL_ASN_PROPERTIES);
+        Set<Property> asnOnlyProperties = new HashSet<>(Property.ALL_ASN_PROPERTIES);
         asnOnlyProperties.remove(Property.IP);
         String asnProperty = RandomPicks.randomFrom(Randomness.get(), asnOnlyProperties).toString();
         config.put("properties", List.of(asnProperty));
@@ -206,7 +206,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-ASN.mmdb");
-        EnumSet<Property> cityOnlyProperties = EnumSet.copyOf(Property.ALL_CITY_PROPERTIES);
+        Set<Property> cityOnlyProperties = new HashSet<>(Property.ALL_CITY_PROPERTIES);
         cityOnlyProperties.remove(Property.IP);
         String cityProperty = RandomPicks.randomFrom(Randomness.get(), cityOnlyProperties).toString();
         config.put("properties", List.of(cityProperty));
@@ -246,7 +246,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
     public void testBuildFields() throws Exception {
         GeoIpProcessor.Factory factory = new GeoIpProcessor.Factory(databaseNodeService);
 
-        Set<Property> properties = EnumSet.noneOf(Property.class);
+        Set<Property> properties = new HashSet<>();
         List<String> fieldNames = new ArrayList<>();
 
         int counter = 0;

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -23,6 +23,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
@@ -35,6 +36,8 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class GeoIpProcessorTests extends ESTestCase {
 
+    private static final Set<GeoIpProcessor.Property> ALL_PROPERTIES = EnumSet.allOf(GeoIpProcessor.Property.class);
+
     public void testCity() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(
             randomAlphaOfLength(10),
@@ -43,7 +46,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -77,7 +80,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             true,
             false,
             "filename"
@@ -99,7 +102,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             true,
             false,
             "filename"
@@ -118,7 +121,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -140,7 +143,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -159,7 +162,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -197,7 +200,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -223,7 +226,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-Country.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -252,7 +255,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-Country.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -279,7 +282,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-ASN.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -308,7 +311,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -332,7 +335,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -353,7 +356,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -383,7 +386,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -413,7 +416,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "filename"
@@ -433,7 +436,7 @@ public class GeoIpProcessorTests extends ESTestCase {
         GeoIpProcessor processor = new GeoIpProcessor(randomAlphaOfLength(10), null, "source_field", () -> {
             loader.preLookup();
             return loader;
-        }, () -> true, "target_field", EnumSet.allOf(GeoIpProcessor.Property.class), false, false, "filename");
+        }, () -> true, "target_field", ALL_PROPERTIES, false, false, "filename");
 
         Map<String, Object> document = new HashMap<>();
         document.put("source_field", List.of("8.8.8.8", "82.171.64.0"));
@@ -464,7 +467,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             true,
             "filename"
@@ -492,7 +495,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             true,
             "filename"
@@ -514,7 +517,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             loader("/GeoLite2-City.mmdb"),
             () -> false,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             true,
             "filename"
@@ -537,7 +540,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             () -> null,
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             false,
             false,
             "GeoLite2-City"
@@ -560,7 +563,7 @@ public class GeoIpProcessorTests extends ESTestCase {
             () -> null,
             () -> true,
             "target_field",
-            EnumSet.allOf(GeoIpProcessor.Property.class),
+            ALL_PROPERTIES,
             true,
             false,
             "GeoLite2-City"

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.test.ESTestCase;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,7 +36,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class GeoIpProcessorTests extends ESTestCase {
 
-    private static final Set<Property> ALL_PROPERTIES = EnumSet.allOf(Property.class);
+    private static final Set<Property> ALL_PROPERTIES = Set.of(Property.values());
 
     public void testCity() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
+import org.elasticsearch.ingest.geoip.GeoIpProcessor.Property;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -36,7 +37,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class GeoIpProcessorTests extends ESTestCase {
 
-    private static final Set<GeoIpProcessor.Property> ALL_PROPERTIES = EnumSet.allOf(GeoIpProcessor.Property.class);
+    private static final Set<Property> ALL_PROPERTIES = EnumSet.allOf(Property.class);
 
     public void testCity() throws Exception {
         GeoIpProcessor processor = new GeoIpProcessor(


### PR DESCRIPTION
Follow up to #106889

Just a cleanup PR. The geoip processor code juggles references to these property enums, and it's a little messy. This drops all the `EnumSet` stuff (which we weren't using to its maximum benefit anyway) in favor of normal immutable sets via `Set.of`. I also extract a static `parseProperties` method to simplify the handling of the valid properties and the default properties.

One nice consequence of this is that there were previously two places where we did `endsWith` checking and properties-handling, but now there is only one place for that (it handles both value properties and default properties at the same time). (Note: there's still some other places where we are doing `endsWith` checking, unfortunately -- this doesn't collapse all of them into just the one, but I have some ideas about how to do better there down the road, stay tuned for more PRs).