### PR TITLE
Cleanup convoluted loop that worked around fixed C2 bug

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -436,10 +436,7 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
         protected InternalAggregation adapt(InternalAggregation delegateResult) {
             InternalDateRange range = (InternalDateRange) delegateResult;
             List<InternalDateHistogram.Bucket> buckets = new ArrayList<>(range.getBuckets().size());
-            // This code below was converted from a regular for loop to a stream forEach to avoid
-            // JDK-8285835. It needs to stay in this form until we upgrade our JDK distribution to
-            // pick up a fix for the compiler crash.
-            range.getBuckets().stream().forEach(rangeBucket -> {
+            for (InternalDateRange.Bucket rangeBucket : range.getBuckets()) {
                 if (rangeBucket.getDocCount() > 0) {
                     buckets.add(
                         new InternalDateHistogram.Bucket(
@@ -451,7 +448,7 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
                         )
                     );
                 }
-            });
+            }
 
             CollectionUtil.introSort(buckets, BucketOrder.key(true).comparator());
 


### PR DESCRIPTION
The bug has been fixed in supported JDKs now, we can revert this fix to cleanup a little and maybe get a tiny bit of performance back as well.

See https://github.com/elastic/elasticsearch/pull/86614 for the original fix