### PR TITLE
[8.14] Fix line break in "The QUICK brown foxes jumped over the dog!" (#107718)

### DIFF
--- a/docs/reference/analysis/index-search-time.asciidoc
+++ b/docs/reference/analysis/index-search-time.asciidoc
@@ -83,8 +83,8 @@ indexed in the `text` field.
 
 Because the field value and query string were analyzed in the same way, they
 created similar tokens. The tokens `quick` and `fox` are exact matches. This
-means the search matches the document containing `"The QUICK brown foxes jumped
-over the dog!"`, just as the user expects.
+means the search matches the document containing
+`"The QUICK brown foxes jumped over the dog!"`, just as the user expects.
 ====
 
 [[different-analyzers]]


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Fix line break in "The QUICK brown foxes jumped over the dog!" (#107718)