### PR TITLE
Refactor geoip database properties

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -69,6 +69,26 @@ public enum Database {
         return defaultProperties;
     }
 
+    /**
+     * Parse the given list of property names and validate them against the supplied databaseType.
+     *
+     * @param propertyNames a list of property names to parse, or null to use the default properties for the associated databaseType
+     * @throws IllegalArgumentException if any of the property names are not valid, or if the databaseType is not valid
+     * @return a set of parsed and validated properties
+     */
+    public Set<Property> parseProperties(@Nullable final List<String> propertyNames) {
+        if (propertyNames != null) {
+            final Set<Property> parsedProperties = new HashSet<>();
+            for (String propertyName : propertyNames) {
+                parsedProperties.add(Property.parseProperty(this.properties, propertyName)); // n.b. this throws if a property is invalid
+            }
+            return Set.copyOf(parsedProperties);
+        } else {
+            // if propertyNames is null, then use the default properties
+            return this.defaultProperties;
+        }
+    }
+
     public enum Property {
 
         IP,
@@ -100,46 +120,6 @@ public enum Database {
                     "illegal property value [" + value + "]. valid values are " + Arrays.toString(properties)
                 );
             }
-        }
-
-        /**
-         * Parse the given list of property names and validate them against the supplied databaseType.
-         *
-         * @param databaseType the type of database to use to validate property names
-         * @param propertyNames a list of property names to parse, or null to use the default properties for the associated databaseType
-         * @throws IllegalArgumentException if any of the property names are not valid, or if the databaseType is not valid
-         * @return a set of parsed and validated properties
-         */
-        public static Set<Property> parseProperties(final String databaseType, @Nullable final List<String> propertyNames) {
-            final Set<Property> validProperties;
-            final Set<Property> defaultProperties;
-
-            if (databaseType.endsWith(CITY_DB_SUFFIX)) {
-                validProperties = City.properties();
-                defaultProperties = City.defaultProperties();
-            } else if (databaseType.endsWith(COUNTRY_DB_SUFFIX)) {
-                validProperties = Country.properties();
-                defaultProperties = Country.defaultProperties();
-            } else if (databaseType.endsWith(ASN_DB_SUFFIX)) {
-                validProperties = Asn.properties();
-                defaultProperties = Asn.defaultProperties();
-            } else {
-                assert false : "Unsupported database type [" + databaseType + "]";
-                throw new IllegalArgumentException("Unsupported database type [" + databaseType + "]");
-            }
-
-            final Set<Property> properties;
-            if (propertyNames != null) {
-                Set<Property> modifiableProperties = new HashSet<>();
-                for (String propertyName : propertyNames) {
-                    modifiableProperties.add(parseProperty(validProperties, propertyName)); // n.b. this throws if a property is invalid
-                }
-                properties = Set.copyOf(modifiableProperties);
-            } else {
-                // if propertyNames is null, then use the default properties for the databaseType
-                properties = defaultProperties;
-            }
-            return properties;
         }
     }
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -16,14 +16,57 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-public final class Database {
+public enum Database {
+
+    City(
+        Set.of(
+            Property.IP,
+            Property.COUNTRY_ISO_CODE,
+            Property.COUNTRY_NAME,
+            Property.CONTINENT_NAME,
+            Property.REGION_ISO_CODE,
+            Property.REGION_NAME,
+            Property.CITY_NAME,
+            Property.TIMEZONE,
+            Property.LOCATION
+        ),
+        Set.of(
+            Property.CONTINENT_NAME,
+            Property.COUNTRY_NAME,
+            Property.COUNTRY_ISO_CODE,
+            Property.REGION_ISO_CODE,
+            Property.REGION_NAME,
+            Property.CITY_NAME,
+            Property.LOCATION
+        )
+    ),
+    Country(
+        Set.of(Property.IP, Property.CONTINENT_NAME, Property.COUNTRY_NAME, Property.COUNTRY_ISO_CODE),
+        Set.of(Property.CONTINENT_NAME, Property.COUNTRY_NAME, Property.COUNTRY_ISO_CODE)
+    ),
+    Asn(
+        Set.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK),
+        Set.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK)
+    );
 
     public static final String CITY_DB_SUFFIX = "-City";
     public static final String COUNTRY_DB_SUFFIX = "-Country";
     public static final String ASN_DB_SUFFIX = "-ASN";
 
