### PR TITLE
Pulling KeyValueProcessor.logAndBuildException() into AbstractProcessor

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/KeyValueProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/KeyValueProcessor.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.ingest.common;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.core.Predicates;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.ConfigurationUtils;
@@ -31,8 +28,6 @@ import java.util.regex.Pattern;
  * The KeyValueProcessor parses and extracts messages of the `key=value` variety into fields with values of the keys.
  */
 public final class KeyValueProcessor extends AbstractProcessor {
-
-    private static final Logger logger = LogManager.getLogger(KeyValueProcessor.class);
 
     public static final String TYPE = "kv";
 
@@ -85,7 +80,7 @@ public final class KeyValueProcessor extends AbstractProcessor {
         );
     }
 
-    private static Consumer<IngestDocument> buildExecution(
+    private Consumer<IngestDocument> buildExecution(
         String fieldSplit,
         String valueSplit,
         TemplateScript.Factory field,
@@ -170,29 +165,7 @@ public final class KeyValueProcessor extends AbstractProcessor {
         };
     }
 
-    /**
-     * Helper method for buildTrimmer and buildSplitter.
-     * <p>
-     * If trace logging is enabled, then we should log the stacktrace (and so the message can be slightly simpler).
-     * On the other hand if trace logging isn't enabled, then we'll need to log some context on the original issue (but not a stacktrace).
-     * <p>
-     * Regardless of the logging level, we should throw an exception that has the context in its message, which this method builds.
-     */
-    private static ElasticsearchException logAndBuildException(String message, Throwable error) {
-        String cause = error.getClass().getName();
-        if (error.getMessage() != null) {
-            cause += ": " + error.getMessage();
-        }
-        String longMessage = message + ": " + cause;
-        if (logger.isTraceEnabled()) {
-            logger.trace(message, error);
-        } else {
-            logger.warn(longMessage);
-        }
-        return new ElasticsearchException(longMessage);
-    }
-
-    private static Function<String, String> buildTrimmer(String trim) {
+    private Function<String, String> buildTrimmer(String trim) {
         if (trim == null) {
             return val -> val;
         } else {
@@ -207,7 +180,7 @@ public final class KeyValueProcessor extends AbstractProcessor {
         }
     }
 
-    private static Function<String, String[]> buildSplitter(String split, boolean fields) {
+    private Function<String, String[]> buildSplitter(String split, boolean fields) {
         int limit = fields ? 0 : 2;
         if (split.length() > 2 || split.length() == 2 && split.charAt(0) != '\\') {
             Pattern splitPattern = Pattern.compile(split);

--- a/server/src/main/java/org/elasticsearch/ingest/AbstractProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/AbstractProcessor.java
@@ -8,6 +8,10 @@
 
 package org.elasticsearch.ingest;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+
 /**
  * An Abstract Processor that holds tag and description information
  * about the processor.
@@ -29,5 +33,37 @@ public abstract class AbstractProcessor implements Processor {
     @Override
     public String getDescription() {
         return description;
+    }
+
+    /**
+     * Helper method to be used by processors that need to catch and log Throwables.
+     * <p>
+     * If trace logging is enabled, then we log the provided message and the full stacktrace
+     * On the other hand if trace logging isn't enabled, then we log the provided message and the message from the Throwable (but not a
+     * stacktrace).
+     * <p>
+     * Regardless of the logging level, we throw an ElasticsearchException that has the context in its message
+     *
+     * @param message A message to be logged and to be included in the message of the returned ElasticsearchException
+     * @param throwable The Throwable that has been caught
+     * @return A new ElasticsearchException whose message includes the passed-in message and the message from the passed-in Throwable. It
+     * will not however wrap the given Throwable.
+     */
+    protected ElasticsearchException logAndBuildException(String message, Throwable throwable) {
+        String cause = throwable.getClass().getName();
+        if (throwable.getMessage() != null) {
+            cause += ": " + throwable.getMessage();
+        }
+        String longMessage = message + ": " + cause;
+        // This method will only be called in exceptional situations, so the cost of looking up the logger won't be bad:
+        Logger logger = LogManager.getLogger(getClass());
+        if (logger.isTraceEnabled()) {
+            logger.trace(message, throwable);
+        } else {
+            logger.warn(longMessage);
+        }
+        // We don't want to wrap the Throwable here because it is probably not one of the exceptions that ElasticsearchException can
+        // serialize:
+        return new ElasticsearchException(longMessage);
     }
 }

--- a/server/src/test/java/org/elasticsearch/ingest/AbstractProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/AbstractProcessorTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.ingest;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.test.ESTestCase;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AbstractProcessorTests extends ESTestCase {
+
+    public void testLogAndBuildException() {
+        final LoggerContextFactory originalFactory = LogManager.getFactory();
+        try {
+            final String message = randomAlphaOfLength(100);
+            final String throwableMessage = randomBoolean() ? null : randomAlphaOfLength(100);
+            AtomicBoolean warnCalled = new AtomicBoolean(false);
+            AtomicBoolean traceCalled = new AtomicBoolean(false);
+            final Throwable throwable = randomFrom(
+                new StackOverflowError(throwableMessage),
+                new RuntimeException(throwableMessage),
+                new IOException(throwableMessage)
+            );
+
+            {
+                // Mock logging so that we can make sure we're logging what we expect:
+                Logger mockLogger = mock(Logger.class);
+                doAnswer(invocationOnMock -> {
+                    warnCalled.set(true);
+                    String logMessage = invocationOnMock.getArgument(0, String.class);
+                    assertThat(logMessage, containsString(message));
+                    if (throwableMessage != null) {
+                        assertThat(logMessage, containsString(throwableMessage));
+                    }
+                    return null;
+                }).when(mockLogger).warn(anyString());
+
+                doAnswer(invocationOnMock -> {
+                    traceCalled.set(true);
+                    String logMessage = invocationOnMock.getArgument(0, String.class);
+                    Throwable logThrowable = invocationOnMock.getArgument(1, Throwable.class);
+                    assertThat(logMessage, containsString(message));
+                    if (throwableMessage != null) {
+                        assertThat(logMessage, not(containsString(throwableMessage)));
+                    }
+                    assertThat(logThrowable, equalTo(throwable));
+                    return null;
+                }).when(mockLogger).trace(anyString(), any(Throwable.class));
+
+                final LoggerContext context = Mockito.mock(LoggerContext.class);
+                when(context.getLogger(TestProcessor.class)).thenReturn(mockLogger);
+
+                final LoggerContextFactory spy = Mockito.spy(originalFactory);
+                Mockito.doReturn(context).when(spy).getContext(any(), any(), any(), anyBoolean());
+                LogManager.setFactory(spy);
+            }
+
+            TestProcessor testProcessor = new TestProcessor();
+
+            {
+                // Run with trace logging disabled
+                ElasticsearchException resultException = testProcessor.logAndBuildException(message, throwable);
+                assertThat(resultException.getRootCause(), equalTo(resultException));
+                String resultMessage = resultException.getMessage();
+                assertNotNull(resultMessage);
+                if (throwableMessage != null) {
+                    assertThat(resultMessage, containsString(throwableMessage));
+                }
+                assertThat(resultMessage, containsString(message));
+
+                assertThat("log.warn not called", warnCalled.get(), is(true));
+                assertThat("log.trace called", traceCalled.get(), is(false));
+            }
+
+            {
+                // Now enable trace logging
+                when(LogManager.getLogger(TestProcessor.class).isTraceEnabled()).thenReturn(true);
+                warnCalled.set(false);
+                ElasticsearchException resultException = testProcessor.logAndBuildException(message, throwable);
+                assertThat(resultException.getRootCause(), equalTo(resultException));
+                String resultMessage = resultException.getMessage();
+                assertNotNull(resultMessage);
+                if (throwableMessage != null) {
+                    assertThat(resultMessage, containsString(throwableMessage));
+                }
+                assertThat(resultMessage, containsString(message));
+
+                assertThat("log.warn called", warnCalled.get(), is(false));
+                assertThat("log.trace not called", traceCalled.get(), is(true));
+            }
+        } finally {
+            LogManager.setFactory(originalFactory);
+        }
+    }
+
+    class TestProcessor extends AbstractProcessor {
+
+        protected TestProcessor() {
+            super("", "");
+
+        }
+
+        @Override
+        public String getType() {
+            return "test";
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/ingest/AbstractProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/AbstractProcessorTests.java
@@ -95,10 +95,13 @@ public class AbstractProcessorTests extends ESTestCase {
                 assertThat("log.trace called", traceCalled.get(), is(false));
             }
 
+            // reset between tests:
+            warnCalled.set(false);
+            traceCalled.set(false);
+
             {
                 // Now enable trace logging
                 when(LogManager.getLogger(TestProcessor.class).isTraceEnabled()).thenReturn(true);
-                warnCalled.set(false);
                 ElasticsearchException resultException = testProcessor.logAndBuildException(message, throwable);
                 assertThat(resultException.getRootCause(), equalTo(resultException));
                 String resultMessage = resultException.getMessage();


### PR DESCRIPTION
This moves the logAndBuildException() method into AbstractProcessor so that it can be used by other processors besides KeyValueProcessor.