### PR TITLE
Remove smart quote in distribution config

### DIFF
--- a/distribution/src/config/elasticsearch.yml
+++ b/distribution/src/config/elasticsearch.yml
@@ -87,7 +87,7 @@
 #
 # Elasticsearch security features are not enabled by default.
 # These features are free, but require configuration changes to enable them.
-# This means that users don’t have to provide credentials and can get full access
+# This means that users don't have to provide credentials and can get full access
 # to the cluster. Network connections are also not encrypted.
 #
 # To protect your data, we strongly encourage you to enable the Elasticsearch security features. 


### PR DESCRIPTION
That may sounds trivial, but the default distribution config contains a smart quote `’` instead of a plain ascii quote `' `, which is breaks in some yaml validation tool such as ansible-test (see: https://docs.ansible.com/ansible/latest/dev_guide/testing/sanity/no-smart-quotes.html)

This only affect version 7.*, that's why i made this pr against the 7.17 branch.