### PR TITLE
Carlosdelest/semantic text add query yaml tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -143,6 +143,17 @@ public abstract class FieldMapper extends Mapper {
     }
 
     /**
+     * Returns any nested object mapper the field can expose that is not directly a {@link NestedObjectMapper}.
+     * Some field mappers can be queried as nested objects without being part of a nested object, and this
+     * method exposes that nested object mapper so nested queries can be performed on then.
+     *
+     * @return nested object mapper the field have
+     */
+    public NestedObjectMapper innerNestedObjectMapper() {
+        return null;
+    }
+
+    /**
      * Will this field ignore malformed values for this field and accept the
      * document ({@code true}) or will it reject documents with malformed
      * values for this field ({@code false}). Some fields don't have a concept

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -145,6 +146,7 @@ public final class MappingLookup {
                 nestedMappers.add((NestedObjectMapper) mapper);
             }
         }
+        nestedMappers.addAll(mappers.stream().map(FieldMapper::innerNestedObjectMapper).filter(Objects::nonNull).toList());
         this.nestedLookup = NestedLookup.build(nestedMappers);
 
         final Map<String, NamedAnalyzer> indexAnalyzersMap = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -1103,7 +1103,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
         notInMultiFields(CONTENT_TYPE)
     );
 
-    public static final class DenseVectorFieldType extends SimpleMappedFieldType {
+    public static final class DenseVectorFieldType extends SimpleMappedFieldType implements KnnFieldType {
         private final ElementType elementType;
         private final Integer dims;
         private final boolean indexed;
@@ -1176,6 +1176,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support term queries");
         }
 
+        @Override
         public Query createKnnQuery(
             byte[] queryVector,
             int numCands,
@@ -1218,6 +1219,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             return knnQuery;
         }
 
+        @Override
         public Query createExactKnnQuery(VectorData queryVector) {
             if (isIndexed() == false) {
                 throw new IllegalArgumentException(
@@ -1291,16 +1293,17 @@ public class DenseVectorFieldMapper extends FieldMapper {
         }
 
         Query createKnnQuery(float[] queryVector, int numCands, Query filter, Float similarityThreshold, BitSetProducer parentFilter) {
-            return createKnnQuery(VectorData.fromFloats(queryVector), numCands, filter, similarityThreshold, parentFilter);
+            return createKnnQuery(VectorData.fromFloats(queryVector), numCands, filter, similarityThreshold, parentFilter, null);
         }
 
+        @Override
         public Query createKnnQuery(
             VectorData queryVector,
             int numCands,
             Query filter,
             Float similarityThreshold,
-            BitSetProducer parentFilter
-        ) {
+            BitSetProducer parentFilter,
+            SearchExecutionContext context) {
             if (isIndexed() == false) {
                 throw new IllegalArgumentException(
                     "to perform knn search on field [" + name() + "], its mapping must have [index] set to [true]"

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/KnnFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/KnnFieldType.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper.vectors;
+
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.join.BitSetProducer;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.search.vectors.VectorData;
+
+public interface KnnFieldType {
+
+    Query createKnnQuery(
+        byte[] queryVector,
+        int numCands,
+        Query filter,
+        Float similarityThreshold,
+        BitSetProducer parentFilter
+    );
+
+    Query createKnnQuery(
+        VectorData queryVector,
+        int numCands,
+        Query filter,
+        Float similarityThreshold,
+        BitSetProducer parentFilter,
+        SearchExecutionContext context);
+
+    Query createExactKnnQuery(VectorData queryVector);
+}

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilder.java
@@ -24,6 +24,7 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NestedObjectMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper;
 import org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.DenseVectorFieldType;
+import org.elasticsearch.index.mapper.vectors.KnnFieldType;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
@@ -396,9 +397,9 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
             throw new IllegalArgumentException("field [" + fieldName + "] does not exist in the mapping");
         }
 
-        if (fieldType instanceof DenseVectorFieldType == false) {
+        if (fieldType instanceof KnnFieldType == false) {
             throw new IllegalArgumentException(
-                "[" + NAME + "] queries are only supported on [" + DenseVectorFieldMapper.CONTENT_TYPE + "] fields"
+                "[" + NAME + "] queries are only supported on [" + DenseVectorFieldMapper.CONTENT_TYPE + "]  and [semantic_text] fields"
             );
         }
 
@@ -412,7 +413,7 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
         BooleanQuery booleanQuery = builder.build();
         Query filterQuery = booleanQuery.clauses().isEmpty() ? null : booleanQuery;
 
-        DenseVectorFieldType vectorFieldType = (DenseVectorFieldType) fieldType;
+        KnnFieldType vectorFieldType = (KnnFieldType) fieldType;
         String parentPath = context.nestedLookup().getNestedParent(fieldName);
 
         if (parentPath != null) {
@@ -446,9 +447,9 @@ public class KnnVectorQueryBuilder extends AbstractQueryBuilder<KnnVectorQueryBu
                 // Now join the filterQuery & parentFilter to provide the matching blocks of children
                 filterQuery = new ToChildBlockJoinQuery(filterQuery, parentBitSet);
             }
-            return vectorFieldType.createKnnQuery(queryVector, adjustedNumCands, filterQuery, vectorSimilarity, parentBitSet);
+            return vectorFieldType.createKnnQuery(queryVector, adjustedNumCands, filterQuery, vectorSimilarity, parentBitSet, context);
         }
-        return vectorFieldType.createKnnQuery(queryVector, adjustedNumCands, filterQuery, vectorSimilarity, null);
+        return vectorFieldType.createKnnQuery(queryVector, adjustedNumCands, filterQuery, vectorSimilarity, null, context);
     }
 
     @Override

--- a/x-pack/plugin/inference/src/main/java/module-info.java
+++ b/x-pack/plugin/inference/src/main/java/module-info.java
@@ -18,6 +18,7 @@ module org.elasticsearch.inference {
     requires org.apache.httpcomponents.httpcore.nio;
     requires org.apache.lucene.core;
     requires org.elasticsearch.logging;
+    requires org.apache.lucene.join;
 
     exports org.elasticsearch.xpack.inference.action;
     exports org.elasticsearch.xpack.inference.registry;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -316,8 +316,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
-            // TODO Check that we can delegate to the chunks
-            return getEmbeddingsField().fieldType().termQuery(value, context);
+            throw new IllegalArgumentException(CONTENT_TYPE + " fields do not support term query");
         }
 
         @Override

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -7,7 +7,9 @@
 
 package org.elasticsearch.xpack.inference.mapper;
 
+import org.apache.lucene.document.FeatureField;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.InferenceFieldMetadata;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.Strings;
@@ -171,6 +173,11 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
     }
 
     @Override
+    public NestedObjectMapper innerNestedObjectMapper() {
+        return fieldType().getChunksField();
+    }
+
+    @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
         XContentParser parser = context.parser();
         if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
@@ -301,7 +308,8 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
         @Override
         public Query termQuery(Object value, SearchExecutionContext context) {
-            throw new IllegalArgumentException(CONTENT_TYPE + " fields do not support term query");
+            // TODO Check that we can delegate to the chunks
+            return getEmbeddingsField().fieldType().termQuery(value, context);
         }
 
         @Override

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/20_semantic_text_field_mapper.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/20_semantic_text_field_mapper.yml
@@ -50,15 +50,13 @@ setup:
                 type: text
 
 ---
-"Sparse vector results indexing":
+"Sparse vector results format":
     - do:
         index:
           index: test-index
           id: doc_1
           body:
             sparse_field: "you know, for testing"
-
-
 
 ---
 "Dense vector results format":

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/20_semantic_text_field_mapper.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/20_semantic_text_field_mapper.yml
@@ -50,13 +50,15 @@ setup:
                 type: text
 
 ---
-"Sparse vector results format":
+"Sparse vector results indexing":
     - do:
         index:
           index: test-index
           id: doc_1
           body:
             sparse_field: "you know, for testing"
+
+
 
 ---
 "Dense vector results format":


### PR DESCRIPTION
WIP to add support for using text_expansion and sparse_vector queries.

We can try to support queries in two different ways:
### Using a `nested` query

```json
{
    "query": {
        "nested": {
            "path": "infer_field.inference.chunks",
            "query": {
                "knn": {
                  "field": "infer_field.inference.chunks.embeddings",
                  "query_vector_builder": {
                    "text_embedding": { 
                        "model_id": "my_e5_small", 
                        "model_text": "android" 
                      }
                    }
                }
            }
        }
    }
}
```

This requires to add `semantic_text` fields to the `NestedLookup` so the `nested` query works correclty

### Using directly the query

```json
{
    "query": {
        "knn": {
          "field": "infer_field",
          "query_vector_builder": {
            "text_embedding": { 
                "model_id": "my_e5_small", 
                "model_text": "android" 
              }
            }
        }
    }
}
```

This requires some more work, as the SemanticTextFieldType would need to:
- Delegate the query to the internal sparse / dense vector field type
- Wrap the generated query into a `ESToParentBlockJoinQuery` to allow nested results to be retrieved

This would imply that:
- Text_expansion queries do not rewrite directly to a boolean query, but use the field types to do so. This way, semantic_text field types can wrap the query internally into a `ESToParentBlockJoinQuery`.
- Interfaces like KnnFieldType / SparseVectorFieldType are created so queries can check the field type supports these queries, and use the appropriate method from them to generate the queries