### PR TITLE
add test ensuring `PainlessPlugin#baseWhiteList()` remains stable-API

### DIFF
--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessPluginTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessPluginTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class PainlessPluginTests extends ESTestCase {
+
+    /**
+     * The {@link PainlessPlugin#baseWhiteList()} signature is relied on from outside
+     * the Elasticsearch code-base and is considered part of the plugin's external API.
+     */
+    public void testBaseWhiteList() {
+        final List<Whitelist> baseWhiteList = PainlessPlugin.baseWhiteList();
+        assertThat(baseWhiteList, is(not(empty())));
+    }
+}


### PR DESCRIPTION
A recent refactor in #106913 introduced `PainlessPlugin#baseWhiteList()` and removed `PainlessPlugin.BASE_WHITELISTS`, which caused builds of Logstash's Elastic integration plugin to break when run against Elasticsearch `main` (https://github.com/elastic/logstash-filter-elastic_integration/issues/135).

Since we need an API-stable way of getting the plugin's default whitelists, here we add a test to document its use and ensure it remains API-stable. We also backport this test to the 8.13 series along with an implementation that falls through to the existing static field in #107120 so that our builds will succeed between now and when 8.14.0 is released.

***

Perhaps worth noting, the method introduced in #106913 in returns `List<Whitelist>`, but is named in a way that mismatches in two ways:

 - the method name is singular, even though it provides a `List`
 - the method name has superfluous capitalization `WhiteList` while the contents are a `Whitelist`

We may want to remedy this mismatch before marking the method as API-stable.
