### PR TITLE
Add counters for downsampling

### DIFF
--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleMetrics.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleMetrics.java
@@ -46,7 +46,7 @@ public class DownsampleMetrics extends AbstractLifecycleComponent {
         meterRegistry.registerLongHistogram(LATENCY_SHARD, "Downsampling action latency per shard", "ms");
         meterRegistry.registerLongHistogram(LATENCY_TOTAL, "Downsampling latency end-to-end", "ms");
         meterRegistry.registerLongCounter(ACTIONS_SHARD, "Number of shard-level downsampling actions", "count");
-        meterRegistry.registerLongCounter(ACTIONS, "Number of index-level downsampling actions", "count");
+        meterRegistry.registerLongCounter(ACTIONS, "Number of downsampling operations", "count");
     }
 
     @Override

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleMetrics.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleMetrics.java
@@ -31,6 +31,9 @@ public class DownsampleMetrics extends AbstractLifecycleComponent {
 
     public static final String LATENCY_SHARD = "es.tsdb.downsample.latency.shard.histogram";
     public static final String LATENCY_TOTAL = "es.tsdb.downsample.latency.total.histogram";
+    public static final String SUCCESS = "es.tsdb.downsample.success.total";
+    public static final String FAILURE = "es.tsdb.downsample.failure.total";
+    public static final String INVALID_CONFIGURATION = "es.tsdb.downsample.invalid_configuration.total";
 
     private final MeterRegistry meterRegistry;
 
@@ -43,6 +46,9 @@ public class DownsampleMetrics extends AbstractLifecycleComponent {
         // Register all metrics to track.
         meterRegistry.registerLongHistogram(LATENCY_SHARD, "Downsampling action latency per shard", "ms");
         meterRegistry.registerLongHistogram(LATENCY_TOTAL, "Downsampling latency end-to-end", "ms");
+        meterRegistry.registerLongCounter(SUCCESS, "Downsampling success", "count");
+        meterRegistry.registerLongCounter(FAILURE, "Downsampling failure", "count");
+        meterRegistry.registerLongCounter(INVALID_CONFIGURATION, "Downsampling failed due to invalid configuration", "count");
     }
 
     @Override
@@ -77,5 +83,17 @@ public class DownsampleMetrics extends AbstractLifecycleComponent {
 
     void recordLatencyTotal(long durationInMilliSeconds, ActionStatus status) {
         meterRegistry.getLongHistogram(LATENCY_TOTAL).record(durationInMilliSeconds, Map.of(ActionStatus.NAME, status.getMessage()));
+    }
+
+    void recordSuccess() {
+        meterRegistry.getLongCounter(SUCCESS).increment();
+    }
+
+    void recordFailure() {
+        meterRegistry.getLongCounter(FAILURE).increment();
+    }
+
+    void recordInvalidConfiguration() {
+        meterRegistry.getLongCounter(INVALID_CONFIGURATION).increment();
     }
 }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleMetrics.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleMetrics.java
@@ -31,9 +31,8 @@ public class DownsampleMetrics extends AbstractLifecycleComponent {
 
     public static final String LATENCY_SHARD = "es.tsdb.downsample.latency.shard.histogram";
     public static final String LATENCY_TOTAL = "es.tsdb.downsample.latency.total.histogram";
-    public static final String SUCCESS = "es.tsdb.downsample.success.total";
-    public static final String FAILURE = "es.tsdb.downsample.failure.total";
-    public static final String INVALID_CONFIGURATION = "es.tsdb.downsample.invalid_configuration.total";
+    public static final String ACTIONS_SHARD = "es.tsdb.downsample.actions.shard.total";
+    public static final String ACTIONS = "es.tsdb.downsample.actions.total";
 
     private final MeterRegistry meterRegistry;
 
@@ -46,9 +45,8 @@ public class DownsampleMetrics extends AbstractLifecycleComponent {
         // Register all metrics to track.
         meterRegistry.registerLongHistogram(LATENCY_SHARD, "Downsampling action latency per shard", "ms");
         meterRegistry.registerLongHistogram(LATENCY_TOTAL, "Downsampling latency end-to-end", "ms");
-        meterRegistry.registerLongCounter(SUCCESS, "Downsampling success", "count");
-        meterRegistry.registerLongCounter(FAILURE, "Downsampling failure", "count");
-        meterRegistry.registerLongCounter(INVALID_CONFIGURATION, "Downsampling failed due to invalid configuration", "count");
+        meterRegistry.registerLongCounter(ACTIONS_SHARD, "Number of shard-level downsampling actions", "count");
+        meterRegistry.registerLongCounter(ACTIONS, "Number of index-level downsampling actions", "count");
     }
 
     @Override
@@ -77,23 +75,13 @@ public class DownsampleMetrics extends AbstractLifecycleComponent {
         }
     }
 
-    void recordLatencyShard(long durationInMilliSeconds, ActionStatus status) {
+    void recordShardOperation(long durationInMilliSeconds, ActionStatus status) {
         meterRegistry.getLongHistogram(LATENCY_SHARD).record(durationInMilliSeconds, Map.of(ActionStatus.NAME, status.getMessage()));
+        meterRegistry.getLongCounter(ACTIONS_SHARD).incrementBy(1L, Map.of(ActionStatus.NAME, status.getMessage()));
     }
 
-    void recordLatencyTotal(long durationInMilliSeconds, ActionStatus status) {
+    void recordOperation(long durationInMilliSeconds, ActionStatus status) {
         meterRegistry.getLongHistogram(LATENCY_TOTAL).record(durationInMilliSeconds, Map.of(ActionStatus.NAME, status.getMessage()));
-    }
-
-    void recordSuccess() {
-        meterRegistry.getLongCounter(SUCCESS).increment();
-    }
-
-    void recordFailure() {
-        meterRegistry.getLongCounter(FAILURE).increment();
-    }
-
-    void recordInvalidConfiguration() {
-        meterRegistry.getLongCounter(INVALID_CONFIGURATION).increment();
+        meterRegistry.getLongCounter(ACTIONS).incrementBy(1L, Map.of(ActionStatus.NAME, status.getMessage()));
     }
 }

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardIndexer.java
@@ -191,7 +191,7 @@ class DownsampleShardIndexer {
                 + task.getNumSent()
                 + "]";
             logger.info(error);
-            downsampleMetrics.recordLatencyShard(duration.millis(), DownsampleMetrics.ActionStatus.MISSING_DOCS);
+            downsampleMetrics.recordShardOperation(duration.millis(), DownsampleMetrics.ActionStatus.MISSING_DOCS);
             throw new DownsampleShardIndexerException(error, false);
         }
 
@@ -204,7 +204,7 @@ class DownsampleShardIndexer {
                 + task.getNumFailed()
                 + "]";
             logger.info(error);
-            downsampleMetrics.recordLatencyShard(duration.millis(), DownsampleMetrics.ActionStatus.FAILED);
+            downsampleMetrics.recordShardOperation(duration.millis(), DownsampleMetrics.ActionStatus.FAILED);
             throw new DownsampleShardIndexerException(error, false);
         }
 
@@ -214,7 +214,7 @@ class DownsampleShardIndexer {
             ActionListener.noop()
         );
         logger.info("Downsampling task [" + task.getPersistentTaskId() + " on shard " + indexShard.shardId() + " completed");
-        downsampleMetrics.recordLatencyShard(duration.millis(), DownsampleMetrics.ActionStatus.SUCCESS);
+        downsampleMetrics.recordShardOperation(duration.millis(), DownsampleMetrics.ActionStatus.SUCCESS);
         return new DownsampleIndexerAction.ShardDownsampleResponse(indexShard.shardId(), task.getNumIndexed());
     }
 

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -180,22 +180,19 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
     }
 
     private void recordSuccessMetrics(long startTime) {
-        recordLatency(startTime, DownsampleMetrics.ActionStatus.SUCCESS);
-        downsampleMetrics.recordSuccess();
+        recordOperation(startTime, DownsampleMetrics.ActionStatus.SUCCESS);
     }
 
     private void recordFailureMetrics(long startTime) {
-        recordLatency(startTime, DownsampleMetrics.ActionStatus.FAILED);
-        downsampleMetrics.recordFailure();
+        recordOperation(startTime, DownsampleMetrics.ActionStatus.FAILED);
     }
 
     private void recordInvalidConfigurationMetrics(long startTime) {
-        recordLatency(startTime, DownsampleMetrics.ActionStatus.INVALID_CONFIGURATION);
-        downsampleMetrics.recordInvalidConfiguration();
+        recordOperation(startTime, DownsampleMetrics.ActionStatus.INVALID_CONFIGURATION);
     }
 
