### PR TITLE
[8.14] Users with monitor privileges can access async_search/status endpoint even when setting keep_alive (#107383)

### DIFF
--- a/docs/changelog/107383.yaml
+++ b/docs/changelog/107383.yaml
@@ -1,0 +1,6 @@
+pr: 107383
+summary: Users with monitor privileges can access async_search/status endpoint 
+  even when setting keep_alive
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
+++ b/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
@@ -177,7 +177,6 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
      * the testWithUsers test is generally testing).
      * @throws IOException
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106871")
     public void testStatusWithUsersWhileSearchIsRunning() throws IOException {
         assumeTrue("[error_query] is only available in snapshot builds", Build.current().isSnapshot());
         String user = randomFrom("user1", "user2");
@@ -249,6 +248,9 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
 
         // user-monitor can access the status
         assertOK(getAsyncStatus(id, "user-monitor"));
+
+        // user-monitor can access status and set keep_alive
+        assertOK(getAsyncStatusAndSetKeepAlive(id, "user-monitor"));
 
         // user-monitor cannot access the result
         exc = expectThrows(ResponseException.class, () -> getAsyncSearch(id, "user-monitor"));
@@ -482,6 +484,13 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
     static Response getAsyncStatus(String id, String user) throws IOException {
         final Request request = new Request("GET", "/_async_search/status/" + id);
         setRunAsHeader(request, user);
+        return client().performRequest(request);
+    }
+
+    static Response getAsyncStatusAndSetKeepAlive(String id, String user) throws IOException {
+        final Request request = new Request("GET", "/_async_search/status/" + id);
+        setRunAsHeader(request, user);
+        request.addParameter("keep_alive", "3m");
         return client().performRequest(request);
     }
 

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncStatusAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportGetAsyncStatusAction.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
+import static org.elasticsearch.xpack.core.async.AsyncTaskIndexService.getTask;
 
 public class TransportGetAsyncStatusAction extends HandledTransportAction<GetAsyncStatusRequest, AsyncStatusResponse> {
     private final TransportService transportService;
@@ -76,7 +77,7 @@ public class TransportGetAsyncStatusAction extends HandledTransportAction<GetAsy
             if (request.getKeepAlive() != null && request.getKeepAlive().getMillis() > 0) {
                 long expirationTime = System.currentTimeMillis() + request.getKeepAlive().getMillis();
                 store.updateExpirationTime(searchId.getDocId(), expirationTime, ActionListener.wrap(p -> {
-                    AsyncSearchTask asyncSearchTask = store.getTaskAndCheckAuthentication(taskManager, searchId, AsyncSearchTask.class);
+                    AsyncSearchTask asyncSearchTask = getTask(taskManager, searchId, AsyncSearchTask.class);
                     if (asyncSearchTask != null) {
                         asyncSearchTask.setExpirationTime(expirationTime);
                     }


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Users with monitor privileges can access async_search/status endpoint even when setting keep_alive (#107383)