### PR TITLE
[8.13] Fix warning typo for test failure (#106971)

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/10_basic.yml
@@ -543,7 +543,7 @@ setup:
 
   - do:
       allowed_warnings:
-        - "index template [my-template4] has index patterns [failure-data-stream1, failure-data-stream2] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template4] will take precedence during new index creation"
+        - "index template [my-template4] has index patterns [failure-data-stream1] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template4] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template4
         body:


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Fix warning typo for test failure (#106971)