### PR TITLE
Removing invalid assertion from SnapshotLifecycleServiceTests

### DIFF
--- a/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
+++ b/x-pack/plugin/slm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
@@ -279,7 +279,6 @@ public class SnapshotLifecycleServiceTests extends ESTestCase {
             clock.fastForwardSeconds(2);
 
             // The existing job should be cancelled and no longer trigger
-            assertBusy(() -> assertThat(triggerCount.get(), equalTo(currentCount2)));
             assertThat(sls.getScheduler().scheduledJobIds(), equalTo(Collections.emptySet()));
 
             // When the service is no longer master, all jobs should be automatically cancelled


### PR DESCRIPTION
SnapshotLifecycleServiceTests.testPolicyCRUD() gets the number of snapshot tasks that have executed, updates the cluster state to cancel any pending snapshot tasks, and then asserts that the number of tasks that has executed is still the same. The problem is that since the scheduler is running in another thread, in between the time that the number of tasks is grabbed and the time that the cluster state update is complete, another task could have begun executing. So it is possible that when we check the number of tasks again after that, it is higher than it was before. This happens rarely from the command line, but I can reproduce it 100% of the time in the debugger by just putting a breakpoint on the line that captures the number of tasks in the `currentCount2` variable. I think it is the assertion that is broken rather than the behavior. This PR removes the bad assertion.
Closes #107506