### PR TITLE
Remove unused XContent parsing logic

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -18,7 +18,6 @@ import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.mapper.Mapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -123,12 +122,6 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
 
         private static final ParseField FULL_NAME = new ParseField("full_name");
         private static final ParseField MAPPING = new ParseField("mapping");
-
-        private static final ConstructingObjectParser<FieldMappingMetadata, String> PARSER = new ConstructingObjectParser<>(
-            "field_mapping_meta_data",
-            true,
-            a -> new FieldMappingMetadata((String) a[0], (BytesReference) a[1])
-        );
 
         /**
          * Returns the mappings as a map. Note that the returned map has a single key which is always the field's {@link Mapper#name}.

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AbstractAllocateAllocationCommand.java
@@ -24,7 +24,6 @@ import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -65,8 +64,6 @@ public abstract class AbstractAllocateAllocationCommand implements AllocationCom
         public void setNode(String node) {
             this.node = node;
         }
-
-        public abstract Builder<T> parse(XContentParser parser) throws IOException;
 
         public abstract T build();
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
@@ -74,8 +74,7 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
 
     public static class Builder extends BasePrimaryAllocationCommand.Builder<AllocateEmptyPrimaryAllocationCommand> {
 
-        @Override
-        public Builder parse(XContentParser parser) throws IOException {
+        private Builder parse(XContentParser parser) throws IOException {
             return EMPTY_PRIMARY_PARSER.parse(parser, this, null);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReplicaAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateReplicaAllocationCommand.java
@@ -64,8 +64,7 @@ public class AllocateReplicaAllocationCommand extends AbstractAllocateAllocation
 
     protected static class Builder extends AbstractAllocateAllocationCommand.Builder<AllocateReplicaAllocationCommand> {
 
-        @Override
-        public Builder parse(XContentParser parser) throws IOException {
+        private Builder parse(XContentParser parser) throws IOException {
             return REPLICA_PARSER.parse(parser, this, null);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateStalePrimaryAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateStalePrimaryAllocationCommand.java
@@ -71,8 +71,7 @@ public class AllocateStalePrimaryAllocationCommand extends BasePrimaryAllocation
 
     public static class Builder extends BasePrimaryAllocationCommand.Builder<AllocateStalePrimaryAllocationCommand> {
 
-        @Override
-        public Builder parse(XContentParser parser) throws IOException {
+        private Builder parse(XContentParser parser) throws IOException {
             return STALE_PRIMARY_PARSER.parse(parser, this, null);
         }
 

--- a/server/src/main/java/org/elasticsearch/tasks/TaskId.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskId.java
@@ -8,13 +8,10 @@
 
 package org.elasticsearch.tasks;
 
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xcontent.ContextParser;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
@@ -86,15 +83,6 @@ public final class TaskId implements Writeable {
             return;
         }
         out.writeLong(id);
-    }
-
-    public static ContextParser<Void, TaskId> parser() {
-        return (p, c) -> {
-            if (p.currentToken() == XContentParser.Token.VALUE_STRING) {
-                return new TaskId(p.text());
-            }
-            throw new ElasticsearchParseException("Expected a string but found [{}] instead", p.currentToken());
-        };
     }
 
     public String getNodeId() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoResponse.java
@@ -17,8 +17,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.license.License;
 import org.elasticsearch.protocol.xpack.license.LicenseStatus;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -31,8 +29,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 public class XPackInfoResponse extends ActionResponse implements ToXContentObject {
     /**
@@ -274,16 +270,6 @@ public class XPackInfoResponse extends ActionResponse implements ToXContentObjec
         @Override
         public int hashCode() {
             return Objects.hash(hash, timestamp);
-        }
-
-        private static final ConstructingObjectParser<BuildInfo, Void> PARSER = new ConstructingObjectParser<>(
-            "build_info",
-            true,
-            (a, v) -> new BuildInfo((String) a[0], (String) a[1])
-        );
-        static {
-            PARSER.declareString(constructorArg(), new ParseField("hash"));
-            PARSER.declareString(constructorArg(), new ParseField("date"));
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/Connection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/Connection.java
@@ -9,18 +9,13 @@ package org.elasticsearch.protocol.xpack.graph;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.protocol.xpack.graph.Vertex.VertexId;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent.Params;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 /**
  * A Connection links exactly two {@link Vertex} objects. The basis of a
@@ -110,51 +105,6 @@ public class Connection {
         builder.field(TARGET.getPreferredName(), vertexNumbers.get(to));
         builder.field(WEIGHT.getPreferredName(), weight);
         builder.field(DOC_COUNT.getPreferredName(), docCount);
-    }
-
-    // When deserializing from XContent we need to wait for all vertices to be loaded before
-    // Connection objects can be created that reference them. This class provides the interim
-    // state for connections.
-    static class UnresolvedConnection {
-        int fromIndex;
-        int toIndex;
-        double weight;
-        long docCount;
-
-        UnresolvedConnection(int fromIndex, int toIndex, double weight, long docCount) {
-            super();
-            this.fromIndex = fromIndex;
-            this.toIndex = toIndex;
-            this.weight = weight;
-            this.docCount = docCount;
-        }
-
-        public Connection resolve(List<Vertex> vertices) {
-            return new Connection(vertices.get(fromIndex), vertices.get(toIndex), weight, docCount);
-        }
-
-        private static final ConstructingObjectParser<UnresolvedConnection, Void> PARSER = new ConstructingObjectParser<>(
-            "ConnectionParser",
-            true,
-            args -> {
-                int source = (Integer) args[0];
-                int target = (Integer) args[1];
-                double weight = (Double) args[2];
-                long docCount = (Long) args[3];
-                return new UnresolvedConnection(source, target, weight, docCount);
-            }
-        );
-
-        static {
-            PARSER.declareInt(constructorArg(), SOURCE);
-            PARSER.declareInt(constructorArg(), TARGET);
-            PARSER.declareDouble(constructorArg(), WEIGHT);
-            PARSER.declareLong(constructorArg(), DOC_COUNT);
-        }
-
-        static UnresolvedConnection fromXContent(XContentParser parser) throws IOException {
-            return PARSER.apply(parser, null);
-        }
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/CheckShrinkReadyStep.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -151,16 +150,6 @@ public class CheckShrinkReadyStep extends ClusterStateWaitStep {
         static final ParseField EXPECTED_SHARDS = new ParseField("expected_shards");
         static final ParseField SHARDS_TO_ALLOCATE = new ParseField("shards_left_to_allocate");
         static final ParseField MESSAGE = new ParseField("message");
-        static final ConstructingObjectParser<CheckShrinkReadyStep.Info, Void> PARSER = new ConstructingObjectParser<>(
-            "check_shrink_ready_step_info",
-            a -> new CheckShrinkReadyStep.Info((String) a[0], (long) a[1], (long) a[2])
-        );
-        static {
-            PARSER.declareString(ConstructingObjectParser.constructorArg(), NODE_ID);
-            PARSER.declareLong(ConstructingObjectParser.constructorArg(), EXPECTED_SHARDS);
-            PARSER.declareLong(ConstructingObjectParser.constructorArg(), SHARDS_TO_ALLOCATE);
-            PARSER.declareString((i, s) -> {}, MESSAGE);
-        }
 
         public Info(String nodeId, long expectedShards, long numberShardsLeftToAllocate) {
             this.nodeId = nodeId;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -21,11 +21,9 @@ import org.elasticsearch.inference.InferenceResults;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
-import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelPrefixStrings;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.EmptyConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
@@ -70,29 +68,8 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
 
         public static final ParseField DOCS = new ParseField("docs");
         public static final ParseField TIMEOUT = new ParseField("timeout");
-        public static final ParseField INFERENCE_CONFIG = new ParseField("inference_config");
 
         public static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(10);
-
-        static final ObjectParser<Request.Builder, Void> PARSER = new ObjectParser<>(NAME, Request.Builder::new);
-        static {
-            PARSER.declareString(Request.Builder::setId, InferModelAction.Request.DEPLOYMENT_ID);
-            PARSER.declareObjectArray(Request.Builder::setDocs, (p, c) -> p.mapOrdered(), DOCS);
-            PARSER.declareString(Request.Builder::setInferenceTimeout, TIMEOUT);
-            PARSER.declareNamedObject(
-                Request.Builder::setUpdate,
-                ((p, c, name) -> p.namedObject(InferenceConfigUpdate.class, name, c)),
-                INFERENCE_CONFIG
-            );
-        }
-
-        public static Request.Builder parseRequest(String id, XContentParser parser) {
-            Request.Builder builder = PARSER.apply(parser, null);
-            if (id != null) {
-                builder.setId(id);
-            }
-            return builder;
-        }
 
         private String id;
         private final List<Map<String, Object>> docs;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartDatafeedAction.java
@@ -55,10 +55,6 @@ public class StartDatafeedAction extends ActionType<NodeAcknowledgedResponse> {
 
     public static class Request extends MasterNodeRequest<Request> implements ToXContentObject {
 
-        public static Request fromXContent(XContentParser parser) {
-            return parseRequest(null, parser);
-        }
-
         public static Request parseRequest(String datafeedId, XContentParser parser) {
             DatafeedParams params = DatafeedParams.PARSER.apply(parser, null);
             if (datafeedId != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StopDatafeedAction.java
@@ -62,10 +62,6 @@ public class StopDatafeedAction extends ActionType<StopDatafeedAction.Response> 
             PARSER.declareBoolean(Request::setAllowNoMatch, ALLOW_NO_MATCH_V7);
         }
 
-        public static Request fromXContent(XContentParser parser) {
-            return parseRequest(null, parser);
-        }
-
         public static Request parseRequest(String datafeedId, XContentParser parser) {
             Request request = PARSER.apply(parser, null);
             if (datafeedId != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Accuracy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Accuracy.java
@@ -17,7 +17,6 @@ import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -36,7 +35,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider.registeredMetricName;
 
 /**
@@ -211,22 +209,6 @@ public class Accuracy implements EvaluationMetric {
 
         private static final ParseField CLASSES = new ParseField("classes");
         private static final ParseField OVERALL_ACCURACY = new ParseField("overall_accuracy");
-
-        @SuppressWarnings("unchecked")
-        private static final ConstructingObjectParser<Result, Void> PARSER = new ConstructingObjectParser<>(
-            "accuracy_result",
-            true,
-            a -> new Result((List<PerClassSingleValue>) a[0], (double) a[1])
-        );
-
-        static {
-            PARSER.declareObjectArray(constructorArg(), PerClassSingleValue.PARSER, CLASSES);
-            PARSER.declareDouble(constructorArg(), OVERALL_ACCURACY);
-        }
-
-        public static Result fromXContent(XContentParser parser) {
-            return PARSER.apply(parser, null);
-        }
 
         /** List of per-class results. */
         private final List<PerClassSingleValue> classes;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Precision.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.aggregations.bucket.filter.Filters;
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator.KeyedFilter;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -44,7 +43,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider.registeredMetricName;
 
 /**
@@ -204,22 +202,6 @@ public class Precision implements EvaluationMetric {
 
         private static final ParseField CLASSES = new ParseField("classes");
         private static final ParseField AVG_PRECISION = new ParseField("avg_precision");
-
-        @SuppressWarnings("unchecked")
-        private static final ConstructingObjectParser<Result, Void> PARSER = new ConstructingObjectParser<>(
-            "precision_result",
-            true,
-            a -> new Result((List<PerClassSingleValue>) a[0], (double) a[1])
-        );
-
-        static {
-            PARSER.declareObjectArray(constructorArg(), PerClassSingleValue.PARSER, CLASSES);
-            PARSER.declareDouble(constructorArg(), AVG_PRECISION);
-        }
-
-        public static Result fromXContent(XContentParser parser) {
-            return PARSER.apply(parser, null);
-        }
 
         /** List of per-class results. */
         private final List<PerClassSingleValue> classes;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/evaluation/classification/Recall.java