-    private void recordLatency(long startTime, DownsampleMetrics.ActionStatus status) {
-        downsampleMetrics.recordLatencyTotal(
+    private void recordOperation(long startTime, DownsampleMetrics.ActionStatus status) {
+        downsampleMetrics.recordOperation(
             TimeValue.timeValueMillis(client.threadPool().relativeTimeInMillis() - startTime).getMillis(),
             status
         );

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -1179,6 +1179,10 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
             assertEquals(1, measurement.attributes().size());
             assertThat(measurement.attributes().get("status"), Matchers.in(List.of("success", "failed", "missing_docs")));
         }
+        List<Measurement> shardActionMeasurements = plugin.getLongCounterMeasurement(DownsampleMetrics.ACTIONS_SHARD);
+        assertThat(shardActionMeasurements.size(), greaterThanOrEqualTo(1));
+        assertThat(shardActionMeasurements.get(0).getLong(), equalTo(1L));
+        assertThat(shardActionMeasurements.get(0).attributes().get("status"), Matchers.in(List.of("success", "failed", "missing_docs")));
 
         // Total latency and counters are recorded after reindex and force-merge complete.
         assertBusy(() -> {
@@ -1193,9 +1197,10 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
                 assertThat(measurement.attributes().get("status"), Matchers.in(List.of("success", "invalid_configuration", "failed")));
             }
 
-            List<Measurement> successMeasurements = plugin.getLongCounterMeasurement(DownsampleMetrics.SUCCESS);
-            assertThat(successMeasurements.size(), greaterThanOrEqualTo(1));
-            assertThat(successMeasurements.get(0).getLong(), equalTo(1L));
+            List<Measurement> actionMeasurements = plugin.getLongCounterMeasurement(DownsampleMetrics.ACTIONS);
+            assertThat(actionMeasurements.size(), greaterThanOrEqualTo(1));
+            assertThat(actionMeasurements.get(0).getLong(), equalTo(1L));
+            assertThat(actionMeasurements.get(0).attributes().get("status"), Matchers.in(List.of("success", "invalid_configuration", "failed")));
         }, 10, TimeUnit.SECONDS);
     }
 

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -1200,7 +1200,10 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
             List<Measurement> actionMeasurements = plugin.getLongCounterMeasurement(DownsampleMetrics.ACTIONS);
             assertThat(actionMeasurements.size(), greaterThanOrEqualTo(1));
             assertThat(actionMeasurements.get(0).getLong(), equalTo(1L));
-            assertThat(actionMeasurements.get(0).attributes().get("status"), Matchers.in(List.of("success", "invalid_configuration", "failed")));
+            assertThat(
+                actionMeasurements.get(0).attributes().get("status"),
+                Matchers.in(List.of("success", "invalid_configuration", "failed"))
+            );
         }, 10, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
This PR adds counters for downsampling: success, failure and failure due to invalid configuration. They will be used in TSDB dashboard to assess health of downsampling functionality.