### PR TITLE
[Connector API] Fix bug with filtering validation toXContent

### DIFF
--- a/docs/changelog/107467.yaml
+++ b/docs/changelog/107467.yaml
@@ -1,0 +1,5 @@
+pr: 107467
+summary: "[Connector API] Fix bug with filtering validation toXContent"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringValidation.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringValidation.java
@@ -69,6 +69,7 @@ public class FilteringValidation implements Writeable, ToXContentObject {
             builder.stringListField(IDS_FIELD.getPreferredName(), ids);
             builder.stringListField(MESSAGES_FIELD.getPreferredName(), messages);
         }
+        builder.endObject();
         return builder;
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorFilteringTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorFilteringTests.java
@@ -202,10 +202,10 @@ public class ConnectorFilteringTests extends ESTestCase {
                                 "value": ".*"
                             }
                         ],
-                         "validation": {
-                             "errors": [{"ids": ["1"], "messages": ["some messages"]}],
-                             "state": "invalid"
-                         }
+                        "validation": {
+                            "errors": [{"ids": ["1"], "messages": ["some messages"]}],
+                            "state": "invalid"
+                        }
                     },
                     "domain": "DEFAULT",
                     "draft": {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorFilteringTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorFilteringTests.java
@@ -202,10 +202,10 @@ public class ConnectorFilteringTests extends ESTestCase {
                                 "value": ".*"
                             }
                         ],
-                        "validation": {
-                            "errors": [],
-                            "state": "valid"
-                        }
+                         "validation": {
+                             "errors": [{"ids": ["1"], "messages": ["some messages"]}],
+                             "state": "invalid"
+                         }
                     },
                     "domain": "DEFAULT",
                     "draft": {


### PR DESCRIPTION
### Changes
- Fix bug with `toXContent` representation of FilteringValidation