### PR TITLE
[8.14] Mute flaky blocked thread pool test (#107625) (#107630)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/indices/SystemIndexThreadPoolTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/SystemIndexThreadPoolTestCase.java
@@ -69,6 +69,7 @@ public abstract class SystemIndexThreadPoolTestCase extends ESIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107625")
     public void testUserThreadPoolsAreBlocked() {
         assertAcked(client().admin().indices().prepareCreate(USER_INDEX));
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Mute flaky blocked thread pool test (#107625) (#107630)