### PR TITLE
Only retrive required stored fields

### DIFF
--- a/docs/changelog/107543.yaml
+++ b/docs/changelog/107543.yaml
@@ -1,0 +1,5 @@
+pr: 107543
+summary: "Fix: only load required stored fields"
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FieldFetcher.java
@@ -170,7 +170,16 @@ public class FieldFetcher {
 
     public Map<String, DocumentField> fetch(Source source, int doc) throws IOException {
         Map<String, DocumentField> documentFields = new HashMap<>();
-        for (FieldContext context : fieldContexts.values()) {
+        Collection<FieldContext> fieldsToLoad = fieldContexts.values();
+        if (storedFieldsSpec != null
+            && storedFieldsSpec.requiredStoredFields() != null
+            && storedFieldsSpec.requiredStoredFields().isEmpty() == false) {
+            fieldsToLoad = fieldContexts.values()
+                .stream()
+                .filter(fc -> storedFieldsSpec.requiredStoredFields().contains(fc.fieldName))
+                .toList();
+        }
+        for (FieldContext context : fieldsToLoad) {
             String field = context.fieldName;
             ValueFetcher valueFetcher = context.valueFetcher;
             final DocumentField docField = valueFetcher.fetchDocumentField(field, source, doc);


### PR DESCRIPTION
When fetching stored fields we need to make sure we only try to fetch
those that actually have a value otherwise we go all the way down to disk
just to try to fetch a field value that does not exist. We observed this issue
as latency spikes in out Rally benchmarks for some queries, especially those
retrieving many documents using non-default values for `size`
This issue was introduced by #106325.

Here we just filter the set of fields to fetch by using what we have available in
`StoredFieldsSpec` for metadata fields.
