### PR TITLE
Allow decoding IP ranges from doc values

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
@@ -107,9 +107,8 @@ public enum RangeType {
         }
 
         @Override
-        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) {
-            // TODO: Implement this.
-            throw new UnsupportedOperationException();
+        public List<RangeFieldMapper.Range> decodeRanges(BytesRef bytes) throws IOException {
+            return BinaryRangeUtil.decodeIPRanges(bytes);
         }
 
         @Override


### PR DESCRIPTION
This logic was not exposed previously because there was no use case. Range fields need to be decoded during aggregations however aggregations on IP fields are not supported:
https://github.com/elastic/elasticsearch/blob/0075c1fb1e82c51c747729924ce67efef6daadeb/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregator.java#L67

https://github.com/elastic/elasticsearch/blob/0075c1fb1e82c51c747729924ce67efef6daadeb/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java#L98

#107081 adds a use case that needs this logic - constructing synthetic source. Given the above context this PR is not expected to change any existing behavior and only unblocks #107081.
