### PR TITLE
Avoid unintentionally clearing the `DataStream.rolloverOnWrite` flag

### DIFF
--- a/docs/changelog/107122.yaml
+++ b/docs/changelog/107122.yaml
@@ -1,0 +1,5 @@
+pr: 107122
+summary: Avoid unintentionally clearing the `DataStream.rolloverOnWrite` flag
+area: Data streams
+type: bug
+issues: []

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -1790,7 +1790,8 @@ public class DataStreamIT extends ESIntegTestCase {
                         original.getIndexMode(),
                         original.getLifecycle(),
                         original.isFailureStore(),
-                        original.getFailureIndices()
+                        original.getFailureIndices(),
+                        original.rolloverOnWrite()
                     );
                     brokenDataStreamHolder.set(broken);
                     return ClusterState.builder(currentState)

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProviderTests.java
@@ -314,7 +314,8 @@ public class DataStreamIndexSettingsProviderTests extends ESTestCase {
                 IndexMode.TIME_SERIES,
                 ds.getLifecycle(),
                 ds.isFailureStore(),
-                ds.getFailureIndices()
+                ds.getFailureIndices(),
+                ds.rolloverOnWrite()
             )
         );
         Metadata metadata = mb.build();

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/UpdateTimeSeriesRangeServiceTests.java
@@ -153,7 +153,8 @@ public class UpdateTimeSeriesRangeServiceTests extends ESTestCase {
                     d.getIndexMode(),
                     d.getLifecycle(),
                     d.isFailureStore(),
-                    d.getFailureIndices()
+                    d.getFailureIndices(),
+                    false
                 )
             )
             .build();

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsResponseTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsResponseTests.java
@@ -88,7 +88,8 @@ public class GetDataStreamsResponseTests extends AbstractWireSerializingTestCase
                 IndexMode.STANDARD,
                 new DataStreamLifecycle(),
                 true,
-                failureStores
+                failureStores,
+                false
             );
 
             String ilmPolicyName = "rollover-30days";
@@ -197,7 +198,8 @@ public class GetDataStreamsResponseTests extends AbstractWireSerializingTestCase
                 IndexMode.STANDARD,
                 new DataStreamLifecycle(null, null, false),
                 true,
-                failureStores
+                failureStores,
+                false
             );
 
             String ilmPolicyName = "rollover-30days";

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
@@ -295,7 +295,8 @@ public class DataStreamLifecycleServiceTests extends ESTestCase {
                 dataStream.getIndexMode(),
                 DataStreamLifecycle.newBuilder().dataRetention(0L).build(),
                 dataStream.isFailureStore(),
-                dataStream.getFailureIndices()
+                dataStream.getFailureIndices(),
+                dataStream.rolloverOnWrite()
             )
         );
         clusterState = ClusterState.builder(clusterState).metadata(builder).build();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -126,38 +126,6 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
         IndexMode indexMode,
         DataStreamLifecycle lifecycle,
         boolean failureStore,
-        List<Index> failureIndices
-    ) {
-        this(
-            name,
-            indices,
-            generation,
-            metadata,
-            hidden,
-            replicated,
-            system,
-            System::currentTimeMillis,
-            allowCustomRouting,
-            indexMode,
-            lifecycle,
-            failureStore,
-            failureIndices,
-            false
-        );
-    }
-
-    public DataStream(
-        String name,
-        List<Index> indices,
-        long generation,
-        Map<String, Object> metadata,
-        boolean hidden,
-        boolean replicated,
-        boolean system,
-        boolean allowCustomRouting,
-        IndexMode indexMode,
-        DataStreamLifecycle lifecycle,
-        boolean failureStore,
         List<Index> failureIndices,
         boolean rolloverOnWrite
     ) {
@@ -212,6 +180,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
         this.failureStore = failureStore;
         this.failureIndices = failureIndices;
         assert assertConsistent(this.indices);
+        assert replicated == false || rolloverOnWrite == false : "replicated data streams cannot be marked for lazy rollover";
         this.rolloverOnWrite = rolloverOnWrite;
     }
 
@@ -227,7 +196,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
         boolean allowCustomRouting,
         IndexMode indexMode
     ) {
-        this(name, indices, generation, metadata, hidden, replicated, system, allowCustomRouting, indexMode, null, false, List.of());
+        this(name, indices, generation, metadata, hidden, replicated, system, allowCustomRouting, indexMode, null, false, List.of(), false);
     }
 
     private static boolean assertConsistent(List<Index> indices) {
@@ -456,7 +425,8 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             indexMode,
             lifecycle,
             failureStore,
-            failureIndices
+            failureIndices,
+            false
         );
     }
 
@@ -534,7 +504,8 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             indexMode,
             lifecycle,
             failureStore,
-            failureIndices
+            failureIndices,
+            rolloverOnWrite
         );
     }
 
@@ -579,7 +550,8 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             indexMode,
             lifecycle,
             failureStore,
-            failureIndices
+            failureIndices,
+            rolloverOnWrite
         );
     }
 
