### PR TITLE
[7.17] [DOCS] Expands the list of possible values of the result parameter of the bulk API. (#107265)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -409,9 +409,7 @@ This parameter is only returned for successful actions.
 `result`::
 (string)
 Result of the operation. Successful values are `created`, `deleted`, and
-`updated`.
-+
-This parameter is only returned for successful operations.
+`updated`. Other valid values are `noop` and `not found`.
 
 `_shards`::
 (object)

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -409,7 +409,7 @@ This parameter is only returned for successful actions.
 `result`::
 (string)
 Result of the operation. Successful values are `created`, `deleted`, and
-`updated`. Other valid values are `noop` and `not found`.
+`updated`. Other valid values are `noop` and `not_found`.
 
 `_shards`::
 (object)


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[DOCS] Expands the list of possible values of the result parameter of the bulk API. (#107265)](https://github.com/elastic/elasticsearch/pull/107265)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)