### PR TITLE
[8.13] [Docs][ESQL] Make functions reference more digestible (#107258)

### DIFF
--- a/docs/reference/esql/esql-functions-operators.asciidoc
+++ b/docs/reference/esql/esql-functions-operators.asciidoc
@@ -1,37 +1,65 @@
 [[esql-functions-operators]]
 === {esql} functions and operators
-
 ++++
 <titleabbrev>Functions and operators</titleabbrev>
 ++++
 
 {esql} provides a comprehensive set of functions and operators for working with data.
-The functions are divided into the following categories:
+The reference documentation is divided into the following categories:
 
 [[esql-functions]]
-<<esql-agg-functions>>::
+==== Functions overview
+
+.*Aggregate functions*
+[%collapsible]
+====
 include::functions/aggregation-functions.asciidoc[tag=agg_list]
+====
 
-<<esql-math-functions>>::
+.*Math functions*
+[%collapsible]
+====
 include::functions/math-functions.asciidoc[tag=math_list]
+====
 
-<<esql-string-functions>>::
+.*String functions*
+[%collapsible]
+====
 include::functions/string-functions.asciidoc[tag=string_list]
+====
 
-<<esql-date-time-functions>>::
+.*Date and time functions*
+[%collapsible]
+====
 include::functions/date-time-functions.asciidoc[tag=date_list]
+====
 
-<<esql-type-conversion-functions>>::
+.*Type conversion functions*
+[%collapsible]
+====
 include::functions/type-conversion-functions.asciidoc[tag=type_list]
+====
 
-<<esql-conditional-functions-and-expressions>>::
+.*Conditional functions and expressions*
+[%collapsible]
+====
 include::functions/conditional-functions-and-expressions.asciidoc[tag=cond_list]
+====
 
-<<esql-mv-functions>>::
+.*Multi value functions*
+[%collapsible]
+====
 include::functions/mv-functions.asciidoc[tag=mv_list]
+====
 
-<<esql-operators>>::
+[[esql-operators-overview]]
+==== Operators overview
+
+.*Operators*
+[%collapsible]
+====
 include::functions/operators.asciidoc[tag=op_list]
+====
 
 include::functions/aggregation-functions.asciidoc[]
 include::functions/math-functions.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Docs][ESQL] Make functions reference more digestible (#107258)](https://github.com/elastic/elasticsearch/pull/107258)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)