### PR TITLE
ES|QL: Make some REST tests deterministic

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
@@ -167,7 +167,7 @@ public abstract class RestEnrichTestCase extends ESRestTestCase {
 
     public void testMatchField_ImplicitFieldsList() throws IOException {
         Map<String, Object> result = runEsql(
-            new RestEsqlTestCase.RequestObjectBuilder().query("from test | enrich countries | keep number")
+            new RestEsqlTestCase.RequestObjectBuilder().query("from test | enrich countries | keep number | sort number")
         );
         var columns = List.of(Map.of("name", "number", "type", "long"));
         var values = List.of(List.of(1000), List.of(1000), List.of(5000));

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -315,7 +315,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         Response response = client().performRequest(bulk);
         assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8), equalTo("{\"errors\":false}"));
 
-        RequestObjectBuilder builder = new RequestObjectBuilder().query(fromIndex() + " | stats min(value) | sort `min(value)`");
+        RequestObjectBuilder builder = new RequestObjectBuilder().query(fromIndex() + " | stats min(value)");
         Map<String, Object> result = runEsql(builder);
         assertMap(
             result,

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -315,14 +315,14 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         Response response = client().performRequest(bulk);
         assertThat(EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8), equalTo("{\"errors\":false}"));
 
-        RequestObjectBuilder builder = new RequestObjectBuilder().query(fromIndex() + " | stats min(value)");
+        RequestObjectBuilder builder = new RequestObjectBuilder().query(fromIndex() + " | stats min(value) | sort `min(value)`");
         Map<String, Object> result = runEsql(builder);
         assertMap(
             result,
             matchesMap().entry("values", List.of(List.of(1))).entry("columns", List.of(Map.of("name", "min(value)", "type", "long")))
         );
 
-        builder = new RequestObjectBuilder().query(fromIndex() + " | stats min(value) by group");
+        builder = new RequestObjectBuilder().query(fromIndex() + " | stats min(value) by group | sort group, `min(value)`");
         result = runEsql(builder);
         assertMap(
             result,


### PR DESCRIPTION
Adding an explicit SORT to two tests to make them more deterministic, especially for scenarios where the execution is on multiple nodes.