### PR TITLE
Make o.e.index.codec.ForUtil a pure utility class

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/postings/ES812PostingsReader.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/postings/ES812PostingsReader.java
@@ -61,8 +61,6 @@ final class ES812PostingsReader extends PostingsReaderBase {
     private final IndexInput posIn;
     private final IndexInput payIn;
 
-    private final int version;
-
     /** Sole constructor. */
     ES812PostingsReader(SegmentReadState state) throws IOException {
         boolean success = false;
@@ -78,7 +76,7 @@ final class ES812PostingsReader extends PostingsReaderBase {
         String docName = IndexFileNames.segmentFileName(state.segmentInfo.name, state.segmentSuffix, ES812PostingsFormat.DOC_EXTENSION);
         try {
             docIn = state.directory.openInput(docName, state.context);
-            version = CodecUtil.checkIndexHeader(
+            int version = CodecUtil.checkIndexHeader(
                 docIn,
                 DOC_CODEC,
                 VERSION_START,
@@ -279,7 +277,7 @@ final class ES812PostingsReader extends PostingsReaderBase {
 
     final class BlockDocsEnum extends PostingsEnum {
 
-        final PForUtil pforUtil = new PForUtil(new ForUtil());
+        final PForUtil pforUtil = new PForUtil();
 
         private final long[] docBuffer = new long[BLOCK_SIZE + 1];
         private final long[] freqBuffer = new long[BLOCK_SIZE];
@@ -526,7 +524,7 @@ final class ES812PostingsReader extends PostingsReaderBase {
     // Also handles payloads + offsets
     final class EverythingEnum extends PostingsEnum {
 
-        final PForUtil pforUtil = new PForUtil(new ForUtil());
+        final PForUtil pforUtil = new PForUtil();
 
         private final long[] docBuffer = new long[BLOCK_SIZE + 1];
         private final long[] freqBuffer = new long[BLOCK_SIZE + 1];
@@ -999,7 +997,7 @@ final class ES812PostingsReader extends PostingsReaderBase {
 
     final class BlockImpactsDocsEnum extends ImpactsEnum {
 
-        final PForUtil pforUtil = new PForUtil(new ForUtil());
+        final PForUtil pforUtil = new PForUtil();
 
         private final long[] docBuffer = new long[BLOCK_SIZE + 1];
         private final long[] freqBuffer = new long[BLOCK_SIZE];
@@ -1196,7 +1194,7 @@ final class ES812PostingsReader extends PostingsReaderBase {
 
     final class BlockImpactsPostingsEnum extends ImpactsEnum {
 
-        final PForUtil pforUtil = new PForUtil(new ForUtil());
+        final PForUtil pforUtil = new PForUtil();
 
         private final long[] docBuffer = new long[BLOCK_SIZE];
         private final long[] freqBuffer = new long[BLOCK_SIZE];
@@ -1476,7 +1474,7 @@ final class ES812PostingsReader extends PostingsReaderBase {
 
     final class BlockImpactsEverythingEnum extends ImpactsEnum {
 
-        final PForUtil pforUtil = new PForUtil(new ForUtil());
+        final PForUtil pforUtil = new PForUtil();
 
         private final long[] docBuffer = new long[BLOCK_SIZE];
         private final long[] freqBuffer = new long[BLOCK_SIZE];

--- a/server/src/main/java/org/elasticsearch/index/codec/postings/ES812PostingsWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/postings/ES812PostingsWriter.java
@@ -35,7 +35,6 @@ import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.BitUtil;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.core.IOUtils;
-import org.elasticsearch.index.codec.ForUtil;
 import org.elasticsearch.index.codec.postings.ES812PostingsFormat.IntBlockTermState;
 
 import java.io.IOException;
@@ -110,7 +109,7 @@ final class ES812PostingsWriter extends PushPostingsWriterBase {
         boolean success = false;
         try {
             CodecUtil.writeIndexHeader(docOut, DOC_CODEC, VERSION_CURRENT, state.segmentInfo.getId(), state.segmentSuffix);
-            pforUtil = new PForUtil(new ForUtil());
+            pforUtil = new PForUtil();
             if (state.fieldInfos.hasProx()) {
                 posDeltaBuffer = new long[BLOCK_SIZE];
                 String posFileName = IndexFileNames.segmentFileName(

--- a/server/src/main/java/org/elasticsearch/index/codec/postings/PForUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/postings/PForUtil.java
@@ -52,14 +52,12 @@ final class PForUtil {
         return true;
     }
 
-    private final ForUtil forUtil;
     // buffer for reading exception data; each exception uses two bytes (pos + high-order bits of the
     // exception)
     private final byte[] exceptionBuff = new byte[MAX_EXCEPTIONS * 2];
 
-    PForUtil(ForUtil forUtil) {
+    PForUtil() {
         assert ForUtil.BLOCK_SIZE <= 256 : "blocksize must fit in one byte. got " + ForUtil.BLOCK_SIZE;
-        this.forUtil = forUtil;
     }
 
     /** Encode 128 integers from {@code longs} into {@code out}. */
@@ -114,7 +112,7 @@ final class PForUtil {
         } else {
             final int token = (numExceptions << 5) | patchedBitsRequired;
             out.writeByte((byte) token);
-            forUtil.encode(longs, patchedBitsRequired, out);
+            ForUtil.encode(longs, patchedBitsRequired, out);
         }
         out.writeBytes(exceptions, exceptions.length);
     }
@@ -127,7 +125,7 @@ final class PForUtil {
         if (bitsPerValue == 0) {
             Arrays.fill(longs, 0, ForUtil.BLOCK_SIZE, in.readVLong());
         } else {
-            forUtil.decode(bitsPerValue, in, longs);
+            ForUtil.decode(bitsPerValue, in, longs);
         }
         for (int i = 0; i < numExceptions; ++i) {
             longs[Byte.toUnsignedInt(in.readByte())] |= Byte.toUnsignedLong(in.readByte()) << bitsPerValue;
@@ -153,7 +151,7 @@ final class PForUtil {
                 }
             } else {
                 // decode the deltas then apply the prefix sum logic
-                forUtil.decodeTo32(bitsPerValue, in, longs);
+                ForUtil.decodeTo32(bitsPerValue, in, longs);
                 prefixSum32(longs, base);
             }
         } else {
@@ -161,7 +159,7 @@ final class PForUtil {
             if (bitsPerValue == 0) {
                 fillSameValue32(longs, in.readVLong());
             } else {
-                forUtil.decodeTo32(bitsPerValue, in, longs);
+                ForUtil.decodeTo32(bitsPerValue, in, longs);
             }
             applyExceptions32(bitsPerValue, numExceptions, in, longs);
             prefixSum32(longs, base);
@@ -177,7 +175,7 @@ final class PForUtil {
             in.readVLong();
             in.skipBytes((numExceptions << 1));
         } else {
-            in.skipBytes(forUtil.numBytes(bitsPerValue) + (numExceptions << 1));
+            in.skipBytes(ForUtil.numBytes(bitsPerValue) + (numExceptions << 1));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/DocValuesForUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/DocValuesForUtil.java
@@ -20,7 +20,6 @@ public class DocValuesForUtil {
     private static final int BITS_IN_FIVE_BYTES = 5 * Byte.SIZE;
     private static final int BITS_IN_SIX_BYTES = 6 * Byte.SIZE;
     private static final int BITS_IN_SEVEN_BYTES = 7 * Byte.SIZE;
-    private final ForUtil forUtil = new ForUtil();
     private final int blockSize;
     private final byte[] encoded;
 
@@ -50,7 +49,7 @@ public class DocValuesForUtil {
 
     public void encode(long[] in, int bitsPerValue, final DataOutput out) throws IOException {
         if (bitsPerValue <= 24) { // these bpvs are handled efficiently by ForUtil
-            forUtil.encode(in, bitsPerValue, out);
+            ForUtil.encode(in, bitsPerValue, out);
         } else if (bitsPerValue <= 32) {
             collapse32(in);
             for (int i = 0; i < blockSize / 2; ++i) {
@@ -76,7 +75,7 @@ public class DocValuesForUtil {
 
     public void decode(int bitsPerValue, final DataInput in, long[] out) throws IOException {
         if (bitsPerValue <= 24) {
-            forUtil.decode(bitsPerValue, in, out);
+            ForUtil.decode(bitsPerValue, in, out);
         } else if (bitsPerValue <= 32) {
             in.readLongs(out, 0, blockSize / 2);
             expand32(out);

--- a/server/src/test/java/org/elasticsearch/index/codec/ForUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/ForUtilTests.java
@@ -53,7 +53,6 @@ public class ForUtilTests extends LuceneTestCase {
         {
             // encode
             IndexOutput out = d.createOutput("test.bin", IOContext.DEFAULT);
-            final ForUtil forUtil = new ForUtil();
 
             for (int i = 0; i < iterations; ++i) {
                 long[] source = new long[ForUtil.BLOCK_SIZE];
@@ -64,7 +63,7 @@ public class ForUtilTests extends LuceneTestCase {
                 }
                 final int bpv = PackedInts.bitsRequired(or);
                 out.writeByte((byte) bpv);
-                forUtil.encode(source, bpv, out);
+                ForUtil.encode(source, bpv, out);
             }
             endPointer = out.getFilePointer();
             out.close();
@@ -73,12 +72,11 @@ public class ForUtilTests extends LuceneTestCase {
         {
             // decode
             IndexInput in = d.openInput("test.bin", IOContext.READONCE);
-            final ForUtil forUtil = new ForUtil();
             for (int i = 0; i < iterations; ++i) {
                 final int bitsPerValue = in.readByte();
                 final long currentFilePointer = in.getFilePointer();
                 final long[] restored = new long[ForUtil.BLOCK_SIZE];
-                forUtil.decode(bitsPerValue, in, restored);
+                ForUtil.decode(bitsPerValue, in, restored);
                 int[] ints = new int[ForUtil.BLOCK_SIZE];
                 for (int j = 0; j < ForUtil.BLOCK_SIZE; ++j) {
                     ints[j] = Math.toIntExact(restored[j]);
@@ -88,7 +86,7 @@ public class ForUtilTests extends LuceneTestCase {
                     ArrayUtil.copyOfSubArray(values, i * ForUtil.BLOCK_SIZE, (i + 1) * ForUtil.BLOCK_SIZE),
                     ints
                 );
-                assertEquals(forUtil.numBytes(bitsPerValue), in.getFilePointer() - currentFilePointer);
+                assertEquals(ForUtil.numBytes(bitsPerValue), in.getFilePointer() - currentFilePointer);
             }
             assertEquals(endPointer, in.getFilePointer());
             in.close();

--- a/server/src/test/java/org/elasticsearch/index/codec/tsdb/DocValuesForUtilTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/tsdb/DocValuesForUtilTests.java
@@ -30,8 +30,6 @@ import java.util.Arrays;
 import java.util.Random;
 
 public class DocValuesForUtilTests extends LuceneTestCase {
-    private final ES87TSDBDocValuesEncoder encoder = new ES87TSDBDocValuesEncoder();
-    private static final ForUtil forUtil = new ForUtil();
 
     public void testEncodeDecode() throws IOException {
         final int iterations = RandomNumbers.randomIntBetween(random(), 50, 1000);
@@ -105,14 +103,14 @@ public class DocValuesForUtilTests extends LuceneTestCase {
             // Encode
             DataOutput dataOutput = new ByteArrayDataOutput(dataOutputBuffer);
             long[] encodeBuffer = Arrays.copyOf(values, values.length);
-            forUtil.encode(encodeBuffer, bitsPerValue, dataOutput);
+            ForUtil.encode(encodeBuffer, bitsPerValue, dataOutput);
 
             // Prepare for decoding
             DataInput dataInput = new ByteArrayDataInput(dataInputBuffer);
             System.arraycopy(dataOutputBuffer, 0, dataInputBuffer, 0, dataOutputBuffer.length);
 
             // Decode
-            forUtil.decode(bitsPerValue, dataInput, decodeBuffer);
+            ForUtil.decode(bitsPerValue, dataInput, decodeBuffer);
 
             assertArrayEquals(decodeBuffer, values);
         }


### PR DESCRIPTION
We've run into heap dumps that had instances of this class consume tens and in one case more than a hundred MB of heap.
It seems reasonable to use a thread-local for the `tmp` long array and trade the cost of looking up the thread-local for the memory savings and cycles saved for allocating and assigning instances and from moving to a `static` call everywhere.
