### PR TITLE
Avoiding use of writeVLong for negative numbers in enrich cache stats

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/action/EnrichStatsAction.java
@@ -203,8 +203,8 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
                     in.readVLong(),
                     in.readVLong(),
                     in.readVLong(),
-                    in.getTransportVersion().onOrAfter(TransportVersions.ENRICH_CACHE_ADDITIONAL_STATS) ? in.readVLong() : -1,
-                    in.getTransportVersion().onOrAfter(TransportVersions.ENRICH_CACHE_ADDITIONAL_STATS) ? in.readVLong() : -1
+                    in.getTransportVersion().onOrAfter(TransportVersions.ENRICH_CACHE_ADDITIONAL_STATS) ? in.readLong() : -1,
+                    in.getTransportVersion().onOrAfter(TransportVersions.ENRICH_CACHE_ADDITIONAL_STATS) ? in.readLong() : -1
                 );
             }
 
@@ -228,8 +228,8 @@ public class EnrichStatsAction extends ActionType<EnrichStatsAction.Response> {
                 out.writeVLong(misses);
                 out.writeVLong(evictions);
                 if (out.getTransportVersion().onOrAfter(TransportVersions.ENRICH_CACHE_ADDITIONAL_STATS)) {
-                    out.writeVLong(hitsTimeInMillis);
-                    out.writeVLong(missesTimeInMillis);
+                    out.writeLong(hitsTimeInMillis);
+                    out.writeLong(missesTimeInMillis);
                 }
             }
         }


### PR DESCRIPTION
The enrich cache updates in #107579 used `StreamOutput::writeVLong` to write a potentially negative number. `writeVLong` does not support negative numbers. 