### PR TITLE
Verify target node during primary relocation

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -757,6 +757,16 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
     private final AtomicBoolean primaryReplicaResyncInProgress = new AtomicBoolean();
 
+    // temporary compatibility shim while adding targetNodeId parameter to dependencies
+    @Deprecated(forRemoval = true)
+    public void relocated(
+        final String targetAllocationId,
+        final BiConsumer<ReplicationTracker.PrimaryContext, ActionListener<Void>> consumer,
+        final ActionListener<Void> listener
+    ) throws IllegalIndexShardStateException, IllegalStateException {
+        relocated(null, targetAllocationId, consumer, listener);
+    }
+
     /**
      * Completes the relocation. Operations are blocked and current operations are drained before changing state to relocated. The provided
      * {@link BiConsumer} is executed after all operations are successfully blocked.
@@ -768,6 +778,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
      * @throws IllegalStateException           if the relocation target is no longer part of the replication group
      */
     public void relocated(
+        final String targetNodeId,
         final String targetAllocationId,
         final BiConsumer<ReplicationTracker.PrimaryContext, ActionListener<Void>> consumer,
         final ActionListener<Void> listener
@@ -788,7 +799,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                          * context via a network operation. Doing this under the mutex can implicitly block the cluster state update thread
                          * on network operations.
                          */
-                        verifyRelocatingState();
+                        verifyRelocatingState(targetNodeId);
                         final ReplicationTracker.PrimaryContext primaryContext = replicationTracker.startRelocationHandoff(
                             targetAllocationId
                         );
@@ -803,7 +814,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                                 try {
                                     // make changes to primaryMode and relocated flag only under mutex
                                     synchronized (mutex) {
-                                        verifyRelocatingState();
+                                        verifyRelocatingState(targetNodeId);
                                         replicationTracker.completeRelocationHandoff();
                                     }
                                     wrappedInnerListener.onResponse(null);
@@ -857,7 +868,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
-    private void verifyRelocatingState() {
+    // TODO only nullable temporarily, remove once deprecated relocated() override is removed
+    private void verifyRelocatingState(@Nullable String targetNodeId) {
         if (state != IndexShardState.STARTED) {
             throw new IndexShardNotStartedException(shardId, state);
         }
@@ -869,6 +881,16 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
         if (shardRouting.relocating() == false) {
             throw new IllegalIndexShardStateException(shardId, IndexShardState.STARTED, ": shard is no longer relocating " + shardRouting);
+        }
+
+        if (targetNodeId != null) {
+            if (targetNodeId.equals(shardRouting.relocatingNodeId()) == false) {
+                throw new IllegalIndexShardStateException(
+                    shardId,
+                    IndexShardState.STARTED,
+                    ": shard is no longer relocating to node [" + targetNodeId + "]: " + shardRouting
+                );
+            }
         }
 
         if (primaryReplicaResyncInProgress.get()) {

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -868,7 +868,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
-    // TODO only nullable temporarily, remove once deprecated relocated() override is removed
+    // TODO only nullable temporarily, remove once deprecated relocated() override is removed, see ES-6725
     private void verifyRelocatingState(@Nullable String targetNodeId) {
         if (state != IndexShardState.STARTED) {
             throw new IndexShardNotStartedException(shardId, state);

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1916,10 +1916,15 @@ public class IndexShardTests extends IndexShardTestCase {
         Thread recoveryThread = new Thread(() -> {
             try {
                 startRecovery.await();
-                shard.relocated(routing.getTargetRelocatingShard().allocationId().getId(), (primaryContext, listener) -> {
-                    relocationStarted.countDown();
-                    listener.onResponse(null);
-                }, ActionListener.noop());
+                shard.relocated(
+                    routing.relocatingNodeId(),
+                    routing.getTargetRelocatingShard().allocationId().getId(),
+                    (primaryContext, listener) -> {
+                        relocationStarted.countDown();
+                        listener.onResponse(null);
+                    },
+                    ActionListener.noop()
+                );
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -2123,29 +2128,48 @@ public class IndexShardTests extends IndexShardTestCase {
         closeShards(shard);
     }
 
-    public void testRelocateMissingTarget() throws Exception {
+    public void testRelocateMismatchedTarget() throws Exception {
         final IndexShard shard = newStartedShard(true);
         final ShardRouting original = shard.routingEntry();
-        final ShardRouting toNode1 = ShardRoutingHelper.relocate(original, "node_1");
-        IndexShardTestCase.updateRoutingEntry(shard, toNode1);
+
+        final ShardRouting wrongTargetNodeShardRouting = ShardRoutingHelper.relocate(original, "node_1");
+        IndexShardTestCase.updateRoutingEntry(shard, wrongTargetNodeShardRouting);
         IndexShardTestCase.updateRoutingEntry(shard, original);
-        final ShardRouting toNode2 = ShardRoutingHelper.relocate(original, "node_2");
-        IndexShardTestCase.updateRoutingEntry(shard, toNode2);
+
+        final ShardRouting wrongTargetAllocationIdShardRouting = ShardRoutingHelper.relocate(original, "node_2");
+        IndexShardTestCase.updateRoutingEntry(shard, wrongTargetAllocationIdShardRouting);
+        IndexShardTestCase.updateRoutingEntry(shard, original);
+
+        final ShardRouting correctShardRouting = ShardRoutingHelper.relocate(original, "node_2");
+        IndexShardTestCase.updateRoutingEntry(shard, correctShardRouting);
+
         final AtomicBoolean relocated = new AtomicBoolean();
-        final IllegalStateException error = expectThrows(
-            IllegalStateException.class,
-            () -> blockingCallRelocated(shard, toNode1, (ctx, listener) -> relocated.set(true))
+
+        final IllegalIndexShardStateException wrongNodeException = expectThrows(
+            IllegalIndexShardStateException.class,
+            () -> blockingCallRelocated(shard, wrongTargetNodeShardRouting, (ctx, listener) -> relocated.set(true))
         );
         assertThat(
-            error.getMessage(),
+            wrongNodeException.getMessage(),
+            equalTo("CurrentState[STARTED] : shard is no longer relocating to node [node_1]: " + correctShardRouting)
+        );
+        assertFalse(relocated.get());
+
+        final IllegalStateException wrongTargetIdException = expectThrows(
+            IllegalStateException.class,
+            () -> blockingCallRelocated(shard, wrongTargetAllocationIdShardRouting, (ctx, listener) -> relocated.set(true))
+        );
+        assertThat(
+            wrongTargetIdException.getMessage(),
             equalTo(
                 "relocation target ["
-                    + toNode1.getTargetRelocatingShard().allocationId().getId()
+                    + wrongTargetAllocationIdShardRouting.getTargetRelocatingShard().allocationId().getId()
                     + "] is no longer part of the replication group"
             )
         );
         assertFalse(relocated.get());
-        blockingCallRelocated(shard, toNode2, (ctx, listener) -> {
+
+        blockingCallRelocated(shard, correctShardRouting, (ctx, listener) -> {
             relocated.set(true);
             listener.onResponse(null);
         });
@@ -4937,7 +4961,7 @@ public class IndexShardTests extends IndexShardTestCase {
         BiConsumer<ReplicationTracker.PrimaryContext, ActionListener<Void>> consumer
     ) {
         PlainActionFuture.<Void, RuntimeException>get(
-            f -> indexShard.relocated(routing.getTargetRelocatingShard().allocationId().getId(), consumer, f)
+            f -> indexShard.relocated(routing.relocatingNodeId(), routing.getTargetRelocatingShard().allocationId().getId(), consumer, f)
         );
     }
 }


### PR DESCRIPTION
If a primary relocation is cancelled and then restarted on a different
node then today we may fail with a somewhat-opaque message saying that
the `relocation target is no longer part of the replication group`. This
commit adds a preliminary check on the target node ID so that we can
fail in this situation with a message that should be easier for users to
understand.