### PR TITLE
ESQL: Update FROM option preference

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/from.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/from.csv-spec
@@ -133,7 +133,7 @@ convertFromDatetimeWithOptions
 required_feature: esql.from_options
 
 // tag::convertFromDatetimeWithOptions[]
-  FROM employees OPTIONS "allow_no_indices"="false","preference"="_shards:0"
+  FROM employees OPTIONS "allow_no_indices"="false","preference"="_local"
 | SORT emp_no
 | EVAL hire_double = to_double(hire_date)
 | KEEP emp_no, hire_date, hire_double


### PR DESCRIPTION
This updates the preference from an imperative `_shards` to a preferential `_local` to make the test more resilient to different sharding scenarios.
