### PR TITLE
[8.13] [DOCS][ESQL] Rename _Learning ESQL_ to _ESQL reference_ (#107259)

### DIFF
--- a/docs/reference/esql/esql-language.asciidoc
+++ b/docs/reference/esql/esql-language.asciidoc
@@ -1,11 +1,10 @@
 [[esql-language]]
-== Learning {esql}
-
+== {esql} reference
 ++++
-<titleabbrev>Learning {esql}</titleabbrev>
+<titleabbrev>{esql} reference</titleabbrev>
 ++++
 
-Detailed information about the {esql} language:
+Detailed reference documentation for the {esql} language:
 
 * <<esql-syntax>>
 * <<esql-commands>>


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [DOCS][ESQL] Rename _Learning ESQL_ to _ESQL reference_ (#107259)