### PR TITLE
Create test indices in `frequent_item_sets_agg.yml` test with explicit `number_of_shards` and `number_of_replicas`

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/frequent_item_sets_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/frequent_item_sets_agg.yml
@@ -58,6 +58,9 @@ setup:
       indices.create:
         index: store-flattened
         body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               data:
@@ -556,6 +559,9 @@ setup:
       indices.create:
         index: unavailable-data
         body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
           mappings:
             properties:
               features:


### PR DESCRIPTION
This PR makes the `number_of_shards` and `number_of_replicas` fixed for the test indices in `frequent_item_sets_agg.yml`:
- `number_of_shards` is set to `1`
- `number_of_replicas` is set to `0`
 
This is the approach that is used, e.g.: by `x-pack/plugin/rollup/qa/rest/out/test/resources/rest-api-spec/test/rollup/20_unsupported_aggs.yml`.