### PR TITLE
Use default replicas for enrich data stream test

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/50_data_stream.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/enrich/50_data_stream.yml
@@ -9,9 +9,6 @@ setup:
         name: enrich-template
         body:
           index_patterns: [my-ds]
-          template:
-            settings:
-              index.number_of_replicas: 0
           data_stream: {}
 
   - do:


### PR DESCRIPTION
In Serverless the index cannot be queried without any replicas, so these must be set to the default value in order for this test to work.
