### PR TITLE
Remove unused thread pool name assertions in tests

### DIFF
--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryCredentialsTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/RepositoryCredentialsTests.java
@@ -15,15 +15,11 @@ import com.amazonaws.services.s3.AmazonS3;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.cluster.metadata.RepositoryMetadata;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -34,7 +30,6 @@ import org.elasticsearch.rest.action.admin.cluster.RestGetRepositoriesAction;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.watcher.ResourceWatcherService;
-import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -254,23 +249,6 @@ public class RepositoryCredentialsTests extends ESSingleNodeTestCase {
 
         public ProxyS3RepositoryPlugin(Settings settings) {
             super(settings);
-        }
-
-        @Override
-        protected S3Repository createRepository(
-            RepositoryMetadata metadata,
-            NamedXContentRegistry registry,
-            ClusterService clusterService,
-            BigArrays bigArrays,
-            RecoverySettings recoverySettings,
-            S3RepositoriesMetrics s3RepositoriesMetrics
-        ) {
-            return new S3Repository(metadata, registry, getService(), clusterService, bigArrays, recoverySettings, s3RepositoriesMetrics) {
-                @Override
-                protected void assertSnapshotOrStatelessPermittedThreadPool() {
-                    // eliminate thread name check as we create repo manually on test/main threads
-                }
-            };
         }
 
         @Override

--- a/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
+++ b/modules/repository-s3/src/test/java/org/elasticsearch/repositories/s3/S3RepositoryTests.java
@@ -130,11 +130,6 @@ public class S3RepositoryTests extends ESTestCase {
             MockBigArrays.NON_RECYCLING_INSTANCE,
             new RecoverySettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             S3RepositoriesMetrics.NOOP
-        ) {
-            @Override
-            protected void assertSnapshotOrStatelessPermittedThreadPool() {
-                // eliminate thread name check as we create repo manually on test/main threads
-            }
-        };
+        );
     }
 }

--- a/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLRepositoryTests.java
+++ b/modules/repository-url/src/test/java/org/elasticsearch/repositories/url/URLRepositoryTests.java
@@ -41,12 +41,7 @@ public class URLRepositoryTests extends ESTestCase {
             MockBigArrays.NON_RECYCLING_INSTANCE,
             new RecoverySettings(baseSettings, new ClusterSettings(baseSettings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)),
             mock(URLHttpClient.Factory.class)
-        ) {
-            @Override
-            protected void assertSnapshotOrStatelessPermittedThreadPool() {
-                // eliminate thread name check as we create repo manually on test/main threads
-            }
-        };
+        );
     }
 
     public void testWhiteListingRepoURL() throws IOException {

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1994,7 +1994,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         return restoreRateLimitingTimeInNanos.count();
     }
 
-    protected void assertSnapshotOrStatelessPermittedThreadPool() {
+    private void assertSnapshotOrStatelessPermittedThreadPool() {
         // The Stateless plugin adds custom thread pools for object store operations
         assert ThreadPool.assertCurrentThreadPool(
             ThreadPool.Names.SNAPSHOT,

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -225,12 +225,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
             clusterService,
             MockBigArrays.NON_RECYCLING_INSTANCE,
             new RecoverySettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS))
-        ) {
-            @Override
-            protected void assertSnapshotOrStatelessPermittedThreadPool() {
-                // eliminate thread name check as we create repo manually
-            }
-        };
+        );
         clusterService.addStateApplier(event -> repository.updateState(event.state()));
         // Apply state once to initialize repo properly like RepositoriesService would
         repository.updateState(clusterService.state());

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -2121,19 +2121,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     transportService,
                     Collections.singletonMap(
                         FsRepository.TYPE,
-                        metadata -> new FsRepository(
-                            metadata,
-                            environment,
-                            xContentRegistry(),
-                            clusterService,
-                            bigArrays,
-                            recoverySettings
-                        ) {
-                            @Override
-                            protected void assertSnapshotOrStatelessPermittedThreadPool() {
-                                // eliminate thread name check as we create repo in the test thread
-                            }
-                        }
+                        metadata -> new FsRepository(metadata, environment, xContentRegistry(), clusterService, bigArrays, recoverySettings)
                     ),
                     emptyMap(),
                     threadPool,

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
@@ -449,13 +449,6 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
                 (metadata) -> new FsRepository(metadata, env, namedXContentRegistry, clusterService, bigArrays, recoverySettings) {
 
                     @Override
-                    protected void assertSnapshotOrStatelessPermittedThreadPool() {
-                        if (enabled.get()) {
-                            super.assertSnapshotOrStatelessPermittedThreadPool();
-                        }
-                    }
-
-                    @Override
                     protected BlobStore createBlobStore() throws Exception {
                         final BlobStore delegate = super.createBlobStore();
                         if (enabled.get()) {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
@@ -246,12 +246,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
         ) {
             return Collections.singletonMap(
                 "test-fs",
-                (metadata) -> new FsRepository(metadata, env, namedXContentRegistry, clusterService, bigArrays, recoverySettings) {
-                    @Override
-                    protected void assertSnapshotOrStatelessPermittedThreadPool() {
-                        // ignore
-                    }
-                }
+                (metadata) -> new FsRepository(metadata, env, namedXContentRegistry, clusterService, bigArrays, recoverySettings)
             );
         }
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -606,13 +606,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                     BlobStoreTestUtil.mockClusterService(repositoryMetadata),
                     MockBigArrays.NON_RECYCLING_INSTANCE,
                     new RecoverySettings(Settings.EMPTY, new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS))
-                ) {
-
-                    @Override
-                    protected void assertSnapshotOrStatelessPermittedThreadPool() {
-                        // eliminate thread name check as we create repo manually on test/main threads
-                    }
-                };
+                );
                 repository.start();
                 releasables.add(repository::stop);
 


### PR DESCRIPTION
Original method assertSnapshotOrStatelessPermittedThreadPool covers testing thread pools names, no need for override.

Follow up for #106208 [comment](https://github.com/elastic/elasticsearch/pull/106208#pullrequestreview-1986768492)
