### PR TITLE
Fix up hot threads timeout docs

### DIFF
--- a/docs/reference/cluster/nodes-hot-threads.asciidoc
+++ b/docs/reference/cluster/nodes-hot-threads.asciidoc
@@ -56,7 +56,9 @@ include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=node-id]
                 troubleshooting, set this parameter to a large number (e.g.
                 `9999`) to get information about all the threads in the system.
 
-include::{es-ref-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
+`timeout`::
+		(Optional, <<time-units, time units>>) Specifies how long to wait for a
+                response from each node. If omitted, waits forever.
 
 `type`::
 		(Optional, string) The type to sample. Available options are `block`, `cpu`, and 


### PR DESCRIPTION
The hot threads API does not support a `?master_timeout` parameter, and
the `?timeout` parameter is not an ack timeout and defaults to an
infinite wait. This commit fixes the incorrect docs.