### PR TITLE
ESQL: Add lookup flavor to `MultivalueDedupe`

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeDouble.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeDouble.java
@@ -165,10 +165,11 @@ public class MultivalueDedupeDouble {
     }
 
     /**
-     * Dedupe values and build a {@link IntBlock} suitable for passing
-     * as the grouping block to a {@link GroupingAggregatorFunction}.
+     * Dedupe values, add them to the hash, and build an {@link IntBlock} of
+     * their hashes. This block is suitable for passing as the grouping block
+     * to a {@link GroupingAggregatorFunction}.
      */
-    public MultivalueDedupe.HashResult hash(BlockFactory blockFactory, LongHash hash) {
+    public MultivalueDedupe.HashResult hashAdd(BlockFactory blockFactory, LongHash hash) {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             boolean sawNull = false;
             for (int p = 0; p < block.getPositionCount(); p++) {
@@ -181,20 +182,50 @@ public class MultivalueDedupeDouble {
                     }
                     case 1 -> {
                         double v = block.getDouble(first);
-                        hash(builder, hash, v);
+                        hashAdd(builder, hash, v);
                     }
                     default -> {
                         if (count < ALWAYS_COPY_MISSING) {
                             copyMissing(first, count);
-                            hashUniquedWork(hash, builder);
+                            hashAddUniquedWork(hash, builder);
                         } else {
                             copyAndSort(first, count);
-                            hashSortedWork(hash, builder);
+                            hashAddSortedWork(hash, builder);
                         }
                     }
                 }
             }
             return new MultivalueDedupe.HashResult(builder.build(), sawNull);
+        }
+    }
+
+    /**
+     * Dedupe values and build an {@link IntBlock} of their hashes. This block is
+     * suitable for passing as the grouping block to a {@link GroupingAggregatorFunction}.
+     */
+    public IntBlock hashLookup(BlockFactory blockFactory, LongHash hash) {
+        try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                int count = block.getValueCount(p);
+                int first = block.getFirstValueIndex(p);
+                switch (count) {
+                    case 0 -> builder.appendInt(0);
+                    case 1 -> {
+                        double v = block.getDouble(first);
+                        hashLookupSingle(builder, hash, v);
+                    }
+                    default -> {
+                        if (count < ALWAYS_COPY_MISSING) {
+                            copyMissing(first, count);
+                            hashLookupUniquedWork(hash, builder);
+                        } else {
+                            copyAndSort(first, count);
+                            hashLookupSortedWork(hash, builder);
+                        }
+                    }
+                }
+            }
+            return builder.build();
         }
     }
 
@@ -341,14 +372,14 @@ public class MultivalueDedupeDouble {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashAddUniquedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hashAdd(builder, hash, work[0]);
             return;
         }
         builder.beginPositionEntry();
         for (int i = 0; i < w; i++) {
-            hash(builder, hash, work[i]);
+            hashAdd(builder, hash, work[i]);
         }
         builder.endPositionEntry();
     }
@@ -356,19 +387,151 @@ public class MultivalueDedupeDouble {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashAddSortedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hashAdd(builder, hash, work[0]);
             return;
         }
         builder.beginPositionEntry();
         double prev = work[0];
