### PR TITLE
Update geoip.asciidoc

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -321,15 +321,15 @@ GET /my_ip_locations/_search
 If you can't <<geoip-automatic-updates,automatically update>> your GeoIP2
 databases from the Elastic endpoint, you have a few other options:
 
-* <<use-proxy-geoip-endpoint,Use a proxy endpoint>>
+* <<use-reverse-proxy-geoip-endpoint,Use a reverse proxy endpoint>>
 * <<use-custom-geoip-endpoint,Use a custom endpoint>>
 * <<manually-update-geoip-databases,Manually update your GeoIP2 databases>>
 
-[[use-proxy-geoip-endpoint]]
-**Use a proxy endpoint**
+[[use-reverse-proxy-geoip-endpoint]]
+**Use a reverse proxy endpoint**
 
 If you can't connect directly to the Elastic GeoIP endpoint, consider setting up
-a secure proxy. You can then specify the proxy endpoint URL in the
+a secure reverse proxy. You can then specify the reverse proxy endpoint URL in the
 <<ingest-geoip-downloader-endpoint,`ingest.geoip.downloader.endpoint`>> setting
 of each node’s `elasticsearch.yml` file.
 


### PR DESCRIPTION
The documention mention that we can use the proxy. But here the workaround mention the usage of reverse proxy

The proxy feature for geoip download is not yet supported  https://github.com/elastic/elasticsearch/issues/77069#issuecomment-1310459152

