### PR TITLE
Fix testDynamicDeletionInterval intermittent failures

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InactiveApiKeysRemover.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InactiveApiKeysRemover.java
@@ -45,7 +45,7 @@ public final class InactiveApiKeysRemover extends AbstractRunnable {
     private final TimeValue timeout;
     private final AtomicLong retentionPeriodInMs;
     private final AtomicLong deleteIntervalInMs;
-    private volatile long lastRunMs;
+    private volatile long lastRunMs = -1;
 
     InactiveApiKeysRemover(Settings settings, Client client, ClusterService clusterService) {
         this.client = client;
@@ -94,7 +94,7 @@ public final class InactiveApiKeysRemover extends AbstractRunnable {
     }
 
     void maybeSubmit(ThreadPool threadPool) {
-        if (threadPool.relativeTimeInMillis() - lastRunMs > deleteIntervalInMs.get()) {
+        if (lastRunMs == -1 || threadPool.relativeTimeInMillis() - lastRunMs > deleteIntervalInMs.get()) {
             if (inProgress.compareAndSet(false, true)) {
                 threadPool.executor(Names.GENERIC).submit(this);
             }


### PR DESCRIPTION
This is a fix for https://github.com/elastic/elasticsearch/issues/107419 

I wasn't able to reproduce this failure locally, but I suspect what happened is that when `lastRunMs` has never been set, it's compared against `threadPool.relativeTimeInMillis()`, which should only be used for relative time checking, not compared to `0`. 

This means that it might not run the remover on the first invalidation, but potentially on the second, which I think is the cause of the failure (removes the first invalidated API key by running the remover after invalidation which is not what the test expects).