### PR TITLE
ESQL: small fixes to generative tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/EsqlQueryGenerator.java
@@ -111,8 +111,14 @@ public class EsqlQueryGenerator {
         if (field == null || policies.isEmpty()) {
             return "";
         }
+
         // TODO add WITH
-        return " | enrich " + randomFrom(policies).policyName() + " on " + field;
+        return " | enrich " + randomFrom(policiesOnKeyword(policies)).policyName() + " on " + field;
+    }
+
+    private static List<CsvTestsDataLoader.EnrichConfig> policiesOnKeyword(List<CsvTestsDataLoader.EnrichConfig> policies) {
+        // TODO make it smarter and extend it to other types
+        return policies.stream().filter(x -> Set.of("languages_policy").contains(x.policyName())).toList();
     }
 
     private static String grok(List<Column> previousOutput) {
@@ -362,7 +368,7 @@ public class EsqlQueryGenerator {
     }
 
     private static String metaFunctions() {
-        return "metadata functions";
+        return "meta functions";
     }
 
     private static String indexPattern(String indexName) {

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/generative/GenerativeRestTest.java
@@ -34,7 +34,8 @@ public abstract class GenerativeRestTest extends ESRestTestCase {
 
     public static final Set<String> ALLOWED_ERRORS = Set.of(
         "Reference \\[.*\\] is ambiguous",
-        "Cannot use field \\[.*\\] due to ambiguities"
+        "Cannot use field \\[.*\\] due to ambiguities",
+        "cannot sort on .*"
     );
 
     public static final Set<Pattern> ALLOWED_ERROR_PATTERNS = ALLOWED_ERRORS.stream()


### PR DESCRIPTION
Small fixes to `GenerativeRestTest`. The test is disabled because of some known bugs, so it missed a few fixes needed after recent feature development. 