### PR TITLE
Prioritize movement of write shards

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -441,7 +441,7 @@ public class DesiredBalanceReconciler {
         private void moveShards() {
             // Iterate over all started shards and check if they can remain. In the presence of throttling shard movements,
             // the goal of this iteration order is to achieve a fairer movement of shards from the nodes that are offloading the shards.
-            for (final var iterator = OrderedShardsIterator.create(routingNodes, moveOrdering); iterator.hasNext();) {
+            for (final var iterator = OrderedShardsIterator.createForNecessaryMoves(allocation, moveOrdering); iterator.hasNext();) {
                 final var shardRouting = iterator.next();
 
                 if (shardRouting.started() == false) {
@@ -500,7 +500,7 @@ public class DesiredBalanceReconciler {
             // Iterate over all started shards and try to move any which are on undesired nodes. In the presence of throttling shard
             // movements, the goal of this iteration order is to achieve a fairer movement of shards from the nodes that are offloading the
             // shards.
-            for (final var iterator = OrderedShardsIterator.create(routingNodes, moveOrdering); iterator.hasNext();) {
+            for (final var iterator = OrderedShardsIterator.createForBalancing(allocation, moveOrdering); iterator.hasNext();) {
                 final var shardRouting = iterator.next();
 
                 totalAllocations++;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/OrderedShardsIterator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/OrderedShardsIterator.java
@@ -8,32 +8,68 @@
 
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.common.collect.Iterators;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
 /**
- * This class iterates all shards from all nodes in order of allocation recency.
- * Shards from the node that had a new shard allocation would appear in the end of iteration.
+ * This class iterates all shards from all nodes.
+ * The shard order is defined by
+ * (1) allocation recency: shards from the node that had a new shard allocation would appear in the end of iteration.
+ * (2) shard priority: data stream write shards, then regular index shards, then the rest
  */
 public class OrderedShardsIterator implements Iterator<ShardRouting> {
 
     private final ArrayDeque<NodeAndShardIterator> queue;
 
-    public static OrderedShardsIterator create(RoutingNodes routingNodes, NodeAllocationOrdering ordering) {
+    public static OrderedShardsIterator createForNecessaryMoves(RoutingAllocation allocation, NodeAllocationOrdering ordering) {
+        return create(allocation.routingNodes(), createShardsComparator(allocation.metadata()), ordering);
+    }
+
+    public static OrderedShardsIterator createForBalancing(RoutingAllocation allocation, NodeAllocationOrdering ordering) {
+        return create(allocation.routingNodes(), createShardsComparator(allocation.metadata()).reversed(), ordering);
+    }
+
+    private static OrderedShardsIterator create(
+        RoutingNodes routingNodes,
+        Comparator<ShardRouting> shardOrder,
+        NodeAllocationOrdering nodeOrder
+    ) {
         var queue = new ArrayDeque<NodeAndShardIterator>(routingNodes.size());
-        for (var nodeId : ordering.sort(routingNodes.getAllNodeIds())) {
+        for (var nodeId : nodeOrder.sort(routingNodes.getAllNodeIds())) {
             var node = routingNodes.node(nodeId);
             if (node.size() > 0) {
-                queue.add(new NodeAndShardIterator(nodeId, Iterators.forArray(node.copyShards())));
+                queue.add(new NodeAndShardIterator(nodeId, sort(shardOrder, node.copyShards())));
             }
         }
         return new OrderedShardsIterator(queue);
+    }
+
+    private static Iterator<ShardRouting> sort(Comparator<ShardRouting> comparator, ShardRouting[] shards) {
+        Arrays.sort(shards, comparator);
+        return Iterators.forArray(shards);
+    }
+
+    private static Comparator<ShardRouting> createShardsComparator(Metadata metadata) {
+        return Comparator.comparing(shard -> {
+            var lookup = metadata.getIndicesLookup().get(shard.getIndexName());
+            if (lookup != null && lookup.getParentDataStream() != null) {
+                // prioritize write indices of the data stream
+                return Objects.equals(lookup.getParentDataStream().getWriteIndex(), shard.index()) ? 0 : 2;
+            } else {
+                // regular index
+                return 1;
+            }
+        });
     }
 
     private OrderedShardsIterator(ArrayDeque<NodeAndShardIterator> queue) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/OrderedShardsIterator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/OrderedShardsIterator.java
@@ -25,7 +25,8 @@ import java.util.Objects;
  * This class iterates all shards from all nodes.
  * The shard order is defined by
  * (1) allocation recency: shards from the node that had a new shard allocation would appear in the end of iteration.
- * (2) shard priority: data stream write shards, then regular index shards, then the rest
+ * (2) shard priority: for necessary moves data stream write shards, then regular index shards, then the rest
+ *                     for rebalancing the order is inverse
  */
 public class OrderedShardsIterator implements Iterator<ShardRouting> {
 


### PR DESCRIPTION
This change enhances shard ordering in OrderedShardsIterator.

Prior shards were ordered by node allocation recency. The ordering within the node was not explicitly defined.
With this change the data stream write index shards are prioritized within the node.

In case of the necessary shard movement, such shards will move first. This might be useful in case of the timeout for the node shutdown.

In case of rebalancing such shards are going to be moved last to minimize disruptions to the ongoing indexing.