### PR TITLE
[ML] Inference API Docs OpenAI model_id is required

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -165,7 +165,7 @@ want to use a different API key, delete the {infer} model and recreate it with
 the same name and the updated API key.
 
 `model_id`:::
-(Optional, string)
+(Required, string)
 The name of the model to use for the {infer} task. Refer to the
 https://platform.openai.com/docs/guides/embeddings/what-are-embeddings[OpenAI documentation]
 for the list of available text embedding models.
@@ -431,4 +431,3 @@ PUT _inference/completion/openai_completion
 }
 ------------------------------------------------------------
 // TEST[skip:TBD]
-


### PR DESCRIPTION
This PR updates the docs for `model_id` to state that it is required. If it is not included for the openai service, a validation error will be returned.