### PR TITLE
Support effective watermark thresholds in node stats API

### DIFF
--- a/docs/changelog/107244.yaml
+++ b/docs/changelog/107244.yaml
@@ -1,0 +1,5 @@
+pr: 107244
+summary: Support effective watermark thresholds in node stats API
+area: Allocation
+type: enhancement
+issues: [106676]

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/90_fs_watermark_stats.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/90_fs_watermark_stats.yml
@@ -1,7 +1,7 @@
 ---
 "Allocation stats":
   - requires:
-      cluster_features: ["gte_v8.15.0"]
+      cluster_features: ["stats.include_disk_thresholds"]
       reason: "fs watermark stats was added in 8.15.0"
       test_runner_features: [arbitrary_key]
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/90_fs_watermark_stats.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/nodes.stats/90_fs_watermark_stats.yml
@@ -1,0 +1,27 @@
+---
+"Allocation stats":
+  - requires:
+      cluster_features: ["gte_v8.15.0"]
+      reason: "fs watermark stats was added in 8.15.0"
+      test_runner_features: [arbitrary_key]
+
+  - do:
+      nodes.info: {}
+  - set:
+      nodes._arbitrary_key_: node_id
+
+  - do:
+      nodes.stats:
+        metric: [ fs ]
+
+  - exists: nodes.$node_id.fs
+  - exists: nodes.$node_id.fs.data
+  - exists: nodes.$node_id.fs.data.0.path
+  - exists: nodes.$node_id.fs.data.0.mount
+  - exists: nodes.$node_id.fs.data.0.type
+  - exists: nodes.$node_id.fs.data.0.total_in_bytes
+  - exists: nodes.$node_id.fs.data.0.free_in_bytes
+  - exists: nodes.$node_id.fs.data.0.available_in_bytes
+  - exists: nodes.$node_id.fs.data.0.low_watermark_free_space_in_bytes
+  - exists: nodes.$node_id.fs.data.0.high_watermark_free_space_in_bytes
+  - exists: nodes.$node_id.fs.data.0.flood_stage_free_space_in_bytes

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
@@ -189,17 +189,17 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
         nodeStats = clusterAdmin().prepareNodesStats().setAllocationStats(true).setFs(true).get();
         dataNode = nodeStats.getNodes().stream().filter(n -> dataNodeName.equals(n.getNode().getName())).findFirst().get();
         path = dataNode.getFs().iterator().next();
-        assertEquals(3000, path.getLowStageFreeBytes().getBytes()); // 3000/10000
-        assertEquals(2000, path.getHighStageFreeBytes().getBytes()); // 2000/10000
-        assertEquals(1000, path.getFloodStageFreeBytes().getBytes()); // 1000/10000
+        assertEquals(3000, path.getLowStageFreeBytes().getBytes());
+        assertEquals(2000, path.getHighStageFreeBytes().getBytes());
+        assertEquals(1000, path.getFloodStageFreeBytes().getBytes());
         assertNull(path.getFrozenFloodStageFreeBytes());
 
         frozenNode = nodeStats.getNodes().stream().filter(n -> frozenNodeName.equals(n.getNode().getName())).findFirst().get();
         path = frozenNode.getFs().iterator().next();
-        assertEquals(3000, path.getLowStageFreeBytes().getBytes()); // 3000/20000
-        assertEquals(2000, path.getHighStageFreeBytes().getBytes()); // 2000/20000
-        assertEquals(1000, path.getFloodStageFreeBytes().getBytes()); // 1000/20000
-        assertEquals(500, path.getFrozenFloodStageFreeBytes().getBytes()); // 500/20000
+        assertEquals(3000, path.getLowStageFreeBytes().getBytes());
+        assertEquals(2000, path.getHighStageFreeBytes().getBytes());
+        assertEquals(1000, path.getFloodStageFreeBytes().getBytes());
+        assertEquals(500, path.getFrozenFloodStageFreeBytes().getBytes());
 
         // effective threshold percent calculated based on headroom
         updateClusterSettings(
@@ -215,9 +215,9 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
         nodeStats = clusterAdmin().prepareNodesStats().setAllocationStats(true).setFs(true).get();
         dataNode = nodeStats.getNodes().stream().filter(n -> dataNodeName.equals(n.getNode().getName())).findFirst().get();
         path = dataNode.getFs().iterator().next();
-        assertEquals(500, path.getLowStageFreeBytes().getBytes()); // 500/10000
-        assertEquals(300, path.getHighStageFreeBytes().getBytes()); // 300/10000
-        assertEquals(100, path.getFloodStageFreeBytes().getBytes()); // 100/10000
+        assertEquals(500, path.getLowStageFreeBytes().getBytes());
+        assertEquals(300, path.getHighStageFreeBytes().getBytes());
+        assertEquals(100, path.getFloodStageFreeBytes().getBytes());
     }
 
     // Retrieves the value of the given block on an index.

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
@@ -165,17 +165,17 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
         NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().setAllocationStats(true).setFs(true).get();
         NodeStats dataNode = nodeStats.getNodes().stream().filter(n -> dataNodeName.equals(n.getNode().getName())).findFirst().get();
         FsInfo.Path path = dataNode.getFs().iterator().next();
-        assertEquals(4000, path.getLowStageFreeBytes().getBytes());
-        assertEquals(3000, path.getHighStageFreeBytes().getBytes());
-        assertEquals(2000, path.getFloodStageFreeBytes().getBytes());
-        assertNull(path.getFrozenFloodStageFreeBytes());
+        assertEquals(4000, path.getLowWatermarkFreeSpace().getBytes());
+        assertEquals(3000, path.getHighWatermarkFreeSpace().getBytes());
+        assertEquals(2000, path.getFloodStageWatermarkFreeSpace().getBytes());
+        assertNull(path.getFrozenFloodStageWatermarkFreeSpace());
 
         NodeStats frozenNode = nodeStats.getNodes().stream().filter(n -> frozenNodeName.equals(n.getNode().getName())).findFirst().get();
         path = frozenNode.getFs().iterator().next();
