### PR TITLE
[ML] Add missing TokenizationConfigUpdate named writable to registry

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
@@ -74,6 +74,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfi
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TokenizationConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TokenizationUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModel;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModelLocation;
@@ -758,6 +759,9 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
         );
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(InferenceConfigUpdate.class, TextSimilarityConfigUpdate.NAME, TextSimilarityConfigUpdate::new)
+        );
+        namedWriteables.add(
+            new NamedWriteableRegistry.Entry(InferenceConfigUpdate.class, TokenizationConfigUpdate.NAME, TokenizationConfigUpdate::new)
         );
 
         // Location

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
@@ -35,6 +35,9 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfi
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfigUpdateTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfigUpdateTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfigUpdate;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfigUpdateTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TokenizationConfigUpdateTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfigUpdateTests;
 
@@ -132,17 +135,20 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
 
     public static InferenceConfigUpdate randomInferenceConfigUpdate() {
         return randomFrom(
-            RegressionConfigUpdateTests.randomRegressionConfigUpdate(),
             ClassificationConfigUpdateTests.randomClassificationConfigUpdate(),
+            EmptyConfigUpdateTests.testInstance(),
+            FillMaskConfigUpdateTests.randomUpdate(),
+            NerConfigUpdateTests.randomUpdate(),
+            PassThroughConfigUpdateTests.randomUpdate(),
+            QuestionAnsweringConfigUpdateTests.randomUpdate(),
+            RegressionConfigUpdateTests.randomRegressionConfigUpdate(),
             ResultsFieldUpdateTests.randomUpdate(),
             TextClassificationConfigUpdateTests.randomUpdate(),
             TextEmbeddingConfigUpdateTests.randomUpdate(),
-            NerConfigUpdateTests.randomUpdate(),
-            FillMaskConfigUpdateTests.randomUpdate(),
-            ZeroShotClassificationConfigUpdateTests.randomUpdate(),
-            PassThroughConfigUpdateTests.randomUpdate(),
-            QuestionAnsweringConfigUpdateTests.randomUpdate(),
-            EmptyConfigUpdateTests.testInstance()
+            TextExpansionConfigUpdateTests.randomUpdate(),
+            TextSimilarityConfigUpdateTests.randomUpdate(),
+            TokenizationConfigUpdateTests.randomUpdate(),
+            ZeroShotClassificationConfigUpdateTests.randomUpdate()
         );
     }
 
@@ -165,6 +171,8 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
                 adjustedUpdate = QuestionAnsweringConfigUpdateTests.mutateForVersion(update, version);
             } else if (nlpConfigUpdate instanceof TextExpansionConfigUpdate update) {
                 adjustedUpdate = TextExpansionConfigUpdateTests.mutateForVersion(update, version);
+            } else if (nlpConfigUpdate instanceof TextSimilarityConfigUpdate update) {
+                adjustedUpdate = TextSimilarityConfigUpdateTests.mutateForVersion(update, version);
             } else {
                 throw new IllegalArgumentException("Unknown update [" + currentUpdate.getName() + "]");
             }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentRequestsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentRequestsTests.java
@@ -14,9 +14,6 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.ml.inference.MlInferenceNamedXContentProvider;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelPrefixStrings;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.EmptyConfigUpdateTests;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfigUpdate;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfigUpdateTests;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,10 +21,6 @@ import java.util.List;
 import java.util.Map;
 
 public class InferTrainedModelDeploymentRequestsTests extends AbstractWireSerializingTestCase<InferTrainedModelDeploymentAction.Request> {
-
-    private static InferenceConfigUpdate randomInferenceConfigUpdate() {
-        return randomFrom(ZeroShotClassificationConfigUpdateTests.createRandom(), EmptyConfigUpdateTests.testInstance());
-    }
 
     @Override
     protected Writeable.Reader<InferTrainedModelDeploymentAction.Request> instanceReader() {
@@ -42,7 +35,7 @@ public class InferTrainedModelDeploymentRequestsTests extends AbstractWireSerial
         if (createQueryStringRequest) {
             request = InferTrainedModelDeploymentAction.Request.forTextInput(
                 randomAlphaOfLength(4),
-                randomBoolean() ? null : randomInferenceConfigUpdate(),
+                randomBoolean() ? null : InferModelActionRequestTests.randomInferenceConfigUpdate(),
                 Arrays.asList(generateRandomStringArray(4, 7, false)),
                 randomBoolean() ? null : TimeValue.parseTimeValue(randomTimeValue(), "timeout")
             );
@@ -54,7 +47,7 @@ public class InferTrainedModelDeploymentRequestsTests extends AbstractWireSerial
 
             request = InferTrainedModelDeploymentAction.Request.forDocs(
                 randomAlphaOfLength(4),
-                randomBoolean() ? null : randomInferenceConfigUpdate(),
+                randomBoolean() ? null : InferModelActionRequestTests.randomInferenceConfigUpdate(),
                 docs,
                 randomBoolean() ? null : TimeValue.parseTimeValue(randomTimeValue(), "timeout")
             );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TokenizationConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TokenizationConfigUpdateTests.java
@@ -13,6 +13,13 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import java.io.IOException;
 
 public class TokenizationConfigUpdateTests extends AbstractWireSerializingTestCase<TokenizationConfigUpdate> {
+
+    public static TokenizationConfigUpdate randomUpdate() {
+        Integer maxSequenceLength = randomBoolean() ? null : randomIntBetween(32, 64);
+        int span = randomIntBetween(8, 16);
+        return new TokenizationConfigUpdate(maxSequenceLength, span);
+    }
+
     @Override
     protected Writeable.Reader<TokenizationConfigUpdate> instanceReader() {
         return TokenizationConfigUpdate::new;
@@ -20,9 +27,7 @@ public class TokenizationConfigUpdateTests extends AbstractWireSerializingTestCa
 
     @Override
     protected TokenizationConfigUpdate createTestInstance() {
-        Integer maxSequenceLength = randomBoolean() ? null : randomIntBetween(32, 64);
-        int span = randomIntBetween(8, 16);
-        return new TokenizationConfigUpdate(maxSequenceLength, span);
+        return randomUpdate();
     }
 
     @Override


### PR DESCRIPTION
non issue as the class in only used internally