### PR TITLE
[8.13] Update mixed cluster test skip version for downsampling (#106942)

### DIFF
--- a/x-pack/plugin/downsample/qa/mixed-cluster/build.gradle
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/build.gradle
@@ -26,7 +26,7 @@ restResources {
 }
 
 def supportedVersion = bwcVersion -> {
-  return bwcVersion.onOrAfter("8.8.0");
+  return bwcVersion.onOrAfter("8.10.0");
 }
 
 BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->

--- a/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
+++ b/x-pack/plugin/downsample/qa/mixed-cluster/src/yamlRestTest/resources/rest-api-spec/test/downsample/10_basic.yml
@@ -1,7 +1,7 @@
 setup:
   - skip:
-      version: " - 8.4.99"
-      reason: "rollup renamed to downsample in 8.5.0"
+      version: " - 8.9.99"
+      reason: "Downsampling executed using persistent task framework from version 8.10"
 
   - do:
       indices.create:
@@ -87,6 +87,9 @@ setup:
 
 ---
 "Downsample index":
+  - skip:
+      version: " - 8.9.99"
+      reason: "Downsampling executed using persistent task framework from version 8.10"
 
   - do:
       indices.downsample:


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Update mixed cluster test skip version for downsampling (#106942)