### PR TITLE
Unwrap exceptions in ES|QL Async Query GET

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/NotSerializableExceptionWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/NotSerializableExceptionWrapper.java
@@ -58,7 +58,7 @@ public final class NotSerializableExceptionWrapper extends ElasticsearchExceptio
     }
 
     @Override
-    protected String getExceptionName() {
+    public String getExceptionName() {
         return name;
     }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -994,27 +994,17 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
             .add(new IndexRequest("test_overlapping_index_patterns_2").id("1").source("field", "foo"))
             .get();
 
-        assertVerificationException("from test_overlapping_index_patterns_* | sort field");
+        assertThrows(VerificationException.class, () -> run("from test_overlapping_index_patterns_* | sort field"));
     }
 
     public void testErrorMessageForUnknownColumn() {
-        var e = assertVerificationException("row a = 1 | eval x = b");
+        var e = expectThrows(VerificationException.class, () -> run("row a = 1 | eval x = b"));
         assertThat(e.getMessage(), containsString("Unknown column [b]"));
     }
 
-    // Straightforward verification. Subclasses can override.
-    protected Exception assertVerificationException(String esqlCommand) {
-        return expectThrows(VerificationException.class, () -> run(esqlCommand));
-    }
-
     public void testErrorMessageForEmptyParams() {
-        var e = assertParsingException("row a = 1 | eval x = ?");
+        var e = expectThrows(ParsingException.class, () -> run("row a = 1 | eval x = ?"));
         assertThat(e.getMessage(), containsString("Not enough actual parameters 0"));
-    }
-
-    // Straightforward verification. Subclasses can override.
-    protected Exception assertParsingException(String esqlCommand) {
-        return expectThrows(ParsingException.class, () -> run(esqlCommand));
     }
 
     public void testEmptyIndex() {

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
@@ -121,20 +121,6 @@ public class EsqlAsyncActionIT extends EsqlActionIT {
         }
     }
 
-    // @com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 100)
-    @Override
-    public void testErrorMessageForUnknownColumn() {
-        var e = expectThrows(VerificationException.class, () -> run("row a = 1 | eval x = b"));
-        assertThat(e.getMessage(), containsString("Unknown column [b]"));
-    }
-
-    // @com.carrotsearch.randomizedtesting.annotations.Repeat(iterations = 100)
-    @Override
-    public void testErrorMessageForEmptyParams() {
-        var e = expectThrows(ParsingException.class, () -> run("row a = 1 | eval x = ?"));
-        assertThat(e.getMessage(), containsString("Not enough actual parameters 0"));
-    }
-
     public static class LocalStateEsqlAsync extends LocalStateCompositeXPackPlugin {
         public LocalStateEsqlAsync(final Settings settings, final Path configPath) {
             super(settings, configPath);

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlAsyncActionIT.java
@@ -24,8 +24,6 @@ import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
 import org.elasticsearch.xpack.core.async.TransportDeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.TestBlockFactory;
-import org.elasticsearch.xpack.esql.VerificationException;
-import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 
 import java.nio.file.Path;
@@ -36,7 +34,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.core.TimeValue.timeValueSeconds;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsEqual.equalTo;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlAsyncGetResultsAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlAsyncGetResultsAction.java
@@ -7,20 +7,29 @@
 
 package org.elasticsearch.xpack.esql.plugin;
 
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchWrapperException;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
+import org.elasticsearch.xpack.esql.VerificationException;
 import org.elasticsearch.xpack.esql.action.EsqlAsyncGetResultAction;
 import org.elasticsearch.xpack.esql.action.EsqlQueryResponse;
 import org.elasticsearch.xpack.esql.action.EsqlQueryTask;
+import org.elasticsearch.xpack.esql.parser.ParsingException;
 import org.elasticsearch.xpack.ql.plugin.AbstractTransportQlAsyncGetResultsAction;
+import org.elasticsearch.xpack.ql.tree.Source;
 
 public class TransportEsqlAsyncGetResultsAction extends AbstractTransportQlAsyncGetResultsAction<EsqlQueryResponse, EsqlQueryTask> {
 
@@ -52,7 +61,56 @@ public class TransportEsqlAsyncGetResultsAction extends AbstractTransportQlAsync
     }
 
     @Override
+    protected void doExecute(Task task, GetAsyncResultRequest request, ActionListener<EsqlQueryResponse> listener) {
+        super.doExecute(task, request, unwrapListener(listener));
+    }
+
+    @Override
     public Writeable.Reader<EsqlQueryResponse> responseReader() {
         return EsqlQueryResponse.reader(blockFactory);
+    }
+
+    static final String PARSE_EX_NAME = ElasticsearchException.getExceptionName(new ParsingException(Source.EMPTY, ""));
+    static final String VERIFY_EX_NAME = ElasticsearchException.getExceptionName(new VerificationException(""));
+
+    /**
+     * Unwraps the exception in the case of failure. This keeps the exception types
+     * the same as the sync API, namely ParsingException and ParsingException.
+     */
+    static <R> ActionListener<R> unwrapListener(ActionListener<R> listener) {
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(R o) {
+                listener.onResponse(o);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (e instanceof ElasticsearchWrapperException && e instanceof ElasticsearchException ee) {
+                    e = unwrapEsException(ee);
+                }
+                if (e instanceof NotSerializableExceptionWrapper wrapper) {
+                    String name = wrapper.getExceptionName();
+                    if (PARSE_EX_NAME.equals(name)) {
+                        e = new ParsingException(Source.EMPTY, e.getMessage());
+                        e.setStackTrace(wrapper.getStackTrace());
+                        e.addSuppressed(wrapper);
+                    } else if (VERIFY_EX_NAME.contains(name)) {
+                        e = new VerificationException(e.getMessage());
+                        e.setStackTrace(wrapper.getStackTrace());
+                        e.addSuppressed(wrapper);
+                    }
+                }
+                listener.onFailure(e);
+            }
+        };
+    }
+
+    static RuntimeException unwrapEsException(ElasticsearchException esEx) {
+        Throwable root = esEx.unwrapCause();
+        if (root instanceof RuntimeException runtimeException) {
+            return runtimeException;
+        }
+        return esEx;
     }
 }


### PR DESCRIPTION
This commit updates the implementation of the ES|QL Async Query Get transport action so that exceptions are unwrapped before being exposed. This ensures that the exceptions seen by the client remain the same between sync and async. 

Specifically, only ParsingException and VerificationException are unwrapped, since these are currently the only ones that are returned.

closes #103870