### PR TITLE
Validate stats formatting in standard InternalStats constructor

### DIFF
--- a/docs/changelog/107678.yaml
+++ b/docs/changelog/107678.yaml
@@ -1,0 +1,6 @@
+pr: 107678
+summary: Validate stats formatting in standard `InternalStats` constructor
+area: Aggregations
+type: bug
+issues:
+ - 107671

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
@@ -27,8 +27,8 @@ setup:
 "fail formatting":
 
   - requires:
-      cluster_features: ["gte_v8.5.0"]
-      reason: "bug fixed in 8.5.0"
+      cluster_features: ["gte_v8.15.0"]
+      reason: "bug fixed in 8.15.0"
   - do:
       catch: /Cannot format stat \[sum\] with format \[DocValueFormat.DateTime\(format\[date_hour_minute_second_millis\] locale\[\], Z, MILLISECONDS\)\]/
       search:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
@@ -1,0 +1,39 @@
+setup:
+  - do:
+      indices.create:
+          index: test_date
+          body:
+            mappings:
+              properties:
+                date_field:
+                   type : date
+                   format: date_hour_minute_second_millis
+
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_date
+               _id:    "1"
+           - date_field: 9999-01-01T00:00:00.000
+           - index:
+               _index: test_date
+               _id:    "2"
+           - date_field: 9999-01-01T00:00:00.000
+
+---
+"fail formatting":
+
+  - do:
+      catch: /Cannot format stat \[sum\] with format \[DocValueFormat.DateTime\(format\[date_hour_minute_second_millis\] locale\[\], Z, MILLISECONDS\)\]/
+      search:
+        index: test_date
+        body:
+          size: 0
+          aggs:
+            the_stats:
+              stats:
+                field: date_field
+

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
@@ -26,6 +26,9 @@ setup:
 ---
 "fail formatting":
 
+  - requires:
+      cluster_features: ["gte_v8.5.0"]
+      reason: "bug fixed in 8.5.0"
   - do:
       catch: /Cannot format stat \[sum\] with format \[DocValueFormat.DateTime\(format\[date_hour_minute_second_millis\] locale\[\], Z, MILLISECONDS\)\]/
       search:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
@@ -26,9 +26,9 @@ setup:
 ---
 "fail formatting":
 
-  - requires:
-      cluster_features: ["gte_v8.15.0"]
-      reason: "bug fixed in 8.15.0"
+  - skip:
+      version: "- 8.14.99"
+      reason: fixed in 8.15.0
   - do:
       catch: /Cannot format stat \[sum\] with format \[DocValueFormat.DateTime\(format\[date_hour_minute_second_millis\] locale\[\], Z, MILLISECONDS\)\]/
       search:

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -70,6 +70,24 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
         this.sum = sum;
         this.min = min;
         this.max = max;
+        verifyFormattingStats();
+    }
+
+    private void verifyFormattingStats() {
+        if (format != DocValueFormat.RAW) {
+            verifyFormattingStat(Fields.MIN, format, min);
+            verifyFormattingStat(Fields.MAX, format, max);
+            verifyFormattingStat(Fields.AVG, format, getAvg());
+            verifyFormattingStat(Fields.SUM, format, sum);
+        }
+    }
+
+    private static void verifyFormattingStat(String stat, DocValueFormat format, double value) {
+        try {
+            format.format(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot format stat [" + stat + "] with format [" + format.toString() + "]", e);
+        }
     }
 
     /**
@@ -105,47 +123,47 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
     }
 
     @Override
-    public long getCount() {
+    public final long getCount() {
         return count;
     }
 
     @Override
-    public double getMin() {
+    public final double getMin() {
         return min;
     }
 
     @Override
-    public double getMax() {
+    public final double getMax() {
         return max;
     }
 
     @Override
-    public double getAvg() {
+    public final double getAvg() {
         return sum / count;
     }
 
     @Override
-    public double getSum() {
+    public final double getSum() {
         return sum;
     }
 
     @Override
-    public String getMinAsString() {
+    public final String getMinAsString() {
         return valueAsString(Metrics.min.name());
     }
 
     @Override
-    public String getMaxAsString() {
+    public final String getMaxAsString() {
         return valueAsString(Metrics.max.name());
     }
 
     @Override
-    public String getAvgAsString() {
+    public final String getAvgAsString() {
         return valueAsString(Metrics.avg.name());
     }
 
     @Override
-    public String getSumAsString() {
+    public final String getSumAsString() {
         return valueAsString(Metrics.sum.name());
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -123,47 +123,47 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
     }
 
     @Override
-    public final long getCount() {
+    public long getCount() {
         return count;
     }
 
     @Override
-    public final double getMin() {
+    public double getMin() {
         return min;
     }
 
     @Override
-    public final double getMax() {
+    public double getMax() {
         return max;
     }
 
     @Override
-    public final double getAvg() {
+    public double getAvg() {
         return sum / count;
     }
 
     @Override
-    public final double getSum() {
+    public double getSum() {
         return sum;
     }
 
     @Override
-    public final String getMinAsString() {
+    public String getMinAsString() {
         return valueAsString(Metrics.min.name());
     }
 
     @Override
-    public final String getMaxAsString() {
+    public String getMaxAsString() {
         return valueAsString(Metrics.max.name());
     }
 
     @Override
-    public final String getAvgAsString() {
+    public String getAvgAsString() {
         return valueAsString(Metrics.avg.name());
     }
 
     @Override
-    public final String getSumAsString() {
+    public String getSumAsString() {
         return valueAsString(Metrics.sum.name());
     }
 


### PR DESCRIPTION
We want to validate stats formatting before we serialize to XContent, as chunked x-content serialization assumes that we 
don't throw exceptions at that point.It is not necessary to do it in the StreamInput constructor as this one has been serialise from an already checked object.

This commit adds starts formatting validation to the standard InternalStats constructor.

fixes https://github.com/elastic/elasticsearch/issues/107671