### PR TITLE
Fix106126 floating point error in cartesian centroid

### DIFF
--- a/server/src/test/java/org/elasticsearch/lucene/spatial/CentroidCalculatorTests.java
+++ b/server/src/test/java/org/elasticsearch/lucene/spatial/CentroidCalculatorTests.java
@@ -319,7 +319,6 @@ public abstract class CentroidCalculatorTests extends ESTestCase {
         assertThat(calculator, matchesCentroid(addFromCalculator));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/106126")
     public void testAddDifferentDimensionalType() {
         Point point = randomPoint();
         Line line = randomLine();
@@ -428,7 +427,7 @@ public abstract class CentroidCalculatorTests extends ESTestCase {
             // Most data (notably geo data) has values within bounds, and an absolute delta makes more sense.
             double delta = (value > 1e28 || value < -1e28) ? Math.abs(value / 1e6)
                 : (value > 1e20 || value < -1e20) ? Math.abs(value / 1e10)
-                : (value > 1e10 || value < -1e10) ? Math.abs(value / 1e15)
+                : (value > 1e9 || value < -1e9) ? Math.abs(value / 1e15)
                 : DELTA;
             return closeTo(value, delta);
         }


### PR DESCRIPTION
Fails 3/10000 times, so we're slightly less restrictive with numerical errors

Fixes #106126