### PR TITLE
Replace UnsupportedOperationException with IllegalArgumentException

### DIFF
--- a/docs/changelog/107038.yaml
+++ b/docs/changelog/107038.yaml
@@ -1,5 +1,5 @@
 pr: 107038
-summary: Replace `UnsupportedOperationException` with `IllegalArgumentException`
+summary: Replace `UnsupportedOperationException` with `IllegalArgumentException` for non-existing columns
 area: Search
 type: bug
 issues: []

--- a/docs/changelog/107038.yaml
+++ b/docs/changelog/107038.yaml
@@ -1,0 +1,5 @@
+pr: 107038
+summary: Replace `UnsupportedOperationException` with `IllegalArgumentException`
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
@@ -156,9 +156,7 @@ public class RestTable {
                 if (headerAliasMap.containsKey(columnHeader)) {
                     ordering.add(new ColumnOrderElement(headerAliasMap.get(columnHeader), reverse));
                 } else {
-                    throw new UnsupportedOperationException(
-                        String.format(Locale.ROOT, "Unable to sort by unknown sort key `%s`", columnHeader)
-                    );
+                    throw new IllegalArgumentException(String.format(Locale.ROOT, "Unable to sort by unknown sort key `%s`", columnHeader));
                 }
             }
             Collections.sort(rowOrder, new TableIndexComparator(table, ordering));

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestTableTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestTableTests.java
@@ -200,7 +200,7 @@ public class RestTableTests extends ESTestCase {
         table.addCell("compare");
         table.endHeaders();
         restRequest.params().put("s", "notaheader");
-        Exception e = expectThrows(UnsupportedOperationException.class, () -> RestTable.getRowOrder(table, restRequest));
+        Exception e = expectThrows(IllegalArgumentException.class, () -> RestTable.getRowOrder(table, restRequest));
         assertEquals("Unable to sort by unknown sort key `notaheader`", e.getMessage());
     }
 


### PR DESCRIPTION
This makes sure the Rest status we return is a `4xx` instead of a `5xx`,
which means the error does not map anymore to "Service Unavailable".