-        assertEquals(8000, path.getLowStageFreeBytes().getBytes());
-        assertEquals(6000, path.getHighStageFreeBytes().getBytes());
-        assertEquals(4000, path.getFloodStageFreeBytes().getBytes());
-        assertEquals(2000, path.getFrozenFloodStageFreeBytes().getBytes());
+        assertEquals(8000, path.getLowWatermarkFreeSpace().getBytes());
+        assertEquals(6000, path.getHighWatermarkFreeSpace().getBytes());
+        assertEquals(4000, path.getFloodStageWatermarkFreeSpace().getBytes());
+        assertEquals(2000, path.getFrozenFloodStageWatermarkFreeSpace().getBytes());
 
         // update dynamic cluster settings, use absolute value, both data and master node have the same thresholds
         updateClusterSettings(
@@ -189,17 +189,17 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
         nodeStats = clusterAdmin().prepareNodesStats().setAllocationStats(true).setFs(true).get();
         dataNode = nodeStats.getNodes().stream().filter(n -> dataNodeName.equals(n.getNode().getName())).findFirst().get();
         path = dataNode.getFs().iterator().next();
-        assertEquals(3000, path.getLowStageFreeBytes().getBytes());
-        assertEquals(2000, path.getHighStageFreeBytes().getBytes());
-        assertEquals(1000, path.getFloodStageFreeBytes().getBytes());
-        assertNull(path.getFrozenFloodStageFreeBytes());
+        assertEquals(3000, path.getLowWatermarkFreeSpace().getBytes());
+        assertEquals(2000, path.getHighWatermarkFreeSpace().getBytes());
+        assertEquals(1000, path.getFloodStageWatermarkFreeSpace().getBytes());
+        assertNull(path.getFrozenFloodStageWatermarkFreeSpace());
 
         frozenNode = nodeStats.getNodes().stream().filter(n -> frozenNodeName.equals(n.getNode().getName())).findFirst().get();
         path = frozenNode.getFs().iterator().next();
-        assertEquals(3000, path.getLowStageFreeBytes().getBytes());
-        assertEquals(2000, path.getHighStageFreeBytes().getBytes());
-        assertEquals(1000, path.getFloodStageFreeBytes().getBytes());
-        assertEquals(500, path.getFrozenFloodStageFreeBytes().getBytes());
+        assertEquals(3000, path.getLowWatermarkFreeSpace().getBytes());
+        assertEquals(2000, path.getHighWatermarkFreeSpace().getBytes());
+        assertEquals(1000, path.getFloodStageWatermarkFreeSpace().getBytes());
+        assertEquals(500, path.getFrozenFloodStageWatermarkFreeSpace().getBytes());
 
         // effective threshold percent calculated based on headroom
         updateClusterSettings(
@@ -215,9 +215,9 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
         nodeStats = clusterAdmin().prepareNodesStats().setAllocationStats(true).setFs(true).get();
         dataNode = nodeStats.getNodes().stream().filter(n -> dataNodeName.equals(n.getNode().getName())).findFirst().get();
         path = dataNode.getFs().iterator().next();
-        assertEquals(500, path.getLowStageFreeBytes().getBytes());
-        assertEquals(300, path.getHighStageFreeBytes().getBytes());
-        assertEquals(100, path.getFloodStageFreeBytes().getBytes());
+        assertEquals(500, path.getLowWatermarkFreeSpace().getBytes());
+        assertEquals(300, path.getHighWatermarkFreeSpace().getBytes());
+        assertEquals(100, path.getFloodStageWatermarkFreeSpace().getBytes());
     }
 
     // Retrieves the value of the given block on an index.

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
@@ -8,20 +8,32 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
 import org.elasticsearch.cluster.DiskUsageIntegTestCase;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.tasks.TaskResultsService;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.NodeRoles;
 
 import java.util.Locale;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_MAX_HEADROOM_SETTING;
+import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING;
 import static org.elasticsearch.index.store.Store.INDEX_STORE_STATS_REFRESH_INTERVAL_SETTING;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertBlocked;
@@ -133,6 +145,79 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
         refreshClusterInfo();
         assertFalse(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
         assertThat(getIndexBlock(indexName, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE), equalTo("true"));
+    }
+
+    public void testNodeStatsIncludingDiskThreshold() {
+        Settings.Builder masterNodeSettings = Settings.builder();
+        masterNodeSettings.put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "60%")
+            .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "70%")
+            .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), "80%")
+            .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING.getKey(), "90%");
+
+        internalCluster().startMasterOnlyNode(masterNodeSettings.build());
+        final String dataNodeName = internalCluster().startDataOnlyNode();
+        final String frozenNodeName = internalCluster().startNode(NodeRoles.onlyRole(DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE));
+
+        getTestFileStore(dataNodeName).setTotalSpace(10000L);
+        getTestFileStore(frozenNodeName).setTotalSpace(20000L);
+
+        // no cluster settings, but master node's yml watermark threshold is different, data node stats based on master node's thresholds
+        NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().setAllocationStats(true).setFs(true).get();
+        NodeStats dataNode = nodeStats.getNodes().stream().filter(n -> dataNodeName.equals(n.getNode().getName())).findFirst().get();
+        FsInfo.Path path = dataNode.getFs().iterator().next();
+        assertEquals(4000, path.getLowStageFreeBytes().getBytes());
+        assertEquals(3000, path.getHighStageFreeBytes().getBytes());
+        assertEquals(2000, path.getFloodStageFreeBytes().getBytes());
+        assertNull(path.getFrozenFloodStageFreeBytes());
+
+        NodeStats frozenNode = nodeStats.getNodes().stream().filter(n -> frozenNodeName.equals(n.getNode().getName())).findFirst().get();
+        path = frozenNode.getFs().iterator().next();
+        assertEquals(8000, path.getLowStageFreeBytes().getBytes());
+        assertEquals(6000, path.getHighStageFreeBytes().getBytes());
+        assertEquals(4000, path.getFloodStageFreeBytes().getBytes());
+        assertEquals(2000, path.getFrozenFloodStageFreeBytes().getBytes());
+
+        // update dynamic cluster settings, use absolute value, both data and master node have the same thresholds
+        updateClusterSettings(
+            Settings.builder()
+                .put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "3000b")
+                .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "2000b")
+                .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), "1000b")
+                .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING.getKey(), "500b")
+        );
+
+        nodeStats = clusterAdmin().prepareNodesStats().setAllocationStats(true).setFs(true).get();
+        dataNode = nodeStats.getNodes().stream().filter(n -> dataNodeName.equals(n.getNode().getName())).findFirst().get();
+        path = dataNode.getFs().iterator().next();
+        assertEquals(3000, path.getLowStageFreeBytes().getBytes()); // 3000/10000
+        assertEquals(2000, path.getHighStageFreeBytes().getBytes()); // 2000/10000
+        assertEquals(1000, path.getFloodStageFreeBytes().getBytes()); // 1000/10000
+        assertNull(path.getFrozenFloodStageFreeBytes());
+
+        frozenNode = nodeStats.getNodes().stream().filter(n -> frozenNodeName.equals(n.getNode().getName())).findFirst().get();
+        path = frozenNode.getFs().iterator().next();
+        assertEquals(3000, path.getLowStageFreeBytes().getBytes()); // 3000/20000
+        assertEquals(2000, path.getHighStageFreeBytes().getBytes()); // 2000/20000
+        assertEquals(1000, path.getFloodStageFreeBytes().getBytes()); // 1000/20000
+        assertEquals(500, path.getFrozenFloodStageFreeBytes().getBytes()); // 500/20000
+
+        // effective threshold percent calculated based on headroom
+        updateClusterSettings(
+            Settings.builder()
+                .put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "60%")
+                .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), "70%")
+                .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), "80%")
+                .put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_MAX_HEADROOM_SETTING.getKey(), "500b")
+                .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getKey(), "300b")
+                .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING.getKey(), "100b")
+        );
+
+        nodeStats = clusterAdmin().prepareNodesStats().setAllocationStats(true).setFs(true).get();
+        dataNode = nodeStats.getNodes().stream().filter(n -> dataNodeName.equals(n.getNode().getName())).findFirst().get();
+        path = dataNode.getFs().iterator().next();
+        assertEquals(500, path.getLowStageFreeBytes().getBytes()); // 500/10000
+        assertEquals(300, path.getHighStageFreeBytes().getBytes()); // 300/10000
+        assertEquals(100, path.getFloodStageFreeBytes().getBytes()); // 100/10000
     }
 
     // Retrieves the value of the given block on an index.

