### PR TITLE
Fix cleanup of enrich policy in test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/20_standard_index.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/20_standard_index.yml
@@ -179,3 +179,11 @@ enrich documents over _bulk via an alias:
       _source:
         baz: slow
         c: 3
+
+  - do:
+      ingest.delete_pipeline:
+        id: test_alias_pipeline
+
+  - do:
+      enrich.delete_policy:
+        name: test_alias_policy


### PR DESCRIPTION
This test is installing a separate policy that isn't getting cleaned up, which is causing a failure in a separate test.
