### PR TITLE
Query API Keys support for both `aggs` and `aggregations` keywords

### DIFF
--- a/docs/changelog/107054.yaml
+++ b/docs/changelog/107054.yaml
@@ -1,0 +1,6 @@
+pr: 107054
+summary: Query API Keys support for both `aggs` and `aggregations` keywords
+area: Security
+type: enhancement
+issues:
+ - 106839

--- a/docs/reference/rest-api/security/query-api-key.asciidoc
+++ b/docs/reference/rest-api/security/query-api-key.asciidoc
@@ -232,7 +232,7 @@ simply mentioning `metadata` (not followed by any dot and sub-field name).
 NOTE: You cannot query the role descriptors of an API key.
 ====
 
-`aggs`::
+`aggs` or `aggregations`::
 (Optional, object) Any <<search-aggregations,aggregations>> to run over the corpus of returned API keys.
 Aggregations and queries work together. Aggregations are computed only on the API keys that match the query.
 This supports only a subset of aggregation types, namely: <<search-aggregations-bucket-terms-aggregation,terms>>,

--- a/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/ApiKeyAggsIT.java
+++ b/x-pack/plugin/security/qa/security-basic/src/javaRestTest/java/org/elasticsearch/xpack/security/ApiKeyAggsIT.java
@@ -98,7 +98,7 @@ public class ApiKeyAggsIT extends SecurityInBasicRestTestCase {
         // other bucket
         assertAggs(API_KEY_USER_AUTH_HEADER, typedAggs, """
             {
-              "aggs": {
+              "aggregations": {
                 "only_user_keys": {
                   "filters": {
                     "other_bucket_key": "other_user_keys",
@@ -267,7 +267,7 @@ public class ApiKeyAggsIT extends SecurityInBasicRestTestCase {
                           "good-api-key-invalidated": { "term": {"invalidated": false}}
                         }
                       },
-                      "aggs": {
+                      "aggregations": {
                         "wrong-field": {
                           "filters": {
                             "filters": {
@@ -487,7 +487,7 @@ public class ApiKeyAggsIT extends SecurityInBasicRestTestCase {
                       { "usernames": { "terms": { "field": "username" } } }
                     ]
                   },
-                  "aggs": {
+                  "aggregations": {
                     "not_expired": {
                       "filter": {
                         "range": {
@@ -564,7 +564,7 @@ public class ApiKeyAggsIT extends SecurityInBasicRestTestCase {
             );
             request.setJsonEntity("""
                 {
-                  "aggs": {
+                  "aggregations": {
                     "all_.security_docs": {
                       "global": {},
                       "aggs": {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestQueryApiKeyAction.java
@@ -36,6 +36,8 @@ import static org.elasticsearch.index.query.AbstractQueryBuilder.parseTopLevelQu
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.search.aggregations.AggregatorFactories.parseAggregators;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.AGGREGATIONS_FIELD;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.AGGS_FIELD;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
@@ -47,19 +49,27 @@ public final class RestQueryApiKeyAction extends ApiKeyBaseRestHandler {
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<Payload, Void> PARSER = new ConstructingObjectParser<>(
         "query_api_key_request_payload",
-        a -> new Payload(
-            (QueryBuilder) a[0],
-            (AggregatorFactories.Builder) a[1],
-            (Integer) a[2],
-            (Integer) a[3],
-            (List<FieldSortBuilder>) a[4],
-            (SearchAfterBuilder) a[5]
-        )
+        a -> {
+            if (a[1] != null && a[2] != null) {
+                throw new IllegalArgumentException("Duplicate 'aggs' or 'aggregations' field");
+            } else {
+                return new Payload(
+                    (QueryBuilder) a[0],
+                    (AggregatorFactories.Builder) (a[1] != null ? a[1] : a[2]),
+                    (Integer) a[3],
+                    (Integer) a[4],
+                    (List<FieldSortBuilder>) a[5],
+                    (SearchAfterBuilder) a[6]
+                );
+            }
+        }
     );
 
     static {
         PARSER.declareObject(optionalConstructorArg(), (p, c) -> parseTopLevelQuery(p), new ParseField("query"));
-        PARSER.declareObject(optionalConstructorArg(), (p, c) -> parseAggregators(p), new ParseField("aggs"));
+        // only one of aggs or aggregations is allowed
+        PARSER.declareObject(optionalConstructorArg(), (p, c) -> parseAggregators(p), AGGREGATIONS_FIELD);
+        PARSER.declareObject(optionalConstructorArg(), (p, c) -> parseAggregators(p), AGGS_FIELD);
         PARSER.declareInt(optionalConstructorArg(), new ParseField("from"));
         PARSER.declareInt(optionalConstructorArg(), new ParseField("size"));
         PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> {


### PR DESCRIPTION
The [Query API Key Information endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-query-api-key.html) supports `aggs` since https://github.com/elastic/elasticsearch/pull/104895.
But some lang clients actually use the `aggregations` term in requests, as the preferred synonym.
This PR adds support for the `aggregations` request term as a synonym for the existing `aggs` term.

Closes https://github.com/elastic/elasticsearch/issues/106839