### PR TITLE
Add links to repo troubleshooting sub-pages

### DIFF
--- a/docs/reference/troubleshooting/snapshot/add-repository.asciidoc
+++ b/docs/reference/troubleshooting/snapshot/add-repository.asciidoc
@@ -2,8 +2,12 @@
 == Troubleshooting broken repositories
 
 There are several situations where the <<health-api, Health API>> might report an issue
-regarding the integrity of snapshot repositories in the cluster. This page explains
-the recommended actions for diagnosing corrupted, unknown, and invalid repositories.
+regarding the integrity of snapshot repositories in the cluster. The following pages explain
+the recommended actions for diagnosing corrupted, unknown, and invalid repositories:
+
+- <<diagnosing-corrupted-repositories>>
+- <<diagnosing-unknown-repositories>>
+- <<diagnosing-invalid-repositories>>
 
 [[diagnosing-corrupted-repositories]]
 === Diagnosing corrupted repositories


### PR DESCRIPTION
Since #104614 the top-level repo troubleshooting page is just a short
paragraph which talks about "this page" but in fact refers to
information spread across a number of subsequent pages. It's not obvious
to the reader that they need to use the navigation menu to get to the
information they seek. Moreover we link to this page from an exception
message today so there's a reasonable chance that users will find it
when trying to troubleshoot a genuine problem.

This commit rewords things slightly and adds links to the subsequent
pages to the body of the page to avoid this confusion.