### PR TITLE
ES|QL: Make two tests deterministic

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -506,7 +506,7 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         for (int i = 1; i <= expectedWarnings; i++) {
             assertThat(
                 warnings.get(i),
-                containsString("org.elasticsearch.xpack.ql.InvalidArgumentException: Cannot parse number [keyword" + (2 * i - 1) + "]")
+                containsString("org.elasticsearch.xpack.ql.InvalidArgumentException: Cannot parse number [keyword")
             );
         }
     }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich-IT_tests_only.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich-IT_tests_only.csv-spec
@@ -146,7 +146,8 @@ emp_no:integer | x:keyword | lang:keyword | language:keyword
 
 
 multivalue
-row a = ["1", "2"] | enrich languages_policy on a with a_lang = language_name;  
+required_feature: esql.mv_sort
+row a = ["1", "2"] | enrich languages_policy on a with a_lang = language_name | eval a_lang = mv_sort(a_lang);  
 
 a:keyword   | a_lang:keyword
 ["1", "2"]  | ["English", "French"] 


### PR DESCRIPTION
Making two more tests deterministic.
The order of results and warnings can be different especially when running in multi-node configuration.

Fixes https://github.com/elastic/elasticsearch/issues/105707

