### PR TITLE
Skip CBs in `TransportBroadcastUnpromotableAction`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportUnpromotableShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportUnpromotableShardRefreshAction.java
@@ -28,7 +28,12 @@ public class TransportUnpromotableShardRefreshAction extends TransportBroadcastU
     UnpromotableShardRefreshRequest,
     ActionResponse.Empty> {
 
-    public static final String NAME = RefreshAction.NAME + "/unpromotable";
+    public static final String NAME = "indices:admin/refresh/unpromotable";
+
+    static {
+        // noinspection ConstantValue just for documentation
+        assert NAME.equals(RefreshAction.NAME + "/unpromotable");
+    }
 
     private final IndicesService indicesService;
 

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
@@ -64,6 +64,8 @@ public abstract class TransportBroadcastUnpromotableAction<Request extends Broad
         transportService.registerRequestHandler(
             transportUnpromotableAction,
             this.executor,
+            false,
+            true,
             requestReader,
             new UnpromotableTransportHandler()
         );

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableAction.java
@@ -65,7 +65,7 @@ public abstract class TransportBroadcastUnpromotableAction<Request extends Broad
             transportUnpromotableAction,
             this.executor,
             false,
-            true,
+            false,
             requestReader,
             new UnpromotableTransportHandler()
         );


### PR DESCRIPTION
`TransportBroadcastUnpromotableAction` derivatives are all small
management actions that we do not want to fail simply because a node is
under other heap pressure. Therefore with this commit we make them skip
the circuit-breaker check.
