### PR TITLE
Recommend NFS over S3-like repositories

### DIFF
--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -541,13 +541,17 @@ MinIO-backed repositories as well as repositories stored on AWS S3. Other
 S3-compatible storage systems may also work with {es}, but these are not
 covered by the {es} test suite.
 
-Note that some storage systems claim to be S3-compatible but do not faithfully
-emulate S3's behaviour in full. The `repository-s3` type requires full
-compatibility with S3. In particular it must support the same set of API
-endpoints, return the same errors in case of failures, and offer consistency and
-performance at least as good as S3 even when accessed concurrently by multiple
-nodes. You will need to work with the supplier of your storage system to address
-any incompatibilities you encounter. Please do not report {es} issues involving
+There are many systems, including some from very well-known storage vendors,
+which claim to offer an S3-compatible API despite failing to emulate S3's
+behaviour in full. If you are using such a system for your snapshots, consider
+using a <<snapshots-filesystem-repository,shared filesystem repository>> based
+on a standardized protocol such as NFS to access your storage system instead.
+The `repository-s3` type requires full compatibility with S3. In particular it
+must support the same set of API endpoints, with the same parameters, return
+the same errors in case of failures, and offer consistency and performance at
+least as good as S3 even when accessed concurrently by multiple nodes. You will
+need to work with the supplier of your storage system to address any
+incompatibilities you encounter. Please do not report {es} issues involving
 storage systems which claim to be S3-compatible unless you can demonstrate that
 the same issue exists when using a genuine AWS S3 repository.
 


### PR DESCRIPTION
Allegedly-S3-compatible APIs are very popular these days, but many
third-party systems offering such an API also support a shared
filesystem interface. Shared filesystem protocols such as NFS are much
better specified than the S3 API, and experience shows that they lead to
fewer compatibility headaches. This commit adds a recommendation to the
`repository-s3` docs to consider such an interface instead.