### PR TITLE
Rename values of `FailureStoreOptions`

### DIFF
--- a/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/put-job.asciidoc
@@ -537,4 +537,4 @@ The API returns the following results:
 // TESTRESPONSE[s/"job_version" : "8.4.0"/"job_version" : $body.job_version/]
 // TESTRESPONSE[s/1656087283340/$body.$_path/]
 // TESTRESPONSE[s/"superuser"/"_es_test_root"/]
-// TESTRESPONSE[s/"ignore_throttled" : true/"ignore_throttled" : true,"failure_store":"false"/]
+// TESTRESPONSE[s/"ignore_throttled" : true/"ignore_throttled" : true,"failure_store":"exclude"/]

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/FailureStoreQueryParamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/FailureStoreQueryParamIT.java
@@ -75,13 +75,13 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
             assertThat(indices.containsKey(failureStoreIndex), is(true));
         }
         {
-            final Response indicesResponse = client().performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "?failure_store=false"));
+            final Response indicesResponse = client().performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "?failure_store=exclude"));
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(1));
             assertThat(indices.containsKey(backingIndex), is(true));
         }
         {
-            final Response indicesResponse = client().performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "?failure_store=true"));
+            final Response indicesResponse = client().performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "?failure_store=only"));
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(1));
             assertThat(indices.containsKey(failureStoreIndex), is(true));
@@ -107,7 +107,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response statsResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_stats?failure_store=true")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_stats?failure_store=only")
             );
             Map<String, Object> indices = (Map<String, Object>) entityAsMap(statsResponse).get("indices");
             assertThat(indices.size(), is(1));
@@ -133,7 +133,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response indicesResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_settings?failure_store=true")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_settings?failure_store=only")
             );
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(1));
@@ -159,7 +159,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response indicesResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_mapping?failure_store=true")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_mapping?failure_store=only")
             );
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(1));

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/FailureStoreQueryParamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/FailureStoreQueryParamIT.java
@@ -81,7 +81,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
             assertThat(indices.containsKey(backingIndex), is(true));
         }
         {
-            final Response indicesResponse = client().performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "?failure_store=only"));
+            final Response indicesResponse = client().performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "?failure_store=true"));
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(1));
             assertThat(indices.containsKey(failureStoreIndex), is(true));
@@ -98,7 +98,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response statsResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_stats?failure_store=true")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_stats?failure_store=include")
             );
             Map<String, Object> indices = (Map<String, Object>) entityAsMap(statsResponse).get("indices");
             assertThat(indices.size(), is(2));
@@ -107,7 +107,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response statsResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_stats?failure_store=only")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_stats?failure_store=true")
             );
             Map<String, Object> indices = (Map<String, Object>) entityAsMap(statsResponse).get("indices");
             assertThat(indices.size(), is(1));
@@ -124,7 +124,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response indicesResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_settings?failure_store=true")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_settings?failure_store=include")
             );
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(2));
@@ -133,7 +133,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response indicesResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_settings?failure_store=only")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_settings?failure_store=true")
             );
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(1));
@@ -150,7 +150,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response indicesResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_mapping?failure_store=true")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_mapping?failure_store=include")
             );
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(2));
@@ -159,7 +159,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
         }
         {
             final Response indicesResponse = client().performRequest(
-                new Request("GET", "/" + DATA_STREAM_NAME + "/_mapping?failure_store=only")
+                new Request("GET", "/" + DATA_STREAM_NAME + "/_mapping?failure_store=true")
             );
             Map<String, Object> indices = entityAsMap(indicesResponse);
             assertThat(indices.size(), is(1));
@@ -183,7 +183,7 @@ public class FailureStoreQueryParamIT extends DisabledSecurityDataStreamTestCase
             assertAcknowledged(client().performRequest(mappingRequest));
         }
         {
-            final Request mappingRequest = new Request("PUT", "/" + DATA_STREAM_NAME + "/_mapping?failure_store=true");
+            final Request mappingRequest = new Request("PUT", "/" + DATA_STREAM_NAME + "/_mapping?failure_store=include");
             mappingRequest.setJsonEntity("""
                 {
                   "properties": {

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/200_rollover_failure_store.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/200_rollover_failure_store.yml
@@ -32,7 +32,7 @@ setup:
   - do:
       indices.rollover:
         alias: "data-stream-for-rollover"
-        failure_store: true
+        target_failure_store: true
 
   - match: { old_index: "/\\.fs-data-stream-for-rollover-(\\d{4}\\.\\d{2}\\.\\d{2}-)?000001/" }
   - match: { new_index: "/\\.fs-data-stream-for-rollover-(\\d{4}\\.\\d{2}\\.\\d{2}-)?000002/" }
@@ -67,7 +67,7 @@ setup:
   - do:
       indices.rollover:
         alias: "data-stream-for-rollover"
-        failure_store: true
+        target_failure_store: true
         body:
           conditions:
             max_docs: 1
@@ -96,7 +96,7 @@ setup:
   - do:
       indices.rollover:
         alias: "data-stream-for-rollover"
-        failure_store: true
+        target_failure_store: true
         body:
           conditions:
             max_docs: 1

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.rollover.json
@@ -64,7 +64,7 @@
         "default":"false",
         "description":"If set to true, the rollover action will only mark a data stream to signal that it needs to be rolled over at the next write. Only allowed on data streams."
       },
-      "failure_store":{
+      "target_failure_store":{
         "type":"boolean",
         "description":"If set to true, the rollover action will be applied on the failure store of the data stream."
       }

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -418,8 +418,8 @@ public record IndicesOptions(
 
         public static final String FAILURE_STORE = "failure_store";
         public static final String INCLUDE_ALL = "include";
-        public static final String INCLUDE_ONLY_REGULAR_INDICES = "false";
-        public static final String INCLUDE_ONLY_FAILURE_INDICES = "true";
+        public static final String INCLUDE_ONLY_REGULAR_INDICES = "exclude";
+        public static final String INCLUDE_ONLY_FAILURE_INDICES = "only";
 
         public static final FailureStoreOptions DEFAULT = new FailureStoreOptions(true, false);
 

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -417,9 +417,9 @@ public record IndicesOptions(
             ToXContentFragment {
 
         public static final String FAILURE_STORE = "failure_store";
-        public static final String INCLUDE_ALL = "true";
+        public static final String INCLUDE_ALL = "include";
         public static final String INCLUDE_ONLY_REGULAR_INDICES = "false";
-        public static final String INCLUDE_ONLY_FAILURE_INDICES = "only";
+        public static final String INCLUDE_ONLY_FAILURE_INDICES = "true";
 
         public static final FailureStoreOptions DEFAULT = new FailureStoreOptions(true, false);
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
@@ -54,7 +54,7 @@ public class RestRolloverIndexAction extends BaseRestHandler {
         rolloverIndexRequest.timeout(request.paramAsTime("timeout", rolloverIndexRequest.timeout()));
         rolloverIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", rolloverIndexRequest.masterNodeTimeout()));
         if (DataStream.isFailureStoreEnabled()) {
-            boolean failureStore = request.paramAsBoolean("failure_store", false);
+            boolean failureStore = request.paramAsBoolean("target_failure_store", false);
             if (failureStore) {
                 rolloverIndexRequest.setIndicesOptions(
                     IndicesOptions.builder(rolloverIndexRequest.indicesOptions())


### PR DESCRIPTION
With these new values, there's a better match between selecting failure stores in read and write operations. 

Failure stores are currently still behind a feature flag, so we can rename these without all hell breaking loose :)