### PR TITLE
Ensure getUser() is the logical user, not API key creator for RCS 2.0

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityContext.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/SecurityContext.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static org.elasticsearch.xpack.core.security.authc.Authentication.getAuthenticationFromCrossClusterAccessMetadata;
 import static org.elasticsearch.xpack.core.security.authc.AuthenticationField.AUTHENTICATION_KEY;
 import static org.elasticsearch.xpack.core.security.authz.AuthorizationServiceField.AUTHORIZATION_INFO_KEY;
 
@@ -71,6 +72,11 @@ public class SecurityContext {
     @Nullable
     public User getUser() {
         Authentication authentication = getAuthentication();
+        if (authentication != null) {
+            if (authentication.isCrossClusterAccess()) {
+                authentication = getAuthenticationFromCrossClusterAccessMetadata(authentication);
+            }
+        }
         return authentication == null ? null : authentication.getEffectiveSubject().getUser();
     }
 


### PR DESCRIPTION
This commit changes SecurityContext#getUser() to provide the original user that initiated the call when run across clusters for RCS 2.0. Before this change the getUser() would provide the RCS 2.0 API key creator as the current user.  