### PR TITLE
ESQL: Default ESQL version on old clients

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlAsyncQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlAsyncQueryAction.java
@@ -46,6 +46,7 @@ public class RestEsqlAsyncQueryAction extends BaseRestHandler {
             esqlRequest = RequestXContent.parseAsync(parser);
         }
 
+        RestEsqlQueryAction.defaultVersionForOldClients(esqlRequest, request);
         LOGGER.info("Beginning execution of ESQL async query.\nQuery string: [{}]", esqlRequest.query());
 
         return channel -> {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
@@ -64,6 +64,7 @@ public class RestEsqlQueryAction extends BaseRestHandler {
         return Set.of(URL_PARAM_DELIMITER, EsqlQueryResponse.DROP_NULL_COLUMNS_OPTION);
     }
 
+    static final String PRODUCT_ORIGIN = "x-elastic-product-origin";
     static final String CLIENT_META = "x-elastic-client-meta";
 
     static void defaultVersionForOldClients(EsqlQueryRequest esqlRequest, RestRequest restRequest) {
@@ -72,6 +73,13 @@ public class RestEsqlQueryAction extends BaseRestHandler {
         }
         String clientMeta = restRequest.header(CLIENT_META);
         if (clientMeta == null) {
+            return;
+        }
+        String product = restRequest.header(PRODUCT_ORIGIN);
+        if ("kibana".equals(product)) {
+            if (clientMeta.contains("es=8.9")) {
+                esqlRequest.esqlVersion(EsqlVersion.ROCKET.versionStringWithoutEmoji());
+            }
             return;
         }
         if (clientMeta.contains("es=8.1") == false) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
@@ -86,12 +86,14 @@ public class RestEsqlQueryAction extends BaseRestHandler {
         }
         String product = restRequest.header(PRODUCT_ORIGIN);
         if ("kibana".equals(product)) {
+            /*
+             * Kibana 8.11 to 8.13 used the 8.9 version of the javascript client.
+             * Kibana 8.14, the version we *want* to send the versions is on the
+             * 8.13 version of the javascript client.
+             */
             if (clientMeta.contains("es=8.9")) {
                 esqlRequest.esqlVersion(EsqlVersion.ROCKET.versionStringWithoutEmoji());
             }
-            return;
-        }
-        if (clientMeta.contains("es=8.1") == false) {
             return;
         }
         if (clientMeta.contains("es=8.13") || clientMeta.contains("es=8.12") || clientMeta.contains("es=8.11")) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryAction.java
@@ -67,6 +67,15 @@ public class RestEsqlQueryAction extends BaseRestHandler {
     static final String PRODUCT_ORIGIN = "x-elastic-product-origin";
     static final String CLIENT_META = "x-elastic-client-meta";
 
+    /**
+     * Default the {@link EsqlQueryRequest#esqlVersion()} to the oldest version
+     * if we can detect that the request comes from an older version of the
+     * official client or an older version of kibana. These versions supported
+     * ESQL but ESQL was not GA, so, <strong>technically</strong> we can break
+     * them. But it's not hugely complicated to make them work smoothly on the
+     * upgrade that starts to require the {@code version} field. This does
+     * just that.
+     */
     static void defaultVersionForOldClients(EsqlQueryRequest esqlRequest, RestRequest restRequest) {
         if (esqlRequest.esqlVersion() != null) {
             return;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryActionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/RestEsqlQueryActionTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.action;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.xpack.esql.version.EsqlVersion;
+import org.hamcrest.Matcher;
+
+import java.util.List;
+
+import static org.elasticsearch.xpack.esql.action.RestEsqlQueryAction.CLIENT_META;
+import static org.elasticsearch.xpack.esql.action.RestEsqlQueryAction.defaultVersionForOldClients;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+public class RestEsqlQueryActionTests extends ESTestCase {
+    public void testNoVersionForNoClient() {
+        EsqlQueryRequest esqlRequest = new EsqlQueryRequest();
+        FakeRestRequest restRequest = new FakeRestRequest();
+        defaultVersionForOldClients(esqlRequest, restRequest);
+        assertThat(esqlRequest.esqlVersion(), nullValue());
+    }
+
+    public void testNoVersionForAlreadySet() {
+        EsqlQueryRequest esqlRequest = new EsqlQueryRequest();
+        esqlRequest.esqlVersion("whatever");
+        FakeRestRequest restRequest = new FakeRestRequest();
+        restRequest.getHttpRequest().getHeaders().put(CLIENT_META, List.of("es=8.13.0"));
+        defaultVersionForOldClients(esqlRequest, restRequest);
+        assertThat(esqlRequest.esqlVersion(), equalTo("whatever"));
+    }
+
+    public void testNoVersionForNewClient() {
+        assertEsqlVersion("es=8.14.0", nullValue(String.class));
+    }
+
+    public void testAddsVersionForPython813() {
+        assertAddsOldest(
+            randomFrom(
+                "es=8.13.0,py=3.11.8,t=8.13.0,ur=2.2.1", // This is what the python client sent for me on 2024-4-12
+                "py=3.11.8,es=8.13.0,ur=2.2.1,t=8.13.0", // This is just a jumbled version of the above
+                "es=8.13.0" // This is all we need to trigger it
+            )
+        );
+    }
+
+    public void testAddsVersionForPython812() {
+        assertAddsOldest(
+            randomFrom(
+                "es=8.12.0,py=3.11.8,t=8.13.0,ur=2.2.1", // This is what the python client sent for me on 2024-4-12
+                "py=3.11.8,t=8.13.0,es=8.12.0,ur=2.2.1", // This is just a jumbled version of the above
+                "es=8.12.0" // This is all we need to trigger it
+            )
+        );
+    }
+
+    private void assertAddsOldest(String clientMeta) {
+        assertEsqlVersion(clientMeta, equalTo(EsqlVersion.ROCKET.versionStringWithoutEmoji()));
+    }
+
+    private void assertEsqlVersion(String clientMeta, Matcher<String> expectedEsqlVersion) {
+        EsqlQueryRequest esqlRequest = new EsqlQueryRequest();
+        FakeRestRequest restRequest = new FakeRestRequest();
+        restRequest.getHttpRequest().getHeaders().put(CLIENT_META, List.of(clientMeta));
+        defaultVersionForOldClients(esqlRequest, restRequest);
+        assertThat(esqlRequest.esqlVersion(), expectedEsqlVersion);
+    }
+}


### PR DESCRIPTION
Soon we will require an ESQL version for all ESQL requests. Kibana is sending it already. The official clients will start sending it in version 8.14+. This defaults the version for the official clients before 8.14. It does so by reading a magic header the clients send, `x-elastic-client-meta` and detecting the version string for any clients that might possibly support ESQL - `es=8.11`, `es=8.12`, and `es=8.13`. If we receive that we'll default to the first version of ESQL.

I've also made this work for kibana versions 8.12 and 8.13 - discover will default to the old version of ESQL.
