### PR TITLE
ES|QL: Make TSDBRestEsqlIT more deterministic

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/TSDBRestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/TSDBRestEsqlIT.java
@@ -22,8 +22,10 @@ import org.junit.ClassRule;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.elasticsearch.xpack.esql.qa.rest.RestEsqlTestCase.runEsqlSync;
 
@@ -71,28 +73,38 @@ public class TSDBRestEsqlIT extends ESRestTestCase {
         assertEquals("k8s.pod.name", columns.get(0).get("name"));
         assertEquals("@timestamp", columns.get(1).get("name"));
 
+        Set<String> expectedNames = Set.of("hamster", "rat", "cow", "cat");
+        Set<String> returnedNames = new HashSet<>();
+
         // Note that _tsid is a hashed value, so tsid no longer is sorted lexicographically.
         @SuppressWarnings("unchecked")
         List<List<?>> values = (List<List<?>>) result.get("values");
         assertEquals(8, values.size());
-        assertEquals("hamster", values.get(0).get(0));
+
+        String name = (String) values.get(0).get(0);
+        returnedNames.add(name);
         assertEquals("2021-04-29T17:29:22.470Z", values.get(0).get(1));
-        assertEquals("hamster", values.get(1).get(0));
+        assertEquals(name, values.get(1).get(0));
         assertEquals("2021-04-29T17:29:12.470Z", values.get(1).get(1));
 
-        assertEquals("rat", values.get(2).get(0));
+        name = (String) values.get(2).get(0);
+        returnedNames.add(name);
         assertEquals("2021-04-29T17:29:22.470Z", values.get(2).get(1));
-        assertEquals("rat", values.get(3).get(0));
+        assertEquals(name, values.get(3).get(0));
         assertEquals("2021-04-29T17:29:12.470Z", values.get(3).get(1));
 
-        assertEquals("cow", values.get(4).get(0));
+        name = (String) values.get(4).get(0);
+        returnedNames.add(name);
         assertEquals("2021-04-29T17:29:22.470Z", values.get(4).get(1));
-        assertEquals("cow", values.get(5).get(0));
+        assertEquals(name, values.get(5).get(0));
         assertEquals("2021-04-29T17:29:12.470Z", values.get(5).get(1));
 
-        assertEquals("cat", values.get(6).get(0));
+        name = (String) values.get(6).get(0);
+        returnedNames.add(name);
         assertEquals("2021-04-29T17:29:22.470Z", values.get(6).get(1));
-        assertEquals("cat", values.get(7).get(0));
+        assertEquals(name, values.get(7).get(0));
         assertEquals("2021-04-29T17:29:12.470Z", values.get(7).get(1));
+
+        assertEquals(expectedNames, returnedNames);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/107557

The test fails quite consistently on Serverless (three nodes, vs. single node in stateful).
My understanding is that what matters here is the order of the series per single `k8s.pod.name`, but that the order of `k8s.pod.name`s is not strictly enforced by TSDB (I could be completely wrong though...)