-        hash(builder, hash, prev);
+        hashAdd(builder, hash, prev);
         for (int i = 1; i < w; i++) {
-            if (prev != work[i]) {
+            if (false == valuesEqual(prev, work[i])) {
                 prev = work[i];
-                hash(builder, hash, prev);
+                hashAdd(builder, hash, prev);
             }
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Looks up an already deduplicated {@link #work} to a hash.
+     */
+    private void hashLookupUniquedWork(LongHash hash, IntBlock.Builder builder) {
+        if (w == 1) {
+            hashLookupSingle(builder, hash, work[0]);
+            return;
+        }
+
+        int i = 1;
+        long firstLookup = hashLookup(hash, work[0]);
+        while (firstLookup < 0) {
+            if (i >= w) {
+                // Didn't find any values
+                builder.appendNull();
+                return;
+            }
+            firstLookup = hashLookup(hash, work[i]);
+            i++;
+        }
+
+        /*
+         * Step 2 - find the next unique value in the hash
+         */
+        boolean foundSecond = false;
+        while (i < w) {
+            long nextLookup = hashLookup(hash, work[i]);
+            if (nextLookup >= 0) {
+                builder.beginPositionEntry();
+                appendFound(builder, firstLookup);
+                appendFound(builder, nextLookup);
+                i++;
+                foundSecond = true;
+                break;
+            }
+            i++;
+        }
+
+        /*
+         * Step 3a - we didn't find a second value, just emit the first one
+         */
+        if (false == foundSecond) {
+            appendFound(builder, firstLookup);
+            return;
+        }
+
+        /*
+         * Step 3b - we found a second value, search for more
+         */
+        while (i < w) {
+            long nextLookup = hashLookup(hash, work[i]);
+            if (nextLookup >= 0) {
+                appendFound(builder, nextLookup);
+            }
+            i++;
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Looks up a sorted {@link #work} to a hash, skipping duplicates.
+     */
+    private void hashLookupSortedWork(LongHash hash, IntBlock.Builder builder) {
+        if (w == 1) {
+            hashLookupSingle(builder, hash, work[0]);
+            return;
+        }
+
+        /*
+         * Step 1 - find the first unique value in the hash
+         *   i will contain the next value to probe
+         *   prev will contain the first value in the array contained in the hash
+         *   firstLookup will contain the first value in the hash
+         */
+        int i = 1;
+        double prev = work[0];
+        long firstLookup = hashLookup(hash, prev);
+        while (firstLookup < 0) {
+            if (i >= w) {
+                // Didn't find any values
+                builder.appendNull();
+                return;
+            }
+            prev = work[i];
+            firstLookup = hashLookup(hash, prev);
+            i++;
+        }
+
+        /*
+         * Step 2 - find the next unique value in the hash
+         */
+        boolean foundSecond = false;
+        while (i < w) {
+            if (false == valuesEqual(prev, work[i])) {
+                long nextLookup = hashLookup(hash, work[i]);
+                if (nextLookup >= 0) {
+                    prev = work[i];
+                    builder.beginPositionEntry();
+                    appendFound(builder, firstLookup);
+                    appendFound(builder, nextLookup);
+                    i++;
+                    foundSecond = true;
+                    break;
+                }
+            }
+            i++;
+        }
+
+        /*
+         * Step 3a - we didn't find a second value, just emit the first one
+         */
+        if (false == foundSecond) {
+            appendFound(builder, firstLookup);
+            return;
+        }
+
+        /*
+         * Step 3b - we found a second value, search for more
+         */
+        while (i < w) {
+            if (false == valuesEqual(prev, work[i])) {
+                long nextLookup = hashLookup(hash, work[i]);
+                if (nextLookup >= 0) {
+                    prev = work[i];
+                    appendFound(builder, nextLookup);
+                }
+            }
+            i++;
         }
         builder.endPositionEntry();
     }
@@ -390,7 +553,7 @@ public class MultivalueDedupeDouble {
         int end = w;
         w = 1;
         for (int i = 1; i < end; i++) {
-            if (prev != work[i]) {
+            if (false == valuesEqual(prev, work[i])) {
                 prev = work[i];
                 work[w++] = prev;
             }
@@ -401,7 +564,28 @@ public class MultivalueDedupeDouble {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(IntBlock.Builder builder, LongHash hash, double v) {
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v)))));
+    private void hashAdd(IntBlock.Builder builder, LongHash hash, double v) {
+        appendFound(builder, hash.add(Double.doubleToLongBits(v)));
+    }
+
+    private long hashLookup(LongHash hash, double v) {
+        return hash.find(Double.doubleToLongBits(v));
+    }
+
+    private void hashLookupSingle(IntBlock.Builder builder, LongHash hash, double v) {
+        long found = hashLookup(hash, v);
+        if (found >= 0) {
+            appendFound(builder, found);
+        } else {
+            builder.appendNull();
+        }
+    }
+
+    private void appendFound(IntBlock.Builder builder, long found) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(found)));
+    }
+
+    private static boolean valuesEqual(double lhs, double rhs) {
+        return lhs == rhs;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/operator/MultivalueDedupeInt.java
@@ -165,10 +165,11 @@ public class MultivalueDedupeInt {
     }
 
     /**
-     * Dedupe values and build a {@link IntBlock} suitable for passing
-     * as the grouping block to a {@link GroupingAggregatorFunction}.
+     * Dedupe values, add them to the hash, and build an {@link IntBlock} of
+     * their hashes. This block is suitable for passing as the grouping block
+     * to a {@link GroupingAggregatorFunction}.
      */
-    public MultivalueDedupe.HashResult hash(BlockFactory blockFactory, LongHash hash) {
+    public MultivalueDedupe.HashResult hashAdd(BlockFactory blockFactory, LongHash hash) {
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             boolean sawNull = false;
             for (int p = 0; p < block.getPositionCount(); p++) {
@@ -181,20 +182,50 @@ public class MultivalueDedupeInt {
                     }
                     case 1 -> {
                         int v = block.getInt(first);
-                        hash(builder, hash, v);
+                        hashAdd(builder, hash, v);
                     }
                     default -> {
                         if (count < ALWAYS_COPY_MISSING) {
                             copyMissing(first, count);
-                            hashUniquedWork(hash, builder);
+                            hashAddUniquedWork(hash, builder);
                         } else {
                             copyAndSort(first, count);
-                            hashSortedWork(hash, builder);
+                            hashAddSortedWork(hash, builder);
                         }
                     }
                 }
             }
             return new MultivalueDedupe.HashResult(builder.build(), sawNull);
+        }
+    }
+
+    /**
+     * Dedupe values and build an {@link IntBlock} of their hashes. This block is
+     * suitable for passing as the grouping block to a {@link GroupingAggregatorFunction}.
+     */
+    public IntBlock hashLookup(BlockFactory blockFactory, LongHash hash) {
+        try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                int count = block.getValueCount(p);
+                int first = block.getFirstValueIndex(p);
+                switch (count) {
+                    case 0 -> builder.appendInt(0);
+                    case 1 -> {
+                        int v = block.getInt(first);
+                        hashLookupSingle(builder, hash, v);
+                    }
+                    default -> {
+                        if (count < ALWAYS_COPY_MISSING) {
+                            copyMissing(first, count);
+                            hashLookupUniquedWork(hash, builder);
+                        } else {
+                            copyAndSort(first, count);
+                            hashLookupSortedWork(hash, builder);
+                        }
+                    }
+                }
+            }
+            return builder.build();
         }
     }
 
@@ -341,14 +372,14 @@ public class MultivalueDedupeInt {
     /**
      * Writes an already deduplicated {@link #work} to a hash.
      */
-    private void hashUniquedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashAddUniquedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hashAdd(builder, hash, work[0]);
             return;
         }
         builder.beginPositionEntry();
         for (int i = 0; i < w; i++) {
-            hash(builder, hash, work[i]);
+            hashAdd(builder, hash, work[i]);
         }
         builder.endPositionEntry();
     }
