### PR TITLE
Add functionality to test if the host CPU supports native SIMD instructions

### DIFF
--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/PosixNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/PosixNativeAccess.java
@@ -28,8 +28,10 @@ abstract class PosixNativeAccess extends AbstractNativeAccess {
     static VectorSimilarityFunctions vectorSimilarityFunctionsOrNull(NativeLibraryProvider libraryProvider) {
         if (isNativeVectorLibSupported()) {
             var lib = new VectorSimilarityFunctions(libraryProvider.getLibrary(VectorLibrary.class));
-            logger.info("Using native vector library; to disable start with -D" + ENABLE_JDK_VECTOR_LIBRARY + "=false");
-            return lib;
+            if (lib.isCpuVectorCapable()) {
+                logger.info("Using native vector library; to disable start with -D" + ENABLE_JDK_VECTOR_LIBRARY + "=false");
+                return lib;
+            }
         }
         return null;
     }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/VectorSimilarityFunctions.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/VectorSimilarityFunctions.java
@@ -48,4 +48,15 @@ public final class VectorSimilarityFunctions implements VectorLibrary {
     public MethodHandle squareDistanceHandle() {
         return vectorLibrary.squareDistanceHandle();
     }
+
+    /**
+     * Returns a boolean telling if the CPU we are running on is "vector capable".
+     * "Vector capable" means that the CPU supports the SIMD/vector instruction set used
+     * to implement the native methods referenced by the MethodHandles exposed by this interface.
+     */
+    @Override
+    public boolean isCpuVectorCapable() {
+        return vectorLibrary.isCpuVectorCapable();
+    }
+
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/VectorLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/VectorLibrary.java
@@ -20,4 +20,6 @@ public non-sealed interface VectorLibrary extends NativeLibrary {
     MethodHandle dotProductHandle();
 
     MethodHandle squareDistanceHandle();
+
+    boolean isCpuVectorCapable();
 }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkVectorLibrary.java
@@ -35,6 +35,8 @@ public final class JdkVectorLibrary implements VectorLibrary {
     static final MethodHandle dot8s$mh = downcallHandle("dot8s", FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT));
     static final MethodHandle sqr8s$mh = downcallHandle("sqr8s", FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, JAVA_INT));
 
+    static final MethodHandle vecCaps$mh = downcallHandle("vec_caps", FunctionDescriptor.of(JAVA_INT));
+
     // Stride of the native implementation - consumes this number of bytes per loop invocation.
     // There must be at least this number of bytes/elements available when going native
     static final int DOT_STRIDE = 32;
@@ -160,5 +162,15 @@ public final class JdkVectorLibrary implements VectorLibrary {
     @Override
     public MethodHandle squareDistanceHandle() {
         return SQR_HANDLE;
+    }
+
+    @Override
+    public boolean isCpuVectorCapable() {
+        try {
+            int caps = (int) vecCaps$mh.invokeExact();
+            return caps != 0;
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
     }
 }

--- a/libs/vec/native/src/vec/c/vec.c
+++ b/libs/vec/native/src/vec/c/vec.c
@@ -18,6 +18,30 @@
 #define SQR8S_STRIDE_BYTES_LEN 16
 #endif
 
+#ifdef __linux__
+    #include <sys/auxv.h>
+    #include <asm/hwcap.h>
+    #ifndef HWCAP_NEON
+    #define HWCAP_NEON 0x1000
+    #endif
+#endif
+
+EXPORT int vec_caps() {
+#ifdef __APPLE__
+    #ifdef TARGET_OS_MAC
+        // All M series Apple silicon support Neon instructions
+        return 1;
+    #else
+        #error "Unsupported Apple platform"
+    #endif
+#elif __linux__
+    int hwcap = getauxval(AT_HWCAP);
+    return (hwcap & HWCAP_NEON) != 0;
+#else
+    #error "Unsupported aarch64 platform"
+#endif
+}
+
 EXPORT int dot8s_stride() {
     return DOT8_STRIDE_BYTES_LEN;
 }

--- a/libs/vec/native/src/vec/headers/vec.h
+++ b/libs/vec/native/src/vec/headers/vec.h
@@ -6,7 +6,15 @@
  * Side Public License, v 1.
  */
 
+#ifdef _MSC_VER
+#define EXPORT extern "C" __declspec(dllexport)
+#elif defined(__GNUC__) && !defined(__clang__)
 #define EXPORT __attribute__((externally_visible,visibility("default")))
+#elif __clang__
+#define EXPORT __attribute__((visibility("default")))
+#endif
+
+EXPORT int vec_caps();
 
 EXPORT int dot8s_stride();
 


### PR DESCRIPTION
This commit adds the ability to check if the host CPU supports the instruction set we use in our native vector code.
This is to avoid having the process terminated (badly) because we tried to execute a non-supported instruction; better know this early, and avoid to take the native code path entirely.

The `int vec_caps()` function, implemented in the native code (C) of the library, returns 0 if the processor does not support (i.e. cannot run) the instructions used to implement the other functions.

On ARM, we use the NEON vector instruction set (https://github.com/elastic/elasticsearch/pull/106133):
- On MacOS, `vec_caps()` is trivial and returns `1`; for M-series CPUs, we can safely assume NEON is always present.
- On Linux systems, we use the mechanism explained in the [ARM development guide](https://documentation-service.arm.com/static/63299276e68c6809a6b41308): call [`getauxval`](https://www.man7.org/linux/man-pages/man3/getauxval.3.html) with `AT_HWCAP`, and test for the `HWCAP_NEON` bit (4096).

I've tested `getauxval` on various ARM systems and emulators (including Graviton on AWS); the NEON instruction set seems to be widely available - I was not able to find a processor supporting `armv8` and _not_ supporting NEON; nevertheless, I think that adding this functionality is good for 3 reasons:
- it is better to err on the safe side
- we would eventually need this for x64 (where support for vector instruction sets is way more sparse)
- we can expand it for future optimizations

The last point: since `vec_caps()` returns an integer, we may want to return different values (e.g. 2) to indicate some "advanced support", and dynamically bind to a different flavor of the function (e.g. `dot8s_2`) that is implemented with a more performant but less diffused instruction set (e.g. AVX512, armv9, etc.)
