### PR TITLE
Validate model_id is required when using the learning_to_rank rescorer

### DIFF
--- a/docs/changelog/107743.yaml
+++ b/docs/changelog/107743.yaml
@@ -1,5 +1,5 @@
 pr: 107743
 summary: Validate `model_id` is required when using the `learning_to_rank` rescorer
-area: Relevance
+area: Search
 type: bug
 issues: []

--- a/docs/changelog/107743.yaml
+++ b/docs/changelog/107743.yaml
@@ -1,0 +1,5 @@
+pr: 107743
+summary: Validate `model_id` is required when using the `learning_to_rank` rescorer
+area: Relevance
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilder.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.ml.inference.ltr;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.query.QueryRewriteContext;
@@ -40,6 +41,7 @@ public class LearningToRankRescorerBuilder extends RescorerBuilder<LearningToRan
     static {
         PARSER.declareString(Builder::setModelId, MODEL_FIELD);
         PARSER.declareObject(Builder::setParams, (p, c) -> p.map(), PARAMS_FIELD);
+        PARSER.declareRequiredFieldSet(MODEL_FIELD.getPreferredName());
     }
 
     public static LearningToRankRescorerBuilder fromXContent(XContentParser parser, LearningToRankService learningToRankService) {
@@ -64,7 +66,7 @@ public class LearningToRankRescorerBuilder extends RescorerBuilder<LearningToRan
         Map<String, Object> params,
         LearningToRankService learningToRankService
     ) {
-        this.modelId = modelId;
+        this.modelId = Strings.requireNonBlank(modelId, "modelId can't be blank");
         this.params = params;
         this.learningToRankConfig = learningToRankConfig;
         this.learningToRankService = learningToRankService;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilder.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.ml.inference.ltr;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.query.QueryRewriteContext;
@@ -66,7 +65,7 @@ public class LearningToRankRescorerBuilder extends RescorerBuilder<LearningToRan
         Map<String, Object> params,
         LearningToRankService learningToRankService
     ) {
-        this.modelId = Strings.requireNonBlank(modelId, "modelId can't be blank");
+        this.modelId = modelId;
         this.params = params;
         this.learningToRankConfig = learningToRankConfig;
         this.learningToRankService = learningToRankService;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilderSerializationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilderSerializationTests.java
@@ -33,7 +33,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.LearningToRankConfigTests.randomLearningToRankConfig;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 
@@ -55,6 +57,22 @@ public class LearningToRankRescorerBuilderSerializationTests extends AbstractBWC
                 }
             }
         }
+    }
+
+    public void testModelIdIsRequired() throws IOException {
+        XContentBuilder jsonBuilder = jsonBuilder().startObject();
+        if (randomBoolean()) {
+            jsonBuilder.field("params", randomParams());
+        }
+        jsonBuilder.endObject();
+
+        XContentParser parser = createParser(jsonBuilder);
+
+        Exception e = assertThrows(
+            IllegalArgumentException.class,
+            () -> LearningToRankRescorerBuilder.fromXContent(parser, mock(LearningToRankService.class))
+        );
+        assertThat(e.getMessage(), containsString("Required one of fields [model_id], but none were specified."));
     }
 
     @Override


### PR DESCRIPTION
This PR improve learning_to_rank rescorer model validation to indicate the user that the model_id is a required field.