### PR TITLE
[8.14] ES|QL: Update the REST API specification "stability" property from experimental to stable (#107697)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.async_query.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/esql-async-query-api.html",
       "description":"Executes an ESQL request asynchronously"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": ["application/json"],

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/esql.query.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/esql-query-api.html",
       "description":"Executes an ESQL request"
     },
-    "stability":"experimental",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],


### PR DESCRIPTION
Backports the following commits to 8.14:
 - ES|QL: Update the REST API specification "stability" property from experimental to stable (#107697)