### PR TITLE
[8.13] [ci] Use just filename for artifact upload and exclude the build dir prefix (#106844)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchBuildCompletePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchBuildCompletePlugin.java
@@ -137,10 +137,17 @@ public abstract class ElasticsearchBuildCompletePlugin implements Plugin<Project
             uploadFile.getParentFile().mkdirs();
             createBuildArchiveTar(parameters.getFilteredFiles().get(), parameters.getProjectDir().get(), uploadFile);
             if (uploadFile.exists() && "true".equals(System.getenv("BUILDKITE"))) {
-                String uploadFilePath = "build/" + uploadFile.getName();
+                String uploadFilePath = uploadFile.getName();
+                File uploadFileDir = uploadFile.getParentFile();
                 try {
                     System.out.println("Uploading buildkite artifact: " + uploadFilePath + "...");
-                    new ProcessBuilder("buildkite-agent", "artifact", "upload", uploadFilePath).start().waitFor();
+                    ProcessBuilder pb = new ProcessBuilder("buildkite-agent", "artifact", "upload", uploadFilePath);
+                    // If we don't switch to the build directory first, the uploaded file will have a `build/` prefix
+                    // Buildkite will flip the `/` to a `\` at upload time on Windows, which will make the search command below fail
+                    // So, if you change this such that the artifact will have a slash/directory in it, you'll need to update the logic
+                    // below as well
+                    pb.directory(uploadFileDir);
+                    pb.start().waitFor();
 
                     System.out.println("Generating buildscan link for artifact...");
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[ci] Use just filename for artifact upload and exclude the build dir prefix (#106844)](https://github.com/elastic/elasticsearch/pull/106844)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)