### PR TITLE
Add node stats effective watermark thresholds docs.

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1853,6 +1853,38 @@ store.
 (integer)
 Total number of bytes available to this Java virtual machine on this file
 store.
+
+`low_watermark_free_space`::
+(<<byte-units,byte value>>)
+Total amount of effective low watermark free disk space available to this Java virtual machine on this file store.
+
+`low_watermark_free_space_in_bytes`::
+(integer)
+Total amount of effective low watermark free bytes available to this Java virtual machine on this file store.
+
+`high_watermark_free_space`::
+(<<byte-units,byte value>>)
+Total amount of effective high watermark free disk space available to this Java virtual machine on this file store.
+
+`high_watermark_free_space_in_bytes`::
+(integer)
+Total amount of effective high watermark free bytes available to this Java virtual machine on this file store.
+
+`flood_stage_free_space`::
+(<<byte-units,byte value>>)
+Total amount of effective flood stage free disk space available to this Java virtual machine on this file store.
+
+`flood_stage_free_space_in_bytes`::
+(integer)
+Total amount of effective flood stage free bytes available to this Java virtual machine on this file store.
+
+`frozen_flood_stage_free_space`::
+(<<byte-units,byte value>>)
+Total amount of effective flood stage free disk space available to this Java virtual machine on this file store for dedicated frozen nodes.
+
+`frozen_flood_stage_free_space_in_bytes`::
+(integer)
+Total amount of effective flood stage free bytes available to this Java virtual machine on this file store for dedicated frozen nodes.
 =======
 
 `io_stats` (Linux only)::


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/107244 we added effective watermark stats in node stat API, this PR update related docs.