### PR TITLE
[TEST] Unmute TextFieldMapperTests#testBlockLoaderParentFromRowStrideReader

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -1454,7 +1454,6 @@ public class TextFieldMapperTests extends MapperTestCase {
         testBlockLoaderFromParent(true, randomBoolean());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104158")
     public void testBlockLoaderParentFromRowStrideReader() throws IOException {
         testBlockLoaderFromParent(false, randomBoolean());
     }


### PR DESCRIPTION
Randomly stumbled upon this - #104158 which is referenced is closed so this can be unmuted.

