### PR TITLE
Remove unused methods from SearchContext

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -481,7 +481,6 @@ final class DefaultSearchContext extends SearchContext {
         return this;
     }
 
-    @Override
     public void addSearchExt(SearchExtBuilder searchExtBuilder) {
         // it's ok to use the writeable name here given that we enforce it to be the same as the name of the element that gets
         // parsed by the corresponding parser. There is one single name and one single way to retrieve the parsed object from the context.
@@ -508,7 +507,6 @@ final class DefaultSearchContext extends SearchContext {
         return suggest;
     }
 
-    @Override
     public void suggest(SuggestionSearchContext suggest) {
         this.suggest = suggest;
     }
@@ -613,7 +611,6 @@ final class DefaultSearchContext extends SearchContext {
         return timeout;
     }
 
-    @Override
     public void timeout(TimeValue timeout) {
         this.timeout = timeout;
     }
@@ -688,7 +685,6 @@ final class DefaultSearchContext extends SearchContext {
         return searchAfter;
     }
 
-    @Override
     public SearchContext collapse(CollapseContext collapse) {
         this.collapse = collapse;
         return this;
@@ -786,7 +782,6 @@ final class DefaultSearchContext extends SearchContext {
         return this.groupStats;
     }
 
-    @Override
     public void groupStats(List<String> groupStats) {
         this.groupStats = groupStats;
     }

--- a/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -140,11 +140,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public void suggest(SuggestionSearchContext suggest) {
-        in.suggest(suggest);
-    }
-
-    @Override
     public RankShardContext rankShardContext() {
         return in.rankShardContext();
     }
@@ -202,11 +197,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public TimeValue timeout() {
         return in.timeout();
-    }
-
-    @Override
-    public void timeout(TimeValue timeout) {
-        in.timeout(timeout);
     }
 
     @Override
@@ -335,11 +325,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public void groupStats(List<String> groupStats) {
-        in.groupStats(groupStats);
-    }
-
-    @Override
     public boolean version() {
         return in.version();
     }
@@ -410,11 +395,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     }
 
     @Override
-    public void addSearchExt(SearchExtBuilder searchExtBuilder) {
-        in.addSearchExt(searchExtBuilder);
-    }
-
-    @Override
     public SearchExtBuilder getSearchExt(String name) {
         return in.getSearchExt(name);
     }
@@ -442,11 +422,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public boolean isCancelled() {
         return in.isCancelled();
-    }
-
-    @Override
-    public SearchContext collapse(CollapseContext collapse) {
-        return in.collapse(collapse);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -122,8 +122,6 @@ public abstract class SearchContext implements Releasable {
 
     public abstract SearchContext aggregations(SearchContextAggregations aggregations);
 
-    public abstract void addSearchExt(SearchExtBuilder searchExtBuilder);
-
     public abstract SearchExtBuilder getSearchExt(String name);
 
     public abstract SearchHighlightContext highlight();
@@ -138,8 +136,6 @@ public abstract class SearchContext implements Releasable {
     }
 
     public abstract SuggestionSearchContext suggest();
-
-    public abstract void suggest(SuggestionSearchContext suggest);
 
     public abstract RankShardContext rankShardContext();
 
@@ -217,8 +213,6 @@ public abstract class SearchContext implements Releasable {
 
     public abstract TimeValue timeout();
 
-    public abstract void timeout(TimeValue timeout);
-
     public abstract int terminateAfter();
 
     public abstract void terminateAfter(int terminateAfter);
@@ -254,8 +248,6 @@ public abstract class SearchContext implements Releasable {
     public abstract SearchContext searchAfter(FieldDoc searchAfter);
 
     public abstract FieldDoc searchAfter();
-
-    public abstract SearchContext collapse(CollapseContext collapse);
 
     public abstract CollapseContext collapse();
 
@@ -309,8 +301,6 @@ public abstract class SearchContext implements Releasable {
 
     @Nullable
     public abstract List<String> groupStats();
-
-    public abstract void groupStats(List<String> groupStats);
 
     public abstract boolean version();
 

--- a/server/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SubSearchContext.java
@@ -9,7 +9,6 @@ package org.elasticsearch.search.internal;
 
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TotalHits;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.search.aggregations.SearchContextAggregations;
 import org.elasticsearch.search.collapse.CollapseContext;
@@ -22,9 +21,6 @@ import org.elasticsearch.search.fetch.subphase.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchHighlightContext;
 import org.elasticsearch.search.query.QuerySearchResult;
 import org.elasticsearch.search.sort.SortAndFormats;
-import org.elasticsearch.search.suggest.SuggestionSearchContext;
-
-import java.util.List;
 
 public class SubSearchContext extends FilteredSearchContext {
 
@@ -86,11 +82,6 @@ public class SubSearchContext extends FilteredSearchContext {
     }
 
     @Override
-    public void suggest(SuggestionSearchContext suggest) {
-        throw new UnsupportedOperationException("Not supported");
-    }
-
-    @Override
     public boolean hasScriptFields() {
         return scriptFields != null && scriptFields.fields().isEmpty() == false;
     }
@@ -139,11 +130,6 @@ public class SubSearchContext extends FilteredSearchContext {
     public SubSearchContext fetchFieldsContext(FetchFieldsContext fetchFieldsContext) {
         this.fetchFieldsContext = fetchFieldsContext;
         return this;
-    }
-
-    @Override
-    public void timeout(TimeValue timeout) {
-        throw new UnsupportedOperationException("Not supported");
     }
 
     @Override
@@ -248,11 +234,6 @@ public class SubSearchContext extends FilteredSearchContext {
     @Override
     public void explain(boolean explain) {
         this.explain = explain;
-    }
-
-    @Override
-    public void groupStats(List<String> groupStats) {
-        throw new UnsupportedOperationException("Not supported");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
@@ -258,11 +258,6 @@ public class RankSearchContext extends SearchContext {
     }
 
     @Override
-    public void addSearchExt(SearchExtBuilder searchExtBuilder) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public SearchExtBuilder getSearchExt(String name) {
         throw new UnsupportedOperationException();
     }
@@ -284,11 +279,6 @@ public class RankSearchContext extends SearchContext {
 
     @Override
     public SuggestionSearchContext suggest() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void suggest(SuggestionSearchContext suggest) {
         throw new UnsupportedOperationException();
     }
 
@@ -358,11 +348,6 @@ public class RankSearchContext extends SearchContext {
     }
 
     @Override
-    public void timeout(TimeValue timeout) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void terminateAfter(int terminateAfter) {
         throw new UnsupportedOperationException();
     }
@@ -394,11 +379,6 @@ public class RankSearchContext extends SearchContext {
 
     @Override
     public SearchContext searchAfter(FieldDoc searchAfter) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SearchContext collapse(CollapseContext collapse) {
         throw new UnsupportedOperationException();
     }
 
@@ -454,11 +434,6 @@ public class RankSearchContext extends SearchContext {
 
     @Override
     public List<String> groupStats() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void groupStats(List<String> groupStats) {
         throw new UnsupportedOperationException();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -172,11 +172,6 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public void addSearchExt(SearchExtBuilder searchExtBuilder) {
-        searchExtBuilders.put(searchExtBuilder.getWriteableName(), searchExtBuilder);
-    }
-
-    @Override
     public SearchExtBuilder getSearchExt(String name) {
         return searchExtBuilders.get(name);
     }
@@ -193,9 +188,6 @@ public class TestSearchContext extends SearchContext {
     public SuggestionSearchContext suggest() {
         return null;
     }
-
-    @Override
-    public void suggest(SuggestionSearchContext suggest) {}
 
     @Override
     public List<RescoreContext> rescore() {
@@ -268,9 +260,6 @@ public class TestSearchContext extends SearchContext {
     }
 
     @Override
-    public void timeout(TimeValue timeout) {}
-
-    @Override
     public int terminateAfter() {
         return terminateAfter;
     }
@@ -338,11 +327,6 @@ public class TestSearchContext extends SearchContext {
     @Override
     public FieldDoc searchAfter() {
         return searchAfter;
-    }
-
-    @Override
-    public SearchContext collapse(CollapseContext collapse) {
-        return null;
     }
 
     @Override
@@ -430,9 +414,6 @@ public class TestSearchContext extends SearchContext {
     public List<String> groupStats() {
         return null;
     }
-
-    @Override
-    public void groupStats(List<String> groupStats) {}
 
     @Override
     public boolean version() {


### PR DESCRIPTION
A couple methods can be removed here, they're only used on `DefaultSearchContext`. That also cleans up some unsupport operation exception code that is never hit.