-    private Database() {
-        // utility class
+    private final Set<Property> properties;
+    private final Set<Property> defaultProperties;
+
+    Database(Set<Property> properties, Set<Property> defaultProperties) {
+        this.properties = properties;
+        this.defaultProperties = defaultProperties;
+    }
+
+    public Set<Property> properties() {
+        return properties;
+    }
+
+    public Set<Property> defaultProperties() {
+        return defaultProperties;
     }
 
     public enum Property {
@@ -40,25 +83,6 @@ public final class Database {
         ASN,
         ORGANIZATION_NAME,
         NETWORK;
-
-        static final Set<Property> ALL_CITY_PROPERTIES = Set.of(
-            Property.IP,
-            Property.COUNTRY_ISO_CODE,
-            Property.COUNTRY_NAME,
-            Property.CONTINENT_NAME,
-            Property.REGION_ISO_CODE,
-            Property.REGION_NAME,
-            Property.CITY_NAME,
-            Property.TIMEZONE,
-            Property.LOCATION
-        );
-        static final Set<Property> ALL_COUNTRY_PROPERTIES = Set.of(
-            Property.IP,
-            Property.CONTINENT_NAME,
-            Property.COUNTRY_NAME,
-            Property.COUNTRY_ISO_CODE
-        );
-        static final Set<Property> ALL_ASN_PROPERTIES = Set.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK);
 
         private static Property parseProperty(Set<Property> validProperties, String value) {
             try {
@@ -91,14 +115,14 @@ public final class Database {
             final Set<Property> defaultProperties;
 
             if (databaseType.endsWith(CITY_DB_SUFFIX)) {
-                validProperties = ALL_CITY_PROPERTIES;
-                defaultProperties = GeoIpProcessor.Factory.DEFAULT_CITY_PROPERTIES;
+                validProperties = City.properties();
+                defaultProperties = City.defaultProperties();
             } else if (databaseType.endsWith(COUNTRY_DB_SUFFIX)) {
-                validProperties = ALL_COUNTRY_PROPERTIES;
-                defaultProperties = GeoIpProcessor.Factory.DEFAULT_COUNTRY_PROPERTIES;
+                validProperties = Country.properties();
+                defaultProperties = Country.defaultProperties();
             } else if (databaseType.endsWith(ASN_DB_SUFFIX)) {
-                validProperties = ALL_ASN_PROPERTIES;
-                defaultProperties = GeoIpProcessor.Factory.DEFAULT_ASN_PROPERTIES;
+                validProperties = Asn.properties();
+                defaultProperties = Asn.defaultProperties();
             } else {
                 assert false : "Unsupported database type [" + databaseType + "]";
                 throw new IllegalArgumentException("Unsupported database type [" + databaseType + "]");

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -123,7 +123,7 @@ public enum Database {
         ORGANIZATION_NAME,
         NETWORK;
 
-        private static Property parseProperty(Set<Property> validProperties, String value) {
+        private static Property parseProperty(final Set<Property> validProperties, final String value) {
             try {
                 Property property = valueOf(value.toUpperCase(Locale.ROOT));
                 if (validProperties.contains(property) == false) {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-public enum Database {
+enum Database {
 
     City(
         Set.of(
@@ -108,7 +108,7 @@ public enum Database {
         }
     }
 
-    public enum Property {
+    enum Property {
 
         IP,
         COUNTRY_ISO_CODE,

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -49,9 +49,28 @@ public enum Database {
         Set.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK)
     );
 
-    public static final String CITY_DB_SUFFIX = "-City";
-    public static final String COUNTRY_DB_SUFFIX = "-Country";
-    public static final String ASN_DB_SUFFIX = "-ASN";
+    private static final String CITY_DB_SUFFIX = "-City";
+    private static final String COUNTRY_DB_SUFFIX = "-Country";
+    private static final String ASN_DB_SUFFIX = "-ASN";
+
+    public static Database getDatabase(final String databaseType, final String databaseFile) {
+        Database database = null;
+        if (databaseType != null) {
+            if (databaseType.endsWith(Database.CITY_DB_SUFFIX)) {
+                database = Database.City;
+            } else if (databaseType.endsWith(Database.COUNTRY_DB_SUFFIX)) {
+                database = Database.Country;
+            } else if (databaseType.endsWith(Database.ASN_DB_SUFFIX)) {
+                database = Database.Asn;
+            }
+        }
+
+        if (database == null) {
+            throw new IllegalArgumentException("Unsupported database type [" + databaseType + "] for file [" + databaseFile + "]");
+        }
+
+        return database;
+    }
 
     private final Set<Property> properties;
     private final Set<Property> defaultProperties;

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.ingest.geoip;
+
+import org.elasticsearch.core.Nullable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public final class Database {
+
+    public static final String CITY_DB_SUFFIX = "-City";
+    public static final String COUNTRY_DB_SUFFIX = "-Country";
+    public static final String ASN_DB_SUFFIX = "-ASN";
+
+    private Database() {
+        // utility class
+    }
+
+    public enum Property {
+
+        IP,
+        COUNTRY_ISO_CODE,
+        COUNTRY_NAME,
+        CONTINENT_NAME,
+        REGION_ISO_CODE,
+        REGION_NAME,
+        CITY_NAME,
+        TIMEZONE,
+        LOCATION,
+        ASN,
+        ORGANIZATION_NAME,
+        NETWORK;
+
+        static final Set<Property> ALL_CITY_PROPERTIES = Set.of(
+            Property.IP,
+            Property.COUNTRY_ISO_CODE,
+            Property.COUNTRY_NAME,
+            Property.CONTINENT_NAME,
+            Property.REGION_ISO_CODE,
+            Property.REGION_NAME,
+            Property.CITY_NAME,
+            Property.TIMEZONE,
+            Property.LOCATION
+        );
+        static final Set<Property> ALL_COUNTRY_PROPERTIES = Set.of(
+            Property.IP,
+            Property.CONTINENT_NAME,
+            Property.COUNTRY_NAME,
+            Property.COUNTRY_ISO_CODE
+        );
+        static final Set<Property> ALL_ASN_PROPERTIES = Set.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK);
+
+        private static Property parseProperty(Set<Property> validProperties, String value) {
+            try {
+                Property property = valueOf(value.toUpperCase(Locale.ROOT));
+                if (validProperties.contains(property) == false) {
+                    throw new IllegalArgumentException("invalid");
+                }
+                return property;
+            } catch (IllegalArgumentException e) {
+                // put the properties in natural order before throwing so that we have reliable error messages -- this is a little
+                // bit inefficient, but we only do this validation at processor construction time so the cost is practically immaterial
+                Property[] properties = validProperties.toArray(new Property[0]);
+                Arrays.sort(properties);
+                throw new IllegalArgumentException(
+                    "illegal property value [" + value + "]. valid values are " + Arrays.toString(properties)
+                );
+            }
+        }
+
+        /**
+         * Parse the given list of property names and validate them against the supplied databaseType.
+         *
+         * @param databaseType the type of database to use to validate property names
+         * @param propertyNames a list of property names to parse, or null to use the default properties for the associated databaseType
+         * @throws IllegalArgumentException if any of the property names are not valid, or if the databaseType is not valid
+         * @return a set of parsed and validated properties
+         */
+        public static Set<Property> parseProperties(final String databaseType, @Nullable final List<String> propertyNames) {
+            final Set<Property> validProperties;
+            final Set<Property> defaultProperties;
+
+            if (databaseType.endsWith(CITY_DB_SUFFIX)) {
+                validProperties = ALL_CITY_PROPERTIES;
+                defaultProperties = GeoIpProcessor.Factory.DEFAULT_CITY_PROPERTIES;
+            } else if (databaseType.endsWith(COUNTRY_DB_SUFFIX)) {
+                validProperties = ALL_COUNTRY_PROPERTIES;
+                defaultProperties = GeoIpProcessor.Factory.DEFAULT_COUNTRY_PROPERTIES;
+            } else if (databaseType.endsWith(ASN_DB_SUFFIX)) {
+                validProperties = ALL_ASN_PROPERTIES;
+                defaultProperties = GeoIpProcessor.Factory.DEFAULT_ASN_PROPERTIES;
+            } else {
+                assert false : "Unsupported database type [" + databaseType + "]";
+                throw new IllegalArgumentException("Unsupported database type [" + databaseType + "]");
+            }
+
+            final Set<Property> properties;
+            if (propertyNames != null) {
+                Set<Property> modifiableProperties = new HashSet<>();
+                for (String propertyName : propertyNames) {
+                    modifiableProperties.add(parseProperty(validProperties, propertyName)); // n.b. this throws if a property is invalid
+                }
+                properties = Set.copyOf(modifiableProperties);
+            } else {
+                // if propertyNames is null, then use the default properties for the databaseType
+                properties = defaultProperties;
+            }
+            return properties;
+        }
+    }
+}

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/Database.java
@@ -16,6 +16,14 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+/**
+ * A high-level representation of a kind of geoip database that is supported by the {@link GeoIpProcessor}.
+ * <p>
+ * A database has a set of properties that are valid to use with it (see {@link Database#properties()}),
+ * as well as a list of default properties to use if no properties are specified (see {@link Database#defaultProperties()}).
+ * <p>
+ * See especially {@link Database#getDatabase(String, String)} which is used to obtain instances of this class.
+ */
 enum Database {
 
     City(
@@ -53,6 +61,15 @@ enum Database {
     private static final String COUNTRY_DB_SUFFIX = "-Country";
     private static final String ASN_DB_SUFFIX = "-ASN";
 
+    /**
+     * Parses the passed-in databaseType (presumably from the passed-in databaseFile) and return the Database instance that is
+     * associated with that databaseType.
+     *
+     * @param databaseType the database type String from the metadata of the database file
+     * @param databaseFile the database file from which the database type was obtained
+     * @throws IllegalArgumentException if the databaseType is not associated with a Database instance
+     * @return the Database instance that is associated with the databaseType
+     */
     public static Database getDatabase(final String databaseType, final String databaseFile) {
         Database database = null;
         if (databaseType != null) {
@@ -80,19 +97,25 @@ enum Database {
         this.defaultProperties = defaultProperties;
     }
 
+    /**
+     * @return a set representing all the valid properties for this database
+     */
     public Set<Property> properties() {
         return properties;
     }
 
+    /**
+     * @return a set representing the default properties for this database
+     */
     public Set<Property> defaultProperties() {
         return defaultProperties;
     }
 
     /**
-     * Parse the given list of property names and validate them against the supplied databaseType.
+     * Parse the given list of property names.
      *
-     * @param propertyNames a list of property names to parse, or null to use the default properties for the associated databaseType
-     * @throws IllegalArgumentException if any of the property names are not valid, or if the databaseType is not valid
+     * @param propertyNames a list of property names to parse, or null to use the default properties for this database
+     * @throws IllegalArgumentException if any of the property names are not valid
      * @return a set of parsed and validated properties
      */
     public Set<Property> parseProperties(@Nullable final List<String> propertyNames) {
@@ -108,6 +131,9 @@ enum Database {
         }
     }
 
+    /**
+     * High-level database 'properties' that represent information that can be extracted from a geoip database.
+     */
     enum Property {
 
         IP,
@@ -123,6 +149,18 @@ enum Database {
         ORGANIZATION_NAME,
         NETWORK;
 
+        /**
+         * Parses a string representation of a property into an actual Property instance. Not all properties that exist are
+         * valid for all kinds of databases, so this method validates the parsed value against the provided set of valid properties.
+         * <p>
+         * See {@link Database#parseProperties(List)} where this is used.
+         *
+         * @param validProperties the valid properties against which to validate the parsed property value
+         * @param value the string representation to parse
+         * @return a parsed, validated Property
+         * @throws IllegalArgumentException if the value does not parse as a Property or if the parsed Property is not
+         * in the passed-in validProperties set
+         */
         private static Property parseProperty(final Set<Property> validProperties, final String value) {
             try {
                 Property property = valueOf(value.toUpperCase(Locale.ROOT));

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -376,21 +376,6 @@ public final class GeoIpProcessor extends AbstractProcessor {
     }
 
     public static final class Factory implements Processor.Factory {
-        static final Set<Property> DEFAULT_CITY_PROPERTIES = Set.of(
-            Property.CONTINENT_NAME,
-            Property.COUNTRY_NAME,
-            Property.COUNTRY_ISO_CODE,
-            Property.REGION_ISO_CODE,
-            Property.REGION_NAME,
-            Property.CITY_NAME,
-            Property.LOCATION
-        );
-        static final Set<Property> DEFAULT_COUNTRY_PROPERTIES = Set.of(
-            Property.CONTINENT_NAME,
-            Property.COUNTRY_NAME,
-            Property.COUNTRY_ISO_CODE
-        );
-        static final Set<Property> DEFAULT_ASN_PROPERTIES = Set.of(Property.IP, Property.ASN, Property.ORGANIZATION_NAME, Property.NETWORK);
 
         private final GeoIpDatabaseProvider geoIpDatabaseProvider;
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -422,10 +422,22 @@ public final class GeoIpProcessor extends AbstractProcessor {
             } finally {
                 geoIpDatabase.release();
             }
-            if (databaseType == null
-                || (databaseType.endsWith(Database.CITY_DB_SUFFIX)
-                    || databaseType.endsWith(Database.COUNTRY_DB_SUFFIX)
-                    || databaseType.endsWith(Database.ASN_DB_SUFFIX)) == false) {
+
+            final Database database;
+            if (databaseType != null) {
+                if (databaseType.endsWith(Database.CITY_DB_SUFFIX)) {
+                    database = Database.City;
+                } else if (databaseType.endsWith(Database.COUNTRY_DB_SUFFIX)) {
+                    database = Database.Country;
+                } else if (databaseType.endsWith(Database.ASN_DB_SUFFIX)) {
+                    database = Database.Asn;
+                } else {
+                    database = null;
+                }
+            } else {
+                database = null;
+            }
+            if (database == null) {
                 throw newConfigurationException(
                     TYPE,
                     processorTag,
@@ -436,7 +448,7 @@ public final class GeoIpProcessor extends AbstractProcessor {
 
             final Set<Property> properties;
             try {
-                properties = Property.parseProperties(databaseType, propertyNames);
+                properties = database.parseProperties(propertyNames);
             } catch (IllegalArgumentException e) {
                 throw newConfigurationException(TYPE, processorTag, "properties", e.getMessage());
             }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -22,7 +22,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.RandomDocumentPicks;
-import org.elasticsearch.ingest.geoip.GeoIpProcessor.Property;
+import org.elasticsearch.ingest.geoip.Database.Property;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.StreamsUtils;

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -100,7 +100,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getField(), equalTo("_field"));
         assertThat(processor.getTargetField(), equalTo("geoip"));
         assertThat(processor.getDatabaseType(), equalTo("GeoLite2-City"));
-        assertThat(processor.getProperties(), sameInstance(GeoIpProcessor.Factory.DEFAULT_CITY_PROPERTIES));
+        assertThat(processor.getProperties(), sameInstance(Database.City.defaultProperties()));
         assertFalse(processor.isIgnoreMissing());
     }
 
@@ -117,7 +117,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getField(), equalTo("_field"));
         assertThat(processor.getTargetField(), equalTo("geoip"));
         assertThat(processor.getDatabaseType(), equalTo("GeoLite2-City"));
-        assertThat(processor.getProperties(), sameInstance(GeoIpProcessor.Factory.DEFAULT_CITY_PROPERTIES));
+        assertThat(processor.getProperties(), sameInstance(Database.City.defaultProperties()));
         assertTrue(processor.isIgnoreMissing());
     }
 
@@ -135,7 +135,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getField(), equalTo("_field"));
         assertThat(processor.getTargetField(), equalTo("geoip"));
         assertThat(processor.getDatabaseType(), equalTo("GeoLite2-Country"));
-        assertThat(processor.getProperties(), sameInstance(GeoIpProcessor.Factory.DEFAULT_COUNTRY_PROPERTIES));
+        assertThat(processor.getProperties(), sameInstance(Database.Country.defaultProperties()));
         assertFalse(processor.isIgnoreMissing());
     }
 
@@ -153,7 +153,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getField(), equalTo("_field"));
         assertThat(processor.getTargetField(), equalTo("geoip"));
         assertThat(processor.getDatabaseType(), equalTo("GeoLite2-ASN"));
-        assertThat(processor.getProperties(), sameInstance(GeoIpProcessor.Factory.DEFAULT_ASN_PROPERTIES));
+        assertThat(processor.getProperties(), sameInstance(Database.Asn.defaultProperties()));
         assertFalse(processor.isIgnoreMissing());
     }
 
@@ -177,7 +177,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         assertThat(processor.getField(), equalTo("_field"));
         assertThat(processor.getTargetField(), equalTo("geoip"));
         assertThat(processor.getDatabaseType(), equalTo("GeoLite2-Country"));
-        assertThat(processor.getProperties(), sameInstance(GeoIpProcessor.Factory.DEFAULT_COUNTRY_PROPERTIES));
+        assertThat(processor.getProperties(), sameInstance(Database.Country.defaultProperties()));
         assertFalse(processor.isIgnoreMissing());
     }
 
@@ -186,7 +186,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-Country.mmdb");
-        Set<Property> asnOnlyProperties = new HashSet<>(Property.ALL_ASN_PROPERTIES);
+        Set<Property> asnOnlyProperties = new HashSet<>(Database.Asn.properties());
         asnOnlyProperties.remove(Property.IP);
         String asnProperty = RandomPicks.randomFrom(Randomness.get(), asnOnlyProperties).toString();
         config.put("properties", List.of(asnProperty));
@@ -206,7 +206,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "_field");
         config.put("database_file", "GeoLite2-ASN.mmdb");
-        Set<Property> cityOnlyProperties = new HashSet<>(Property.ALL_CITY_PROPERTIES);
+        Set<Property> cityOnlyProperties = new HashSet<>(Database.City.properties());
         cityOnlyProperties.remove(Property.IP);
         String cityProperty = RandomPicks.randomFrom(Randomness.get(), cityOnlyProperties).toString();
         config.put("properties", List.of(cityProperty));
@@ -251,7 +251,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
 
         int counter = 0;
         int numFields = scaledRandomIntBetween(1, Property.values().length);
-        for (Property property : Property.ALL_CITY_PROPERTIES) {
+        for (Property property : Database.City.properties()) {
             properties.add(property);
             fieldNames.add(property.name().toLowerCase(Locale.ROOT));
             if (++counter >= numFields) {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.RandomDocumentPicks;
-import org.elasticsearch.ingest.geoip.GeoIpProcessor.Property;
+import org.elasticsearch.ingest.geoip.Database.Property;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;


### PR DESCRIPTION
Drops the `DEFAULT_CITY_PROPERTIES` and `ALL_CITY_PROPERTIES` constants in favor of creating a `City` thing that has those sets as properties (for example). Tidies up some of the code around that kind of dispatch.

The goal of this is to make adding a new database type more straightforward -- you'd add some code into the `Database.Property` enum for the new properties for the type, and add a new `Database.Whatever` for the kind of database you're adding.

~I'm tagging this as 'WIP' because it still needs javadocs.~ edit: All set!