### PR TITLE
[DOCS] Makes Inference APIs main page more informative

### DIFF
--- a/docs/reference/inference/delete-inference.asciidoc
+++ b/docs/reference/inference/delete-inference.asciidoc
@@ -4,12 +4,14 @@
 
 experimental[]
 
-Deletes an {infer} model deployment.
+Deletes an {infer} endpoint.
 
-IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER,
-OpenAI, or Hugging Face, in your cluster. This is not the same feature that you
-can use on an ML node with custom {ml} models. If you want to train and use your
-own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
+{ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
+Hugging Face. For built-in models and models uploaded though Eland, the {infer}
+APIs offer an alternative way to use and manage trained models. However, if you
+do not plan to use the {infer} APIs to use these models or if you want to use
+non-NLP models, use the <<ml-df-trained-models-apis>>.
 
 
 [discrete]

--- a/docs/reference/inference/get-inference.asciidoc
+++ b/docs/reference/inference/get-inference.asciidoc
@@ -4,12 +4,14 @@
 
 experimental[]
 
-Retrieves {infer} model information.
+Retrieves {infer} endpoint information.
 
-IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER,
-OpenAI, or Hugging Face, in your cluster. This is not the same feature that you
-can use on an ML node with custom {ml} models. If you want to train and use your
-own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
+{ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
+Hugging Face. For built-in models and models uploaded though Eland, the {infer}
+APIs offer an alternative way to use and manage trained models. However, if you
+do not plan to use the {infer} APIs to use these models or if you want to use
+non-NLP models, use the <<ml-df-trained-models-apis>>.
 
 
 [discrete]
@@ -37,10 +39,10 @@ own model, use the <<ml-df-trained-models-apis>>.
 
 You can get information in a single API request for:
 
-* a single {infer} model by providing the task type and the model ID,
-* all of the {infer} models for a certain task type by providing the task type
-and a wildcard expression,
-* all of the {infer} models by using a wildcard expression.
+* a single {infer} endpoint by providing the task type and the {infer} ID,
+* all of the {infer} endpoints for a certain task type by providing the task
+type and a wildcard expression,
+* all of the {infer} endpoints by using a wildcard expression.
 
 
 [discrete]

--- a/docs/reference/inference/inference-apis.asciidoc
+++ b/docs/reference/inference/inference-apis.asciidoc
@@ -4,12 +4,16 @@
 
 experimental[]
 
-IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER, 
-OpenAI, or Hugging Face, in your cluster. This is not the same feature that you 
-can use on an ML node with custom {ml} models. If you want to train and use your 
-own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
+{ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
+Hugging Face. For built-in models and models uploaded though Eland, the {infer}
+APIs offer an alternative way to use and manage trained models. However, if you
+do not plan to use the {infer} APIs to use these models or if you want to use
+non-NLP models, use the <<ml-df-trained-models-apis>>.
 
-You can use the following APIs to manage {infer} models and perform {infer}:
+The {infer} APIs enable you to create {infer} endpoints and use {ml} models of
+different providers - such as Cohere, OpenAI, or HuggingFace - as a service. Use
+the following APIs to manage {infer} models and perform {infer}:
 
 * <<delete-inference-api>>
 * <<get-inference-api>>

--- a/docs/reference/inference/post-inference.asciidoc
+++ b/docs/reference/inference/post-inference.asciidoc
@@ -4,12 +4,14 @@
 
 experimental[]
 
-Performs an inference task on an input text by using an {infer} model.
+Performs an inference task on an input text by using an {infer} endpoint.
 
-IMPORTANT: The {infer} APIs enable you to use certain services, such as ELSER,
-OpenAI, or Hugging Face, in your cluster. This is not the same feature that you
-can use on an ML node with custom {ml} models. If you want to train and use your
-own model, use the <<ml-df-trained-models-apis>>.
+IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
+{ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
+Hugging Face. For built-in models and models uploaded though Eland, the {infer}
+APIs offer an alternative way to use and manage trained models. However, if you
+do not plan to use the {infer} APIs to use these models or if you want to use
+non-NLP models, use the <<ml-df-trained-models-apis>>.
 
 
 [discrete]
@@ -34,8 +36,9 @@ own model, use the <<ml-df-trained-models-apis>>.
 
 The perform {infer} API enables you to use {ml} models to perform specific tasks
 on data that you provide as an input. The API returns a response with the
-results of the tasks. The {infer} model you use can perform one specific task
-that has been defined when the model was created with the <<put-inference-api>>.
+results of the tasks. The {infer} endpoint you use can perform one specific task
+that has been defined when the endpoint was created with the 
+<<put-inference-api>>.
 
 
 [discrete]

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -4,7 +4,7 @@
 
 experimental[]
 
-Creates a model to perform an {infer} task.
+Creates an {infer} endpoint to perform an {infer} task.
 
 IMPORTANT: The {infer} APIs enable you to use certain services, such as built-in
 {ml} models (ELSER, E5), models uploaded through Eland, Cohere, OpenAI, or
@@ -33,8 +33,8 @@ or if you want to use non-NLP models, use the <<ml-df-trained-models-apis>>.
 [[put-inference-api-desc]]
 ==== {api-description-title}
 
-The create {infer} API enables you to create and configure a {ml} model to
-perform a specific {infer} task.
+The create {infer} API enables you to create an {infer} endpoint and configure a
+{ml} model to perform a specific {infer} task.
 
 The following services are available through the {infer} API:
 


### PR DESCRIPTION
## Overview

This PR:
* applies the `endpoint` terminology for all the inference API reference doc pages.
* makes the inference APIs main page more informative by adding an intro paragraph.