@@ -21,7 +21,6 @@ import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.PipelineAggregatorBuilders;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregation;
-import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -40,7 +39,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xpack.core.ml.dataframe.evaluation.MlEvaluationNamedXContentProvider.registeredMetricName;
 
 /**
@@ -174,22 +172,6 @@ public class Recall implements EvaluationMetric {
 
         private static final ParseField CLASSES = new ParseField("classes");
         private static final ParseField AVG_RECALL = new ParseField("avg_recall");
-
-        @SuppressWarnings("unchecked")
-        private static final ConstructingObjectParser<Result, Void> PARSER = new ConstructingObjectParser<>(
-            "recall_result",
-            true,
-            a -> new Result((List<PerClassSingleValue>) a[0], (double) a[1])
-        );
-
-        static {
-            PARSER.declareObjectArray(constructorArg(), PerClassSingleValue.PARSER, CLASSES);
-            PARSER.declareDouble(constructorArg(), AVG_RECALL);
-        }
-
-        public static Result fromXContent(XContentParser parser) {
-            return PARSER.apply(parser, null);
-        }
 
         /** List of per-class results. */
         private final List<PerClassSingleValue> classes;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/FeatureImportanceBaseline.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/FeatureImportanceBaseline.java
@@ -132,10 +132,6 @@ public class FeatureImportanceBaseline implements ToXContentObject, Writeable {
             return parser;
         }
 
