### PR TITLE
Make `MasterServiceTests#testAcking` deterministic

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -706,7 +706,6 @@ public class MasterService extends AbstractLifecycleComponent {
         public void onCommit(TimeValue commitTime) {
             TimeValue ackTimeout = contextPreservingAckListener.ackTimeout();
             if (ackTimeout == null) {
-                assert false : "ackTimeout must always be present: " + contextPreservingAckListener;
                 ackTimeout = TimeValue.ZERO;
             }
             final TimeValue timeLeft = TimeValue.timeValueNanos(Math.max(0, ackTimeout.nanos() - commitTime.nanos()));

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -706,6 +706,7 @@ public class MasterService extends AbstractLifecycleComponent {
         public void onCommit(TimeValue commitTime) {
             TimeValue ackTimeout = contextPreservingAckListener.ackTimeout();
             if (ackTimeout == null) {
+                assert false : "ackTimeout must always be present: " + contextPreservingAckListener;
                 ackTimeout = TimeValue.ZERO;
             }
             final TimeValue timeLeft = TimeValue.timeValueNanos(Math.max(0, ackTimeout.nanos() - commitTime.nanos()));


### PR DESCRIPTION
No need to use a real concurrent `ThreadPool` here, we can cover
everything we need with a fake threadpool, making the test deterministic
(and faster).

Relates #107044