### PR TITLE
[Connector API] Simplify updating draft filtering rules

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/332_connector_update_filtering.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/332_connector_update_filtering.yml
@@ -13,91 +13,27 @@ setup:
           is_native: false
           service_type: super-connector
 ---
-"Update Connector Filtering with advanced snippet value array":
+"Update Connector Filtering - Advanced snippet value as array":
   - do:
       connector.update_filtering:
         connector_id: test-connector
         body:
-          filtering:
-            - active:
-                advanced_snippet:
-                  created_at: "2023-05-25T12:30:00.000Z"
-                  updated_at: "2023-05-25T12:30:00.000Z"
-                  value:
-                    - tables:
-                        - some_table
-                      query: 'SELECT id, st_geohash(coordinates) FROM my_db.some_table;'
-                rules:
-                  - created_at: "2023-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-0
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2023-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: DEFAULT
-              draft:
-                advanced_snippet:
-                  created_at: "2023-05-25T12:30:00.000Z"
-                  updated_at: "2023-05-25T12:30:00.000Z"
-                  value:
-                    - tables:
-                        - some_table
-                      query: 'SELECT id, st_geohash(coordinates) FROM my_db.some_table;'
-                    - tables:
-                        - another_table
-                      query: 'SELECT id, st_geohash(coordinates) FROM my_db.another_table;'
-                rules:
-                  - created_at: "2023-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-0
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2023-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-            - active:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-1
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: TEST
-              draft:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-1
-                    order: 0
-                    policy: exclude
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
+          advanced_snippet:
+            created_at: "2023-05-25T12:30:00.000Z"
+            updated_at: "2023-05-25T12:30:00.000Z"
+            value:
+              - tables:
+                  - some_table
+                query: 'SELECT id, st_geohash(coordinates) FROM my_db.some_table;'
+          rules:
+            - created_at: "2023-05-25T12:30:00.000Z"
+              field: _
+              id: RULE-DRAFT-0
+              order: 0
+              policy: include
+              rule: regex
+              updated_at: "2023-05-25T12:30:00.000Z"
+              value: ".*"
 
   - match: { result: updated }
 
@@ -105,19 +41,23 @@ setup:
       connector.get:
         connector_id: test-connector
 
