### PR TITLE
[DOCS] Expands the list of possible values of the result parameter of the bulk API

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -414,9 +414,7 @@ This parameter is only returned for successful actions.
 `result`::
 (string)
 Result of the operation. Successful values are `created`, `deleted`, and
-`updated`.
-+
-This parameter is only returned for successful operations.
+`updated`. Other valid values are `noop` and `not found`.
 
 `_shards`::
 (object)


### PR DESCRIPTION
## Overview

This PR expands the list of possible values of the bulk API's `result` response parameter (adds `noop` and `not found`). 

List of valid values: https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/action/DocWriteResponse.java#L55

### Preview

[Bulk API - Response body](https://elasticsearch_bk_107265.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/docs-bulk.html#bulk-api-response-body)