### PR TITLE
Set visibility of `failure_store` param of Rollover API to `feature_flag`

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -66,7 +66,9 @@
       },
       "failure_store":{
         "type":"boolean",
-        "description":"If set to true, the rollover action will be applied on the failure store of the data stream."
+        "description":"If set to true, the rollover action will be applied on the failure store of the data stream.",
+        "visibility": "feature_flag",
+        "feature_flag": "es.failure_store_feature_flag_enabled"
       }
     },
     "body":{


### PR DESCRIPTION
Follow up of https://github.com/elastic/elasticsearch/pull/106715