### PR TITLE
Renaming GeoIpDownloaderStatsAction

### DIFF
--- a/docs/reference/ingest/apis/geoip-stats-api.asciidoc
+++ b/docs/reference/ingest/apis/geoip-stats-api.asciidoc
@@ -4,8 +4,8 @@
 <titleabbrev>GeoIP stats</titleabbrev>
 ++++
 
-Gets download statistics for GeoIP2 databases used with the
-<<geoip-processor,`geoip` processor>>.
+Gets statistics about the <<geoip-processor,`geoip` processor>>, including
+download statistics for GeoIP2 databases used with it.
 
 [source,console]
 ----
@@ -60,7 +60,7 @@ Total number of database updates skipped.
 
 `nodes`::
 (object)
-Downloaded GeoIP2 databases for each node.
+Statistics for each node.
 +
 .Properties of `nodes`
 [%collapsible%open]

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -30,7 +30,7 @@ import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.ingest.AbstractProcessor;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
-import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStatsAction;
+import org.elasticsearch.ingest.geoip.stats.GeoIpStatsAction;
 import org.elasticsearch.persistent.PersistentTaskParams;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.plugins.IngestPlugin;
@@ -121,13 +121,10 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             }
         });
         assertBusy(() -> {
-            GeoIpDownloaderStatsAction.Response response = client().execute(
-                GeoIpDownloaderStatsAction.INSTANCE,
-                new GeoIpDownloaderStatsAction.Request()
-            ).actionGet();
-            assertThat(response.getStats().getDatabasesCount(), equalTo(0));
+            GeoIpStatsAction.Response response = client().execute(GeoIpStatsAction.INSTANCE, new GeoIpStatsAction.Request()).actionGet();
+            assertThat(response.getDownloaderStats().getDatabasesCount(), equalTo(0));
             assertThat(response.getNodes(), not(empty()));
-            for (GeoIpDownloaderStatsAction.NodeResponse nodeResponse : response.getNodes()) {
+            for (GeoIpStatsAction.NodeResponse nodeResponse : response.getNodes()) {
                 assertThat(nodeResponse.getConfigDatabases(), empty());
                 assertThat(nodeResponse.getDatabases(), empty());
                 assertThat(nodeResponse.getFilesInTemp().stream().filter(s -> s.endsWith(".txt") == false).toList(), empty());
@@ -703,12 +700,9 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             });
 
         assertBusy(() -> {
-            GeoIpDownloaderStatsAction.Response response = client().execute(
-                GeoIpDownloaderStatsAction.INSTANCE,
-                new GeoIpDownloaderStatsAction.Request()
-            ).actionGet();
+            GeoIpStatsAction.Response response = client().execute(GeoIpStatsAction.INSTANCE, new GeoIpStatsAction.Request()).actionGet();
             assertThat(response.getNodes(), not(empty()));
-            for (GeoIpDownloaderStatsAction.NodeResponse nodeResponse : response.getNodes()) {
+            for (GeoIpStatsAction.NodeResponse nodeResponse : response.getNodes()) {
                 assertThat(
                     nodeResponse.getConfigDatabases(),
                     containsInAnyOrder("GeoLite2-Country.mmdb", "GeoLite2-City.mmdb", "GeoLite2-ASN.mmdb")
@@ -751,12 +745,9 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             });
 
         assertBusy(() -> {
-            GeoIpDownloaderStatsAction.Response response = client().execute(
-                GeoIpDownloaderStatsAction.INSTANCE,
-                new GeoIpDownloaderStatsAction.Request()
-            ).actionGet();
+            GeoIpStatsAction.Response response = client().execute(GeoIpStatsAction.INSTANCE, new GeoIpStatsAction.Request()).actionGet();
             assertThat(response.getNodes(), not(empty()));
-            for (GeoIpDownloaderStatsAction.NodeResponse nodeResponse : response.getNodes()) {
+            for (GeoIpStatsAction.NodeResponse nodeResponse : response.getNodes()) {
                 assertThat(nodeResponse.getConfigDatabases(), empty());
             }
         });

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
@@ -11,7 +11,7 @@ package org.elasticsearch.ingest.geoip;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStatsAction;
+import org.elasticsearch.ingest.geoip.stats.GeoIpStatsAction;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.reindex.ReindexPlugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -65,8 +65,8 @@ public class GeoIpDownloaderStatsIT extends AbstractGeoIpIT {
          * slowly to pass.
          */
         assumeTrue("only test with fixture to have stable results", getEndpoint() != null);
-        GeoIpDownloaderStatsAction.Request req = new GeoIpDownloaderStatsAction.Request();
-        GeoIpDownloaderStatsAction.Response response = client().execute(GeoIpDownloaderStatsAction.INSTANCE, req).actionGet();
+        GeoIpStatsAction.Request req = new GeoIpStatsAction.Request();
+        GeoIpStatsAction.Response response = client().execute(GeoIpStatsAction.INSTANCE, req).actionGet();
         XContentTestUtils.JsonMapView jsonMapView = new XContentTestUtils.JsonMapView(convertToMap(response));
         assertThat(jsonMapView.get("stats.successful_downloads"), equalTo(0));
         assertThat(jsonMapView.get("stats.failed_downloads"), equalTo(0));
@@ -78,7 +78,7 @@ public class GeoIpDownloaderStatsIT extends AbstractGeoIpIT {
         updateClusterSettings(Settings.builder().put(GeoIpDownloaderTaskExecutor.ENABLED_SETTING.getKey(), true));
 
         assertBusy(() -> {
-            GeoIpDownloaderStatsAction.Response res = client().execute(GeoIpDownloaderStatsAction.INSTANCE, req).actionGet();
+            GeoIpStatsAction.Response res = client().execute(GeoIpStatsAction.INSTANCE, req).actionGet();
             XContentTestUtils.JsonMapView view = new XContentTestUtils.JsonMapView(convertToMap(res));
             assertThat(view.get("stats.successful_downloads"), equalTo(4));
             assertThat(view.get("stats.failed_downloads"), equalTo(0));

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -28,8 +28,8 @@ import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.ingest.IngestService;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStats;
-import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStatsAction;
-import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStatsTransportAction;
+import org.elasticsearch.ingest.geoip.stats.GeoIpStatsAction;
+import org.elasticsearch.ingest.geoip.stats.GeoIpStatsTransportAction;
 import org.elasticsearch.ingest.geoip.stats.RestGeoIpDownloaderStatsAction;
 import org.elasticsearch.persistent.PersistentTaskParams;
 import org.elasticsearch.persistent.PersistentTaskState;
@@ -144,7 +144,7 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, SystemInd
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return List.of(new ActionHandler<>(GeoIpDownloaderStatsAction.INSTANCE, GeoIpDownloaderStatsTransportAction.class));
+        return List.of(new ActionHandler<>(GeoIpStatsAction.INSTANCE, GeoIpStatsTransportAction.class));
     }
 
     @Override

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/IngestGeoIpPlugin.java
@@ -30,7 +30,7 @@ import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStats;
 import org.elasticsearch.ingest.geoip.stats.GeoIpStatsAction;
 import org.elasticsearch.ingest.geoip.stats.GeoIpStatsTransportAction;
-import org.elasticsearch.ingest.geoip.stats.RestGeoIpDownloaderStatsAction;
+import org.elasticsearch.ingest.geoip.stats.RestGeoIpStatsAction;
 import org.elasticsearch.persistent.PersistentTaskParams;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
@@ -159,7 +159,7 @@ public class IngestGeoIpPlugin extends Plugin implements IngestPlugin, SystemInd
         Supplier<DiscoveryNodes> nodesInCluster,
         Predicate<NodeFeature> clusterSupportsFeature
     ) {
-        return List.of(new RestGeoIpDownloaderStatsAction());
+        return List.of(new RestGeoIpStatsAction());
     }
 
     @Override

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsAction.java
@@ -30,11 +30,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-public class GeoIpDownloaderStatsAction {
+public class GeoIpStatsAction {
 
     public static final ActionType<Response> INSTANCE = new ActionType<>("cluster:monitor/ingest/geoip/stats");
 
-    private GeoIpDownloaderStatsAction() {/* no instances */}
+    private GeoIpStatsAction() {/* no instances */}
 
     public static class Request extends BaseNodesRequest<Request> implements ToXContentObject {
 
@@ -89,8 +89,8 @@ public class GeoIpDownloaderStatsAction {
             super(clusterName, nodes, failures);
         }
 
-        public GeoIpDownloaderStats getStats() {
-            return getNodes().stream().map(n -> n.stats).filter(Objects::nonNull).findFirst().orElse(GeoIpDownloaderStats.EMPTY);
+        public GeoIpDownloaderStats getDownloaderStats() {
+            return getNodes().stream().map(n -> n.downloaderStats).filter(Objects::nonNull).findFirst().orElse(GeoIpDownloaderStats.EMPTY);
         }
 
         @Override
@@ -105,7 +105,7 @@ public class GeoIpDownloaderStatsAction {
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            GeoIpDownloaderStats stats = getStats();
+            GeoIpDownloaderStats stats = getDownloaderStats();
             builder.startObject();
             builder.field("stats", stats);
             builder.startObject("nodes");
@@ -153,14 +153,14 @@ public class GeoIpDownloaderStatsAction {
 
     public static class NodeResponse extends BaseNodeResponse {
 
-        private final GeoIpDownloaderStats stats;
+        private final GeoIpDownloaderStats downloaderStats;
         private final Set<String> databases;
         private final Set<String> filesInTemp;
         private final Set<String> configDatabases;
 
         protected NodeResponse(StreamInput in) throws IOException {
             super(in);
-            stats = in.readBoolean() ? new GeoIpDownloaderStats(in) : null;
+            downloaderStats = in.readBoolean() ? new GeoIpDownloaderStats(in) : null;
             databases = in.readCollectionAsImmutableSet(StreamInput::readString);
             filesInTemp = in.readCollectionAsImmutableSet(StreamInput::readString);
             configDatabases = in.getTransportVersion().onOrAfter(TransportVersions.V_8_0_0)
@@ -170,20 +170,20 @@ public class GeoIpDownloaderStatsAction {
 
         protected NodeResponse(
             DiscoveryNode node,
-            GeoIpDownloaderStats stats,
+            GeoIpDownloaderStats downloaderStats,
             Set<String> databases,
             Set<String> filesInTemp,
             Set<String> configDatabases
         ) {
             super(node);
-            this.stats = stats;
+            this.downloaderStats = downloaderStats;
             this.databases = Set.copyOf(databases);
             this.filesInTemp = Set.copyOf(filesInTemp);
             this.configDatabases = Set.copyOf(configDatabases);
         }
 
-        public GeoIpDownloaderStats getStats() {
-            return stats;
+        public GeoIpDownloaderStats getDownloaderStats() {
+            return downloaderStats;
         }
 
         public Set<String> getDatabases() {
@@ -201,9 +201,9 @@ public class GeoIpDownloaderStatsAction {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeBoolean(stats != null);
-            if (stats != null) {
-                stats.writeTo(out);
+            out.writeBoolean(downloaderStats != null);
+            if (downloaderStats != null) {
+                downloaderStats.writeTo(out);
             }
             out.writeStringCollection(databases);
             out.writeStringCollection(filesInTemp);
@@ -217,7 +217,7 @@ public class GeoIpDownloaderStatsAction {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             NodeResponse that = (NodeResponse) o;
-            return stats.equals(that.stats)
+            return downloaderStats.equals(that.downloaderStats)
                 && databases.equals(that.databases)
                 && filesInTemp.equals(that.filesInTemp)
                 && Objects.equals(configDatabases, that.configDatabases);
@@ -225,7 +225,7 @@ public class GeoIpDownloaderStatsAction {
 
         @Override
         public int hashCode() {
-            return Objects.hash(stats, databases, filesInTemp, configDatabases);
+            return Objects.hash(downloaderStats, databases, filesInTemp, configDatabases);
         }
     }
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsTransportAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsTransportAction.java
@@ -18,10 +18,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.ingest.geoip.DatabaseNodeService;
 import org.elasticsearch.ingest.geoip.GeoIpDownloader;
 import org.elasticsearch.ingest.geoip.GeoIpDownloaderTaskExecutor;
-import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStatsAction.NodeRequest;
-import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStatsAction.NodeResponse;
-import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStatsAction.Request;
-import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStatsAction.Response;
+import org.elasticsearch.ingest.geoip.stats.GeoIpStatsAction.NodeRequest;
+import org.elasticsearch.ingest.geoip.stats.GeoIpStatsAction.NodeResponse;
+import org.elasticsearch.ingest.geoip.stats.GeoIpStatsAction.Request;
+import org.elasticsearch.ingest.geoip.stats.GeoIpStatsAction.Response;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -29,14 +29,14 @@ import org.elasticsearch.transport.TransportService;
 import java.io.IOException;
 import java.util.List;
 
-public class GeoIpDownloaderStatsTransportAction extends TransportNodesAction<Request, Response, NodeRequest, NodeResponse> {
+public class GeoIpStatsTransportAction extends TransportNodesAction<Request, Response, NodeRequest, NodeResponse> {
 
     private final TransportService transportService;
     private final DatabaseNodeService registry;
     private final GeoIpDownloaderTaskExecutor geoIpDownloaderTaskExecutor;
 
     @Inject
-    public GeoIpDownloaderStatsTransportAction(
+    public GeoIpStatsTransportAction(
         TransportService transportService,
         ClusterService clusterService,
         ThreadPool threadPool,
@@ -45,7 +45,7 @@ public class GeoIpDownloaderStatsTransportAction extends TransportNodesAction<Re
         GeoIpDownloaderTaskExecutor geoIpDownloaderTaskExecutor
     ) {
         super(
-            GeoIpDownloaderStatsAction.INSTANCE.name(),
+            GeoIpStatsAction.INSTANCE.name(),
             clusterService,
             transportService,
             actionFilters,
@@ -75,10 +75,10 @@ public class GeoIpDownloaderStatsTransportAction extends TransportNodesAction<Re
     @Override
     protected NodeResponse nodeOperation(NodeRequest request, Task task) {
         GeoIpDownloader geoIpTask = geoIpDownloaderTaskExecutor.getCurrentTask();
-        GeoIpDownloaderStats stats = geoIpTask == null || geoIpTask.getStatus() == null ? null : geoIpTask.getStatus();
+        GeoIpDownloaderStats downloaderStats = geoIpTask == null || geoIpTask.getStatus() == null ? null : geoIpTask.getStatus();
         return new NodeResponse(
             transportService.getLocalNode(),
-            stats,
+            downloaderStats,
             registry.getAvailableDatabases(),
             registry.getFilesInTemp(),
             registry.getConfigDatabases()

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/RestGeoIpDownloaderStatsAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/RestGeoIpDownloaderStatsAction.java
@@ -34,10 +34,6 @@ public class RestGeoIpDownloaderStatsAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
-        return channel -> client.execute(
-            GeoIpDownloaderStatsAction.INSTANCE,
-            new GeoIpDownloaderStatsAction.Request(),
-            new RestToXContentListener<>(channel)
-        );
+        return channel -> client.execute(GeoIpStatsAction.INSTANCE, new GeoIpStatsAction.Request(), new RestToXContentListener<>(channel));
     }
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/RestGeoIpStatsAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/RestGeoIpStatsAction.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 @ServerlessScope(Scope.INTERNAL)
-public class RestGeoIpDownloaderStatsAction extends BaseRestHandler {
+public class RestGeoIpStatsAction extends BaseRestHandler {
 
     @Override
     public String getName() {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsActionNodeResponseSerializingTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsActionNodeResponseSerializingTests.java
@@ -15,30 +15,29 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.Set;
 
-public class GeoIpDownloaderStatsActionNodeResponseSerializingTests extends AbstractWireSerializingTestCase<
-    GeoIpDownloaderStatsAction.NodeResponse> {
+public class GeoIpStatsActionNodeResponseSerializingTests extends AbstractWireSerializingTestCase<GeoIpStatsAction.NodeResponse> {
 
     @Override
-    protected Writeable.Reader<GeoIpDownloaderStatsAction.NodeResponse> instanceReader() {
-        return GeoIpDownloaderStatsAction.NodeResponse::new;
+    protected Writeable.Reader<GeoIpStatsAction.NodeResponse> instanceReader() {
+        return GeoIpStatsAction.NodeResponse::new;
     }
 
     @Override
-    protected GeoIpDownloaderStatsAction.NodeResponse createTestInstance() {
+    protected GeoIpStatsAction.NodeResponse createTestInstance() {
         return createRandomInstance();
     }
 
     @Override
-    protected GeoIpDownloaderStatsAction.NodeResponse mutateInstance(GeoIpDownloaderStatsAction.NodeResponse instance) {
+    protected GeoIpStatsAction.NodeResponse mutateInstance(GeoIpStatsAction.NodeResponse instance) {
         return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
     }
 
-    static GeoIpDownloaderStatsAction.NodeResponse createRandomInstance() {
+    static GeoIpStatsAction.NodeResponse createRandomInstance() {
         DiscoveryNode node = DiscoveryNodeUtils.create("id");
         Set<String> databases = Set.copyOf(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
         Set<String> files = Set.copyOf(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
         Set<String> configDatabases = Set.copyOf(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
-        return new GeoIpDownloaderStatsAction.NodeResponse(
+        return new GeoIpStatsAction.NodeResponse(
             node,
             GeoIpDownloaderStatsSerializingTests.createRandomInstance(),
             databases,

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsActionNodeResponseTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsActionNodeResponseTests.java
@@ -18,14 +18,14 @@ import java.util.Set;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
-public class GeoIpDownloaderStatsActionNodeResponseTests extends ESTestCase {
+public class GeoIpStatsActionNodeResponseTests extends ESTestCase {
 
     public void testInputsAreDefensivelyCopied() {
         DiscoveryNode node = DiscoveryNodeUtils.create("id");
         Set<String> databases = new HashSet<>(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
         Set<String> files = new HashSet<>(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
         Set<String> configDatabases = new HashSet<>(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
-        GeoIpDownloaderStatsAction.NodeResponse nodeResponse = new GeoIpDownloaderStatsAction.NodeResponse(
+        GeoIpStatsAction.NodeResponse nodeResponse = new GeoIpStatsAction.NodeResponse(
             node,
             GeoIpDownloaderStatsSerializingTests.createRandomInstance(),
             databases,

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsActionResponseSerializingTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpStatsActionResponseSerializingTests.java
@@ -14,25 +14,24 @@ import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.List;
 
-public class GeoIpDownloaderStatsActionResponseSerializingTests extends AbstractWireSerializingTestCase<
-    GeoIpDownloaderStatsAction.Response> {
+public class GeoIpStatsActionResponseSerializingTests extends AbstractWireSerializingTestCase<GeoIpStatsAction.Response> {
 
     @Override
-    protected Writeable.Reader<GeoIpDownloaderStatsAction.Response> instanceReader() {
-        return GeoIpDownloaderStatsAction.Response::new;
+    protected Writeable.Reader<GeoIpStatsAction.Response> instanceReader() {
+        return GeoIpStatsAction.Response::new;
     }
 
     @Override
-    protected GeoIpDownloaderStatsAction.Response createTestInstance() {
-        List<GeoIpDownloaderStatsAction.NodeResponse> nodeResponses = randomList(
+    protected GeoIpStatsAction.Response createTestInstance() {
+        List<GeoIpStatsAction.NodeResponse> nodeResponses = randomList(
             10,
-            GeoIpDownloaderStatsActionNodeResponseSerializingTests::createRandomInstance
+            GeoIpStatsActionNodeResponseSerializingTests::createRandomInstance
         );
-        return new GeoIpDownloaderStatsAction.Response(ClusterName.DEFAULT, nodeResponses, List.of());
+        return new GeoIpStatsAction.Response(ClusterName.DEFAULT, nodeResponses, List.of());
     }
 
     @Override
-    protected GeoIpDownloaderStatsAction.Response mutateInstance(GeoIpDownloaderStatsAction.Response instance) {
+    protected GeoIpStatsAction.Response mutateInstance(GeoIpStatsAction.Response instance) {
         return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
     }
 }


### PR DESCRIPTION
The `/_ingest/geoip/stats` is backed by classes with the word `Downloader` in their names, like `GeoIpDownloaderStatsAction`, `GeoIpDownloaderStatsTransportAction`, and `RestGeoIpDownloaderStatsAction`. But the URL of the API does not imply anything downloader-specific. This PR renames the API's backing classes to not contain the word "Downloader" so that it is not confusing if other non-downloader geoip stats are added to the API in the future.
The URL is not changing because it is already not downloader-specific. The REST action's name (unfortunately `geoip_downloader_stats`) is not changing, to avoid backward compatibility problems. The other changes are not publicly visible, and are only being made to avoid developer confusion in the future. I have updated the documentation for the API to not be 100% downloader-centric.