### PR TITLE
Remove executor lookups from `TransportInstanceSingleOperationAction`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationAction.java
@@ -43,6 +43,7 @@ import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
 
 import static org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.EXCLUDED_DATA_STREAMS_KEY;
 
@@ -81,7 +82,7 @@ public abstract class TransportInstanceSingleOperationAction<
         new AsyncSingleAction(request, listener).start();
     }
 
-    protected abstract String executor(ShardId shardId);
+    protected abstract Executor executor(ShardId shardId);
 
     protected abstract void shardOperation(Request request, ActionListener<Response> listener);
 
@@ -259,7 +260,8 @@ public abstract class TransportInstanceSingleOperationAction<
     }
 
     private void handleShardRequest(Request request, TransportChannel channel, Task task) {
-        threadPool.executor(executor(request.shardId))
-            .execute(ActionRunnable.wrap(new ChannelActionListener<Response>(channel), l -> shardOperation(request, l)));
+        executor(request.shardId).execute(
+            ActionRunnable.wrap(new ChannelActionListener<Response>(channel), l -> shardOperation(request, l))
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -51,7 +51,7 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 
 import static org.elasticsearch.ExceptionsHelper.unwrapCause;
 import static org.elasticsearch.action.bulk.TransportBulkAction.unwrappingSingleItemBulkResponse;
@@ -88,9 +88,9 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
     }
 
     @Override
-    protected String executor(ShardId shardId) {
+    protected Executor executor(ShardId shardId) {
         final IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
-        return indexService.getIndexSettings().getIndexMetadata().isSystem() ? Names.SYSTEM_WRITE : Names.WRITE;
+        return threadPool.executor(indexService.getIndexSettings().getIndexMetadata().isSystem() ? Names.SYSTEM_WRITE : Names.WRITE);
     }
 
     @Override
@@ -321,9 +321,9 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 request.id()
             );
 
-            final ExecutorService executor;
+            final Executor executor;
             try {
-                executor = threadPool.executor(executor(request.getShardId()));
+                executor = executor(request.getShardId());
             } catch (Exception e) {
                 // might fail if shard no longer exists locally, in which case we cannot retry
                 e.addSuppressed(versionConflictEngineException);

--- a/server/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/single/instance/TransportInstanceSingleOperationActionTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
@@ -52,6 +53,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -114,8 +116,8 @@ public class TransportInstanceSingleOperationActionTests extends ESTestCase {
         }
 
         @Override
-        protected String executor(ShardId shardId) {
-            return ThreadPool.Names.SAME;
+        protected Executor executor(ShardId shardId) {
+            return EsExecutors.DIRECT_EXECUTOR_SERVICE;
         }
 
         @Override


### PR DESCRIPTION
Replaces the `String` names (plus associated threadpool) with proper
`Executor` instances.

Relates #106279 (removes another usage of `SAME`)
Relates #106938, #105460, #99787, #97879 etc.