### PR TITLE
[8.14] Use #addWithoutBreaking when adding a negative number of bytes to the circuit breaker in SequenceMatcher (#107655)

### DIFF
--- a/docs/changelog/107655.yaml
+++ b/docs/changelog/107655.yaml
@@ -1,0 +1,6 @@
+pr: 107655
+summary: "Use #addWithoutBreaking when adding a negative number of bytes to the circuit\
+  \ breaker in `SequenceMatcher`"
+area: EQL
+type: bug
+issues: []

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/sequence/SequenceMatcher.java
@@ -434,12 +434,22 @@ public class SequenceMatcher {
     // sequences.
     private void trackMemory() {
         long newRamBytesUsedInFlight = ramBytesUsedInFlight();
-        circuitBreaker.addEstimateBytesAndMaybeBreak(newRamBytesUsedInFlight - prevRamBytesUsedInFlight, CB_INFLIGHT_LABEL);
+        addRequestCircuitBreakerBytes(newRamBytesUsedInFlight - prevRamBytesUsedInFlight, CB_INFLIGHT_LABEL);
         prevRamBytesUsedInFlight = newRamBytesUsedInFlight;
 
         long newRamBytesUsedCompleted = ramBytesUsedCompleted();
-        circuitBreaker.addEstimateBytesAndMaybeBreak(newRamBytesUsedCompleted - prevRamBytesUsedCompleted, CB_COMPLETED_LABEL);
+        addRequestCircuitBreakerBytes(newRamBytesUsedCompleted - prevRamBytesUsedCompleted, CB_COMPLETED_LABEL);
         prevRamBytesUsedCompleted = newRamBytesUsedCompleted;
+    }
+
+    private void addRequestCircuitBreakerBytes(long bytes, String label) {
+        // Only use the potential to circuit break if bytes are being incremented, In the case of 0
+        // bytes, it will trigger the parent circuit breaker.
+        if (bytes >= 0) {
+            circuitBreaker.addEstimateBytesAndMaybeBreak(bytes, label);
+        } else {
+            circuitBreaker.addWithoutBreaking(bytes);
+        }
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Use #addWithoutBreaking when adding a negative number of bytes to the circuit breaker in SequenceMatcher (#107655)