### PR TITLE
[8.14] Abstract realm cache clear for role mappers (#107360)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/UserRoleMapper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/UserRoleMapper.java
@@ -46,7 +46,7 @@ public interface UserRoleMapper {
      * the whole cluster depending on whether this role-mapper has node-local data or cluster-wide
      * data.
      */
-    void refreshRealmOnChange(CachingRealm realm);
+    void clearRealmCacheOnChange(CachingRealm realm);
 
     /**
      * A representation of a user for whom roles should be mapped.

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealm.java
@@ -89,7 +89,7 @@ public class JwtRealm extends Realm implements CachingRealm, ReloadableSecurityC
         throws SettingsException {
         super(realmConfig);
         this.userRoleMapper = userRoleMapper;
-        this.userRoleMapper.refreshRealmOnChange(this);
+        this.userRoleMapper.clearRealmCacheOnChange(this);
         this.allowedClockSkew = realmConfig.getSetting(JwtRealmSettings.ALLOWED_CLOCK_SKEW);
 
         this.populateUserMetadata = realmConfig.getSetting(JwtRealmSettings.POPULATE_USER_METADATA);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
@@ -86,7 +86,7 @@ public final class KerberosRealm extends Realm implements CachingRealm {
     ) {
         super(config);
         this.userRoleMapper = nativeRoleMappingStore;
-        this.userRoleMapper.refreshRealmOnChange(this);
+        this.userRoleMapper.clearRealmCacheOnChange(this);
         final TimeValue ttl = config.getSetting(KerberosRealmSettings.CACHE_TTL_SETTING);
         if (ttl.getNanos() > 0) {
             this.userPrincipalNameToUserCache = (userPrincipalNameToUserCache == null)

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealm.java
@@ -90,7 +90,7 @@ public final class LdapRealm extends CachingUsernamePasswordRealm implements Rel
         this.roleMapper = roleMapper;
         this.threadPool = threadPool;
         this.executionTimeout = config.getSetting(LdapRealmSettings.EXECUTION_TIMEOUT);
-        roleMapper.refreshRealmOnChange(this);
+        roleMapper.clearRealmCacheOnChange(this);
     }
 
     static SessionFactory sessionFactory(RealmConfig config, SSLService sslService, ThreadPool threadPool) throws LDAPException {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -92,7 +92,7 @@ public class PkiRealm extends Realm implements CachingRealm {
         this.trustManager = trustManagers(config);
         this.principalPattern = config.getSetting(PkiRealmSettings.USERNAME_PATTERN_SETTING);
         this.roleMapper = roleMapper;
-        this.roleMapper.refreshRealmOnChange(this);
+        this.roleMapper.clearRealmCacheOnChange(this);
         this.cache = CacheBuilder.<BytesKey, User>builder()
             .setExpireAfterWrite(config.getSetting(PkiRealmSettings.CACHE_TTL_SETTING))
             .setMaximumWeight(config.getSetting(PkiRealmSettings.CACHE_MAX_USERS_SETTING))

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapper.java
@@ -21,9 +21,8 @@ import org.elasticsearch.watcher.FileWatcher;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
-import org.elasticsearch.xpack.core.security.authc.support.CachingRealm;
 import org.elasticsearch.xpack.core.security.authc.support.DnRoleMapperSettings;
-import org.elasticsearch.xpack.core.security.authc.support.UserRoleMapper;
+import org.elasticsearch.xpack.security.authc.support.mapper.AbstractRoleMapperClearRealmCache;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -34,9 +33,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
@@ -48,19 +45,17 @@ import static org.elasticsearch.xpack.security.authc.ldap.support.LdapUtils.rela
 /**
  * This class loads and monitors the file defining the mappings of DNs to internal ES Roles.
  */
-public class DnRoleMapper implements UserRoleMapper {
+public class DnRoleMapper extends AbstractRoleMapperClearRealmCache {
     private static final Logger logger = LogManager.getLogger(DnRoleMapper.class);
 
     protected final RealmConfig config;
 
     private final Path file;
     private final boolean useUnmappedGroupsAsRoles;
-    private final CopyOnWriteArrayList<Runnable> listeners = new CopyOnWriteArrayList<>();
     private volatile Map<String, List<String>> dnRoles;
 
     public DnRoleMapper(RealmConfig config, ResourceWatcherService watcherService) {
         this.config = config;
-
         useUnmappedGroupsAsRoles = config.getSetting(DnRoleMapperSettings.USE_UNMAPPED_GROUPS_AS_ROLES_SETTING);
         file = resolveFile(config);
         dnRoles = parseFileLenient(file, logger, config.type(), config.name());
@@ -71,15 +66,6 @@ public class DnRoleMapper implements UserRoleMapper {
         } catch (IOException e) {
             throw new ElasticsearchException("failed to start file watcher for role mapping file [" + file.toAbsolutePath() + "]", e);
         }
-    }
-
-    @Override
-    public void refreshRealmOnChange(CachingRealm realm) {
-        addListener(realm::expireAll);
-    }
-
-    synchronized void addListener(Runnable listener) {
-        listeners.add(Objects.requireNonNull(listener, "listener cannot be null"));
     }
 
     public static Path resolveFile(RealmConfig realmConfig) {
@@ -232,10 +218,6 @@ public class DnRoleMapper implements UserRoleMapper {
         return roles;
     }
 
-    public void notifyRefresh() {
-        listeners.forEach(Runnable::run);
-    }
-
     private class FileListener implements FileChangesListener {
         @Override
         public void onFileCreated(Path file) {
@@ -260,10 +242,9 @@ public class DnRoleMapper implements UserRoleMapper {
                         config.type(),
                         config.name()
                     );
-                    notifyRefresh();
+                    clearRealmCachesOnLocalNode();
                 }
             }
         }
     }
-
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/AbstractRoleMapperClearRealmCache.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/AbstractRoleMapperClearRealmCache.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc.support.mapper;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheAction;
+import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheRequest;
+import org.elasticsearch.xpack.core.security.authc.support.CachingRealm;
+import org.elasticsearch.xpack.core.security.authc.support.UserRoleMapper;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+/**
+ * This is the base class for {@link UserRoleMapper} implementations that need to notify registered {@link CachingRealm}s,
+ * when the role mapping rules change, to invalidate their caches that could rely on the obsolete role mapping rules.
+ */
+public abstract class AbstractRoleMapperClearRealmCache implements UserRoleMapper {
+
+    private static final Logger logger = LogManager.getLogger(AbstractRoleMapperClearRealmCache.class);
+    private final List<String> realmNamesToClearCaches = new CopyOnWriteArrayList<>();
+    private final List<Runnable> localRealmCacheInvalidators = new CopyOnWriteArrayList<>();
+
+    /**
+     * Indicates that the provided realm should have its cache cleared if this store is updated.
+     * @see ClearRealmCacheAction
+     */
+    @Override
+    public void clearRealmCacheOnChange(CachingRealm realm) {
+        realmNamesToClearCaches.add(realm.name());
+        localRealmCacheInvalidators.add(realm::expireAll);
+    }
+
+    /**
+     * {@link UserRoleMapper} implementations should be calling this method after role mappings changed,
+     * in order to clear realm caches across the cluster.
+     */
+    protected void clearRealmCachesOnAllNodes(Client client, ActionListener<Void> listener) {
+        if (realmNamesToClearCaches.isEmpty()) {
+            listener.onResponse(null);
+            return;
+        }
+        final String[] realmNames = this.realmNamesToClearCaches.toArray(Strings.EMPTY_ARRAY);
+        executeAsyncWithOrigin(
+            client,
+            SECURITY_ORIGIN,
+            ClearRealmCacheAction.INSTANCE,
+            new ClearRealmCacheRequest().realms(realmNames),
+            ActionListener.wrap(response -> {
+                logger.debug(() -> format("Cleared cached in realms [%s] due to role mapping change", Arrays.toString(realmNames)));
+                listener.onResponse(null);
+            }, ex -> {
+                logger.warn(() -> "Failed to clear cache for realms [" + Arrays.toString(realmNames) + "]", ex);
+                listener.onFailure(ex);
+            })
+        );
+    }
+
+    // public for testing
+    /**
+     * {@link UserRoleMapper} implementations should be calling this method after role mappings changed,
+     * in order to clear realm caches on the local node only.
+     */
+    public void clearRealmCachesOnLocalNode() {
+        localRealmCacheInvalidators.forEach(Runnable::run);
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
@@ -54,8 +54,8 @@ public class CompositeRoleMapper implements UserRoleMapper {
     }
 
     @Override
-    public void refreshRealmOnChange(CachingRealm realm) {
-        this.delegates.forEach(mapper -> mapper.refreshRealmOnChange(realm));
+    public void clearRealmCacheOnChange(CachingRealm realm) {
+        this.delegates.forEach(mapper -> mapper.clearRealmCacheOnChange(realm));
     }
 
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/ExcludingRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/ExcludingRoleMapper.java
@@ -44,7 +44,7 @@ public class ExcludingRoleMapper implements UserRoleMapper {
     }
 
     @Override
-    public void refreshRealmOnChange(CachingRealm realm) {
-        delegate.refreshRealmOnChange(realm);
+    public void clearRealmCacheOnChange(CachingRealm realm) {
+        delegate.clearRealmCacheOnChange(realm);
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.ContextPreservingActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.CheckedBiConsumer;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -33,12 +32,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.security.ScrollHelper;
-import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheAction;
-import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.DeleteRoleMappingRequest;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
-import org.elasticsearch.xpack.core.security.authc.support.CachingRealm;
-import org.elasticsearch.xpack.core.security.authc.support.UserRoleMapper;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.TemplateRoleName;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.ExpressionModel;
@@ -46,14 +41,12 @@ import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.elasticsearch.xpack.security.support.SecuritySystemIndices;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -82,7 +75,7 @@ import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SEC
  * is done by this class. Modification operations make a best effort attempt to clear the cache
  * on all nodes for the user that was modified.
  */
-public class NativeRoleMappingStore implements UserRoleMapper {
+public class NativeRoleMappingStore extends AbstractRoleMapperClearRealmCache {
 
     /**
      * This setting is never registered by the security plugin - in order to disable the native role APIs
@@ -112,7 +105,6 @@ public class NativeRoleMappingStore implements UserRoleMapper {
     private final Client client;
     private final SecurityIndexManager securityIndex;
     private final ScriptService scriptService;
-    private final List<String> realmsToRefresh = new CopyOnWriteArrayList<>();
     private final boolean lastLoadCacheEnabled;
     private final AtomicReference<List<ExpressionRoleMapping>> lastLoadRef = new AtomicReference<>(null);
     private final boolean enabled;
@@ -219,7 +211,13 @@ public class NativeRoleMappingStore implements UserRoleMapper {
         } else {
             try {
                 logger.trace("Modifying role mapping [{}] for [{}]", name, request.getClass().getSimpleName());
-                inner.accept(request, ActionListener.wrap(r -> refreshRealms(listener, r), listener::onFailure));
+                inner.accept(
+                    request,
+                    ActionListener.wrap(
+                        r -> clearRealmCachesOnAllNodes(client, ActionListener.wrap(aVoid -> listener.onResponse(r), listener::onFailure)),
+                        listener::onFailure
+                    )
+                );
             } catch (Exception e) {
                 logger.error(() -> "failed to modify role-mapping [" + name + "]", e);
                 listener.onFailure(e);
@@ -392,7 +390,9 @@ public class NativeRoleMappingStore implements UserRoleMapper {
             || isIndexDeleted(previousState, currentState)
             || Objects.equals(previousState.indexUUID, currentState.indexUUID) == false
             || previousState.isIndexUpToDate != currentState.isIndexUpToDate) {
-            refreshRealms(ActionListener.noop(), null);
+            // the notification that the index state changed is received on every node
+            // this means that here we need only to invalidate the local realm caches only
+            clearRealmCachesOnLocalNode();
         }
     }
 
@@ -412,38 +412,6 @@ public class NativeRoleMappingStore implements UserRoleMapper {
             logger.debug("Mapping user [{}] to roles [{}]", user, roles);
             listener.onResponse(roles);
         }, listener::onFailure));
-    }
-
-    /**
-     * Indicates that the provided realm should have its cache cleared if this store is updated
-     * (that is, {@link #putRoleMapping(PutRoleMappingRequest, ActionListener)} or
-     * {@link #deleteRoleMapping(DeleteRoleMappingRequest, ActionListener)} are called).
-     * @see ClearRealmCacheAction
-     */
-    @Override
-    public void refreshRealmOnChange(CachingRealm realm) {
-        realmsToRefresh.add(realm.name());
-    }
-
-    private <Result> void refreshRealms(ActionListener<Result> listener, Result result) {
-        if (enabled == false || realmsToRefresh.isEmpty()) {
-            listener.onResponse(result);
-            return;
-        }
-        final String[] realmNames = this.realmsToRefresh.toArray(Strings.EMPTY_ARRAY);
-        executeAsyncWithOrigin(
-            client,
-            SECURITY_ORIGIN,
-            ClearRealmCacheAction.INSTANCE,
-            new ClearRealmCacheRequest().realms(realmNames),
-            ActionListener.wrap(response -> {
-                logger.debug(() -> format("Cleared cached in realms [%s] due to role mapping change", Arrays.toString(realmNames)));
-                listener.onResponse(result);
-            }, ex -> {
-                logger.warn(() -> "Failed to clear cache for realms [" + Arrays.toString(realmNames) + "]", ex);
-                listener.onFailure(ex);
-            })
-        );
     }
 
     protected static ExpressionRoleMapping buildMapping(String id, BytesReference source) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmAuthenticateFailedTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmAuthenticateFailedTests.java
@@ -160,7 +160,7 @@ public class KerberosRealmAuthenticateFailedTests extends KerberosRealmTestCase 
             eq(krbDebug),
             anyActionListener()
         );
-        verify(mockNativeRoleMappingStore).refreshRealmOnChange(kerberosRealm);
+        verify(mockNativeRoleMappingStore).clearRealmCacheOnChange(kerberosRealm);
         verifyNoMoreInteractions(mockKerberosTicketValidator, mockNativeRoleMappingStore);
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmCacheTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmCacheTests.java
@@ -65,7 +65,7 @@ public class KerberosRealmCacheTests extends KerberosRealmTestCase {
             eq(krbDebug),
             anyActionListener()
         );
-        verify(mockNativeRoleMappingStore).refreshRealmOnChange(kerberosRealm);
+        verify(mockNativeRoleMappingStore).clearRealmCacheOnChange(kerberosRealm);
         verify(mockNativeRoleMappingStore).resolveRoles(any(UserData.class), anyActionListener());
         verifyNoMoreInteractions(mockKerberosTicketValidator, mockNativeRoleMappingStore);
     }
@@ -74,7 +74,7 @@ public class KerberosRealmCacheTests extends KerberosRealmTestCase {
         final String outToken = randomAlphaOfLength(10);
         final List<String> userNames = Arrays.asList(randomPrincipalName(), randomPrincipalName());
         final KerberosRealm kerberosRealm = createKerberosRealm(userNames.toArray(new String[0]));
-        verify(mockNativeRoleMappingStore).refreshRealmOnChange(kerberosRealm);
+        verify(mockNativeRoleMappingStore).clearRealmCacheOnChange(kerberosRealm);
 
         final String authNUsername = randomFrom(userNames);
         final byte[] decodedTicket = randomByteArrayOfLength(10);
@@ -154,7 +154,7 @@ public class KerberosRealmCacheTests extends KerberosRealmTestCase {
             eq(krbDebug),
             anyActionListener()
         );
-        verify(mockNativeRoleMappingStore).refreshRealmOnChange(kerberosRealm);
+        verify(mockNativeRoleMappingStore).clearRealmCacheOnChange(kerberosRealm);
         verify(mockNativeRoleMappingStore, times(2)).resolveRoles(any(UserData.class), anyActionListener());
         verifyNoMoreInteractions(mockKerberosTicketValidator, mockNativeRoleMappingStore);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTests.java
@@ -97,7 +97,7 @@ public class KerberosRealmTests extends KerberosRealmTestCase {
             eq(krbDebug),
             anyActionListener()
         );
-        verify(mockNativeRoleMappingStore).refreshRealmOnChange(kerberosRealm);
+        verify(mockNativeRoleMappingStore).clearRealmCacheOnChange(kerberosRealm);
         verify(mockNativeRoleMappingStore).resolveRoles(any(UserData.class), anyActionListener());
         verifyNoMoreInteractions(mockKerberosTicketValidator, mockNativeRoleMappingStore);
     }
@@ -255,7 +255,7 @@ public class KerberosRealmTests extends KerberosRealmTestCase {
             eq(krbDebug),
             anyActionListener()
         );
-        verify(mockNativeRoleMappingStore).refreshRealmOnChange(kerberosRealm);
+        verify(mockNativeRoleMappingStore).clearRealmCacheOnChange(kerberosRealm);
         verifyNoMoreInteractions(mockKerberosTicketValidator, mockNativeRoleMappingStore);
         verify(otherRealm, times(2)).lookupUser(eq(expectedUsername), anyActionListener());
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/ActiveDirectoryRealmTests.java
@@ -318,7 +318,7 @@ public class ActiveDirectoryRealmTests extends ESTestCase {
         verify(sessionFactory, times(1)).session(eq("CN=ironman"), any(SecureString.class), anyActionListener());
 
         // Refresh the role mappings
-        roleMapper.notifyRefresh();
+        roleMapper.clearRealmCachesOnLocalNode();
 
         for (int i = 0; i < count; i++) {
             PlainActionFuture<AuthenticationResult<User>> future = new PlainActionFuture<>();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/LdapRealmTests.java
@@ -259,7 +259,7 @@ public class LdapRealmTests extends LdapTestCase {
         // verify one and only one session -> caching is working
         verify(ldapFactory, times(1)).session(anyString(), any(SecureString.class), anyActionListener());
 
-        roleMapper.notifyRefresh();
+        roleMapper.clearRealmCachesOnLocalNode();
 
         future = new PlainActionFuture<>();
         ldap.authenticate(new UsernamePasswordToken(VALID_USERNAME, new SecureString(PASSWORD)), future);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/pki/PkiRealmTests.java
@@ -140,7 +140,7 @@ public class PkiRealmTests extends ESTestCase {
         X509AuthenticationToken token = buildToken();
         UserRoleMapper roleMapper = buildRoleMapper(roles, token.dn());
         PkiRealm realm = buildRealm(roleMapper, globalSettings);
-        verify(roleMapper).refreshRealmOnChange(realm);
+        verify(roleMapper).clearRealmCacheOnChange(realm);
 
         final String expectedUsername = PkiRealm.getPrincipalFromSubjectDN(
             Pattern.compile(PkiRealmSettings.DEFAULT_USERNAME_PATTERN),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ExcludingRoleMapperTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/ExcludingRoleMapperTests.java
@@ -71,9 +71,9 @@ public class ExcludingRoleMapperTests extends ESTestCase {
     public void testRefreshRealmOnChange() {
         final UserRoleMapper delegate = mock(UserRoleMapper.class);
         final CachingRealm realm = mock(CachingRealm.class);
-        new ExcludingRoleMapper(delegate, randomSet(0, 5, () -> randomAlphaOfLengthBetween(3, 6))).refreshRealmOnChange(realm);
+        new ExcludingRoleMapper(delegate, randomSet(0, 5, () -> randomAlphaOfLengthBetween(3, 6))).clearRealmCacheOnChange(realm);
 
-        verify(delegate, times(1)).refreshRealmOnChange(same(realm));
+        verify(delegate, times(1)).clearRealmCacheOnChange(same(realm));
         verify(delegate, times(0)).resolveRoles(any(UserRoleMapper.UserData.class), anyActionListener());
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.script.ScriptModule;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.mustache.MustacheScriptEngine;
@@ -36,18 +35,15 @@ import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheAction;
 import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheRequest;
 import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheResponse;
 import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRequest;
-import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
+import org.elasticsearch.xpack.core.security.authc.support.CachingRealm;
 import org.elasticsearch.xpack.core.security.authc.support.UserRoleMapper;
-import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.TemplateRoleName;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.FieldExpression;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.FieldExpression.FieldValue;
 import org.elasticsearch.xpack.core.security.test.TestRestrictedIndices;
-import org.elasticsearch.xpack.core.security.user.User;
-import org.elasticsearch.xpack.security.authc.support.CachingUsernamePasswordRealm;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -425,33 +421,38 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
     }
 
     public void testCacheClearOnIndexHealthChange() {
-        final AtomicInteger numInvalidation = new AtomicInteger(0);
-        final NativeRoleMappingStore store = buildRoleMappingStoreForInvalidationTesting(numInvalidation, true);
+        final AtomicInteger numGlobalInvalidation = new AtomicInteger(0);
+        final AtomicInteger numLocalInvalidation = new AtomicInteger(0);
+        final NativeRoleMappingStore store = buildRoleMappingStoreForInvalidationTesting(numGlobalInvalidation, numLocalInvalidation, true);
 
         int expectedInvalidation = 0;
         // existing to no longer present
         SecurityIndexManager.State previousState = dummyState(randomFrom(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW));
         SecurityIndexManager.State currentState = dummyState(null);
         store.onSecurityIndexStateChange(previousState, currentState);
-        assertEquals(++expectedInvalidation, numInvalidation.get());
+        assertEquals(++expectedInvalidation, numLocalInvalidation.get());
+        assertEquals(0, numGlobalInvalidation.get());
 
         // doesn't exist to exists
         previousState = dummyState(null);
         currentState = dummyState(randomFrom(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW));
         store.onSecurityIndexStateChange(previousState, currentState);
-        assertEquals(++expectedInvalidation, numInvalidation.get());
+        assertEquals(++expectedInvalidation, numLocalInvalidation.get());
+        assertEquals(0, numGlobalInvalidation.get());
 
         // green or yellow to red
         previousState = dummyState(randomFrom(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW));
         currentState = dummyState(ClusterHealthStatus.RED);
         store.onSecurityIndexStateChange(previousState, currentState);
-        assertEquals(expectedInvalidation, numInvalidation.get());
+        assertEquals(expectedInvalidation, numLocalInvalidation.get());
+        assertEquals(0, numGlobalInvalidation.get());
 
         // red to non red
         previousState = dummyState(ClusterHealthStatus.RED);
         currentState = dummyState(randomFrom(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW));
         store.onSecurityIndexStateChange(previousState, currentState);
-        assertEquals(++expectedInvalidation, numInvalidation.get());
+        assertEquals(++expectedInvalidation, numLocalInvalidation.get());
+        assertEquals(0, numGlobalInvalidation.get());
 
         // green to yellow or yellow to green
         previousState = dummyState(randomFrom(ClusterHealthStatus.GREEN, ClusterHealthStatus.YELLOW));
@@ -459,28 +460,38 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
             previousState.indexHealth == ClusterHealthStatus.GREEN ? ClusterHealthStatus.YELLOW : ClusterHealthStatus.GREEN
         );
         store.onSecurityIndexStateChange(previousState, currentState);
-        assertEquals(expectedInvalidation, numInvalidation.get());
+        assertEquals(expectedInvalidation, numLocalInvalidation.get());
+        assertEquals(0, numGlobalInvalidation.get());
     }
 
     public void testCacheClearOnIndexOutOfDateChange() {
-        final AtomicInteger numInvalidation = new AtomicInteger(0);
-        final NativeRoleMappingStore store = buildRoleMappingStoreForInvalidationTesting(numInvalidation, true);
+        final AtomicInteger numGlobalInvalidation = new AtomicInteger(0);
+        final AtomicInteger numLocalInvalidation = new AtomicInteger(0);
+        final NativeRoleMappingStore store = buildRoleMappingStoreForInvalidationTesting(numGlobalInvalidation, numLocalInvalidation, true);
 
         store.onSecurityIndexStateChange(indexState(false, null), indexState(true, null));
-        assertEquals(1, numInvalidation.get());
+        assertEquals(0, numGlobalInvalidation.get());
+        assertEquals(1, numLocalInvalidation.get());
 
         store.onSecurityIndexStateChange(indexState(true, null), indexState(false, null));
-        assertEquals(2, numInvalidation.get());
+        assertEquals(0, numGlobalInvalidation.get());
+        assertEquals(2, numLocalInvalidation.get());
     }
 
     public void testCacheIsNotClearedIfNoRealmsAreAttached() {
-        final AtomicInteger numInvalidation = new AtomicInteger(0);
-        final NativeRoleMappingStore store = buildRoleMappingStoreForInvalidationTesting(numInvalidation, false);
+        final AtomicInteger numGlobalInvalidation = new AtomicInteger(0);
+        final AtomicInteger numLocalInvalidation = new AtomicInteger(0);
+        final NativeRoleMappingStore store = buildRoleMappingStoreForInvalidationTesting(
+            numGlobalInvalidation,
+            numLocalInvalidation,
+            false
+        );
 
         final SecurityIndexManager.State noIndexState = dummyState(null);
         final SecurityIndexManager.State greenIndexState = dummyState(ClusterHealthStatus.GREEN);
         store.onSecurityIndexStateChange(noIndexState, greenIndexState);
-        assertEquals(0, numInvalidation.get());
+        assertEquals(0, numGlobalInvalidation.get());
+        assertEquals(0, numLocalInvalidation.get());
     }
 
     public void testPutRoleMappingWillValidateTemplateRoleNamesBeforeSave() {
@@ -499,7 +510,11 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
         expectThrows(IllegalArgumentException.class, () -> nativeRoleMappingStore.putRoleMapping(putRoleMappingRequest, null));
     }
 
-    private NativeRoleMappingStore buildRoleMappingStoreForInvalidationTesting(AtomicInteger invalidationCounter, boolean attachRealm) {
+    private NativeRoleMappingStore buildRoleMappingStoreForInvalidationTesting(
+        AtomicInteger globalInvalidationCounter,
+        AtomicInteger localInvalidationCounter,
+        boolean attachRealm
+    ) {
         final Settings settings = Settings.builder().put("path.home", createTempDir()).build();
 
         final ThreadPool threadPool = mock(ThreadPool.class);
@@ -518,7 +533,7 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
 
             @SuppressWarnings("unchecked")
             ActionListener<ClearRealmCacheResponse> listener = (ActionListener<ClearRealmCacheResponse>) invocationOnMock.getArguments()[2];
-            invalidationCounter.incrementAndGet();
+            globalInvalidationCounter.incrementAndGet();
             listener.onResponse(new ClearRealmCacheResponse(new ClusterName("cluster"), Collections.emptyList(), Collections.emptyList()));
             return null;
         }).when(client).execute(eq(ClearRealmCacheAction.INSTANCE), any(ClearRealmCacheRequest.class), anyActionListener());
@@ -531,26 +546,13 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
         );
 
         if (attachRealm) {
-            final Environment env = TestEnvironment.newEnvironment(settings);
-            final RealmConfig.RealmIdentifier identifier = new RealmConfig.RealmIdentifier("ldap", realmName);
-            final RealmConfig realmConfig = new RealmConfig(
-                identifier,
-                Settings.builder().put(settings).put(RealmSettings.getFullSettingKey(identifier, RealmSettings.ORDER_SETTING), 0).build(),
-                env,
-                threadContext
-            );
-            final CachingUsernamePasswordRealm mockRealm = new CachingUsernamePasswordRealm(realmConfig, threadPool) {
-                @Override
-                protected void doAuthenticate(UsernamePasswordToken token, ActionListener<AuthenticationResult<User>> listener) {
-                    listener.onResponse(AuthenticationResult.notHandled());
-                }
-
-                @Override
-                protected void doLookupUser(String username, ActionListener<User> listener) {
-                    listener.onResponse(null);
-                }
-            };
-            store.refreshRealmOnChange(mockRealm);
+            CachingRealm mockRealm = mock(CachingRealm.class);
+            when(mockRealm.name()).thenReturn("mockRealm");
+            doAnswer(inv -> {
+                localInvalidationCounter.incrementAndGet();
+                return null;
+            }).when(mockRealm).expireAll();
+            store.clearRealmCacheOnChange(mockRealm);
         }
         return store;
     }

--- a/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
+++ b/x-pack/qa/security-example-spi-extension/src/main/java/org/elasticsearch/example/realm/CustomRoleMappingRealm.java
@@ -42,7 +42,7 @@ public final class CustomRoleMappingRealm extends Realm implements CachingRealm 
         super(config);
         this.cache = CacheBuilder.<String, User>builder().build();
         this.roleMapper = roleMapper;
-        this.roleMapper.refreshRealmOnChange(this);
+        this.roleMapper.clearRealmCacheOnChange(this);
     }
 
     @Override


### PR DESCRIPTION
Backport of https://github.com/elastic/elasticsearch/pull/107360

This is mostly a refactoring but also a minor bug-fix.
The bug-fix avoids potentially many unnecessary realm cache invalidations when
the state of the .security index changes.