### PR TITLE
[ML] Inference api adding poll peek

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/AdjustableCapacityBlockingQueue.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/AdjustableCapacityBlockingQueue.java
@@ -145,6 +145,40 @@ public class AdjustableCapacityBlockingQueue<E> {
         }
     }
 
+    public E peek() {
+        final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+
+        readLock.lock();
+        try {
+            var oldItem = prioritizedReadingQueue.peek();
+
+            if (oldItem != null) {
+                return oldItem;
+            }
+
+            return currentQueue.peek();
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    public E poll() {
+        final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+
+        readLock.lock();
+        try {
+            var oldItem = prioritizedReadingQueue.poll();
+
+            if (oldItem != null) {
+                return oldItem;
+            }
+
+            return currentQueue.poll();
+        } finally {
+            readLock.unlock();
+        }
+    }
+
     /**
      * Returns the number of elements stored in the queue. If the capacity was recently changed, the value returned could be
      * greater than the capacity. This occurs when the capacity was reduced and there were more elements in the queue than the

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/AdjustableCapacityBlockingQueueTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/common/AdjustableCapacityBlockingQueueTests.java
@@ -233,6 +233,65 @@ public class AdjustableCapacityBlockingQueueTests extends ESTestCase {
         assertThat(queue.size(), is(0));
     }
 
+    public void testPeek_ReturnsItemWithoutRemoving() {
+        var queue = new AdjustableCapacityBlockingQueue<>(QUEUE_CREATOR, 1);
+        assertThat(queue.size(), is(0));
+
+        queue.offer(0);
+        assertThat(queue.size(), is(1));
+        assertThat(queue.peek(), is(0));
+        assertThat(queue.size(), is(1));
+        assertThat(queue.peek(), is(0));
+    }
+
+    public void testPeek_ExistingItem_RemainsAtFront_AfterCapacityChange() throws InterruptedException {
+        var queue = new AdjustableCapacityBlockingQueue<>(QUEUE_CREATOR, 1);
+        queue.offer(0);
+        assertThat(queue.size(), is(1));
+        assertThat(queue.remainingCapacity(), is(0));
+        assertThat(queue.peek(), is(0));
+
+        queue.setCapacity(2);
+        assertThat(queue.remainingCapacity(), is(1));
+        assertThat(queue.peek(), is(0));
+
+        queue.offer(1);
+        assertThat(queue.peek(), is(0));
+        assertThat(queue.take(), is(0));
+        assertThat(queue.peek(), is(1));
+    }
+
+    public void testPoll_ReturnsNull_WhenNoItemsAreAvailable() {
+        var queue = new AdjustableCapacityBlockingQueue<>(QUEUE_CREATOR, 1);
+        assertNull(queue.poll());
+    }
+
+    public void testPoll_ReturnsFirstElement() {
+        var queue = new AdjustableCapacityBlockingQueue<>(QUEUE_CREATOR, 1);
+        queue.offer(0);
+        assertThat(queue.poll(), is(0));
+        assertThat(queue.size(), is(0));
+        assertThat(queue.remainingCapacity(), is(1));
+    }
+
+    public void testPoll_ReturnsFirstElement_AfterCapacityIncrease() {
+        var queue = new AdjustableCapacityBlockingQueue<>(QUEUE_CREATOR, 1);
+        queue.offer(0);
+        queue.setCapacity(2);
+        queue.offer(1);
+
+        assertThat(queue.remainingCapacity(), is(0));
+        assertThat(queue.size(), is(2));
+
+        assertThat(queue.poll(), is(0));
+        assertThat(queue.size(), is(1));
+        assertThat(queue.remainingCapacity(), is(1));
+
+        assertThat(queue.poll(), is(1));
+        assertThat(queue.size(), is(0));
+        assertThat(queue.remainingCapacity(), is(2));
+    }
+
     public static <E> AdjustableCapacityBlockingQueue.QueueCreator<E> mockQueueCreator(BlockingQueue<E> backingQueue) {
         return new AdjustableCapacityBlockingQueue.QueueCreator<>() {
             @Override


### PR DESCRIPTION
This PR is targeting 8.15

Part of this issue: https://github.com/elastic/elasticsearch/issues/105993

This PR adds a few new methods to the `AdjustableCapacityBlockingQueue` to enable the new queuing logic for rate limiting.