### PR TITLE
[7.17] [ci] Add Buildkite metrics/logs links to buildscans (#107719)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -6,6 +6,9 @@
  * Side Public License, v 1.
  */
 
+import java.lang.management.ManagementFactory;
+import java.time.LocalDateTime;
+
 import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.internal.info.BuildParams
@@ -117,6 +120,13 @@ buildScan {
           tag matrix
         }
       }
+
+      def uptime = ManagementFactory.getRuntimeMXBean().getUptime() / 1000;
+      def metricsStartTime = LocalDateTime.now().minusSeconds(uptime.longValue()).minusMinutes(15).toString()
+      def metricsEndTime = LocalDateTime.now().plusMinutes(15).toString()
+
+      link 'Agent Metrics', "https://es-buildkite-agents.elastic.dev/app/metrics/detail/host/${System.getenv('BUILDKITE_AGENT_NAME')}?_a=(time:(from:%27${metricsStartTime}Z%27,interval:%3E%3D1m,to:%27${metricsEndTime}Z%27))"
+      link 'Agent Logs', "https://es-buildkite-agents.elastic.dev/app/logs/stream?logFilter=(filters:!(),query:(language:kuery,query:%27host.name:%20${System.getenv('BUILDKITE_AGENT_NAME')}%27),timeRange:(from:%27${metricsStartTime}Z%27,to:%27${metricsEndTime}Z%27))"
 
       if (branch) {
         tag branch


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Add Buildkite metrics/logs links to buildscans (#107719)](https://github.com/elastic/elasticsearch/pull/107719)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)