### PR TITLE
Connector API: Followup on #106060

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
@@ -45,10 +46,14 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
 
     @Nullable
     private final String category;
+    @Nullable
     private final Object defaultValue;
+    @Nullable
     private final List<ConfigurationDependency> dependsOn;
+    @Nullable
     private final ConfigurationDisplayType display;
     private final String label;
+    @Nullable
     private final List<ConfigurationSelectOption> options;
     @Nullable
     private final Integer order;
@@ -58,9 +63,13 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
     private final boolean sensitive;
     @Nullable
     private final String tooltip;
+    @Nullable
     private final ConfigurationFieldType type;
+    @Nullable
     private final List<String> uiRestrictions;
+    @Nullable
     private final List<ConfigurationValidation> validations;
+    @Nullable
     private final Object value;
 
     /**
@@ -378,43 +387,40 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
         out.writeGenericValue(value);
     }
 
-    public Map<String, Object> toMap() {
+    public Map<String, Object> togti Map() {
         Map<String, Object> map = new HashMap<>();
-        if (category != null) {
-            map.put(CATEGORY_FIELD.getPreferredName(), category);
-        }
+
+        Optional.ofNullable(category).ifPresent(c -> map.put(CATEGORY_FIELD.getPreferredName(), c));
         map.put(DEFAULT_VALUE_FIELD.getPreferredName(), defaultValue);
-        if (dependsOn != null) {
-            map.put(DEPENDS_ON_FIELD.getPreferredName(), dependsOn.stream().map(ConfigurationDependency::toMap).toList());
-        }
-        if (display != null) {
-            map.put(DISPLAY_FIELD.getPreferredName(), display.toString());
-        }
+
+        Optional.ofNullable(dependsOn)
+            .ifPresent(d -> map.put(DEPENDS_ON_FIELD.getPreferredName(), d.stream().map(ConfigurationDependency::toMap).toList()));
+
+        Optional.ofNullable(display).ifPresent(d -> map.put(DISPLAY_FIELD.getPreferredName(), d.toString()));
+
         map.put(LABEL_FIELD.getPreferredName(), label);
-        if (options != null) {
-            map.put(OPTIONS_FIELD.getPreferredName(), options.stream().map(ConfigurationSelectOption::toMap).toList());
-        }
-        if (order != null) {
-            map.put(ORDER_FIELD.getPreferredName(), order);
-        }
-        if (placeholder != null) {
-            map.put(PLACEHOLDER_FIELD.getPreferredName(), placeholder);
-        }
+
+        Optional.ofNullable(options)
+            .ifPresent(o -> map.put(OPTIONS_FIELD.getPreferredName(), o.stream().map(ConfigurationSelectOption::toMap).toList()));
+
+        Optional.ofNullable(order).ifPresent(o -> map.put(ORDER_FIELD.getPreferredName(), o));
+
+        Optional.ofNullable(placeholder).ifPresent(p -> map.put(PLACEHOLDER_FIELD.getPreferredName(), p));
+
         map.put(REQUIRED_FIELD.getPreferredName(), required);
         map.put(SENSITIVE_FIELD.getPreferredName(), sensitive);
-        if (tooltip != null) {
-            map.put(TOOLTIP_FIELD.getPreferredName(), tooltip);
-        }
-        if (type != null) {
-            map.put(TYPE_FIELD.getPreferredName(), type.toString());
-        }
-        if (uiRestrictions != null) {
-            map.put(UI_RESTRICTIONS_FIELD.getPreferredName(), uiRestrictions);
-        }
-        if (validations != null) {
-            map.put(VALIDATIONS_FIELD.getPreferredName(), validations.stream().map(ConfigurationValidation::toMap).toList());
-        }
+
+        Optional.ofNullable(tooltip).ifPresent(t -> map.put(TOOLTIP_FIELD.getPreferredName(), t));
+
+        Optional.ofNullable(type).ifPresent(t -> map.put(TYPE_FIELD.getPreferredName(), t.toString()));
+
+        Optional.ofNullable(uiRestrictions).ifPresent(u -> map.put(UI_RESTRICTIONS_FIELD.getPreferredName(), u));
+
+        Optional.ofNullable(validations)
+            .ifPresent(v -> map.put(VALIDATIONS_FIELD.getPreferredName(), v.stream().map(ConfigurationValidation::toMap).toList()));
+
         map.put(VALUE_FIELD.getPreferredName(), value);
+
         return map;
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConfiguration.java
@@ -387,7 +387,7 @@ public class ConnectorConfiguration implements Writeable, ToXContentObject {
         out.writeGenericValue(value);
     }
 
-    public Map<String, Object> togti Map() {
+    public Map<String, Object> toMap() {
         Map<String, Object> map = new HashMap<>();
 
         Optional.ofNullable(category).ifPresent(c -> map.put(CATEGORY_FIELD.getPreferredName(), c));

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidation.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/configuration/ConfigurationValidation.java
@@ -19,7 +19,6 @@ import org.elasticsearch.xcontent.XContentParseException;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -103,10 +102,7 @@ public class ConfigurationValidation implements Writeable, ToXContentObject {
     }
 
     public Map<String, Object> toMap() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(CONSTRAINT_FIELD.getPreferredName(), constraint);
-        map.put(TYPE_FIELD.getPreferredName(), type.toString());
-        return map;
+        return Map.of(CONSTRAINT_FIELD.getPreferredName(), constraint, TYPE_FIELD.getPreferredName(), type.toString());
     }
 
     public static ConfigurationValidation fromXContent(XContentParser parser) throws IOException {


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

Addressing comments from #106060 that were not included in the original PR. 

### Changes
- Use `Map.of` where possible
- Use more expressive `Optional.ofNullable(...)` pattern when building the map
- Correctly annotate configuration properties with `@Nullable`
  - We need to make this compatible with crawler configuration hence almost everything except for: label, sensitive, required is nullable so the null checks in code are needed 

