### PR TITLE
Don't escape `.` in ESQL wildcard tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLikeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLikeTests.java
@@ -32,7 +32,7 @@ public class WildcardLikeTests extends AbstractFunctionTestCase {
     @ParametersFactory
     public static Iterable<Object[]> parameters() {
         return RLikeTests.parameters(str -> {
-            for (String syntax : new String[] { "\\", ".", "*" }) {
+            for (String syntax : new String[] { "\\", "*" }) {
                 str = str.replace(syntax, "\\" + syntax);
             }
             return str;


### PR DESCRIPTION
`.` is not a wildcard character....

Closes #106791
