### PR TITLE
[8.13] [DOCS] Fixes a typo in the HuggingFace tutorial. (#107321)

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -359,7 +359,7 @@ after the endpoint initialization has been finished.
 
 [discrete]
 [[inference-example-hugging-face-supported-models]]
-The list of supported models for the Hugging Face service:
+The list of recommended models for the Hugging Face service:
 
 * https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2[all-MiniLM-L6-v2]
 * https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2[all-MiniLM-L12-v2]

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
@@ -51,7 +51,7 @@ PUT hugging-face-embeddings
   }
 }
 --------------------------------------------------
-<1> The name of the field to contain the generated tokens. It must be refrenced
+<1> The name of the field to contain the generated tokens. It must be referenced
 in the {infer} pipeline configuration in the next step.
 <2> The field to contain the tokens is a `dense_vector` field.
 <3> The output dimensions of the model. Find this value in the


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [DOCS] Fixes a typo in the HugggingFace tutorial. (#107321)