### PR TITLE
[Docs][ESQL] Make functions reference more digestible

### DIFF
--- a/docs/reference/esql/esql-functions-operators.asciidoc
+++ b/docs/reference/esql/esql-functions-operators.asciidoc
@@ -1,40 +1,80 @@
 [[esql-functions-operators]]
 === {esql} functions and operators
-
 ++++
 <titleabbrev>Functions and operators</titleabbrev>
 ++++
 
 {esql} provides a comprehensive set of functions and operators for working with data.
-The functions are divided into the following categories:
+The reference documentation is divided into the following categories:
 
 [[esql-functions]]
+==== Functions overview
+
+.*Aggregate functions*
+[%collapsible]
+====
 <<esql-agg-functions>>::
 include::functions/aggregation-functions.asciidoc[tag=agg_list]
+====
 
+.*Math functions*
+[%collapsible]
+====
 <<esql-math-functions>>::
 include::functions/math-functions.asciidoc[tag=math_list]
+====
 
+.*String functions*
+[%collapsible]
+====
 <<esql-string-functions>>::
 include::functions/string-functions.asciidoc[tag=string_list]
+====
 
+.*Date and time functions*
+[%collapsible]
+====
 <<esql-date-time-functions>>::
 include::functions/date-time-functions.asciidoc[tag=date_list]
+====
 
+.*Spatial functions*
+[%collapsible]
+====
 <<esql-spatial-functions>>::
 include::functions/spatial-functions.asciidoc[tag=spatial_list]
+====
 
+.*Type conversion functions*
+[%collapsible]
+====
 <<esql-type-conversion-functions>>::
 include::functions/type-conversion-functions.asciidoc[tag=type_list]
+====
 
+.*Conditional functions and expressions*
+[%collapsible]
+====
 <<esql-conditional-functions-and-expressions>>::
 include::functions/conditional-functions-and-expressions.asciidoc[tag=cond_list]
+====
 
+.*Multi value functions*
+[%collapsible]
+====
 <<esql-mv-functions>>::
 include::functions/mv-functions.asciidoc[tag=mv_list]
+====
 
+[[esql-operators-overview]]
+==== Operators overview
+
+.*Operators*
+[%collapsible]
+====
 <<esql-operators>>::
 include::functions/operators.asciidoc[tag=op_list]
+====
 
 include::functions/aggregation-functions.asciidoc[]
 include::functions/math-functions.asciidoc[]

--- a/docs/reference/esql/esql-functions-operators.asciidoc
+++ b/docs/reference/esql/esql-functions-operators.asciidoc
@@ -13,56 +13,48 @@ The reference documentation is divided into the following categories:
 .*Aggregate functions*
 [%collapsible]
 ====
-<<esql-agg-functions>>::
 include::functions/aggregation-functions.asciidoc[tag=agg_list]
 ====
 
 .*Math functions*
 [%collapsible]
 ====
-<<esql-math-functions>>::
 include::functions/math-functions.asciidoc[tag=math_list]
 ====
 
 .*String functions*
 [%collapsible]
 ====
-<<esql-string-functions>>::
 include::functions/string-functions.asciidoc[tag=string_list]
 ====
 
 .*Date and time functions*
 [%collapsible]
 ====
-<<esql-date-time-functions>>::
 include::functions/date-time-functions.asciidoc[tag=date_list]
 ====
 
 .*Spatial functions*
 [%collapsible]
 ====
-<<esql-spatial-functions>>::
 include::functions/spatial-functions.asciidoc[tag=spatial_list]
 ====
 
 .*Type conversion functions*
 [%collapsible]
 ====
-<<esql-type-conversion-functions>>::
 include::functions/type-conversion-functions.asciidoc[tag=type_list]
 ====
 
 .*Conditional functions and expressions*
 [%collapsible]
 ====
-<<esql-conditional-functions-and-expressions>>::
 include::functions/conditional-functions-and-expressions.asciidoc[tag=cond_list]
 ====
 
 .*Multi value functions*
 [%collapsible]
 ====
-<<esql-mv-functions>>::
 include::functions/mv-functions.asciidoc[tag=mv_list]
 ====
 
@@ -72,7 +64,6 @@ include::functions/mv-functions.asciidoc[tag=mv_list]
 .*Operators*
 [%collapsible]
 ====
-<<esql-operators>>::
 include::functions/operators.asciidoc[tag=op_list]
 ====
 


### PR DESCRIPTION
Makes the functions overview page more digestible so you can see all available categories in one glance, and click collapsible toggle to display. This is nicer than the current experience where it's a giant list you have to scroll through, and basically duplicates the TOC.

## Before

![image](https://github.com/elastic/elasticsearch/assets/32779855/33c8e6bb-491f-4953-a62a-531a5d1c9a7b)


## After
<img width="818" alt="Screenshot 2024-04-09 at 12 45 45" src="https://github.com/elastic/elasticsearch/assets/32779855/f2441691-fc7d-468c-8195-a07cb13509dd">

