### PR TITLE
Fix regression in get index settings (human=true) where the version was not displayed in human-readable format

### DIFF
--- a/docs/changelog/107447.yaml
+++ b/docs/changelog/107447.yaml
@@ -1,0 +1,5 @@
+pr: 107447
+summary: "Fix regression in get index settings (human=true) where the version was not displayed in human-readable format"
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2752,7 +2752,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         Settings.Builder builder = Settings.builder().put(settings);
         IndexVersion version = SETTING_INDEX_VERSION_CREATED.get(settings);
         if (version.equals(IndexVersions.ZERO) == false) {
-            builder.put(SETTING_VERSION_CREATED_STRING, version.toString());
+            builder.put(SETTING_VERSION_CREATED_STRING, version.toReleaseVersion());
         }
         Long creationDate = settings.getAsLong(SETTING_CREATION_DATE, null);
         if (creationDate != null) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/HumanReadableIndexSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/HumanReadableIndexSettingsTests.java
@@ -30,7 +30,7 @@ public class HumanReadableIndexSettingsTests extends ESTestCase {
 
         Settings humanSettings = IndexMetadata.addHumanReadableSettings(testSettings);
         assertThat(humanSettings.size(), equalTo(4));
-        assertEquals(versionCreated.toString(), humanSettings.get(IndexMetadata.SETTING_VERSION_CREATED_STRING, null));
+        assertEquals(versionCreated.toReleaseVersion(), humanSettings.get(IndexMetadata.SETTING_VERSION_CREATED_STRING, null));
         ZonedDateTime creationDate = ZonedDateTime.ofInstant(Instant.ofEpochMilli(created), ZoneOffset.UTC);
         assertEquals(creationDate.toString(), humanSettings.get(IndexMetadata.SETTING_CREATION_DATE_STRING, null));
     }


### PR DESCRIPTION
Fixed a regression in the get index settings with the `human=true` option, where the field `settings.index.version.created_string` displayed the index version in a non human-readable format, such as `8090099`. Now, the method `IndexVersion.toReleaseVersion` is used to return a string that represents the Elasticsearch release version of this index.

Fixes [106795](https://github.com/elastic/elasticsearch/issues/106795)