### PR TITLE
[8.11] Call out `monitor` privilege for index and component templates (#106970)

### DIFF
--- a/docs/reference/indices/get-component-template.asciidoc
+++ b/docs/reference/indices/get-component-template.asciidoc
@@ -51,7 +51,7 @@ GET /_component_template/template_1
 
 * If the {es} {security-features} are enabled, you must have the
 `manage_index_templates` or `manage` <<privileges-list-cluster,cluster
-privilege>> to use this API.
+privilege>> to update templates, or the `monitor` cluster privilege to retrieve templates.
 
 [[get-component-template-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/indices/get-index-template.asciidoc
+++ b/docs/reference/indices/get-index-template.asciidoc
@@ -46,7 +46,7 @@ GET /_index_template/template_1
 
 * If the {es} {security-features} are enabled, you must have the
 `manage_index_templates` or `manage` <<privileges-list-cluster,cluster
-privilege>> to use this API.
+privilege>> to use this API, or the `monitor` cluster privilege to retrieve templates.
 
 [[get-template-api-path-params]]
 ==== {api-path-parms-title}


### PR DESCRIPTION
Backports the following commits to 8.11:
 - Call out `monitor` privilege for index and component templates (#106970)