### PR TITLE
Optimize GeoBounds and GeoCentroid aggregations for single value fields

### DIFF
--- a/docs/changelog/107663.yaml
+++ b/docs/changelog/107663.yaml
@@ -1,0 +1,5 @@
+pr: 107663
+summary: Optimize `GeoBounds` and `GeoCentroid` aggregations for single value fields
+area: Geo
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
@@ -11,6 +11,8 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.GeoPointValues;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -67,64 +69,64 @@ final class GeoBoundsAggregator extends MetricsAggregator {
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) {
         final MultiGeoPointValues values = valuesSource.geoPointValues(aggCtx.getLeafReaderContext());
+        final GeoPointValues singleton = FieldData.unwrapSingleton(values);
+        return singleton != null ? getLeafCollector(singleton, sub) : getLeafCollector(values, sub);
+    }
+
+    private LeafBucketCollector getLeafCollector(MultiGeoPointValues values, LeafBucketCollector sub) {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                if (bucket >= tops.size()) {
-                    long from = tops.size();
-                    tops = bigArrays().grow(tops, bucket + 1);
-                    tops.fill(from, tops.size(), Double.NEGATIVE_INFINITY);
-                    bottoms = bigArrays().resize(bottoms, tops.size());
-                    bottoms.fill(from, bottoms.size(), Double.POSITIVE_INFINITY);
-                    posLefts = bigArrays().resize(posLefts, tops.size());
-                    posLefts.fill(from, posLefts.size(), Double.POSITIVE_INFINITY);
-                    posRights = bigArrays().resize(posRights, tops.size());
-                    posRights.fill(from, posRights.size(), Double.NEGATIVE_INFINITY);
-                    negLefts = bigArrays().resize(negLefts, tops.size());
-                    negLefts.fill(from, negLefts.size(), Double.POSITIVE_INFINITY);
-                    negRights = bigArrays().resize(negRights, tops.size());
-                    negRights.fill(from, negRights.size(), Double.NEGATIVE_INFINITY);
-                }
-
+                growBucket(bucket);
                 if (values.advanceExact(doc)) {
-                    final int valuesCount = values.docValueCount();
-
-                    for (int i = 0; i < valuesCount; ++i) {
-                        GeoPoint value = values.nextValue();
-                        double top = tops.get(bucket);
-                        if (value.lat() > top) {
-                            top = value.lat();
-                        }
-                        double bottom = bottoms.get(bucket);
-                        if (value.lat() < bottom) {
-                            bottom = value.lat();
-                        }
-                        double posLeft = posLefts.get(bucket);
-                        if (value.lon() >= 0 && value.lon() < posLeft) {
-                            posLeft = value.lon();
-                        }
-                        double posRight = posRights.get(bucket);
-                        if (value.lon() >= 0 && value.lon() > posRight) {
-                            posRight = value.lon();
-                        }
-                        double negLeft = negLefts.get(bucket);
-                        if (value.lon() < 0 && value.lon() < negLeft) {
-                            negLeft = value.lon();
-                        }
-                        double negRight = negRights.get(bucket);
-                        if (value.lon() < 0 && value.lon() > negRight) {
-                            negRight = value.lon();
-                        }
-                        tops.set(bucket, top);
-                        bottoms.set(bucket, bottom);
-                        posLefts.set(bucket, posLeft);
-                        posRights.set(bucket, posRight);
-                        negLefts.set(bucket, negLeft);
-                        negRights.set(bucket, negRight);
+                    for (int i = 0; i < values.docValueCount(); ++i) {
+                        addPoint(values.nextValue(), bucket);
                     }
                 }
             }
         };
