### PR TITLE
[8.13] ESQL: Fix fully pruned aggregates (#106673)

### DIFF
--- a/docs/changelog/106673.yaml
+++ b/docs/changelog/106673.yaml
@@ -1,0 +1,6 @@
+pr: 106673
+summary: "ESQL: Fix fully pruned aggregates"
+area: ES|QL
+type: bug
+issues:
+ - 106427

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1226,3 +1226,188 @@ FROM employees
 vals:l
 183
 ;
+
+emptyProjectInStatWithEval#[skip:-8.13.99,reason:fixed in 8.14]
+FROM employees
+| STATS c = COUNT(salary)
+| EVAL x = 3.14
+| DROP c
+;
+
+x:d
+3.14
+;
+
+emptyProjectInStatWithCountGroupAndEval#[skip:-8.13.99,reason:fixed in 8.14]
+FROM employees
+| STATS c = COUNT(salary) BY gender
+| EVAL x = 3.14
+| DROP c, gender
+;
+
+x:d
+3.14
+3.14
+3.14
+;
+
+
+emptyProjectInStatWithMinGroupAndEval#[skip:-8.13.99,reason:fixed in 8.14]
+FROM employees
+| STATS m = MIN(salary) BY gender
+| EVAL x = 3.14
+| DROP m, gender
+;
+
+x:d
+3.14
+3.14
+3.14
+;
+
+emptyProjectInStatOnlyGroupAndEval#[skip:-8.13.99,reason:fixed in 8.14]
+FROM employees
+| STATS BY gender
+| EVAL x = 3.14
+| DROP gender
+;
+
+x:d
+3.14
+3.14
+3.14
+;
+
+emptyProjectInStatWithTwoGroupsAndEval#[skip:-8.13.99,reason:fixed in 8.14]
+FROM employees
+| STATS c = COUNT(salary) BY gender, still_hired
+| EVAL x = 3.14
+| DROP c, gender, still_hired
+;
+
+x:d
+3.14
+3.14
+3.14
+3.14
+3.14
+3.14
+;
+
+emptyProjectInStatDueToAnotherStat#[skip:-8.13.99,reason:fixed in 8.14]
+FROM employees
+| STATS s = SUM(salary), m = MIN(salary)
+| EVAL x = 3.14
+| STATS rows = COUNT(*)
+;
+
+rows:l
+1
+;
+
+emptyProjectInStatDueToAnotherStatWithGroups#[skip:-8.13.99,reason:fixed in 8.14]
+FROM employees
+| STATS m = MEDIAN(salary) BY gender, still_hired
+| EVAL x = 3.14
+| STATS rows = COUNT(*)
+;
+
+rows:l
+6
+;
+
+sumOfConst#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS s1 = sum(1), s2point1 = sum(2.1), s_mv = sum([-1, 0, 3]) * 3, s_null = sum(null), rows = count(*)
+;
+
+s1:l | s2point1:d | s_mv:l | s_null:d | rows:l
+100  | 210.0      | 600    | null     | 100
+;
+
+sumOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS s2point1 = round(sum(2.1), 1), s_mv = sum([-1, 0, 3]), rows = count(*) by languages
+| SORT languages
+;
+
+s2point1:d | s_mv:l | rows:l | languages:i
+31.5       | 30     | 15     | 1
+39.9       | 38     | 19     | 2
+35.7       | 34     | 17     | 3
+37.8       | 36     | 18     | 4
+44.1       | 42     | 21     | 5
+21.0       | 20     | 10     | null
+;
+
+avgOfConst#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS s1 = avg(1), s_mv = avg([-1, 0, 3]) * 3, s_null = avg(null)
+;
+
+s1:d | s_mv:d | s_null:d
+1.0  | 2.0    | null
+;
+
+avgOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS s2point1 = avg(2.1), s_mv = avg([-1, 0, 3]) * 3 by languages
+| SORT languages
+;
+
+s2point1:d | s_mv:d | languages:i
+2.1        | 2.0    | 1
+2.1        | 2.0    | 2
+2.1        | 2.0    | 3
+2.1        | 2.0    | 4
+2.1        | 2.0    | 5
+2.1        | 2.0    | null
+;
+
+minOfConst#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS s1 = min(1), s_mv = min([-1, 0, 3]), s_null = min(null)
+;
+
+s1:i | s_mv:i | s_null:null
+1    | -1     | null
+;
+
+minOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS s2point1 = min(2.1), s_mv = min([-1, 0, 3]) by languages
+| SORT languages
+;
+
+s2point1:d | s_mv:i | languages:i
+2.1        | -1     | 1
+2.1        | -1     | 2
+2.1        | -1     | 3
+2.1        | -1     | 4
+2.1        | -1     | 5
+2.1        | -1     | null
+;
+
+maxOfConst#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS s1 = max(1), s_mv = max([-1, 0, 3]), s_null = max(null)
+;
+
+s1:i | s_mv:i | s_null:null
+1    | 3      | null
+;
+
+maxOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
+FROM employees
+| STATS s2point1 = max(2.1), s_mv = max([-1, 0, 3]) by languages
+| SORT languages
+;
+
+s2point1:d | s_mv:i | languages:i
+2.1        | 3      | 1
+2.1        | 3      | 2
+2.1        | 3      | 3
+2.1        | 3      | 4
+2.1        | 3      | 5
+2.1        | 3      | null
+;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1227,7 +1227,7 @@ vals:l
 183
 ;
 
-emptyProjectInStatWithEval#[skip:-8.13.99,reason:fixed in 8.14]
+emptyProjectInStatWithEval#[skip:-8.13.0,reason:fixed in 8.13.1]
 FROM employees
 | STATS c = COUNT(salary)
 | EVAL x = 3.14
@@ -1238,7 +1238,7 @@ x:d
 3.14
 ;
 
-emptyProjectInStatWithCountGroupAndEval#[skip:-8.13.99,reason:fixed in 8.14]
+emptyProjectInStatWithCountGroupAndEval#[skip:-8.13.0,reason:fixed in 8.13.1]
 FROM employees
 | STATS c = COUNT(salary) BY gender
 | EVAL x = 3.14
@@ -1252,7 +1252,7 @@ x:d
 ;
 
 
-emptyProjectInStatWithMinGroupAndEval#[skip:-8.13.99,reason:fixed in 8.14]
+emptyProjectInStatWithMinGroupAndEval#[skip:-8.13.0,reason:fixed in 8.13.1]
 FROM employees
 | STATS m = MIN(salary) BY gender
 | EVAL x = 3.14
@@ -1265,7 +1265,7 @@ x:d
 3.14
 ;
 
-emptyProjectInStatOnlyGroupAndEval#[skip:-8.13.99,reason:fixed in 8.14]
+emptyProjectInStatOnlyGroupAndEval#[skip:-8.13.0,reason:fixed in 8.13.1]
 FROM employees
 | STATS BY gender
 | EVAL x = 3.14
@@ -1278,7 +1278,7 @@ x:d
 3.14
 ;
 
-emptyProjectInStatWithTwoGroupsAndEval#[skip:-8.13.99,reason:fixed in 8.14]
+emptyProjectInStatWithTwoGroupsAndEval#[skip:-8.13.0,reason:fixed in 8.13.1]
 FROM employees
 | STATS c = COUNT(salary) BY gender, still_hired
 | EVAL x = 3.14
@@ -1294,7 +1294,7 @@ x:d
 3.14
 ;
 
-emptyProjectInStatDueToAnotherStat#[skip:-8.13.99,reason:fixed in 8.14]
+emptyProjectInStatDueToAnotherStat#[skip:-8.13.0,reason:fixed in 8.13.1]
 FROM employees
 | STATS s = SUM(salary), m = MIN(salary)
 | EVAL x = 3.14
@@ -1305,7 +1305,7 @@ rows:l
 1
 ;
 
-emptyProjectInStatDueToAnotherStatWithGroups#[skip:-8.13.99,reason:fixed in 8.14]
+emptyProjectInStatDueToAnotherStatWithGroups#[skip:-8.13.0,reason:fixed in 8.13.1]
 FROM employees
 | STATS m = MEDIAN(salary) BY gender, still_hired
 | EVAL x = 3.14
@@ -1314,100 +1314,4 @@ FROM employees
 
 rows:l
 6
-;
-
-sumOfConst#[skip:-8.13.99,reason:supported in 8.14]
-FROM employees
-| STATS s1 = sum(1), s2point1 = sum(2.1), s_mv = sum([-1, 0, 3]) * 3, s_null = sum(null), rows = count(*)
-;
-
-s1:l | s2point1:d | s_mv:l | s_null:d | rows:l
-100  | 210.0      | 600    | null     | 100
-;
-
-sumOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
-FROM employees
-| STATS s2point1 = round(sum(2.1), 1), s_mv = sum([-1, 0, 3]), rows = count(*) by languages
-| SORT languages
-;
-
-s2point1:d | s_mv:l | rows:l | languages:i
-31.5       | 30     | 15     | 1
-39.9       | 38     | 19     | 2
-35.7       | 34     | 17     | 3
-37.8       | 36     | 18     | 4
-44.1       | 42     | 21     | 5
-21.0       | 20     | 10     | null
-;
-
-avgOfConst#[skip:-8.13.99,reason:supported in 8.14]
-FROM employees
-| STATS s1 = avg(1), s_mv = avg([-1, 0, 3]) * 3, s_null = avg(null)
-;
-
-s1:d | s_mv:d | s_null:d
-1.0  | 2.0    | null
-;
-
-avgOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
-FROM employees
-| STATS s2point1 = avg(2.1), s_mv = avg([-1, 0, 3]) * 3 by languages
-| SORT languages
-;
-
-s2point1:d | s_mv:d | languages:i
-2.1        | 2.0    | 1
-2.1        | 2.0    | 2
-2.1        | 2.0    | 3
-2.1        | 2.0    | 4
-2.1        | 2.0    | 5
-2.1        | 2.0    | null
-;
-
-minOfConst#[skip:-8.13.99,reason:supported in 8.14]
-FROM employees
-| STATS s1 = min(1), s_mv = min([-1, 0, 3]), s_null = min(null)
-;
-
-s1:i | s_mv:i | s_null:null
-1    | -1     | null
-;
-
-minOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
-FROM employees
-| STATS s2point1 = min(2.1), s_mv = min([-1, 0, 3]) by languages
-| SORT languages
-;
-
-s2point1:d | s_mv:i | languages:i
-2.1        | -1     | 1
-2.1        | -1     | 2
-2.1        | -1     | 3
-2.1        | -1     | 4
-2.1        | -1     | 5
-2.1        | -1     | null
-;
-
-maxOfConst#[skip:-8.13.99,reason:supported in 8.14]
-FROM employees
-| STATS s1 = max(1), s_mv = max([-1, 0, 3]), s_null = max(null)
-;
-
-s1:i | s_mv:i | s_null:null
-1    | 3      | null
-;
-
-maxOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
-FROM employees
-| STATS s2point1 = max(2.1), s_mv = max([-1, 0, 3]) by languages
-| SORT languages
-;
-
-s2point1:d | s_mv:i | languages:i
-2.1        | 3      | 1
-2.1        | 3      | 2
-2.1        | 3      | 3
-2.1        | 3      | 4
-2.1        | 3      | 5
-2.1        | 3      | null
 ;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -997,11 +997,23 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
                     recheck = false;
                     if (p instanceof Aggregate aggregate) {
                         var remaining = seenProjection.get() ? removeUnused(aggregate.aggregates(), used) : null;
-                        // no aggregates, no need
+
                         if (remaining != null) {
                             if (remaining.isEmpty()) {
-                                recheck = true;
-                                p = aggregate.child();
+                                // We still need to have a plan that produces 1 row per group.
+                                if (aggregate.groupings().isEmpty()) {
+                                    p = new LocalRelation(
+                                        aggregate.source(),
+                                        List.of(new EmptyAttribute(aggregate.source())),
+                                        LocalSupplier.of(
+                                            new Block[] { BlockUtils.constantBlock(PlannerUtils.NON_BREAKING_BLOCK_FACTORY, null, 1) }
+                                        )
+                                    );
+                                } else {
+                                    // Aggs cannot produce pages with 0 columns, so retain one grouping.
+                                    remaining = List.of(Expressions.attribute(aggregate.groupings().get(0)));
+                                    p = new Aggregate(aggregate.source(), aggregate.child(), aggregate.groupings(), remaining);
+                                }
                             } else {
                                 p = new Aggregate(aggregate.source(), aggregate.child(), aggregate.groupings(), remaining);
                             }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.ql.expression.Alias;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.AttributeMap;
 import org.elasticsearch.xpack.ql.expression.AttributeSet;
+import org.elasticsearch.xpack.ql.expression.EmptyAttribute;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.ExpressionSet;
 import org.elasticsearch.xpack.ql.expression.Expressions;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -221,6 +221,78 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         assertThat(relation.supplier().get(), emptyArray());
     }
 
+    /**
+     * Expects
+     *
+     * EsqlProject[[x{r}#6]]
+     * \_Eval[[1[INTEGER] AS x]]
+     *   \_Limit[1000[INTEGER]]
+     *     \_LocalRelation[[{e}#18],[ConstantNullBlock[positions=1]]]
+     */
+    public void testEmptyProjectInStatWithEval() {
+        var plan = plan("""
+            from test
+            | where languages > 1
+            | stats c = count(salary)
+            | eval x = 1, c2 = c*2
+            | drop c, c2
+            """);
+
+        var project = as(plan, Project.class);
+        var eval = as(project.child(), Eval.class);
+        var limit = as(eval.child(), Limit.class);
+        var singleRowRelation = as(limit.child(), LocalRelation.class);
+        var singleRow = singleRowRelation.supplier().get();
+        assertThat(singleRow.length, equalTo(1));
+        assertThat(singleRow[0].getPositionCount(), equalTo(1));
+
+        var exprs = eval.fields();
+        assertThat(exprs.size(), equalTo(1));
+        var alias = as(exprs.get(0), Alias.class);
+        assertThat(alias.name(), equalTo("x"));
+        assertThat(alias.child().fold(), equalTo(1));
+    }
+
+    /**
+     * Expects
+     *
+     * EsqlProject[[x{r}#8]]
+     * \_Eval[[1[INTEGER] AS x]]
+     *   \_Limit[1000[INTEGER]]
+     *     \_Aggregate[[emp_no{f}#15],[emp_no{f}#15]]
+     *       \_Filter[languages{f}#18 > 1[INTEGER]]
+     *         \_EsRelation[test][_meta_field{f}#21, emp_no{f}#15, first_name{f}#16, ..]
+     */
+    public void testEmptyProjectInStatWithGroupAndEval() {
+        var plan = plan("""
+            from test
+            | where languages > 1
+            | stats c = count(salary) by emp_no
+            | eval x = 1, c2 = c*2
+            | drop c, emp_no, c2
+            """);
+
+        var project = as(plan, Project.class);
+        var eval = as(project.child(), Eval.class);
+        var limit = as(eval.child(), Limit.class);
+        var agg = as(limit.child(), Aggregate.class);
+        var filter = as(agg.child(), Filter.class);
+        var relation = as(filter.child(), EsRelation.class);
+
+        assertThat(Expressions.names(agg.groupings()), contains("emp_no"));
+        assertThat(Expressions.names(agg.aggregates()), contains("emp_no"));
+
+        var exprs = eval.fields();
+        assertThat(exprs.size(), equalTo(1));
+        var alias = as(exprs.get(0), Alias.class);
+        assertThat(alias.name(), equalTo("x"));
+        assertThat(alias.child().fold(), equalTo(1));
+
+        var filterCondition = as(filter.condition(), GreaterThan.class);
+        assertThat(Expressions.name(filterCondition.left()), equalTo("languages"));
+        assertThat(filterCondition.right().fold(), equalTo(1));
+    }
+
     public void testCombineProjections() {
         var plan = plan("""
             from test


### PR DESCRIPTION
This will backport the following commits from `main` to `8.13`:
 - [ESQL: Fix fully pruned aggregates (#106673)](https://github.com/elastic/elasticsearch/pull/106673)