### PR TITLE
[8.13] Fix typo in text_expansion query docs example (#107572)

### DIFF
--- a/docs/reference/query-dsl/text-expansion-query.asciidoc
+++ b/docs/reference/query-dsl/text-expansion-query.asciidoc
@@ -224,12 +224,12 @@ GET my-index/_search
       "text_expansion":{
          "ml.tokens":{
             "model_id":".elser_model_2",
-            "model_text":"How is the weather in Jamaica?"
-         },
-         "pruning_config": {
-             "tokens_freq_ratio_threshold": 5,
-             "tokens_weight_threshold": 0.4,
-             "only_score_pruned_tokens": false
+            "model_text":"How is the weather in Jamaica?",
+            "pruning_config": {
+               "tokens_freq_ratio_threshold": 5,
+               "tokens_weight_threshold": 0.4,
+               "only_score_pruned_tokens": false
+           }
          }
       }
    },
@@ -240,12 +240,12 @@ GET my-index/_search
             "text_expansion": {
                "ml.tokens": {
                   "model_id": ".elser_model_2",
-                  "model_text": "How is the weather in Jamaica?"
-               },
-               "pruning_config": {
-                  "tokens_freq_ratio_threshold": 5,
-                  "tokens_weight_threshold": 0.4,
-                  "only_score_pruned_tokens": true
+                  "model_text": "How is the weather in Jamaica?",
+                  "pruning_config": {
+                     "tokens_freq_ratio_threshold": 5,
+                     "tokens_weight_threshold": 0.4,
+                     "only_score_pruned_tokens": true
+                  }
                }
             }
          }


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Fix typo in text_expansion query docs example (#107572)