--- a/server/src/main/java/module-info.java
+++ b/server/src/main/java/module-info.java
@@ -423,6 +423,7 @@ module org.elasticsearch.server {
             org.elasticsearch.cluster.metadata.MetadataFeatures,
             org.elasticsearch.rest.RestFeatures,
             org.elasticsearch.indices.IndicesFeatures,
+            org.elasticsearch.action.admin.cluster.allocation.AllocationStatsFeatures,
             org.elasticsearch.search.retriever.RetrieversFeatures;
 
     uses org.elasticsearch.plugins.internal.SettingsExtension;

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -175,6 +175,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_AZURE_OPENAI_EMBEDDINGS = def(8_634_00_0);
     public static final TransportVersion ILM_SHRINK_ENABLE_WRITE = def(8_635_00_0);
     public static final TransportVersion GEOIP_CACHE_STATS = def(8_636_00_0);
+    public static final TransportVersion WATERMARK_THRESHOLDS_STATS = def(8_637_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/AllocationStatsFeatures.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/AllocationStatsFeatures.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.admin.cluster.allocation;
+
+import org.elasticsearch.features.FeatureSpecification;
+import org.elasticsearch.features.NodeFeature;
+
+import java.util.Set;
+
+public class AllocationStatsFeatures implements FeatureSpecification {
+    public static final NodeFeature INCLUDE_DISK_THRESHOLD_SETTINGS = new NodeFeature("stats.include_disk_thresholds");
+
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(INCLUDE_DISK_THRESHOLD_SETTINGS);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -84,7 +84,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
         listener.onResponse(
             new Response(
                 allocationStatsService.stats(),
-                clusterService.state().getMinTransportVersion().onOrAfter(TransportVersions.WATERMARK_THRESHOLDS_STATS)
+                clusterService.state().clusterFeatures().clusterHasFeature(AllocationStatsFeatures.INCLUDE_DISK_THRESHOLD_SETTINGS)
                     ? diskThresholdSettings
                     : null
             )

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.FeatureService;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -44,6 +45,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
 
     private final AllocationStatsService allocationStatsService;
     private final DiskThresholdSettings diskThresholdSettings;
+    private final FeatureService featureService;
 
     @Inject
     public TransportGetAllocationStatsAction(
@@ -52,7 +54,8 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        AllocationStatsService allocationStatsService
+        AllocationStatsService allocationStatsService,
+        FeatureService featureService
     ) {
         super(
             TYPE.name(),
@@ -67,6 +70,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
         );
         this.allocationStatsService = allocationStatsService;
         this.diskThresholdSettings = new DiskThresholdSettings(clusterService.getSettings(), clusterService.getClusterSettings());
+        this.featureService = featureService;
     }
 
     @Override
@@ -84,7 +88,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
         listener.onResponse(
             new Response(
                 allocationStatsService.stats(),
-                clusterService.state().clusterFeatures().clusterHasFeature(AllocationStatsFeatures.INCLUDE_DISK_THRESHOLD_SETTINGS)
+                featureService.clusterHasFeature(clusterService.state(), AllocationStatsFeatures.INCLUDE_DISK_THRESHOLD_SETTINGS)
                     ? diskThresholdSettings
                     : null
             )

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -137,7 +137,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
             super(in);
             this.nodeAllocationStats = in.readImmutableMap(StreamInput::readString, NodeAllocationStats::new);
             if (in.getTransportVersion().onOrAfter(TransportVersions.WATERMARK_THRESHOLDS_STATS)) {
-                this.diskThresholdSettings = DiskThresholdSettings.readFrom(in);
+                this.diskThresholdSettings = in.readOptionalWriteable(DiskThresholdSettings::readFrom);
             } else {
                 this.diskThresholdSettings = null;
             }
@@ -147,7 +147,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
         public void writeTo(StreamOutput out) throws IOException {
             out.writeMap(nodeAllocationStats, StreamOutput::writeString, StreamOutput::writeWriteable);
             if (out.getTransportVersion().onOrAfter(TransportVersions.WATERMARK_THRESHOLDS_STATS)) {
-                diskThresholdSettings.writeTo(out);
+                out.writeOptionalWriteable(diskThresholdSettings);
             } else {
                 assert diskThresholdSettings == null;
             }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -81,11 +81,14 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
 
     @Override
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
-        if (clusterService.state().getMinTransportVersion().before(TransportVersions.WATERMARK_THRESHOLDS_STATS)) {
-            listener.onResponse(new Response(allocationStatsService.stats(), null));
-            return;
-        }
-        listener.onResponse(new Response(allocationStatsService.stats(), diskThresholdSettings));
+        listener.onResponse(
+            new Response(
+                allocationStatsService.stats(),
+                clusterService.state().getMinTransportVersion().onOrAfter(TransportVersions.WATERMARK_THRESHOLDS_STATS)
+                    ? diskThresholdSettings
+                    : null
+            )
+        );
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -122,7 +122,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
 
         private final Map<String, NodeAllocationStats> nodeAllocationStats;
         @Nullable // for bwc
-        private DiskThresholdSettings diskThresholdSettings = null;
+        private final DiskThresholdSettings diskThresholdSettings;
 
         public Response(Map<String, NodeAllocationStats> nodeAllocationStats, DiskThresholdSettings diskThresholdSettings) {
             this.nodeAllocationStats = nodeAllocationStats;
@@ -134,6 +134,8 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
             this.nodeAllocationStats = in.readImmutableMap(StreamInput::readString, NodeAllocationStats::new);
             if (in.getTransportVersion().onOrAfter(TransportVersions.WATERMARK_THRESHOLDS_STATS)) {
                 this.diskThresholdSettings = DiskThresholdSettings.readFrom(in);
+            } else {
+                this.diskThresholdSettings = null;
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetAllocationStatsAction.java
@@ -21,11 +21,13 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.allocation.AllocationStatsService;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationStats;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -41,6 +43,7 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
     public static final ActionType<TransportGetAllocationStatsAction.Response> TYPE = new ActionType<>("cluster:monitor/allocation/stats");
 
     private final AllocationStatsService allocationStatsService;
+    private final DiskThresholdSettings diskThresholdSettings;
 
     @Inject
     public TransportGetAllocationStatsAction(
@@ -63,13 +66,14 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
             threadPool.executor(ThreadPool.Names.MANAGEMENT)
         );
         this.allocationStatsService = allocationStatsService;
+        this.diskThresholdSettings = new DiskThresholdSettings(clusterService.getSettings(), clusterService.getClusterSettings());
     }
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         if (clusterService.state().getMinTransportVersion().before(TransportVersions.ALLOCATION_STATS)) {
             // The action is not available before ALLOCATION_STATS
-            listener.onResponse(new Response(Map.of()));
+            listener.onResponse(new Response(Map.of(), null));
             return;
         }
         super.doExecute(task, request, listener);
@@ -77,7 +81,11 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
 
     @Override
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
-        listener.onResponse(new Response(allocationStatsService.stats()));
+        if (clusterService.state().getMinTransportVersion().before(TransportVersions.WATERMARK_THRESHOLDS_STATS)) {
+            listener.onResponse(new Response(allocationStatsService.stats(), null));
+            return;
+        }
+        listener.onResponse(new Response(allocationStatsService.stats(), diskThresholdSettings));
     }
 
     @Override
@@ -110,23 +118,39 @@ public class TransportGetAllocationStatsAction extends TransportMasterNodeReadAc
     public static class Response extends ActionResponse {
 
         private final Map<String, NodeAllocationStats> nodeAllocationStats;
+        @Nullable // for bwc
+        private DiskThresholdSettings diskThresholdSettings = null;
 
-        public Response(Map<String, NodeAllocationStats> nodeAllocationStats) {
+        public Response(Map<String, NodeAllocationStats> nodeAllocationStats, DiskThresholdSettings diskThresholdSettings) {
             this.nodeAllocationStats = nodeAllocationStats;
+            this.diskThresholdSettings = diskThresholdSettings;
         }
 
         public Response(StreamInput in) throws IOException {
             super(in);
             this.nodeAllocationStats = in.readImmutableMap(StreamInput::readString, NodeAllocationStats::new);
+            if (in.getTransportVersion().onOrAfter(TransportVersions.WATERMARK_THRESHOLDS_STATS)) {
+                this.diskThresholdSettings = DiskThresholdSettings.readFrom(in);
+            }
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeMap(nodeAllocationStats, StreamOutput::writeString, StreamOutput::writeWriteable);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.WATERMARK_THRESHOLDS_STATS)) {
+                diskThresholdSettings.writeTo(out);
+            } else {
+                assert diskThresholdSettings == null;
+            }
         }
 
         public Map<String, NodeAllocationStats> getNodeAllocationStats() {
             return nodeAllocationStats;
+        }
+
+        @Nullable // for bwc
+        public DiskThresholdSettings getDiskThresholdSettings() {
+            return diskThresholdSettings;
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -12,6 +12,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationStats;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -171,7 +172,10 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
         this.nodeAllocationStats = nodeAllocationStats;
     }
 
-    public NodeStats withNodeAllocationStats(@Nullable NodeAllocationStats nodeAllocationStats) {
+    public NodeStats withNodeAllocationStats(
+        @Nullable NodeAllocationStats nodeAllocationStats,
+        @Nullable DiskThresholdSettings masterThresholdSettings
+    ) {
         return new NodeStats(
             getNode(),
             timestamp,
@@ -180,7 +184,7 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
             process,
             jvm,
             threadPool,
-            fs,
+            fs.setEffectiveWatermarks(masterThresholdSettings, getNode().isDedicatedFrozenNode()),
             transport,
             http,
             breaker,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -184,7 +184,7 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
             process,
             jvm,
             threadPool,
-            fs.setEffectiveWatermarks(masterThresholdSettings, getNode().isDedicatedFrozenNode()),
+            FsInfo.setEffectiveWatermarks(fs, masterThresholdSettings, getNode().isDedicatedFrozenNode()),
             transport,
             http,
             breaker,

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -86,7 +86,9 @@ public class TransportNodesStatsAction extends TransportNodesAction<
         ActionListener<NodesStatsResponse> listener
     ) {
         Set<String> metrics = request.getNodesStatsRequestParameters().requestedMetrics();
-        if (NodesStatsRequestParameters.Metric.ALLOCATIONS.containedIn(metrics)) {
+        if (NodesStatsRequestParameters.Metric.ALLOCATIONS.containedIn(metrics)
+            || NodesStatsRequestParameters.Metric.FS.containedIn(metrics)
+        ) {
             client.execute(
                 TransportGetAllocationStatsAction.TYPE,
                 new TransportGetAllocationStatsAction.Request(new TaskId(clusterService.localNode().getId(), task.getId())),

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -87,8 +87,7 @@ public class TransportNodesStatsAction extends TransportNodesAction<
     ) {
         Set<String> metrics = request.getNodesStatsRequestParameters().requestedMetrics();
         if (NodesStatsRequestParameters.Metric.ALLOCATIONS.containedIn(metrics)
-            || NodesStatsRequestParameters.Metric.FS.containedIn(metrics)
-        ) {
+            || NodesStatsRequestParameters.Metric.FS.containedIn(metrics)) {
             client.execute(
                 TransportGetAllocationStatsAction.TYPE,
                 new TransportGetAllocationStatsAction.Request(new TaskId(clusterService.localNode().getId(), task.getId())),

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/TransportNodesStatsAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.routing.allocation.NodeAllocationStats;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -90,7 +91,10 @@ public class TransportNodesStatsAction extends TransportNodesAction<
                 TransportGetAllocationStatsAction.TYPE,
                 new TransportGetAllocationStatsAction.Request(new TaskId(clusterService.localNode().getId(), task.getId())),
                 listener.delegateFailure((l, r) -> {
-                    ActionListener.respondAndRelease(l, newResponse(request, merge(responses, r.getNodeAllocationStats()), failures));
+                    ActionListener.respondAndRelease(
+                        l,
+                        newResponse(request, merge(responses, r.getNodeAllocationStats(), r.getDiskThresholdSettings()), failures)
+                    );
                 })
             );
         } else {
@@ -98,9 +102,13 @@ public class TransportNodesStatsAction extends TransportNodesAction<
         }
     }
 
-    private static List<NodeStats> merge(List<NodeStats> responses, Map<String, NodeAllocationStats> allocationStats) {
+    private static List<NodeStats> merge(
+        List<NodeStats> responses,
+        Map<String, NodeAllocationStats> allocationStats,
+        DiskThresholdSettings masterThresholdSettings
+    ) {
         return responses.stream()
-            .map(response -> response.withNodeAllocationStats(allocationStats.get(response.getNode().getId())))
+            .map(response -> response.withNodeAllocationStats(allocationStats.get(response.getNode().getId()), masterThresholdSettings))
             .toList();
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.cluster.routing.allocation;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -17,6 +20,7 @@ import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.UpdateForV9;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +28,7 @@ import java.util.Map;
 /**
  * A container to keep settings for disk thresholds up to date with cluster setting changes.
  */
-public class DiskThresholdSettings {
+public class DiskThresholdSettings implements Writeable {
     public static final Setting<Boolean> CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING = Setting.boolSetting(
         "cluster.routing.allocation.disk.threshold_enabled",
         true,
@@ -197,6 +201,61 @@ public class DiskThresholdSettings {
         );
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING, this::setRerouteInterval);
         clusterSettings.addSettingsUpdateConsumer(CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING, this::setEnabled);
+    }
+
+    public DiskThresholdSettings(
+        RelativeByteSizeValue lowStageWatermark,
+        ByteSizeValue lowStageMaxHeadroom,
+        RelativeByteSizeValue highStageWatermark,
+        ByteSizeValue highStageMaxHeadroom,
+        RelativeByteSizeValue floodStageWatermark,
+        ByteSizeValue floodStageMaxHeadroom,
+        RelativeByteSizeValue frozenFloodStageWatermark,
+        ByteSizeValue frozenFloodStageMaxHeadroom
+    ) {
+        this.lowStageWatermark = lowStageWatermark;
+        this.lowStageMaxHeadroom = lowStageMaxHeadroom;
+        this.highStageWatermark = highStageWatermark;
+        this.highStageMaxHeadroom = highStageMaxHeadroom;
+        this.floodStageWatermark = floodStageWatermark;
+        this.floodStageMaxHeadroom = floodStageMaxHeadroom;
+        this.frozenFloodStageWatermark = frozenFloodStageWatermark;
+        this.frozenFloodStageMaxHeadroom = frozenFloodStageMaxHeadroom;
+    }
+
+    public static DiskThresholdSettings readFrom(StreamInput in) throws IOException {
+        RelativeByteSizeValue lowStageWatermark = RelativeByteSizeValue.readFrom(in);
+        ByteSizeValue lowStageMaxHeadroom = ByteSizeValue.readFrom(in);
+        RelativeByteSizeValue highStageWatermark = RelativeByteSizeValue.readFrom(in);
+        ByteSizeValue highStageMaxHeadroom = ByteSizeValue.readFrom(in);
+        RelativeByteSizeValue floodStageWatermark = RelativeByteSizeValue.readFrom(in);
+        ByteSizeValue floodStageMaxHeadroom = ByteSizeValue.readFrom(in);
+        RelativeByteSizeValue frozenFloodStageWatermark = RelativeByteSizeValue.readFrom(in);
+        ByteSizeValue frozenFloodStageMaxHeadroom = ByteSizeValue.readFrom(in);
+
+        DiskThresholdSettings diskThresholdSettings = new DiskThresholdSettings(
+            lowStageWatermark,
+            lowStageMaxHeadroom,
+            highStageWatermark,
+            highStageMaxHeadroom,
+            floodStageWatermark,
+            floodStageMaxHeadroom,
+            frozenFloodStageWatermark,
+            frozenFloodStageMaxHeadroom
+        );
+        return diskThresholdSettings;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        lowStageWatermark.writeTo(out);
+        lowStageMaxHeadroom.writeTo(out);
+        highStageWatermark.writeTo(out);
+        highStageMaxHeadroom.writeTo(out);
+        floodStageWatermark.writeTo(out);
+        floodStageMaxHeadroom.writeTo(out);
+        frozenFloodStageWatermark.writeTo(out);
+        frozenFloodStageMaxHeadroom.writeTo(out);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdSettings.java
@@ -224,16 +224,16 @@ public class DiskThresholdSettings implements Writeable {
     }
 
     public static DiskThresholdSettings readFrom(StreamInput in) throws IOException {
-        RelativeByteSizeValue lowStageWatermark = RelativeByteSizeValue.readFrom(in);
-        ByteSizeValue lowStageMaxHeadroom = ByteSizeValue.readFrom(in);
-        RelativeByteSizeValue highStageWatermark = RelativeByteSizeValue.readFrom(in);
-        ByteSizeValue highStageMaxHeadroom = ByteSizeValue.readFrom(in);
-        RelativeByteSizeValue floodStageWatermark = RelativeByteSizeValue.readFrom(in);
-        ByteSizeValue floodStageMaxHeadroom = ByteSizeValue.readFrom(in);
-        RelativeByteSizeValue frozenFloodStageWatermark = RelativeByteSizeValue.readFrom(in);
-        ByteSizeValue frozenFloodStageMaxHeadroom = ByteSizeValue.readFrom(in);
+        final var lowStageWatermark = RelativeByteSizeValue.readFrom(in);
+        final var lowStageMaxHeadroom = ByteSizeValue.readFrom(in);
+        final var highStageWatermark = RelativeByteSizeValue.readFrom(in);
+        final var highStageMaxHeadroom = ByteSizeValue.readFrom(in);
+        final var floodStageWatermark = RelativeByteSizeValue.readFrom(in);
+        final var floodStageMaxHeadroom = ByteSizeValue.readFrom(in);
+        final var frozenFloodStageWatermark = RelativeByteSizeValue.readFrom(in);
+        final var frozenFloodStageMaxHeadroom = ByteSizeValue.readFrom(in);
 
-        DiskThresholdSettings diskThresholdSettings = new DiskThresholdSettings(
+        return new DiskThresholdSettings(
             lowStageWatermark,
             lowStageMaxHeadroom,
             highStageWatermark,
@@ -243,7 +243,6 @@ public class DiskThresholdSettings implements Writeable {
             frozenFloodStageWatermark,
             frozenFloodStageMaxHeadroom
         );
-        return diskThresholdSettings;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/unit/RatioValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/RatioValue.java
@@ -9,11 +9,16 @@
 package org.elasticsearch.common.unit;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
 
 /**
  * Utility class to represent ratio and percentage values between 0 and 100
  */
-public class RatioValue {
+public class RatioValue implements Writeable {
     private final double percent;
 
     public RatioValue(double percent) {
@@ -80,5 +85,14 @@ public class RatioValue {
         } else {
             return value.substring(0, Math.min(i + 1, value.length())) + "%";
         }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeDouble(percent);
+    }
+
+    public static RatioValue readFrom(StreamInput in) throws IOException {
+        return new RatioValue(in.readDouble());
     }
 }

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -534,11 +534,10 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
     }
 
     public FsInfo setEffectiveWatermarks(final DiskThresholdSettings masterThresholdSettings, boolean isDedicatedFrozenNode) {
-        if (masterThresholdSettings == null) {
-            return this;
-        }
-        for (Path path : paths) {
-            path.setEffectiveWatermarks(masterThresholdSettings, isDedicatedFrozenNode);
+        if (masterThresholdSettings != null) {
+            for (Path path : paths) {
+                path.setEffectiveWatermarks(masterThresholdSettings, isDedicatedFrozenNode);
+            }
         }
         return this;
     }

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -8,10 +8,12 @@
 
 package org.elasticsearch.monitor.fs;
 
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.xcontent.ToXContentFragment;
@@ -35,6 +37,11 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         long total = -1;
         long free = -1;
         long available = -1;
+
+        ByteSizeValue lowStageFreeBytes = null;
+        ByteSizeValue highStageFreeBytes = null;
+        ByteSizeValue floodStageFreeBytes = null;
+        ByteSizeValue frozenFloodStageFreeBytes = null;
 
         public Path() {}
 
@@ -92,6 +99,33 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             return ByteSizeValue.ofBytes(available);
         }
 
+        public void setEffectiveWatermarks(final DiskThresholdSettings masterThresholdSettings, boolean isDedicatedFrozenNode) {
+            lowStageFreeBytes = masterThresholdSettings.getFreeBytesThresholdLowStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
+            highStageFreeBytes = masterThresholdSettings.getFreeBytesThresholdHighStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
+            floodStageFreeBytes = masterThresholdSettings.getFreeBytesThresholdFloodStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
+            if (isDedicatedFrozenNode) {
+                frozenFloodStageFreeBytes = masterThresholdSettings.getFreeBytesThresholdFrozenFloodStage(
+                    new ByteSizeValue(total, ByteSizeUnit.BYTES)
+                );
+            }
+        }
+
+        public ByteSizeValue getLowStageFreeBytes() {
+            return lowStageFreeBytes;
+        }
+
+        public ByteSizeValue getHighStageFreeBytes() {
+            return highStageFreeBytes;
+        }
+
+        public ByteSizeValue getFloodStageFreeBytes() {
+            return floodStageFreeBytes;
+        }
+
+        public ByteSizeValue getFrozenFloodStageFreeBytes() {
+            return frozenFloodStageFreeBytes;
+        }
+
         private static long addLong(long current, long other) {
             if (current == -1 && other == -1) {
                 return 0;
@@ -121,6 +155,14 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             static final String FREE_IN_BYTES = "free_in_bytes";
             static final String AVAILABLE = "available";
             static final String AVAILABLE_IN_BYTES = "available_in_bytes";
+            static final String LOW_WATERMARK_FREE_SPACE = "low_watermark_free_space";
+            static final String LOW_WATERMARK_FREE_SPACE_IN_BYTES = "low_watermark_free_space_in_bytes";
+            static final String HIGH_WATERMARK_FREE_SPACE = "high_watermark_free_space";
+            static final String HIGH_WATERMARK_FREE_SPACE_IN_BYTES = "high_watermark_free_space_in_bytes";
+            static final String FLOOD_STAGE_FREE_SPACE = "flood_stage_free_space";
+            static final String FLOOD_STAGE_FREE_SPACE_IN_BYTES = "flood_stage_free_space_in_bytes";
+            static final String FROZEN_FLOOD_STAGE_FREE_SPACE = "frozen_flood_stage_free_space";
+            static final String FROZEN_FLOOD_STAGE_FREE_SPACE_IN_BYTES = "frozen_flood_stage_free_space_in_bytes";
         }
 
         @Override
@@ -144,6 +186,31 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             }
             if (available != -1) {
                 builder.humanReadableField(Fields.AVAILABLE_IN_BYTES, Fields.AVAILABLE, getAvailable());
+            }
+
+            if (lowStageFreeBytes != null) {
+                builder.humanReadableField(
+                    Fields.LOW_WATERMARK_FREE_SPACE_IN_BYTES,
+                    Fields.LOW_WATERMARK_FREE_SPACE,
+                    getLowStageFreeBytes()
+                );
+            }
+            if (highStageFreeBytes != null) {
+                builder.humanReadableField(
+                    Fields.HIGH_WATERMARK_FREE_SPACE_IN_BYTES,
+                    Fields.HIGH_WATERMARK_FREE_SPACE,
+                    getHighStageFreeBytes()
+                );
+            }
+            if (floodStageFreeBytes != null) {
+                builder.humanReadableField(Fields.FLOOD_STAGE_FREE_SPACE_IN_BYTES, Fields.FLOOD_STAGE_FREE_SPACE, getFloodStageFreeBytes());
+            }
+            if (frozenFloodStageFreeBytes != null) {
+                builder.humanReadableField(
+                    Fields.FROZEN_FLOOD_STAGE_FREE_SPACE_IN_BYTES,
+                    Fields.FROZEN_FLOOD_STAGE_FREE_SPACE,
+                    getFrozenFloodStageFreeBytes()
+                );
             }
 
             builder.endObject();
@@ -458,6 +525,16 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
             paths[i] = new Path(in);
         }
         this.total = total();
+    }
+
+    public FsInfo setEffectiveWatermarks(final DiskThresholdSettings masterThresholdSettings, boolean isDedicatedFrozenNode) {
+        if (masterThresholdSettings == null) {
+            return this;
+        }
+        for (Path path : paths) {
+            path.setEffectiveWatermarks(masterThresholdSettings, isDedicatedFrozenNode);
+        }
+        return this;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -38,10 +38,10 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         long free = -1;
         long available = -1;
 
-        ByteSizeValue lowStageFreeBytes = null;
-        ByteSizeValue highStageFreeBytes = null;
-        ByteSizeValue floodStageFreeBytes = null;
-        ByteSizeValue frozenFloodStageFreeBytes = null;
+        ByteSizeValue lowWatermarkFreeSpace = null;
+        ByteSizeValue highWatermarkFreeSpace = null;
+        ByteSizeValue floodStageWatermarkFreeSpace = null;
+        ByteSizeValue frozenFloodStageWatermarkFreeSpace = null;
 
         public Path() {}
 
@@ -100,30 +100,32 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         }
 
         public void setEffectiveWatermarks(final DiskThresholdSettings masterThresholdSettings, boolean isDedicatedFrozenNode) {
-            lowStageFreeBytes = masterThresholdSettings.getFreeBytesThresholdLowStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
-            highStageFreeBytes = masterThresholdSettings.getFreeBytesThresholdHighStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
-            floodStageFreeBytes = masterThresholdSettings.getFreeBytesThresholdFloodStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
+            lowWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdLowStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
+            highWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdHighStage(new ByteSizeValue(total, ByteSizeUnit.BYTES));
+            floodStageWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdFloodStage(
+                new ByteSizeValue(total, ByteSizeUnit.BYTES)
+            );
             if (isDedicatedFrozenNode) {
-                frozenFloodStageFreeBytes = masterThresholdSettings.getFreeBytesThresholdFrozenFloodStage(
+                frozenFloodStageWatermarkFreeSpace = masterThresholdSettings.getFreeBytesThresholdFrozenFloodStage(
                     new ByteSizeValue(total, ByteSizeUnit.BYTES)
                 );
             }
         }
 
-        public ByteSizeValue getLowStageFreeBytes() {
-            return lowStageFreeBytes;
+        public ByteSizeValue getLowWatermarkFreeSpace() {
+            return lowWatermarkFreeSpace;
         }
 
-        public ByteSizeValue getHighStageFreeBytes() {
-            return highStageFreeBytes;
+        public ByteSizeValue getHighWatermarkFreeSpace() {
+            return highWatermarkFreeSpace;
         }
 
-        public ByteSizeValue getFloodStageFreeBytes() {
-            return floodStageFreeBytes;
+        public ByteSizeValue getFloodStageWatermarkFreeSpace() {
+            return floodStageWatermarkFreeSpace;
         }
 
-        public ByteSizeValue getFrozenFloodStageFreeBytes() {
-            return frozenFloodStageFreeBytes;
+        public ByteSizeValue getFrozenFloodStageWatermarkFreeSpace() {
+            return frozenFloodStageWatermarkFreeSpace;
         }
 
         private static long addLong(long current, long other) {
@@ -188,28 +190,32 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
                 builder.humanReadableField(Fields.AVAILABLE_IN_BYTES, Fields.AVAILABLE, getAvailable());
             }
 
-            if (lowStageFreeBytes != null) {
+            if (lowWatermarkFreeSpace != null) {
                 builder.humanReadableField(
                     Fields.LOW_WATERMARK_FREE_SPACE_IN_BYTES,
                     Fields.LOW_WATERMARK_FREE_SPACE,
-                    getLowStageFreeBytes()
+                    getLowWatermarkFreeSpace()
                 );
             }
-            if (highStageFreeBytes != null) {
+            if (highWatermarkFreeSpace != null) {
                 builder.humanReadableField(
                     Fields.HIGH_WATERMARK_FREE_SPACE_IN_BYTES,
                     Fields.HIGH_WATERMARK_FREE_SPACE,
-                    getHighStageFreeBytes()
+                    getHighWatermarkFreeSpace()
                 );
             }
-            if (floodStageFreeBytes != null) {
-                builder.humanReadableField(Fields.FLOOD_STAGE_FREE_SPACE_IN_BYTES, Fields.FLOOD_STAGE_FREE_SPACE, getFloodStageFreeBytes());
+            if (floodStageWatermarkFreeSpace != null) {
+                builder.humanReadableField(
+                    Fields.FLOOD_STAGE_FREE_SPACE_IN_BYTES,
+                    Fields.FLOOD_STAGE_FREE_SPACE,
+                    getFloodStageWatermarkFreeSpace()
+                );
             }
-            if (frozenFloodStageFreeBytes != null) {
+            if (frozenFloodStageWatermarkFreeSpace != null) {
                 builder.humanReadableField(
                     Fields.FROZEN_FLOOD_STAGE_FREE_SPACE_IN_BYTES,
                     Fields.FROZEN_FLOOD_STAGE_FREE_SPACE,
-                    getFrozenFloodStageFreeBytes()
+                    getFrozenFloodStageWatermarkFreeSpace()
                 );
             }
 

--- a/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/fs/FsInfo.java
@@ -16,6 +16,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -533,13 +534,17 @@ public class FsInfo implements Iterable<FsInfo.Path>, Writeable, ToXContentFragm
         this.total = total();
     }
 
-    public FsInfo setEffectiveWatermarks(final DiskThresholdSettings masterThresholdSettings, boolean isDedicatedFrozenNode) {
-        if (masterThresholdSettings != null) {
-            for (Path path : paths) {
+    public static FsInfo setEffectiveWatermarks(
+        @Nullable final FsInfo fsInfo,
+        @Nullable final DiskThresholdSettings masterThresholdSettings,
+        boolean isDedicatedFrozenNode
+    ) {
+        if (fsInfo != null && masterThresholdSettings != null) {
+            for (Path path : fsInfo.paths) {
                 path.setEffectiveWatermarks(masterThresholdSettings, isDedicatedFrozenNode);
             }
         }
-        return this;
+        return fsInfo;
     }
 
     @Override

--- a/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
+++ b/server/src/main/resources/META-INF/services/org.elasticsearch.features.FeatureSpecification
@@ -12,4 +12,5 @@ org.elasticsearch.cluster.service.TransportFeatures
 org.elasticsearch.cluster.metadata.MetadataFeatures
 org.elasticsearch.rest.RestFeatures
 org.elasticsearch.indices.IndicesFeatures
+org.elasticsearch.action.admin.cluster.allocation.AllocationStatsFeatures
 org.elasticsearch.search.retriever.RetrieversFeatures


### PR DESCRIPTION
Adds to the `fs` component of the node stats API some additional values
indicating the disk watermarks that are currently in effect.

Relates #106676