### PR TITLE
ES|QL: regex warnings in csv-spec tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -134,14 +133,11 @@ public class MultiClustersIT extends ESRestTestCase {
 
     private Map<String, Object> runEsql(RestEsqlTestCase.RequestObjectBuilder requestObject) throws IOException {
         if (supportsAsync()) {
-            return RestEsqlTestCase.runEsqlAsync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
+            return RestEsqlTestCase.runEsqlAsync(requestObject);
         } else {
-            return RestEsqlTestCase.runEsqlSync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
+            return RestEsqlTestCase.runEsqlSync(requestObject);
         }
     }
-
-    private static final List<String> NO_WARNINGS = List.of();
-    private static final List<Pattern> NO_WARNINGS_REGEX = List.of();
 
     public void testCount() throws Exception {
         {

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClustersIT.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -133,13 +134,14 @@ public class MultiClustersIT extends ESRestTestCase {
 
     private Map<String, Object> runEsql(RestEsqlTestCase.RequestObjectBuilder requestObject) throws IOException {
         if (supportsAsync()) {
-            return RestEsqlTestCase.runEsqlAsync(requestObject, NO_WARNINGS);
+            return RestEsqlTestCase.runEsqlAsync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
         } else {
-            return RestEsqlTestCase.runEsqlSync(requestObject, NO_WARNINGS);
+            return RestEsqlTestCase.runEsqlSync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
         }
     }
 
     private static final List<String> NO_WARNINGS = List.of();
+    private static final List<Pattern> NO_WARNINGS_REGEX = List.of();
 
     public void testCount() throws Exception {
         {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.apache.lucene.geo.GeoEncodingUtils.decodeLatitude;
 import static org.apache.lucene.geo.GeoEncodingUtils.decodeLongitude;
@@ -143,7 +144,11 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
 
     protected final void doTest() throws Throwable {
         RequestObjectBuilder builder = new RequestObjectBuilder(randomFrom(XContentType.values()));
-        Map<String, Object> answer = runEsql(builder.query(testCase.query), testCase.expectedWarnings(false));
+        Map<String, Object> answer = runEsql(
+            builder.query(testCase.query),
+            testCase.expectedWarnings(false),
+            testCase.expectedWarningsRegex()
+        );
         var expectedColumnsWithValues = loadCsvSpecValues(testCase.expectedResults);
 
         var metadata = answer.get("columns");
@@ -160,12 +165,16 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         assertResults(expectedColumnsWithValues, actualColumns, actualValues, testCase.ignoreOrder, logger);
     }
 
-    private Map<String, Object> runEsql(RequestObjectBuilder requestObject, List<String> expectedWarnings) throws IOException {
+    private Map<String, Object> runEsql(
+        RequestObjectBuilder requestObject,
+        List<String> expectedWarnings,
+        List<Pattern> expectedWarningsRegex
+    ) throws IOException {
         if (mode == Mode.ASYNC) {
             assert supportsAsync();
-            return RestEsqlTestCase.runEsqlAsync(requestObject, expectedWarnings);
+            return RestEsqlTestCase.runEsqlAsync(requestObject, expectedWarnings, expectedWarningsRegex);
         } else {
-            return RestEsqlTestCase.runEsqlSync(requestObject, expectedWarnings);
+            return RestEsqlTestCase.runEsqlSync(requestObject, expectedWarnings, expectedWarningsRegex);
         }
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
@@ -145,11 +144,7 @@ public abstract class RestEnrichTestCase extends ESRestTestCase {
     public void testNonExistentEnrichPolicy() throws IOException {
         ResponseException re = expectThrows(
             ResponseException.class,
-            () -> RestEsqlTestCase.runEsqlSync(
-                new RestEsqlTestCase.RequestObjectBuilder().query("from test | enrich countris"),
-                NO_WARNINGS,
-                NO_WARNINGS_REGEX
-            )
+            () -> RestEsqlTestCase.runEsqlSync(new RestEsqlTestCase.RequestObjectBuilder().query("from test | enrich countris"))
         );
         assertThat(
             EntityUtils.toString(re.getResponse().getEntity()),
@@ -193,14 +188,11 @@ public abstract class RestEnrichTestCase extends ESRestTestCase {
 
     private Map<String, Object> runEsql(RestEsqlTestCase.RequestObjectBuilder requestObject) throws IOException {
         if (mode == Mode.ASYNC) {
-            return RestEsqlTestCase.runEsqlAsync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
+            return RestEsqlTestCase.runEsqlAsync(requestObject);
         } else {
-            return RestEsqlTestCase.runEsqlSync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
+            return RestEsqlTestCase.runEsqlSync(requestObject);
         }
     }
-
-    private static final List<String> NO_WARNINGS = List.of();
-    private static final List<Pattern> NO_WARNINGS_REGEX = List.of();
 
     @Override
     protected boolean preserveClusterUponCompletion() {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEnrichTestCase.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
@@ -144,7 +145,11 @@ public abstract class RestEnrichTestCase extends ESRestTestCase {
     public void testNonExistentEnrichPolicy() throws IOException {
         ResponseException re = expectThrows(
             ResponseException.class,
-            () -> RestEsqlTestCase.runEsqlSync(new RestEsqlTestCase.RequestObjectBuilder().query("from test | enrich countris"), List.of())
+            () -> RestEsqlTestCase.runEsqlSync(
+                new RestEsqlTestCase.RequestObjectBuilder().query("from test | enrich countris"),
+                NO_WARNINGS,
+                NO_WARNINGS_REGEX
+            )
         );
         assertThat(
             EntityUtils.toString(re.getResponse().getEntity()),
@@ -188,13 +193,14 @@ public abstract class RestEnrichTestCase extends ESRestTestCase {
 
     private Map<String, Object> runEsql(RestEsqlTestCase.RequestObjectBuilder requestObject) throws IOException {
         if (mode == Mode.ASYNC) {
-            return RestEsqlTestCase.runEsqlAsync(requestObject, NO_WARNINGS);
+            return RestEsqlTestCase.runEsqlAsync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
         } else {
-            return RestEsqlTestCase.runEsqlSync(requestObject, NO_WARNINGS);
+            return RestEsqlTestCase.runEsqlSync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
         }
     }
 
     private static final List<String> NO_WARNINGS = List.of();
+    private static final List<Pattern> NO_WARNINGS_REGEX = List.of();
 
     @Override
     protected boolean preserveClusterUponCompletion() {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -905,13 +905,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         if (shouldLog()) {
             LOGGER.info("RESPONSE warnings (after muted)={}", warnings);
         }
-        if (allowedWarningsRegex.isEmpty()) {
-            assertMap(warnings.stream().sorted().toList(), matchesList(allowedWarnings.stream().sorted().toList()));
-        } else {
-            for (String warning : warnings) {
-                assertTrue("Unexpected warning: " + warning, allowedWarningsRegex.stream().anyMatch(x -> x.matcher(warning).matches()));
-            }
-        }
+        EsqlTestUtils.assertWarnings(warnings, allowedWarnings, allowedWarningsRegex);
         return response.getEntity();
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -668,6 +668,10 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         return runEsqlSync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
     }
 
+    public static Map<String, Object> runEsqlAsync(RequestObjectBuilder requestObject) throws IOException {
+        return runEsqlAsync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
+    }
+
     static Map<String, Object> runEsql(
         RequestObjectBuilder requestObject,
         List<String> expectedWarnings,

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -909,10 +909,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
             assertMap(warnings.stream().sorted().toList(), matchesList(allowedWarnings.stream().sorted().toList()));
         } else {
             for (String warning : warnings) {
-                assertTrue(
-                    "Unexpected warning: " + warning,
-                    allowedWarningsRegex.stream().anyMatch(x -> x.matcher(String.valueOf(warning)).matches())
-                );
+                assertTrue("Unexpected warning: " + warning, allowedWarningsRegex.stream().anyMatch(x -> x.matcher(warning).matches()));
             }
         }
         return response.getEntity();

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -50,6 +50,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.IntFunction;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
@@ -76,6 +77,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
     private static final Logger LOGGER = LogManager.getLogger(RestEsqlTestCase.class);
 
     private static final List<String> NO_WARNINGS = List.of();
+    private static final List<Pattern> NO_WARNINGS_REGEX = List.of();
 
     private static final String MAPPING_ALL_TYPES;
 
@@ -393,7 +395,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         options.addHeader("Content-Type", mediaType);
         options.addHeader("Accept", "text/csv; header=absent");
         request.setOptions(options);
-        HttpEntity entity = performRequest(request, List.of());
+        HttpEntity entity = performRequest(request, NO_WARNINGS, NO_WARNINGS_REGEX);
         String actual = Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8));
         assertEquals("keyword0,0\r\n", actual);
     }
@@ -452,7 +454,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
                     "Line 1:29: evaluation of [" + comparison + "] failed, treating result as null. Only first 20 failures recorded.",
                     "Line 1:29: java.lang.IllegalArgumentException: single-value function encountered multi-value"
                 );
-                var result = runEsql(query, expectedWarnings, mode);
+                var result = runEsql(query, expectedWarnings, NO_WARNINGS_REGEX, mode);
 
                 var values = as(result.get("values"), ArrayList.class);
                 assertThat(
@@ -660,22 +662,31 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
     }
 
     public Map<String, Object> runEsql(RequestObjectBuilder requestObject) throws IOException {
-        return runEsql(requestObject, NO_WARNINGS, mode);
+        return runEsql(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX, mode);
     }
 
     public static Map<String, Object> runEsqlSync(RequestObjectBuilder requestObject) throws IOException {
-        return runEsqlSync(requestObject, NO_WARNINGS);
+        return runEsqlSync(requestObject, NO_WARNINGS, NO_WARNINGS_REGEX);
     }
 
-    static Map<String, Object> runEsql(RequestObjectBuilder requestObject, List<String> expectedWarnings, Mode mode) throws IOException {
+    static Map<String, Object> runEsql(
+        RequestObjectBuilder requestObject,
+        List<String> expectedWarnings,
+        List<Pattern> expectedWarningsRegex,
+        Mode mode
+    ) throws IOException {
         if (mode == ASYNC) {
-            return runEsqlAsync(requestObject, expectedWarnings);
+            return runEsqlAsync(requestObject, expectedWarnings, expectedWarningsRegex);
         } else {
-            return runEsqlSync(requestObject, expectedWarnings);
+            return runEsqlSync(requestObject, expectedWarnings, expectedWarningsRegex);
         }
     }
 
-    public static Map<String, Object> runEsqlSync(RequestObjectBuilder requestObject, List<String> expectedWarnings) throws IOException {
+    public static Map<String, Object> runEsqlSync(
+        RequestObjectBuilder requestObject,
+        List<String> expectedWarnings,
+        List<Pattern> expectedWarningsRegex
+    ) throws IOException {
         requestObject.build();
         Request request = prepareRequest(SYNC);
         String mediaType = attachBody(requestObject, request);
@@ -691,11 +702,15 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         }
         request.setOptions(options);
 
-        HttpEntity entity = performRequest(request, expectedWarnings);
+        HttpEntity entity = performRequest(request, expectedWarnings, expectedWarningsRegex);
         return entityToMap(entity, requestObject.contentType());
     }
 
-    public static Map<String, Object> runEsqlAsync(RequestObjectBuilder requestObject, List<String> expectedWarnings) throws IOException {
+    public static Map<String, Object> runEsqlAsync(
+        RequestObjectBuilder requestObject,
+        List<String> expectedWarnings,
+        List<Pattern> expectedWarningsRegex
+    ) throws IOException {
         addAsyncParameters(requestObject);
         requestObject.build();
         Request request = prepareRequest(ASYNC);
@@ -729,7 +744,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
             // no id returned from an async call, must have completed immediately and without keep_on_completion
             assertThat(requestObject.keepOnCompletion(), either(nullValue()).or(is(false)));
             assertThat((boolean) json.get("is_running"), is(false));
-            assertWarnings(response, expectedWarnings);
+            assertWarnings(response, expectedWarnings, expectedWarningsRegex);
             json.remove("is_running"); // remove this to not mess up later map assertions
             return Collections.unmodifiableMap(json);
         } else {
@@ -738,7 +753,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
             if ((boolean) json.get("is_running") == false) {
                 // must have completed immediately so keep_on_completion must be true
                 assertThat(requestObject.keepOnCompletion(), is(true));
-                assertWarnings(response, expectedWarnings);
+                assertWarnings(response, expectedWarnings, expectedWarningsRegex);
                 // we already have the results, but let's remember them so that we can compare to async get
                 initialColumns = json.get("columns");
                 initialValues = json.get("values");
@@ -762,7 +777,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
             assertEquals(initialValues, result.get("values"));
         }
 
-        assertWarnings(response, expectedWarnings);
+        assertWarnings(response, expectedWarnings, expectedWarningsRegex);
         assertDeletable(id);
         return removeAsyncProperties(result);
     }
@@ -836,7 +851,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         }
         request.setOptions(options);
 
-        HttpEntity entity = performRequest(request, List.of());
+        HttpEntity entity = performRequest(request, NO_WARNINGS, NO_WARNINGS_REGEX);
         return Streams.copyToString(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8));
     }
 
@@ -869,8 +884,9 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         return mediaType;
     }
 
-    private static HttpEntity performRequest(Request request, List<String> allowedWarnings) throws IOException {
-        return assertWarnings(performRequest(request), allowedWarnings);
+    private static HttpEntity performRequest(Request request, List<String> allowedWarnings, List<Pattern> allowedWarningsRegex)
+        throws IOException {
+        return assertWarnings(performRequest(request), allowedWarnings, allowedWarningsRegex);
     }
 
     private static Response performRequest(Request request) throws IOException {
@@ -883,13 +899,22 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         return response;
     }
 
-    private static HttpEntity assertWarnings(Response response, List<String> allowedWarnings) {
+    private static HttpEntity assertWarnings(Response response, List<String> allowedWarnings, List<Pattern> allowedWarningsRegex) {
         List<String> warnings = new ArrayList<>(response.getWarnings());
         warnings.removeAll(mutedWarnings());
         if (shouldLog()) {
             LOGGER.info("RESPONSE warnings (after muted)={}", warnings);
         }
-        assertMap(warnings, matchesList(allowedWarnings));
+        if (allowedWarningsRegex.isEmpty()) {
+            assertMap(warnings.stream().sorted().toList(), matchesList(allowedWarnings.stream().sorted().toList()));
+        } else {
+            for (String warning : warnings) {
+                assertTrue(
+                    "Unexpected warning: " + warning,
+                    allowedWarningsRegex.stream().anyMatch(x -> x.matcher(String.valueOf(warning)).matches())
+                );
+            }
+        }
         return response.getEntity();
     }
 

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -54,7 +54,6 @@ import java.util.regex.Pattern;
 
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
-import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.test.MapMatcher.matchesMap;
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.as;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/EsqlTestUtils.java
@@ -43,11 +43,15 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
+import static org.elasticsearch.test.ListMatcher.matchesList;
+import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.xpack.ql.TestUtils.of;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertTrue;
 
 public final class EsqlTestUtils {
 
@@ -243,5 +247,15 @@ public final class EsqlTestUtils {
         all.add(enrich);
         all.addAll(after);
         return String.join(" | ", all);
+    }
+
+    public static void assertWarnings(List<String> warnings, List<String> allowedWarnings, List<Pattern> allowedWarningsRegex) {
+        if (allowedWarningsRegex.isEmpty()) {
+            assertMap(warnings.stream().sorted().toList(), matchesList(allowedWarnings.stream().sorted().toList()));
+        } else {
+            for (String warning : warnings) {
+                assertTrue("Unexpected warning: " + warning, allowedWarningsRegex.stream().anyMatch(x -> x.matcher(warning).matches()));
+            }
+        }
     }
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/README.md
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/README.md
@@ -209,8 +209,8 @@ The same, using regular expressions:
 addLongOverflow
 row max = 9223372036854775807 | eval sum = max + 1 | keep sum;
 
-warningRegex:Line 1:44: evaluation of \[max + 1\] failed, treating result as null. Only first 20 failures recorded.
-warningRegex:Line 1:44: java.lang.ArithmeticException: long overflow
+warningRegex:Line \d+:\d+: evaluation of \[max + 1\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line \d+:\d+: java.lang.ArithmeticException: long overflow
 
 sum:long
 null

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/README.md
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/README.md
@@ -102,7 +102,7 @@ include::{esql-specs}/floats.csv-spec[tag=sin-result]
 <details>
   <summary>What is this asciidoc syntax?</summary>
 
-The first section is a source code block for the ES|QL query: 
+The first section is a source code block for the ES|QL query:
 
 - a [source](https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-blocks/) code block (delimited by `----`)
 	- `source.merge.styled,esql` indicates custom syntax highlighting for ES|QL
@@ -176,3 +176,44 @@ row a = [true, false, false, true]
 ```
 
 That skips nodes that don't have the `esql.mv_sort` feature.
+
+
+### Warnings
+
+Some queries can return warnings, eg. for number overflows or when a multi-value is passed to a funciton
+that does not support it.
+
+Each CSV-SPEC test has to also assert all the expected warnings.
+
+Warnings can be specified as plain text or as a regular expression (but a single test cannot have a mix of both).
+Each warning has to be specified on a single row, between the query and the result, prefixed by `warning:` or `warningRegex:`.
+If multiple warnings are defined, the order is not relevant.
+
+This is an example of how to test a query that returns two warnings:
+
+```csv-spec
+addLongOverflow
+row max = 9223372036854775807 | eval sum = max + 1 | keep sum;
+
+warning:Line 1:44: evaluation of [max + 1] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:44: java.lang.ArithmeticException: long overflow
+
+sum:long
+null
+;
+```
+
+The same, using regular expressions:
+
+```csv-spec
+addLongOverflow
+row max = 9223372036854775807 | eval sum = max + 1 | keep sum;
+
+warningRegex:Line 1:44: evaluation of \[max + 1\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 1:44: java.lang.ArithmeticException: long overflow
+
+sum:long
+null
+;
+```
+

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -172,8 +172,8 @@ required_feature: esql.mv_warn
 
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | where eq in (ip0, ip1) | keep card, host, ip0, ip1, eq;
 ignoreOrder:true
-warningRegex:Line .*: evaluation of \[ip0==ip1\] failed, treating result as null. Only first 20 failures recorded.
-warningRegex:Line .*: evaluation of \[eq in \(ip0, ip1\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line \d+:\d+: evaluation of \[ip0==ip1\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line \d+:\d+: evaluation of \[eq in \(ip0, ip1\)\] failed, treating result as null. Only first 20 failures recorded.
 warningRegex:java.lang.IllegalArgumentException: single-value function encountered multi-value
 
 card:keyword   |host:keyword   |ip0:ip                                                                           |ip1:ip                   |eq:ip

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -150,10 +150,9 @@ required_feature: esql.mv_warn
 
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | where eq in (ip0, ip1) | keep card, host, ip0, ip1, eq;
 ignoreOrder:true
-warning:Line 1:27: evaluation of [ip0==ip1] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:27: java.lang.IllegalArgumentException: single-value function encountered multi-value
-warning:Line 1:55: evaluation of [eq in (ip0, ip1)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:55: java.lang.IllegalArgumentException: single-value function encountered multi-value
+warningRegex:Line 1:27: evaluation of \[ip0==ip1\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 1:55: evaluation of \[eq in \(ip0, ip1\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:java.lang.IllegalArgumentException: single-value function encountered multi-value
 
 card:keyword   |host:keyword   |ip0:ip                                                                           |ip1:ip                   |eq:ip
 eth0           |alpha          |127.0.0.1                                                                        |127.0.0.1                |127.0.0.1

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -172,8 +172,8 @@ required_feature: esql.mv_warn
 
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | where eq in (ip0, ip1) | keep card, host, ip0, ip1, eq;
 ignoreOrder:true
-warningRegex:Line 1:27: evaluation of \[ip0==ip1\] failed, treating result as null. Only first 20 failures recorded.
-warningRegex:Line 1:55: evaluation of \[eq in \(ip0, ip1\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line .*: evaluation of \[ip0==ip1\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line .*: evaluation of \[eq in \(ip0, ip1\)\] failed, treating result as null. Only first 20 failures recorded.
 warningRegex:java.lang.IllegalArgumentException: single-value function encountered multi-value
 
 card:keyword   |host:keyword   |ip0:ip                                                                           |ip1:ip                   |eq:ip

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -150,6 +150,28 @@ required_feature: esql.mv_warn
 
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | where eq in (ip0, ip1) | keep card, host, ip0, ip1, eq;
 ignoreOrder:true
+warning:Line 1:27: evaluation of [ip0==ip1] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:27: java.lang.IllegalArgumentException: single-value function encountered multi-value
+warning:Line 1:55: evaluation of [eq in (ip0, ip1)] failed, treating result as null. Only first 20 failures recorded.
+warning:Line 1:55: java.lang.IllegalArgumentException: single-value function encountered multi-value
+
+card:keyword   |host:keyword   |ip0:ip                                                                           |ip1:ip                   |eq:ip
+eth0           |alpha          |127.0.0.1                                                                        |127.0.0.1                |127.0.0.1
+eth1           |alpha          |::1                                                                              |::1                      |::1
+eth0           |beta           |127.0.0.1                                                                        |::1                      |::1
+eth1           |beta           |127.0.0.1                                                                        |127.0.0.2                |127.0.0.2
+eth1           |beta           |127.0.0.1                                                                        |128.0.0.1                |128.0.0.1
+lo0            |gamma          |fe80::cae2:65ff:fece:feb9                                                        |fe81::cae2:65ff:fece:feb9|fe81::cae2:65ff:fece:feb9
+eth0           |gamma          |fe80::cae2:65ff:fece:feb9                                                        |127.0.0.3                |127.0.0.3
+eth0           |epsilon        |[fe80::cae2:65ff:fece:feb9, fe80::cae2:65ff:fece:fec0, fe80::cae2:65ff:fece:fec1]|fe80::cae2:65ff:fece:fec1|fe80::cae2:65ff:fece:fec1
+;
+
+
+inWithWarningsRegex#[skip:-8.13.99, reason:regex warnings in tests introduced in v 8.14.0]
+required_feature: esql.mv_warn
+
+from hosts | eval eq=case(ip0==ip1, ip0, ip1) | where eq in (ip0, ip1) | keep card, host, ip0, ip1, eq;
+ignoreOrder:true
 warningRegex:Line 1:27: evaluation of \[ip0==ip1\] failed, treating result as null. Only first 20 failures recorded.
 warningRegex:Line 1:55: evaluation of \[eq in \(ip0, ip1\)\] failed, treating result as null. Only first 20 failures recorded.
 warningRegex:java.lang.IllegalArgumentException: single-value function encountered multi-value

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -98,10 +98,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 
-import static org.elasticsearch.test.ListMatcher.matchesList;
-import static org.elasticsearch.test.MapMatcher.assertMap;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.ExpectedResults;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.isEnabled;
 import static org.elasticsearch.xpack.esql.CsvTestUtils.loadCsvSpecValues;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -471,13 +471,6 @@ public class CsvTests extends ESTestCase {
                 normalized.add(normW);
             }
         }
-        List<Pattern> expectedWarningsRegex = testCase.expectedWarningsRegex();
-        if (expectedWarningsRegex.isEmpty()) {
-            assertMap(normalized.stream().sorted().toList(), matchesList(testCase.expectedWarnings(true).stream().sorted().toList()));
-        } else {
-            for (String warning : normalized) {
-                assertTrue("Unexpected warning: " + warning, expectedWarningsRegex.stream().anyMatch(x -> x.matcher(warning).matches()));
-            }
-        }
+        EsqlTestUtils.assertWarnings(normalized, testCase.expectedWarnings(true), testCase.expectedWarningsRegex());
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -476,10 +476,7 @@ public class CsvTests extends ESTestCase {
             assertMap(normalized.stream().sorted().toList(), matchesList(testCase.expectedWarnings(true).stream().sorted().toList()));
         } else {
             for (String warning : normalized) {
-                assertTrue(
-                    "Unexpected warning: " + warning,
-                    expectedWarningsRegex.stream().anyMatch(x -> x.matcher(String.valueOf(warning)).matches())
-                );
+                assertTrue("Unexpected warning: " + warning, expectedWarningsRegex.stream().anyMatch(x -> x.matcher(warning).matches()));
             }
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -98,6 +98,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
@@ -470,6 +471,16 @@ public class CsvTests extends ESTestCase {
                 normalized.add(normW);
             }
         }
-        assertMap(normalized, matchesList(testCase.expectedWarnings(true)));
+        List<Pattern> expectedWarningsRegex = testCase.expectedWarningsRegex();
+        if (expectedWarningsRegex.isEmpty()) {
+            assertMap(normalized.stream().sorted().toList(), matchesList(testCase.expectedWarnings(true).stream().sorted().toList()));
+        } else {
+            for (String warning : normalized) {
+                assertTrue(
+                    "Unexpected warning: " + warning,
+                    expectedWarningsRegex.stream().anyMatch(x -> x.matcher(String.valueOf(warning)).matches())
+                );
+            }
+        }
     }
 }

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -68,7 +69,17 @@ public final class CsvSpecReader {
                 // read data
                 String lower = line.toLowerCase(Locale.ROOT);
                 if (lower.startsWith("warning:")) {
-                    testCase.expectedWarnings.add(line.substring("warning:".length()).trim());
+                    if (testCase.expectedWarningsRegex.isEmpty()) {
+                        testCase.expectedWarnings.add(line.substring("warning:".length()).trim());
+                    } else {
+                        throw new IllegalArgumentException("Cannot mix warnings and regex warnings in CSV SPEC files: [" + line + "]");
+                    }
+                } else if (lower.startsWith("warningregex:")) {
+                    if (testCase.expectedWarnings.isEmpty()) {
+                        testCase.expectedWarningsRegex.add(Pattern.compile(".*" + line.substring("warningregex:".length()).trim() + ".*"));
+                    } else {
+                        throw new IllegalArgumentException("Cannot mix warnings and regex warnings in CSV SPEC files: [" + line + "]");
+                    }
                 } else if (lower.startsWith("ignoreorder:")) {
                     testCase.ignoreOrder = Boolean.parseBoolean(line.substring("ignoreOrder:".length()).trim());
                 } else if (line.startsWith(";")) {
@@ -93,6 +104,7 @@ public final class CsvSpecReader {
         public String earlySchema;
         public String expectedResults;
         private final List<String> expectedWarnings = new ArrayList<>();
+        private final List<Pattern> expectedWarningsRegex = new ArrayList<>();
         public boolean ignoreOrder;
         public List<String> requiredFeatures = List.of();
 
@@ -136,6 +148,10 @@ public final class CsvSpecReader {
          */
         public void adjustExpectedWarnings(Function<String, String> updater) {
             expectedWarnings.replaceAll(updater::apply);
+        }
+
+        public List<Pattern> expectedWarningsRegex() {
+            return expectedWarningsRegex;
         }
     }
 

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
@@ -69,17 +69,15 @@ public final class CsvSpecReader {
                 // read data
                 String lower = line.toLowerCase(Locale.ROOT);
                 if (lower.startsWith("warning:")) {
-                    if (testCase.expectedWarningsRegex.isEmpty()) {
-                        testCase.expectedWarnings.add(line.substring("warning:".length()).trim());
-                    } else {
+                    if (testCase.expectedWarningsRegex.isEmpty() == false) {
                         throw new IllegalArgumentException("Cannot mix warnings and regex warnings in CSV SPEC files: [" + line + "]");
                     }
+                    testCase.expectedWarnings.add(line.substring("warning:".length()).trim());
                 } else if (lower.startsWith("warningregex:")) {
-                    if (testCase.expectedWarnings.isEmpty()) {
-                        testCase.expectedWarningsRegex.add(Pattern.compile(".*" + line.substring("warningregex:".length()).trim() + ".*"));
-                    } else {
+                    if (testCase.expectedWarnings.isEmpty() == false) {
                         throw new IllegalArgumentException("Cannot mix warnings and regex warnings in CSV SPEC files: [" + line + "]");
                     }
+                    testCase.expectedWarningsRegex.add(Pattern.compile(".*" + line.substring("warningregex:".length()).trim() + ".*"));
                 } else if (lower.startsWith("ignoreorder:")) {
                     testCase.ignoreOrder = Boolean.parseBoolean(line.substring("ignoreOrder:".length()).trim());
                 } else if (line.startsWith(";")) {


### PR DESCRIPTION
This PR adds an option to declare warnings as regular expressions in `csv-spec` tests, using `warningRegex:` prefix instead of `warning:`.

It also relaxes a bit the checks, so that the order of warnings no longer matters.

This is general enough so that any test that extends `RestEsqlTestCase` can benefit from it.