### PR TITLE
[DOCS] Update tutorial to discourage editing managed ILM policies

### DIFF
--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -65,23 +65,23 @@ node.roles: [ data_warm ]
 cluster.
 
 [discrete]
-[[example-using-index-lifecycle-policy-view-ilm-policy]]
-==== View and edit the policy
+[[example-using-index-lifecycle-policy-duplicate-ilm-policy]]
+==== Duplicate the policy
 
 {agent} uses data streams with an index pattern of `logs-*-*` to store log
 monitoring data. The managed `logs@lifecycle` {ilm-init} policy automatically manages
 backing indices for these data streams. 
 
-If you don't want to use the policy defaults, then you can duplicate the managed policy and customize it.
+If you don't want to use the policy defaults, then you can customize the managed policy and then save it as a new policy. You can then use the new policy in related component templates and index templates.
 
-You should only edit duplicates of managed policies. Changes to managed policies might be rolled back or overwritten.
+CAUTION: You should never edit managed policies directly. Changes to managed policies might be rolled back or overwritten.
 
-To duplicate the `logs@lifecycle` policy in {kib}:
+To save the `logs@lifecycle` policy as a new policy in {kib}:
 
-. Open the menu and go to **Stack Management > Index Lifecycle Policies**.
+. Open the menu and go to **Stack Management** > **Index Lifecycle Policies**.
 . Toggle **Include managed system policies**.
 . Select the `logs@lifecycle` policy.
-. On the **Edit policy logs** page, toggle **Save as new policy**, and then provide a new name for the policy.
+. On the **Edit policy logs** page, toggle **Save as new policy**, and then provide a new name for the policy, for example, `logs-custom`.
 
 The `logs@lifecycle` policy uses the recommended rollover defaults: Start writing to a new
 index when the current write index reaches 50GB or becomes 30 days old.
@@ -128,10 +128,27 @@ image::images/ilm/tutorial-ilm-delete-rollover.png[Add a delete phase]
 
 . Click **Save as new policy**.
 
-[discrete]
-[[ilm-ex-next-steps]]
-==== Next steps
+TIP:  Copies of managed {ilm-init} policies are also marked as **Managed**. You can use the <<ilm-put-lifecycle,Create or update lifecycle policy API>> to update the `_meta.managed` parameter to `false`.
 
-- Configure a settings <<indices-component-template,component template>> that uses the new {ilm-init} policy. Consider cloning the managed **logs@settings** template and updating the `index.lifecycle.name` setting.
-- Use your new {ilm-init} policy or component template in an <<index-templates,index template>>. Consider cloning the managed **logs** index template. Make sure to set the index template priority to a higher value than the managed template.
-- Optional: Copies of managed {ilm-init} policies are also marked as **Managed**. Use the <<ilm-put-lifecycle,Create or update lifecycle policy API>> to update the `_meta.managed` parameter to `false`.
+[discrete]
+[[example-using-index-lifecycle-policy-apply-policy]]
+==== Apply the policy
+
+To apply your new {ilm-init} policy to the `logs` index template, edit the `logs@settings` component template.
+
+. Click on the **Component Template** tab and search for `logs`.
+. Select the `logs@settings` template and click **Manage** > **Edit**.
+. Under **Index settings**, set the ILM policy name created in the previous step:
++
+[source,console]
+--------------------------------------------------
+{
+    "index": {
+        "lifecycle": {
+            "name": "logs-custom"
+        }
+    }
+}
+--------------------------------------------------
++
+. Continue to **Review**, and then click **Save component template**.

--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -142,7 +142,7 @@ A `*@custom` component template allows you to customize the mappings and setting
 . Under **Logistics**, name the component template `logs@custom`.
 . Under **Index settings**, set the {ilm-init} policy name created in the previous step:
 +