-  - match: { filtering.0.domain: DEFAULT }
-  - match: { filtering.0.active.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
-  - match: { filtering.0.active.advanced_snippet.value.0.tables.0.: "some_table" }
-  - match: { filtering.0.active.rules.0.id: "RULE-ACTIVE-0" }
-  - match: { filtering.0.draft.rules.0.id: "RULE-DRAFT-0" }
 
-  - match: { filtering.1.domain: TEST }
-  - match: { filtering.1.active.advanced_snippet.created_at: "2021-05-25T12:30:00.000Z" }
-  - match: { filtering.1.active.rules.0.id: "RULE-ACTIVE-1" }
-  - match: { filtering.1.draft.rules.0.id: "RULE-DRAFT-1" }
+  - match: { filtering.0.draft.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
+  - match: { filtering.0.draft.advanced_snippet.value.0.tables.0.: "some_table" }
+  - match: { filtering.0.draft.rules.0.id: "RULE-DRAFT-0" }
+  - match: { filtering.0.draft.validation.errors: [] }
+  - match: { filtering.0.draft.validation.state: edited }
+
+  # Default domain and active should be unchanged
+  - match: { filtering.0.domain: DEFAULT }
+  - match: { filtering.0.active.advanced_snippet.value: {} }
+  - match: { filtering.0.active.advanced_snippet.value: {} }
+  - match: { filtering.0.active.rules.0.field: _ }
+  - match: { filtering.0.active.rules.0.id: DEFAULT }
+  - match: { filtering.0.active.rules.0.rule: regex }
 
 ---
-"Update Connector Filtering with advanced snippet value object":
+"Update Connector Filtering - Update full filtering object":
   - do:
       connector.update_filtering:
         connector_id: test-connector
@@ -219,77 +159,9 @@ setup:
       connector.update_filtering:
         connector_id: test-connector
         body:
-          filtering:
-            - active:
-                advanced_snippet:
-                  created_at: "2023-05-25T12:30:00.000Z"
-                  updated_at: "2023-05-25T12:30:00.000Z"
-                  value: "string literal"
-                rules:
-                  - created_at: "2023-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-0
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2023-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: DEFAULT
-              draft:
-                advanced_snippet:
-                  created_at: "2023-05-25T12:30:00.000Z"
-                  updated_at: "2023-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2023-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-0
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2023-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-            - active:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-1
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: TEST
-              draft:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-1
-                    order: 0
-                    policy: exclude
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
+          rules: [ ]
+          advanced_snippet:
+            value: "string literal"
 
 ---
 "Update Connector Filtering - Connector doesn't exist":
@@ -298,77 +170,9 @@ setup:
       connector.update_filtering:
         connector_id: test-non-existent-connector
         body:
-          filtering:
-            - active:
-                advanced_snippet:
-                  created_at: "2023-05-25T12:30:00.000Z"
-                  updated_at: "2023-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2023-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-0
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2023-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: DEFAULT
-              draft:
-                advanced_snippet:
-                  created_at: "2023-05-25T12:30:00.000Z"
-                  updated_at: "2023-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2023-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-0
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2023-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-            - active:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-1
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: TEST
-              draft:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-1
-                    order: 0
-                    policy: exclude
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
+          rules: []
+          advanced_snippet:
+            value: {}
 
 ---
 "Update Connector Filtering - Required fields are missing":
@@ -377,8 +181,7 @@ setup:
       connector.update_filtering:
         connector_id: test-connector
         body:
-          filtering:
-            - domain: some_domain
+          rules: []
 
   - match:
       status: 400
@@ -390,74 +193,7 @@ setup:
       connector.update_filtering:
         connector_id: test-connector
         body:
-          filtering:
-            - active:
-                advanced_snippet:
-                  created_at: "this-is-not-a-datetime-!!!!"
-                  updated_at: "2023-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2023-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-0
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2023-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: DEFAULT
-              draft:
-                advanced_snippet:
-                  created_at: "2023-05-25T12:30:00.000Z"
-                  updated_at: "2023-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2023-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-0
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2023-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-            - active:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-1
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: TEST
-              draft:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-1
-                    order: 0
-                    policy: exclude
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
+          rules: [ ]
+          advanced_snippet:
+            updated_at: "wrong datetime"
+            value: { }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/332_connector_update_filtering.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/332_connector_update_filtering.yml
@@ -13,7 +13,7 @@ setup:
           is_native: false
           service_type: super-connector
 ---
-"Update Connector Filtering - Advanced snippet value as array":
+"Update Connector Filtering - Update draft":
   - do:
       connector.update_filtering:
         connector_id: test-connector
@@ -28,7 +28,7 @@ setup:
           rules:
             - created_at: "2023-05-25T12:30:00.000Z"
               field: _
-              id: RULE-DRAFT-0
+              id: DEFAULT
               order: 0
               policy: include
               rule: regex
@@ -44,7 +44,7 @@ setup:
 
   - match: { filtering.0.draft.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
   - match: { filtering.0.draft.advanced_snippet.value.0.tables.0.: "some_table" }
-  - match: { filtering.0.draft.rules.0.id: "RULE-DRAFT-0" }
+  - match: { filtering.0.draft.rules.0.id: DEFAULT }
   - match: { filtering.0.draft.validation.errors: [] }
   - match: { filtering.0.draft.validation.state: edited }
 
@@ -55,6 +55,71 @@ setup:
   - match: { filtering.0.active.rules.0.field: _ }
   - match: { filtering.0.active.rules.0.id: DEFAULT }
   - match: { filtering.0.active.rules.0.rule: regex }
+
+
+---
+"Update Connector Filtering - Update draft rules only":
+  - do:
+      connector.update_filtering:
+        connector_id: test-connector
+        body:
+          rules:
+            - created_at: "2023-05-25T12:30:00.000Z"
+              field: my_field
+              id: MY-RULE-1
+              order: 0
+              policy: exclude
+              rule: regex
+              updated_at: "2023-05-25T12:30:00.000Z"
+              value: "tax-.*"
+            - created_at: "2023-05-25T12:30:00.000Z"
+              field: _
+              id: DEFAULT
+              order: 1
+              policy: include
+              rule: regex
+              updated_at: "2023-05-25T12:30:00.000Z"
+              value: ".*"
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { filtering.0.draft.rules.0.id: MY-RULE-1 }
+  - match: { filtering.0.draft.rules.1.id: DEFAULT }
+
+  # Default domain and active should be unchanged
+  - match: { filtering.0.domain: DEFAULT }
+  - match: { filtering.0.active.advanced_snippet.value: {} }
+  - match: { filtering.0.active.advanced_snippet.value: {} }
+  - match: { filtering.0.active.rules.0.field: _ }
+  - match: { filtering.0.active.rules.0.id: DEFAULT }
+  - match: { filtering.0.active.rules.0.rule: regex }
+
+---
+"Update Connector Filtering - Update draft advanced snippet only":
+  - do:
+      connector.update_filtering:
+        connector_id: test-connector
+        body:
+          advanced_snippet:
+            created_at: "2023-05-25T12:30:00.000Z"
+            updated_at: "2023-05-25T12:30:00.000Z"
+            value:
+              - tables:
+                  - some_table
+                query: 'SELECT id, st_geohash(coordinates) FROM my_db.some_table;'
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { filtering.0.draft.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
+  - match: { filtering.0.draft.advanced_snippet.value.0.tables.0.: "some_table" }
 
 ---
 "Update Connector Filtering - Update full filtering object":
@@ -72,7 +137,7 @@ setup:
                 rules:
                   - created_at: "2023-05-25T12:30:00.000Z"
                     field: _
-                    id: RULE-ACTIVE-0
+                    id: DEFAULT
                     order: 0
                     policy: include
                     rule: regex
@@ -81,7 +146,6 @@ setup:
                 validation:
                   errors: []
                   state: valid
-              domain: DEFAULT
               draft:
                 advanced_snippet:
                   created_at: "2023-05-25T12:30:00.000Z"
@@ -90,7 +154,7 @@ setup:
                 rules:
                   - created_at: "2023-05-25T12:30:00.000Z"
                     field: _
-                    id: RULE-DRAFT-0
+                    id: DEFAULT
                     order: 0
                     policy: include
                     rule: regex
@@ -99,41 +163,7 @@ setup:
                 validation:
                   errors: []
                   state: valid
-            - active:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-ACTIVE-1
-                    order: 0
-                    policy: include
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
-              domain: TEST
-              draft:
-                advanced_snippet:
-                  created_at: "2021-05-25T12:30:00.000Z"
-                  updated_at: "2021-05-25T12:30:00.000Z"
-                  value: {}
-                rules:
-                  - created_at: "2021-05-25T12:30:00.000Z"
-                    field: _
-                    id: RULE-DRAFT-1
-                    order: 0
-                    policy: exclude
-                    rule: regex
-                    updated_at: "2021-05-25T12:30:00.000Z"
-                    value: ".*"
-                validation:
-                  errors: []
-                  state: valid
+
 
   - match: { result: updated }
 
@@ -144,13 +174,9 @@ setup:
   - match: { filtering.0.domain: DEFAULT }
   - match: { filtering.0.active.advanced_snippet.created_at: "2023-05-25T12:30:00.000Z" }
   - match: { filtering.0.active.advanced_snippet.value.some_filtering_key: "some_filtering_value" }
-  - match: { filtering.0.active.rules.0.id: "RULE-ACTIVE-0" }
-  - match: { filtering.0.draft.rules.0.id: "RULE-DRAFT-0" }
+  - match: { filtering.0.active.rules.0.id: "DEFAULT" }
+  - match: { filtering.0.draft.rules.0.id: "DEFAULT" }
 
-  - match: { filtering.1.domain: TEST }
-  - match: { filtering.1.active.advanced_snippet.created_at: "2021-05-25T12:30:00.000Z" }
-  - match: { filtering.1.active.rules.0.id: "RULE-ACTIVE-1" }
-  - match: { filtering.1.draft.rules.0.id: "RULE-DRAFT-1" }
 
 ---
 "Update Connector Filtering with value literal - Wrong advanced snippet value":
@@ -159,9 +185,34 @@ setup:
       connector.update_filtering:
         connector_id: test-connector
         body:
-          rules: [ ]
           advanced_snippet:
             value: "string literal"
+
+---
+"Update Connector Filtering with value literal - Empty rules":
+  - do:
+      catch: "bad_request"
+      connector.update_filtering:
+        connector_id: test-connector
+        body:
+          rules: [ ]
+
+---
+"Update Connector Filtering with value literal - Default rule not present":
+  - do:
+      catch: "bad_request"
+      connector.update_filtering:
+        connector_id: test-connector
+        body:
+          rules:
+            - created_at: "2023-05-25T12:30:00.000Z"
+              field: my_field
+              id: MY_RULE
+              order: 0
+              policy: exclude
+              rule: regex
+              updated_at: "2023-05-25T12:30:00.000Z"
+              value: "hello-not-default-rule.*"
 
 ---
 "Update Connector Filtering - Connector doesn't exist":
@@ -170,7 +221,6 @@ setup:
       connector.update_filtering:
         connector_id: test-non-existent-connector
         body:
-          rules: []
           advanced_snippet:
             value: {}
 
@@ -180,8 +230,7 @@ setup:
       catch: "bad_request"
       connector.update_filtering:
         connector_id: test-connector
-        body:
-          rules: []
+        body: {}
 
   - match:
       status: 400

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -601,20 +601,24 @@ public class ConnectorIndexService {
         ActionListener<UpdateResponse> listener
     ) {
         try {
-
             getConnector(connectorId, listener.delegateFailure((l, connector) -> {
-
                 List<ConnectorFiltering> connectorFilteringList = fromXContentBytesConnectorFiltering(
                     connector.getSourceRef(),
                     XContentType.JSON
                 );
-
                 // Connectors represent their filtering configuration as a singleton list
                 ConnectorFiltering connectorFilteringSingleton = connectorFilteringList.get(0);
 
+                // If advanced snippet or rules are not defined, keep the current draft state
+                FilteringAdvancedSnippet newDraftAdvancedSnippet = advancedSnippet == null
+                    ? connectorFilteringSingleton.getDraft().getAdvancedSnippet()
+                    : advancedSnippet;
+
+                List<FilteringRule> newDraftRules = rules == null ? connectorFilteringSingleton.getDraft().getRules() : rules;
+
                 ConnectorFiltering connectorFilteringWithUpdatedDraft = connectorFilteringSingleton.setDraft(
-                    new FilteringRules.Builder().setRules(rules)
-                        .setAdvancedSnippet(advancedSnippet)
+                    new FilteringRules.Builder().setRules(newDraftRules)
+                        .setAdvancedSnippet(newDraftAdvancedSnippet)
                         .setFilteringValidationInfo(FilteringValidationInfo.getInitialDraftValidationInfo())
                         .build()
                 );

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -40,12 +40,12 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.action.PostConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.PutConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorApiKeyIdAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorConfigurationAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorErrorAction;
-import org.elasticsearch.xpack.application.connector.action.UpdateConnectorFilteringAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorIndexNameAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorLastSyncStatsAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorNameAction;
@@ -54,6 +54,10 @@ import org.elasticsearch.xpack.application.connector.action.UpdateConnectorPipel
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorSchedulingAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorServiceTypeAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorStatusAction;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringAdvancedSnippet;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRule;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringValidationInfo;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -68,6 +72,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.application.connector.ConnectorFiltering.fromXContentBytesConnectorFiltering;
 
 /**
  * A service that manages persistent {@link Connector} configurations.
@@ -548,19 +553,19 @@ public class ConnectorIndexService {
     }
 
     /**
-     * Updates the {@link ConnectorFiltering} property of a {@link Connector}.
+     * Sets the {@link ConnectorFiltering} property of a {@link Connector}.
      *
-     * @param request   Request for updating connector filtering property.
-     * @param listener  Listener to respond to a successful response or an error.
+     * @param connectorId The ID of the {@link Connector} to update.
+     * @param filtering   The list of {@link ConnectorFiltering} .
+     * @param listener    Listener to respond to a successful response or an error.
      */
-    public void updateConnectorFiltering(UpdateConnectorFilteringAction.Request request, ActionListener<UpdateResponse> listener) {
+    public void updateConnectorFiltering(String connectorId, List<ConnectorFiltering> filtering, ActionListener<UpdateResponse> listener) {
         try {
-            String connectorId = request.getConnectorId();
             final UpdateRequest updateRequest = new UpdateRequest(CONNECTOR_INDEX_NAME, connectorId).doc(
                 new IndexRequest(CONNECTOR_INDEX_NAME).opType(DocWriteRequest.OpType.INDEX)
                     .id(connectorId)
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .source(Map.of(Connector.FILTERING_FIELD.getPreferredName(), request.getFiltering()))
+                    .source(Map.of(Connector.FILTERING_FIELD.getPreferredName(), filtering))
             );
             client.update(updateRequest, new DelegatingIndexNotFoundActionListener<>(connectorId, listener, (l, updateResponse) -> {
                 if (updateResponse.getResult() == UpdateResponse.Result.NOT_FOUND) {
@@ -569,6 +574,60 @@ public class ConnectorIndexService {
                 }
                 l.onResponse(updateResponse);
             }));
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Updates the draft filtering in a given {@link Connector}.
+     *
+     * @param connectorId     The ID of the {@link Connector} to be updated.
+     * @param advancedSnippet An instance of {@link FilteringAdvancedSnippet}.
+     * @param rules           A list of instances of {@link FilteringRule} to be applied.
+     * @param listener        Listener to respond to a successful response or an error.
+     */
+    public void updateConnectorFilteringDraft(
+        String connectorId,
+        FilteringAdvancedSnippet advancedSnippet,
+        List<FilteringRule> rules,
+        ActionListener<UpdateResponse> listener
+    ) {
+        try {
+
+            getConnector(connectorId, listener.delegateFailure((l, connector) -> {
+
+                List<ConnectorFiltering> connectorFilteringList = fromXContentBytesConnectorFiltering(
+                    connector.getSourceRef(),
+                    XContentType.JSON
+                );
+
+                // Connectors represent their filtering configuration as a singleton list
+                ConnectorFiltering connectorFilteringSingleton = connectorFilteringList.get(0);
+
+                ConnectorFiltering connectorFilteringWithUpdatedDraft = connectorFilteringSingleton.setDraft(
+                    new FilteringRules.Builder().setRules(rules)
+                        .setAdvancedSnippet(advancedSnippet)
+                        .setFilteringValidationInfo(FilteringValidationInfo.getInitialDraftValidationInfo())
+                        .build()
+                );
+
+                final UpdateRequest updateRequest = new UpdateRequest(CONNECTOR_INDEX_NAME, connectorId).doc(
+                    new IndexRequest(CONNECTOR_INDEX_NAME).opType(DocWriteRequest.OpType.INDEX)
+                        .id(connectorId)
+                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                        .source(Map.of(Connector.FILTERING_FIELD.getPreferredName(), List.of(connectorFilteringWithUpdatedDraft)))
+                );
+
+                client.update(updateRequest, new DelegatingIndexNotFoundActionListener<>(connectorId, listener, (ll, updateResponse) -> {
+                    if (updateResponse.getResult() == UpdateResponse.Result.NOT_FOUND) {
+                        ll.onFailure(new ResourceNotFoundException(connectorNotFoundErrorMsg(connectorId)));
+                        return;
+                    }
+                    ll.onResponse(updateResponse);
+                }));
+            }));
+
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportUpdateConnectorFilteringAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportUpdateConnectorFilteringAction.java
@@ -56,6 +56,8 @@ public class TransportUpdateConnectorFilteringAction extends HandledTransportAct
         List<ConnectorFiltering> filtering = request.getFiltering();
         FilteringAdvancedSnippet advancedSnippet = request.getAdvancedSnippet();
         List<FilteringRule> rules = request.getRules();
+        // If [filtering] is not present in request body, it means that user's intention is to
+        // update draft's rules or advanced snippet
         if (request.getFiltering() == null) {
             connectorIndexService.updateConnectorFilteringDraft(
                 connectorId,
@@ -63,7 +65,9 @@ public class TransportUpdateConnectorFilteringAction extends HandledTransportAct
                 rules,
                 listener.map(r -> new ConnectorUpdateActionResponse(r.getResult()))
             );
-        } else {
+        }
+        // Otherwise override the whole filtering object (discouraged in docs)
+        else {
             connectorIndexService.updateConnectorFiltering(
                 connectorId,
                 filtering,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportUpdateConnectorFilteringAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportUpdateConnectorFilteringAction.java
@@ -16,7 +16,12 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringAdvancedSnippet;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRule;
+
+import java.util.List;
 
 public class TransportUpdateConnectorFilteringAction extends HandledTransportAction<
     UpdateConnectorFilteringAction.Request,
@@ -47,6 +52,23 @@ public class TransportUpdateConnectorFilteringAction extends HandledTransportAct
         UpdateConnectorFilteringAction.Request request,
         ActionListener<ConnectorUpdateActionResponse> listener
     ) {
-        connectorIndexService.updateConnectorFiltering(request, listener.map(r -> new ConnectorUpdateActionResponse(r.getResult())));
+        String connectorId = request.getConnectorId();
+        List<ConnectorFiltering> filtering = request.getFiltering();
+        FilteringAdvancedSnippet advancedSnippet = request.getAdvancedSnippet();
+        List<FilteringRule> rules = request.getRules();
+        if (request.getFiltering() == null) {
+            connectorIndexService.updateConnectorFilteringDraft(
+                connectorId,
+                advancedSnippet,
+                rules,
+                listener.map(r -> new ConnectorUpdateActionResponse(r.getResult()))
+            );
+        } else {
+            connectorIndexService.updateConnectorFiltering(
+                connectorId,
+                filtering,
+                listener.map(r -> new ConnectorUpdateActionResponse(r.getResult()))
+            );
+        }
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringAction.java
@@ -97,7 +97,7 @@ public class UpdateConnectorFilteringAction {
                 validationException = addValidationError("[connector_id] cannot be [null] or [\"\"].", validationException);
             }
 
-            // If [filtering] is not present in the request payload it means that the user should define [rules] and/or [advances_snippet]
+            // If [filtering] is not present in the request payload it means that the user should define [rules] and/or [advanced_snippet]
             if (filtering == null) {
                 if (rules == null && advancedSnippet == null) {
                     validationException = addValidationError("[advanced_snippet] and [rules] cannot be both [null].", validationException);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -23,13 +24,16 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.application.connector.ConnectorFiltering;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringAdvancedSnippet;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRule;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRules;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 public class UpdateConnectorFilteringAction {
 
@@ -41,17 +45,31 @@ public class UpdateConnectorFilteringAction {
     public static class Request extends ConnectorActionRequest implements ToXContentObject {
 
         private final String connectorId;
+        @Nullable
         private final List<ConnectorFiltering> filtering;
+        @Nullable
+        private final FilteringAdvancedSnippet advancedSnippet;
+        @Nullable
+        private final List<FilteringRule> rules;
 
-        public Request(String connectorId, List<ConnectorFiltering> filtering) {
+        public Request(
+            String connectorId,
+            List<ConnectorFiltering> filtering,
+            FilteringAdvancedSnippet advancedSnippet,
+            List<FilteringRule> rules
+        ) {
             this.connectorId = connectorId;
             this.filtering = filtering;
+            this.advancedSnippet = advancedSnippet;
+            this.rules = rules;
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
             this.connectorId = in.readString();
             this.filtering = in.readOptionalCollectionAsList(ConnectorFiltering::new);
+            this.advancedSnippet = new FilteringAdvancedSnippet(in);
+            this.rules = in.readCollectionAsList(FilteringRule::new);
         }
 
         public String getConnectorId() {
@@ -62,6 +80,14 @@ public class UpdateConnectorFilteringAction {
             return filtering;
         }
 
+        public FilteringAdvancedSnippet getAdvancedSnippet() {
+            return advancedSnippet;
+        }
+
+        public List<FilteringRule> getRules() {
+            return rules;
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             ActionRequestValidationException validationException = null;
@@ -70,8 +96,25 @@ public class UpdateConnectorFilteringAction {
                 validationException = addValidationError("[connector_id] cannot be [null] or [\"\"].", validationException);
             }
 
+            // If [filtering] is not present in the request payload it means that the user should define both [rules] and [advances_snippet]
             if (filtering == null) {
-                validationException = addValidationError("[filtering] cannot be [null].", validationException);
+                if (rules == null && advancedSnippet == null) {
+                    validationException = addValidationError(
+                        "[filtering], [advanced_snippet] and [rules] cannot be all [null].",
+                        validationException
+                    );
+                } else if (rules == null) {
+                    validationException = addValidationError("[rules] cannot be [null].", validationException);
+                } else if (advancedSnippet == null) {
+                    validationException = addValidationError("[advanced_snippet] cannot be [null].", validationException);
+                }
+            }
+            // If [filtering] is present we don't expect [rules] and [advances_snippet] in the request body
+            else if (rules != null || advancedSnippet != null) {
+                validationException = addValidationError(
+                    "If [filtering] is specified, [rules] and [advanced_snippet] should not be present in the request body.",
+                    validationException
+                );
             }
 
             return validationException;
@@ -82,11 +125,22 @@ public class UpdateConnectorFilteringAction {
             new ConstructingObjectParser<>(
                 "connector_update_filtering_request",
                 false,
-                ((args, connectorId) -> new UpdateConnectorFilteringAction.Request(connectorId, (List<ConnectorFiltering>) args[0]))
+                ((args, connectorId) -> new UpdateConnectorFilteringAction.Request(
+                    connectorId,
+                    (List<ConnectorFiltering>) args[0],
+                    (FilteringAdvancedSnippet) args[1],
+                    (List<FilteringRule>) args[2]
+                ))
             );
 
         static {
-            PARSER.declareObjectArray(constructorArg(), (p, c) -> ConnectorFiltering.fromXContent(p), Connector.FILTERING_FIELD);
+            PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> ConnectorFiltering.fromXContent(p), Connector.FILTERING_FIELD);
+            PARSER.declareObject(
+                optionalConstructorArg(),
+                (p, c) -> FilteringAdvancedSnippet.fromXContent(p),
+                FilteringRules.ADVANCED_SNIPPET_FIELD
+            );
+            PARSER.declareObjectArray(optionalConstructorArg(), (p, c) -> FilteringRule.fromXContent(p), FilteringRules.RULES_FIELD);
         }
 
         public static UpdateConnectorFilteringAction.Request fromXContentBytes(
@@ -110,6 +164,8 @@ public class UpdateConnectorFilteringAction {
             builder.startObject();
             {
                 builder.field(Connector.FILTERING_FIELD.getPreferredName(), filtering);
+                builder.field(FilteringRules.ADVANCED_SNIPPET_FIELD.getPreferredName(), advancedSnippet);
+                builder.xContentList(FilteringRules.RULES_FIELD.getPreferredName(), rules);
             }
             builder.endObject();
             return builder;
@@ -120,6 +176,8 @@ public class UpdateConnectorFilteringAction {
             super.writeTo(out);
             out.writeString(connectorId);
             out.writeOptionalCollection(filtering);
+            advancedSnippet.writeTo(out);
+            out.writeCollection(rules);
         }
 
         @Override
@@ -127,12 +185,15 @@ public class UpdateConnectorFilteringAction {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
-            return Objects.equals(connectorId, request.connectorId) && Objects.equals(filtering, request.filtering);
+            return Objects.equals(connectorId, request.connectorId)
+                && Objects.equals(filtering, request.filtering)
+                && Objects.equals(advancedSnippet, request.advancedSnippet)
+                && Objects.equals(rules, request.rules);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(connectorId, filtering);
+            return Objects.hash(connectorId, filtering, advancedSnippet, rules);
         }
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringAdvancedSnippet.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringAdvancedSnippet.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.application.connector.filtering;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -24,6 +25,7 @@ import java.time.Instant;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * Represents an advanced snippet used in filtering processes, providing detailed criteria or rules.
@@ -31,8 +33,9 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
  * actual snippet content represented as a map.
  */
 public class FilteringAdvancedSnippet implements Writeable, ToXContentObject {
-
+    @Nullable
     private final Instant advancedSnippetCreatedAt;
+    @Nullable
     private final Instant advancedSnippetUpdatedAt;
     private final Object advancedSnippetValue;
 
@@ -48,14 +51,26 @@ public class FilteringAdvancedSnippet implements Writeable, ToXContentObject {
     }
 
     public FilteringAdvancedSnippet(StreamInput in) throws IOException {
-        this.advancedSnippetCreatedAt = in.readInstant();
-        this.advancedSnippetUpdatedAt = in.readInstant();
+        this.advancedSnippetCreatedAt = in.readOptionalInstant();
+        this.advancedSnippetUpdatedAt = in.readOptionalInstant();
         this.advancedSnippetValue = in.readGenericValue();
     }
 
     private static final ParseField CREATED_AT_FIELD = new ParseField("created_at");
     private static final ParseField UPDATED_AT_FIELD = new ParseField("updated_at");
     private static final ParseField VALUE_FIELD = new ParseField("value");
+
+    public Instant getAdvancedSnippetCreatedAt() {
+        return advancedSnippetCreatedAt;
+    }
+
+    public Instant getAdvancedSnippetUpdatedAt() {
+        return advancedSnippetUpdatedAt;
+    }
+
+    public Object getAdvancedSnippetValue() {
+        return advancedSnippetValue;
+    }
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<FilteringAdvancedSnippet, Void> PARSER = new ConstructingObjectParser<>(
@@ -69,13 +84,13 @@ public class FilteringAdvancedSnippet implements Writeable, ToXContentObject {
 
     static {
         PARSER.declareField(
-            constructorArg(),
+            optionalConstructorArg(),
             (p, c) -> ConnectorUtils.parseInstant(p, CREATED_AT_FIELD.getPreferredName()),
             CREATED_AT_FIELD,
             ObjectParser.ValueType.STRING
         );
         PARSER.declareField(
-            constructorArg(),
+            optionalConstructorArg(),
             (p, c) -> ConnectorUtils.parseInstant(p, UPDATED_AT_FIELD.getPreferredName()),
             UPDATED_AT_FIELD,
             ObjectParser.ValueType.STRING
@@ -108,8 +123,8 @@ public class FilteringAdvancedSnippet implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeInstant(advancedSnippetCreatedAt);
-        out.writeInstant(advancedSnippetUpdatedAt);
+        out.writeOptionalInstant(advancedSnippetCreatedAt);
+        out.writeOptionalInstant(advancedSnippetUpdatedAt);
         out.writeGenericValue(advancedSnippetValue);
     }
 
@@ -133,14 +148,15 @@ public class FilteringAdvancedSnippet implements Writeable, ToXContentObject {
         private Instant advancedSnippetCreatedAt;
         private Instant advancedSnippetUpdatedAt;
         private Object advancedSnippetValue;
+        private final Instant currentTimestamp = Instant.now();
 
         public Builder setAdvancedSnippetCreatedAt(Instant advancedSnippetCreatedAt) {
-            this.advancedSnippetCreatedAt = advancedSnippetCreatedAt;
+            this.advancedSnippetCreatedAt = Objects.requireNonNullElse(advancedSnippetCreatedAt, currentTimestamp);
             return this;
         }
 
         public Builder setAdvancedSnippetUpdatedAt(Instant advancedSnippetUpdatedAt) {
-            this.advancedSnippetUpdatedAt = advancedSnippetUpdatedAt;
+            this.advancedSnippetUpdatedAt = Objects.requireNonNullElse(advancedSnippetUpdatedAt, currentTimestamp);
             return this;
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringAdvancedSnippet.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringAdvancedSnippet.java
@@ -36,7 +36,7 @@ public class FilteringAdvancedSnippet implements Writeable, ToXContentObject {
     @Nullable
     private final Instant advancedSnippetCreatedAt;
     @Nullable
-    private final Instant advancedSnippetUpdatedAt;
+    private Instant advancedSnippetUpdatedAt;
     private final Object advancedSnippetValue;
 
     /**

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringAdvancedSnippet.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringAdvancedSnippet.java
@@ -36,7 +36,7 @@ public class FilteringAdvancedSnippet implements Writeable, ToXContentObject {
     @Nullable
     private final Instant advancedSnippetCreatedAt;
     @Nullable
-    private Instant advancedSnippetUpdatedAt;
+    private final Instant advancedSnippetUpdatedAt;
     private final Object advancedSnippetValue;
 
     /**

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRule.java
@@ -186,6 +186,18 @@ public class FilteringRule implements Writeable, ToXContentObject {
             && Objects.equals(value, that.value);
     }
 
+    /**
+     * Compares this {@code FilteringRule} to another rule for equality, ignoring differences
+     * in created_at, updated_at timestamps and order.
+    */
+    public boolean equalsExceptForTimestampsAndOrder(FilteringRule that) {
+        return Objects.equals(field, that.field)
+            && Objects.equals(id, that.id)
+            && policy == that.policy
+            && rule == that.rule
+            && Objects.equals(value, that.value);
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(createdAt, field, id, order, policy, rule, updatedAt, value);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRule.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.Objects;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * Represents a single rule used for filtering in a data processing or querying context.
@@ -75,13 +76,13 @@ public class FilteringRule implements Writeable, ToXContentObject {
     }
 
     public FilteringRule(StreamInput in) throws IOException {
-        this.createdAt = in.readInstant();
+        this.createdAt = in.readOptionalInstant();
         this.field = in.readString();
         this.id = in.readString();
         this.order = in.readInt();
         this.policy = in.readEnum(FilteringPolicy.class);
         this.rule = in.readEnum(FilteringRuleCondition.class);
-        this.updatedAt = in.readInstant();
+        this.updatedAt = in.readOptionalInstant();
         this.value = in.readString();
     }
 
@@ -110,7 +111,7 @@ public class FilteringRule implements Writeable, ToXContentObject {
 
     static {
         PARSER.declareField(
-            constructorArg(),
+            optionalConstructorArg(),
             (p, c) -> ConnectorUtils.parseInstant(p, CREATED_AT_FIELD.getPreferredName()),
             CREATED_AT_FIELD,
             ObjectParser.ValueType.STRING
@@ -131,7 +132,7 @@ public class FilteringRule implements Writeable, ToXContentObject {
             ObjectParser.ValueType.STRING
         );
         PARSER.declareField(
-            constructorArg(),
+            optionalConstructorArg(),
             (p, c) -> ConnectorUtils.parseInstant(p, UPDATED_AT_FIELD.getPreferredName()),
             UPDATED_AT_FIELD,
             ObjectParser.ValueType.STRING
@@ -160,13 +161,13 @@ public class FilteringRule implements Writeable, ToXContentObject {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeInstant(createdAt);
+        out.writeOptionalInstant(createdAt);
         out.writeString(field);
         out.writeString(id);
         out.writeInt(order);
         out.writeEnum(policy);
         out.writeEnum(rule);
-        out.writeInstant(updatedAt);
+        out.writeOptionalInstant(updatedAt);
         out.writeString(value);
     }
 
@@ -200,9 +201,10 @@ public class FilteringRule implements Writeable, ToXContentObject {
         private FilteringRuleCondition rule;
         private Instant updatedAt;
         private String value;
+        private final Instant currentTimestamp = Instant.now();
 
         public Builder setCreatedAt(Instant createdAt) {
-            this.createdAt = createdAt;
+            this.createdAt = Objects.requireNonNullElse(createdAt, currentTimestamp);
             return this;
         }
 
@@ -232,7 +234,7 @@ public class FilteringRule implements Writeable, ToXContentObject {
         }
 
         public Builder setUpdatedAt(Instant updatedAt) {
-            this.updatedAt = updatedAt;
+            this.updatedAt = Objects.requireNonNullElse(updatedAt, currentTimestamp);
             return this;
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRules.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRules.java
@@ -69,9 +69,9 @@ public class FilteringRules implements Writeable, ToXContentObject {
         return filteringValidationInfo;
     }
 
-    private static final ParseField ADVANCED_SNIPPET_FIELD = new ParseField("advanced_snippet");
-    private static final ParseField RULES_FIELD = new ParseField("rules");
-    private static final ParseField VALIDATION_FIELD = new ParseField("validation");
+    public static final ParseField ADVANCED_SNIPPET_FIELD = new ParseField("advanced_snippet");
+    public static final ParseField RULES_FIELD = new ParseField("rules");
+    public static final ParseField VALIDATION_FIELD = new ParseField("validation");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<FilteringRules, Void> PARSER = new ConstructingObjectParser<>(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringValidationInfo.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringValidationInfo.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -103,6 +104,12 @@ public class FilteringValidationInfo implements Writeable, ToXContentObject {
     @Override
     public int hashCode() {
         return Objects.hash(validationErrors, validationState);
+    }
+
+    public static FilteringValidationInfo getInitialDraftValidationInfo() {
+        return new FilteringValidationInfo.Builder().setValidationErrors(Collections.emptyList())
+            .setValidationState(FilteringValidationState.EDITED)
+            .build();
     }
 
     public static class Builder {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -28,7 +28,6 @@ import org.elasticsearch.xpack.application.connector.action.PutConnectorAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorApiKeyIdAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorConfigurationAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorErrorAction;
-import org.elasticsearch.xpack.application.connector.action.UpdateConnectorFilteringAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorIndexNameAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorLastSeenAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorLastSyncStatsAction;
@@ -38,6 +37,9 @@ import org.elasticsearch.xpack.application.connector.action.UpdateConnectorPipel
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorSchedulingAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorServiceTypeAction;
 import org.elasticsearch.xpack.application.connector.action.UpdateConnectorStatusAction;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringAdvancedSnippet;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringRule;
+import org.elasticsearch.xpack.application.connector.filtering.FilteringValidationInfo;
 import org.junit.Before;
 
 import java.util.ArrayList;
@@ -246,15 +248,44 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
             .mapToObj((i) -> ConnectorTestUtils.getRandomConnectorFiltering())
             .collect(Collectors.toList());
 
-        UpdateConnectorFilteringAction.Request updateFilteringRequest = new UpdateConnectorFilteringAction.Request(
-            connectorId,
-            filteringList
-        );
-
-        DocWriteResponse updateResponse = awaitUpdateConnectorFiltering(updateFilteringRequest);
+        DocWriteResponse updateResponse = awaitUpdateConnectorFiltering(connectorId, filteringList);
         assertThat(updateResponse.status(), equalTo(RestStatus.OK));
         Connector indexedConnector = awaitGetConnector(connectorId);
         assertThat(filteringList, equalTo(indexedConnector.getFiltering()));
+    }
+
+    public void testUpdateConnectorFiltering_updateDraft() throws Exception {
+        Connector connector = ConnectorTestUtils.getRandomConnector();
+        String connectorId = randomUUID();
+
+        DocWriteResponse resp = buildRequestAndAwaitPutConnector(connectorId, connector);
+        assertThat(resp.status(), anyOf(equalTo(RestStatus.CREATED), equalTo(RestStatus.OK)));
+
+        FilteringAdvancedSnippet advancedSnippet = ConnectorTestUtils.getRandomConnectorFiltering().getDraft().getAdvancedSnippet();
+        List<FilteringRule> rules = ConnectorTestUtils.getRandomConnectorFiltering().getDraft().getRules();
+
+        DocWriteResponse updateResponse = awaitUpdateConnectorFilteringDraft(connectorId, advancedSnippet, rules);
+        assertThat(updateResponse.status(), equalTo(RestStatus.OK));
+        Connector indexedConnector = awaitGetConnector(connectorId);
+
+        // Assert that draft got updated
+        assertThat(advancedSnippet, equalTo(indexedConnector.getFiltering().get(0).getDraft().getAdvancedSnippet()));
+        assertThat(rules, equalTo(indexedConnector.getFiltering().get(0).getDraft().getRules()));
+        // Assert that draft is marked as EDITED
+        assertThat(
+            FilteringValidationInfo.getInitialDraftValidationInfo(),
+            equalTo(indexedConnector.getFiltering().get(0).getDraft().getFilteringValidationInfo())
+        );
+        // Assert that default active rules are unchanged, avoid comparing timestamps
+        assertThat(
+            ConnectorFiltering.getDefaultConnectorFilteringConfig().getActive().getAdvancedSnippet().getAdvancedSnippetValue(),
+            equalTo(indexedConnector.getFiltering().get(0).getActive().getAdvancedSnippet().getAdvancedSnippetValue())
+        );
+        // Assert that domain is unchanged
+        assertThat(
+            ConnectorFiltering.getDefaultConnectorFilteringConfig().getDomain(),
+            equalTo(indexedConnector.getFiltering().get(0).getDomain())
+        );
     }
 
     public void testUpdateConnectorLastSeen() throws Exception {
@@ -715,12 +746,42 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         return resp.get();
     }
 
-    private UpdateResponse awaitUpdateConnectorFiltering(UpdateConnectorFilteringAction.Request updateFiltering) throws Exception {
+    private UpdateResponse awaitUpdateConnectorFiltering(String connectorId, List<ConnectorFiltering> filtering) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<UpdateResponse> resp = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
-        connectorIndexService.updateConnectorFiltering(updateFiltering, new ActionListener<>() {
+        connectorIndexService.updateConnectorFiltering(connectorId, filtering, new ActionListener<>() {
 
+            @Override
+            public void onResponse(UpdateResponse indexResponse) {
+                resp.set(indexResponse);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                exc.set(e);
+                latch.countDown();
+            }
+        });
+
+        assertTrue("Timeout waiting for update filtering request", latch.await(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        if (exc.get() != null) {
+            throw exc.get();
+        }
+        assertNotNull("Received null response from update filtering request", resp.get());
+        return resp.get();
+    }
+
+    private UpdateResponse awaitUpdateConnectorFilteringDraft(
+        String connectorId,
+        FilteringAdvancedSnippet advancedSnippet,
+        List<FilteringRule> rules
+    ) throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<UpdateResponse> resp = new AtomicReference<>(null);
+        final AtomicReference<Exception> exc = new AtomicReference<>(null);
+        connectorIndexService.updateConnectorFilteringDraft(connectorId, advancedSnippet, rules, new ActionListener<>() {
             @Override
             public void onResponse(UpdateResponse indexResponse) {
                 resp.set(indexResponse);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -210,7 +210,6 @@ public final class ConnectorTestUtils {
                 )
                 .build()
         )
-            .setDomain(randomAlphaOfLength(10))
             .setDraft(
                 new FilteringRules.Builder().setAdvancedSnippet(
                     new FilteringAdvancedSnippet.Builder().setAdvancedSnippetCreatedAt(currentTimestamp)

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringActionRequestBWCSerializingTests.java
@@ -31,7 +31,9 @@ public class UpdateConnectorFilteringActionRequestBWCSerializingTests extends Ab
         this.connectorId = randomUUID();
         return new UpdateConnectorFilteringAction.Request(
             connectorId,
-            List.of(ConnectorTestUtils.getRandomConnectorFiltering(), ConnectorTestUtils.getRandomConnectorFiltering())
+            List.of(ConnectorTestUtils.getRandomConnectorFiltering(), ConnectorTestUtils.getRandomConnectorFiltering()),
+            ConnectorTestUtils.getRandomConnectorFiltering().getActive().getAdvancedSnippet(),
+            ConnectorTestUtils.getRandomConnectorFiltering().getActive().getRules()
         );
     }
 


### PR DESCRIPTION
### Changes

- This is backward compatible change that affects the `PUT _connector/{id}/_filtering` endpoint
- We add `rules` and `advanced_snippet` request body parameters
  - They simplify inputting draft filtering rules that will be in turn validated by the framework 
  - This is same logic [as what Kibana does under the hood](https://github.com/elastic/kibana/blob/main/packages/kbn-search-connectors/lib/update_filtering_draft.ts)
- Added uni tests, yaml tests, tested manually

Example request, note timestamps (created_at, updated_at) are optional, if not provided current timestamp will be used:
```
PUT _connector/{id}/_filtering
{
  "advanced_snippet": {
    "value": [
      {
        "tables": [
          "some_table"
        ],
        "query": "SELECT id, st_geohash(coordinates) FROM my_db.some_table;"
      }
    ]
  },
  "rules": [
    {
      "field": "_",
      "id": "RULE-DRAFT-0",
      "order": 0,
      "policy": "include",
      "rule": "regex",
      "value": ".*"
    }
  ]
}
```
If timestamps are not provided the current timestmap is used. API logic takes care about setting validation info to `EDITED` state, from which point the framework can carry out the validation.
