### PR TITLE
Create a utility method for running tests with blocked thread pools

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/indices/SystemIndexThreadPoolUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/SystemIndexThreadPoolUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Collection;
+import java.util.concurrent.Phaser;
+
+/**
+ * Static utility methods for testing system index thread pools
+ *
+ * <p>Some of our plugins already have large and well-developed integration test cases,
+ * and can't also subclass {@link SystemIndexThreadPoolTestCase}. Integration tests for
+ * such plugins can call {@link #runWithBlockedThreadPools(Collection, InternalTestCluster, Runnable)}
+ * directly.</p>
+ */
+public class SystemIndexThreadPoolUtils {
+
+    private SystemIndexThreadPoolUtils() {
+        throw new AssertionError("This is a utility class and shouldn't be instantiated");
+    }
+
+    public static void runWithBlockedThreadPools(
+        Collection<String> threadPoolsToBlock,
+        InternalTestCluster internalCluster,
+        Runnable runnable
+    ) {
+        Phaser phaser = new Phaser();
+        Runnable waitAction = () -> {
+            phaser.arriveAndAwaitAdvance();
+            phaser.arriveAndAwaitAdvance();
+        };
+        phaser.register(); // register this test's thread
+
+        for (String nodeName : internalCluster.getNodeNames()) {
+            ThreadPool threadPool = internalCluster.getInstance(ThreadPool.class, nodeName);
+            for (String threadPoolName : threadPoolsToBlock) {
+                ThreadPool.Info info = threadPool.info(threadPoolName);
+                phaser.bulkRegister(info.getMax());
+                for (int i = 0; i < info.getMax(); i++) {
+                    threadPool.executor(threadPoolName).submit(waitAction);
+                }
+            }
+        }
+        phaser.arriveAndAwaitAdvance();
+        try {
+            runnable.run();
+        } finally {
+            phaser.arriveAndAwaitAdvance();
+        }
+    }
+}


### PR DESCRIPTION
Some of our plugins integration test case classes that handle a lot of crucial setup and teardown logic. Rather than trying to reverse engineer that logic for a subclass of `SystemIndexThreadPoolTestCase`, we should make a utility method available that can be used with the existing integration test superclass for that plugin.

For example, in my first pass at Watcher system index thread pool tests for https://github.com/elastic/elasticsearch/pull/107591, I copied [some boilerplate](https://github.com/elastic/elasticsearch/pull/107591/commits/459b790f070c3008752457f0f752e73da760e777#diff-86fbe17ff7bebe7207882e52595a2817a68d4d5f7161b2d04d3ca449fc6fb887R51) just to get the tests running. When I started writing tests for security indices, bringing logic over from `SecurityIntegTestCase` was going to be difficult and time-consuming.

This refactoring keeps the `SystemIndexThreadPoolTestCase` for plugins that don't have a standard test case superclass, which is the case with Kibana.