### PR TITLE
Unregistered setting to disable the native role mapping store

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/DisableNativeRoleMappingsStoreTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/DisableNativeRoleMappingsStoreTests.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authz.store;
+
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.SecurityIntegTestCase;
+import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingRequest;
+import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
+import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.containsString;
+
+public class DisableNativeRoleMappingsStoreTests extends SecurityIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        List<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(PrivateCustomPlugin.class);
+        return plugins;
+    }
+
+    public void testPutRoleMappingDisallowed() {
+        NativeRoleMappingStore nativeRoleMappingStore = internalCluster().getInstance(NativeRoleMappingStore.class);
+        PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        nativeRoleMappingStore.putRoleMapping(new PutRoleMappingRequest(), future);
+        ExecutionException e = expectThrows(ExecutionException.class, future::get);
+        assertThat(e.getMessage(), containsString("Native role mapping management is disabled"));
+    }
+
+    public void testDeleteRoleMappingDisallowed() {
+        NativeRoleMappingStore nativeRoleMappingStore = internalCluster().getInstance(NativeRoleMappingStore.class);
+        PlainActionFuture<Boolean> future = new PlainActionFuture<>();
+        nativeRoleMappingStore.deleteRoleMapping(new DeleteRoleMappingRequest(), future);
+        ExecutionException e = expectThrows(ExecutionException.class, future::get);
+        assertThat(e.getMessage(), containsString("Native role mapping management is disabled"));
+    }
+
+    public static class PrivateCustomPlugin extends Plugin {
+
+        public static final Setting<Boolean> NATIVE_ROLE_MAPPINGS_SETTING = Setting.boolSetting(
+            "xpack.security.authc.native_role_mappings.enabled",
+            true,
+            Setting.Property.NodeScope
+        );
+
+        public PrivateCustomPlugin() {}
+
+        @Override
+        public Settings additionalSettings() {
+            return Settings.builder().put(NATIVE_ROLE_MAPPINGS_SETTING.getKey(), false).build();
+        }
+
+        @Override
+        public List<Setting<?>> getSettings() {
+            return List.of(NATIVE_ROLE_MAPPINGS_SETTING);
+        }
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
@@ -48,7 +48,6 @@ import org.elasticsearch.xpack.security.support.SecuritySystemIndices;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +84,17 @@ import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SEC
  */
 public class NativeRoleMappingStore implements UserRoleMapper {
 
+    /**
+     * This setting is never registered by the security plugin - in order to disable the native role APIs
+     * another plugin must register it as a boolean setting and cause it to be set to `false`.
+     *
+     * If this setting is set to <code>false</code> then
+     * <ul>
+     *     <li>the Rest APIs for native role mappings management are disabled.</li>
+     *     <li>The native role mappings store will not map any roles to any user.</li>
+     * </ul>
+     */
+    public static final String NATIVE_ROLE_MAPPINGS_ENABLED = "xpack.security.authc.native_role_mappings.enabled";
     private static final Logger logger = LogManager.getLogger(NativeRoleMappingStore.class);
     static final String DOC_TYPE_FIELD = "doc_type";
     static final String DOC_TYPE_ROLE_MAPPING = "role-mapping";
@@ -105,6 +115,7 @@ public class NativeRoleMappingStore implements UserRoleMapper {
     private final List<String> realmsToRefresh = new CopyOnWriteArrayList<>();
     private final boolean lastLoadCacheEnabled;
     private final AtomicReference<List<ExpressionRoleMapping>> lastLoadRef = new AtomicReference<>(null);
+    private final boolean enabled;
 
     public NativeRoleMappingStore(Settings settings, Client client, SecurityIndexManager securityIndex, ScriptService scriptService) {
         this.settings = settings;
@@ -112,16 +123,7 @@ public class NativeRoleMappingStore implements UserRoleMapper {
         this.securityIndex = securityIndex;
         this.scriptService = scriptService;
         this.lastLoadCacheEnabled = LAST_LOAD_CACHE_ENABLED_SETTING.get(settings);
-    }
-
-    private static String getNameFromId(String id) {
-        assert id.startsWith(ID_PREFIX);
-        return id.substring(ID_PREFIX.length());
-    }
-
-    // package-private for testing
-    static String getIdForName(String name) {
-        return ID_PREFIX + name;
+        this.enabled = settings.getAsBoolean(NATIVE_ROLE_MAPPINGS_ENABLED, true);
     }
 
     /**
@@ -129,6 +131,10 @@ public class NativeRoleMappingStore implements UserRoleMapper {
      * <em>package private</em> for unit testing
      */
     protected void loadMappings(ActionListener<List<ExpressionRoleMapping>> listener) {
+        if (enabled == false) {
+            listener.onResponse(List.of());
+            return;
+        }
         if (securityIndex.isIndexUpToDate() == false) {
             listener.onFailure(
                 new IllegalStateException(
@@ -164,25 +170,10 @@ public class NativeRoleMappingStore implements UserRoleMapper {
                         () -> format("failed to load role mappings from index [%s] skipping all mappings.", SECURITY_MAIN_ALIAS),
                         ex
                     );
-                    listener.onResponse(Collections.emptyList());
+                    listener.onResponse(List.of());
                 })),
                 doc -> buildMapping(getNameFromId(doc.getId()), doc.getSourceRef())
             );
-        }
-    }
-
-    protected static ExpressionRoleMapping buildMapping(String id, BytesReference source) {
-        try (
-            XContentParser parser = XContentHelper.createParserNotCompressed(
-                LoggingDeprecationHandler.XCONTENT_PARSER_CONFIG,
-                source,
-                XContentType.JSON
-            )
-        ) {
-            return ExpressionRoleMapping.parse(id, parser);
-        } catch (Exception e) {
-            logger.warn(() -> "Role mapping [" + id + "] cannot be parsed and will be skipped", e);
-            return null;
         }
     }
 
@@ -190,6 +181,10 @@ public class NativeRoleMappingStore implements UserRoleMapper {
      * Stores (create or update) a single mapping in the index
      */
     public void putRoleMapping(PutRoleMappingRequest request, ActionListener<Boolean> listener) {
+        if (enabled == false) {
+            listener.onFailure(new IllegalStateException("Native role mapping management is disabled"));
+            return;
+        }
         // Validate all templates before storing the role mapping
         for (TemplateRoleName templateRoleName : request.getRoleTemplates()) {
             templateRoleName.validate(scriptService);
@@ -201,6 +196,10 @@ public class NativeRoleMappingStore implements UserRoleMapper {
      * Deletes a named mapping from the index
      */
     public void deleteRoleMapping(DeleteRoleMappingRequest request, ActionListener<Boolean> listener) {
+        if (enabled == false) {
+            listener.onFailure(new IllegalStateException("Native role mapping management is disabled"));
+            return;
+        }
         modifyMapping(request.getName(), this::innerDeleteMapping, request, listener);
     }
 
@@ -229,6 +228,10 @@ public class NativeRoleMappingStore implements UserRoleMapper {
     }
 
     private void innerPutMapping(PutRoleMappingRequest request, ActionListener<Boolean> listener) {
+        if (enabled == false) {
+            listener.onFailure(new IllegalStateException("Native role mapping management is disabled"));
+            return;
+        }
         final ExpressionRoleMapping mapping = request.getMapping();
         securityIndex.prepareIndexIfNeededThenExecute(listener::onFailure, () -> {
             final XContentBuilder xContentBuilder;
@@ -266,6 +269,10 @@ public class NativeRoleMappingStore implements UserRoleMapper {
     }
 
     private void innerDeleteMapping(DeleteRoleMappingRequest request, ActionListener<Boolean> listener) {
+        if (enabled == false) {
+            listener.onFailure(new IllegalStateException("Native role mapping management is disabled"));
+            return;
+        }
         final SecurityIndexManager frozenSecurityIndex = securityIndex.defensiveCopy();
         if (frozenSecurityIndex.indexExists() == false) {
             listener.onResponse(false);
@@ -307,7 +314,9 @@ public class NativeRoleMappingStore implements UserRoleMapper {
      * Otherwise it retrieves the specified mappings by name.
      */
     public void getRoleMappings(Set<String> names, ActionListener<List<ExpressionRoleMapping>> listener) {
-        if (names == null || names.isEmpty()) {
+        if (enabled == false) {
+            listener.onResponse(List.of());
+        } else if (names == null || names.isEmpty()) {
             getMappings(listener);
         } else {
             getMappings(listener.safeMap(mappings -> mappings.stream().filter(m -> names.contains(m.getName())).toList()));
@@ -315,10 +324,14 @@ public class NativeRoleMappingStore implements UserRoleMapper {
     }
 
     private void getMappings(ActionListener<List<ExpressionRoleMapping>> listener) {
+        if (enabled == false) {
+            listener.onResponse(List.of());
+            return;
+        }
         final SecurityIndexManager frozenSecurityIndex = securityIndex.defensiveCopy();
         if (frozenSecurityIndex.indexExists() == false) {
             logger.debug("The security index does not exist - no role mappings can be loaded");
-            listener.onResponse(Collections.emptyList());
+            listener.onResponse(List.of());
             return;
         }
         final List<ExpressionRoleMapping> lastLoad = lastLoadRef.get();
@@ -329,7 +342,7 @@ public class NativeRoleMappingStore implements UserRoleMapper {
                 listener.onResponse(lastLoad);
             } else {
                 logger.debug("The security index exists but is closed - no role mappings can be loaded");
-                listener.onResponse(Collections.emptyList());
+                listener.onResponse(List.of());
             }
         } else if (frozenSecurityIndex.isAvailable(SEARCH_SHARDS) == false) {
             final ElasticsearchException unavailableReason = frozenSecurityIndex.getUnavailableReason(SEARCH_SHARDS);
@@ -365,18 +378,13 @@ public class NativeRoleMappingStore implements UserRoleMapper {
      * </ul>
      */
     public void usageStats(ActionListener<Map<String, Object>> listener) {
-        if (securityIndex.indexIsClosed() || securityIndex.isAvailable(SEARCH_SHARDS) == false) {
-            reportStats(listener, Collections.emptyList());
+        if (enabled == false) {
+            reportStats(listener, List.of());
+        } else if (securityIndex.indexIsClosed() || securityIndex.isAvailable(SEARCH_SHARDS) == false) {
+            reportStats(listener, List.of());
         } else {
             getMappings(ActionListener.wrap(mappings -> reportStats(listener, mappings), listener::onFailure));
         }
-    }
-
-    private static void reportStats(ActionListener<Map<String, Object>> listener, List<ExpressionRoleMapping> mappings) {
-        Map<String, Object> usageStats = new HashMap<>();
-        usageStats.put("size", mappings.size());
-        usageStats.put("enabled", mappings.stream().filter(ExpressionRoleMapping::isEnabled).count());
-        listener.onResponse(usageStats);
     }
 
     public void onSecurityIndexStateChange(SecurityIndexManager.State previousState, SecurityIndexManager.State currentState) {
@@ -386,28 +394,6 @@ public class NativeRoleMappingStore implements UserRoleMapper {
             || previousState.isIndexUpToDate != currentState.isIndexUpToDate) {
             refreshRealms(ActionListener.noop(), null);
         }
-    }
-
-    private <Result> void refreshRealms(ActionListener<Result> listener, Result result) {
-        if (realmsToRefresh.isEmpty()) {
-            listener.onResponse(result);
-            return;
-        }
-
-        final String[] realmNames = this.realmsToRefresh.toArray(Strings.EMPTY_ARRAY);
-        executeAsyncWithOrigin(
-            client,
-            SECURITY_ORIGIN,
-            ClearRealmCacheAction.INSTANCE,
-            new ClearRealmCacheRequest().realms(realmNames),
-            ActionListener.wrap(response -> {
-                logger.debug(() -> format("Cleared cached in realms [%s] due to role mapping change", Arrays.toString(realmNames)));
-                listener.onResponse(result);
-            }, ex -> {
-                logger.warn(() -> "Failed to clear cache for realms [" + Arrays.toString(realmNames) + "]", ex);
-                listener.onFailure(ex);
-            })
-        );
     }
 
     @Override
@@ -437,5 +423,58 @@ public class NativeRoleMappingStore implements UserRoleMapper {
     @Override
     public void refreshRealmOnChange(CachingRealm realm) {
         realmsToRefresh.add(realm.name());
+    }
+
+    private <Result> void refreshRealms(ActionListener<Result> listener, Result result) {
+        if (enabled == false || realmsToRefresh.isEmpty()) {
+            listener.onResponse(result);
+            return;
+        }
+        final String[] realmNames = this.realmsToRefresh.toArray(Strings.EMPTY_ARRAY);
+        executeAsyncWithOrigin(
+            client,
+            SECURITY_ORIGIN,
+            ClearRealmCacheAction.INSTANCE,
+            new ClearRealmCacheRequest().realms(realmNames),
+            ActionListener.wrap(response -> {
+                logger.debug(() -> format("Cleared cached in realms [%s] due to role mapping change", Arrays.toString(realmNames)));
+                listener.onResponse(result);
+            }, ex -> {
+                logger.warn(() -> "Failed to clear cache for realms [" + Arrays.toString(realmNames) + "]", ex);
+                listener.onFailure(ex);
+            })
+        );
+    }
+
+    protected static ExpressionRoleMapping buildMapping(String id, BytesReference source) {
+        try (
+            XContentParser parser = XContentHelper.createParserNotCompressed(
+                LoggingDeprecationHandler.XCONTENT_PARSER_CONFIG,
+                source,
+                XContentType.JSON
+            )
+        ) {
+            return ExpressionRoleMapping.parse(id, parser);
+        } catch (Exception e) {
+            logger.warn(() -> "Role mapping [" + id + "] cannot be parsed and will be skipped", e);
+            return null;
+        }
+    }
+
+    // package-private for testing
+    static String getIdForName(String name) {
+        return ID_PREFIX + name;
+    }
+
+    private static void reportStats(ActionListener<Map<String, Object>> listener, List<ExpressionRoleMapping> mappings) {
+        Map<String, Object> usageStats = new HashMap<>();
+        usageStats.put("size", mappings.size());
+        usageStats.put("enabled", mappings.stream().filter(ExpressionRoleMapping::isEnabled).count());
+        listener.onResponse(usageStats);
+    }
+
+    private static String getNameFromId(String id) {
+        assert id.startsWith(ID_PREFIX);
+        return id.substring(ID_PREFIX.length());
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/NativeRoleMappingBaseRestHandler.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/NativeRoleMappingBaseRestHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rest.action.rolemapping;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
+import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
+
+abstract class NativeRoleMappingBaseRestHandler extends SecurityBaseRestHandler {
+
+    private static final Logger logger = LogManager.getLogger(NativeRoleMappingBaseRestHandler.class);
+
+    NativeRoleMappingBaseRestHandler(Settings settings, XPackLicenseState licenseState) {
+        super(settings, licenseState);
+    }
+
+    @Override
+    protected Exception innerCheckFeatureAvailable(RestRequest request) {
+        Boolean nativeRoleMappingsEnabled = settings.getAsBoolean(NativeRoleMappingStore.NATIVE_ROLE_MAPPINGS_ENABLED, true);
+        if (nativeRoleMappingsEnabled == false) {
+            logger.debug(
+                "Attempt to call [{} {}] but [{}] is [{}]",
+                request.method(),
+                request.rawPath(),
+                NativeRoleMappingStore.NATIVE_ROLE_MAPPINGS_ENABLED,
+                settings.get(NativeRoleMappingStore.NATIVE_ROLE_MAPPINGS_ENABLED)
+            );
+            return new ElasticsearchStatusException(
+                "Native role mapping management is not enabled in this Elasticsearch instance",
+                RestStatus.GONE
+            );
+        } else {
+            return null;
+        }
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestDeleteRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestDeleteRoleMappingAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.rest.action.RestBuilderListener;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingResponse;
-import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,7 +29,7 @@ import static org.elasticsearch.rest.RestRequest.Method.DELETE;
  * Rest endpoint to delete a role-mapping from the {@link org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore}
  */
 @ServerlessScope(Scope.INTERNAL)
-public class RestDeleteRoleMappingAction extends SecurityBaseRestHandler {
+public class RestDeleteRoleMappingAction extends NativeRoleMappingBaseRestHandler {
 
     public RestDeleteRoleMappingAction(Settings settings, XPackLicenseState licenseState) {
         super(settings, licenseState);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestGetRoleMappingsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestGetRoleMappingsAction.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.security.action.rolemapping.GetRoleMappingsRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.rolemapping.GetRoleMappingsResponse;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
-import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
 
 import java.io.IOException;
 import java.util.List;
@@ -31,7 +30,7 @@ import static org.elasticsearch.rest.RestRequest.Method.GET;
  * Rest endpoint to retrieve a role-mapping from the org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore
  */
 @ServerlessScope(Scope.INTERNAL)
-public class RestGetRoleMappingsAction extends SecurityBaseRestHandler {
+public class RestGetRoleMappingsAction extends NativeRoleMappingBaseRestHandler {
 
     public RestGetRoleMappingsAction(Settings settings, XPackLicenseState licenseState) {
         super(settings, licenseState);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestPutRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/rolemapping/RestPutRoleMappingAction.java
@@ -19,7 +19,6 @@ import org.elasticsearch.rest.action.RestBuilderListener;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequestBuilder;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingResponse;
-import org.elasticsearch.xpack.security.rest.action.SecurityBaseRestHandler;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,7 +32,7 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
  * @see org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore
  */
 @ServerlessScope(Scope.INTERNAL)
-public class RestPutRoleMappingAction extends SecurityBaseRestHandler {
+public class RestPutRoleMappingAction extends NativeRoleMappingBaseRestHandler {
 
     public RestPutRoleMappingAction(Settings settings, XPackLicenseState licenseState) {
         super(settings, licenseState);


### PR DESCRIPTION
This PR introduces a new unregistered setting that can be used
(by other plugins that register the setting) to disable the index-based
native role mappings store.