### PR TITLE
Converting the inner record-like classes in EnrichStatsAction to records

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -128,50 +128,16 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
             return Objects.hash(executingPolicies, coordinatorStats, cacheStats);
         }
 
-        public static class CoordinatorStats implements Writeable, ToXContentFragment {
-
-            private final String nodeId;
-            private final int queueSize;
-            private final int remoteRequestsCurrent;
-            private final long remoteRequestsTotal;
-            private final long executedSearchesTotal;
-
-            public CoordinatorStats(
-                String nodeId,
-                int queueSize,
-                int remoteRequestsCurrent,
-                long remoteRequestsTotal,
-                long executedSearchesTotal
-            ) {
-                this.nodeId = nodeId;
-                this.queueSize = queueSize;
-                this.remoteRequestsCurrent = remoteRequestsCurrent;
-                this.remoteRequestsTotal = remoteRequestsTotal;
-                this.executedSearchesTotal = executedSearchesTotal;
-            }
+        public record CoordinatorStats(
+            String nodeId,
+            int queueSize,
+            int remoteRequestsCurrent,
+            long remoteRequestsTotal,
+            long executedSearchesTotal
+        ) implements Writeable, ToXContentFragment {
 
             public CoordinatorStats(StreamInput in) throws IOException {
                 this(in.readString(), in.readVInt(), in.readVInt(), in.readVLong(), in.readVLong());
-            }
-
-            public String getNodeId() {
-                return nodeId;
-            }
-
-            public int getQueueSize() {
-                return queueSize;
-            }
-
-            public int getRemoteRequestsCurrent() {
-                return remoteRequestsCurrent;
-            }
-
-            public long getRemoteRequestsTotal() {
-                return remoteRequestsTotal;
-            }
-
-            public long getExecutedSearchesTotal() {
-                return executedSearchesTotal;
             }
 
             @Override
@@ -192,45 +158,12 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
                 builder.field("executed_searches_total", executedSearchesTotal);
                 return builder;
             }
-
-            @Override
-            public boolean equals(Object o) {
-                if (this == o) return true;
-                if (o == null || getClass() != o.getClass()) return false;
-                CoordinatorStats stats = (CoordinatorStats) o;
-                return Objects.equals(nodeId, stats.nodeId)
-                    && queueSize == stats.queueSize
-                    && remoteRequestsCurrent == stats.remoteRequestsCurrent
-                    && remoteRequestsTotal == stats.remoteRequestsTotal
-                    && executedSearchesTotal == stats.executedSearchesTotal;
-            }
-
-            @Override
-            public int hashCode() {
-                return Objects.hash(nodeId, queueSize, remoteRequestsCurrent, remoteRequestsTotal, executedSearchesTotal);
-            }
         }
 
-        public static class ExecutingPolicy implements Writeable, ToXContentFragment {
-
-            private final String name;
-            private final TaskInfo taskInfo;
-
-            public ExecutingPolicy(String name, TaskInfo taskInfo) {
-                this.name = name;
-                this.taskInfo = taskInfo;
-            }
+        public record ExecutingPolicy(String name, TaskInfo taskInfo) implements Writeable, ToXContentFragment {
 
             ExecutingPolicy(StreamInput in) throws IOException {
                 this(in.readString(), TaskInfo.from(in));
-            }
-
-            public String getName() {
-                return name;
-            }
-
-            public TaskInfo getTaskInfo() {
-                return taskInfo;
             }
 
             @Override
@@ -249,59 +182,15 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
                 builder.endObject();
                 return builder;
             }
-
-            @Override
-            public boolean equals(Object o) {
-                if (this == o) return true;
-                if (o == null || getClass() != o.getClass()) return false;
-                ExecutingPolicy that = (ExecutingPolicy) o;
-                return name.equals(that.name) && taskInfo.equals(that.taskInfo);
-            }
-
-            @Override
-            public int hashCode() {
-                return Objects.hash(name, taskInfo);
-            }
         }
 
