### PR TITLE
Making test document larger to reliably force StackOverflowError in GsubProcessorTests

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GsubProcessorTests.java
@@ -31,7 +31,6 @@ public class GsubProcessorTests extends AbstractStringProcessorTestCase<String> 
         return "127-0-0-1";
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107416")
     public void testStackOverflow() {
         // This tests that we rethrow StackOverflowErrors as ElasticsearchExceptions so that we don't take down the node
         String badRegex = "( (?=(?:[^'\"]|'[^']*'|\"[^\"]*\")*$))";
@@ -45,7 +44,7 @@ public class GsubProcessorTests extends AbstractStringProcessorTestCase<String> 
             "targetField"
         );
         StringBuilder badSourceBuilder = new StringBuilder("key1=x key2=");
-        badSourceBuilder.append("x".repeat(3000));
+        badSourceBuilder.append("x".repeat(10000));
         Map<String, Object> source = Map.of("field", badSourceBuilder.toString());
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), source);
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));


### PR DESCRIPTION
The size of the document used to trigger a StackOverflowError in GsubProcessorTests.testStackOverflow() was just large enough to cause it on a mac. On the linux CI boxes, occasionally it does not cause a StackOverflowError, and as a result the test fails. This change makes the document more than 3x larger, making a StackOverflowError guaranteed.
Closes #107416