@@ -639,7 +611,8 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             indexMode,
             lifecycle,
             failureStore,
-            failureIndices
+            failureIndices,
+            rolloverOnWrite
         );
     }
 
@@ -694,7 +667,8 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
             indexMode,
             lifecycle,
             failureStore,
-            failureIndices
+            failureIndices,
+            rolloverOnWrite
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamService.java
@@ -314,7 +314,8 @@ public class MetadataCreateDataStreamService {
             indexMode,
             lifecycle == null && isDslOnlyMode ? DataStreamLifecycle.DEFAULT : lifecycle,
             template.getDataStreamTemplate().hasFailureStore(),
-            failureIndices
+            failureIndices,
+            false
         );
         Metadata.Builder builder = Metadata.builder(currentState.metadata()).put(newDataStream);
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsService.java
@@ -212,7 +212,8 @@ public class MetadataDataStreamsService {
                     dataStream.getIndexMode(),
                     lifecycle,
                     dataStream.isFailureStore(),
-                    dataStream.getFailureIndices()
+                    dataStream.getFailureIndices(),
+                    dataStream.rolloverOnWrite()
                 )
             );
         }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -716,7 +716,8 @@ public final class RestoreService implements ClusterStateApplier {
             dataStream.getIndexMode(),
             dataStream.getLifecycle(),
             dataStream.isFailureStore(),
-            dataStream.getFailureIndices()
+            dataStream.getFailureIndices(),
+            dataStream.rolloverOnWrite()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataDataStreamsServiceTests.java
@@ -356,7 +356,8 @@ public class MetadataDataStreamsServiceTests extends MapperServiceTestCase {
             original.getIndexMode(),
             original.getLifecycle(),
             original.isFailureStore(),
-            original.getFailureIndices()
+            original.getFailureIndices(),
+            original.rolloverOnWrite()
         );
         var brokenState = ClusterState.builder(state).metadata(Metadata.builder(state.getMetadata()).put(broken).build()).build();
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/metadata/DataStreamTestHelper.java
@@ -136,7 +136,8 @@ public final class DataStreamTestHelper {
             null,
             lifecycle,
             failureStores.size() > 0,
-            failureStores
+            failureStores,
+            false
         );
     }
 
@@ -293,13 +294,14 @@ public final class DataStreamTestHelper {
             failureIndices = randomIndexInstances();
         }
 
+        boolean replicated = randomBoolean();
         return new DataStream(
             dataStreamName,
             indices,
             generation,
             metadata,
             randomBoolean(),
-            randomBoolean(),
+            replicated,
             false, // Some tests don't work well with system data streams, since these data streams require special handling
             timeProvider,
             randomBoolean(),
@@ -307,7 +309,7 @@ public final class DataStreamTestHelper {
             randomBoolean() ? DataStreamLifecycle.newBuilder().dataRetention(randomMillisUpToYear9999()).build() : null,
             failureStore,
             failureIndices,
-            randomBoolean()
+            replicated == false && randomBoolean()
         );
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportPutFollowAction.java
@@ -334,7 +334,10 @@ public final class TransportPutFollowAction extends TransportMasterNodeAction<Pu
                 remoteDataStream.getIndexMode(),
                 remoteDataStream.getLifecycle(),
                 remoteDataStream.isFailureStore(),
-                remoteDataStream.getFailureIndices()
+                remoteDataStream.getFailureIndices(),
+                // Replicated data streams can't be rolled over, so having the `rolloverOnWrite` flag set to `true` wouldn't make sense
+                // (and potentially even break things).
+                false
             );
         } else {
             if (localDataStream.isReplicated() == false) {
@@ -387,7 +390,8 @@ public final class TransportPutFollowAction extends TransportMasterNodeAction<Pu
                 localDataStream.getIndexMode(),
                 localDataStream.getLifecycle(),
                 localDataStream.isFailureStore(),
-                localDataStream.getFailureIndices()
+                localDataStream.getFailureIndices(),
+                localDataStream.rolloverOnWrite()
             );
         }
     }

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/xpack/core/action/DataStreamLifecycleUsageTransportActionIT.java
@@ -122,19 +122,21 @@ public class DataStreamLifecycleUsageTransportActionIT extends ESIntegTestCase {
                     indices.add(index);
                 }
                 boolean systemDataStream = randomBoolean();
+                boolean replicated = randomBoolean();
                 DataStream dataStream = new DataStream(
                     randomAlphaOfLength(50),
                     indices,
                     randomLongBetween(0, 1000),
                     Map.of(),
                     systemDataStream || randomBoolean(),
-                    randomBoolean(),
+                    replicated,
                     systemDataStream,
                     randomBoolean(),
                     IndexMode.STANDARD,
                     lifecycle,
                     false,
-                    List.of()
+                    List.of(),
+                    replicated == false && randomBoolean()
                 );
                 dataStreamMap.put(dataStream.getName(), dataStream);
             }


### PR DESCRIPTION
Manual backport of https://github.com/elastic/elasticsearch/pull/107122. That PR came after auto-sharding, so I had to manually resolve some conflicts.