-        public static class CacheStats implements Writeable, ToXContentFragment {
-
-            private final String nodeId;
-            private final long count;
-            private final long hits;
-            private final long misses;
-            private final long evictions;
-
-            public CacheStats(String nodeId, long count, long hits, long misses, long evictions) {
-                this.nodeId = nodeId;
-                this.count = count;
-                this.hits = hits;
-                this.misses = misses;
-                this.evictions = evictions;
-            }
+        public record CacheStats(String nodeId, long count, long hits, long misses, long evictions)
+            implements
+                Writeable,
+                ToXContentFragment {
 
             public CacheStats(StreamInput in) throws IOException {
                 this(in.readString(), in.readVLong(), in.readVLong(), in.readVLong(), in.readVLong());
-            }
-
-            public String getNodeId() {
-                return nodeId;
-            }
-
-            public long getCount() {
-                return count;
-            }
-
-            public long getHits() {
-                return hits;
-            }
-
-            public long getMisses() {
-                return misses;
-            }
-
-            public long getEvictions() {
-                return evictions;
             }
 
             @Override
@@ -321,23 +210,6 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
                 out.writeVLong(hits);
                 out.writeVLong(misses);
                 out.writeVLong(evictions);
-            }
-
-            @Override
-            public boolean equals(Object o) {
-                if (this == o) return true;
-                if (o == null || getClass() != o.getClass()) return false;
-                CacheStats that = (CacheStats) o;
-                return count == that.count
-                    && hits == that.hits
-                    && misses == that.misses
-                    && evictions == that.evictions
-                    && nodeId.equals(that.nodeId);
-            }
-
-            @Override
-            public int hashCode() {
-                return Objects.hash(nodeId, count, hits, misses, evictions);
             }
         }
     }

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
@@ -268,12 +268,12 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
             .actionGet();
         assertThat(statsResponse.getCoordinatorStats().size(), equalTo(internalCluster().size()));
         String nodeId = getNodeId(coordinatingNode);
-        CoordinatorStats stats = statsResponse.getCoordinatorStats().stream().filter(s -> s.getNodeId().equals(nodeId)).findAny().get();
-        assertThat(stats.getNodeId(), equalTo(nodeId));
-        assertThat(stats.getRemoteRequestsTotal(), greaterThanOrEqualTo(1L));
+        CoordinatorStats stats = statsResponse.getCoordinatorStats().stream().filter(s -> s.nodeId().equals(nodeId)).findAny().get();
+        assertThat(stats.nodeId(), equalTo(nodeId));
+        assertThat(stats.remoteRequestsTotal(), greaterThanOrEqualTo(1L));
         // 'numDocs' lookups are done, but not 'numDocs' searches, because searches may get cached:
         // and not all enrichments may happen via the same node.
