### PR TITLE
[Do not merge] Snapshot restore &  `match_only_text` cause cluster state size differences

### DIFF
--- a/modules/data-streams/build.gradle
+++ b/modules/data-streams/build.gradle
@@ -20,6 +20,7 @@ restResources {
 
 dependencies {
   testImplementation project(path: ':test:test-clusters')
+  internalClusterTestImplementation project(":modules:mapper-extras")
 }
 
 tasks.named('yamlRestTest') {


### PR DESCRIPTION
While working on https://github.com/elastic/elasticsearch/pull/107281 we noticed that when we were running `testPartialRestoreSnapshotThatIncludesDataStream` and we would include the global state, we would get the assertion error `cluster state size does not match`. 

The easiest way to reproduce is to run the following test in this branch:

```
 ./gradlew ':modules:data-streams:internalClusterTest' --tests "org.elasticsearch.datastreams.DataStreamsSnapshotsIT.testPartialRestoreSnapshotThatIncludesDataStream"
```

As you see the only changes are that we include a template with a field `match_only_text`.

We have noticed this issue only when we combine the global state restore and a template with this field. Looking for other similar failures (https://github.com/elastic/elasticsearch/issues/59140), we believe the reason is that there is something being mutated on the local node after the restoration. But this is just an assumption.