### PR TITLE
Fix line break in "The QUICK brown foxes jumped over the dog!"

### DIFF
--- a/docs/changelog/107709.yaml
+++ b/docs/changelog/107709.yaml
@@ -1,0 +1,5 @@
+pr: 107709
+summary: "Example line wrap is incorrect"
+area: analysis|index-search-time.asciidoc
+type: enhancement
+issues: []

--- a/docs/changelog/107709.yaml
+++ b/docs/changelog/107709.yaml
@@ -1,5 +1,0 @@
-pr: 107709
-summary: "Example line wrap is incorrect"
-area: analysis|index-search-time.asciidoc
-type: enhancement
-issues: []

--- a/docs/reference/analysis/index-search-time.asciidoc
+++ b/docs/reference/analysis/index-search-time.asciidoc
@@ -83,7 +83,8 @@ indexed in the `text` field.
 
 Because the field value and query string were analyzed in the same way, they
 created similar tokens. The tokens `quick` and `fox` are exact matches. This
-means the search matches the document containing `"The QUICK brown foxes jumped over the dog!"`, just as the user expects.
+means the search matches the document containing
+`"The QUICK brown foxes jumped over the dog!"`, just as the user expects.
 ====
 
 [[different-analyzers]]

--- a/docs/reference/analysis/index-search-time.asciidoc
+++ b/docs/reference/analysis/index-search-time.asciidoc
@@ -83,8 +83,7 @@ indexed in the `text` field.
 
 Because the field value and query string were analyzed in the same way, they
 created similar tokens. The tokens `quick` and `fox` are exact matches. This
-means the search matches the document containing `"The QUICK brown foxes jumped
-over the dog!"`, just as the user expects.
+means the search matches the document containing `"The QUICK brown foxes jumped over the dog!"`, just as the user expects.
 ====
 
 [[different-analyzers]]


### PR DESCRIPTION
Preformatted strings preserve line breaks, but no line break was intended here.