### PR TITLE
[DOCS] Fixes search request in semantic search tutorial

### DIFF
--- a/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
@@ -8,7 +8,7 @@ GET cohere-embeddings/_search
     "field": "content_embedding",
     "query_vector_builder": {
       "text_embedding": {
-        "inference_id": "cohere_embeddings",
+        "model_id": "cohere_embeddings",
         "model_text": "Muscles in human body"
       }
     },
@@ -83,7 +83,7 @@ GET openai-embeddings/_search
     "field": "content_embedding",
     "query_vector_builder": {
       "text_embedding": {
-        "inference_id": "openai_embeddings",
+        "model_id": "openai_embeddings",
         "model_text": "Calculate fuel cost"
       }
     },


### PR DESCRIPTION
## Overview

This PR changes `inference_id` to `model_id` in the search request of the semantic search tutorial as `query_vector_builder` doesn't support `inference_id` yet.