### PR TITLE
Remove allowedFields argument from SearchExecutionContext constructor

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -715,7 +715,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             mapperService,
             mappingLookup,
             parseRuntimeMappings(runtimeMappings, mapperService, indexSettings, mappingLookup),
-            null,
             indexSettings,
             new Index(
                 RemoteClusterAware.buildRemoteIndexName(clusterAlias, indexSettings.getIndex().getName()),

--- a/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/CoordinatorRewriteContext.java
@@ -50,7 +50,6 @@ public class CoordinatorRewriteContext extends QueryRewriteContext {
             null,
             null,
             null,
-            null,
             null
         );
         this.indexLongFieldRange = indexLongFieldRange;

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -68,7 +68,6 @@ public class QueryRewriteContext {
         final MapperService mapperService,
         final MappingLookup mappingLookup,
         final Map<String, MappedFieldType> runtimeMappings,
-        final Predicate<String> allowedFields,
         final IndexSettings indexSettings,
         final Index fullyQualifiedIndex,
         final Predicate<String> indexNameMatcher,
@@ -85,7 +84,6 @@ public class QueryRewriteContext {
         this.mappingLookup = Objects.requireNonNull(mappingLookup);
         this.allowUnmappedFields = indexSettings == null || indexSettings.isDefaultAllowUnmappedFields();
         this.runtimeMappings = runtimeMappings;
-        this.allowedFields = allowedFields;
         this.indexSettings = indexSettings;
         this.fullyQualifiedIndex = fullyQualifiedIndex;
         this.indexNameMatcher = indexNameMatcher;
@@ -103,7 +101,6 @@ public class QueryRewriteContext {
             null,
             MappingLookup.EMPTY,
             Collections.emptyMap(),
-            null,
             null,
             null,
             null,

--- a/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/SearchExecutionContext.java
@@ -197,7 +197,6 @@ public class SearchExecutionContext extends QueryRewriteContext {
             allowExpensiveQueries,
             valuesSourceRegistry,
             parseRuntimeMappings(runtimeMappings, mapperService, indexSettings, mappingLookup),
-            null,
             requestSize
         );
     }
@@ -223,7 +222,6 @@ public class SearchExecutionContext extends QueryRewriteContext {
             source.allowExpensiveQueries,
             source.getValuesSourceRegistry(),
             source.runtimeMappings,
-            source.allowedFields,
             source.requestSize
         );
     }
@@ -248,7 +246,6 @@ public class SearchExecutionContext extends QueryRewriteContext {
         BooleanSupplier allowExpensiveQueries,
         ValuesSourceRegistry valuesSourceRegistry,
         Map<String, MappedFieldType> runtimeMappings,
-        Predicate<String> allowedFields,
         Integer requestSize
     ) {
         super(
@@ -258,7 +255,6 @@ public class SearchExecutionContext extends QueryRewriteContext {
             mapperService,
             mappingLookup,
             runtimeMappings,
-            allowedFields,
             indexSettings,
             fullyQualifiedIndex,
             indexNameMatcher,

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -591,7 +591,6 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 mapperService,
                 mapperService.mappingLookup(),
                 emptyMap(),
-                null,
                 idxSettings,
                 new Index(
                     RemoteClusterAware.buildRemoteIndexName(null, idxSettings.getIndex().getName()),


### PR DESCRIPTION
allowedFields is a mutable instance member, that only ever gets set via its setter. It does not need to be provided via constructor. Removing a needless argument seems important given the number of other arguments already present.