-        public static ClassBaseline fromXContent(XContentParser parser, boolean lenient) throws IOException {
-            return lenient ? LENIENT_PARSER.parse(parser, null) : STRICT_PARSER.parse(parser, null);
-        }
-
         public final Object className;
         public final double baseline;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TotalFeatureImportance.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/metadata/TotalFeatureImportance.java
@@ -226,10 +226,6 @@ public class TotalFeatureImportance implements ToXContentObject, Writeable {
             return parser;
         }
 
-        public static ClassImportance fromXContent(XContentParser parser, boolean lenient) throws IOException {
-            return lenient ? LENIENT_PARSER.parse(parser, null) : STRICT_PARSER.parse(parser, null);
-        }
-
         public final Object className;
         public final Importance importance;
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/trigger/Trigger.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/trigger/Trigger.java
@@ -7,20 +7,10 @@
 package org.elasticsearch.xpack.core.watcher.trigger;
 
 import org.elasticsearch.xcontent.ToXContentObject;
-import org.elasticsearch.xcontent.XContentParser;
-
-import java.io.IOException;
 
 public interface Trigger extends ToXContentObject {
 
     String type();
-
-    interface Parser<T extends Trigger> {
-
-        String type();
-
-        T parse(XContentParser parser) throws IOException;
-    }
 
     interface Builder<T extends Trigger> {
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorScheduling.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorScheduling.java
@@ -184,10 +184,6 @@ public class ConnectorScheduling implements Writeable, ToXContentObject {
             return PARSER.parse(parser, null);
         }
 
-        public static ConstructingObjectParser<ScheduleConfig, Void> getParser() {
-            return PARSER;
-        }
-
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobErrorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobErrorAction.java
@@ -135,9 +135,6 @@ public class UpdateConnectorSyncJobErrorAction {
             return builder;
         }
 
-        public static UpdateConnectorSyncJobErrorAction.Request parse(XContentParser parser) {
-            return PARSER.apply(parser, null);
-        }
     }
 
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobIngestionStatsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/action/UpdateConnectorSyncJobIngestionStatsAction.java
@@ -84,10 +84,6 @@ public class UpdateConnectorSyncJobIngestionStatsAction {
             this.lastSeen = lastSeen;
         }
 
-        public static UpdateConnectorSyncJobIngestionStatsAction.Request parse(XContentParser parser) {
-            return PARSER.apply(parser, null);
-        }
-
         public String getConnectorSyncJobId() {
             return connectorSyncJobId;
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/GetQueryRulesetAction.java
@@ -154,14 +154,6 @@ public class GetQueryRulesetAction {
             return Objects.hash(queryRuleset);
         }
 
-        private static final ConstructingObjectParser<Response, String> PARSER = new ConstructingObjectParser<>(
-            "get_query_ruleset_response",
-            p -> new Response((QueryRuleset) p[0])
-        );
-        static {
-            PARSER.declareObject(constructorArg(), (p, c) -> QueryRuleset.fromXContent(c, p), QUERY_RULESET_FIELD);
-        }
-
         public static Response fromXContent(String resourceName, XContentParser parser) throws IOException {
             return new Response(QueryRuleset.fromXContent(resourceName, parser));
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/GetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/GetSearchApplicationAction.java
@@ -128,20 +128,6 @@ public class GetSearchApplicationAction {
             this.searchApp = new SearchApplication(name, indices, analyticsCollectionName, updatedAtMillis, template);
         }
 
-        private static final ConstructingObjectParser<Response, String> PARSER = new ConstructingObjectParser<>(
-            "get_search_application_response",
-            p -> new Response((SearchApplication) p[0])
-        );
-        public static final ParseField SEARCH_APPLICATION_FIELD = new ParseField("searchApp");
-
-        static {
-            PARSER.declareObject(constructorArg(), (p, c) -> SearchApplication.fromXContent(c, p), SEARCH_APPLICATION_FIELD);
-        }
-
-        public static Response parse(XContentParser parser) {
-            return PARSER.apply(parser, null);
-        }
-
         public static Response fromXContent(String resourceName, XContentParser parser) throws IOException {
             return new Response(SearchApplication.fromXContent(resourceName, parser));
         }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/watch/WatchParser.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/watch/WatchParser.java
@@ -91,18 +91,6 @@ public class WatchParser {
         return parse(name, includeStatus, false, source, now, xContentType, false, sourceSeqNo, sourcePrimaryTerm);
     }
 
-    public Watch parse(
-        String name,
-        boolean includeStatus,
-        BytesReference source,
-        ZonedDateTime now,
-        XContentType xContentType,
-        long sourceSeqNo,
-        long sourcePrimaryTerm
-    ) throws IOException {
-        return parse(name, includeStatus, false, source, now, xContentType, false, sourceSeqNo, sourcePrimaryTerm);
-    }
-
     /**
      * Parses the watch represented by the given source. When parsing, any sensitive data that the
      * source might contain (e.g. passwords) will be converted to {@link Secret secrets}


### PR DESCRIPTION
Another round of mostly automatically cleaning up unused xcontent parser methods and parser instances that become unused as a result.

