### PR TITLE
Fix `TransportTasksActionTests#testFailedTasksCount`

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -563,7 +563,6 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         responseLatch.await(10, TimeUnit.SECONDS);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107043")
     public void testFailedTasksCount() throws Exception {
         Settings settings = Settings.builder().put(MockTaskManager.USE_MOCK_TASK_MANAGER_SETTING.getKey(), true).build();
         setupTestNodes(settings);
@@ -605,14 +604,14 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
 
         // Make sure that actions are still registered in the task manager on all nodes
         // Twice on the coordinating node and once on all other nodes.
-        assertEquals(4, listeners[0].getEvents().size());
-        assertEquals(2, listeners[0].getRegistrationEvents().size());
-        assertEquals(2, listeners[0].getUnregistrationEvents().size());
-        for (int i = 1; i < listeners.length; i++) {
-            assertEquals(2, listeners[i].getEvents().size());
-            assertEquals(1, listeners[i].getRegistrationEvents().size());
-            assertEquals(1, listeners[i].getUnregistrationEvents().size());
-        }
+        assertBusy(() -> {
+            assertEquals(2, listeners[0].getRegistrationEvents().size());
+            assertEquals(2, listeners[0].getUnregistrationEvents().size());
+            for (int i = 1; i < listeners.length; i++) {
+                assertEquals(1, listeners[i].getRegistrationEvents().size());
+                assertEquals(1, listeners[i].getUnregistrationEvents().size());
+            }
+        });
     }
 
     private List<String> getAllTaskDescriptions() {


### PR DESCRIPTION
Prior to #106733 when the `TestNodesAction` threw an exception it would
immediately unregister the task:

https://github.com/elastic/elasticsearch/blob/d39d1e2c249f49b8170d4f50329934d871b2b382/server/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java#L78

However with that change the exception is caught and passed to the
`TaskTransportChannel`, so unregistration happens after sending the
response and may therefore not be recorded by the time the test makes
its assertion. This commit fixes the test with a busy-wait.

Closes #107043