### PR TITLE
Update 8.13 known issues with JDK 22 bug / recommendation to downgrade

### DIFF
--- a/docs/reference/release-notes/8.13.0.asciidoc
+++ b/docs/reference/release-notes/8.13.0.asciidoc
@@ -7,6 +7,9 @@ Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 [float]
 === Known issues
 
+* Due to a bug in the bundled JDK 22 nodes might crash abruptly under high memory pressure.
+  We recommend https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#jvm-version[downgrading to JDK 21.0.2] asap to mitigate the issue.
+
 * Nodes upgraded to 8.13.0 fail to load downsampling persistent tasks. This prevents them from joining the cluster, blocking its upgrade (issue: {es-issue}106880[#106880])
 +
 This affects clusters running version 8.10 or later, with an active downsampling


### PR DESCRIPTION
Update 8.13 known issues with JDK 22 bug / recommendation to downgrade.

I'll follow up adding this to 8.13.1 as well once backported.