### PR TITLE
[8.14] ESQL: Fix mixed cluster tests (#107680)

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -71,7 +71,6 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
 
     public static Set<EsqlVersion> availableVersions() {
         if ("true".equals(System.getProperty("tests.version_parameter_unsupported"))) {
-            // TODO: skip tests with explicitly set version and/or strip the version if it's 2024.04.01.
             return Set.of();
         }
         return Build.current().isSnapshot() ? Set.of(EsqlVersion.values()) : Set.of(EsqlVersion.releasedAscending());
@@ -157,6 +156,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         RequestObjectBuilder builder = new RequestObjectBuilder(randomFrom(XContentType.values()));
 
         String versionString = null;
+        // TODO: skip tests with explicitly set version and/or strip the version if it's 2024.04.01.
         if (availableVersions().isEmpty() == false) {
             EsqlVersion version = randomFrom(availableVersions());
             versionString = randomBoolean() ? version.toString() : version.versionStringWithoutEmoji();

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/FieldExtractorTestCase.java
@@ -26,7 +26,7 @@ import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.elasticsearch.xpack.esql.EsqlTestUtils;
+import org.elasticsearch.xpack.esql.version.EsqlVersion;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 
@@ -1435,7 +1435,14 @@ public abstract class FieldExtractorTestCase extends ESRestTestCase {
     }
 
     private static Map<String, Object> runEsql(String query) throws IOException {
-        return runEsqlSync(new RestEsqlTestCase.RequestObjectBuilder().query(query).version(EsqlTestUtils.latestEsqlVersionOrSnapshot()));
+        // Use the latest released version or SNAPSHOT, if available.
+        String versionString = EsqlSpecTestCase.availableVersions()
+            .stream()
+            .max(Comparator.comparingInt(EsqlVersion::id))
+            .map(EsqlVersion::toString)
+            .orElse(null);
+
+        return runEsqlSync(new RestEsqlTestCase.RequestObjectBuilder().query(query).version(versionString));
     }
 
 }

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -1552,7 +1552,7 @@ s2point1:d | s_mv:i | languages:i
 2.1        | 3      | null
 ;
 
-evalOverridingKey
+evalOverridingKey#[skip:-8.13.1,reason:fixed in 8.13.2]
 FROM employees
 | EVAL k = languages
 | STATS c = COUNT() BY languages, k


### PR DESCRIPTION
Backports the following commits to 8.14:
 - ESQL: Fix mixed cluster tests (#107680)