+    }
+
+    private LeafBucketCollector getLeafCollector(GeoPointValues values, LeafBucketCollector sub) {
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                growBucket(bucket);
+                if (values.advanceExact(doc)) {
+                    addPoint(values.pointValue(), bucket);
+                }
+            }
+        };
+    }
+
+    private void growBucket(long bucket) {
+        if (bucket >= tops.size()) {
+            long from = tops.size();
+            tops = bigArrays().grow(tops, bucket + 1);
+            tops.fill(from, tops.size(), Double.NEGATIVE_INFINITY);
+            bottoms = bigArrays().resize(bottoms, tops.size());
+            bottoms.fill(from, bottoms.size(), Double.POSITIVE_INFINITY);
+            posLefts = bigArrays().resize(posLefts, tops.size());
+            posLefts.fill(from, posLefts.size(), Double.POSITIVE_INFINITY);
+            posRights = bigArrays().resize(posRights, tops.size());
+            posRights.fill(from, posRights.size(), Double.NEGATIVE_INFINITY);
+            negLefts = bigArrays().resize(negLefts, tops.size());
+            negLefts.fill(from, negLefts.size(), Double.POSITIVE_INFINITY);
+            negRights = bigArrays().resize(negRights, tops.size());
+            negRights.fill(from, negRights.size(), Double.NEGATIVE_INFINITY);
+        }
+    }
+
+    private void addPoint(GeoPoint value, long bucket) {
+        tops.set(bucket, Math.max(tops.get(bucket), value.lat()));
+        bottoms.set(bucket, Math.min(bottoms.get(bucket), value.lat()));
+        if (value.lon() >= 0) {
+            posLefts.set(bucket, Math.min(posLefts.get(bucket), value.lon()));
+            posRights.set(bucket, Math.max(posRights.get(bucket), value.lon()));
+        } else {
+            negLefts.set(bucket, Math.min(negLefts.get(bucket), value.lon()));
+            negRights.set(bucket, Math.max(negRights.get(bucket), value.lon()));
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
@@ -12,6 +12,8 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.GeoPointValues;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -53,35 +55,28 @@ final class GeoCentroidAggregator extends MetricsAggregator {
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) throws IOException {
         final MultiGeoPointValues values = valuesSource.geoPointValues(aggCtx.getLeafReaderContext());
+        final GeoPointValues singleton = FieldData.unwrapSingleton(values);
+        return singleton != null ? getLeafCollector(singleton, sub) : getLeafCollector(values, sub);
+    }
+
+    private LeafBucketCollector getLeafCollector(MultiGeoPointValues values, LeafBucketCollector sub) {
         final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
-
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                latSum = bigArrays().grow(latSum, bucket + 1);
-                lonSum = bigArrays().grow(lonSum, bucket + 1);
-                lonCompensations = bigArrays().grow(lonCompensations, bucket + 1);
-                latCompensations = bigArrays().grow(latCompensations, bucket + 1);
-                counts = bigArrays().grow(counts, bucket + 1);
-
+                growBucket(bucket);
                 if (values.advanceExact(doc)) {
                     final int valueCount = values.docValueCount();
                     // increment by the number of points for this document
                     counts.increment(bucket, valueCount);
                     // Compute the sum of double values with Kahan summation algorithm which is more
                     // accurate than naive summation.
-                    double sumLat = latSum.get(bucket);
-                    double compensationLat = latCompensations.get(bucket);
-                    double sumLon = lonSum.get(bucket);
-                    double compensationLon = lonCompensations.get(bucket);
-
-                    compensatedSumLat.reset(sumLat, compensationLat);
-                    compensatedSumLon.reset(sumLon, compensationLon);
-
+                    compensatedSumLat.reset(latSum.get(bucket), latCompensations.get(bucket));
+                    compensatedSumLon.reset(lonSum.get(bucket), lonCompensations.get(bucket));
                     // update the sum
                     for (int i = 0; i < valueCount; ++i) {
-                        GeoPoint value = values.nextValue();
+                        final GeoPoint value = values.nextValue();
                         // latitude
                         compensatedSumLat.add(value.getLat());
                         // longitude
@@ -94,6 +89,47 @@ final class GeoCentroidAggregator extends MetricsAggregator {
                 }
             }
         };
+    }
+
+    private LeafBucketCollector getLeafCollector(GeoPointValues values, LeafBucketCollector sub) {
+        final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
+        final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                growBucket(bucket);
+                if (values.advanceExact(doc)) {
+                    // increment by the number of points for this document
+                    counts.increment(bucket, 1);
+                    // Compute the sum of double values with Kahan summation algorithm which is more
+                    // accurate than naive summation.
+                    compensatedSumLat.reset(latSum.get(bucket), latCompensations.get(bucket));
+                    compensatedSumLon.reset(lonSum.get(bucket), lonCompensations.get(bucket));
+                    // update the sum
+                    final GeoPoint value = values.pointValue();
+                    // latitude
+                    compensatedSumLat.add(value.getLat());
+                    // longitude
+                    compensatedSumLon.add(value.getLon());
+
+                    lonSum.set(bucket, compensatedSumLon.value());
+                    lonCompensations.set(bucket, compensatedSumLon.delta());
+                    latSum.set(bucket, compensatedSumLat.value());
+                    latCompensations.set(bucket, compensatedSumLat.delta());
+                }
+            }
+        };
+    }
+
+    private void growBucket(long bucket) {
+        if (bucket >= latSum.size()) {
+            final long newSize = bucket + 1;
+            latSum = bigArrays().grow(latSum, newSize);
+            lonSum = bigArrays().grow(lonSum, newSize);
+            lonCompensations = bigArrays().grow(lonCompensations, newSize);
+            latCompensations = bigArrays().grow(latCompensations, newSize);
+            counts = bigArrays().grow(counts, newSize);
+        }
     }
 
     @Override


### PR DESCRIPTION
I notice looking to a flamegraph for a aggregation workflow that we are not optimizing for single value fields for some geo aggregations. This is an easy win so let's optimize for single value fields in  GeoBounds and GeoCentroid aggregations.