### PR TITLE
[Profiling] Add CO2/costs for TopN on top-level

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetTopNFunctionsResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetTopNFunctionsResponse.java
@@ -19,11 +19,21 @@ import java.util.List;
 public class GetTopNFunctionsResponse extends ActionResponse implements ToXContentObject {
     private final long selfCount;
     private final long totalCount;
+    private final double annualCo2Tons;
+    private final double annualCostsUsd;
     private final List<TopNFunction> topNFunctions;
 
-    public GetTopNFunctionsResponse(long selfCount, long totalCount, List<TopNFunction> topNFunctions) {
+    public GetTopNFunctionsResponse(
+        long selfCount,
+        long totalCount,
+        double annualCo2Tons,
+        double annualCostsUsd,
+        List<TopNFunction> topNFunctions
+    ) {
         this.selfCount = selfCount;
         this.totalCount = totalCount;
+        this.annualCo2Tons = annualCo2Tons;
+        this.annualCostsUsd = annualCostsUsd;
         this.topNFunctions = topNFunctions;
     }
 
@@ -40,6 +50,14 @@ public class GetTopNFunctionsResponse extends ActionResponse implements ToXConte
         return totalCount;
     }
 
+    public double getAnnualCo2Tons() {
+        return annualCo2Tons;
+    }
+
+    public double getAnnualCostsUsd() {
+        return annualCostsUsd;
+    }
+
     public List<TopNFunction> getTopN() {
         return topNFunctions;
     }
@@ -49,6 +67,8 @@ public class GetTopNFunctionsResponse extends ActionResponse implements ToXConte
         builder.startObject();
         builder.field("self_count", selfCount);
         builder.field("total_count", totalCount);
+        builder.field("self_annual_co2_tons", annualCo2Tons);
+        builder.field("self_annual_cost_usd", annualCostsUsd);
         builder.xContentList("topn", topNFunctions);
         builder.endObject();
         return builder;

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TopNFunction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TopNFunction.java
@@ -123,12 +123,20 @@ final class TopNFunction implements Cloneable, ToXContentObject, Comparable<TopN
         this.totalCount += totalCount;
     }
 
+    public double getSelfAnnualCO2Tons() {
+        return selfAnnualCO2Tons;
+    }
+
     public void addSelfAnnualCO2Tons(double co2Tons) {
         this.selfAnnualCO2Tons += co2Tons;
     }
 
     public void addTotalAnnualCO2Tons(double co2Tons) {
         this.totalAnnualCO2Tons += co2Tons;
+    }
+
+    public double getSelfAnnualCostsUSD() {
+        return selfAnnualCostsUSD;
     }
 
     public void addSelfAnnualCostsUSD(double costs) {

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetTopNFunctionsAction.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/TransportGetTopNFunctionsAction.java
@@ -134,17 +134,22 @@ public class TransportGetTopNFunctionsAction extends TransportAction<GetStackTra
             functions.sort(Collections.reverseOrder());
             long sumSelfCount = 0;
             long sumTotalCount = 0;
+            double sumAnnualCo2Tons = 0.0d;
+            double sumAnnualCostsUsd = 0.0d;
+
             for (int i = 0; i < functions.size(); i++) {
                 TopNFunction topNFunction = functions.get(i);
                 topNFunction.setRank(i + 1);
                 sumSelfCount += topNFunction.getSelfCount();
                 sumTotalCount += topNFunction.getTotalCount();
+                sumAnnualCo2Tons += topNFunction.getSelfAnnualCO2Tons();
+                sumAnnualCostsUsd += topNFunction.getSelfAnnualCostsUSD();
             }
             // limit at the end so global stats are independent of the limit
             if (limit != null && limit > 0 && limit < functions.size()) {
                 functions = functions.subList(0, limit);
             }
-            return new GetTopNFunctionsResponse(sumSelfCount, sumTotalCount, functions);
+            return new GetTopNFunctionsResponse(sumSelfCount, sumTotalCount, sumAnnualCo2Tons, sumAnnualCostsUsd, functions);
         }
 
         public boolean isExists(String frameGroupID) {

--- a/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/TopNFunctionsBuilderTests.java
+++ b/x-pack/plugin/profiling/src/test/java/org/elasticsearch/xpack/profiling/action/TopNFunctionsBuilderTests.java
@@ -21,6 +21,9 @@ public class TopNFunctionsBuilderTests extends ESTestCase {
 
         assertEquals(7L, response.getSelfCount());
         assertEquals(14L, response.getTotalCount());
+        assertEquals(1.5d, response.getAnnualCo2Tons(), 0.001d);
+        assertEquals(48.2d, response.getAnnualCostsUsd(), 0.001d);
+
         assertEquals(2, response.getTopN().size());
         assertEquals(foo, response.getTopN().get(0));
         assertEquals(bar, response.getTopN().get(1));
@@ -35,9 +38,12 @@ public class TopNFunctionsBuilderTests extends ESTestCase {
 
         GetTopNFunctionsResponse response = builder.build();
 
-        // total counts are independent of the limit
+        // total values are independent of the limit
         assertEquals(7L, response.getSelfCount());
         assertEquals(14L, response.getTotalCount());
+        assertEquals(1.5d, response.getAnnualCo2Tons(), 0.001d);
+        assertEquals(48.2d, response.getAnnualCostsUsd(), 0.001d);
+
         assertEquals(1, response.getTopN().size());
         assertEquals(foo, response.getTopN().get(0));
     }
@@ -53,6 +59,8 @@ public class TopNFunctionsBuilderTests extends ESTestCase {
 
         assertEquals(7L, response.getSelfCount());
         assertEquals(14L, response.getTotalCount());
+        assertEquals(1.5d, response.getAnnualCo2Tons(), 0.001d);
+        assertEquals(48.2d, response.getAnnualCostsUsd(), 0.001d);
         // still limited to the available two functions
         assertEquals(2, response.getTopN().size());
         assertEquals(foo, response.getTopN().get(0));


### PR DESCRIPTION
Wit this commit we add CO2 emission and cost information on the top-level of the TopN functions API response. This is needed by the UI to show summary info.