### PR TITLE
Only block readiness if no file settings have been applied yet

### DIFF
--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -254,7 +254,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
     // protected to allow mock service to override
     protected boolean areFileSettingsApplied(ClusterState clusterState) {
         ReservedStateMetadata fileSettingsMetadata = clusterState.metadata().reservedStateMetadata().get(FileSettingsService.NAMESPACE);
-        return fileSettingsMetadata != null && fileSettingsMetadata.errorMetadata() == null;
+        return fileSettingsMetadata != null && fileSettingsMetadata.version() > 0;
     }
 
     private void setReady(boolean ready) {

--- a/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
@@ -55,7 +55,7 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
 
     private static Metadata emptyReservedStateMetadata;
     static {
-        var fileSettingsState = new ReservedStateMetadata.Builder(FileSettingsService.NAMESPACE).version(-1L);
+        var fileSettingsState = new ReservedStateMetadata.Builder(FileSettingsService.NAMESPACE).version(1L);
         emptyReservedStateMetadata = new Metadata.Builder().put(fileSettingsState.build()).build();
     }
 


### PR DESCRIPTION
Only block readiness if no file settings have been applied yet, but do not block on previous errors.

This allows nodes to start up if previous file settings exist regardless if an error has been recorded.
Otherwise, unless the file settings version changes, the settings won't be re-applied if their version matches. But in that case the error won't ever be cleared and the nodes just remain not ready.
