### PR TITLE
Remove executor lookups from `TransportWriteAction`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -115,7 +115,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             actionFilters,
             BulkShardRequest::new,
             BulkShardRequest::new,
-            ExecutorSelector::getWriteExecutorForShard,
+            ExecutorSelector.getWriteExecutorForShard(threadPool),
             false,
             indexingPressure,
             systemIndices
@@ -167,7 +167,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             public void onTimeout(TimeValue timeout) {
                 mappingUpdateListener.onFailure(new MapperException("timed out while waiting for a dynamic mapping update"));
             }
-        }), listener, threadPool, executor(primary), postWriteRefresh, postWriteAction, documentParsingProvider);
+        }), listener, executor(primary), postWriteRefresh, postWriteAction, documentParsingProvider);
     }
 
     @Override
@@ -188,8 +188,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         MappingUpdatePerformer mappingUpdater,
         Consumer<ActionListener<Void>> waitForMappingUpdate,
         ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener,
-        ThreadPool threadPool,
-        String executorName
+        Executor executor
     ) {
         performOnPrimary(
             request,
@@ -199,8 +198,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             mappingUpdater,
             waitForMappingUpdate,
             listener,
-            threadPool,
-            executorName,
+            executor,
             null,
             null,
             DocumentParsingProvider.EMPTY_INSTANCE
@@ -215,15 +213,12 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         MappingUpdatePerformer mappingUpdater,
         Consumer<ActionListener<Void>> waitForMappingUpdate,
         ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener,
-        ThreadPool threadPool,
-        String executorName,
+        Executor executor,
         @Nullable PostWriteRefresh postWriteRefresh,
         @Nullable Consumer<Runnable> postWriteAction,
         DocumentParsingProvider documentParsingProvider
     ) {
         new ActionRunnable<>(listener) {
-
-            private final Executor executor = threadPool.executor(executorName);
 
             private final BulkPrimaryExecutionContext context = new BulkPrimaryExecutionContext(request, primary);
 

--- a/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/resync/TransportResyncReplicationAction.java
@@ -70,7 +70,7 @@ public class TransportResyncReplicationAction extends TransportWriteAction<
             actionFilters,
             ResyncReplicationRequest::new,
             ResyncReplicationRequest::new,
-            ExecutorSelector::getWriteExecutorForShard,
+            ExecutorSelector.getWriteExecutorForShard(threadPool),
             true, /* we should never reject resync because of thread pool capacity on primary */
             indexingPressure,
             systemIndices

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLeaseSyncAction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardClosedException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardNotInPrimaryModeException;
+import org.elasticsearch.indices.ExecutorSelector;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.node.NodeClosedException;
@@ -50,6 +51,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -88,7 +90,7 @@ public class RetentionLeaseSyncAction extends TransportWriteAction<
             actionFilters,
             RetentionLeaseSyncAction.Request::new,
             RetentionLeaseSyncAction.Request::new,
-            (service, ignore) -> ThreadPool.Names.MANAGEMENT,
+            new ManagementOnlyExecutorFunction(threadPool),
             false,
             indexingPressure,
             systemIndices
@@ -261,6 +263,23 @@ public class RetentionLeaseSyncAction extends TransportWriteAction<
     @Override
     protected Response newResponseInstance(StreamInput in) throws IOException {
         return new Response(in);
+    }
+
+    /**
+     * A {@code BiFunction<ExecutorSelector, IndexShard, Executor>} for passing to the super constructor which always returns the
+     * MANAGEMENT executor (but looks it up once at construction time and caches the result, unlike how the obvious lambda would work).
+     */
+    private static class ManagementOnlyExecutorFunction implements BiFunction<ExecutorSelector, IndexShard, Executor> {
+        private final Executor executor;
+
+        ManagementOnlyExecutorFunction(ThreadPool threadPool) {
+            executor = threadPool.executor(ThreadPool.Names.MANAGEMENT);
+        }
+
+        @Override
+        public Executor apply(ExecutorSelector executorSelector, IndexShard indexShard) {
+            return executor;
+        }
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/indices/ExecutorSelector.java
+++ b/server/src/main/java/org/elasticsearch/indices/ExecutorSelector.java
@@ -12,6 +12,8 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Objects;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
 
 /**
  * Some operations need to use different executors for different index patterns.
@@ -93,12 +95,11 @@ public class ExecutorSelector {
 
     /**
      * This is a convenience method for the case when we need to find an executor for a shard.
-     * Note that it can be passed to methods as a {@link java.util.function.BiFunction}.
-     * @param executorSelector An executor selector service.
-     * @param shard A shard for which we need to find an executor.
-     * @return Name of the executor that should be used for write operations on this shard.
+     * @return a {@link java.util.function.BiFunction} which returns the executor that should be used for write operations on this shard.
      */
-    public static String getWriteExecutorForShard(ExecutorSelector executorSelector, IndexShard shard) {
-        return executorSelector.executorForWrite(shard.shardId().getIndexName());
+    public static BiFunction<ExecutorSelector, IndexShard, Executor> getWriteExecutorForShard(ThreadPool threadPool) {
+        return (executorSelector, indexShard) -> threadPool.executor(
+            executorSelector.executorForWrite(indexShard.shardId().getIndexName())
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -241,8 +241,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
                     throw new AssertionError(e);
                 }
             }), latch::countDown),
-            threadPool,
-            Names.WRITE
+            threadPool.executor(Names.WRITE)
         );
 
         latch.await();
@@ -936,8 +935,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
                 assertThat(response.status(), equalTo(RestStatus.CREATED));
                 assertThat(response.getSeqNo(), equalTo(13L));
             }), latch),
