### PR TITLE
[Transform] Fix TransformRobustnessIT.testTransformLifecycleInALoop test

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
@@ -139,8 +139,14 @@ public class TransformRobustnessIT extends TransformRestTestCase {
 
                 // Stop the transform with force set randomly.
                 stopTransform(transformId, force);
-                // After the transform is stopped, there should be no transform task left.
-                assertThat(getTransformTasks(), is(empty()));
+                if (force) {
+                    // If the "force" has been used, then the persistent task is removed from the cluster state but the local task can still
+                    // be seen by the PersistentTasksNodeService. We need to wait until PersistentTasksNodeService reconciles the state.
+                    assertBusy(() -> assertThat(getTransformTasks(), is(empty())));
+                } else {
+                    // If the "force" hasn't been used then we can expect the local task to be already gone.
+                    assertThat(getTransformTasks(), is(empty()));
+                }
                 assertThat(getTransformTasksFromClusterState(transformId), is(empty()));
 
                 // Delete the transform.


### PR DESCRIPTION
This PR adds `assertBusy` in order to wait until the persistent task disappears from the `PersistentTasksNodeService`.

Fixes https://github.com/elastic/elasticsearch/issues/107501