### PR TITLE
[DOCS] Remove obsolete accounting circuit breaker settings

### DIFF
--- a/docs/reference/modules/indices/circuit_breaker.asciidoc
+++ b/docs/reference/modules/indices/circuit_breaker.asciidoc
@@ -97,24 +97,6 @@ also as a structured object which is reflected by default overhead.
     A constant that all in flight requests estimations are multiplied with to determine a
     final estimation. Defaults to 2.
 
-[[accounting-circuit-breaker]]
-[discrete]
-==== Accounting requests circuit breaker
-
-The accounting circuit breaker allows Elasticsearch to limit the memory
-usage of things held in memory that are not released when a request is
-completed. This includes things like the Lucene segment memory.
-
-`indices.breaker.accounting.limit`::
-    (<<dynamic-cluster-setting,Dynamic>>)
-    Limit for accounting breaker, defaults to 100% of JVM heap. This means that it is bound
-    by the limit configured for the parent circuit breaker.
-
-`indices.breaker.accounting.overhead`::
-    (<<dynamic-cluster-setting,Dynamic>>)
-    A constant that all accounting estimations are multiplied with to determine a
-    final estimation. Defaults to 1
-
 [[script-compilation-circuit-breaker]]
 [discrete]
 ==== Script compilation circuit breaker


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/85849

Removes the **Accounting requests** circuit breaker settings from the circuit breaker docs. These settings were [removed as part of the v8.0.0 alpha](https://github.com/elastic/elasticsearch/pull/75674).


<img width="883" alt="image" src="https://github.com/elastic/elasticsearch/assets/58563081/0753b0dc-f7c4-4409-891e-fa342a503943">
