### PR TITLE
Fix and unmute "Test frequent item sets unsupported types" yml test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/frequent_item_sets_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/frequent_item_sets_agg.yml
@@ -7,6 +7,9 @@ setup:
       indices.create:
         index: store
         body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               features:
@@ -433,9 +436,6 @@ setup:
 ---
 "Test frequent item sets unsupported types":
 
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/106215"
   - do:
       catch: /Field \[geo_point\] of type \[geo_point\] is not supported for aggregation \[frequent_item_sets\]/
       search:


### PR DESCRIPTION
This PR fixes the "Test frequent item sets unsupported types" by making the index always have 1 shard and no replicas.
This is the approach that is used, e.g.: by `x-pack/plugin/rollup/qa/rest/out/test/resources/rest-api-spec/test/rollup/20_unsupported_aggs.yml`.

Fixes https://github.com/elastic/elasticsearch/issues/106215