-[source,console-result]
+[source,json]
 --------------------------------------------------
 {
     "index": {

--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -134,11 +134,13 @@ TIP:  Copies of managed {ilm-init} policies are also marked as **Managed**. You 
 [[example-using-index-lifecycle-policy-apply-policy]]
 ==== Apply the policy
 
-To apply your new {ilm-init} policy to the `logs` index template, edit the `logs@settings` component template.
+To apply your new {ilm-init} policy to the `logs` index template, create or edit the `logs@custom` component template. 
 
-. Click on the **Component Template** tab and search for `logs`.
-. Select the `logs@settings` template and click **Manage** > **Edit**.
-. Under **Index settings**, set the ILM policy name created in the previous step:
+A `*@custom` component template allows you to customize the mappings and settings of managed index templates, without having to override managed index templates or component templates. This type of component template is automatically picked up by the index template. <<put-component-template-api-path-params,Learn more>>.
+
+. Click on the **Component Template** tab and click **Create component template**.
+. Under **Logistics**, name the component template `logs@custom`.
+. Under **Index settings**, set the {ilm-init} policy name created in the previous step:
 +
 [source,console]
 --------------------------------------------------
@@ -152,3 +154,5 @@ To apply your new {ilm-init} policy to the `logs` index template, edit the `logs
 --------------------------------------------------
 +
 . Continue to **Review**, and then click **Save component template**.
+. Click the **Index Templates**, tab, and then select the `logs` index template.
+. In the summary, view the **Component templates** list. `logs@custom` should be listed.

--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -142,7 +142,7 @@ A `*@custom` component template allows you to customize the mappings and setting
 . Under **Logistics**, name the component template `logs@custom`.
 . Under **Index settings**, set the {ilm-init} policy name created in the previous step:
 +
-[source,json]
+[source,JSON]
 --------------------------------------------------
 {
     "index": {

--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -142,7 +142,7 @@ A `*@custom` component template allows you to customize the mappings and setting
 . Under **Logistics**, name the component template `logs@custom`.
 . Under **Index settings**, set the {ilm-init} policy name created in the previous step:
 +
-[source,console]
+[source,console-result]
 --------------------------------------------------
 {
     "index": {

--- a/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
+++ b/docs/reference/ilm/example-index-lifecycle-policy.asciidoc
@@ -1,5 +1,3 @@
-[role="xpack"]
-
 [[example-using-index-lifecycle-policy]]
 === Tutorial: Customize built-in {ilm-init} policies
 
@@ -9,9 +7,9 @@
 
 {es} includes the following built-in {ilm-init} policies:
 
-- `logs`
-- `metrics`
-- `synthetics`
+- `logs@lifecycle`
+- `metrics@lifecycle`
+- `synthetics@lifecycle`
 
 {agent} uses these policies to manage backing indices for its data streams.
 This tutorial shows you how to use {kib}’s **Index Lifecycle Policies** to
@@ -68,19 +66,24 @@ cluster.
 
 [discrete]
 [[example-using-index-lifecycle-policy-view-ilm-policy]]
-==== View the policy
+==== View and edit the policy
 
 {agent} uses data streams with an index pattern of `logs-*-*` to store log
-monitoring data. The built-in `logs` {ilm-init} policy automatically manages
-backing indices for these data streams.
+monitoring data. The managed `logs@lifecycle` {ilm-init} policy automatically manages
+backing indices for these data streams. 
 
-To view the `logs` policy in {kib}:
+If you don't want to use the policy defaults, then you can duplicate the managed policy and customize it.
+
+You should only edit duplicates of managed policies. Changes to managed policies might be rolled back or overwritten.
+
+To duplicate the `logs@lifecycle` policy in {kib}:
 
 . Open the menu and go to **Stack Management > Index Lifecycle Policies**.
-. Select **Include managed system policies**.
-. Select the `logs` policy.
+. Toggle **Include managed system policies**.
+. Select the `logs@lifecycle` policy.
+. On the **Edit policy logs** page, toggle **Save as new policy**, and then provide a new name for the policy.
 
-The `logs` policy uses the recommended rollover defaults: Start writing to a new
+The `logs@lifecycle` policy uses the recommended rollover defaults: Start writing to a new
 index when the current write index reaches 50GB or becomes 30 days old.
 
 To view or change the rollover settings, click **Advanced settings** for the hot
@@ -90,16 +93,12 @@ settings.
 [role="screenshot"]
 image::images/ilm/tutorial-ilm-hotphaserollover-default.png[View rollover defaults]
 
-Note that {kib} displays a warning that editing a managed policy can break
-Kibana. For this tutorial, you can ignore that warning and proceed with
-modifying the policy.
-
 [discrete]
 [[ilm-ex-modify-policy]]
 ==== Modify the policy
 
-The default `logs` policy is designed to prevent the creation of many tiny daily
-indices. You can modify the policy to meet your performance requirements and
+The default `logs@lifecycle` policy is designed to prevent the creation of many tiny daily
+indices. You can modify your copy of the policy to meet your performance requirements and
 manage resource usage.
 
 . Activate the warm phase and click **Advanced settings**.
@@ -127,4 +126,12 @@ deletes indices 90 days after rollover.
 [role="screenshot"]
 image::images/ilm/tutorial-ilm-delete-rollover.png[Add a delete phase]
 
-. Click **Save Policy**.
+. Click **Save as new policy**.
+
+[discrete]
+[[ilm-ex-next-steps]]
+==== Next steps
+
+- Configure a settings <<indices-component-template,component template>> that uses the new {ilm-init} policy. Consider cloning the managed **logs@settings** template and updating the `index.lifecycle.name` setting.
+- Use your new {ilm-init} policy or component template in an <<index-templates,index template>>. Consider cloning the managed **logs** index template. Make sure to set the index template priority to a higher value than the managed template.
+- Optional: Copies of managed {ilm-init} policies are also marked as **Managed**. Use the <<ilm-put-lifecycle,Create or update lifecycle policy API>> to update the `_meta.managed` parameter to `false`.


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/103264

Updates the [Tutorial: Customize built-in ILM policies](https://www.elastic.co/guide/en/elasticsearch/reference/current/example-using-index-lifecycle-policy.html) tutorial

Instead of instructing users to edit the policy, instruct them to use the **Save as new policy** toggle to create a new policy, and then reference the new policy in a new `logs@custom` component template, which allows you to override managed component template + index template settings + mappings.

@ platform docs writers: this is my biggest PR so far, so please give me any style feedback that you have!
