### PR TITLE
Add ability to create REST client requests in a builder style

### DIFF
--- a/client/rest/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/Request.java
@@ -72,17 +72,19 @@ public final class Request {
      * @throws IllegalArgumentException if a parameter with that name has
      *      already been set
      */
-    public void addParameter(String name, String value) {
+    public Request addParameter(String name, String value) {
         Objects.requireNonNull(name, "url parameter name cannot be null");
         if (parameters.containsKey(name)) {
             throw new IllegalArgumentException("url parameter [" + name + "] has already been set to [" + parameters.get(name) + "]");
         } else {
             parameters.put(name, value);
         }
+        return this;
     }
 
-    public void addParameters(Map<String, String> paramSource) {
+    public Request addParameters(Map<String, String> paramSource) {
         paramSource.forEach(this::addParameter);
+        return this;
     }
 
     /**
@@ -98,8 +100,9 @@ public final class Request {
      * Set the body of the request. If not set or set to {@code null} then no
      * body is sent with the request.
      */
-    public void setEntity(HttpEntity entity) {
+    public Request setEntity(HttpEntity entity) {
         this.entity = entity;
+        return this;
     }
 
     /**
@@ -109,8 +112,9 @@ public final class Request {
      * If you need a different content type then use
      * {@link #setEntity(HttpEntity)}.
      */
-    public void setJsonEntity(String body) {
+    public Request setJsonEntity(String body) {
         setEntity(body == null ? null : new NStringEntity(body, ContentType.APPLICATION_JSON));
+        return this;
     }
 
     /**
@@ -125,18 +129,20 @@ public final class Request {
      * Set the portion of an HTTP request to Elasticsearch that can be
      * manipulated without changing Elasticsearch's behavior.
      */
-    public void setOptions(RequestOptions options) {
+    public Request setOptions(RequestOptions options) {
         Objects.requireNonNull(options, "options cannot be null");
         this.options = options;
+        return this;
     }
 
     /**
      * Set the portion of an HTTP request to Elasticsearch that can be
      * manipulated without changing Elasticsearch's behavior.
      */
-    public void setOptions(RequestOptions.Builder options) {
+    public Request setOptions(RequestOptions.Builder options) {
         Objects.requireNonNull(options, "options cannot be null");
         this.options = options.build();
+        return this;
     }
 
     /**

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientGzipCompressionTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientGzipCompressionTests.java
@@ -145,9 +145,8 @@ public class RestClientGzipCompressionTests extends RestClientTestCase {
         RestClient restClient = createClient(false);
 
         // Send non-compressed request, expect compressed response
-        Request request = new Request("POST", "/");
-        request.setEntity(new StringEntity("plain request, gzip response", ContentType.TEXT_PLAIN));
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Accept-Encoding", "gzip").build());
+        Request request = new Request("POST", "/").setEntity(new StringEntity("plain request, gzip response", ContentType.TEXT_PLAIN))
+            .setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Accept-Encoding", "gzip").build());
 
         Response response = restClient.performRequest(request);
 
@@ -162,9 +161,8 @@ public class RestClientGzipCompressionTests extends RestClientTestCase {
         RestClient restClient = createClient(false);
 
         // Send non-compressed request, expect compressed response
-        Request request = new Request("POST", "/");
-        request.setEntity(new StringEntity("plain request, gzip response", ContentType.TEXT_PLAIN));
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Accept-Encoding", "gzip").build());
+        Request request = new Request("POST", "/").setEntity(new StringEntity("plain request, gzip response", ContentType.TEXT_PLAIN))
+            .setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Accept-Encoding", "gzip").build());
 
         FutureResponse futureResponse = new FutureResponse();
         restClient.performRequestAsync(request, futureResponse);

--- a/docs/changelog/107078.yaml
+++ b/docs/changelog/107078.yaml
@@ -1,0 +1,5 @@
+pr: 107078
+summary: Add ability to create REST client requests in a builder style
+area: Java Low Level REST Client
+type: enhancement
+issues: []

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/MlDeprecationIT.java
@@ -80,7 +80,7 @@ public class MlDeprecationIT extends ESRestTestCase {
     }
 
     private Response buildAndPutJob(String jobId) throws Exception {
-        String jobConfig = """
+        Request request = new Request("PUT", "/_ml/anomaly_detectors/" + jobId).setOptions(REQUEST_OPTIONS).setJsonEntity("""
             {
                 "analysis_config" : {
                     "bucket_span": "3600s",
@@ -90,18 +90,12 @@ public class MlDeprecationIT extends ESRestTestCase {
                     "time_field":"time",
                     "time_format":"yyyy-MM-dd HH:mm:ssX"
                 }
-            }""";
-
-        Request request = new Request("PUT", "/_ml/anomaly_detectors/" + jobId);
-        request.setOptions(REQUEST_OPTIONS);
-        request.setJsonEntity(jobConfig);
+            }""");
         return client().performRequest(request);
     }
 
     private Response indexDoc(String index, String docId, String source) throws IOException {
-        Request request = new Request("PUT", "/" + index + "/_doc/" + docId);
-        request.setOptions(REQUEST_OPTIONS);
-        request.setJsonEntity(source);
+        Request request = new Request("PUT", "/" + index + "/_doc/" + docId).setOptions(REQUEST_OPTIONS).setJsonEntity(source);
         return client().performRequest(request);
     }
 

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdpRestTestCase.java
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdpRestTestCase.java
@@ -61,8 +61,9 @@ public abstract class IdpRestTestCase extends ESRestTestCase {
             true
         );
         final String endpoint = "/_security/user/" + username;
-        final Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        final String body = Strings.format("""
+        final Request request = new Request(HttpPut.METHOD_NAME, endpoint).setJsonEntity(
+            Strings.format(
+                """
             {
                 "username": "%s",
                 "full_name": "%s",
@@ -70,10 +71,9 @@ public abstract class IdpRestTestCase extends ESRestTestCase {
                 "password": "%s",
                 "roles": [ "%s" ]
             }
-            """, user.principal(), user.fullName(), user.email(), password.toString(), role);
-        request.setJsonEntity(body);
-        request.addParameters(Map.of("refresh", "true"));
-        request.setOptions(RequestOptions.DEFAULT);
+            """, user.principal(), user.fullName(), user.email(), password.toString(), role))
+            .addParameters(Map.of("refresh", "true"))
+            .setOptions(RequestOptions.DEFAULT);
         adminClient().performRequest(request);
 
         return user;
@@ -81,10 +81,9 @@ public abstract class IdpRestTestCase extends ESRestTestCase {
 
     protected void deleteUser(String username) throws IOException {
         final String endpoint = "/_security/user/" + username;
-        final Request request = new Request(HttpDelete.METHOD_NAME, endpoint);
-        request.addParameters(Map.of("refresh", "true"));
-        request.setOptions(RequestOptions.DEFAULT);
-        adminClient().performRequest(request);
+        adminClient().performRequest(
+            new Request(HttpDelete.METHOD_NAME, endpoint).addParameters(Map.of("refresh", "true")).setOptions(RequestOptions.DEFAULT)
+        );
     }
 
     protected void createRole(

--- a/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdpRestTestCase.java
+++ b/x-pack/plugin/identity-provider/qa/idp-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/idp/IdpRestTestCase.java
@@ -61,9 +61,7 @@ public abstract class IdpRestTestCase extends ESRestTestCase {
             true
         );
         final String endpoint = "/_security/user/" + username;
-        final Request request = new Request(HttpPut.METHOD_NAME, endpoint).setJsonEntity(
-            Strings.format(
-                """
+        final Request request = new Request(HttpPut.METHOD_NAME, endpoint).setJsonEntity(Strings.format("""
             {
                 "username": "%s",
                 "full_name": "%s",

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ClusterPrivilegeIntegrationTests.java
@@ -192,9 +192,8 @@ public class ClusterPrivilegeIntegrationTests extends AbstractPrivilegeTestCase 
         assertAccessIsDenied("user_e", "PUT", "/_snapshot/my-repo", repoJson);
         assertAccessIsAllowed("user_a", "PUT", "/_snapshot/my-repo", repoJson);
 
-        Request createBar = new Request("PUT", "/someindex/_doc/1");
-        createBar.setJsonEntity("{ \"name\" : \"elasticsearch\" }");
-        createBar.addParameter("refresh", "true");
+        Request createBar = new Request("PUT", "/someindex/_doc/1").setJsonEntity("{ \"name\" : \"elasticsearch\" }")
+            .addParameter("refresh", "true");
         assertAccessIsDenied("user_a", createBar);
         assertAccessIsDenied("user_b", createBar);
         assertAccessIsDenied("user_d", createBar);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/CreateDocsIndexPrivilegeTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/CreateDocsIndexPrivilegeTests.java
@@ -57,9 +57,7 @@ public class CreateDocsIndexPrivilegeTests extends AbstractPrivilegeTestCase {
 
     @Before
     public void insertBaseDocumentsAsAdmin() throws Exception {
-        Request request = new Request("PUT", "/" + INDEX_NAME + "/_doc/1");
-        request.setJsonEntity(jsonDoc);
-        request.addParameter("refresh", "true");
+        Request request = new Request("PUT", "/" + INDEX_NAME + "/_doc/1").setJsonEntity(jsonDoc).addParameter("refresh", "true");
         assertAccessIsAllowed("admin", request);
     }
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndexPrivilegeIntegTests.java
@@ -156,9 +156,7 @@ public class IndexPrivilegeIntegTests extends AbstractPrivilegeTestCase {
     public void insertBaseDocumentsAsAdmin() throws Exception {
         // indices: a,b,c,abc
         for (String index : new String[] { "a", "b", "c", "abc" }) {
-            Request request = new Request("PUT", "/" + index + "/_doc/1");
-            request.setJsonEntity(jsonDoc);
-            request.addParameter("refresh", "true");
+            Request request = new Request("PUT", "/" + index + "/_doc/1").setJsonEntity(jsonDoc).addParameter("refresh", "true");
             assertAccessIsAllowed("admin", request);
         }
     }

--- a/x-pack/plugin/slm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/slm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -690,16 +690,17 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
 
     private static void createComposableTemplate(RestClient client, String templateName, String indexPattern, Template template)
         throws IOException {
-        XContentBuilder builder = jsonBuilder();
-        template.toXContent(builder, ToXContent.EMPTY_PARAMS);
-        StringEntity templateJSON = new StringEntity(String.format(Locale.ROOT, """
-            {
-              "index_patterns": "%s",
-              "data_stream": {},
-              "template": %s
-            }""", indexPattern, Strings.toString(builder)), ContentType.APPLICATION_JSON);
-        Request createIndexTemplateRequest = new Request("PUT", "_index_template/" + templateName);
-        createIndexTemplateRequest.setEntity(templateJSON);
+        Request createIndexTemplateRequest = new Request("PUT", "_index_template/" + templateName).setEntity(
+            new StringEntity(
+                String.format(Locale.ROOT, """
+                    {
+                      "index_patterns": "%s",
+                      "data_stream": {},
+                      "template": %s
+                    }""", indexPattern, Strings.toString(template.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS))),
+                ContentType.APPLICATION_JSON
+            )
+        );
         client.performRequest(createIndexTemplateRequest);
     }
 

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/ContinuousTestCase.java
@@ -112,10 +112,7 @@ public abstract class ContinuousTestCase extends ESRestTestCase {
 
     protected Response search(String index, String query, Map<String, String> queryParameters) throws IOException {
         try {
-            Request searchRequest = new Request("GET", index + "/_search");
-            searchRequest.setJsonEntity(query);
-            searchRequest.addParameters(queryParameters);
-            return client().performRequest(searchRequest);
+            return client().performRequest(new Request("GET", index + "/_search").setJsonEntity(query).addParameters(queryParameters));
         } catch (Exception e) {
             logger.error("Search failed with an exception.", e);
             throw e;

--- a/x-pack/qa/security-example-spi-extension/src/javaRestTest/java/org/elasticsearch/example/role/CustomRolesProviderIT.java
+++ b/x-pack/qa/security-example-spi-extension/src/javaRestTest/java/org/elasticsearch/example/role/CustomRolesProviderIT.java
@@ -55,18 +55,13 @@ public class CustomRolesProviderIT extends ESRestTestCase {
 
     public void setupTestUser(String role) throws IOException {
         final String endpoint = "/_security/user/" + TEST_USER;
-        Request request = new Request(HttpPut.METHOD_NAME, endpoint);
-        final String body = Strings.format("""
+        adminClient().performRequest(new Request(HttpPut.METHOD_NAME, endpoint).setJsonEntity(Strings.format("""
             {
                 "username": "%s",
                 "password": "%s",
                 "roles": [ "%s" ]
             }
-            """, TEST_USER, TEST_PWD, role);
-        request.setJsonEntity(body);
-        request.addParameters(Map.of("refresh", "true"));
-        request.setOptions(RequestOptions.DEFAULT);
-        adminClient().performRequest(request);
+            """, TEST_USER, TEST_PWD, role)).addParameters(Map.of("refresh", "true")).setOptions(RequestOptions.DEFAULT));
     }
 
     public void testAuthorizedCustomRoleSucceeds() throws Exception {


### PR DESCRIPTION
Add an option to chain `setJsonEntity`, `setEntity`, `addParameter`, `setOptions` calls on `Request`, so we can create client requests in a builder style without requiring explicitly declare `Request` as a variable. 