@@ -356,19 +387,151 @@ public class MultivalueDedupeInt {
     /**
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
-    private void hashSortedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashAddSortedWork(LongHash hash, IntBlock.Builder builder) {
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hashAdd(builder, hash, work[0]);
             return;
         }
         builder.beginPositionEntry();
         int prev = work[0];
-        hash(builder, hash, prev);
+        hashAdd(builder, hash, prev);
         for (int i = 1; i < w; i++) {
-            if (prev != work[i]) {
+            if (false == valuesEqual(prev, work[i])) {
                 prev = work[i];
-                hash(builder, hash, prev);
+                hashAdd(builder, hash, prev);
             }
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Looks up an already deduplicated {@link #work} to a hash.
+     */
+    private void hashLookupUniquedWork(LongHash hash, IntBlock.Builder builder) {
+        if (w == 1) {
+            hashLookupSingle(builder, hash, work[0]);
+            return;
+        }
+
+        int i = 1;
+        long firstLookup = hashLookup(hash, work[0]);
+        while (firstLookup < 0) {
+            if (i >= w) {
+                // Didn't find any values
+                builder.appendNull();
+                return;
+            }
+            firstLookup = hashLookup(hash, work[i]);
+            i++;
+        }
+
+        /*
+         * Step 2 - find the next unique value in the hash
+         */
+        boolean foundSecond = false;
+        while (i < w) {
+            long nextLookup = hashLookup(hash, work[i]);
+            if (nextLookup >= 0) {
+                builder.beginPositionEntry();
+                appendFound(builder, firstLookup);
+                appendFound(builder, nextLookup);
+                i++;
+                foundSecond = true;
+                break;
+            }
+            i++;
+        }
+
+        /*
+         * Step 3a - we didn't find a second value, just emit the first one
+         */
+        if (false == foundSecond) {
+            appendFound(builder, firstLookup);
+            return;
+        }
+
+        /*
+         * Step 3b - we found a second value, search for more
+         */
+        while (i < w) {
+            long nextLookup = hashLookup(hash, work[i]);
+            if (nextLookup >= 0) {
+                appendFound(builder, nextLookup);
+            }
+            i++;
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Looks up a sorted {@link #work} to a hash, skipping duplicates.
+     */
+    private void hashLookupSortedWork(LongHash hash, IntBlock.Builder builder) {
+        if (w == 1) {
+            hashLookupSingle(builder, hash, work[0]);
+            return;
+        }
+
+        /*
+         * Step 1 - find the first unique value in the hash
+         *   i will contain the next value to probe
+         *   prev will contain the first value in the array contained in the hash
+         *   firstLookup will contain the first value in the hash
+         */
+        int i = 1;
+        int prev = work[0];
+        long firstLookup = hashLookup(hash, prev);
+        while (firstLookup < 0) {
+            if (i >= w) {
+                // Didn't find any values
+                builder.appendNull();
+                return;
+            }
+            prev = work[i];
+            firstLookup = hashLookup(hash, prev);
+            i++;
+        }
+
+        /*
+         * Step 2 - find the next unique value in the hash
+         */
+        boolean foundSecond = false;
+        while (i < w) {
+            if (false == valuesEqual(prev, work[i])) {
+                long nextLookup = hashLookup(hash, work[i]);
+                if (nextLookup >= 0) {
+                    prev = work[i];
+                    builder.beginPositionEntry();
+                    appendFound(builder, firstLookup);
+                    appendFound(builder, nextLookup);
+                    i++;
+                    foundSecond = true;
+                    break;
+                }
+            }
+            i++;
+        }
+
+        /*
+         * Step 3a - we didn't find a second value, just emit the first one
+         */
+        if (false == foundSecond) {
+            appendFound(builder, firstLookup);
+            return;
+        }
+
+        /*
+         * Step 3b - we found a second value, search for more
+         */
+        while (i < w) {
+            if (false == valuesEqual(prev, work[i])) {
+                long nextLookup = hashLookup(hash, work[i]);
+                if (nextLookup >= 0) {
+                    prev = work[i];
+                    appendFound(builder, nextLookup);
+                }
+            }
+            i++;
         }
         builder.endPositionEntry();
     }
@@ -390,7 +553,7 @@ public class MultivalueDedupeInt {
         int end = w;
         w = 1;
         for (int i = 1; i < end; i++) {
-            if (prev != work[i]) {
+            if (false == valuesEqual(prev, work[i])) {
                 prev = work[i];
                 work[w++] = prev;
             }
@@ -401,7 +564,28 @@ public class MultivalueDedupeInt {
         work = ArrayUtil.grow(work, size);
     }
 
-    private void hash(IntBlock.Builder builder, LongHash hash, int v) {
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
+    private void hashAdd(IntBlock.Builder builder, LongHash hash, int v) {
+        appendFound(builder, hash.add(v));
+    }
+
+    private long hashLookup(LongHash hash, int v) {
+        return hash.find(v);
+    }
+
+    private void hashLookupSingle(IntBlock.Builder builder, LongHash hash, int v) {
+        long found = hashLookup(hash, v);
+        if (found >= 0) {
+            appendFound(builder, found);
+        } else {
+            builder.appendNull();
+        }
+    }
+
+    private void appendFound(IntBlock.Builder builder, long found) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(found)));
+    }
+
+    private static boolean valuesEqual(int lhs, int rhs) {
+        return lhs == rhs;
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -86,8 +86,7 @@ final class BytesRefBlockHash extends BlockHash {
     }
 
     private IntBlock add(BytesRefBlock block) {
-        // TODO: use block factory
-        MultivalueDedupe.HashResult result = new MultivalueDedupeBytesRef(block).hash(blockFactory, bytesRefHash);
+        MultivalueDedupe.HashResult result = new MultivalueDedupeBytesRef(block).hashAdd(blockFactory, bytesRefHash);
         seenNull |= result.sawNull();
         return result.ords();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/DoubleBlockHash.java
@@ -80,9 +80,23 @@ final class DoubleBlockHash extends BlockHash {
     }
 
     private IntBlock add(DoubleBlock block) {
-        MultivalueDedupe.HashResult result = new MultivalueDedupeDouble(block).hash(blockFactory, longHash);
+        MultivalueDedupe.HashResult result = new MultivalueDedupeDouble(block).hashAdd(blockFactory, longHash);
         seenNull |= result.sawNull();
         return result.ords();
+    }
+
+    private IntVector lookup(DoubleVector vector) {
+        int positions = vector.getPositionCount();
+        try (var builder = blockFactory.newIntVectorFixedBuilder(positions)) {
+            for (int i = 0; i < positions; i++) {
+                builder.appendInt(Math.toIntExact(hashOrdToGroupNullReserved(longHash.add(Double.doubleToLongBits(vector.getDouble(i))))));
+            }
+            return builder.build();
+        }
+    }
+
+    private IntBlock lookup(DoubleBlock block) {
+        return new MultivalueDedupeDouble(block).hashLookup(blockFactory, longHash);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/IntBlockHash.java
@@ -77,7 +77,7 @@ final class IntBlockHash extends BlockHash {
     }
 
     private IntBlock add(IntBlock block) {
-        MultivalueDedupe.HashResult result = new MultivalueDedupeInt(block).hash(blockFactory, longHash);
+        MultivalueDedupe.HashResult result = new MultivalueDedupeInt(block).hashAdd(blockFactory, longHash);
         seenNull |= result.sawNull();
         return result.ords();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/LongBlockHash.java
@@ -80,7 +80,7 @@ final class LongBlockHash extends BlockHash {
     }
 
     private IntBlock add(LongBlock block) {
-        MultivalueDedupe.HashResult result = new MultivalueDedupeLong(block).hash(blockFactory, longHash);
+        MultivalueDedupe.HashResult result = new MultivalueDedupeLong(block).hashAdd(blockFactory, longHash);
         seenNull |= result.sawNull();
         return result.ords();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/PackedValuesBlockHash.java
@@ -106,9 +106,9 @@ final class PackedValuesBlockHash extends BlockHash {
         }
 
         /**
-         * Encodes one permutation of the keys at time into {@link #bytes}. The encoding is
-         * mostly provided by {@link BatchEncoder} with nulls living in a bit mask at the
-         * front of the bytes.
+         * Encodes one permutation of the keys at time into {@link #bytes} and adds it
+         * to the {@link #bytesRefHash}. The encoding is mostly provided by
+         * {@link BatchEncoder} with nulls living in a bit mask at the front of the bytes.
          */
         void add() {
             for (position = 0; position < positionCount; position++) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/X-MultivalueDedupe.java.st
@@ -206,13 +206,14 @@ $endif$
     }
 
     /**
-     * Dedupe values and build a {@link IntBlock} suitable for passing
-     * as the grouping block to a {@link GroupingAggregatorFunction}.
+     * Dedupe values, add them to the hash, and build an {@link IntBlock} of
+     * their hashes. This block is suitable for passing as the grouping block
+     * to a {@link GroupingAggregatorFunction}.
      */
 $if(BytesRef)$
-    public MultivalueDedupe.HashResult hash(BlockFactory blockFactory, BytesRefHash hash) {
+    public MultivalueDedupe.HashResult hashAdd(BlockFactory blockFactory, BytesRefHash hash) {
 $else$
-    public MultivalueDedupe.HashResult hash(BlockFactory blockFactory, LongHash hash) {
+    public MultivalueDedupe.HashResult hashAdd(BlockFactory blockFactory, LongHash hash) {
 $endif$
         try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
             boolean sawNull = false;
@@ -230,20 +231,58 @@ $if(BytesRef)$
 $else$
                         $type$ v = block.get$Type$(first);
 $endif$
-                        hash(builder, hash, v);
+                        hashAdd(builder, hash, v);
                     }
                     default -> {
                         if (count < ALWAYS_COPY_MISSING) {
                             copyMissing(first, count);
-                            hashUniquedWork(hash, builder);
+                            hashAddUniquedWork(hash, builder);
                         } else {
                             copyAndSort(first, count);
-                            hashSortedWork(hash, builder);
+                            hashAddSortedWork(hash, builder);
                         }
                     }
                 }
             }
             return new MultivalueDedupe.HashResult(builder.build(), sawNull);
+        }
+    }
+
+    /**
+     * Dedupe values and build an {@link IntBlock} of their hashes. This block is
+     * suitable for passing as the grouping block to a {@link GroupingAggregatorFunction}.
+     */
+$if(BytesRef)$
+    public IntBlock hashLookup(BlockFactory blockFactory, BytesRefHash hash) {
+$else$
+    public IntBlock hashLookup(BlockFactory blockFactory, LongHash hash) {
+$endif$
+        try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(block.getPositionCount())) {
+            for (int p = 0; p < block.getPositionCount(); p++) {
+                int count = block.getValueCount(p);
+                int first = block.getFirstValueIndex(p);
+                switch (count) {
+                    case 0 -> builder.appendInt(0);
+                    case 1 -> {
+$if(BytesRef)$
+                        BytesRef v = block.getBytesRef(first, work[0]);
+$else$
+                        $type$ v = block.get$Type$(first);
+$endif$
+                        hashLookupSingle(builder, hash, v);
+                    }
+                    default -> {
+                        if (count < ALWAYS_COPY_MISSING) {
+                            copyMissing(first, count);
+                            hashLookupUniquedWork(hash, builder);
+                        } else {
+                            copyAndSort(first, count);
+                            hashLookupSortedWork(hash, builder);
+                        }
+                    }
+                }
+            }
+            return builder.build();
         }
     }
 
@@ -434,17 +473,17 @@ $endif$
      * Writes an already deduplicated {@link #work} to a hash.
      */
 $if(BytesRef)$
-    private void hashUniquedWork(BytesRefHash hash, IntBlock.Builder builder) {
+    private void hashAddUniquedWork(BytesRefHash hash, IntBlock.Builder builder) {
 $else$
-    private void hashUniquedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashAddUniquedWork(LongHash hash, IntBlock.Builder builder) {
 $endif$
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hashAdd(builder, hash, work[0]);
             return;
         }
         builder.beginPositionEntry();
         for (int i = 0; i < w; i++) {
-            hash(builder, hash, work[i]);
+            hashAdd(builder, hash, work[i]);
         }
         builder.endPositionEntry();
     }
@@ -453,26 +492,162 @@ $endif$
      * Writes a sorted {@link #work} to a hash, skipping duplicates.
      */
 $if(BytesRef)$
-    private void hashSortedWork(BytesRefHash hash, IntBlock.Builder builder) {
+    private void hashAddSortedWork(BytesRefHash hash, IntBlock.Builder builder) {
 $else$
-    private void hashSortedWork(LongHash hash, IntBlock.Builder builder) {
+    private void hashAddSortedWork(LongHash hash, IntBlock.Builder builder) {
 $endif$
         if (w == 1) {
-            hash(builder, hash, work[0]);
+            hashAdd(builder, hash, work[0]);
             return;
         }
         builder.beginPositionEntry();
         $type$ prev = work[0];
-        hash(builder, hash, prev);
+        hashAdd(builder, hash, prev);
         for (int i = 1; i < w; i++) {
-$if(BytesRef)$
-            if (false == prev.equals(work[i])) {
-$else$
-            if (prev != work[i]) {
-$endif$
+            if (false == valuesEqual(prev, work[i])) {
                 prev = work[i];
-                hash(builder, hash, prev);
+                hashAdd(builder, hash, prev);
             }
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Looks up an already deduplicated {@link #work} to a hash.
+     */
+$if(BytesRef)$
+    private void hashLookupUniquedWork(BytesRefHash hash, IntBlock.Builder builder) {
+$else$
+    private void hashLookupUniquedWork(LongHash hash, IntBlock.Builder builder) {
+$endif$
+        if (w == 1) {
+            hashLookupSingle(builder, hash, work[0]);
+            return;
+        }
+
+        int i = 1;
+        long firstLookup = hashLookup(hash, work[0]);
+        while (firstLookup < 0) {
+            if (i >= w) {
+                // Didn't find any values
+                builder.appendNull();
+                return;
+            }
+            firstLookup = hashLookup(hash, work[i]);
+            i++;
+        }
+
+        /*
+         * Step 2 - find the next unique value in the hash
+         */
+        boolean foundSecond = false;
+        while (i < w) {
+            long nextLookup = hashLookup(hash, work[i]);
+            if (nextLookup >= 0) {
+                builder.beginPositionEntry();
+                appendFound(builder, firstLookup);
+                appendFound(builder, nextLookup);
+                i++;
+                foundSecond = true;
+                break;
+            }
+            i++;
+        }
+
+        /*
+         * Step 3a - we didn't find a second value, just emit the first one
+         */
+        if (false == foundSecond) {
+            appendFound(builder, firstLookup);
+            return;
+        }
+
+        /*
+         * Step 3b - we found a second value, search for more
+         */
+        while (i < w) {
+            long nextLookup = hashLookup(hash, work[i]);
+            if (nextLookup >= 0) {
+                appendFound(builder, nextLookup);
+            }
+            i++;
+        }
+        builder.endPositionEntry();
+    }
+
+    /**
+     * Looks up a sorted {@link #work} to a hash, skipping duplicates.
+     */
+$if(BytesRef)$
+    private void hashLookupSortedWork(BytesRefHash hash, IntBlock.Builder builder) {
+$else$
+    private void hashLookupSortedWork(LongHash hash, IntBlock.Builder builder) {
+$endif$
+        if (w == 1) {
+            hashLookupSingle(builder, hash, work[0]);
+            return;
+        }
+
+        /*
+         * Step 1 - find the first unique value in the hash
+         *   i will contain the next value to probe
+         *   prev will contain the first value in the array contained in the hash
+         *   firstLookup will contain the first value in the hash
+         */
+        int i = 1;
+        $type$ prev = work[0];
+        long firstLookup = hashLookup(hash, prev);
+        while (firstLookup < 0) {
+            if (i >= w) {
+                // Didn't find any values
+                builder.appendNull();
+                return;
+            }
+            prev = work[i];
+            firstLookup = hashLookup(hash, prev);
+            i++;
+        }
+
+        /*
+         * Step 2 - find the next unique value in the hash
+         */
+        boolean foundSecond = false;
+        while (i < w) {
+            if (false == valuesEqual(prev, work[i])) {
+                long nextLookup = hashLookup(hash, work[i]);
+                if (nextLookup >= 0) {
+                    prev = work[i];
+                    builder.beginPositionEntry();
+                    appendFound(builder, firstLookup);
+                    appendFound(builder, nextLookup);
+                    i++;
+                    foundSecond = true;
+                    break;
+                }
+            }
+            i++;
+        }
+
+        /*
+         * Step 3a - we didn't find a second value, just emit the first one
+         */
+        if (false == foundSecond) {
+            appendFound(builder, firstLookup);
+            return;
+        }
+
+        /*
+         * Step 3b - we found a second value, search for more
+         */
+        while (i < w) {
+            if (false == valuesEqual(prev, work[i])) {
+                long nextLookup = hashLookup(hash, work[i]);
+                if (nextLookup >= 0) {
+                    prev = work[i];
+                    appendFound(builder, nextLookup);
+                }
+            }
+            i++;
         }
         builder.endPositionEntry();
     }
@@ -494,8 +669,8 @@ $endif$
         int end = w;
         w = 1;
         for (int i = 1; i < end; i++) {
+            if (false == valuesEqual(prev, work[i])) {
 $if(BytesRef)$
-            if (false == prev.equals(work[i])) {
                 prev = work[i];
                 work[w].bytes = prev.bytes;
                 work[w].offset = prev.offset;
@@ -503,7 +678,6 @@ $if(BytesRef)$
                 w++;
             }
 $else$
-            if (prev != work[i]) {
                 prev = work[i];
                 work[w++] = prev;
             }
@@ -530,14 +704,51 @@ $if(BytesRef)$
 $endif$
 
 $if(BytesRef)$
-    private void hash(IntBlock.Builder builder, BytesRefHash hash, BytesRef v) {
+    private void hashAdd(IntBlock.Builder builder, BytesRefHash hash, BytesRef v) {
 $else$
-    private void hash(IntBlock.Builder builder, LongHash hash, $type$ v) {
+    private void hashAdd(IntBlock.Builder builder, LongHash hash, $type$ v) {
 $endif$
 $if(double)$
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(Double.doubleToLongBits(v)))));
+        appendFound(builder, hash.add(Double.doubleToLongBits(v)));
 $else$
-        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(hash.add(v))));
+        appendFound(builder, hash.add(v));
+$endif$
+    }
+
+$if(BytesRef)$
+    private long hashLookup(BytesRefHash hash, BytesRef v) {
+$else$
+    private long hashLookup(LongHash hash, $type$ v) {
+$endif$
+$if(double)$
+        return hash.find(Double.doubleToLongBits(v));
+$else$
+        return hash.find(v);
+$endif$
+    }
+
+$if(BytesRef)$
+    private void hashLookupSingle(IntBlock.Builder builder, BytesRefHash hash, BytesRef v) {
+$else$
+    private void hashLookupSingle(IntBlock.Builder builder, LongHash hash, $type$ v) {
+$endif$
+        long found = hashLookup(hash, v);
+        if (found >= 0) {
+            appendFound(builder, found);
+        } else {
+            builder.appendNull();
+        }
+    }
+
+    private void appendFound(IntBlock.Builder builder, long found) {
+        builder.appendInt(Math.toIntExact(BlockHash.hashOrdToGroupNullReserved(found)));
+    }
+
+    private static boolean valuesEqual($type$ lhs, $type$ rhs) {
+$if(BytesRef)$
+        return lhs.equals(rhs);
+$else$
+        return lhs == rhs;
 $endif$
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -861,6 +861,41 @@ public class BasicBlockTests extends ESTestCase {
         int valueCount() {
             return values.stream().mapToInt(l -> l == null ? 0 : l.size()).sum();
         }
+
+        /**
+         * Build a {@link RandomBlock} contain the values of two blocks, preserving the relative order.
+         */
+        public BasicBlockTests.RandomBlock merge(BasicBlockTests.RandomBlock rhs) {
+            int estimatedSize = values().size() + rhs.values().size();
+            int l = 0;
+            int r = 0;
+            List<List<Object>> mergedValues = new ArrayList<>(estimatedSize);
+            try (Block.Builder mergedBlock = block.elementType().newBlockBuilder(estimatedSize, block.blockFactory())) {
+                while (l < values.size() && r < rhs.values.size()) {
+                    if (randomBoolean()) {
+                        mergedValues.add(values.get(l));
+                        mergedBlock.copyFrom(block, l, l + 1);
+                        l++;
+                    } else {
+                        mergedValues.add(rhs.values.get(r));
+                        mergedBlock.copyFrom(rhs.block, r, r + 1);
+                        r++;
+                    }
+                }
+                while (l < values.size()) {
+                    mergedValues.add(values.get(l));
+                    mergedBlock.copyFrom(block, l, l + 1);
+                    l++;
+                }
+                while (r < rhs.values.size()) {
+                    mergedValues.add(rhs.values.get(r));
+                    mergedBlock.copyFrom(rhs.block, r, r + 1);
+                    r++;
+                }
+                return new BasicBlockTests.RandomBlock(mergedValues, mergedBlock.build());
+            }
+        }
+
     }
 
     public static RandomBlock randomBlock(


### PR DESCRIPTION
The infrastruction that powers aggregation grouping uses a method called `MultivalueDedupe#hash` which deduplicates all the values in a row, adds them to the hash, and then returns all of the ordinals it added. This renames that method to `hashAdd` and adds another method `hashLookup` which performs the same deduplication and then looks the values up in the hash instead of adding them. It produces the same values as `hashAdd` would return, except when the hash doesn't contain the value - in that case it just adds `null` to the block of ordinals.

Think of this as looking up what the aggregation ordinal would be, rather than building ordinals. I have big plans for this.