### PR TITLE
[Transform] Prevent the ResourceNotFoundException from being thrown on force-stop

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
@@ -113,6 +113,51 @@ public class TransformRobustnessIT extends TransformRestTestCase {
         }
     }
 
+    public void testInterruptedBatchTransformLifecycltInALoop() throws IOException {
+        createReviewsIndex();
+
+        String transformId = "test_interrupted_batch_lifecycle_in_a_loop";
+        String destIndex = transformId + "-dest";
+        for (int i = 0; i < 100; ++i) {
+            long sleepAfterStartMillis = randomLongBetween(0, 1_000);
+            boolean force = randomBoolean();
+            try {
+                // Create the batch transform.
+                createPivotReviewsTransform(transformId, destIndex, null);
+                assertThat(getTransformTasks(), is(empty()));
+                assertThat(getTransformTasksFromClusterState(transformId), is(empty()));
+
+                startTransform(transformId);
+                // There is 1 transform task after start.
+                assertThat(getTransformTasks(), hasSize(1));
+                assertThat(getTransformTasksFromClusterState(transformId), hasSize(1));
+
+                Thread.sleep(sleepAfterStartMillis);
+
+                // Stop the transform with force set randomly.
+                stopTransform(transformId, force);
+                // After the transform is stopped, there should be no transform task left.
+                if (force) {
+                    // If the "force" has been used, then the persistent task is removed from the cluster state but the local task can still
+                    // be seen by the PersistentTasksNodeService. We need to wait until PersistentTasksNodeService reconciles the state.
+                    assertBusy(() -> assertThat(getTransformTasks(), is(empty())));
+                } else {
+                    // If the "force" hasn't been used then we can expect the local task to be already gone.
+                    assertThat(getTransformTasks(), is(empty()));
+                }
+                assertThat(getTransformTasksFromClusterState(transformId), is(empty()));
+
+                // Delete the transform.
+                deleteTransform(transformId);
+            } catch (AssertionError | Exception e) {
+                throw new AssertionError(
+                    format("Failure at iteration %d (sleepAfterStart=%sms,force=%s): %s", i, sleepAfterStartMillis, force, e.getMessage()),
+                    e
+                );
+            }
+        }
+    }
+
     public void testContinuousTransformLifecycleInALoop() throws Exception {
         createReviewsIndex();
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -165,6 +165,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                     );
 
                     final ActionListener<Response> doExecuteListener = cancelTransformTasksListener(
+                        persistentTasksService,
                         transformNodeAssignments.getWaitingForAssignment(),
                         finalListener
                     );
@@ -173,9 +174,8 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                         // When force==true, we **do not** fan out to individual tasks (i.e. taskOperation method will not be called) as we
                         // want to make sure that the persistent tasks will be removed from cluster state even if these tasks are no longer
                         // visible by the PersistentTasksService.
-                        cancelTransformTasksListener(transformNodeAssignments.getAssigned(), doExecuteListener).onResponse(
-                            new Response(true)
-                        );
+                        cancelTransformTasksListener(persistentTasksService, transformNodeAssignments.getAssigned(), doExecuteListener)
+                            .onResponse(new Response(true));
                     } else if (transformNodeAssignments.getExecutorNodes().isEmpty()) {
                         doExecuteListener.onResponse(new Response(true));
                     } else {
@@ -195,6 +195,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
                             // found transforms without a config
                         } else if (request.isForce()) {
                             final ActionListener<Response> doExecuteListener = cancelTransformTasksListener(
+                                persistentTasksService,
                                 transformNodeAssignments.getWaitingForAssignment(),
                                 finalListener
                             );
@@ -488,6 +489,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
         }));
     }
 
+    // Visible for testing
     /**
      * Creates and returns the listener that sends remove request for every task in the given set.
      *
@@ -495,7 +497,8 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
      * @param finalListener listener that should be called once all the given tasks are removed
      * @return listener that removes given tasks in parallel
      */
-    private ActionListener<Response> cancelTransformTasksListener(
+    static ActionListener<Response> cancelTransformTasksListener(
+        final PersistentTasksService persistentTasksService,
         final Set<String> transformTasks,
         final ActionListener<Response> finalListener
     ) {
@@ -505,16 +508,23 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
         return ActionListener.wrap(response -> {
             GroupedActionListener<PersistentTask<?>> groupedListener = new GroupedActionListener<>(
                 transformTasks.size(),
-                ActionListener.wrap(r -> finalListener.onResponse(response), finalListener::onFailure)
+                ActionListener.wrap(unused -> finalListener.onResponse(response), finalListener::onFailure)
             );
 
             for (String taskId : transformTasks) {
-                persistentTasksService.sendRemoveRequest(taskId, null, groupedListener);
+                persistentTasksService.sendRemoveRequest(taskId, null, ActionListener.wrap(groupedListener::onResponse, e -> {
+                    // If we are about to remove a persistent task which does not exist, treat it as success.
+                    if (e instanceof ResourceNotFoundException) {
+                        groupedListener.onResponse(null);
+                        return;
+                    }
+                    groupedListener.onFailure(e);
+                }));
             }
         }, e -> {
             GroupedActionListener<PersistentTask<?>> groupedListener = new GroupedActionListener<>(
                 transformTasks.size(),
-                ActionListener.wrap(r -> finalListener.onFailure(e), finalListener::onFailure)
+                ActionListener.wrap(unused -> finalListener.onFailure(e), finalListener::onFailure)
             );
 
             for (String taskId : transformTasks) {


### PR DESCRIPTION
This PR addresses the following race condition:
1/ transform starts
2/ persistent task is created
3/ stop transform with `force=true` is called while the transform finishes
4/ while persistent task is being removed, `ResourceNotFoundException` is thrown by `PersistentTasksClusterService`

This PR solves the problem by allowing `ResourceNotFoundException` being thrown and ignoring it if we are to remove the task anyway.

Marking as `>non-issue` as the bug this PR is fixing was introduced in https://github.com/elastic/elasticsearch/pull/106989, so in the current release cycle (`8.14`).

Relates https://github.com/elastic/elasticsearch/issues/106811