### PR TITLE
Remove redundant testing of Java 22

### DIFF
--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -85,7 +85,6 @@ steps:
               - graalvm-ce17
               - openjdk17
               - openjdk21
-              - openjdk22
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -108,7 +107,6 @@ steps:
               - graalvm-ce17
               - openjdk17
               - openjdk21
-              - openjdk22
             BWC_VERSION: $BWC_LIST
         agents:
           provider: gcp

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -416,7 +416,6 @@ steps:
               - graalvm-ce17
               - openjdk17
               - openjdk21
-              - openjdk22
             GRADLE_TASK:
               - checkPart1
               - checkPart2
@@ -439,7 +438,6 @@ steps:
               - graalvm-ce17
               - openjdk17
               - openjdk21
-              - openjdk22
             BWC_VERSION: ["7.17.20", "8.13.1", "8.14.0"]
         agents:
           provider: gcp


### PR DESCRIPTION
With #106482 the bundled JDK is now Java 22 which means all of our existing testing uses this runtime by default. It's therefore not necessary to have Java 22 explicitly tested in our Java compatibility jobs.