### PR TITLE
Make unknown named writeables fail tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
@@ -23,6 +23,8 @@ import java.util.Objects;
  */
 public class NamedWriteableRegistry {
 
+    static boolean ignoreDeserializationErrors; // disable assertions just to test production behaviour
+
     /** An entry in the registry, made up of a category class and name, and a reader for that category class. */
     public static class Entry {
 
@@ -139,10 +141,14 @@ public class NamedWriteableRegistry {
     }
 
     private static <T> void throwOnUnknownWritable(Class<T> categoryClass, String name) {
-        throw new IllegalArgumentException("Unknown NamedWriteable [" + categoryClass.getName() + "][" + name + "]");
+        final var message = "Unknown NamedWriteable [" + categoryClass.getName() + "][" + name + "]";
+        assert ignoreDeserializationErrors : message;
+        throw new IllegalArgumentException(message);
     }
 
     private static <T> void throwOnUnknownCategory(Class<T> categoryClass) {
-        throw new IllegalArgumentException("Unknown NamedWriteable category [" + categoryClass.getName() + "]");
+        final var message = "Unknown NamedWriteable category [" + categoryClass.getName() + "]";
+        assert ignoreDeserializationErrors : message;
+        throw new IllegalArgumentException(message);
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/NamedWriteableRegistry.java
@@ -140,6 +140,10 @@ public class NamedWriteableRegistry {
         return readers;
     }
 
+    public boolean hasReaders(Class<?> categoryClass) {
+        return registry.containsKey(categoryClass);
+    }
+
     private static <T> void throwOnUnknownWritable(Class<T> categoryClass, String name) {
         final var message = "Unknown NamedWriteable [" + categoryClass.getName() + "][" + name + "]";
         assert ignoreDeserializationErrors : message;

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinValidationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinValidationServiceTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistryTests;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -306,7 +307,7 @@ public class JoinValidationServiceTests extends ESTestCase {
                     }
                 };
 
-                try (var out = new BytesStreamOutput()) {
+                try (var ignored = NamedWriteableRegistryTests.ignoringUnknownNamedWriteables(); var out = new BytesStreamOutput()) {
                     request.writeTo(out);
                     out.flush();
                     final var handler = joiningNodeTransport.getRequestHandlers().getHandler(action);

--- a/server/src/test/java/org/elasticsearch/common/io/stream/NamedWriteableRegistryTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/NamedWriteableRegistryTests.java
@@ -25,7 +25,7 @@ public class NamedWriteableRegistryTests extends ESTestCase {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {}
+        public void writeTo(StreamOutput out) {}
     }
 
     public void testEmpty() throws IOException {
@@ -39,7 +39,7 @@ public class NamedWriteableRegistryTests extends ESTestCase {
         assertNotNull(reader.read(null));
     }
 
-    public void testDuplicates() throws IOException {
+    public void testDuplicates() {
         NamedWriteableRegistry.Entry entry = new NamedWriteableRegistry.Entry(NamedWriteable.class, "test", DummyNamedWriteable::new);
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -48,16 +48,32 @@ public class NamedWriteableRegistryTests extends ESTestCase {
         assertTrue(e.getMessage(), e.getMessage().contains("is already registered"));
     }
 
-    public void testUnknownCategory() throws IOException {
-        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.emptyList());
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> registry.getReader(NamedWriteable.class, "test"));
-        assertTrue(e.getMessage(), e.getMessage().contains("Unknown NamedWriteable category ["));
+    public void testUnknownCategory() {
+        try {
+            NamedWriteableRegistry.ignoreDeserializationErrors = true;
+            NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.emptyList());
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> registry.getReader(NamedWriteable.class, "test")
+            );
+            assertTrue(e.getMessage(), e.getMessage().contains("Unknown NamedWriteable category ["));
+        } finally {
+            NamedWriteableRegistry.ignoreDeserializationErrors = false;
+        }
     }
 
-    public void testUnknownName() throws IOException {
-        NamedWriteableRegistry.Entry entry = new NamedWriteableRegistry.Entry(NamedWriteable.class, "test", DummyNamedWriteable::new);
-        NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.singletonList(entry));
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> registry.getReader(NamedWriteable.class, "dne"));
-        assertTrue(e.getMessage(), e.getMessage().contains("Unknown NamedWriteable ["));
+    public void testUnknownName() {
+        try {
+            NamedWriteableRegistry.ignoreDeserializationErrors = true;
+            NamedWriteableRegistry.Entry entry = new NamedWriteableRegistry.Entry(NamedWriteable.class, "test", DummyNamedWriteable::new);
+            NamedWriteableRegistry registry = new NamedWriteableRegistry(Collections.singletonList(entry));
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> registry.getReader(NamedWriteable.class, "dne")
+            );
+            assertTrue(e.getMessage(), e.getMessage().contains("Unknown NamedWriteable ["));
+        } finally {
+            NamedWriteableRegistry.ignoreDeserializationErrors = false;
+        }
     }
 }

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/session/Cursors.java
@@ -122,18 +122,18 @@ public final class Cursors {
         return internalDecodeFromStringWithZone(base64, new NamedWriteableRegistry(List.of()) {
             @Override
             public <T> Map<String, Writeable.Reader<?>> getReaders(Class<T> categoryClass) {
-                try {
+                if (writeableRegistry.hasReaders(categoryClass)) {
                     return writeableRegistry.getReaders(categoryClass);
-                } catch (IllegalArgumentException iae) {
+                } else {
                     return WRITEABLE_REGISTRY.getReaders(categoryClass);
                 }
             }
 
             @Override
             public <T> Writeable.Reader<? extends T> getReader(Class<T> categoryClass, String name) {
-                try {
+                if (writeableRegistry.hasReaders(categoryClass)) {
                     return writeableRegistry.getReader(categoryClass, name);
-                } catch (IllegalArgumentException iae) {
+                } else {
                     return WRITEABLE_REGISTRY.getReader(categoryClass, name);
                 }
             }


### PR DESCRIPTION
Encountering an unknown `NamedWriteable` is always a bug, but today we
only throw an `IllegalArgumentException` if we encounter one and it's
possible this exception is handled without failing the test. This commit
adds assertions to make sure we notice all unknown `NamedWriteable`
situations.