### PR TITLE
[build-tools] licensingDir should be relative to enable caching between builds in different directories

### DIFF
--- a/docs/changelog/107657.yaml
+++ b/docs/changelog/107657.yaml
@@ -1,5 +1,0 @@
-pr: 107312
-summary: licensingDir should be relative to enable caching between builds
-area: Delivery/Build
-type: enhancement
-issues: []

--- a/docs/changelog/107657.yaml
+++ b/docs/changelog/107657.yaml
@@ -1,5 +1,5 @@
 pr: 107312
 summary: licensingDir should be relative to enable caching between builds
-area: Build
+area: Delivery/Build
 type: enhancement
 issues: []

--- a/docs/changelog/107657.yaml
+++ b/docs/changelog/107657.yaml
@@ -1,0 +1,5 @@
+pr: 107312
+summary: licensingDir should be relative to enable caching between builds
+area: Build
+type: enhancement
+issues: []

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -134,6 +134,8 @@ tasks.register("extractNativeLicenses", Copy) {
 tasks.named('generateNotice').configure {
   dependsOn "extractNativeLicenses"
   inputs.dir("${project.buildDir}/extractedNativeLicenses/platform/licenses")
+    .withPropertyName('licensingDir')
+    .withPathSensitivity(PathSensitivity.RELATIVE)
   licenseDirs.add(tasks.named("extractNativeLicenses").map {new File(it.destinationDir, "platform/licenses") })
 }
 


### PR DESCRIPTION
Enable better caching of the generated file in "licensingDir".