### PR TITLE
Relax assertion on `progress` value being updated to `end`

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/ProgressListenableActionFuture.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/ProgressListenableActionFuture.java
@@ -136,7 +136,7 @@ class ProgressListenableActionFuture extends PlainActionFuture<Long> {
         super.done(success);
         final List<Tuple<Long, ActionListener<Long>>> listenersToExecute;
         synchronized (this) {
-            assert progress == end || success == false;
+            assert completed == false;
             completed = true;
             listenersToExecute = this.listeners;
             listeners = null;


### PR DESCRIPTION
This change removes an assertion in `ProgressListenableActionFuture` that checks if the progress value has been updated up to the end of the completed range.

But ranges may or may not be fully written before being marked as completed (the remaining bytes can just be padding bytes), so there is no point on advancing the progress up to the end of the range before range completion.