### PR TITLE
ES|QL: Make more tests deterministic

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/keep.csv-spec
@@ -280,10 +280,10 @@ avg_salary:double | x:double
 ;
 
 averageOfEvalValue
-from employees | eval ratio = salary / height | stats avg(ratio);
+from employees | eval ratio = salary / height | stats avg = avg(ratio) | eval avg = round(avg, 8);
 
-avg(ratio):double
-27517.279737149947
+avg:double
+27517.27973715
 ;
 
 simpleWhere

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -137,6 +137,7 @@ avgOfDouble
 FROM employees
 | STATS AVG(height)
 // end::avg[]
+| EVAL `AVG(height)` = ROUND(`AVG(height)`, 5)
 ;
 
 // tag::avg-result[]
@@ -159,7 +160,7 @@ h:double
 1.76818359375
 ;
 avgOfScaledFloat
-from employees | stats h = avg(height.scaled_float);
+from employees | stats h = avg(height.scaled_float) | eval h = round(h, 4);
 
 h:double
 1.7682
@@ -1025,13 +1026,13 @@ c:long | cd:long
 docsStatsAvgNestedExpression#[skip:-8.12.99,reason:supported in 8.13+]
 // tag::docsStatsAvgNestedExpression[]
 FROM employees
-| STATS avg_salary_change = AVG(MV_AVG(salary_change))
+| STATS avg_salary_change = ROUND(AVG(MV_AVG(salary_change)), 10)
 // end::docsStatsAvgNestedExpression[]
 ;
 
 // tag::docsStatsAvgNestedExpression-result[]
 avg_salary_change:double
-1.3904535864978902
+1.3904535865
 // end::docsStatsAvgNestedExpression-result[]
 ;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -799,7 +799,7 @@ emp_no:integer | full_name:keyword | full_name_2:keyword | job_positions:keyword
 ;
 
 showTextFields
-from hosts | where host == "beta" | keep host, host_group, description;
+from hosts | sort description, card, ip0, ip1 | where host == "beta" | keep host, host_group, description;
 ignoreOrder:true
 
 host:keyword     | host_group:text          | description:text


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/105540
Fixes https://github.com/elastic/elasticsearch/issues/103866

Making a few more ES|QL CSV tests deterministic, especially those that involve `AVG()` (mostly failures like `expected:<27517.27973714994[7]> but was:<27517.27973714994[4]>` due to double precision in distributed execution)