### PR TITLE
[8.13] SQL: Fix JdbcPreparedStatementIT.testDatetimeWithNanos (#107629)

### DIFF
--- a/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
+++ b/x-pack/plugin/sql/qa/jdbc/src/main/java/org/elasticsearch/xpack/sql/qa/jdbc/PreparedStatementTestCase.java
@@ -163,7 +163,7 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
             versionSupportsDateNanos()
         );
 
-        long randomTimestampWitnNanos = randomTimeInNanos();
+        long randomTimestampWitnNanos = randomTimestampWithNanos();
         int randomNanosOnly = extractNanosOnly(randomTimestampWitnNanos);
         setupIndexForDateTimeTestsWithNanos(randomTimestampWitnNanos);
 
@@ -195,7 +195,7 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
             versionSupportsDateNanos()
         );
 
-        long randomTimestampWitnNanos = randomTimeInNanos();
+        long randomTimestampWitnNanos = randomTimestampWithNanos();
         int randomNanosOnly = extractNanosOnly(randomTimestampWitnNanos);
         setupIndexForDateTimeTestsWithNanos(randomTimestampWitnNanos);
 
@@ -216,6 +216,14 @@ public abstract class PreparedStatementTestCase extends JdbcIntegrationTestCase 
                 }
             }
         }
+    }
+
+    private static long randomTimestampWithNanos() {
+        long randomTimestampWithNanos = randomTimeInNanos();
+        // Indexing will jiggle the value by adding -1, 0, 1. The query will truncate it from ns to ms and expect no match. If the
+        // jiggled value will round to no sub-ms fraction, the query will match. So ensure that won't happen.
+        randomTimestampWithNanos += (randomTimestampWithNanos % 1_000_000 < 10) ? 10 : 0;
+        return randomTimestampWithNanos;
     }
 
     public void testDate() throws IOException, SQLException {


### PR DESCRIPTION
Backports the following commits to 8.13:
 - SQL: Fix JdbcPreparedStatementIT.testDatetimeWithNanos (#107629)