### PR TITLE
ESQL: Re-enable 8.14 bwc tests after backport

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/bucket.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/bucket.csv-spec
@@ -422,7 +422,7 @@ FROM employees
 56.0           |28000.0        |28000.0
 ;
 
-reuseGroupingFunction#[skip:-8.14.99, reason:BUCKET renamed in 8.14]
+reuseGroupingFunction#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | STATS sum = 1 + BUCKET(salary, 1000.) BY b1k = BUCKET(salary, 1000.)
 | SORT sum
@@ -436,7 +436,7 @@ FROM employees
 28001.0        |28000.0
 ;
 
-reuseGroupingFunctionWithExpression#[skip:-8.14.99, reason:BUCKET renamed in 8.14]
+reuseGroupingFunctionWithExpression#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | STATS sum = BUCKET(salary % 2 + 13, 1.) + 1 BY bucket = BUCKET(salary % 2 + 13, 1.)
 | SORT sum
@@ -447,7 +447,7 @@ FROM employees
 15.0           |14.0
 ;
 
-reuseGroupingFunctionWithinAggs#[skip:-8.14.99, reason:BUCKET renamed in 8.14]
+reuseGroupingFunctionWithinAggs#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | STATS sum = 1 + MAX(1 + BUCKET(salary, 1000.)) BY BUCKET(salary, 1000.) + 1
 | SORT sum
@@ -461,7 +461,7 @@ FROM employees
 28002.0        |28001.0
 ;
 
-reuseGroupingFunctionWithAggsExpression#[skip:-8.14.99, reason:BUCKET renamed in 8.14]
+reuseGroupingFunctionWithAggsExpression#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | STATS sum = 1 + AVG(BUCKET(salary, 1000.)) + BUCKET(salary, 1000.) BY bucket = BUCKET(salary, 1000.)
 | SORT sum
@@ -475,7 +475,7 @@ FROM employees
 56001.0        |28000.0
 ;
 
-reuseMultipleGroupingFunctionWithAggsExpression#[skip:-8.14.99, reason:BUCKET renamed in 8.14]
+reuseMultipleGroupingFunctionWithAggsExpression#[skip:-8.13.99, reason:BUCKET renamed in 8.14]
 FROM employees
 | STATS sum = b2k + AVG(BUCKET(salary, 1000.)) + BUCKET(salary, 1000.) BY b1k = BUCKET(salary, 1000.), b2k = BUCKET(salary, 2000.)
 | SORT sum


### PR DESCRIPTION
Re-enable some `BUCKET` BWC tests against 8.14 after #107578 got backported to that branch.