-        assertThat(stats.getExecutedSearchesTotal(), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo((long) numDocs)));
+        assertThat(stats.executedSearchesTotal(), allOf(greaterThanOrEqualTo(0L), lessThanOrEqualTo((long) numDocs)));
     }
 
     private static List<String> createSourceIndex(int numDocs) {

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichProcessorIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichProcessorIT.java
@@ -52,9 +52,9 @@ public class EnrichProcessorIT extends ESSingleNodeTestCase {
         var statsRequest = new EnrichStatsAction.Request();
         var statsResponse = client().execute(EnrichStatsAction.INSTANCE, statsRequest).actionGet();
         assertThat(statsResponse.getCacheStats().size(), equalTo(1));
-        assertThat(statsResponse.getCacheStats().get(0).getCount(), equalTo(0L));
-        assertThat(statsResponse.getCacheStats().get(0).getMisses(), equalTo(0L));
-        assertThat(statsResponse.getCacheStats().get(0).getHits(), equalTo(0L));
+        assertThat(statsResponse.getCacheStats().get(0).count(), equalTo(0L));
+        assertThat(statsResponse.getCacheStats().get(0).misses(), equalTo(0L));
+        assertThat(statsResponse.getCacheStats().get(0).hits(), equalTo(0L));
 
         String policyName = "device-enrich-policy";
         String sourceIndexName = "devices-idx";
@@ -128,9 +128,9 @@ public class EnrichProcessorIT extends ESSingleNodeTestCase {
         // Verify that there was a cache miss and a new entry was added to enrich cache.
         statsResponse = client().execute(EnrichStatsAction.INSTANCE, statsRequest).actionGet();
         assertThat(statsResponse.getCacheStats().size(), equalTo(1));
-        assertThat(statsResponse.getCacheStats().get(0).getCount(), equalTo(1L));
-        assertThat(statsResponse.getCacheStats().get(0).getMisses(), equalTo(1L));
-        assertThat(statsResponse.getCacheStats().get(0).getHits(), equalTo(0L));
+        assertThat(statsResponse.getCacheStats().get(0).count(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).misses(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).hits(), equalTo(0L));
 
         simulatePipelineRequest = new SimulatePipelineRequest(new BytesArray("""
             {
@@ -164,9 +164,9 @@ public class EnrichProcessorIT extends ESSingleNodeTestCase {
         // Verify that enrich lookup was served from cache:
         statsResponse = client().execute(EnrichStatsAction.INSTANCE, statsRequest).actionGet();
         assertThat(statsResponse.getCacheStats().size(), equalTo(1));
-        assertThat(statsResponse.getCacheStats().get(0).getCount(), equalTo(1L));
-        assertThat(statsResponse.getCacheStats().get(0).getMisses(), equalTo(1L));
-        assertThat(statsResponse.getCacheStats().get(0).getHits(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).count(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).misses(), equalTo(1L));
+        assertThat(statsResponse.getCacheStats().get(0).hits(), equalTo(1L));
     }
 
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportEnrichStatsAction.java
@@ -84,7 +84,7 @@ public class TransportEnrichStatsAction extends TransportMasterNodeAction<Enrich
             List<CoordinatorStats> coordinatorStats = response.getNodes()
                 .stream()
                 .map(EnrichCoordinatorStatsAction.NodeResponse::getCoordinatorStats)
-                .sorted(Comparator.comparing(CoordinatorStats::getNodeId))
+                .sorted(Comparator.comparing(CoordinatorStats::nodeId))
                 .collect(Collectors.toList());
             List<ExecutingPolicy> policyExecutionTasks = taskManager.getTasks()
                 .values()
@@ -92,13 +92,13 @@ public class TransportEnrichStatsAction extends TransportMasterNodeAction<Enrich
                 .filter(t -> t.getAction().equals(EnrichPolicyExecutor.TASK_ACTION))
                 .map(t -> t.taskInfo(clusterService.localNode().getId(), true))
                 .map(t -> new ExecutingPolicy(t.description(), t))
-                .sorted(Comparator.comparing(ExecutingPolicy::getName))
+                .sorted(Comparator.comparing(ExecutingPolicy::name))
                 .collect(Collectors.toList());
             List<EnrichStatsAction.Response.CacheStats> cacheStats = response.getNodes()
                 .stream()
                 .map(EnrichCoordinatorStatsAction.NodeResponse::getCacheStats)
                 .filter(Objects::nonNull)
-                .sorted(Comparator.comparing(EnrichStatsAction.Response.CacheStats::getNodeId))
+                .sorted(Comparator.comparing(EnrichStatsAction.Response.CacheStats::nodeId))
                 .collect(Collectors.toList());
             delegate.onResponse(new EnrichStatsAction.Response(policyExecutionTasks, coordinatorStats, cacheStats));
         });

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/BasicEnrichTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/BasicEnrichTests.java
@@ -150,9 +150,9 @@ public class BasicEnrichTests extends ESSingleNodeTestCase {
             .actionGet();
         assertThat(statsResponse.getCoordinatorStats().size(), equalTo(1));
         String localNodeId = getInstanceFromNode(ClusterService.class).localNode().getId();
-        assertThat(statsResponse.getCoordinatorStats().get(0).getNodeId(), equalTo(localNodeId));
-        assertThat(statsResponse.getCoordinatorStats().get(0).getRemoteRequestsTotal(), greaterThanOrEqualTo(1L));
-        assertThat(statsResponse.getCoordinatorStats().get(0).getExecutedSearchesTotal(), equalTo((long) numDocs));
+        assertThat(statsResponse.getCoordinatorStats().get(0).nodeId(), equalTo(localNodeId));
+        assertThat(statsResponse.getCoordinatorStats().get(0).remoteRequestsTotal(), greaterThanOrEqualTo(1L));
+        assertThat(statsResponse.getCoordinatorStats().get(0).executedSearchesTotal(), equalTo((long) numDocs));
     }
 
     public void testIngestDataWithGeoMatchProcessor() {
@@ -230,9 +230,9 @@ public class BasicEnrichTests extends ESSingleNodeTestCase {
             .actionGet();
         assertThat(statsResponse.getCoordinatorStats().size(), equalTo(1));
         String localNodeId = getInstanceFromNode(ClusterService.class).localNode().getId();
-        assertThat(statsResponse.getCoordinatorStats().get(0).getNodeId(), equalTo(localNodeId));
-        assertThat(statsResponse.getCoordinatorStats().get(0).getRemoteRequestsTotal(), greaterThanOrEqualTo(1L));
-        assertThat(statsResponse.getCoordinatorStats().get(0).getExecutedSearchesTotal(), equalTo(1L));
+        assertThat(statsResponse.getCoordinatorStats().get(0).nodeId(), equalTo(localNodeId));
+        assertThat(statsResponse.getCoordinatorStats().get(0).remoteRequestsTotal(), greaterThanOrEqualTo(1L));
+        assertThat(statsResponse.getCoordinatorStats().get(0).executedSearchesTotal(), equalTo(1L));
     }
 
     public void testMultiplePolicies() {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichCacheTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichCacheTests.java
@@ -84,27 +84,27 @@ public class EnrichCacheTests extends ESTestCase {
         enrichCache.put(searchRequest2, searchResponse);
         enrichCache.put(searchRequest3, searchResponse);
         var cacheStats = enrichCache.getStats("_id");
-        assertThat(cacheStats.getCount(), equalTo(3L));
-        assertThat(cacheStats.getHits(), equalTo(0L));
-        assertThat(cacheStats.getMisses(), equalTo(0L));
-        assertThat(cacheStats.getEvictions(), equalTo(0L));
+        assertThat(cacheStats.count(), equalTo(3L));
+        assertThat(cacheStats.hits(), equalTo(0L));
+        assertThat(cacheStats.misses(), equalTo(0L));
+        assertThat(cacheStats.evictions(), equalTo(0L));
 
         assertThat(enrichCache.get(searchRequest1), notNullValue());
         assertThat(enrichCache.get(searchRequest2), notNullValue());
         assertThat(enrichCache.get(searchRequest3), notNullValue());
         assertThat(enrichCache.get(searchRequest4), nullValue());
         cacheStats = enrichCache.getStats("_id");
-        assertThat(cacheStats.getCount(), equalTo(3L));
-        assertThat(cacheStats.getHits(), equalTo(3L));
-        assertThat(cacheStats.getMisses(), equalTo(1L));
-        assertThat(cacheStats.getEvictions(), equalTo(0L));
+        assertThat(cacheStats.count(), equalTo(3L));
+        assertThat(cacheStats.hits(), equalTo(3L));
+        assertThat(cacheStats.misses(), equalTo(1L));
+        assertThat(cacheStats.evictions(), equalTo(0L));
 
         enrichCache.put(searchRequest4, searchResponse);
         cacheStats = enrichCache.getStats("_id");
-        assertThat(cacheStats.getCount(), equalTo(3L));
-        assertThat(cacheStats.getHits(), equalTo(3L));
-        assertThat(cacheStats.getMisses(), equalTo(1L));
-        assertThat(cacheStats.getEvictions(), equalTo(1L));
+        assertThat(cacheStats.count(), equalTo(3L));
+        assertThat(cacheStats.hits(), equalTo(3L));
+        assertThat(cacheStats.misses(), equalTo(1L));
+        assertThat(cacheStats.evictions(), equalTo(1L));
 
         // Simulate enrich policy execution, which should make current cache entries unused.
         metadata = Metadata.builder()
@@ -142,10 +142,10 @@ public class EnrichCacheTests extends ESTestCase {
         assertThat(enrichCache.get(searchRequest3), notNullValue());
         assertThat(enrichCache.get(searchRequest4), nullValue());
         cacheStats = enrichCache.getStats("_id");
-        assertThat(cacheStats.getCount(), equalTo(3L));
-        assertThat(cacheStats.getHits(), equalTo(6L));
-        assertThat(cacheStats.getMisses(), equalTo(6L));
-        assertThat(cacheStats.getEvictions(), equalTo(4L));
+        assertThat(cacheStats.count(), equalTo(3L));
+        assertThat(cacheStats.hits(), equalTo(6L));
+        assertThat(cacheStats.misses(), equalTo(6L));
+        assertThat(cacheStats.evictions(), equalTo(4L));
     }
 
     public void testPutIfAbsent() throws InterruptedException {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactoryTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichProcessorFactoryTests.java
@@ -303,10 +303,10 @@ public class EnrichProcessorFactoryTests extends ESTestCase {
             assertThat(failure[0], nullValue());
             assertThat(result[0], notNullValue());
             assertThat(requestCounter[0], equalTo(1));
-            assertThat(enrichCache.getStats("_id").getCount(), equalTo(1L));
-            assertThat(enrichCache.getStats("_id").getMisses(), equalTo(1L));
-            assertThat(enrichCache.getStats("_id").getHits(), equalTo(0L));
-            assertThat(enrichCache.getStats("_id").getEvictions(), equalTo(0L));
+            assertThat(enrichCache.getStats("_id").count(), equalTo(1L));
+            assertThat(enrichCache.getStats("_id").misses(), equalTo(1L));
+            assertThat(enrichCache.getStats("_id").hits(), equalTo(0L));
+            assertThat(enrichCache.getStats("_id").evictions(), equalTo(0L));
 
             // No search is performed, result is read from the cache:
             result[0] = null;
@@ -318,10 +318,10 @@ public class EnrichProcessorFactoryTests extends ESTestCase {
             assertThat(failure[0], nullValue());
             assertThat(result[0], notNullValue());
             assertThat(requestCounter[0], equalTo(1));
-            assertThat(enrichCache.getStats("_id").getCount(), equalTo(1L));
-            assertThat(enrichCache.getStats("_id").getMisses(), equalTo(1L));
-            assertThat(enrichCache.getStats("_id").getHits(), equalTo(1L));
-            assertThat(enrichCache.getStats("_id").getEvictions(), equalTo(0L));
+            assertThat(enrichCache.getStats("_id").count(), equalTo(1L));
+            assertThat(enrichCache.getStats("_id").misses(), equalTo(1L));
+            assertThat(enrichCache.getStats("_id").hits(), equalTo(1L));
+            assertThat(enrichCache.getStats("_id").evictions(), equalTo(0L));
         }
     }
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichCoordinatorDocTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/EnrichCoordinatorDocTests.java
@@ -109,11 +109,11 @@ public class EnrichCoordinatorDocTests extends BaseMonitoringDocTestCase<EnrichC
                         DATE_TIME_FORMATTER.formatMillis(timestamp),
                         intervalMillis,
                         DATE_TIME_FORMATTER.formatMillis(nodeTimestamp),
-                        stats.getNodeId(),
-                        stats.getQueueSize(),
-                        stats.getRemoteRequestsCurrent(),
-                        stats.getRemoteRequestsTotal(),
-                        stats.getExecutedSearchesTotal()
+                        stats.nodeId(),
+                        stats.queueSize(),
+                        stats.remoteRequestsCurrent(),
+                        stats.remoteRequestsTotal(),
+                        stats.executedSearchesTotal()
                     )
                 )
             )

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/ExecutingPolicyDocTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/monitoring/collector/enrich/ExecutingPolicyDocTests.java
@@ -72,23 +72,21 @@ public class ExecutingPolicyDocTests extends BaseMonitoringDocTestCase<Executing
 
         final ExecutingPolicyDoc document = new ExecutingPolicyDoc("_cluster", timestamp, intervalMillis, node, executingPolicy);
         final BytesReference xContent = XContentHelper.toXContent(document, XContentType.JSON, false);
-        Optional<Map.Entry<String, String>> header = executingPolicy.getTaskInfo().headers().entrySet().stream().findAny();
+        Optional<Map.Entry<String, String>> header = executingPolicy.taskInfo().headers().entrySet().stream().findAny();
         Object[] args = new Object[] {
             DATE_TIME_FORMATTER.formatMillis(timestamp),
             intervalMillis,
             DATE_TIME_FORMATTER.formatMillis(nodeTimestamp),
-            executingPolicy.getName(),
-            executingPolicy.getTaskInfo().taskId().getNodeId(),
-            executingPolicy.getTaskInfo().taskId().getId(),
-            executingPolicy.getTaskInfo().type(),
-            executingPolicy.getTaskInfo().action(),
-            executingPolicy.getTaskInfo().description(),
-            executingPolicy.getTaskInfo().startTime(),
-            executingPolicy.getTaskInfo().runningTimeNanos(),
-            executingPolicy.getTaskInfo().cancellable(),
-            executingPolicy.getTaskInfo().cancellable()
-                ? Strings.format("\"cancelled\": %s,", executingPolicy.getTaskInfo().cancelled())
-                : "",
+            executingPolicy.name(),
+            executingPolicy.taskInfo().taskId().getNodeId(),
+            executingPolicy.taskInfo().taskId().getId(),
+            executingPolicy.taskInfo().type(),
+            executingPolicy.taskInfo().action(),
+            executingPolicy.taskInfo().description(),
+            executingPolicy.taskInfo().startTime(),
+            executingPolicy.taskInfo().runningTimeNanos(),
+            executingPolicy.taskInfo().cancellable(),
+            executingPolicy.taskInfo().cancellable() ? Strings.format("\"cancelled\": %s,", executingPolicy.taskInfo().cancelled()) : "",
             header.map(entry -> { return Strings.format("""
                 {"%s":"%s"}""", entry.getKey(), entry.getValue()); }).orElse("{}") };
         assertThat(xContent.utf8ToString(), equalTo(XContentHelper.stripWhitespace(Strings.format("""


### PR DESCRIPTION
EnrichStatsAction has several inner classes that are effectively records. This changes converts those inner classes to records. It also removes the custom getters, and updates any clients to use the built-in record getters.