### PR TITLE
Health report supports cluster resilience indicator.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterResilienceIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterResilienceIndicatorService.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.coordination;
+
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.health.Diagnosis;
+import org.elasticsearch.health.HealthIndicatorDetails;
+import org.elasticsearch.health.HealthIndicatorImpact;
+import org.elasticsearch.health.HealthIndicatorResult;
+import org.elasticsearch.health.HealthIndicatorService;
+import org.elasticsearch.health.HealthStatus;
+import org.elasticsearch.health.ImpactArea;
+import org.elasticsearch.health.SimpleHealthIndicatorDetails;
+import org.elasticsearch.health.node.HealthInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * This indicator reports the health of cluster resilience.
+ * <p>
+ * The indicator will report:
+ * * YELLOW status:
+ *    1. There's gte 3 nodes in the cluster and lt 3 of them are master-eligible.
+ *    2. A two-node cluster has two master-eligible nodes.
+ * * GREEN otherwise
+ * </p>
+ */
+public class ClusterResilienceIndicatorService implements HealthIndicatorService {
+
+    public static final String NAME = "cluster_resilience";
+    public static final String MASTER_LESS_THEN_3_IMPACT_ID = "master_less_then_3";
+    public static final String TWO_NODES_MASTER_IMPACT_ID = "two_nodes_master";
+    private final ClusterService clusterService;
+
+    public static final Diagnosis DESIGNING_FOR_RESILIENCE = new Diagnosis(
+        new Diagnosis.Definition(
+            NAME,
+            "designing_for_resilience",
+            "The Elasticsearch cluster is not designed for high availability.",
+            "See designing for resilience guidance at " + ReferenceDocs.DESIGNING_FOR_RESILIENCE,
+            ReferenceDocs.DESIGNING_FOR_RESILIENCE.toString()
+        ),
+        null
+    );
+
+    public ClusterResilienceIndicatorService(ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    @Override
+    public String name() {
+        return NAME;
+    }
+
+    @Override
+    public HealthIndicatorResult calculate(boolean verbose, int maxAffectedResourcesCount, HealthInfo healthInfo) {
+        var state = clusterService.state();
+        HealthStatus status;
+        String summary = null;
+        final List<HealthIndicatorImpact> impacts = new ArrayList<>();
+        int masterAndDataNodeNum = state.nodes().getMasterAndDataNodes().size();
+        int masterNodeNum = state.nodes().getMasterNodes().size();
+        if (masterAndDataNodeNum > 3 && masterNodeNum < 3) {
+            // There's ≥3 nodes in the cluster and <3 of them are master-eligible
+            status = HealthStatus.YELLOW;
+            summary = "This cluster does not have enough master-eligible nodes to tolerate master failure.";
+            String impactDesc = String.format(Locale.ROOT,"The cluster total master and data nodes is %d which is more than 3, " +
+                "but only has %d master-eligible nodes which is less than three, " +
+                "this would not resilient to master failure.", masterAndDataNodeNum, masterNodeNum);
+            impacts.add(new HealthIndicatorImpact(NAME, MASTER_LESS_THEN_3_IMPACT_ID,
+                2, impactDesc, List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)));
+        } else if (masterAndDataNodeNum == 2 && masterNodeNum == 2) {
+            // A two-node cluster has two master-eligible nodes
+            status = HealthStatus.YELLOW;
+            summary = "This cluster cannot reliably tolerate the loss of either node due to both two nodes are master-eligible.";
+            String impactDesc = "The cluster has 2 nodes and both of them are master-eligible nodes, " +
+                "the election will fail if either node is unavailable, your cluster cannot reliably tolerate the loss of either node.";
+            impacts.add(new HealthIndicatorImpact(NAME, TWO_NODES_MASTER_IMPACT_ID,
+                2, impactDesc, List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)));
+        } else {
+            status = HealthStatus.GREEN;
+        }
+
+        return createIndicator(status, summary, getDetails(verbose), impacts,
+            status == HealthStatus.GREEN ? List.of() : getDiagnosis(verbose));
+    }
+
+    private HealthIndicatorDetails getDetails(boolean verbose) {
+        if (verbose) {
+            var state = clusterService.state();
+            return new SimpleHealthIndicatorDetails(
+                Map.of(
+                    "number_of_nodes",
+                    state.nodes().size(),
+                    "number_of_master_and_data_nodes",
+                    state.nodes().getMasterAndDataNodes().size(),
+                    "number_of_master_nodes",
+                    state.nodes().getMasterNodes().size(),
+                    "number_of_data_nodes",
+                    state.nodes().getDataNodes().size()
+                )
+            );
+        } else {
+            return HealthIndicatorDetails.EMPTY;
+        }
+    }
+
+    private List<Diagnosis> getDiagnosis(boolean verbose) {
+        if (verbose) {
+            return List.of(DESIGNING_FOR_RESILIENCE);
+        } else {
+            return List.of();
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
+++ b/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
@@ -72,6 +72,7 @@ public enum ReferenceDocs {
     CONTACT_SUPPORT,
     UNASSIGNED_SHARDS,
     EXECUTABLE_JNA_TMPDIR,
+    DESIGNING_FOR_RESILIENCE,
     // this comment keeps the ';' on the next line so every entry above has a trailing ',' which makes the diff for adding new links cleaner
     ;
 

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.ClusterInfoService;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.coordination.ClusterResilienceIndicatorService;
 import org.elasticsearch.cluster.coordination.CoordinationDiagnosticsService;
 import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.coordination.MasterHistoryService;
@@ -1208,7 +1209,8 @@ class NodeConstruction {
             new StableMasterHealthIndicatorService(coordinationDiagnosticsService, clusterService),
             new RepositoryIntegrityHealthIndicatorService(clusterService, featureService),
             new DiskHealthIndicatorService(clusterService, featureService),
-            new ShardsCapacityHealthIndicatorService(clusterService, featureService)
+            new ShardsCapacityHealthIndicatorService(clusterService, featureService),
+            new ClusterResilienceIndicatorService(clusterService)
         );
         var pluginHealthIndicatorServices = pluginsService.filterPlugins(HealthPlugin.class)
             .flatMap(plugin -> plugin.getHealthIndicatorServices().stream());

--- a/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
+++ b/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
@@ -32,5 +32,6 @@
   "BOOTSTRAP_CHECK_SECURITY_MINIMAL_SETUP": "security-minimal-setup.html",
   "CONTACT_SUPPORT": "troubleshooting.html#troubleshooting-contact-support",
   "UNASSIGNED_SHARDS": "red-yellow-cluster-status.html",
-  "EXECUTABLE_JNA_TMPDIR": "executable-jna-tmpdir.html"
+  "EXECUTABLE_JNA_TMPDIR": "executable-jna-tmpdir.html",
+  "DESIGNING_FOR_RESILIENCE": "high-availability-cluster-design.html"
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterResilienceIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterResilienceIndicatorServiceTests.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.coordination;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.health.Diagnosis;
+import org.elasticsearch.health.HealthIndicatorImpact;
+import org.elasticsearch.health.HealthIndicatorResult;
+import org.elasticsearch.health.HealthStatus;
+import org.elasticsearch.health.ImpactArea;
+import org.elasticsearch.health.SimpleHealthIndicatorDetails;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.coordination.ClusterResilienceIndicatorService.NAME;
+import static org.elasticsearch.health.HealthStatus.YELLOW;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ClusterResilienceIndicatorServiceTests extends ESTestCase {
+
+    public void testLessThen3MasterNodes() {
+        ClusterState clusterState = createClusterState(2, 3);
+        var clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+
+        ClusterResilienceIndicatorService service = new ClusterResilienceIndicatorService(clusterService);
+        HealthIndicatorResult result = service.calculate(true, 0, null);
+
+        assertThat(
+            result,
+            equalTo(
+                createExpectedResult(
+                    YELLOW,
+                    "This cluster does not have enough master-eligible nodes to tolerate master failure.",
+                    Map.of("number_of_nodes", 5, "number_of_master_and_data_nodes", 5,
+                        "number_of_master_nodes", 2, "number_of_data_nodes", 5),
+                    List.of(
+                        new HealthIndicatorImpact(
+                            NAME,
+                            ClusterResilienceIndicatorService.MASTER_LESS_THEN_3_IMPACT_ID,
+                            2,
+                            "The cluster total master and data nodes is 5 which is more than 3, " +
+                                "but only has 2 master-eligible nodes which is less than three, " +
+                                "this would not resilient to master failure.",
+                            List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)
+                        )
+                    ),
+                    List.of(ClusterResilienceIndicatorService.DESIGNING_FOR_RESILIENCE)
+                )
+            )
+        );
+    }
+
+    public void test2NodesBothAreMasterNodes() {
+        ClusterState clusterState = createClusterState(2, 0);
+        var clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+
+        ClusterResilienceIndicatorService service = new ClusterResilienceIndicatorService(clusterService);
+        HealthIndicatorResult result = service.calculate(true, 0, null);
+
+        assertThat(
+            result,
+            equalTo(
+                createExpectedResult(
+                    YELLOW,
+                    "This cluster cannot reliably tolerate the loss of either node due to both two nodes are master-eligible.",
+                    Map.of("number_of_nodes", 2, "number_of_master_and_data_nodes", 2,
+                        "number_of_master_nodes", 2, "number_of_data_nodes", 2),
+                    List.of(
+                        new HealthIndicatorImpact(
+                            NAME,
+                            ClusterResilienceIndicatorService.TWO_NODES_MASTER_IMPACT_ID,
+                            2,
+                            "The cluster has 2 nodes and both of them are master-eligible nodes, " +
+                                "the election will fail if either node is unavailable, " +
+                                "your cluster cannot reliably tolerate the loss of either node.",
+                            List.of(ImpactArea.DEPLOYMENT_MANAGEMENT)
+                        )
+                    ),
+                    List.of(ClusterResilienceIndicatorService.DESIGNING_FOR_RESILIENCE)
+                )
+            )
+        );
+    }
+
+    private ClusterState createClusterState(int masterAndDataNodeNum, int dataNodeNum) {
+        DiscoveryNodes.Builder nodesBulder = DiscoveryNodes.builder();
+        for (int i=0; i<masterAndDataNodeNum; i++) {
+            String nodeName = "node" + i + "_md";
+            DiscoveryNode node = DiscoveryNodeUtils.create(nodeName);
+            nodesBulder.localNodeId(nodeName).masterNodeId(nodeName).add(node).build();
+        }
+        for (int i=0; i<dataNodeNum; i++) {
+            String nodeName = "node" + i + "_d";
+            DiscoveryNode node = DiscoveryNodeUtils.create(nodeName, buildNewFakeTransportAddress(), Map.of(),
+                Set.of(DiscoveryNodeRole.DATA_ROLE));
+            nodesBulder.add(node);
+        }
+
+        ClusterState clusterState = mock(ClusterState.class);
+        when(clusterState.nodes()).thenReturn(nodesBulder.build());
+        return clusterState;
+    }
+
+    private HealthIndicatorResult createExpectedResult(
+        HealthStatus status,
+        String symptom,
+        Map<String, Object> details,
+        List<HealthIndicatorImpact> impacts,
+        List<Diagnosis> diagnosisList
+    ) {
+        return new HealthIndicatorResult(
+            NAME,
+            status,
+            symptom,
+            new SimpleHealthIndicatorDetails(details),
+            impacts,
+            diagnosisList
+        );
+    }
+}


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/106640, support cluster resilience indicator in health report.