### PR TITLE
ESQL: Use specific version in security IT

### DIFF
--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -156,7 +156,7 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         RequestObjectBuilder builder = new RequestObjectBuilder(randomFrom(XContentType.values()));
 
         String versionString = null;
-        // TODO: skip tests with explicitly set version and/or strip the version if it's 2024.04.01.
+        // TODO: Read version range from csv-spec and skip if none of the versions are available.
         if (availableVersions().isEmpty() == false) {
             EsqlVersion version = randomFrom(availableVersions());
             versionString = randomBoolean() ? version.toString() : version.versionStringWithoutEmoji();

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/RestEsqlTestCase.java
@@ -701,7 +701,8 @@ public abstract class RestEsqlTestCase extends ESRestTestCase {
         RequestOptions.Builder options = request.getOptions().toBuilder();
         options.setWarningsHandler(WarningsHandler.PERMISSIVE); // We assert the warnings ourselves
         options.addHeader("Content-Type", mediaType);
-        if ("true".equals(System.getProperty("tests.version_parameter_unsupported"))) {
+
+        if (EsqlSpecTestCase.availableVersions().isEmpty()) {
             // Masquerade as an old version of the official client, so we get the oldest version by default
             options.addHeader("x-elastic-client-meta", "es=8.13");
         }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
@@ -44,6 +44,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTestCase {
+    private static final String ESQL_VERSION = "2024.04.01";
 
     private static final AtomicReference<Map<String, Object>> API_KEY_MAP_REF = new AtomicReference<>();
     private static final AtomicReference<Map<String, Object>> REST_API_KEY_MAP_REF = new AtomicReference<>();
@@ -690,9 +691,7 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
                 body.endObject();
             }
         }
-        // TODO: we should use the latest or a random version, even when new versions are released.
-        String version = Build.current().isSnapshot() ? "snapshot" : "2024.04.01";
-        body.field("version", version);
+        body.field("version", ESQL_VERSION);
         body.endObject();
         Request request = new Request("POST", "_query");
         request.setJsonEntity(org.elasticsearch.common.Strings.toString(body));


### PR DESCRIPTION
Do not use the SNAPSHOT language version in RemoteClusterSecurityEsqlIT.

Initially, I wanted to keep this on the latest language version so that its tests automatically fail when we make breaking changes to the language; since testing language features is not the point of these tests, I think it's better to keep the version on `2024.04.01` instead.