### PR TITLE
(Doc+) Point ingest to Alias not Bootstrapped Index

### DIFF
--- a/docs/reference/ilm/ilm-tutorial.asciidoc
+++ b/docs/reference/ilm/ilm-tutorial.asciidoc
@@ -184,7 +184,7 @@ stream's write index.
 This process repeats each time a rollover condition is met.
 You can search across all of the data stream's backing indices, managed by the `timeseries_policy`,
 with the `timeseries` data stream name.
-Write operations are routed to the current write index. Read operations will be handled by all
+You will point ingest towards the alias which will route write operations to its current write index. Read operations will be handled by all
 backing indices.
 
 [discrete]


### PR DESCRIPTION
👋 howdy, team!   

Sometimes users believe they should point client-side (e.g. Logstash's Elasticsearch output `index`) to the bootstrapped index. This highlights they point ingest towards the alias.

cc: @dakrone 