### PR TITLE
Remove x-pack references from SQL docs

### DIFF
--- a/docs/reference/sql/getting-started.asciidoc
+++ b/docs/reference/sql/getting-started.asciidoc
@@ -40,7 +40,7 @@ Frank Herbert  |Dune           |604            |1965-06-01T00:00:00.000Z
 // TESTRESPONSE[non_json]
 
 You can also use the <<sql-cli>>. There is a script to start it
-shipped in x-pack's bin directory:
+shipped in the Elasticsearch `bin` directory:
 
 [source,bash]
 --------------------------------------------------

--- a/docs/reference/sql/index.asciidoc
+++ b/docs/reference/sql/index.asciidoc
@@ -1,4 +1,3 @@
-[role="xpack"]
 [[xpack-sql]]
 = SQL
 
@@ -11,8 +10,7 @@
 [partintro]
 --
 
-X-Pack includes a SQL feature to execute SQL queries against {es}
-indices and return results in tabular format.
+{es} includes a SQL feature to execute SQL queries against indices and return results in tabular format.
 
 The following chapters aim to cover everything from usage, to syntax and drivers.
 Experienced users or those in a hurry might want to jump directly to

--- a/docs/reference/sql/overview.asciidoc
+++ b/docs/reference/sql/overview.asciidoc
@@ -1,4 +1,3 @@
-[role="xpack"]
 [[sql-overview]]
 == Overview
 
@@ -8,7 +7,7 @@
 [discrete]
 === Introduction
 
-{es-sql} is an X-Pack component that allows SQL-like queries to be executed in real-time against {es}.
+{es-sql} is an component that allows SQL-like queries to be executed in real-time against {es}.
 Whether using the REST interface, command-line or JDBC, any client can use SQL to search and aggregate data
 _natively_ inside {es}.
 One can think of {es-sql} as a _translator_, one that understands both SQL and {es} and makes it easy to read and process data in real-time, at scale by leveraging {es} capabilities.

--- a/docs/reference/sql/overview.asciidoc
+++ b/docs/reference/sql/overview.asciidoc
@@ -7,7 +7,7 @@
 [discrete]
 === Introduction
 
-{es-sql} is an component that allows SQL-like queries to be executed in real-time against {es}.
+{es-sql} is a feature that allows SQL-like queries to be executed in real-time against {es}.
 Whether using the REST interface, command-line or JDBC, any client can use SQL to search and aggregate data
 _natively_ inside {es}.
 One can think of {es-sql} as a _translator_, one that understands both SQL and {es} and makes it easy to read and process data in real-time, at scale by leveraging {es} capabilities.


### PR DESCRIPTION
- Fixes https://github.com/elastic/elasticsearch/issues/107005
- Removes x-pack references from this area of the docs because x-pack is no longer needed
