### PR TITLE
Remove AwaitsFix of fixed test

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsResponseTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsResponseTests.java
@@ -63,7 +63,6 @@ public class GetDataStreamsResponseTests extends AbstractWireSerializingTestCase
     }
 
     @SuppressWarnings("unchecked")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/102813")
     public void testResponseIlmAndDataStreamLifecycleRepresentation() throws Exception {
         // we'll test a data stream with 3 backing indices and a failure store - two backing indices managed by ILM (having the ILM policy
         // configured for them) and the remainder without any ILM policy configured


### PR DESCRIPTION
This `@AwaitsFixed` linked to https://github.com/elastic/elasticsearch/issues/102813, which was marked as a duplicate of https://github.com/elastic/elasticsearch/issues/102337, which in turn was fixed by https://github.com/elastic/elasticsearch/pull/102724.