### PR TITLE
Update 8.13.1 known issues with JDK 22 bug / recommendation to downgrade

### DIFF
--- a/docs/reference/release-notes/8.13.1.asciidoc
+++ b/docs/reference/release-notes/8.13.1.asciidoc
@@ -8,7 +8,7 @@ Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 === Known issues
 
 * Due to a bug in the bundled JDK 22 nodes might crash abruptly under high memory pressure.
-We recommend https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#jvm-version[downgrading to JDK 21.0.2] asap to mitigate the issue.
+We recommend <<jvm-version,downgrading to JDK 21.0.2>> asap to mitigate the issue.
 
 [[bug-8.13.1]]
 [float]

--- a/docs/reference/release-notes/8.13.1.asciidoc
+++ b/docs/reference/release-notes/8.13.1.asciidoc
@@ -3,6 +3,13 @@
 
 Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 
+[[known-issues-8.13.1]]
+[float]
+=== Known issues
+
+* Due to a bug in the bundled JDK 22 nodes might crash abruptly under high memory pressure.
+We recommend https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html#jvm-version[downgrading to JDK 21.0.2] asap to mitigate the issue.
+
 [[bug-8.13.1]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Update 8.13.1 known issues with JDK 22 bug / recommendation to downgrade.

This is a follow up on https://github.com/elastic/elasticsearch/pull/107156