### PR TITLE
[ML] Fix NPE in ML assignment notifier

### DIFF
--- a/docs/changelog/107312.yaml
+++ b/docs/changelog/107312.yaml
@@ -1,0 +1,5 @@
+pr: 107312
+summary: Fix NPE in ML assignment notifier
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -300,7 +300,7 @@ public class MlAssignmentNotifier implements ClusterStateListener {
                 final String taskName = task.getTaskName();
                 if (MlTasks.JOB_TASK_NAME.equals(taskName) || MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME.equals(taskName)) {
                     // Ignore failed tasks - they don't need to be assigned to a node
-                    if (((MlTaskState) task.getState()).isFailed()) {
+                    if (task.getState() == null || ((MlTaskState) task.getState()).isFailed()) {
                         continue;
                     }
                     final String mlId = ((MlTaskParams) task.getParams()).getMlId();


### PR DESCRIPTION
This NPE has been observed in logs. The actual error is harmless but the logging is noisy. 

The problem stems from the fact that the persistent task may not be initialised with a state, this is perfectly valid and the code should account for it. 

```
java.lang.NullPointerException: Cannot invoke "org.elasticsearch.xpack.core.ml.utils.MlTaskState.isFailed()" because the return value of "org.elasticsearch.persistent.PersistentTasksCustomMetadata$PersistentTask.getState()" is null
	at org.elasticsearch.ml@8.14.0/org.elasticsearch.xpack.ml.MlAssignmentNotifier.findLongTimeUnassignedTasks(MlAssignmentNotifier.java:303)
	at org.elasticsearch.ml@8.14.0/org.elasticsearch.xpack.ml.MlAssignmentNotifier.logLongTimeUnassigned(MlAssignmentNotifier.java:270)
	at org.elasticsearch.ml@8.14.0/org.elasticsearch.xpack.ml.MlAssignmentNotifier.lambda$clusterChanged$0(MlAssignmentNotifier.java:94)
	at org.elasticsearch.server@8.14.0/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:917)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```