### PR TITLE
[Inference API] Consolidate common service fields in new superclass OpenAiServiceSettings

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiService.java
@@ -288,9 +288,11 @@ public class OpenAiService extends SenderService {
         var similarityToUse = similarityFromModel == null ? SimilarityMeasure.DOT_PRODUCT : similarityFromModel;
 
         OpenAiEmbeddingsServiceSettings serviceSettings = new OpenAiEmbeddingsServiceSettings(
-            model.getServiceSettings().modelId(),
-            model.getServiceSettings().uri(),
-            model.getServiceSettings().organizationId(),
+            new OpenAiServiceSettings(
+                model.getServiceSettings().modelId(),
+                model.getServiceSettings().uri(),
+                model.getServiceSettings().organizationId()
+            ),
             similarityToUse,
             embeddingSize,
             model.getServiceSettings().maxInputTokens(),

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceSettings.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.openai;
+
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.TransportVersions;
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.inference.ModelConfigurations;
+import org.elasticsearch.inference.ServiceSettings;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.elasticsearch.xpack.inference.services.ServiceFields.MODEL_ID;
+import static org.elasticsearch.xpack.inference.services.ServiceFields.URL;
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.convertToUri;
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.createOptionalUri;
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractOptionalString;
+import static org.elasticsearch.xpack.inference.services.ServiceUtils.extractRequiredString;
+import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFields.ORGANIZATION;
+
+public class OpenAiServiceSettings implements ServiceSettings {
+
+    public static final String NAME = "openai_service_settings";
+
+    private final String modelId;
+
+    private final URI uri;
+
+    private final String organizationId;
+
+    public static OpenAiServiceSettings fromMap(Map<String, Object> map) {
+        ValidationException validationException = new ValidationException();
+
+        String modelId = extractRequiredString(map, MODEL_ID, ModelConfigurations.SERVICE_SETTINGS, validationException);
+        String organizationId = extractOptionalString(map, ORGANIZATION, ModelConfigurations.SERVICE_SETTINGS, validationException);
+
+        String url = extractOptionalString(map, URL, ModelConfigurations.SERVICE_SETTINGS, validationException);
+        URI uri = convertToUri(url, URL, ModelConfigurations.SERVICE_SETTINGS, validationException);
+
+        if (validationException.validationErrors().isEmpty() == false) {
+            throw validationException;
+        }
+
+        return new OpenAiServiceSettings(modelId, uri, organizationId);
+    }
+
+    public OpenAiServiceSettings(String modelId, @Nullable URI uri, @Nullable String organizationId) {
+        this.uri = uri;
+        this.modelId = modelId;
+        this.organizationId = organizationId;
+    }
+
+    public OpenAiServiceSettings(String modelId, @Nullable String uri, @Nullable String organizationId) {
+        this(modelId, createOptionalUri(uri), organizationId);
+    }
+
+    public OpenAiServiceSettings(StreamInput in) throws IOException {
+        this.modelId = in.readString();
+        this.uri = createOptionalUri(in.readOptionalString());
+        this.organizationId = in.readOptionalString();
+    }
+
+    public String modelId() {
+        return modelId;
+    }
+
+    public URI uri() {
+        return uri;
+    }
+
+    public String organizationId() {
+        return organizationId;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+
+        toXContentFragment(builder);
+
+        builder.endObject();
+        return builder;
+    }
+
+    public XContentBuilder toXContentFragment(XContentBuilder builder) throws IOException {
+        builder.field(MODEL_ID, modelId);
+
+        if (uri != null) {
+            builder.field(URL, uri.toString());
+        }
+
+        if (organizationId != null) {
+            builder.field(ORGANIZATION, organizationId);
+        }
+
+        return builder;
+    }
+
+    @Override
+    public ToXContentObject getFilteredXContentObject() {
+        return this;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersions.ML_TEXT_EMBEDDING_INFERENCE_SERVICE_ADDED;
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        var uriToWrite = uri != null ? uri.toString() : null;
+        out.writeString(modelId);
+        out.writeOptionalString(uriToWrite);
+        out.writeOptionalString(organizationId);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        OpenAiServiceSettings that = (OpenAiServiceSettings) object;
+        return Objects.equals(modelId, that.modelId)
+            && Objects.equals(uri, that.uri)
+            && Objects.equals(organizationId, that.organizationId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(modelId, uri, organizationId);
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/OpenAiServiceSettingsTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.services.openai;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.inference.services.ServiceFields;
+import org.elasticsearch.xpack.inference.services.ServiceUtils;
+import org.elasticsearch.xpack.inference.services.openai.completion.OpenAiChatCompletionServiceSettings;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+public class OpenAiServiceSettingsTests extends AbstractWireSerializingTestCase<OpenAiServiceSettings> {
+
+    public void testFromMap_CreatesSettingsCorrectly() {
+        var modelId = "some model";
+        var url = "https://www.elastic.co";
+        var org = "organization";
+
+        var serviceSettings = OpenAiServiceSettings.fromMap(
+            new HashMap<>(Map.of(ServiceFields.MODEL_ID, modelId, ServiceFields.URL, url, OpenAiServiceFields.ORGANIZATION, org))
+        );
+
+        assertThat(serviceSettings, is(new OpenAiServiceSettings(modelId, ServiceUtils.createUri(url), org)));
+    }
+
+    public void testFromMap_MissingUrl_DoesNotThrowException() {
+        var modelId = "some model";
+        var organization = "org";
+
+        var serviceSettings = OpenAiServiceSettings.fromMap(
+            new HashMap<>(Map.of(ServiceFields.MODEL_ID, modelId, OpenAiServiceFields.ORGANIZATION, organization))
+        );
+
+        assertNull(serviceSettings.uri());
+        assertThat(serviceSettings.modelId(), is(modelId));
+        assertThat(serviceSettings.organizationId(), is(organization));
+    }
+
+    public void testFromMap_EmptyUrl_ThrowsError() {
+        var thrownException = expectThrows(
+            ValidationException.class,
+            () -> OpenAiServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, "", ServiceFields.MODEL_ID, "model")))
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            containsString(
+                Strings.format(
+                    "Validation Failed: 1: [service_settings] Invalid value empty string. [%s] must be a non-empty string;",
+                    ServiceFields.URL
+                )
+            )
+        );
+    }
+
+    public void testFromMap_MissingOrganization_DoesNotThrowException() {
+        var modelId = "some model";
+
+        var serviceSettings = OpenAiChatCompletionServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.MODEL_ID, modelId)));
+
+        assertNull(serviceSettings.uri());
+        assertThat(serviceSettings.modelId(), is(modelId));
+    }
+
+    public void testFromMap_EmptyOrganization_ThrowsError() {
+        var thrownException = expectThrows(
+            ValidationException.class,
+            () -> OpenAiServiceSettings.fromMap(
+                new HashMap<>(Map.of(OpenAiServiceFields.ORGANIZATION, "", ServiceFields.MODEL_ID, "model"))
+            )
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            containsString(
+                org.elasticsearch.common.Strings.format(
+                    "Validation Failed: 1: [service_settings] Invalid value empty string. [%s] must be a non-empty string;",
+                    OpenAiServiceFields.ORGANIZATION
+                )
+            )
+        );
+    }
+
+    public void testFromMap_InvalidUrl_ThrowsError() {
+        var url = "https://www.abc^.com";
+        var thrownException = expectThrows(
+            ValidationException.class,
+            () -> OpenAiServiceSettings.fromMap(new HashMap<>(Map.of(ServiceFields.URL, url, ServiceFields.MODEL_ID, "model")))
+        );
+
+        assertThat(
+            thrownException.getMessage(),
+            is(Strings.format("Validation Failed: 1: [service_settings] Invalid url [%s] received for field [%s];", url, ServiceFields.URL))
+        );
+    }
+
+    @Override
+    protected Writeable.Reader<OpenAiServiceSettings> instanceReader() {
+        return OpenAiServiceSettings::new;
+    }
+
+    @Override
+    protected OpenAiServiceSettings createTestInstance() {
+        return createRandomWithNonNullUrl();
+    }
+
+    @Override
+    protected OpenAiServiceSettings mutateInstance(OpenAiServiceSettings instance) throws IOException {
+        return createRandomWithNonNullUrl();
+    }
+
+    public static OpenAiServiceSettings createRandomWithNonNullUrl() {
+        return createRandom(randomAlphaOfLength(8));
+    }
+
+    public static OpenAiServiceSettings createRandom(String url) {
+        var modelId = randomAlphaOfLength(8);
+        var organizationId = randomFrom(randomAlphaOfLength(15), null);
+
+        return new OpenAiServiceSettings(modelId, ServiceUtils.createUri(url), organizationId);
+    }
+}

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/completion/OpenAiChatCompletionModelTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiServiceSettings;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
 import java.util.Map;
