### PR TITLE
Adding metering stats actions to view_metadata index privilege

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -142,8 +142,8 @@ public final class IndexPrivilege extends Privilege {
         TransportFieldCapabilitiesAction.NAME + "*",
         GetRollupIndexCapsAction.NAME + "*",
         GetCheckpointAction.NAME + "*", // transform internal action
-        "indices:monitor/get/metering/stats", //serverless only
-        "indices:admin/get/metering/stats" //serverless only
+        "indices:monitor/get/metering/stats", // serverless only
+        "indices:admin/get/metering/stats" // serverless only
     );
     private static final Automaton MANAGE_FOLLOW_INDEX_AUTOMATON = patterns(
         PutFollowAction.NAME,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/IndexPrivilege.java
@@ -141,7 +141,9 @@ public final class IndexPrivilege extends Privilege {
         TransportResolveClusterAction.NAME,
         TransportFieldCapabilitiesAction.NAME + "*",
         GetRollupIndexCapsAction.NAME + "*",
-        GetCheckpointAction.NAME + "*" // transform internal action
+        GetCheckpointAction.NAME + "*", // transform internal action
+        "indices:monitor/get/metering/stats", //serverless only
+        "indices:admin/get/metering/stats" //serverless only
     );
     private static final Automaton MANAGE_FOLLOW_INDEX_AUTOMATON = patterns(
         PutFollowAction.NAME,


### PR DESCRIPTION
This PR adds two specific action names, that will be introduced in serverless, to the view_metadata automaton.
The actions will need view_metadata privileges on indexes to access statistical information (e.g. doc count, normalized size, etc.)