### PR TITLE
Painless plugin public api 8.13

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/PainlessPlugin.java
@@ -74,6 +74,10 @@ public final class PainlessPlugin extends Plugin implements ScriptPlugin, Extens
         WhitelistLoader.loadFromResourceFiles(PainlessPlugin.class, WhitelistAnnotationParser.BASE_ANNOTATION_PARSERS, BASE_WHITELIST_FILES)
     );
 
+    public static List<Whitelist> baseWhiteList() {
+        return BASE_WHITELISTS;
+    }
+
     /*
      * Contexts from Core that need custom whitelists can add them to the map below.
      * Whitelist resources should be added as appropriately named, separate files

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessPluginTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/PainlessPluginTests.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.painless;
+
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public class PainlessPluginTests extends ESTestCase {
+
+    /**
+     * The {@link PainlessPlugin#baseWhiteList()} signature is relied on from outside
+     * the Elasticsearch code-base and is considered part of the plugin's external API.
+     */
+    public void testBaseWhiteList() {
+        final List<Whitelist> baseWhiteList = PainlessPlugin.baseWhiteList();
+        assertThat(baseWhiteList, is(not(empty())));
+    }
+}


### PR DESCRIPTION
This is a backport of #107119 to the 8.13 series that implements `PainlessPlugin#baseWhiteList` by returning the existing `PanilessPlugin.BASE_WHITELIST`.