### PR TITLE
typo: "not found" -> "not_found"

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -414,7 +414,7 @@ This parameter is only returned for successful actions.
 `result`::
 (string)
 Result of the operation. Successful values are `created`, `deleted`, and
-`updated`. Other valid values are `noop` and `not found`.
+`updated`. Other valid values are `noop` and `not_found`.
 
 `_shards`::
 (object)


### PR DESCRIPTION
Late review catch on https://github.com/elastic/elasticsearch/pull/107265