### PR TITLE
Lossy source mapping validation shouldn't fail if source mode is specified.

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -185,12 +185,13 @@ public class SourceFieldMapper extends MetadataFieldMapper {
                 if (mode.get() == Mode.DISABLED) {
                     disallowed.add("mode=disabled");
                 }
-                assert disallowed.isEmpty() == false;
-                throw new MapperParsingException(
-                    disallowed.size() == 1
-                        ? "Parameter [" + disallowed.get(0) + "] is not allowed in source"
-                        : "Parameters [" + String.join(",", disallowed) + "] are not allowed in source"
-                );
+                if (disallowed.isEmpty() == false) {
+                    throw new MapperParsingException(
+                        disallowed.size() == 1
+                            ? "Parameter [" + disallowed.get(0) + "] is not allowed in source"
+                            : "Parameters [" + String.join(",", disallowed) + "] are not allowed in source"
+                    );
+                }
             }
             SourceFieldMapper sourceFieldMapper = new SourceFieldMapper(
                 mode.get(),

--- a/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/SourceFieldMapperTests.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class SourceFieldMapperTests extends MetadataMapperTestCase {
 
@@ -242,6 +243,18 @@ public class SourceFieldMapperTests extends MetadataMapperTestCase {
 
     public void testSupportsNonDefaultParameterValues() throws IOException {
         Settings settings = Settings.builder().put(SourceFieldMapper.LOSSY_PARAMETERS_ALLOWED_SETTING_NAME, false).build();
+        {
+            var sourceFieldMapper = createMapperService(settings, topMapping(b -> b.startObject("_source").endObject())).documentMapper()
+                .sourceMapper();
+            assertThat(sourceFieldMapper, notNullValue());
+        }
+        {
+            var sourceFieldMapper = createMapperService(
+                settings,
+                topMapping(b -> b.startObject("_source").field("mode", randomBoolean() ? "synthetic" : "stored").endObject())
+            ).documentMapper().sourceMapper();
+            assertThat(sourceFieldMapper, notNullValue());
+        }
         Exception e = expectThrows(
             MapperParsingException.class,
             () -> createMapperService(settings, topMapping(b -> b.startObject("_source").field("enabled", false).endObject()))


### PR DESCRIPTION
Removed the assert that didn't allow this and
added lossy source mapping tests with source mode.