### PR TITLE
[DOCS] Unhide `manage_data_stream_lifecycle` permission

### DIFF
--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -360,11 +360,9 @@ All {Ilm} operations relating to managing the execution of policies of an index
 or data stream. This includes operations such as retrying policies and removing
 a policy from an index or data stream.
 
-ifeval::["{release-state}"!="released"]
 `manage_data_stream_lifecycle`::
-All data stream lifecycle operations relating to reading and managing the built-in lifecycle of a data stream.
+All <<data-stream-lifecycle, Data stream lifecycle>> operations relating to reading and managing the built-in lifecycle of a data stream.
 This includes operations such as adding and removing a lifecycle from a data stream.
-endif::[]
 
 `manage_leader_index`::
 All actions that are required to manage the lifecycle of a leader index, which


### PR DESCRIPTION
Data stream lifecycles is [no longer marked as technical preview](https://github.com/elastic/elasticsearch/pull/107582) in the 8.14 docs, so we need to unhide the `manage_data_stream_lifecycle` permission as well

fixes #96386 