### PR TITLE
ESQL: Exclude 8.13.2 and earlier from mixed cluster tests

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 GradleUtils.extendSourceSet(project, "javaRestTest", "yamlRestTest")
 
 def supportedVersion = bwcVersion -> {
-  // ESQL is available in 8.11 or later
-  return bwcVersion.onOrAfter(Version.fromString("8.11.0"));
+  // ESQL is available in 8.11 or later, but nodes older than 8.13.3 fail because of unknown `version` parameter in requests to /_query.
+  return bwcVersion.onOrAfter(Version.fromString("8.13.3"));
 }
 
 BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseName ->


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/107403

Tests send the ESQL version in REST requests to /_query, which is unknown to nodes older than 8.13.3. Exclude pre-8.13.3 nodes from this test. As ESQL is not GA yet, this should be fine.
