### PR TITLE
[ci] Add Buildkite metrics/logs links to buildscans

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,8 +125,8 @@ buildScan {
       def metricsStartTime = LocalDateTime.now().minusSeconds(uptime.longValue()).minusHours(1).toString()
       def metricsEndTime = LocalDateTime.now().plusHours(1).toString()
 
-      link 'Agent Metrics', "https://es-buildkite-agents.elastic.dev/app/metrics/detail/host/${System.getenv('BUILDKITE_AGENT_NAME')}?_a=(time:(from:%27${metricsStartTime}%27,interval:%3E%3D1m,to:%27${metricsEndTime}%27))"
-      link 'Agent Logs', "https://es-buildkite-agents.elastic.dev/app/logs/stream?logFilter=(filters:!(),query:(language:kuery,query:%27host.name:%20${System.getenv('BUILDKITE_AGENT_NAME')}%27),timeRange:(from:%27${metricsStartTime}%27,to:%27${metricsEndTime}Z%27))"
+      link 'Agent Metrics', "https://es-buildkite-agents.elastic.dev/app/metrics/detail/host/${System.getenv('BUILDKITE_AGENT_NAME')}?_a=(time:(from:%27${metricsStartTime}Z%27,interval:%3E%3D1m,to:%27${metricsEndTime}Z%27))"
+      link 'Agent Logs', "https://es-buildkite-agents.elastic.dev/app/logs/stream?logFilter=(filters:!(),query:(language:kuery,query:%27host.name:%20${System.getenv('BUILDKITE_AGENT_NAME')}%27),timeRange:(from:%27${metricsStartTime}Z%27,to:%27${metricsEndTime}Z%27))"
 
       if (branch) {
         tag branch

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -122,8 +122,8 @@ buildScan {
       }
 
       def uptime = ManagementFactory.getRuntimeMXBean().getUptime() / 1000;
-      def metricsStartTime = LocalDateTime.now().minusSeconds(uptime.longValue()).minusHours(1).toString()
-      def metricsEndTime = LocalDateTime.now().plusHours(1).toString()
+      def metricsStartTime = LocalDateTime.now().minusSeconds(uptime.longValue()).minusMinutes(15).toString()
+      def metricsEndTime = LocalDateTime.now().plusMinutes(15).toString()
 
       link 'Agent Metrics', "https://es-buildkite-agents.elastic.dev/app/metrics/detail/host/${System.getenv('BUILDKITE_AGENT_NAME')}?_a=(time:(from:%27${metricsStartTime}Z%27,interval:%3E%3D1m,to:%27${metricsEndTime}Z%27))"
       link 'Agent Logs', "https://es-buildkite-agents.elastic.dev/app/logs/stream?logFilter=(filters:!(),query:(language:kuery,query:%27host.name:%20${System.getenv('BUILDKITE_AGENT_NAME')}%27),timeRange:(from:%27${metricsStartTime}Z%27,to:%27${metricsEndTime}Z%27))"

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -6,6 +6,9 @@
  * Side Public License, v 1.
  */
 
+import java.lang.management.ManagementFactory;
+import java.time.LocalDateTime;
+
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.internal.info.BuildParams
@@ -117,6 +120,13 @@ buildScan {
           tag matrix
         }
       }
+
+      def uptime = ManagementFactory.getRuntimeMXBean().getUptime() / 1000;
+      def metricsStartTime = LocalDateTime.now().minusSeconds(uptime.longValue()).minusHours(1).toString()
+      def metricsEndTime = LocalDateTime.now().plusHours(1).toString()
+
+      link 'Agent Metrics', "https://es-buildkite-agents.elastic.dev/app/metrics/detail/host/${System.getEnv('BUILDKITE_AGENT_NAME')}?_a=(time:(from:%27${metricsStartTime}%27,interval:%3E%3D1m,to:%27${metricsEndTime}%27))"
+      link 'Agent Logs', "https://es-buildkite-agents.elastic.dev/app/logs/stream?logFilter=(filters:!(),query:(language:kuery,query:%27host.name:%20${System.getEnv('BUILDKITE_AGENT_NAME')}%27),timeRange:(from:%27${metricsStartTime}%27,to:%27${metricsEndTime}Z%27))"
 
       if (branch) {
         tag branch

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,8 +125,8 @@ buildScan {
       def metricsStartTime = LocalDateTime.now().minusSeconds(uptime.longValue()).minusHours(1).toString()
       def metricsEndTime = LocalDateTime.now().plusHours(1).toString()
 
-      link 'Agent Metrics', "https://es-buildkite-agents.elastic.dev/app/metrics/detail/host/${System.getEnv('BUILDKITE_AGENT_NAME')}?_a=(time:(from:%27${metricsStartTime}%27,interval:%3E%3D1m,to:%27${metricsEndTime}%27))"
-      link 'Agent Logs', "https://es-buildkite-agents.elastic.dev/app/logs/stream?logFilter=(filters:!(),query:(language:kuery,query:%27host.name:%20${System.getEnv('BUILDKITE_AGENT_NAME')}%27),timeRange:(from:%27${metricsStartTime}%27,to:%27${metricsEndTime}Z%27))"
+      link 'Agent Metrics', "https://es-buildkite-agents.elastic.dev/app/metrics/detail/host/${System.getenv('BUILDKITE_AGENT_NAME')}?_a=(time:(from:%27${metricsStartTime}%27,interval:%3E%3D1m,to:%27${metricsEndTime}%27))"
+      link 'Agent Logs', "https://es-buildkite-agents.elastic.dev/app/logs/stream?logFilter=(filters:!(),query:(language:kuery,query:%27host.name:%20${System.getenv('BUILDKITE_AGENT_NAME')}%27),timeRange:(from:%27${metricsStartTime}%27,to:%27${metricsEndTime}Z%27))"
 
       if (branch) {
         tag branch


### PR DESCRIPTION
Makes it much easier to get to the system logs and metrics for agents, and highlights that they exist at all. Most folks probably don't know that we have this.

Since each agent runs one job, the JVM uptime with a little bit of padding should work in almost all cases as the "start time" of the agent used for the default view of the graph.