### PR TITLE
[Test] Explicitly specify number of shards to 1

### DIFF
--- a/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
+++ b/x-pack/plugin/sql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/single_node/JdbcShardFailureIT.java
@@ -99,6 +99,9 @@ public class JdbcShardFailureIT extends JdbcIntegrationTestCase {
               "aliases": {
                 "test": {}
               },
+              "settings": {
+                "number_of_shards": 1
+              },
               "mappings": {
                 "properties": {
                   "bool": {


### PR DESCRIPTION
The test assumes number of shards defaults to 1 which may not true in certain deployment types. This PR makes it explicity configure it to 1.

Relates: #106707
