### PR TITLE
[ML] Add GET _inference for all inference endpoints

### DIFF
--- a/docs/changelog/107517.yaml
+++ b/docs/changelog/107517.yaml
@@ -1,0 +1,5 @@
+pr: 107517
+summary: Add GET `_inference` for all inference endpoints
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/reference/inference/get-inference.asciidoc
+++ b/docs/reference/inference/get-inference.asciidoc
@@ -18,6 +18,8 @@ non-NLP models, use the <<ml-df-trained-models-apis>>.
 [[get-inference-api-request]]
 ==== {api-request-title}
 
+`GET /_inference`
+
 `GET /_inference/_all`
 
 `GET /_inference/<inference_id>`

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.get_model.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.get_model.json
@@ -12,6 +12,12 @@
     "url":{
       "paths":[
         {
+          "path":"/_inference",
+          "methods":[
+            "GET"
+          ]
+        },
+        {
           "path":"/_inference/{inference_id}",
           "methods":[
             "GET"

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestGetInferenceModelAction.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/rest/RestGetInferenceModelAction.java
@@ -34,7 +34,12 @@ public class RestGetInferenceModelAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "_inference/_all"), new Route(GET, INFERENCE_ID_PATH), new Route(GET, TASK_TYPE_INFERENCE_ID_PATH));
+        return List.of(
+            new Route(GET, "_inference"),
+            new Route(GET, "_inference/_all"),
+            new Route(GET, INFERENCE_ID_PATH),
+            new Route(GET, TASK_TYPE_INFERENCE_ID_PATH)
+        );
     }
 
     @Override

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/inference/inference_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/inference/inference_crud.yml
@@ -38,3 +38,21 @@
             "input": "important text"
           }
   - match: { error.reason: "Unknown task_type [bad]" }
+
+---
+"Test get all":
+  - do:
+      inference.get_model:
+        inference_id: "*"
+  - length: { models: 0}
+
+  - do:
+      inference.get_model:
+        inference_id: _all
+  - length: { models: 0}
+
+  - do:
+      inference.get_model:
+        inference_id: ""
+  - length: { models: 0}
+


### PR DESCRIPTION
Allows calling `GET _inference` to return on inference endpoints. This is in addition to the currently supported wildcard options: `GET _inference/_all` and `GET _inference/*`