### PR TITLE
[8.13] [Connector API] Support numeric for configuration select option value type (#107059)

### DIFF
--- a/docs/changelog/107059.yaml
+++ b/docs/changelog/107059.yaml
@@ -1,0 +1,5 @@
+pr: 107059
+summary: "[Connector API] Support numeric for configuration select option value type"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/335_connector_update_configuration.yml
@@ -162,6 +162,46 @@ setup:
   - match: { configuration.some_field.tooltip: null }
 
 ---
+"Update Connector Configuration with numeric select options":
+  - do:
+      connector.update_configuration:
+        connector_id: test-connector
+        body:
+          configuration:
+            some_field:
+              default_value: null
+              depends_on:
+                - field: some_field
+                  value: 31
+              display: numeric
+              label: Very important field
+              options:
+                - label: ten
+                  value: 10
+                - label: five
+                  value: 5
+              order: 4
+              required: true
+              sensitive: false
+              tooltip: null
+              type: str
+              ui_restrictions: [ ]
+              validations:
+                - constraint: 0
+                  type: greater_than
+              value: 123
+
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { configuration.some_field.options.0.value: 10 }
+  - match: { configuration.some_field.options.1.value: 5 }
+
+---
 "Update Connector Configuration - Connector doesn't exist":
   - do:
       catch: "missing"

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorConfigurationTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorConfigurationTests.java
@@ -89,6 +89,54 @@ public class ConnectorConfigurationTests extends ESTestCase {
         assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
     }
 
+    public void testToXContent_WithNumericSelectOptions() throws IOException {
+        String content = XContentHelper.stripWhitespace("""
+            {
+               "default_value": null,
+               "depends_on": [
+                 {
+                   "field": "some_field",
+                   "value": true
+                 }
+               ],
+               "display": "textbox",
+               "label": "Very important field",
+               "options": [
+                 {
+                   "label": "five",
+                   "value": 5
+                 },
+                 {
+                   "label": "ten",
+                   "value": 10
+                 }
+               ],
+               "order": 4,
+               "required": true,
+               "sensitive": false,
+               "tooltip": "Wow, this tooltip is useful.",
+               "type": "str",
+               "ui_restrictions": [],
+               "validations": [
+                  {
+                     "constraint": 0,
+                     "type": "greater_than"
+                  }
+               ],
+               "value": ""
+            }
+            """);
+
+        ConnectorConfiguration configuration = ConnectorConfiguration.fromXContentBytes(new BytesArray(content), XContentType.JSON);
+        boolean humanReadable = true;
+        BytesReference originalBytes = toShuffledXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, humanReadable);
+        ConnectorConfiguration parsed;
+        try (XContentParser parser = createParser(XContentType.JSON.xContent(), originalBytes)) {
+            parsed = ConnectorConfiguration.fromXContent(parser);
+        }
+        assertToXContentEquivalent(originalBytes, toXContent(parsed, XContentType.JSON, humanReadable), XContentType.JSON);
+    }
+
     public void testToXContentCrawlerConfig_WithNullValue() throws IOException {
         String content = XContentHelper.stripWhitespace("""
             {


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Connector API] Support numeric for configuration select option value type (#107059)