### PR TITLE
Split the mappings for failure stores out of the index template service

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.metadata;
+
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.mapper.RoutingFieldMapper;
+
+import java.io.IOException;
+
+/**
+ * A utility class that contains the mappings and settings logic for failure store indices that are a part of data streams.
+ */
+public class DataStreamFailureStoreDefinition {
+
+    public static final CompressedXContent DATA_STREAM_FAILURE_STORE_MAPPING;
+
+    static {
+        try {
+            /*
+             * The data stream failure store mapping. The JSON content is as follows:
+             * {
+             *   "_doc": {
+             *     "dynamic": false,
+             *     "_routing": {
+             *       "required": false
+             *     },
+             *     "properties": {
+             *       "@timestamp": {
+             *         "type": "date",
+             *         "ignore_malformed": false
+             *       },
+             *       "document": {
+             *         "properties": {
+             *           "id": {
+             *             "type": "keyword"
+             *           },
+             *           "routing": {
+             *             "type": "keyword"
+             *           },
+             *           "index": {
+             *             "type": "keyword"
+             *           }
+             *         }
+             *       },
+             *       "error": {
+             *         "properties": {
+             *           "message": {
+             *              "type": "wildcard"
+             *           },
+             *           "stack_trace": {
+             *              "type": "text"
+             *           },
+             *           "type": {
+             *              "type": "keyword"
+             *           },
+             *           "pipeline": {
+             *              "type": "keyword"
+             *           },
+             *           "pipeline_trace": {
+             *              "type": "keyword"
+             *           },
+             *           "processor": {
+             *              "type": "keyword"
+             *           }
+             *         }
+             *       }
+             *     }
+             *   }
+             * }
+             */
+            DATA_STREAM_FAILURE_STORE_MAPPING = new CompressedXContent(
+                (builder, params) -> builder.startObject(MapperService.SINGLE_MAPPING_NAME)
+                    .field("dynamic", false)
+                    .startObject(RoutingFieldMapper.NAME)
+                    .field("required", false)
+                    .endObject()
+                    .startObject("properties")
+                    .startObject(MetadataIndexTemplateService.DEFAULT_TIMESTAMP_FIELD)
+                    .field("type", DateFieldMapper.CONTENT_TYPE)
+                    .field("ignore_malformed", false)
+                    .endObject()
+                    .startObject("document")
+                    .startObject("properties")
+                    // document.source is unmapped so that it can be persisted in source only without worrying that the document might cause
+                    // a mapping error
+                    .startObject("id")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("routing")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("index")
+                    .field("type", "keyword")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .startObject("error")
+                    .startObject("properties")
+                    .startObject("message")
+                    .field("type", "wildcard")
+                    .endObject()
+                    .startObject("stack_trace")
+                    .field("type", "text")
+                    .endObject()
+                    .startObject("type")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("pipeline")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("pipeline_trace")
+                    .field("type", "keyword")
+                    .endObject()
+                    .startObject("processor")
+                    .field("type", "keyword")
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+                    .endObject()
+            );
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -92,8 +92,6 @@ public class MetadataIndexTemplateService {
 
     private static final CompressedXContent DEFAULT_TIMESTAMP_MAPPING_WITH_ROUTING;
 
-    private static final CompressedXContent DATA_STREAM_FAILURE_STORE_MAPPING;
-
     static {
         final Map<String, Map<String, String>> defaultTimestampField = Map.of(
             DEFAULT_TIMESTAMP_FIELD,
@@ -122,110 +120,6 @@ public class MetadataIndexTemplateService {
                     .map(defaultTimestampField)
                     .endObject()
             );
-            /*
-             * The data stream failure store mapping. The JSON content is as follows:
-             * {
-             *   "_doc": {
-             *     "dynamic": false,
-             *     "_routing": {
-             *       "required": false
-             *     },
-             *     "properties": {
-             *       "@timestamp": {
-             *         "type": "date",
-             *         "ignore_malformed": false
-             *       },
-             *       "document": {
-             *         "properties": {
-             *           "id": {
-             *             "type": "keyword"
-             *           },
-             *           "routing": {
-             *             "type": "keyword"
-             *           },
-             *           "index": {
-             *             "type": "keyword"
-             *           }
-             *         }
-             *       },
-             *       "error": {
-             *         "properties": {
-             *           "message": {
-             *              "type": "wildcard"
-             *           },
-             *           "stack_trace": {
-             *              "type": "text"
-             *           },
-             *           "type": {
-             *              "type": "keyword"
-             *           },
-             *           "pipeline": {
-             *              "type": "keyword"
-             *           },
-             *           "pipeline_trace": {
-             *              "type": "keyword"
-             *           },
-             *           "processor": {
-             *              "type": "keyword"
-             *           }
-             *         }
-             *       }
-             *     }
-             *   }
-             * }
-             */
-            DATA_STREAM_FAILURE_STORE_MAPPING = new CompressedXContent(
-                (builder, params) -> builder.startObject(MapperService.SINGLE_MAPPING_NAME)
-                    .field("dynamic", false)
-                    .startObject(RoutingFieldMapper.NAME)
-                    .field("required", false)
-                    .endObject()
-                    .startObject("properties")
-                    .startObject(DEFAULT_TIMESTAMP_FIELD)
-                    .field("type", DateFieldMapper.CONTENT_TYPE)
-                    .field("ignore_malformed", false)
-                    .endObject()
-                    .startObject("document")
-                    .startObject("properties")
-                    // document.source is unmapped so that it can be persisted in source only without worrying that the document might cause
-                    // a mapping error
-                    .startObject("id")
-                    .field("type", "keyword")
-                    .endObject()
-                    .startObject("routing")
-                    .field("type", "keyword")
-                    .endObject()
-                    .startObject("index")
-                    .field("type", "keyword")
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .startObject("error")
-                    .startObject("properties")
-                    .startObject("message")
-                    .field("type", "wildcard")
-                    .endObject()
-                    .startObject("stack_trace")
-                    .field("type", "text")
-                    .endObject()
-                    .startObject("type")
-                    .field("type", "keyword")
-                    .endObject()
-                    .startObject("pipeline")
-                    .field("type", "keyword")
-                    .endObject()
-                    .startObject("pipeline_trace")
-                    .field("type", "keyword")
-                    .endObject()
-                    .startObject("processor")
-                    .field("type", "keyword")
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject()
-                    .endObject()
-            );
-
         } catch (IOException e) {
             throw new AssertionError(e);
         }
@@ -1446,7 +1340,10 @@ public class MetadataIndexTemplateService {
         Objects.requireNonNull(template, "Composable index template must be provided");
         // Check if this is a failure store index, and if it is, discard any template mappings. Failure store mappings are predefined.
         if (template.getDataStreamTemplate() != null && indexName.startsWith(DataStream.FAILURE_STORE_PREFIX)) {
-            return List.of(DATA_STREAM_FAILURE_STORE_MAPPING, ComposableIndexTemplate.DataStreamTemplate.DATA_STREAM_MAPPING_SNIPPET);
+            return List.of(
+                DataStreamFailureStoreDefinition.DATA_STREAM_FAILURE_STORE_MAPPING,
+                ComposableIndexTemplate.DataStreamTemplate.DATA_STREAM_MAPPING_SNIPPET
+            );
         }
         List<CompressedXContent> mappings = template.composedOf()
             .stream()


### PR DESCRIPTION
As part of on going failure store development, I'm anticipating the need for having the failure store mappings and configuration code in their own place. This makes it easier to find compared to having to remember that these mappings are in the template service or that specific settings are in the create data stream service. 

Eventually we'll want to add some logic for managing mapping versions. This could be a reasonable spot to start when that happens. 

Finally, I'd like to do some additional refactoring related to failure store specific settings which will follow after this PR and those changes would live in this file as well.