-            threadPool,
-            Names.WRITE
+            threadPool.executor(Names.WRITE)
         );
         latch.await();
     }
@@ -1026,8 +1024,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
                 new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(result ->
                 // Assert that we still need to fsync the location that was successfully written
                 assertThat(((WritePrimaryResult<BulkShardRequest, BulkShardResponse>) result).location, equalTo(resultLocation1))), latch),
-                rejectingThreadPool,
-                Names.WRITE
+                rejectingThreadPool.executor(Names.WRITE)
             );
             latch.await();
 
@@ -1098,8 +1095,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
                     closeShards(shard);
                 }
             }), latch),
-            threadPool,
-            Names.WRITE
+            threadPool.executor(Names.WRITE)
         );
 
         latch.await();
@@ -1148,8 +1144,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
                 (update, shardId, listener) -> fail("the master should not be contacted as the operation yielded a noop mapping update"),
                 listener -> listener.onResponse(null),
                 ActionTestUtils.assertNoFailureListener(result -> {}),
-                threadPool,
-                Names.WRITE
+                threadPool.executor(Names.WRITE)
             )
         );
         assertThat(
@@ -1219,8 +1214,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
                 BulkItemResponse primaryResponse = result.replicaRequest().items()[0].getPrimaryResponse();
                 assertFalse(primaryResponse.isFailed());
             }), latch),
-            threadPool,
-            Names.WRITE
+            threadPool.executor(Names.WRITE)
         );
 
         latch.await();

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportWriteActionTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.Index;
@@ -430,7 +431,7 @@ public class TransportWriteActionTests extends ESTestCase {
                 new ActionFilters(new HashSet<>()),
                 TestRequest::new,
                 TestRequest::new,
-                (service, ignore) -> ThreadPool.Names.SAME,
+                (service, ignore) -> EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 false,
                 new IndexingPressure(Settings.EMPTY),
                 EmptySystemIndices.INSTANCE
@@ -458,7 +459,7 @@ public class TransportWriteActionTests extends ESTestCase {
                 new ActionFilters(new HashSet<>()),
                 TestRequest::new,
                 TestRequest::new,
-                (service, ignore) -> ThreadPool.Names.SAME,
+                (service, ignore) -> EsExecutors.DIRECT_EXECUTOR_SERVICE,
                 false,
                 new IndexingPressure(settings),
                 EmptySystemIndices.INSTANCE

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -895,8 +895,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                     );
                     listener.onResponse((TransportWriteAction.WritePrimaryResult<BulkShardRequest, BulkShardResponse>) result);
                 }),
-                threadPool,
-                Names.WRITE
+                threadPool.executor(Names.WRITE)
             );
         } catch (Exception e) {
             listener.onFailure(e);

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/TransportBulkShardOperationsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/bulk/TransportBulkShardOperationsAction.java
@@ -66,7 +66,7 @@ public class TransportBulkShardOperationsAction extends TransportWriteAction<
             actionFilters,
             BulkShardOperationsRequest::new,
             BulkShardOperationsRequest::new,
-            ExecutorSelector::getWriteExecutorForShard,
+            ExecutorSelector.getWriteExecutorForShard(threadPool),
             false,
             indexingPressure,
             systemIndices

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -1583,8 +1583,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             mappingUpdater,
             waitForMappingUpdate,
             future,
-            threadPool,
-            Names.WRITE
+            threadPool.executor(Names.WRITE)
         );
 
         TransportReplicationAction.PrimaryResult<BulkShardRequest, BulkShardResponse> result = future.get();


### PR DESCRIPTION
Replaces the `String` names (plus associated threadpool) with proper
`Executor` instances.

Relates #106279 (removes a couple more usages of `SAME`)
Relates #105460, #99787, #97879 etc.