### PR TITLE
[Connector API] Support updating single schedule type (full, incremental or access_control)

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/331_connector_update_scheduling.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/331_connector_update_scheduling.yml
@@ -91,6 +91,15 @@ setup:
               interval: 3 0 0 * * ?
 
 ---
+"Update Connector Scheduling - Schedules are missing":
+  - do:
+      catch: "bad_request"
+      connector.update_scheduling:
+        connector_id: test-connector
+        body:
+          scheduling: {}
+
+---
 "Update Connector Scheduling - Wrong CRON expression":
   - do:
       catch: "bad_request"

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/331_connector_update_scheduling.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/331_connector_update_scheduling.yml
@@ -44,6 +44,34 @@ setup:
   - match: { scheduling.incremental.enabled: false }
   - match: { scheduling.incremental.interval: "3 0 0 * * ?" }
 
+
+---
+"Update Connector Scheduling - Update single schedule only":
+  - do:
+      connector.update_scheduling:
+        connector_id: test-connector
+        body:
+          scheduling:
+            incremental:
+              enabled: true
+              interval: 3 0 0 * * ?
+
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { scheduling.incremental.enabled: true }
+  - match: { scheduling.incremental.interval: "3 0 0 * * ?" }
+
+  # Other schedules are unchanged (those are defaults when connector is created)
+  - match: { scheduling.full.enabled: false }
+  - match: { scheduling.full.interval: "0 0 0 * * ?" }
+  - match: { scheduling.access_control.enabled: false }
+  - match: { scheduling.access_control.interval: "0 0 0 * * ?" }
+
 ---
 "Update Connector Scheduling - Connector doesn't exist":
   - do:
@@ -58,18 +86,6 @@ setup:
             full:
               enabled: false
               interval: 2 0 0 * * ?
-            incremental:
-              enabled: false
-              interval: 3 0 0 * * ?
-
----
-"Update Connector Scheduling - Required fields are missing":
-  - do:
-      catch: "bad_request"
-      connector.update_scheduling:
-        connector_id: test-connector
-        body:
-          scheduling:
             incremental:
               enabled: false
               interval: 3 0 0 * * ?

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorScheduling.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorScheduling.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class ConnectorScheduling implements Writeable, ToXContentObject {
 
@@ -45,15 +46,27 @@ public class ConnectorScheduling implements Writeable, ToXContentObject {
      * @param incremental   connector incremental sync schedule represented as {@link ScheduleConfig}
      */
     private ConnectorScheduling(ScheduleConfig accessControl, ScheduleConfig full, ScheduleConfig incremental) {
-        this.accessControl = Objects.requireNonNull(accessControl, ACCESS_CONTROL_FIELD.getPreferredName());
-        this.full = Objects.requireNonNull(full, FULL_FIELD.getPreferredName());
-        this.incremental = Objects.requireNonNull(incremental, INCREMENTAL_FIELD.getPreferredName());
+        this.accessControl = accessControl;
+        this.full = full;
+        this.incremental = incremental;
     }
 
     public ConnectorScheduling(StreamInput in) throws IOException {
         this.accessControl = new ScheduleConfig(in);
         this.full = new ScheduleConfig(in);
         this.incremental = new ScheduleConfig(in);
+    }
+
+    public ScheduleConfig getAccessControl() {
+        return accessControl;
+    }
+
+    public ScheduleConfig getFull() {
+        return full;
+    }
+
+    public ScheduleConfig getIncremental() {
+        return incremental;
     }
 
     private static final ConstructingObjectParser<ConnectorScheduling, Void> PARSER = new ConstructingObjectParser<>(
@@ -67,13 +80,18 @@ public class ConnectorScheduling implements Writeable, ToXContentObject {
 
     static {
         PARSER.declareField(
-            constructorArg(),
+            optionalConstructorArg(),
             (p, c) -> ScheduleConfig.fromXContent(p),
             ACCESS_CONTROL_FIELD,
             ObjectParser.ValueType.OBJECT
         );
-        PARSER.declareField(constructorArg(), (p, c) -> ScheduleConfig.fromXContent(p), FULL_FIELD, ObjectParser.ValueType.OBJECT);
-        PARSER.declareField(constructorArg(), (p, c) -> ScheduleConfig.fromXContent(p), INCREMENTAL_FIELD, ObjectParser.ValueType.OBJECT);
+        PARSER.declareField(optionalConstructorArg(), (p, c) -> ScheduleConfig.fromXContent(p), FULL_FIELD, ObjectParser.ValueType.OBJECT);
+        PARSER.declareField(
+            optionalConstructorArg(),
+            (p, c) -> ScheduleConfig.fromXContent(p),
+            INCREMENTAL_FIELD,
+            ObjectParser.ValueType.OBJECT
+        );
     }
 
     public static ConnectorScheduling fromXContentBytes(BytesReference source, XContentType xContentType) {
@@ -92,9 +110,15 @@ public class ConnectorScheduling implements Writeable, ToXContentObject {
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         {
-            builder.field(ACCESS_CONTROL_FIELD.getPreferredName(), accessControl);
-            builder.field(FULL_FIELD.getPreferredName(), full);
-            builder.field(INCREMENTAL_FIELD.getPreferredName(), incremental);
+            if (accessControl != null) {
+                builder.field(ACCESS_CONTROL_FIELD.getPreferredName(), accessControl);
+            }
+            if (full != null) {
+                builder.field(FULL_FIELD.getPreferredName(), full);
+            }
+            if (incremental != null) {
+                builder.field(INCREMENTAL_FIELD.getPreferredName(), incremental);
+            }
         }
         builder.endObject();
         return builder;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorSchedulingAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorSchedulingAction.java
@@ -73,6 +73,15 @@ public class UpdateConnectorSchedulingAction {
                 validationException = addValidationError("[scheduling] cannot be [null].", validationException);
             }
 
+            if (Objects.isNull(scheduling.getFull())
+                && Objects.isNull(scheduling.getIncremental())
+                && Objects.isNull(scheduling.getIncremental())) {
+                validationException = addValidationError(
+                    "[scheduling] object needs to define at least one schedule type: [full | incremental | access_control]",
+                    validationException
+                );
+            }
+
             return validationException;
         }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -325,7 +325,7 @@ public final class ConnectorTestUtils {
     /**
      * Second (0 - 59) Minute (0 - 59) Hour (0 - 23) Day of month (1 - 31) Month (1 - 12)
      */
-    private static Cron getRandomCronExpression() {
+    public static Cron getRandomCronExpression() {
         return new Cron(
             String.format(
                 Locale.ROOT,


### PR DESCRIPTION
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

This is backward compatible enhancement, it relaxes the requirement to provide all schedules (full, incremental, AC) when calling update schedule API.

Now a user can pass only single schedule type. e.g. `full` with enabled flag and cron expression. Only `full` schedule will be updated, other schedules (access_control and incremental) will remain unchanged. 

This improves the UX when controlling scheduling via API.

## Changes
- Support updating single schedule type at a time in `_scheduling` endpoint call
- Add unit, yaml tests 