### PR TITLE
[Transform] Only trigger action once per thread

### DIFF
--- a/docs/changelog/107232.yaml
+++ b/docs/changelog/107232.yaml
@@ -1,0 +1,6 @@
+pr: 107232
+summary: Only trigger action once per thread
+area: Transform
+type: bug
+issues:
+ - 107215


### PR DESCRIPTION
TransformScheduler can trigger its tasks on multiple threads. TransformTask uses an AtomicReference to manage one trigger event per thread by cycling between "Started" and "Indexing". The Retry Listener now has the same protection. "shouldRunAction" will cycle to false during execution and back to true if the action fails and should be retried.

Fix #107215

