### PR TITLE
Fix flaky retriever test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/20_knn_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/20_knn_retriever.yml
@@ -17,6 +17,8 @@ setup:
                 type: dense_vector
                 dims: 5
                 index: true
+                index_options:
+                  type: hnsw
                 similarity: l2_norm
 
   - do:


### PR DESCRIPTION
This test uses fake and tiny vectors, it can be a little flaky for quantization being the default. Forcing to use raw vectors.