### PR TITLE
ES|QL: make one more test deterministic

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -235,7 +235,7 @@ h:double
 ;
 
 sumOfScaledFloat
-from employees | stats h = sum(height.scaled_float);
+from employees | stats h = sum(height.scaled_float) | eval h = round(h, 10);
 
 h:double
 176.82


### PR DESCRIPTION
Minimal double precision errors on multi-node execution:

```
row 0 column 0:0: expected "176.82" but was "176.82000000000002"
```

