### PR TITLE
Adjust exception checking for geoip downloader error logging.

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -10,6 +10,7 @@ package org.elasticsearch.ingest.geoip;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
@@ -347,7 +348,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
             new GeoIpTaskParams(),
             null,
             ActionListener.wrap(r -> logger.debug("Started geoip downloader task"), e -> {
-                Throwable t = e instanceof RemoteTransportException ? e.getCause() : e;
+                Throwable t = e instanceof RemoteTransportException ? ExceptionsHelper.unwrapCause(e) : e;
                 if (t instanceof ResourceAlreadyExistsException == false) {
                     logger.error("failed to create geoip downloader task", e);
                     onFailure.run();
@@ -360,7 +361,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
         ActionListener<PersistentTasksCustomMetadata.PersistentTask<?>> listener = ActionListener.wrap(
             r -> logger.debug("Stopped geoip downloader task"),
             e -> {
-                Throwable t = e instanceof RemoteTransportException ? e.getCause() : e;
+                Throwable t = e instanceof RemoteTransportException ? ExceptionsHelper.unwrapCause(e) : e;
                 if (t instanceof ResourceNotFoundException == false) {
                     logger.error("failed to remove geoip downloader task", e);
                     onFailure.run();
@@ -373,7 +374,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
                 // regardless of whether DATABASES_INDEX is an alias, resolve it to a concrete index
                 Index databasesIndex = databasesAbstraction.getWriteIndex();
                 client.admin().indices().prepareDelete(databasesIndex.getName()).execute(ActionListener.wrap(rr -> {}, e -> {
-                    Throwable t = e instanceof RemoteTransportException ? e.getCause() : e;
+                    Throwable t = e instanceof RemoteTransportException ? ExceptionsHelper.unwrapCause(e) : e;
                     if (t instanceof ResourceNotFoundException == false) {
                         logger.warn("failed to remove " + databasesIndex, e);
                     }


### PR DESCRIPTION
Sometimes an exception is wrapped multiple times and then these logs are being emitted:

```
org.elasticsearch.transport.RemoteTransportException: [es-es-index-64c4d7dcd-4d7qb][10.2.58.152:9300][cluster:admin/persistent/start]
Caused by: org.elasticsearch.transport.RemoteTransportException: [es-es-index-64c4d7dcd-j7s7v][10.2.9.216:9300][cluster:admin/persistent/start]
Caused by: org.elasticsearch.ResourceAlreadyExistsException: task with id {geoip-downloader} already exist
	at org.elasticsearch.persistent.PersistentTasksClusterService$1.execute(PersistentTasksClusterService.java:120)
	at org.elasticsearch.cluster.service.MasterService$UnbatchedExecutor.execute(MasterService.java:550)
	at org.elasticsearch.cluster.service.MasterService.innerExecuteTasks(MasterService.java:1039)
	at org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:1004)
	at org.elasticsearch.cluster.service.MasterService.executeAndPublishBatch(MasterService.java:232)
	at org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.lambda$run$2(MasterService.java:1645)
	at org.elasticsearch.action.ActionListener.run(ActionListener.java:356)
	at org.elasticsearch.cluster.service.MasterService$BatchingTaskQueue$Processor.run(MasterService.java:1642)
	at org.elasticsearch.cluster.service.MasterService$5.lambda$doRun$0(MasterService.java:1237)
	at org.elasticsearch.action.ActionListener.run(ActionListener.java:356)
	at org.elasticsearch.cluster.service.MasterService$5.doRun(MasterService.java:1216)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:984)
	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.lang.Thread.run(Thread.java:1583)
```

In this case the real cause is `ResourceAlreadyExistsException`, which should't be logged as an error. Adjusted the exception cause checking to take into account that an exeception maybe wrapped twice by a `RemoteTransportException`.