### PR TITLE
Capture hot threads during slow cluster state application

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierRecordingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierRecordingService.java
@@ -10,6 +10,7 @@ package org.elasticsearch.cluster.service;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.service.ClusterApplierRecordingService.Stats.Recording;
@@ -98,6 +99,7 @@ public final class ClusterApplierRecordingService {
 
                     @Override
                     public void onFailure(Exception e) {
+                        assert e instanceof ElasticsearchTimeoutException : e; // didn't complete in time
                         HotThreads.logLocalHotThreads(
                             logger,
                             Level.DEBUG,

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierRecordingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierRecordingService.java
@@ -7,7 +7,13 @@
  */
 package org.elasticsearch.cluster.service;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.service.ClusterApplierRecordingService.Stats.Recording;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -16,6 +22,8 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.monitor.jvm.HotThreads;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -28,9 +36,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.LongSupplier;
 
 public final class ClusterApplierRecordingService {
+
+    private static final Logger logger = LogManager.getLogger(ClusterApplierRecordingService.class);
 
     private final Map<String, MeanMetric> recordedActions = new HashMap<>();
 
@@ -59,13 +68,16 @@ public final class ClusterApplierRecordingService {
     static final class Recorder {
 
         private String currentAction;
-        private long startTimeMS;
+        private long startMillis;
         private boolean recording;
+        private SubscribableListener<Void> currentListener;
         private final List<Tuple<String, Long>> recordings = new LinkedList<>();
-        private final LongSupplier currentTimeSupplier;
+        private final ThreadPool threadPool;
+        private final TimeValue debugLoggingTimeout;
 
-        Recorder(LongSupplier currentTimeSupplier) {
-            this.currentTimeSupplier = currentTimeSupplier;
+        Recorder(ThreadPool threadPool, TimeValue debugLoggingTimeout) {
+            this.threadPool = threadPool;
+            this.debugLoggingTimeout = debugLoggingTimeout;
         }
 
         Releasable record(String action) {
@@ -75,14 +87,39 @@ public final class ClusterApplierRecordingService {
 
             this.recording = true;
             this.currentAction = action;
-            this.startTimeMS = currentTimeSupplier.getAsLong();
+            this.startMillis = threadPool.rawRelativeTimeInMillis();
+
+            if (logger.isDebugEnabled()) {
+                currentListener = new SubscribableListener<>();
+                currentListener.addTimeout(debugLoggingTimeout, threadPool, threadPool.generic());
+                currentListener.addListener(new ActionListener<>() {
+                    @Override
+                    public void onResponse(Void unused) {}
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        HotThreads.logLocalHotThreads(
+                            logger,
+                            Level.DEBUG,
+                            "hot threads while applying cluster state [" + currentAction + ']',
+                            ReferenceDocs.LOGGING
+                        );
+                    }
+                });
+            }
+
             return this::stop;
         }
 
         void stop() {
             recording = false;
-            long timeSpentMS = currentTimeSupplier.getAsLong() - this.startTimeMS;
-            recordings.add(new Tuple<>(currentAction, timeSpentMS));
+            long elapsedMillis = threadPool.rawRelativeTimeInMillis() - this.startMillis;
+            recordings.add(new Tuple<>(currentAction, elapsedMillis));
+
+            if (currentListener != null) {
+                currentListener.onResponse(null);
+                currentListener = null;
+            }
         }
 
         List<Tuple<String, Long>> getRecordings() {

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -340,6 +340,7 @@ public final class ClusterSettings extends AbstractScopedSettings {
         IndexModule.NODE_STORE_ALLOW_MMAP,
         IndexSettings.NODE_DEFAULT_REFRESH_INTERVAL_SETTING,
         ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+        ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING,
         ClusterService.USER_DEFINED_METADATA,
         MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
         MasterService.MASTER_SERVICE_STARVATION_LOGGING_THRESHOLD_SETTING,

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierRecordingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierRecordingServiceTests.java
@@ -8,11 +8,18 @@
 
 package org.elasticsearch.cluster.service;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.cluster.service.ClusterApplierRecordingService.Recorder;
 import org.elasticsearch.cluster.service.ClusterApplierRecordingService.Stats.Recording;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
 
 import java.util.Map;
 
@@ -20,22 +27,37 @@ import static org.hamcrest.Matchers.contains;
 
 public class ClusterApplierRecordingServiceTests extends ESTestCase {
 
+    private DeterministicTaskQueue deterministicTaskQueue;
+    private ThreadPool threadPool;
+
+    @Before
+    public void createThreadPool() {
+        deterministicTaskQueue = new DeterministicTaskQueue();
+        deterministicTaskQueue.scheduleAt(between(0, 1000000), () -> {});
+        deterministicTaskQueue.runAllTasks();
+        threadPool = deterministicTaskQueue.getThreadPool();
+    }
+
+    private void advanceTime(long millis) {
+        deterministicTaskQueue.scheduleAt(deterministicTaskQueue.getCurrentTimeMillis() + millis, () -> {});
+        deterministicTaskQueue.runAllTasks();
+    }
+
     public void testRecorder() {
-        long[] currentTime = new long[1];
-        var recorder = new Recorder(() -> currentTime[0]);
+        var recorder = new Recorder(threadPool, TimeValue.ZERO);
         {
             Releasable releasable = recorder.record("action1");
-            currentTime[0] = 5;
+            advanceTime(5);
             releasable.close();
         }
         {
             Releasable releasable = recorder.record("action2");
-            currentTime[0] = 42;
+            advanceTime(37);
             releasable.close();
         }
         {
             Releasable releasable = recorder.record("action3");
-            currentTime[0] = 45;
+            advanceTime(3);
             releasable.close();
         }
 
@@ -44,8 +66,8 @@ public class ClusterApplierRecordingServiceTests extends ESTestCase {
     }
 
     public void testRecorderAlreadyRecording() {
-        var recorder = new Recorder(() -> 1L);
-        Releasable releasable = recorder.record("action1");
+        var recorder = new Recorder(threadPool, TimeValue.ZERO);
+        Releasable ignored = recorder.record("action1");
         expectThrows(IllegalStateException.class, () -> recorder.record("action2"));
     }
 
@@ -53,16 +75,15 @@ public class ClusterApplierRecordingServiceTests extends ESTestCase {
         var service = new ClusterApplierRecordingService();
 
         {
-            long[] currentTime = new long[1];
-            var recorder = new Recorder(() -> currentTime[0]);
+            var recorder = new Recorder(threadPool, TimeValue.ZERO);
             try (var r = recorder.record("action1")) {
-                currentTime[0] = 5;
+                advanceTime(5);
             }
             try (var r = recorder.record("action2")) {
-                currentTime[0] = 42;
+                advanceTime(37);
             }
             try (var r = recorder.record("action3")) {
-                currentTime[0] = 45;
+                advanceTime(3);
             }
             service.updateStats(recorder);
             var stats = service.getStats();
@@ -76,16 +97,15 @@ public class ClusterApplierRecordingServiceTests extends ESTestCase {
             );
         }
         {
-            long[] currentTime = new long[1];
-            var recorder = new Recorder(() -> currentTime[0]);
+            var recorder = new Recorder(threadPool, TimeValue.ZERO);
             try (var r = recorder.record("action1")) {
-                currentTime[0] = 3;
+                advanceTime(3);
             }
             try (var r = recorder.record("action2")) {
-                currentTime[0] = 35;
+                advanceTime(32);
             }
             try (var r = recorder.record("action3")) {
-                currentTime[0] = 41;
+                advanceTime(6);
             }
             service.updateStats(recorder);
             var stats = service.getStats();
@@ -99,13 +119,12 @@ public class ClusterApplierRecordingServiceTests extends ESTestCase {
             );
         }
         {
-            long[] currentTime = new long[1];
-            var recorder = new Recorder(() -> currentTime[0]);
+            var recorder = new Recorder(threadPool, TimeValue.ZERO);
             try (var r = recorder.record("action1")) {
-                currentTime[0] = 2;
+                advanceTime(2);
             }
             try (var r = recorder.record("action3")) {
-                currentTime[0] = 6;
+                advanceTime(4);
             }
             service.updateStats(recorder);
             var stats = service.getStats();
@@ -114,6 +133,44 @@ public class ClusterApplierRecordingServiceTests extends ESTestCase {
                 contains(Map.entry("action3", new Recording(3, 13)), Map.entry("action1", new Recording(3, 10)))
             );
         }
+    }
+
+    @TestLogging(reason = "testing debug logging", value = "org.elasticsearch.cluster.service.ClusterApplierRecordingService:DEBUG")
+    public void testSlowTaskDebugLogging() {
+        final var debugLoggingTimeout = TimeValue.timeValueMillis(between(1, 100000));
+        var recorder = new Recorder(threadPool, debugLoggingTimeout);
+
+        var action1 = recorder.record("action1");
+        deterministicTaskQueue.scheduleAt(
+            deterministicTaskQueue.getCurrentTimeMillis() + debugLoggingTimeout.millis() + between(1, 1000),
+            action1::close
+        );
+        MockLogAppender.assertThatLogger(
+            deterministicTaskQueue::runAllTasksInTimeOrder,
+            ClusterApplierRecordingService.class,
+            new MockLogAppender.SeenEventExpectation(
+                "hot threads",
+                ClusterApplierRecordingService.class.getCanonicalName(),
+                Level.DEBUG,
+                "hot threads while applying cluster state [action1]"
+            )
+        );
+
+        var action2 = recorder.record("action2");
+        deterministicTaskQueue.scheduleAt(
+            randomLongBetween(0, deterministicTaskQueue.getCurrentTimeMillis() + debugLoggingTimeout.millis() - 1),
+            action2::close
+        );
+        MockLogAppender.assertThatLogger(
+            deterministicTaskQueue::runAllTasksInTimeOrder,
+            ClusterApplierRecordingService.class,
+            new MockLogAppender.UnseenEventExpectation(
+                "hot threads",
+                ClusterApplierRecordingService.class.getCanonicalName(),
+                Level.DEBUG,
+                "*"
+            )
+        );
     }
 
 }

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnomalyJobCRUDIT.java
@@ -68,7 +68,8 @@ public class AnomalyJobCRUDIT extends MlSingleNodeTestCase {
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -165,7 +165,8 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ClusterService.USER_DEFINED_METADATA,
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/EstablishedMemUsageIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/EstablishedMemUsageIT.java
@@ -56,7 +56,8 @@ public class EstablishedMemUsageIT extends BaseMlIntegTestCase {
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES,
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobModelSnapshotCRUDIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobModelSnapshotCRUDIT.java
@@ -68,7 +68,8 @@ public class JobModelSnapshotCRUDIT extends MlSingleNodeTestCase {
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -128,7 +128,8 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobStorageDeletionTaskIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobStorageDeletionTaskIT.java
@@ -72,7 +72,8 @@ public class JobStorageDeletionTaskIT extends BaseMlIntegTestCase {
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES,
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsActionTests.java
@@ -121,7 +121,8 @@ public class TransportGetTrainedModelsStatsActionTests extends ESTestCase {
                     MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -82,7 +82,8 @@ public class DatafeedJobBuilderTests extends ESTestCase {
                     MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -98,7 +98,8 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
                     MasterService.MASTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -436,7 +436,8 @@ public class JobResultsPersisterTests extends ESTestCase {
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES,
                     ClusterService.USER_DEFINED_METADATA,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/task/OpenJobPersistentTasksExecutorTests.java
@@ -100,6 +100,7 @@ public class OpenJobPersistentTasksExecutorTests extends ESTestCase {
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ClusterService.USER_DEFINED_METADATA,
                     ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING,
                     MachineLearning.CONCURRENT_JOB_ALLOCATIONS,
                     MachineLearning.MAX_MACHINE_MEMORY_PERCENT,
                     MachineLearning.MAX_LAZY_ML_NODES,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/persistence/ResultsPersisterServiceTests.java
@@ -408,7 +408,8 @@ public class ResultsPersisterServiceTests extends ESTestCase {
                     OperationRouting.USE_ADAPTIVE_REPLICA_SELECTION_SETTING,
                     ClusterService.USER_DEFINED_METADATA,
                     ResultsPersisterService.PERSIST_RESULTS_MAX_RETRIES,
-                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_LOGGING_THRESHOLD_SETTING,
+                    ClusterApplierService.CLUSTER_SERVICE_SLOW_TASK_THREAD_DUMP_TIMEOUT_SETTING
                 )
             )
         );


### PR DESCRIPTION
Today we emit a warning when applying the cluster state takes more than
30s by default. Experience shows that it's almost always one task that
exceeds the limit, and usually that task is the
`IndicesClusterStateService` (see #89821). This commit adds a `DEBUG`
logger that will capture a thread dump if a task is running for longer
than a configurable duration so we can get more insight into the cause
of the slow execution.