### PR TITLE
Throw an Exception instead of returning null

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NoopNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NoopNativeAccess.java
@@ -32,12 +32,12 @@ class NoopNativeAccess implements NativeAccess {
     @Override
     public Zstd getZstd() {
         logger.warn("cannot compress with zstd because native access is not available");
-        return null;
+        throw new NoopNativeAccessException("Cannot compress with zstd because native access is not available");
     }
 
     @Override
     public CloseableByteBuffer newBuffer(int len) {
         logger.warn("cannot allocate buffer because native access is not available");
-        return null;
+        throw new NoopNativeAccessException("Cannot allocate buffer because native access is not available");
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NoopNativeAccessException.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NoopNativeAccessException.java
@@ -1,0 +1,9 @@
+package org.elasticsearch.nativeaccess;
+
+import org.elasticsearch.ElasticsearchException;
+
+public class NoopNativeAccessException extends ElasticsearchException {
+    public NoopNativeAccessException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
Throw a NoopNativeAccessException instead of returning null in NoopNativeAccess#getZstd and NoopNativeAccess#newBuffer

This PR closes the #107311 
