### PR TITLE
ESQL: Fix bug when combining projections

### DIFF
--- a/docs/changelog/107131.yaml
+++ b/docs/changelog/107131.yaml
@@ -1,0 +1,6 @@
+pr: 107131
+summary: "ESQL: Fix bug when combining projections"
+area: ES|QL
+type: bug
+issues:
+ - 107083

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1550,3 +1550,37 @@ s2point1:d | s_mv:i | languages:i
 2.1        | 3      | 5
 2.1        | 3      | null
 ;
+
+evalOverridingKey
+FROM employees
+| EVAL k = languages
+| STATS c = COUNT() BY languages, k
+| DROP k
+| SORT languages
+;
+
+c:l| languages:i
+15 | 1
+19 | 2
+17 | 3
+18 | 4
+21 | 5
+10 | null
+;
+
+evalMultipleOverridingKeys
+FROM employees
+| EVAL k = languages, k1 = k
+| STATS c = COUNT() BY languages, k, k1, languages
+| DROP k
+| SORT languages
+;
+
+c:l | k1:i | languages:i
+15  | 1    | 1
+19  | 2    | 2
+17  | 3    | 3
+18  | 4    | 4
+21  | 5    | 5
+10  | null | null
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1568,7 +1568,7 @@ c:l| languages:i
 10 | null
 ;
 
-evalMultipleOverridingKeys
+evalMultipleOverridingKeys#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | EVAL k = languages, k1 = k
 | STATS c = COUNT() BY languages, k, k1, languages


### PR DESCRIPTION
Recursive aliases (eval x = 1, x1 = x) were not taken into account when
 combining projections causing the target field to be lost (and only the
 immediate intermediate named expression to be used instead which became
 invalid).

Fix #107083