### PR TITLE
Extract failure store specific settings to the failure store

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
@@ -23,6 +23,7 @@ import java.io.IOException;
  */
 public class DataStreamFailureStoreDefinition {
 
+    public static final String FAILURE_STORE_REFRESH_INTERVAL_SETTING_NAME = "data_streams.failure_store.refresh_interval";
     public static final CompressedXContent DATA_STREAM_FAILURE_STORE_MAPPING;
 
     static {
@@ -134,8 +135,6 @@ public class DataStreamFailureStoreDefinition {
             throw new AssertionError(e);
         }
     }
-
-    public static final String FAILURE_STORE_REFRESH_INTERVAL_SETTING_NAME = "data_streams.failure_store.refresh_interval";
 
     public static TimeValue getFailureStoreRefreshInterval(Settings settings) {
         return settings.getAsTime(FAILURE_STORE_REFRESH_INTERVAL_SETTING_NAME, null);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamFailureStoreDefinition.java
@@ -9,6 +9,9 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
@@ -130,5 +133,45 @@ public class DataStreamFailureStoreDefinition {
         } catch (IOException e) {
             throw new AssertionError(e);
         }
+    }
+
+    public static final String FAILURE_STORE_REFRESH_INTERVAL_SETTING_NAME = "data_streams.failure_store.refresh_interval";
+
+    public static TimeValue getFailureStoreRefreshInterval(Settings settings) {
+        return settings.getAsTime(FAILURE_STORE_REFRESH_INTERVAL_SETTING_NAME, null);
+    }
+
+    /**
+     * Like {@link DataStreamFailureStoreDefinition#applyFailureStoreSettings} but optionally applied on an existing {@link Settings}
+     * @param existingSettings initial settings to update
+     * @param nodeSettings settings from the cluster service which capture the node's current settings
+     * @return either the existing settings if no changes are needed, or a new settings instance which includes failure store specific
+     * settings
+     */
+    public static Settings buildFailureStoreIndexSettings(Settings existingSettings, Settings nodeSettings) {
+        // Optionally set a custom refresh interval for the failure store index.
+        TimeValue refreshInterval = getFailureStoreRefreshInterval(nodeSettings);
+        if (refreshInterval != null) {
+            return Settings.builder()
+                .put(existingSettings)
+                .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), refreshInterval)
+                .build();
+        }
+        return existingSettings;
+    }
+
+    /**
+     * Like {@link DataStreamFailureStoreDefinition#buildFailureStoreIndexSettings} but for usage with a {@link Settings.Builder}
+     * @param nodeSettings settings from the cluster service which capture the node's current settings
+     * @param builder to capture failure store specific index settings
+     * @return the original settings builder, with any failure store specific settings applied
+     */
+    public static Settings.Builder applyFailureStoreSettings(Settings nodeSettings, Settings.Builder builder) {
+        // Optionally set a custom refresh interval for the failure store index.
+        TimeValue refreshInterval = getFailureStoreRefreshInterval(nodeSettings);
+        if (refreshInterval != null) {
+            builder.put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), refreshInterval);
+        }
+        return builder;
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -31,7 +31,6 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
@@ -422,15 +421,10 @@ public class MetadataCreateDataStreamService {
             return currentState;
         }
 
-        var indexSettings = MetadataRolloverService.HIDDEN_INDEX_SETTINGS;
-        // Optionally set a custom refresh interval for the failure store index.
-        var refreshInterval = getFailureStoreRefreshInterval(settings);
-        if (refreshInterval != null) {
-            indexSettings = Settings.builder()
-                .put(indexSettings)
-                .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), refreshInterval)
-                .build();
-        }
+        var indexSettings = DataStreamFailureStoreDefinition.buildFailureStoreIndexSettings(
+            MetadataRolloverService.HIDDEN_INDEX_SETTINGS,
+            settings
+        );
 
         CreateIndexClusterStateUpdateRequest createIndexRequest = new CreateIndexClusterStateUpdateRequest(
             cause,
@@ -488,9 +482,5 @@ public class MetadataCreateDataStreamService {
         }
         // Sanity check (this validation logic should already have been executed when merging mappings):
         fieldMapper.validate(mappingLookup);
-    }
-
-    public static TimeValue getFailureStoreRefreshInterval(Settings settings) {
-        return settings.getAsTime(FAILURE_STORE_REFRESH_INTERVAL_SETTING_NAME, null);
     }
 }


### PR DESCRIPTION
This refactoring PR moves the failure store specific settings logic to the same place that we manage their mappings.

This is the follow on PR that was mentioned in #107025
