### PR TITLE
[TEST] Add retries in concurrent downsampling action

### DIFF
--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -553,7 +553,10 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
                 fail("downsample index has not been created");
             }
         });
-        downsample(sourceIndex, downsampleIndex, config);
+
+        // Downsample with retries, in case the downsampled index is not ready.
+        assertBusy(() -> downsample(sourceIndex, downsampleIndex, config), 120, TimeUnit.SECONDS);
+
         // We must wait until the in-progress downsample ends, otherwise data will not be cleaned up
         assertBusy(() -> assertTrue("In progress downsample did not complete", downsampleListener.success), 60, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
This helps in case the downsampled index is not ready to process.

Fixes #107210