### PR TITLE
Expand release note for #105044

### DIFF
--- a/docs/reference/release-notes/8.13.0.asciidoc
+++ b/docs/reference/release-notes/8.13.0.asciidoc
@@ -389,7 +389,7 @@ Security::
 
 Snapshot/Restore::
 * Add s3 `HeadObject` request to request stats {es-pull}105105[#105105]
-* Expose `OperationPurpose` via `CustomQueryParameter` to s3 logs {es-pull}105044[#105044]
+* Expose `OperationPurpose` in S3 access logs using a https://docs.aws.amazon.com/AmazonS3/latest/userguide/LogFormat.html#LogFormatCustom[custom query-string parameter] {es-pull}105044[#105044]
 * Fix blob cache race, decay, time dependency {es-pull}104784[#104784]
 * Pause shard snapshots on graceful shutdown {es-pull}101717[#101717]
 * Retry indefinitely for s3 indices blob read errors {es-pull}103300[#103300]


### PR DESCRIPTION
Users of supposedly-S3-compatible storage may need to be aware of this
change, so this commit expands the release notes to link to the relevant
S3 documentation.