### PR TITLE
Fix field usage tests to allow sorts to pull points.

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/60_field_usage.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/60_field_usage.yml
@@ -115,7 +115,8 @@ setup:
   - match: { testindex.shards.0.stats.fields.price.inverted_index.proximity: 0 }
   - match: { testindex.shards.0.stats.fields.price.stored_fields: 0 }
   - gt: { testindex.shards.0.stats.fields.price.doc_values: 0 }
-  - match: { testindex.shards.0.stats.fields.price.points: 0 }
+  # dynamic pruning may pull points because of the sort
+  - gte: { testindex.shards.0.stats.fields.price.points: 0 }
   - match: { testindex.shards.0.stats.fields.price.norms: 0 }
   - match: { testindex.shards.0.stats.fields.price.term_vectors: 0 }
   - match: { testindex.shards.0.stats.fields.price.inverted_index.term_frequencies: 0 }


### PR DESCRIPTION
The test currently assumes that sorting by `price` only looks at doc values, however it may also look at points to dynamically prune irrelevant hits.

Note: this essentially aligns this test with the `main` branch.