@@ -57,7 +58,7 @@ public class OpenAiChatCompletionModelTests extends ESTestCase {
             "id",
             TaskType.COMPLETION,
             "service",
-            new OpenAiChatCompletionServiceSettings(modelName, url, org, null),
+            new OpenAiChatCompletionServiceSettings(new OpenAiServiceSettings(modelName, url, org), null),
             new OpenAiChatCompletionTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsModelTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.inference.services.openai.OpenAiServiceSettings;
 import org.elasticsearch.xpack.inference.services.settings.DefaultSecretSettings;
 
 import java.util.Map;
@@ -59,7 +60,13 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             inferenceEntityId,
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(modelName, url, org, SimilarityMeasure.DOT_PRODUCT, 1536, null, false),
+            new OpenAiEmbeddingsServiceSettings(
+                new OpenAiServiceSettings(modelName, url, org),
+                SimilarityMeasure.DOT_PRODUCT,
+                1536,
+                null,
+                false
+            ),
             new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
@@ -76,7 +83,13 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(modelName, url, org, SimilarityMeasure.DOT_PRODUCT, 1536, null, false),
+            new OpenAiEmbeddingsServiceSettings(
+                new OpenAiServiceSettings(modelName, url, org),
+                SimilarityMeasure.DOT_PRODUCT,
+                1536,
+                null,
+                false
+            ),
             new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
@@ -94,7 +107,13 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(modelName, url, org, SimilarityMeasure.DOT_PRODUCT, 1536, tokenLimit, false),
+            new OpenAiEmbeddingsServiceSettings(
+                new OpenAiServiceSettings(modelName, url, org),
+                SimilarityMeasure.DOT_PRODUCT,
+                1536,
+                tokenLimit,
+                false
+            ),
             new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
@@ -113,7 +132,13 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(modelName, url, org, SimilarityMeasure.DOT_PRODUCT, dimensions, tokenLimit, false),
+            new OpenAiEmbeddingsServiceSettings(
+                new OpenAiServiceSettings(modelName, url, org),
+                SimilarityMeasure.DOT_PRODUCT,
+                dimensions,
+                tokenLimit,
+                false
+            ),
             new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
@@ -134,7 +159,13 @@ public class OpenAiEmbeddingsModelTests extends ESTestCase {
             "id",
             TaskType.TEXT_EMBEDDING,
             "service",
-            new OpenAiEmbeddingsServiceSettings(modelName, url, org, similarityMeasure, dimensions, tokenLimit, dimensionsSetByUser),
+            new OpenAiEmbeddingsServiceSettings(
+                new OpenAiServiceSettings(modelName, url, org),
+                similarityMeasure,
+                dimensions,
+                tokenLimit,
+                dimensionsSetByUser
+            ),
             new OpenAiEmbeddingsTaskSettings(user),
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );


### PR DESCRIPTION
Follow-up for https://github.com/elastic/elasticsearch/pull/106476#discussion_r1530534767.

TLDR: Moved common settings from `OpenAiChatCompletionServiceSettings` and `OpenAiEmbeddingsServiceSettings` to a new common super class `OpenAiServiceSettings`.