### PR TITLE
Wait correctly for search tasks to complete on node shutdown.

### DIFF
--- a/docs/changelog/107426.yaml
+++ b/docs/changelog/107426.yaml
@@ -1,0 +1,5 @@
+pr: 107426
+summary: Support wait indefinitely for search tasks to complete on node shutdown
+area: Infra/Node Lifecycle
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -155,7 +155,7 @@ public class Node implements Closeable {
 
     public static final Setting<TimeValue> MAXIMUM_SHUTDOWN_TIMEOUT_SETTING = Setting.positiveTimeSetting(
         "node.maximum_shutdown_grace_period",
-        TimeValue.timeValueMillis(0),
+        TimeValue.ZERO,
         Setting.Property.NodeScope
     );
 
@@ -617,7 +617,7 @@ public class Node implements Closeable {
         CompletableFuture<Void> allStoppers = CompletableFuture.allOf(futures.values().toArray(new CompletableFuture[stoppers.size()]));
 
         try {
-            if (maxTimeout.millis() == 0) {
+            if (TimeValue.ZERO.equals(maxTimeout)) {
                 FutureUtils.get(allStoppers);
             } else {
                 FutureUtils.get(allStoppers, maxTimeout.millis(), TimeUnit.MILLISECONDS);
@@ -652,7 +652,7 @@ public class Node implements Closeable {
                 // be spending on finishing those searches.
                 final TimeValue pollPeriod = TimeValue.timeValueMillis(500);
                 millisWaited += pollPeriod.millis();
-                if (millisWaited >= asyncSearchTimeout.millis()) {
+                if (TimeValue.ZERO.equals(asyncSearchTimeout) == false && millisWaited >= asyncSearchTimeout.millis()) {
                     logger.warn(
                         format(
                             "timed out after waiting [%s] for [%d] search tasks to finish",


### PR DESCRIPTION
If using `TimeValue.ZERO` for `node.maximum_shutdown_grace_period`, nodes should wait indefinitely for search tasks to complete on shutdown. Currently we time out instantly in this case.

Note, usage of `TimeValue.ZERO` to encode "forever" is inconsistent with other TimeValue settings. Typically `-1` / `TimeValue.MINUS_ONE` is used in that case. I haven't changed this as we might be explicitly setting `0` rather than using the default, but happy to do. Let me know.

