### PR TITLE
Improve test isolation in DeprecationHttpIT based on xOpaqueId

### DIFF
--- a/x-pack/plugin/deprecation/qa/common/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationTestUtils.java
+++ b/x-pack/plugin/deprecation/qa/common/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationTestUtils.java
@@ -17,18 +17,25 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.common.logging.DeprecatedMessage.X_OPAQUE_ID_FIELD_NAME;
+
 public class DeprecationTestUtils {
     /**
      * Same as <code>DeprecationIndexingAppender#DEPRECATION_MESSAGES_DATA_STREAM</code>, but that class isn't visible from here.
      */
     public static final String DATA_STREAM_NAME = ".logs-deprecation.elasticsearch-default";
 
-    @SuppressWarnings("unchecked")
     static List<Map<String, Object>> getIndexedDeprecations(RestClient client) throws IOException {
+        return getIndexedDeprecations(client, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<Map<String, Object>> getIndexedDeprecations(RestClient client, String xOpaqueId) throws IOException {
         Response response;
         try {
             client.performRequest(new Request("POST", "/" + DATA_STREAM_NAME + "/_refresh?ignore_unavailable=true"));
-            response = client.performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "/_search"));
+            String query = xOpaqueId != null ? "?q=" + X_OPAQUE_ID_FIELD_NAME + ":" + xOpaqueId : null;
+            response = client.performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "/_search" + query));
         } catch (Exception e) {
             // It can take a moment for the index to be created. If it doesn't exist then the client
             // throws an exception. Translate it into an assertion error so that assertBusy() will

--- a/x-pack/plugin/deprecation/qa/common/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationTestUtils.java
+++ b/x-pack/plugin/deprecation/qa/common/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationTestUtils.java
@@ -34,7 +34,7 @@ public class DeprecationTestUtils {
         Response response;
         try {
             client.performRequest(new Request("POST", "/" + DATA_STREAM_NAME + "/_refresh?ignore_unavailable=true"));
-            String query = xOpaqueId != null ? "?q=" + X_OPAQUE_ID_FIELD_NAME + ":" + xOpaqueId : null;
+            String query = xOpaqueId == null ? "" : "?q=" + X_OPAQUE_ID_FIELD_NAME + ":" + xOpaqueId;
             response = client.performRequest(new Request("GET", "/" + DATA_STREAM_NAME + "/_search" + query));
         } catch (Exception e) {
             // It can take a moment for the index to be created. If it doesn't exist then the client

--- a/x-pack/plugin/deprecation/qa/rest/build.gradle
+++ b/x-pack/plugin/deprecation/qa/rest/build.gradle
@@ -27,6 +27,7 @@ restResources {
 testClusters.configureEach {
   testDistribution = 'DEFAULT'
   setting 'cluster.deprecation_indexing.enabled', 'true'
+  setting 'cluster.deprecation_indexing.flush_interval', '100ms'
   setting 'xpack.security.enabled', 'false'
   setting 'xpack.license.self_generated.type', 'trial'
 }

--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -14,11 +14,9 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.Strings;
@@ -31,13 +29,13 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.hamcrest.Matcher;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +47,6 @@ import static org.elasticsearch.common.logging.DeprecatedMessage.X_OPAQUE_ID_FIE
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasEntry;
@@ -60,65 +57,31 @@ import static org.hamcrest.Matchers.matchesRegex;
 /**
  * Tests that deprecation message are returned via response headers, and can be indexed into a data stream.
  */
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101596")
 public class DeprecationHttpIT extends ESRestTestCase {
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private String xOpaqueId() {
+        String name = testName.getMethodName();
+        int pos = name.indexOf(" "); // additional suffix in case of repeated runs
+        return pos == -1 ? name : name.substring(0, pos) + "-" + name.hashCode();
+    }
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        return true; // isolation is based on xOpaqueId
+    }
 
     @Before
     public void assertIndexingIsEnabled() throws Exception {
-
         // make sure the deprecation logs indexing is enabled
-        Response response = client().performRequest(new Request("GET", "/_cluster/settings?include_defaults=true&flat_settings=true"));
-        assertOK(response);
+        Response response = performScopedRequest(new Request("GET", "/_cluster/settings?include_defaults=true&flat_settings=true"));
+
         ObjectMapper mapper = new ObjectMapper();
         final JsonNode jsonNode = mapper.readTree(response.getEntity().getContent());
-
         final boolean defaultValue = jsonNode.at("/defaults/cluster.deprecation_indexing.enabled").asBoolean();
         assertTrue(defaultValue);
-
-        // assert index does not exist, which will prevent previous tests to interfere
-        assertBusy(() -> {
-
-            try {
-                client().performRequest(new Request("GET", "/_data_stream/" + DeprecationTestUtils.DATA_STREAM_NAME));
-            } catch (ResponseException e) {
-                if (e.getResponse().getStatusLine().getStatusCode() == 404) {
-                    return;
-                }
-            }
-
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
-            logger.warn(documents);
-            // if data stream is still present, that means that previous test (could be different class) created a deprecation
-            // hence resetting again
-            resetDeprecationIndexAndCache();
-            fail("Index should be removed on startup");
-        }, 30, TimeUnit.SECONDS);
-    }
-
-    @After
-    public void cleanUp() throws Exception {
-        resetDeprecationIndexAndCache();
-
-        // switch logging setting to default
-        configureWriteDeprecationLogsToIndex(null);
-    }
-
-    private void resetDeprecationIndexAndCache() throws Exception {
-        // making sure the deprecation indexing cache is reset and index is deleted
-        assertBusy(() -> {
-            try {
-                client().performRequest(new Request("DELETE", "_logging/deprecation_cache"));
-                client().performRequest(new Request("DELETE", "/_data_stream/" + DeprecationTestUtils.DATA_STREAM_NAME));
-            } catch (Exception e) {
-                throw new AssertionError(e);
-            }
-        }, 30, TimeUnit.SECONDS);
-
-        assertBusy(() -> {
-            // wait for the data stream to really be deleted
-            var response = ESRestTestCase.entityAsMap(client().performRequest(new Request("GET", "/_data_stream")));
-            assertThat((Collection<?>) response.get("data_streams"), empty());
-        });
     }
 
     /**
@@ -149,7 +112,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
             final Request request = new Request("PUT", "_cluster/settings");
             ///
             request.setJsonEntity(Strings.toString(builder));
-            final Response response = client().performRequest(request);
+            final Response response = performScopedRequest(request);
 
             final List<String> deprecatedWarnings = getWarningHeaders(response.getHeaders());
             assertThat(deprecatedWarnings, everyItem(matchesRegex(HeaderWarning.WARNING_HEADER_PATTERN)));
@@ -174,11 +137,10 @@ public class DeprecationHttpIT extends ESRestTestCase {
             );
 
             assertBusy(() -> {
-                List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+                List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
                 logger.warn(documents);
                 assertThat(documents, hasSize(2));
             });
-
         } finally {
             cleanupSettings();
         }
@@ -197,7 +159,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
 
         final Request request = new Request("PUT", "_cluster/settings");
         request.setJsonEntity(Strings.toString(builder));
-        client().performRequest(request);
+        performScopedRequest(request);
     }
 
     /**
@@ -219,19 +181,17 @@ public class DeprecationHttpIT extends ESRestTestCase {
             for (int j = 0; j < randomDocCount; j++) {
                 final Request request = new Request("PUT", indices[i] + "/" + j);
                 request.setJsonEntity("{ \"field\": " + j + " }");
-                assertOK(client().performRequest(request));
+                performScopedRequest(request);
             }
         }
 
         final String commaSeparatedIndices = String.join(",", indices);
 
-        client().performRequest(new Request("POST", commaSeparatedIndices + "/_refresh"));
-
+        performScopedRequest(new Request("POST", commaSeparatedIndices + "/_refresh"));
         // trigger all index deprecations
         Request request = new Request("GET", "/" + commaSeparatedIndices + "/_search");
         request.setJsonEntity("{ \"query\": { \"bool\": { \"filter\": [ { \"deprecated\": {} } ] } } }");
-        Response response = client().performRequest(request);
-        assertOK(response);
+        Response response = performScopedRequest(request);
 
         final List<String> deprecatedWarnings = getWarningHeaders(response.getHeaders());
         final List<Matcher<? super String>> headerMatchers = new ArrayList<>();
@@ -244,14 +204,12 @@ public class DeprecationHttpIT extends ESRestTestCase {
     }
 
     public void testDeprecationWarningsAppearInHeaders() throws Exception {
-        doTestDeprecationWarningsAppearInHeaders();
+        doTestDeprecationWarningsAppearInHeaders(xOpaqueId());
     }
 
     public void testDeprecationHeadersDoNotGetStuck() throws Exception {
-        doTestDeprecationWarningsAppearInHeaders();
-        doTestDeprecationWarningsAppearInHeaders();
-        if (rarely()) {
-            doTestDeprecationWarningsAppearInHeaders();
+        for (int i = 0; i < 3; i++) {
+            doTestDeprecationWarningsAppearInHeaders(xOpaqueId() + "-" + i);
         }
     }
 
@@ -260,7 +218,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
      * <p>
      * Re-running this back-to-back helps to ensure that warnings are not being maintained across requests.
      */
-    private void doTestDeprecationWarningsAppearInHeaders() throws Exception {
+    private void doTestDeprecationWarningsAppearInHeaders(String xOpaqueId) throws Exception {
         final boolean useDeprecatedField = randomBoolean();
         final boolean useNonDeprecatedSetting = randomBoolean();
 
@@ -281,11 +239,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
         // trigger all deprecations
         Request request = new Request("GET", "/_test_cluster/deprecated_settings");
         request.setEntity(buildSettingsRequest(settings, useDeprecatedField ? "deprecated_settings" : "settings"));
-        String xOpaqueId = "XOpaqueId-doTestDeprecationWarningsAppearInHeaders" + randomInt();
-        final RequestOptions options = request.getOptions().toBuilder().addHeader("X-Opaque-Id", xOpaqueId).build();
-        request.setOptions(options);
-        Response response = client().performRequest(request);
-        assertOK(response);
+        Response response = performScopedRequest(request, xOpaqueId);
 
         final List<String> deprecatedWarnings = getWarningHeaders(response.getHeaders());
         final List<Matcher<? super String>> headerMatchers = new ArrayList<>(4);
@@ -303,25 +257,19 @@ public class DeprecationHttpIT extends ESRestTestCase {
 
         // expect to index same number of new deprecations as the number of header warnings in the response
         assertBusy(() -> {
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
-            long indexedDeprecations = documents.stream().filter(m -> xOpaqueId.equals(m.get(X_OPAQUE_ID_FIELD_NAME))).count();
-            assertThat(documents.toString(), indexedDeprecations, equalTo((long) headerMatchers.size()));
+            var documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId);
+            logger.warn(documents);
+            assertThat(documents, hasSize(headerMatchers.size()));
         });
-
     }
 
     public void testDeprecationRouteThrottling() throws Exception {
-
-        final Request deprecatedRequest = deprecatedRequest("GET", "xOpaqueId-testDeprecationRouteThrottling");
-        assertOK(client().performRequest(deprecatedRequest));
-
-        assertOK(client().performRequest(deprecatedRequest));
-
-        final Request postRequest = deprecatedRequest("POST", "xOpaqueId-testDeprecationRouteThrottling");
-        assertOK(client().performRequest(postRequest));
+        performScopedRequest(deprecatedRequest("GET"));
+        performScopedRequest(deprecatedRequest("GET"));
+        performScopedRequest(deprecatedRequest("POST"));
 
         assertBusy(() -> {
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
 
             logger.warn(documents);
 
@@ -347,40 +295,39 @@ public class DeprecationHttpIT extends ESRestTestCase {
     }
 
     public void testDisableDeprecationLogIndexing() throws Exception {
-        final Request deprecatedRequest = deprecatedRequest("GET", "xOpaqueId-testDisableDeprecationLogIndexing");
-        assertOK(client().performRequest(deprecatedRequest));
+        performScopedRequest(deprecatedRequest("GET"));
         configureWriteDeprecationLogsToIndex(false);
 
-        final Request postRequest = deprecatedRequest("POST", "xOpaqueId-testDisableDeprecationLogIndexing");
-        assertOK(client().performRequest(postRequest));
+        try {
+            performScopedRequest(deprecatedRequest("POST"));
+            assertBusy(() -> {
+                List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
 
-        assertBusy(() -> {
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+                logger.warn(documents);
 
-            logger.warn(documents);
-
-            assertThat(
-                documents,
-                containsInAnyOrder(
-                    allOf(
-                        hasEntry(KEY_FIELD_NAME, "deprecated_route_GET_/_test_cluster/deprecated_settings"),
-                        hasEntry("message", "[/_test_cluster/deprecated_settings] exists for deprecated tests")
-                    ),
-                    allOf(
-                        hasEntry(KEY_FIELD_NAME, "deprecated_settings"),
-                        hasEntry("message", "[deprecated_settings] usage is deprecated. use [settings] instead")
+                assertThat(
+                    documents,
+                    containsInAnyOrder(
+                        allOf(
+                            hasEntry(KEY_FIELD_NAME, "deprecated_route_GET_/_test_cluster/deprecated_settings"),
+                            hasEntry("message", "[/_test_cluster/deprecated_settings] exists for deprecated tests")
+                        ),
+                        allOf(
+                            hasEntry(KEY_FIELD_NAME, "deprecated_settings"),
+                            hasEntry("message", "[deprecated_settings] usage is deprecated. use [settings] instead")
+                        )
                     )
-                )
-            );
-        }, 30, TimeUnit.SECONDS);
+                );
+            }, 30, TimeUnit.SECONDS);
+        } finally {
+            configureWriteDeprecationLogsToIndex(null);
+        }
 
     }
 
     // triggers two deprecations - endpoint and setting
-    private Request deprecatedRequest(String method, String xOpaqueId) throws IOException {
+    private Request deprecatedRequest(String method) throws IOException {
         final Request getRequest = new Request(method, "/_test_cluster/deprecated_settings");
-        final RequestOptions options = getRequest.getOptions().toBuilder().addHeader("X-Opaque-Id", xOpaqueId).build();
-        getRequest.setOptions(options);
         getRequest.setEntity(
             buildSettingsRequest(
                 Collections.singletonList(TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE1),
@@ -394,12 +341,10 @@ public class DeprecationHttpIT extends ESRestTestCase {
      * Check that deprecation messages can be recorded to an index
      */
     public void testDeprecationMessagesCanBeIndexed() throws Exception {
-
-        final Request request = deprecatedRequest("GET", "xOpaqueId-testDeprecationMessagesCanBeIndexed");
-        assertOK(client().performRequest(request));
+        performScopedRequest(deprecatedRequest("GET"));
 
         assertBusy(() -> {
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
 
             logger.warn(documents);
 
@@ -410,7 +355,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("@timestamp"),
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
-                        hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationMessagesCanBeIndexed"),
+                        hasEntry(X_OPAQUE_ID_FIELD_NAME, xOpaqueId()),
                         hasEntry("elasticsearch.event.category", "settings"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -428,7 +373,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("@timestamp"),
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
-                        hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationMessagesCanBeIndexed"),
+                        hasEntry(X_OPAQUE_ID_FIELD_NAME, xOpaqueId()),
                         hasEntry("elasticsearch.event.category", "api"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -452,23 +397,17 @@ public class DeprecationHttpIT extends ESRestTestCase {
      * Check that a deprecation message with CRITICAL level can be recorded to an index
      */
     public void testDeprecationCriticalWarnMessagesCanBeIndexed() throws Exception {
-
         final Request request = new Request("GET", "/_test_cluster/only_deprecated_setting");
-        final RequestOptions options = request.getOptions()
-            .toBuilder()
-            .addHeader("X-Opaque-Id", "xOpaqueId-testDeprecationCriticalWarnMessagesCanBeIndexed")
-            .build();
-        request.setOptions(options);
         request.setEntity(
             buildSettingsRequest(
                 Collections.singletonList(TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE3),
                 "deprecation_critical"
             )
         );
-        assertOK(client().performRequest(request));
+        performScopedRequest(request);
 
         assertBusy(() -> {
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
 
             logger.warn(documents);
 
@@ -479,7 +418,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("@timestamp"),
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
-                        hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationCriticalWarnMessagesCanBeIndexed"),
+                        hasEntry(X_OPAQUE_ID_FIELD_NAME, xOpaqueId()),
                         hasEntry("elasticsearch.event.category", "settings"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -505,21 +444,16 @@ public class DeprecationHttpIT extends ESRestTestCase {
     public void testDeprecationWarnMessagesCanBeIndexed() throws Exception {
 
         final Request request = new Request("GET", "/_test_cluster/deprecated_settings");
-        final RequestOptions options = request.getOptions()
-            .toBuilder()
-            .addHeader("X-Opaque-Id", "xOpaqueId-testDeprecationWarnMessagesCanBeIndexed")
-            .build();
-        request.setOptions(options);
         request.setEntity(
             buildSettingsRequest(
                 Collections.singletonList(TestDeprecationHeaderRestAction.TEST_DEPRECATED_SETTING_TRUE1),
                 "deprecation_warning"
             )
         );
-        assertOK(client().performRequest(request));
+        performScopedRequest(request);
 
         assertBusy(() -> {
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
 
             logger.warn(documents);
 
@@ -530,7 +464,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("@timestamp"),
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
-                        hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationWarnMessagesCanBeIndexed"),
+                        hasEntry(X_OPAQUE_ID_FIELD_NAME, xOpaqueId()),
                         hasEntry("elasticsearch.event.category", "settings"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -548,7 +482,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("@timestamp"),
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
-                        hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testDeprecationWarnMessagesCanBeIndexed"),
+                        hasEntry(X_OPAQUE_ID_FIELD_NAME, xOpaqueId()),
                         hasEntry("elasticsearch.event.category", "api"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -576,7 +510,6 @@ public class DeprecationHttpIT extends ESRestTestCase {
         final Request compatibleRequest = new Request("GET", "/_test_cluster/compat_only");
         final RequestOptions compatibleOptions = compatibleRequest.getOptions()
             .toBuilder()
-            .addHeader("X-Opaque-Id", "xOpaqueId-testCompatibleMessagesCanBeIndexed")
             .addHeader("Accept", "application/vnd.elasticsearch+json;compatible-with=" + RestApiVersion.minimumSupported().major)
             .addHeader("Content-Type", "application/vnd.elasticsearch+json;compatible-with=" + RestApiVersion.minimumSupported().major)
             .build();
@@ -587,8 +520,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                 "deprecated_settings"
             )
         );
-        Response deprecatedApiResponse = client().performRequest(compatibleRequest);
-        assertOK(deprecatedApiResponse);
+        Response deprecatedApiResponse = performScopedRequest(compatibleRequest);
 
         final List<String> deprecatedWarnings = getWarningHeaders(deprecatedApiResponse.getHeaders());
         final List<String> actualWarningValues = deprecatedWarnings.stream()
@@ -600,7 +532,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
         );
 
         assertBusy(() -> {
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
 
             logger.warn(documents);
 
@@ -611,7 +543,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("@timestamp"),
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
-                        hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testCompatibleMessagesCanBeIndexed"),
+                        hasEntry(X_OPAQUE_ID_FIELD_NAME, xOpaqueId()),
                         hasEntry("elasticsearch.event.category", "compatible_api"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -629,7 +561,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                         hasKey("@timestamp"),
                         hasKey("elasticsearch.cluster.name"),
                         hasKey("elasticsearch.cluster.uuid"),
-                        hasEntry(X_OPAQUE_ID_FIELD_NAME, "xOpaqueId-testCompatibleMessagesCanBeIndexed"),
+                        hasEntry(X_OPAQUE_ID_FIELD_NAME, xOpaqueId()),
                         hasEntry("elasticsearch.event.category", "compatible_api"),
                         hasKey("elasticsearch.node.id"),
                         hasKey("elasticsearch.node.name"),
@@ -654,15 +586,14 @@ public class DeprecationHttpIT extends ESRestTestCase {
      */
     public void testDeprecationIndexingCacheReset() throws Exception {
 
-        final Request deprecatedRequest = deprecatedRequest("GET", "xOpaqueId-testDeprecationIndexingCacheReset");
-        assertOK(client().performRequest(deprecatedRequest));
+        performScopedRequest(deprecatedRequest("GET"));
 
-        client().performRequest(new Request("DELETE", "/_logging/deprecation_cache"));
+        performScopedRequest(new Request("DELETE", "/_logging/deprecation_cache"));
 
-        assertOK(client().performRequest(deprecatedRequest));
+        performScopedRequest(deprecatedRequest("GET"));
 
         assertBusy(() -> {
-            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client());
+            List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
 
             logger.warn(documents);
 
@@ -694,8 +625,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
     private void configureWriteDeprecationLogsToIndex(Boolean value) throws IOException {
         final Request request = new Request("PUT", "_cluster/settings");
         request.setJsonEntity("{ \"persistent\": { \"cluster.deprecation_indexing.enabled\": " + value + " } }");
-        final Response response = client().performRequest(request);
-        assertOK(response);
+        performScopedRequest(request);
     }
 
     private List<String> getWarningHeaders(Header[] headers) {
@@ -713,6 +643,17 @@ public class DeprecationHttpIT extends ESRestTestCase {
         builder.endArray().endObject();
 
         return new StringEntity(Strings.toString(builder), ContentType.APPLICATION_JSON);
+    }
+
+    private Response performScopedRequest(Request req) throws IOException {
+        return performScopedRequest(req, xOpaqueId());
+    }
+
+    private Response performScopedRequest(Request req, String xOpaqueId) throws IOException {
+        req.setOptions(req.getOptions().toBuilder().addHeader("X-Opaque-Id", xOpaqueId).build());
+        Response response = client().performRequest(req);
+        assertOK(response);
+        return response;
     }
 
     /**


### PR DESCRIPTION
Rather than trying extremely hard to pretend isolation on a shared resource (the deprecation index), this instead attempts to provide isolation by strictly using a unique xOpaqueId per test case.

This should even allow to preserve cluster state between runs:
```
    @Override
    protected boolean preserveClusterUponCompletion() {
        return true; // isolation is based on xOpaqueId
    }
```

Additionally this sets the flush interval of the deprecation bulk processor to achieve reasonably fast test runs.

Also, on the positive side, this makes the test much simpler again and allows to focus primarily on the functional aspects.