### PR TITLE
[8.13] Add links to repo troubleshooting sub-pages (#107604)

### DIFF
--- a/docs/reference/troubleshooting/snapshot/add-repository.asciidoc
+++ b/docs/reference/troubleshooting/snapshot/add-repository.asciidoc
@@ -2,8 +2,12 @@
 == Troubleshooting broken repositories
 
 There are several situations where the <<health-api, Health API>> might report an issue
-regarding the integrity of snapshot repositories in the cluster. This page explains
-the recommended actions for diagnosing corrupted, unknown, and invalid repositories.
+regarding the integrity of snapshot repositories in the cluster. The following pages explain
+the recommended actions for diagnosing corrupted, unknown, and invalid repositories:
+
+- <<diagnosing-corrupted-repositories>>
+- <<diagnosing-unknown-repositories>>
+- <<diagnosing-invalid-repositories>>
 
 [[diagnosing-corrupted-repositories]]
 === Diagnosing corrupted repositories


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Add links to repo troubleshooting sub-pages (#107604)