### PR TITLE
Remove `String`-based timeout support

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/rest/RestDataStreamLifecycleStatsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/rest/RestDataStreamLifecycleStatsAction.java
@@ -35,11 +35,8 @@ public class RestDataStreamLifecycleStatsAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
-        String masterNodeTimeout = restRequest.param("master_timeout");
         GetDataStreamLifecycleStatsAction.Request request = new GetDataStreamLifecycleStatsAction.Request();
-        if (masterNodeTimeout != null) {
-            request.masterNodeTimeout(masterNodeTimeout);
-        }
+        request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
         return channel -> client.execute(
             GetDataStreamLifecycleStatsAction.INSTANCE,
             request,

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/rest/RestExplainDataStreamLifecycleAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/rest/RestExplainDataStreamLifecycleAction.java
@@ -41,10 +41,7 @@ public class RestExplainDataStreamLifecycleAction extends BaseRestHandler {
         ExplainDataStreamLifecycleAction.Request explainRequest = new ExplainDataStreamLifecycleAction.Request(indices);
         explainRequest.includeDefaults(restRequest.paramAsBoolean("include_defaults", false));
         explainRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, IndicesOptions.strictExpandOpen()));
-        String masterNodeTimeout = restRequest.param("master_timeout");
-        if (masterNodeTimeout != null) {
-            explainRequest.masterNodeTimeout(masterNodeTimeout);
-        }
+        explainRequest.masterNodeTimeout(restRequest.paramAsTime("master_timeout", explainRequest.masterNodeTimeout()));
         return channel -> client.execute(
             ExplainDataStreamLifecycleAction.INSTANCE,
             explainRequest,

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ClientScrollableHitSourceTests.java
@@ -96,7 +96,7 @@ public class ClientScrollableHitSourceTests extends ESTestCase {
             responses::add,
             failureHandler,
             new ParentTaskAssigningClient(client, parentTask),
-            new SearchRequest().scroll("1m")
+            new SearchRequest().scroll(TimeValue.timeValueMinutes(1))
         );
 
         hitSource.start();

--- a/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/discovery/azure/classic/AzureSimpleTests.java
+++ b/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/discovery/azure/classic/AzureSimpleTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cloud.azure.classic.AbstractAzureComputeServiceTestCase
 import org.elasticsearch.cloud.azure.classic.management.AzureComputeService.Discovery;
 import org.elasticsearch.cloud.azure.classic.management.AzureComputeService.Management;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import static org.hamcrest.Matchers.containsString;
@@ -26,7 +27,16 @@ public class AzureSimpleTests extends AbstractAzureComputeServiceTestCase {
 
         final String node1 = internalCluster().startNode(settings);
         registerAzureNode(node1);
-        assertNotNull(client().admin().cluster().prepareState().setMasterNodeTimeout("1s").get().getState().nodes().getMasterNodeId());
+        assertNotNull(
+            client().admin()
+                .cluster()
+                .prepareState()
+                .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNodeId()
+        );
 
         // We expect having 1 node as part of the cluster, let's test that
         assertNumberOfNodes(1);
@@ -39,7 +49,16 @@ public class AzureSimpleTests extends AbstractAzureComputeServiceTestCase {
 
         final String node1 = internalCluster().startNode(settings);
         registerAzureNode(node1);
-        assertNotNull(client().admin().cluster().prepareState().setMasterNodeTimeout("1s").get().getState().nodes().getMasterNodeId());
+        assertNotNull(
+            client().admin()
+                .cluster()
+                .prepareState()
+                .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNodeId()
+        );
 
         // We expect having 1 node as part of the cluster, let's test that
         assertNumberOfNodes(1);

--- a/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/discovery/azure/classic/AzureTwoStartedNodesTests.java
+++ b/plugins/discovery-azure-classic/src/internalClusterTest/java/org/elasticsearch/discovery/azure/classic/AzureTwoStartedNodesTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cloud.azure.classic.AbstractAzureComputeServiceTestCase
 import org.elasticsearch.cloud.azure.classic.management.AzureComputeService.Discovery;
 import org.elasticsearch.cloud.azure.classic.management.AzureComputeService.Management;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
@@ -29,12 +30,30 @@ public class AzureTwoStartedNodesTests extends AbstractAzureComputeServiceTestCa
         logger.info("--> start first node");
         final String node1 = internalCluster().startNode(settings);
         registerAzureNode(node1);
-        assertNotNull(client().admin().cluster().prepareState().setMasterNodeTimeout("1s").get().getState().nodes().getMasterNodeId());
+        assertNotNull(
+            client().admin()
+                .cluster()
+                .prepareState()
+                .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNodeId()
+        );
 
         logger.info("--> start another node");
         final String node2 = internalCluster().startNode(settings);
         registerAzureNode(node2);
-        assertNotNull(client().admin().cluster().prepareState().setMasterNodeTimeout("1s").get().getState().nodes().getMasterNodeId());
+        assertNotNull(
+            client().admin()
+                .cluster()
+                .prepareState()
+                .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
+                .get()
+                .getState()
+                .nodes()
+                .getMasterNodeId()
+        );
 
         // We expect having 2 nodes as part of the cluster, let's test that
         assertNumberOfNodes(2);

--- a/plugins/discovery-gce/src/internalClusterTest/java/org/elasticsearch/discovery/gce/GceDiscoverTests.java
+++ b/plugins/discovery-gce/src/internalClusterTest/java/org/elasticsearch/discovery/gce/GceDiscoverTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cloud.gce.GceInstancesService;
 import org.elasticsearch.cloud.gce.util.Access;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugin.discovery.gce.GceDiscoveryPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -67,7 +68,7 @@ public class GceDiscoverTests extends ESIntegTestCase {
         ClusterStateResponse clusterStateResponse = client(masterNode).admin()
             .cluster()
             .prepareState()
-            .setMasterNodeTimeout("1s")
+            .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
             .clear()
             .setNodes(true)
             .get();
@@ -79,7 +80,7 @@ public class GceDiscoverTests extends ESIntegTestCase {
         clusterStateResponse = client(secondNode).admin()
             .cluster()
             .prepareState()
-            .setMasterNodeTimeout("1s")
+            .setMasterNodeTimeout(TimeValue.timeValueSeconds(1))
             .clear()
             .setNodes(true)
             .setLocal(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
@@ -48,7 +48,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
             final ClusterStateRequestBuilder clusterStateRequestBuilder = clusterAdmin().prepareState()
                 .clear()
                 .setNodes(true)
-                .setMasterNodeTimeout("100ms");
+                .setMasterNodeTimeout(TimeValue.timeValueMillis(100));
             final ClusterStateResponse clusterStateResponse;
             try {
                 clusterStateResponse = clusterStateRequestBuilder.get();
@@ -68,7 +68,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
                 .clear()
                 .setLocal(true)
                 .setNodes(true)
-                .setMasterNodeTimeout("100ms")
+                .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
                 .get()
                 .getState()
                 .nodes();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -317,11 +317,23 @@ public class CreateIndexIT extends ESIntegTestCase {
 
         // all should fail
         settings = Settings.builder().put(settings).put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), "all").build();
-        assertFalse(indicesAdmin().prepareCreate("test-idx-2").setSettings(settings).setTimeout("100ms").get().isShardsAcknowledged());
+        assertFalse(
+            indicesAdmin().prepareCreate("test-idx-2")
+                .setSettings(settings)
+                .setTimeout(TimeValue.timeValueMillis(100))
+                .get()
+                .isShardsAcknowledged()
+        );
 
         // the numeric equivalent of all should also fail
         settings = Settings.builder().put(settings).put(SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), Integer.toString(numReplicas + 1)).build();
-        assertFalse(indicesAdmin().prepareCreate("test-idx-3").setSettings(settings).setTimeout("100ms").get().isShardsAcknowledged());
+        assertFalse(
+            indicesAdmin().prepareCreate("test-idx-3")
+                .setSettings(settings)
+                .setTimeout(TimeValue.timeValueMillis(100))
+                .get()
+                .isShardsAcknowledged()
+        );
     }
 
     public void testInvalidPartitionSize() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING;
@@ -38,7 +39,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
         assertFalse(
             prepareCreate(indexName).setSettings(settings)
                 .setWaitForActiveShards(randomBoolean() ? ActiveShardCount.from(1) : ActiveShardCount.ALL)
-                .setTimeout("100ms")
+                .setTimeout(TimeValue.timeValueMillis(100))
                 .get()
                 .isShardsAcknowledged()
         );
@@ -70,7 +71,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
         assertFalse(
             prepareCreate(indexName).setSettings(settings)
                 .setWaitForActiveShards(randomIntBetween(numDataNodes + 1, numReplicas + 1))
-                .setTimeout("100ms")
+                .setTimeout(TimeValue.timeValueMillis(100))
                 .get()
                 .isShardsAcknowledged()
         );
@@ -101,7 +102,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
         assertFalse(
             prepareCreate(indexName).setSettings(settings)
                 .setWaitForActiveShards(ActiveShardCount.ALL)
-                .setTimeout("100ms")
+                .setTimeout(TimeValue.timeValueMillis(100))
                 .get()
                 .isShardsAcknowledged()
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -56,13 +56,16 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
     public void testHealth() {
         logger.info("--> running cluster health on an index that does not exists");
-        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("test1").setWaitForYellowStatus().setTimeout("1s").get();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("test1")
+            .setWaitForYellowStatus()
+            .setTimeout(TimeValue.timeValueSeconds(1))
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
 
         logger.info("--> running cluster wide health");
-        healthResponse = clusterAdmin().prepareHealth().setWaitForGreenStatus().setTimeout("10s").get();
+        healthResponse = clusterAdmin().prepareHealth().setWaitForGreenStatus().setTimeout(TimeValue.timeValueSeconds(10)).get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
@@ -71,13 +74,16 @@ public class ClusterHealthIT extends ESIntegTestCase {
         createIndex("test1");
 
         logger.info("--> running cluster health on an index that does exists");
-        healthResponse = clusterAdmin().prepareHealth("test1").setWaitForGreenStatus().setTimeout("10s").get();
+        healthResponse = clusterAdmin().prepareHealth("test1").setWaitForGreenStatus().setTimeout(TimeValue.timeValueSeconds(10)).get();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
 
         logger.info("--> running cluster health on an index that does exists and an index that doesn't exists");
-        healthResponse = clusterAdmin().prepareHealth("test1", "test2").setWaitForYellowStatus().setTimeout("1s").get();
+        healthResponse = clusterAdmin().prepareHealth("test1", "test2")
+            .setWaitForYellowStatus()
+            .setTimeout(TimeValue.timeValueSeconds(1))
+            .get();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.plugins.ClusterPlugin;
@@ -243,7 +244,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
                     indexSettings(numberOfShards, 0).put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), Long.MAX_VALUE)
                 )
                 .setMapping(mapping)
-                .setTimeout("60s")
+                .setTimeout(TimeValue.timeValueMinutes(1))
         );
         ensureGreen(); // wait for green state, so its both green, and there are no more pending events
         MappingMetadata masterMappingMetadata = indicesAdmin().prepareGetMappings("test").get().getMappings().get("test");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SpecificMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SpecificMasterNodesIT.java
@@ -12,6 +12,7 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.action.admin.cluster.configuration.AddVotingConfigExclusionsRequest;
 import org.elasticsearch.action.admin.cluster.configuration.TransportAddVotingConfigExclusionsAction;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -35,7 +36,15 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         logger.info("--> start data node / non master node");
         internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
         try {
-            assertThat(clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId(), nullValue());
+            assertThat(
+                clusterAdmin().prepareState()
+                    .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
+                    .get()
+                    .getState()
+                    .nodes()
+                    .getMasterNodeId(),
+                nullValue()
+            );
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
             // all is well, no master elected
@@ -56,7 +65,15 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         internalCluster().stopCurrentMasterNode();
 
         try {
-            assertThat(clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId(), nullValue());
+            assertThat(
+                clusterAdmin().prepareState()
+                    .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
+                    .get()
+                    .getState()
+                    .nodes()
+                    .getMasterNodeId(),
+                nullValue()
+            );
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
             // all is well, no master elected
@@ -81,7 +98,15 @@ public class SpecificMasterNodesIT extends ESIntegTestCase {
         logger.info("--> start data node / non master node");
         internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
         try {
-            assertThat(clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId(), nullValue());
+            assertThat(
+                clusterAdmin().prepareState()
+                    .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
+                    .get()
+                    .getState()
+                    .nodes()
+                    .getMasterNodeId(),
+                nullValue()
+            );
             fail("should not be able to find master");
         } catch (MasterNotDiscoveredException e) {
             // all is well, no master elected

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.plugins.Plugin;
@@ -158,14 +159,14 @@ public class RareClusterStateIT extends ESIntegTestCase {
         );
 
         logger.info("--> delete index");
-        assertFalse(indicesAdmin().prepareDelete("test").setTimeout("0s").get().isAcknowledged());
+        assertFalse(indicesAdmin().prepareDelete("test").setTimeout(TimeValue.ZERO).get().isAcknowledged());
         logger.info("--> and recreate it");
         assertFalse(
             prepareCreate("test").setSettings(
                 Settings.builder()
                     .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                     .put(IndexMetadata.SETTING_WAIT_FOR_ACTIVE_SHARDS.getKey(), "0")
-            ).setTimeout("0s").get().isAcknowledged()
+            ).setTimeout(TimeValue.ZERO).get().isAcknowledged()
         );
 
         // unblock publications & do a trivial cluster state update to bring data node up to date

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -428,7 +428,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                     .cluster()
                     .prepareHealth()
                     .setWaitForNodes("2")
-                    .setTimeout("2s")
+                    .setTimeout(TimeValue.timeValueSeconds(2))
                     .get()
                     .isTimedOut()
             );
@@ -456,7 +456,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
         networkDisruption.startDisrupting();
         // We know this will time out due to the partition, we check manually below to not proceed until
         // the delete has been applied to the master node and the master eligible node.
-        internalCluster().client(masterNode1).admin().indices().prepareDelete(idxName).setTimeout("0s").get();
+        internalCluster().client(masterNode1).admin().indices().prepareDelete(idxName).setTimeout(TimeValue.ZERO).get();
         // Don't restart the master node until we know the index deletion has taken effect on master and the master eligible node.
         assertBusy(() -> {
             for (String masterNode : allMasterEligibleNodes) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -180,7 +180,8 @@ public class CorruptedFileIT extends ESIntegTestCase {
         setReplicaCount(2, "test");
         ClusterHealthResponse health = clusterAdmin().health(
             new ClusterHealthRequest("test").waitForGreenStatus()
-                .timeout("5m") // sometimes due to cluster rebalacing and random settings default timeout is just not enough.
+                // sometimes due to cluster rebalancing and random settings default timeout is just not enough.
+                .timeout(TimeValue.timeValueMinutes(5))
                 .waitForNoRelocatingShards(true)
         ).actionGet();
         if (health.isTimedOut()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -328,7 +328,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
 
         // Wait for the index to turn green before attempting to close it
         ClusterHealthResponse health = clusterAdmin().prepareHealth()
-            .setTimeout("30s")
+            .setTimeout(TimeValue.timeValueSeconds(30))
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/OpenCloseIndexIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.rest.RestStatus;
@@ -233,7 +234,12 @@ public class OpenCloseIndexIT extends ESIntegTestCase {
         assertAcked(client.admin().indices().prepareCreate("test").setSettings(settings).get());
         assertAcked(client.admin().indices().prepareClose("test").get());
 
-        OpenIndexResponse response = client.admin().indices().prepareOpen("test").setTimeout("100ms").setWaitForActiveShards(2).get();
+        OpenIndexResponse response = client.admin()
+            .indices()
+            .prepareOpen("test")
+            .setTimeout(TimeValue.timeValueMillis(100))
+            .setWaitForActiveShards(2)
+            .get();
         assertThat(response.isShardsAcknowledged(), equalTo(false));
         assertBusy(
             () -> assertThat(

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.plugins.Plugin;
@@ -115,7 +116,10 @@ public class ReadinessClusterIT extends ESIntegTestCase {
     }
 
     private void expectMasterNotFound() {
-        expectThrows(MasterNotDiscoveredException.class, clusterAdmin().prepareState().setMasterNodeTimeout("100ms"));
+        expectThrows(
+            MasterNotDiscoveredException.class,
+            clusterAdmin().prepareState().setMasterNodeTimeout(TimeValue.timeValueMillis(100))
+        );
     }
 
     public void testReadinessDuringRestarts() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -46,7 +46,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         internalCluster().startNode();
         createIndex("test");
 
-        final String healthTimeout = "1m";
+        final var healthTimeout = TimeValue.timeValueMinutes(1);
 
         for (int i = 0; i < 1000; i++) {
             prepareIndex("test").setId(Long.toString(i)).setSource(Map.<String, Object>of("test", "value" + i)).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
@@ -101,7 +101,12 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
             logger.info("--> waiting for GREEN health status ...");
             // make sure the cluster state is green, and all has been recovered
-            assertNoTimeout(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForGreenStatus());
+            assertNoTimeout(
+                clusterAdmin().prepareHealth()
+                    .setWaitForEvents(Priority.LANGUID)
+                    .setTimeout(TimeValue.timeValueMinutes(5))
+                    .setWaitForGreenStatus()
+            );
 
             logger.info("--> waiting for {} docs to be indexed ...", totalNumDocs);
             waitForDocs(totalNumDocs, indexer);
@@ -157,7 +162,12 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             allowNodes("test", 4);
 
             logger.info("--> waiting for GREEN health status ...");
-            assertNoTimeout(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForGreenStatus());
+            assertNoTimeout(
+                clusterAdmin().prepareHealth()
+                    .setWaitForEvents(Priority.LANGUID)
+                    .setTimeout(TimeValue.timeValueMinutes(5))
+                    .setWaitForGreenStatus()
+            );
 
             logger.info("--> waiting for {} docs to be indexed ...", totalNumDocs);
             waitForDocs(totalNumDocs, indexer);
@@ -217,7 +227,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             assertNoTimeout(
                 clusterAdmin().prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
-                    .setTimeout("5m")
+                    .setTimeout(TimeValue.timeValueMinutes(5))
                     .setWaitForGreenStatus()
                     .setWaitForNoRelocatingShards(true)
             );
@@ -232,21 +242,30 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             allowNodes("test", 3);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForNoRelocatingShards(true)
+                clusterAdmin().prepareHealth()
+                    .setWaitForEvents(Priority.LANGUID)
+                    .setTimeout(TimeValue.timeValueMinutes(5))
+                    .setWaitForNoRelocatingShards(true)
             );
 
             logger.info("--> allow 2 nodes for index [test] ...");
             allowNodes("test", 2);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForNoRelocatingShards(true)
+                clusterAdmin().prepareHealth()
+                    .setWaitForEvents(Priority.LANGUID)
+                    .setTimeout(TimeValue.timeValueMinutes(5))
+                    .setWaitForNoRelocatingShards(true)
             );
 
             logger.info("--> allow 1 nodes for index [test] ...");
             allowNodes("test", 1);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForNoRelocatingShards(true)
+                clusterAdmin().prepareHealth()
+                    .setWaitForEvents(Priority.LANGUID)
+                    .setTimeout(TimeValue.timeValueMinutes(5))
+                    .setWaitForNoRelocatingShards(true)
             );
 
             logger.info("--> marking and waiting for indexing threads to stop ...");
@@ -254,7 +273,10 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             logger.info("--> indexing threads stopped");
 
             assertNoTimeout(
-                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForNoRelocatingShards(true)
+                clusterAdmin().prepareHealth()
+                    .setWaitForEvents(Priority.LANGUID)
+                    .setTimeout(TimeValue.timeValueMinutes(5))
+                    .setWaitForNoRelocatingShards(true)
             );
 
             logger.info("--> refreshing the index");

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -349,7 +349,7 @@ public class RelocationIT extends ESIntegTestCase {
                 clusterAdmin().prepareHealth()
                     .setWaitForNoRelocatingShards(true)
                     .setWaitForEvents(Priority.LANGUID)
-                    .setTimeout("30s")
+                    .setTimeout(TimeValue.timeValueSeconds(30))
                     .get()
                     .isTimedOut()
             );

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchServiceCleanupOnLostMasterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchServiceCleanupOnLostMasterIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.coordination.FollowersChecker;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.CheckedBiConsumer;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -70,7 +71,10 @@ public class SearchServiceCleanupOnLostMasterIT extends ESIntegTestCase {
 
         index("test", "test", "{}");
 
-        assertResponse(prepareSearch("test").setScroll("30m"), response -> assertThat(response.getScrollId(), is(notNullValue())));
+        assertResponse(
+            prepareSearch("test").setScroll(TimeValue.timeValueMinutes(30)),
+            response -> assertThat(response.getScrollId(), is(notNullValue()))
+        );
         loseMaster.accept(master, dataNode);
         // in the past, this failed because the search context for the scroll would prevent the shard lock from being released.
         ensureYellow();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileRelocatingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileRelocatingIT.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ESIntegTestCase;
 
@@ -127,7 +128,7 @@ public class SearchWhileRelocatingIT extends ESIntegTestCase {
                 .setWaitForYellowStatus()
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForEvents(Priority.LANGUID)
-                .setTimeout("5m")
+                .setTimeout(TimeValue.timeValueMinutes(5))
                 .get();
             assertNoTimeout(resp);
             // if we hit only non-critical exceptions we make sure that the post search works

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -105,7 +105,7 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
 
         SearchRequest searchRequest = new SearchRequest(localIndex, REMOTE_CLUSTER + ":" + remoteIndex);
         if (randomBoolean()) {
-            searchRequest = searchRequest.scroll("1m");
+            searchRequest = searchRequest.scroll(TimeValue.timeValueMinutes(1));
         }
         searchRequest.allowPartialSearchResults(false);
         if (randomBoolean()) {
@@ -286,7 +286,7 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
 
         SearchRequest searchRequest = new SearchRequest(localIndex, REMOTE_CLUSTER + ":" + "no_such_index*");
         if (randomBoolean()) {
-            searchRequest = searchRequest.scroll("1m");
+            searchRequest = searchRequest.scroll(TimeValue.timeValueMinutes(1));
         }
         searchRequest.allowPartialSearchResults(false);
         if (randomBoolean()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchLeakIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchLeakIT.java
@@ -130,7 +130,7 @@ public class CrossClusterSearchLeakIT extends AbstractMultiClustersTestCase {
                     .size(between(scroll ? 1 : 0, 1000))
             );
             if (scroll) {
-                searchRequest.scroll("30s");
+                searchRequest.scroll(TimeValue.timeValueSeconds(30));
             }
             searchRequest.setCcsMinimizeRoundtrips(rarely());
             futures.add(client(LOCAL_CLUSTER).search(searchRequest));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/nested/SimpleNestedIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.sort.NestedSortBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -619,7 +620,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
             );
 
         if (randomBoolean()) {
-            searchRequestBuilder.setScroll("10m");
+            searchRequestBuilder.setScroll(TimeValue.timeValueMinutes(10));
         }
 
         assertResponse(searchRequestBuilder, response -> {
@@ -640,7 +641,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
             );
 
         if (randomBoolean()) {
-            searchRequestBuilder.setScroll("10m");
+            searchRequestBuilder.setScroll(TimeValue.timeValueMinutes(10));
         }
 
         assertResponse(searchRequestBuilder, response -> {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/DuelScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/DuelScrollIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -48,7 +49,7 @@ public class DuelScrollIT extends ESIntegTestCase {
                 SearchResponse searchScrollResponse = prepareSearch("index").setSearchType(context.searchType)
                     .addSort(context.sort)
                     .setSize(context.scrollRequestSize)
-                    .setScroll("10m")
+                    .setScroll(TimeValue.timeValueMinutes(10))
                     .get();
                 try {
 
@@ -65,7 +66,7 @@ public class DuelScrollIT extends ESIntegTestCase {
                     String scrollId = searchScrollResponse.getScrollId();
                     while (true) {
                         searchScrollResponse.decRef();
-                        searchScrollResponse = client().prepareSearchScroll(scrollId).setScroll("10m").get();
+                        searchScrollResponse = client().prepareSearchScroll(scrollId).setScroll(TimeValue.timeValueMinutes(10)).get();
                         assertNoFailures(searchScrollResponse);
                         assertThat(searchScrollResponse.getHits().getTotalHits().value, equalTo((long) context.numDocs));
                         if (searchScrollResponse.getHits().getHits().length == 0) {
@@ -232,7 +233,7 @@ public class DuelScrollIT extends ESIntegTestCase {
                     .setQuery(QueryBuilders.matchQuery("foo", "true"))
                     .addSort(SortBuilders.fieldSort("_doc"))
                     .setTrackScores(trackScores)
-                    .setScroll("10m")
+                    .setScroll(TimeValue.timeValueMinutes(10))
                     .get();
 
                 int scrollDocs = 0;
@@ -251,7 +252,7 @@ public class DuelScrollIT extends ESIntegTestCase {
                         }
                         scrollDocs += scroll.getHits().getHits().length;
                         scroll.decRef();
-                        scroll = client().prepareSearchScroll(scroll.getScrollId()).setScroll("10m").get();
+                        scroll = client().prepareSearchScroll(scroll.getScrollId()).setScroll(TimeValue.timeValueMinutes(10)).get();
                     }
                     assertEquals(control.getHits().getTotalHits().value, scrollDocs);
                 } catch (AssertionError e) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -458,7 +458,7 @@ public class SearchScrollIT extends ESIntegTestCase {
             SearchRequestBuilder builder = prepareSearch("index").setSearchType(searchType)
                 .setQuery(QueryBuilders.matchAllQuery())
                 .setSize(Integer.MAX_VALUE)
-                .setScroll("1m");
+                .setScroll(TimeValue.timeValueMinutes(1));
 
             SearchResponse response = builder.get();
             try {
@@ -477,7 +477,7 @@ public class SearchScrollIT extends ESIntegTestCase {
         prepareIndex("index").setId("1").setSource("field", "value").execute().get();
         refresh();
 
-        SearchResponse searchResponse = prepareSearch("index").setSize(1).setScroll("1m").get();
+        SearchResponse searchResponse = prepareSearch("index").setSize(1).setScroll(TimeValue.timeValueMinutes(1)).get();
         try {
             assertThat(searchResponse.getScrollId(), is(notNullValue()));
 
@@ -498,7 +498,8 @@ public class SearchScrollIT extends ESIntegTestCase {
         refresh();
 
         assertResponse(
-            prepareSearch("test").addSort(new FieldSortBuilder("no_field").order(SortOrder.ASC).missing("_last")).setScroll("1m"),
+            prepareSearch("test").addSort(new FieldSortBuilder("no_field").order(SortOrder.ASC).missing("_last"))
+                .setScroll(TimeValue.timeValueMinutes(1)),
             response -> {
                 assertHitCount(response, 1);
                 assertSearchHits(response, "1");
@@ -510,7 +511,8 @@ public class SearchScrollIT extends ESIntegTestCase {
         );
 
         assertResponse(
-            prepareSearch("test").addSort(new FieldSortBuilder("no_field").order(SortOrder.ASC).missing("_first")).setScroll("1m"),
+            prepareSearch("test").addSort(new FieldSortBuilder("no_field").order(SortOrder.ASC).missing("_first"))
+                .setScroll(TimeValue.timeValueMinutes(1)),
             response -> {
                 assertHitCount(response, 1);
                 assertSearchHits(response, "1");

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
@@ -73,7 +73,7 @@ public class SearchAfterIT extends ESIntegTestCase {
                 prepareSearch("test").addSort("field1", SortOrder.ASC)
                     .setQuery(matchAllQuery())
                     .searchAfter(new Object[] { 0 })
-                    .setScroll("1m")
+                    .setScroll(TimeValue.timeValueMinutes(1))
             );
             assertThat(e.getMessage(), containsString("[search_after] cannot be used in a scroll context"));
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.seqno.RetentionLeaseActions;
@@ -237,7 +238,12 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("--> shutdown one of the nodes");
         internalCluster().stopRandomDataNode();
         assertThat(
-            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForNodes("<2").get().isTimedOut(),
+            clusterAdmin().prepareHealth()
+                .setWaitForEvents(Priority.LANGUID)
+                .setTimeout(TimeValue.timeValueMinutes(1))
+                .setWaitForNodes("<2")
+                .get()
+                .isTimedOut(),
             equalTo(false)
         );
 
@@ -415,7 +421,12 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         });
 
         assertThat(
-            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("1m").setWaitForNodes("2").get().isTimedOut(),
+            clusterAdmin().prepareHealth()
+                .setWaitForEvents(Priority.LANGUID)
+                .setTimeout(TimeValue.timeValueMinutes(1))
+                .setWaitForNodes("2")
+                .get()
+                .isTimedOut(),
             equalTo(false)
         );
 
@@ -644,7 +655,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         assertAcked(indicesAdmin().prepareDelete(sourceIdx).get());
         assertAcked(indicesAdmin().prepareDelete(shrunkIdx).get());
         internalCluster().stopRandomDataNode();
-        clusterAdmin().prepareHealth().setTimeout("30s").setWaitForNodes("1");
+        clusterAdmin().prepareHealth().setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("1");
 
         logger.info("--> start a new data node");
         final Settings dataSettings = Settings.builder()
@@ -652,7 +663,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             .put(Environment.PATH_HOME_SETTING.getKey(), createTempDir()) // to get a new node id
             .build();
         internalCluster().startDataOnlyNode(dataSettings);
-        clusterAdmin().prepareHealth().setTimeout("30s").setWaitForNodes("2");
+        clusterAdmin().prepareHealth().setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("2");
 
         logger.info("--> restore the shrunk index and ensure all shards are allocated");
         RestoreSnapshotResponse restoreResponse = clusterAdmin().prepareRestoreSnapshot(repo, snapshot)

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoriesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoriesIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.RepositoryConflictException;
@@ -171,7 +172,7 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
                     .put("compress", randomBoolean())
                     .put("chunk_size", randomIntBetween(5, 100), ByteSizeUnit.BYTES)
             )
-            .setTimeout("0s")
+            .setTimeout(TimeValue.ZERO)
             .get();
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(false));
 
@@ -188,7 +189,9 @@ public class RepositoriesIT extends AbstractSnapshotIntegTestCase {
         assertThat(putRepositoryResponse.isAcknowledged(), equalTo(true));
 
         logger.info("-->  deleting repository test-repo-2 with 0s timeout - shouldn't ack");
-        AcknowledgedResponse deleteRepositoryResponse = clusterAdmin().prepareDeleteRepository("test-repo-2").setTimeout("0s").get();
+        AcknowledgedResponse deleteRepositoryResponse = clusterAdmin().prepareDeleteRepository("test-repo-2")
+            .setTimeout(TimeValue.ZERO)
+            .get();
         assertThat(deleteRepositoryResponse.isAcknowledged(), equalTo(false));
 
         logger.info("-->  deleting repository test-repo-1 with standard timeout - should ack");

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequest.java
@@ -127,10 +127,6 @@ public class ClusterHealthRequest extends MasterNodeReadRequest<ClusterHealthReq
         return this;
     }
 
-    public ClusterHealthRequest timeout(String timeout) {
-        return this.timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
-    }
-
     public ClusterHealthStatus waitForStatus() {
         return waitForStatus;
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/ClusterHealthRequestBuilder.java
@@ -40,11 +40,6 @@ public class ClusterHealthRequestBuilder extends MasterNodeReadOperationRequestB
         return this;
     }
 
-    public ClusterHealthRequestBuilder setTimeout(String timeout) {
-        request.timeout(timeout);
-        return this;
-    }
-
     public ClusterHealthRequestBuilder setWaitForStatus(ClusterHealthStatus waitForStatus) {
         request.waitForStatus(waitForStatus);
         return this;

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequest.java
@@ -355,13 +355,6 @@ public class BulkRequest extends ActionRequest
         return this;
     }
 
-    /**
-     * A timeout to wait if the index operation can't be performed immediately. Defaults to {@code 1m}.
-     */
-    public final BulkRequest timeout(String timeout) {
-        return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
-    }
-
     public TimeValue timeout() {
         return timeout;
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestBuilder.java
@@ -165,14 +165,6 @@ public class BulkRequestBuilder extends ActionRequestLazyBuilder<BulkRequest, Bu
     }
 
     /**
-     * A timeout to wait if the index operation can't be performed immediately. Defaults to {@code 1m}.
-     */
-    public final BulkRequestBuilder setTimeout(String timeout) {
-        this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return this;
-    }
-
-    /**
      * The number of actions currently in the bulk.
      */
     public int numberOfActions() {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -693,13 +693,6 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
     }
 
     /**
-     * If set, will enable scrolling of the search request for the specified timeout.
-     */
-    public SearchRequest scroll(String keepAlive) {
-        return scroll(new Scroll(TimeValue.parseTimeValue(keepAlive, null, getClass().getSimpleName() + ".Scroll.keepAlive")));
-    }
-
-    /**
      * Sets if this request should use the request cache or not, assuming that it can (for
      * example, if "now" is used, it will never be cached). By default (not set, or null,
      * will default to the index level setting if request cache is enabled or not).

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequestBuilder.java
@@ -78,14 +78,6 @@ public class SearchRequestBuilder extends ActionRequestBuilder<SearchRequest, Se
     }
 
     /**
-     * If set, will enable scrolling of the search request for the specified timeout.
-     */
-    public SearchRequestBuilder setScroll(String keepAlive) {
-        request.scroll(keepAlive);
-        return this;
-    }
-
-    /**
      * An optional timeout to control how long search is allowed to take.
      */
     public SearchRequestBuilder setTimeout(TimeValue timeout) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollRequest.java
@@ -97,13 +97,6 @@ public class SearchScrollRequest extends ActionRequest implements ToXContentObje
         return scroll(new Scroll(keepAlive));
     }
 
-    /**
-     * If set, will enable scrolling of the search request for the specified timeout.
-     */
-    public SearchScrollRequest scroll(String keepAlive) {
-        return scroll(new Scroll(TimeValue.parseTimeValue(keepAlive, null, getClass().getSimpleName() + ".keepAlive")));
-    }
-
     @Override
     public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
         return new SearchTask(id, type, action, this::getDescription, parentTaskId, headers);

--- a/server/src/main/java/org/elasticsearch/action/search/SearchScrollRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchScrollRequestBuilder.java
@@ -49,12 +49,4 @@ public class SearchScrollRequestBuilder extends ActionRequestBuilder<SearchScrol
         request.scroll(keepAlive);
         return this;
     }
-
-    /**
-     * If set, will enable scrolling of the search request for the specified timeout.
-     */
-    public SearchScrollRequestBuilder setScroll(String keepAlive) {
-        request.scroll(keepAlive);
-        return this;
-    }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -57,30 +57,6 @@ public abstract class AcknowledgedRequest<Request extends MasterNodeRequest<Requ
      * Sets the {@link #ackTimeout}, which specifies how long to wait for all relevant nodes to apply a cluster state update and acknowledge
      * this to the elected master.
      *
-     * @param timeout timeout as a string
-     * @return this request, for method chaining.
-     * @deprecated use {@link #ackTimeout()} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public final Request timeout(String timeout) {
-        return ackTimeout(timeout);
-    }
-
-    /**
-     * Sets the {@link #ackTimeout}, which specifies how long to wait for all relevant nodes to apply a cluster state update and acknowledge
-     * this to the elected master.
-     *
-     * @param ackTimeout timeout as a string
-     * @return this request, for method chaining.
-     */
-    public final Request ackTimeout(String ackTimeout) {
-        return ackTimeout(TimeValue.parseTimeValue(ackTimeout, this.ackTimeout, getClass().getSimpleName() + ".ackTimeout"));
-    }
-
-    /**
-     * Sets the {@link #ackTimeout}, which specifies how long to wait for all relevant nodes to apply a cluster state update and acknowledge
-     * this to the elected master.
-     *
      * @param timeout timeout as a {@link TimeValue}
      * @return this request, for method chaining.
      * @deprecated use {@link #ackTimeout()} instead.

--- a/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequestBuilder.java
@@ -36,13 +36,4 @@ public abstract class AcknowledgedRequestBuilder<
         return (RequestBuilder) this;
     }
 
-    /**
-     * Timeout to wait for the operation to be acknowledged by current cluster nodes. Defaults
-     * to {@code 10s}.
-     */
-    @SuppressWarnings("unchecked")
-    public RequestBuilder setTimeout(String timeout) {
-        request.ackTimeout(timeout);
-        return (RequestBuilder) this;
-    }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/master/MasterNodeOperationRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/MasterNodeOperationRequestBuilder.java
@@ -37,13 +37,4 @@ public abstract class MasterNodeOperationRequestBuilder<
         return (RequestBuilder) this;
     }
 
-    /**
-     * Sets the master node timeout in case the master has not yet been discovered.
-     */
-    @SuppressWarnings("unchecked")
-    public final RequestBuilder setMasterNodeTimeout(String timeout) {
-        request.masterNodeTimeout(timeout);
-        return (RequestBuilder) this;
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/MasterNodeRequest.java
@@ -49,14 +49,6 @@ public abstract class MasterNodeRequest<Request extends MasterNodeRequest<Reques
     }
 
     /**
-     * Specifies how long to wait when the master has not been discovered yet, or is disconnected, or is busy processing other tasks. The
-     * value {@link TimeValue#MINUS_ONE} means to wait forever.
-     */
-    public final Request masterNodeTimeout(String timeout) {
-        return masterNodeTimeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".masterNodeTimeout"));
-    }
-
-    /**
      * @return how long to wait when the master has not been discovered yet, or is disconnected, or is busy processing other tasks. The
      * value {@link TimeValue#MINUS_ONE} means to wait forever.
      */

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -77,12 +77,6 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
         return (Request) this;
     }
 
-    @SuppressWarnings("unchecked")
-    public final Request timeout(String timeout) {
-        this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (Request) this;
-    }
-
     public DiscoveryNode[] concreteNodes() {
         return concreteNodes;
     }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/NodesOperationRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/NodesOperationRequestBuilder.java
@@ -36,9 +36,4 @@ public abstract class NodesOperationRequestBuilder<
         return (RequestBuilder) this;
     }
 
-    @SuppressWarnings("unchecked")
-    public final RequestBuilder setTimeout(String timeout) {
-        request.timeout(timeout);
-        return (RequestBuilder) this;
-    }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequest.java
@@ -98,13 +98,6 @@ public abstract class ReplicationRequest<Request extends ReplicationRequest<Requ
         return (Request) this;
     }
 
-    /**
-     * A timeout to wait if the index operation can't be performed immediately. Defaults to {@code 1m}.
-     */
-    public final Request timeout(String timeout) {
-        return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
-    }
-
     public TimeValue timeout() {
         return timeout;
     }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationRequestBuilder.java
@@ -38,15 +38,6 @@ public abstract class ReplicationRequestBuilder<
         return (RequestBuilder) this;
     }
 
-    /**
-     * A timeout to wait if the index operation can't be performed immediately. Defaults to {@code 1m}.
-     */
-    @SuppressWarnings("unchecked")
-    public RequestBuilder setTimeout(String timeout) {
-        this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (RequestBuilder) this;
-    }
-
     @SuppressWarnings("unchecked")
     public RequestBuilder setIndex(String index) {
         this.index = index;

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequest.java
@@ -106,13 +106,6 @@ public abstract class InstanceShardOperationRequest<Request extends InstanceShar
         return (Request) this;
     }
 
-    /**
-     * A timeout to wait if the index operation can't be performed immediately. Defaults to {@code 1m}.
-     */
-    public final Request timeout(String timeout) {
-        return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
-    }
-
     public String concreteIndex() {
         return concreteIndex;
     }

--- a/server/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/support/single/instance/InstanceShardOperationRequestBuilder.java
@@ -46,15 +46,6 @@ public abstract class InstanceShardOperationRequestBuilder<
         return (RequestBuilder) this;
     }
 
-    /**
-     * A timeout to wait if the index operation can't be performed immediately. Defaults to {@code 1m}.
-     */
-    @SuppressWarnings("unchecked")
-    public RequestBuilder setTimeout(String timeout) {
-        this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (RequestBuilder) this;
-    }
-
     protected void apply(Request request) {
         if (index != null) {
             request.index(index);

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/BaseTasksRequest.java
@@ -170,12 +170,6 @@ public class BaseTasksRequest<Request extends BaseTasksRequest<Request>> extends
         return (Request) this;
     }
 
-    @SuppressWarnings("unchecked")
-    public final Request setTimeout(String timeout) {
-        this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        return (Request) this;
-    }
-
     public boolean match(Task task) {
         if (CollectionUtils.isEmpty(getActions()) == false && Regex.simpleMatch(getActions(), task.getAction()) == false) {
             return false;

--- a/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java
@@ -253,14 +253,6 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
     }
 
     /**
-     * Timeout to wait for the shards on to be available for each bulk request?
-     */
-    public Self setTimeout(String timeout) {
-        this.timeout = TimeValue.parseTimeValue(timeout, this.timeout, getClass().getSimpleName() + ".timeout");
-        return self();
-    }
-
-    /**
      * The number of shard copies that must be active before proceeding with the write.
      */
     public ActiveShardCount getWaitForActiveShards() {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -38,7 +38,7 @@ public class RestClusterStatsAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         ClusterStatsRequest clusterStatsRequest = new ClusterStatsRequest().nodesIds(request.paramAsStringArray("nodeId", null));
-        clusterStatsRequest.timeout(request.param("timeout"));
+        clusterStatsRequest.timeout(request.paramAsTime("timeout", null));
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()
             .cluster()
             .clusterStats(clusterStatsRequest, new NodesResponseRestListener<>(channel));

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.admin.cluster.node.hotthreads.TransportNodesHotT
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.RestApiVersion;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.monitor.jvm.HotThreads;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -110,9 +109,9 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
         nodesHotThreadsRequest.sortOrder(
             HotThreads.SortOrder.of(request.param("sort", nodesHotThreadsRequest.sortOrder().getOrderValue()))
         );
-        nodesHotThreadsRequest.interval(TimeValue.parseTimeValue(request.param("interval"), nodesHotThreadsRequest.interval(), "interval"));
+        nodesHotThreadsRequest.interval(request.paramAsTime("interval", nodesHotThreadsRequest.interval()));
         nodesHotThreadsRequest.snapshots(request.paramAsInt("snapshots", nodesHotThreadsRequest.snapshots()));
-        nodesHotThreadsRequest.timeout(request.param("timeout"));
+        nodesHotThreadsRequest.timeout(request.paramAsTime("timeout", nodesHotThreadsRequest.timeout()));
         return channel -> client.execute(TransportNodesHotThreadsAction.TYPE, nodesHotThreadsRequest, new RestResponseListener<>(channel) {
             @Override
             public RestResponse buildResponse(NodesHotThreadsResponse response) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesInfoAction.java
@@ -86,7 +86,7 @@ public class RestNodesInfoAction extends BaseRestHandler {
         }
 
         final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest(nodeIds);
-        nodesInfoRequest.timeout(request.param("timeout"));
+        nodesInfoRequest.timeout(request.paramAsTime("timeout", null));
         // shortcut, don't do checks if only all is specified
         if (metrics.size() == 1 && metrics.contains("_all")) {
             nodesInfoRequest.all();

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesStatsAction.java
@@ -90,7 +90,7 @@ public class RestNodesStatsAction extends BaseRestHandler {
         Set<String> metrics = Strings.tokenizeByCommaToSet(request.param("metric", "_all"));
 
         NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(nodesIds);
-        nodesStatsRequest.timeout(request.param("timeout"));
+        nodesStatsRequest.timeout(request.paramAsTime("timeout", null));
         // level parameter validation
         nodesStatsRequest.setIncludeShardsStats(NodeStatsLevel.of(request, NodeStatsLevel.NODE) != NodeStatsLevel.NODE);
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesUsageAction.java
@@ -48,7 +48,7 @@ public class RestNodesUsageAction extends BaseRestHandler {
         Set<String> metrics = Strings.tokenizeByCommaToSet(request.param("metric", "_all"));
 
         NodesUsageRequest nodesUsageRequest = new NodesUsageRequest(nodesIds);
-        nodesUsageRequest.timeout(request.param("timeout"));
+        nodesUsageRequest.timeout(request.paramAsTime("timeout", null));
 
         if (metrics.size() == 1 && metrics.contains("_all")) {
             nodesUsageRequest.all();

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestReloadSecureSettingsAction.java
@@ -63,7 +63,7 @@ public final class RestReloadSecureSettingsAction extends BaseRestHandler implem
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         final NodesReloadSecureSettingsRequest reloadSecureSettingsRequest = new NodesReloadSecureSettingsRequest();
         reloadSecureSettingsRequest.nodesIds(Strings.splitStringByCommaToArray(request.param("nodeId")));
-        reloadSecureSettingsRequest.timeout(request.param("timeout"));
+        reloadSecureSettingsRequest.timeout(request.paramAsTime("timeout", null));
         request.withContentOrSourceParamParserOrNull(parser -> {
             if (parser != null) {
                 final ParsedRequestBody parsedRequestBody = PARSER.parse(parser, null);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/create/CreateSnapshotRequestTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.admin.cluster.snapshots.create;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.ToXContent.MapParams;
@@ -96,7 +97,7 @@ public class CreateSnapshotRequestTests extends ESTestCase {
         }
 
         if (randomBoolean()) {
-            original.masterNodeTimeout("60s");
+            original.masterNodeTimeout(TimeValue.timeValueMinutes(1));
         }
 
         XContentBuilder builder = original.toXContent(XContentFactory.jsonBuilder(), new MapParams(Collections.emptyMap()));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/state/ClusterStateRequestTests.java
@@ -86,7 +86,7 @@ public class ClusterStateRequestTests extends ESTestCase {
     public void testDescription() {
         assertThat(new ClusterStateRequest().clear().getDescription(), equalTo("cluster state [master timeout [30s]]"));
         assertThat(
-            new ClusterStateRequest().masterNodeTimeout("5m").getDescription(),
+            new ClusterStateRequest().masterNodeTimeout(TimeValue.timeValueMinutes(5)).getDescription(),
             equalTo("cluster state [routing table, nodes, metadata, blocks, customs, master timeout [5m]]")
         );
         assertThat(new ClusterStateRequest().clear().routingTable(true).getDescription(), containsString("routing table"));

--- a/server/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
@@ -93,7 +93,7 @@ public class SearchScrollRequestTests extends ESTestCase {
     public void testToXContent() throws IOException {
         SearchScrollRequest searchScrollRequest = new SearchScrollRequest();
         searchScrollRequest.scrollId("SCROLL_ID");
-        searchScrollRequest.scroll("1m");
+        searchScrollRequest.scroll(TimeValue.timeValueMinutes(1));
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             searchScrollRequest.toXContent(builder, ToXContent.EMPTY_PARAMS);
             assertEquals("""

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -1312,7 +1312,7 @@ public class TransportSearchActionTests extends ESTestCase {
         }
         {
             SearchRequest searchRequest = new SearchRequest();
-            searchRequest.scroll("5s");
+            searchRequest.scroll(TimeValue.timeValueSeconds(5));
             assertFalse(TransportSearchAction.shouldMinimizeRoundtrips(searchRequest));
         }
         {
@@ -1467,7 +1467,7 @@ public class TransportSearchActionTests extends ESTestCase {
         }
         {
             SearchRequest searchRequest = new SearchRequest().source(new SearchSourceBuilder().sort(SortBuilders.fieldSort("timestamp")))
-                .scroll("5m");
+                .scroll(TimeValue.timeValueMinutes(5));
             assertTrue(
                 TransportSearchAction.shouldPreFilterSearchShards(
                     clusterState,
@@ -1553,7 +1553,7 @@ public class TransportSearchActionTests extends ESTestCase {
             SearchRequest searchRequest = new SearchRequest().source(
                 new SearchSourceBuilder().query(QueryBuilders.rangeQuery("timestamp"))
             );
-            searchRequest.scroll("5s");
+            searchRequest.scroll(TimeValue.timeValueSeconds(5));
             assertTrue(
                 TransportSearchAction.shouldPreFilterSearchShards(
                     clusterState,

--- a/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/TransportReplicationActionTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
@@ -277,7 +278,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         {
             setStateWithBlock(clusterService, retryableBlock, globalBlock);
 
-            Request requestWithTimeout = (globalBlock ? new Request(shardId) : new Request(shardId)).timeout("5ms");
+            Request requestWithTimeout = new Request(shardId).timeout(TimeValue.timeValueMillis(5));
             PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
             ReplicationTask task = maybeTask();
 
@@ -318,7 +319,8 @@ public class TransportReplicationActionTests extends ESTestCase {
             assertIndexShardUninitialized();
         }
         {
-            Request requestWithTimeout = new Request(new ShardId("unknown", "_na_", 0)).index("unknown").timeout("5ms");
+            Request requestWithTimeout = new Request(new ShardId("unknown", "_na_", 0)).index("unknown")
+                .timeout(TimeValue.timeValueMillis(5));
             PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
             ReplicationTask task = maybeTask();
 
@@ -425,7 +427,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
         logger.debug("--> using initial state:\n{}", clusterService.state());
 
-        Request request = new Request(shardId).timeout("1ms");
+        Request request = new Request(shardId).timeout(TimeValue.timeValueMillis(1));
         PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
         TestAction.ReroutePhase reroutePhase = action.new ReroutePhase(task, request, listener);
         reroutePhase.run();
@@ -513,7 +515,8 @@ public class TransportReplicationActionTests extends ESTestCase {
         setState(clusterService, state);
         logger.debug("--> relocation ongoing state:\n{}", clusterService.state());
 
-        Request request = new Request(shardId).timeout("1ms").routedBasedOnClusterVersion(clusterService.state().version() + 1);
+        Request request = new Request(shardId).timeout(TimeValue.timeValueMillis(1))
+            .routedBasedOnClusterVersion(clusterService.state().version() + 1);
         PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
         TestAction.ReroutePhase reroutePhase = action.new ReroutePhase(null, request, listener);
         reroutePhase.run();
@@ -555,7 +558,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         setState(clusterService, state(index, true, randomBoolean() ? ShardRoutingState.INITIALIZING : ShardRoutingState.UNASSIGNED));
         logger.debug("--> using initial state:\n{}", clusterService.state());
 
-        Request request = new Request(new ShardId("unknown_index", "_na_", 0)).timeout("1ms");
+        Request request = new Request(new ShardId("unknown_index", "_na_", 0)).timeout(TimeValue.timeValueMillis(1));
         PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
         ReplicationTask task = maybeTask();
 
@@ -567,7 +570,7 @@ public class TransportReplicationActionTests extends ESTestCase {
 
         // try again with a request that is based on a newer cluster state, make sure we waited until that
         // cluster state for the index to appear
-        request = new Request(new ShardId("unknown_index", "_na_", 0)).timeout("1ms");
+        request = new Request(new ShardId("unknown_index", "_na_", 0)).timeout(TimeValue.timeValueMillis(1));
         request.routedBasedOnClusterVersion(clusterService.state().version() + 1);
         listener = new PlainActionFuture<>();
         task = maybeTask();
@@ -578,7 +581,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         assertPhase(task, "failed");
         assertTrue(request.isRetrySet.get());
 
-        request = new Request(new ShardId(index, "_na_", 10)).timeout("1ms");
+        request = new Request(new ShardId(index, "_na_", 10)).timeout(TimeValue.timeValueMillis(1));
         listener = new PlainActionFuture<>();
         reroutePhase = action.new ReroutePhase(null, request, listener);
         reroutePhase.run();
@@ -602,7 +605,9 @@ public class TransportReplicationActionTests extends ESTestCase {
         );
         assertThat(clusterService.state().metadata().indices().get(index).getState(), equalTo(IndexMetadata.State.CLOSE));
         logger.debug("--> using initial state:\n{}", clusterService.state());
-        Request request = new Request(new ShardId(clusterService.state().metadata().indices().get(index).getIndex(), 0)).timeout("1ms");
+        Request request = new Request(new ShardId(clusterService.state().metadata().indices().get(index).getIndex(), 0)).timeout(
+            TimeValue.timeValueMillis(1)
+        );
         PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
         ReplicationTask task = maybeTask();
 
@@ -631,9 +636,9 @@ public class TransportReplicationActionTests extends ESTestCase {
         Request request = new Request(shardId);
         boolean timeout = randomBoolean();
         if (timeout) {
-            request.timeout("0s");
+            request.timeout(TimeValue.ZERO);
         } else {
-            request.timeout("1h");
+            request.timeout(TimeValue.timeValueHours(1));
         }
         PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
         ReplicationTask task = maybeTask();
@@ -714,7 +719,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         final ShardId shardId = new ShardId(index, "_na_", 0);
         ClusterState state = stateWithActivePrimary(index, true, randomInt(5));
         setState(clusterService, state);
-        Request request = new Request(shardId).timeout("1ms");
+        Request request = new Request(shardId).timeout(TimeValue.timeValueMillis(1));
         PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
         ReplicationTask task = maybeTask();
         AtomicBoolean executed = new AtomicBoolean();
@@ -784,7 +789,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         // simulate execution of the primary phase on the relocation target node
         state = ClusterState.builder(state).nodes(DiscoveryNodes.builder(state.nodes()).localNodeId(primaryTargetNodeId)).build();
         setState(clusterService, state);
-        Request request = new Request(shardId).timeout("1ms");
+        Request request = new Request(shardId).timeout(TimeValue.timeValueMillis(1));
         PlainActionFuture<TestResponse> listener = new PlainActionFuture<>();
         ReplicationTask task = maybeTask();
         AtomicBoolean executed = new AtomicBoolean();
@@ -1121,7 +1126,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         PlainActionFuture<TransportResponse> listener = new PlainActionFuture<>();
         final boolean wrongAllocationId = randomBoolean();
         final long requestTerm = wrongAllocationId && randomBoolean() ? primaryTerm : primaryTerm + randomIntBetween(1, 10);
-        Request request = new Request(shardId).timeout("1ms");
+        Request request = new Request(shardId).timeout(TimeValue.timeValueMillis(1));
         action.handlePrimaryRequest(
             new TransportReplicationAction.ConcreteShardRequest<>(
                 request,
@@ -1171,7 +1176,7 @@ public class TransportReplicationActionTests extends ESTestCase {
         setState(clusterService, state);
 
         PlainActionFuture<TransportResponse> listener = new PlainActionFuture<>();
-        Request request = new Request(shardId).timeout("1ms");
+        Request request = new Request(shardId).timeout(TimeValue.timeValueMillis(1));
         action.handleReplicaRequest(
             new TransportReplicationAction.ConcreteReplicaRequest<>(
                 request,

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -246,7 +246,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         createIndex("index");
         prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         assertResponse(
-            client().prepareSearch("index").setSize(1).setScroll("1m"),
+            client().prepareSearch("index").setSize(1).setScroll(TimeValue.timeValueMinutes(1)),
             searchResponse -> assertThat(searchResponse.getScrollId(), is(notNullValue()))
         );
         SearchService service = getInstanceFromNode(SearchService.class);
@@ -260,7 +260,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         createIndex("index");
         prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         assertResponse(
-            client().prepareSearch("index").setSize(1).setScroll("1m"),
+            client().prepareSearch("index").setSize(1).setScroll(TimeValue.timeValueMinutes(1)),
             searchResponse -> assertThat(searchResponse.getScrollId(), is(notNullValue()))
         );
         SearchService service = getInstanceFromNode(SearchService.class);
@@ -274,7 +274,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         createIndex("index");
         prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         assertResponse(
-            client().prepareSearch("index").setSize(1).setScroll("1m"),
+            client().prepareSearch("index").setSize(1).setScroll(TimeValue.timeValueMinutes(1)),
             searchResponse -> assertThat(searchResponse.getScrollId(), is(notNullValue()))
         );
         SearchService service = getInstanceFromNode(SearchService.class);
@@ -478,7 +478,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("index", Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).build());
         prepareIndex("index").setId("1").setSource("field", "value").setRefreshPolicy(IMMEDIATE).get();
         assertResponse(
-            client().prepareSearch("index").setSize(1).setScroll("1m"),
+            client().prepareSearch("index").setSize(1).setScroll(TimeValue.timeValueMinutes(1)),
             searchResponse -> assertThat(searchResponse.getScrollId(), is(notNullValue()))
         );
         SearchService service = getInstanceFromNode(SearchService.class);
@@ -787,7 +787,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         LinkedList<String> clearScrollIds = new LinkedList<>();
 
         for (int i = 0; i < SearchService.MAX_OPEN_SCROLL_CONTEXT.get(Settings.EMPTY); i++) {
-            assertResponse(client().prepareSearch("index").setSize(1).setScroll("1m"), searchResponse -> {
+            assertResponse(client().prepareSearch("index").setSize(1).setScroll(TimeValue.timeValueMinutes(1)), searchResponse -> {
                 if (randomInt(4) == 0) clearScrollIds.addLast(searchResponse.getScrollId());
             });
         }
@@ -797,7 +797,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         client().clearScroll(clearScrollRequest);
 
         for (int i = 0; i < clearScrollIds.size(); i++) {
-            client().prepareSearch("index").setSize(1).setScroll("1m").get().decRef();
+            client().prepareSearch("index").setSize(1).setScroll(TimeValue.timeValueMinutes(1)).get().decRef();
         }
 
         final ShardScrollRequestTest request = new ShardScrollRequestTest(indexShard.shardId());

--- a/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
@@ -111,7 +112,7 @@ public class SliceBuilderTests extends ESTestCase {
     }
 
     private ShardSearchRequest createScrollRequest(int shardIndex, int numShards) {
-        SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true).scroll("1m");
+        SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true).scroll(TimeValue.timeValueMinutes(1));
         return new ShardSearchRequest(
             OriginalIndices.NONE,
             searchRequest,

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/AutoFollowIT.java
@@ -735,7 +735,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
         // Need to set this, because following an index in the same cluster
         request.setFollowIndexNamePattern("copy-{{leader_index}}");
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
 
         assertTrue(followerClient().execute(PutAutoFollowPatternAction.INSTANCE, request).actionGet().isAcknowledged());
@@ -744,7 +744,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
     private void deleteAutoFollowPattern(final String name) {
         DeleteAutoFollowPatternAction.Request request = new DeleteAutoFollowPatternAction.Request(name);
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         assertTrue(followerClient().execute(DeleteAutoFollowPatternAction.INSTANCE, request).actionGet().isAcknowledged());
     }
@@ -752,7 +752,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
     private AutoFollowStats getAutoFollowStats() {
         CcrStatsAction.Request request = new CcrStatsAction.Request();
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         return followerClient().execute(CcrStatsAction.INSTANCE, request).actionGet().getAutoFollowStats();
     }
@@ -766,7 +766,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
     private void pauseAutoFollowPattern(final String name) {
         ActivateAutoFollowPatternAction.Request request = new ActivateAutoFollowPatternAction.Request(name, false);
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         assertAcked(followerClient().execute(ActivateAutoFollowPatternAction.INSTANCE, request).actionGet());
     }
@@ -774,7 +774,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
     private void resumeAutoFollowPattern(final String name) {
         ActivateAutoFollowPatternAction.Request request = new ActivateAutoFollowPatternAction.Request(name, true);
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         assertAcked(followerClient().execute(ActivateAutoFollowPatternAction.INSTANCE, request).actionGet());
     }
@@ -783,7 +783,7 @@ public class AutoFollowIT extends CcrIntegTestCase {
         GetAutoFollowPatternAction.Request request = new GetAutoFollowPatternAction.Request();
         request.setName(name);
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         GetAutoFollowPatternAction.Response response = followerClient().execute(GetAutoFollowPatternAction.INSTANCE, request).actionGet();
         assertTrue(response.getAutoFollowPatterns().containsKey(name));

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowStatsAction.java
@@ -40,9 +40,7 @@ public class RestFollowStatsAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) {
         final FollowStatsAction.StatsRequest request = new FollowStatsAction.StatsRequest();
         request.setIndices(Strings.splitStringByCommaToArray(restRequest.param("index")));
-        if (restRequest.hasParam("timeout")) {
-            request.setTimeout(restRequest.param("timeout"));
-        }
+        request.setTimeout(restRequest.paramAsTime("timeout", request.getTimeout()));
         return channel -> client.execute(
             FollowStatsAction.INSTANCE,
             request,

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrIntegTestCase.java
@@ -595,7 +595,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
         request.getParameters().setMaxReadRequestOperationCount(between(1, 10000));
         request.waitForActiveShards(waitForActiveShards);
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         return request;
     }
@@ -606,7 +606,7 @@ public abstract class CcrIntegTestCase extends ESTestCase {
         request.getParameters().setMaxRetryDelay(TimeValue.timeValueMillis(10));
         request.getParameters().setReadPollTimeout(TimeValue.timeValueMillis(10));
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         return request;
     }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrSingleNodeTestCase.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/CcrSingleNodeTestCase.java
@@ -104,7 +104,7 @@ public abstract class CcrSingleNodeTestCase extends ESSingleNodeTestCase {
         request.getParameters().setMaxRetryDelay(TimeValue.timeValueMillis(1));
         request.getParameters().setReadPollTimeout(TimeValue.timeValueMillis(1));
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         return request;
     }
@@ -118,7 +118,7 @@ public abstract class CcrSingleNodeTestCase extends ESSingleNodeTestCase {
         request.getParameters().setReadPollTimeout(TimeValue.timeValueMillis(1));
         request.waitForActiveShards(ActiveShardCount.ONE);
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("10s", "20s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(10, 20, 30)));
         }
         return request;
     }

--- a/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotIT.java
+++ b/x-pack/plugin/core/src/internalClusterTest/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotIT.java
@@ -277,7 +277,7 @@ public class SourceOnlySnapshotIT extends AbstractSnapshotIntegTestCase {
             assertEquals(numDocsExpected, searchResponse.getHits().getTotalHits().value);
         });
         SearchResponse searchResponse = prepareSearch(index).addSort(SeqNoFieldMapper.NAME, SortOrder.ASC)
-            .setScroll("1m")
+            .setScroll(TimeValue.timeValueMinutes(1))
             .slice(new SliceBuilder(SeqNoFieldMapper.NAME, randomIntBetween(0, 1), 2))
             .setSize(randomIntBetween(1, 10))
             .get();
@@ -349,11 +349,11 @@ public class SourceOnlySnapshotIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> delete index and stop the data node");
         assertAcked(client().admin().indices().prepareDelete(sourceIdx).get());
         internalCluster().stopRandomDataNode();
-        assertFalse(clusterAdmin().prepareHealth().setTimeout("30s").setWaitForNodes("1").get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("1").get().isTimedOut());
 
         final String newDataNode = internalCluster().startDataOnlyNode();
         logger.info("--> start a new data node " + newDataNode);
-        assertFalse(clusterAdmin().prepareHealth().setTimeout("30s").setWaitForNodes("2").get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setTimeout(TimeValue.timeValueSeconds(30)).setWaitForNodes("2").get().isTimedOut());
 
         logger.info("--> restore the index and ensure all shards are allocated");
         RestoreSnapshotResponse restoreResponse = clusterAdmin().prepareRestoreSnapshot(repo, snapshot)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/graph/GraphExploreRequest.java
@@ -170,11 +170,6 @@ public class GraphExploreRequest extends ActionRequest implements IndicesRequest
         return this;
     }
 
-    public GraphExploreRequest timeout(String timeout) {
-        timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
-        return this;
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/CcrStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/CcrStatsAction.java
@@ -68,10 +68,6 @@ public class CcrStatsAction extends ActionType<CcrStatsAction.Response> {
             this.timeout = timeout;
         }
 
-        public void setTimeout(String timeout) {
-            this.timeout = TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout");
-        }
-
         @Override
         public boolean equals(Object o) {
             if (this == o) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/action/GraphExploreRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/graph/action/GraphExploreRequestBuilder.java
@@ -97,15 +97,6 @@ public class GraphExploreRequestBuilder extends ActionRequestBuilder<GraphExplor
     }
 
     /**
-     * An optional timeout to control how long the graph exploration is allowed
-     * to take.
-     */
-    public GraphExploreRequestBuilder setTimeout(String timeout) {
-        request.timeout(timeout);
-        return this;
-    }
-
-    /**
      * Add a stage in the graph exploration. Each hop represents a stage of
      * querying elasticsearch to identify terms which can then be connnected
      * to other terms in a subsequent hop.

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ccr/action/CcrStatsActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ccr/action/CcrStatsActionTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.core.ccr.action;
 
 import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 
@@ -24,8 +25,8 @@ public class CcrStatsActionTests extends AbstractWireSerializingTestCase<CcrStat
     @Override
     protected CcrStatsAction.Request createTestInstance() {
         var request = new CcrStatsAction.Request();
-        request.setTimeout(randomFrom("1s", "5s", "10s", "15s"));
-        request.masterNodeTimeout(randomFrom("1s", "5s", "10s", "15s"));
+        request.setTimeout(TimeValue.timeValueSeconds(randomFrom(1, 5, 10, 15)));
+        request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(1, 5, 10, 15)));
         return request;
     }
 
@@ -35,12 +36,12 @@ public class CcrStatsActionTests extends AbstractWireSerializingTestCase<CcrStat
             case 0 -> {
                 var mutatedInstance = new CcrStatsAction.Request();
                 mutatedInstance.setTimeout(instance.getTimeout());
-                mutatedInstance.masterNodeTimeout(randomFrom("20s", "25s", "30s"));
+                mutatedInstance.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(20, 25, 30)));
                 yield mutatedInstance;
             }
             case 1 -> {
                 var mutatedInstance = new CcrStatsAction.Request();
-                mutatedInstance.setTimeout(randomFrom("20s", "25s", "30s"));
+                mutatedInstance.setTimeout(TimeValue.timeValueSeconds(randomFrom(20, 25, 30)));
                 mutatedInstance.masterNodeTimeout(instance.masterNodeTimeout());
                 yield mutatedInstance;
             }
@@ -52,7 +53,7 @@ public class CcrStatsActionTests extends AbstractWireSerializingTestCase<CcrStat
         // In previous version `timeout` is not set
         var request = new CcrStatsAction.Request();
         if (randomBoolean()) {
-            request.masterNodeTimeout(randomFrom("20s", "25s", "30s"));
+            request.masterNodeTimeout(TimeValue.timeValueSeconds(randomFrom(20, 25, 30)));
         }
         assertSerialization(request, TransportVersionUtils.getPreviousVersion(TransportVersions.CCR_STATS_API_TIMEOUT_PARAM));
         assertSerialization(request, TransportVersions.MINIMUM_CCS_VERSION);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestExplainLifecycleAction.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/action/RestExplainLifecycleAction.java
@@ -40,11 +40,7 @@ public class RestExplainLifecycleAction extends BaseRestHandler {
         explainLifecycleRequest.indicesOptions(IndicesOptions.fromRequest(restRequest, IndicesOptions.strictExpandOpen()));
         explainLifecycleRequest.onlyManaged(restRequest.paramAsBoolean("only_managed", false));
         explainLifecycleRequest.onlyErrors(restRequest.paramAsBoolean("only_errors", false));
-        String masterNodeTimeout = restRequest.param("master_timeout");
-        if (masterNodeTimeout != null) {
-            explainLifecycleRequest.masterNodeTimeout(masterNodeTimeout);
-        }
-
+        explainLifecycleRequest.masterNodeTimeout(restRequest.paramAsTime("master_timeout", explainLifecycleRequest.masterNodeTimeout()));
         return channel -> client.execute(ExplainLifecycleAction.INSTANCE, explainLifecycleRequest, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/BatchedDocumentsIterator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/persistence/BatchedDocumentsIterator.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -32,7 +33,7 @@ import java.util.Objects;
 public abstract class BatchedDocumentsIterator<T> implements BatchedIterator<T> {
     private static final Logger LOGGER = LogManager.getLogger(BatchedDocumentsIterator.class);
 
-    private static final String CONTEXT_ALIVE_DURATION = "5m";
+    private static final TimeValue CONTEXT_ALIVE_DURATION = TimeValue.timeValueMinutes(5);
     private static final int BATCH_SIZE = 10000;
 
     private final OriginSettingClient client;

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityClearScrollTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/SecurityClearScrollTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.search.MultiSearchRequestBuilder;
 import org.elasticsearch.action.search.MultiSearchResponse;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.SecurityIntegTestCase;
 import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.xcontent.XContentType;
@@ -77,7 +78,7 @@ public class SecurityClearScrollTests extends SecurityIntegTestCase {
         MultiSearchRequestBuilder multiSearchRequestBuilder = client().prepareMultiSearch();
         int count = randomIntBetween(5, 15);
         for (int i = 0; i < count; i++) {
-            multiSearchRequestBuilder.add(prepareSearch("index").setScroll("10m").setSize(1));
+            multiSearchRequestBuilder.add(prepareSearch("index").setScroll(TimeValue.timeValueMinutes(10)).setSize(1));
         }
         scrollIds = new ArrayList<>();
         assertResponse(multiSearchRequestBuilder, multiSearchResponse -> scrollIds.addAll(getScrollIds(multiSearchResponse)));

--- a/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
+++ b/x-pack/plugin/voting-only-node/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePluginTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.blobstore.BlobStore;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.index.IndexVersion;
@@ -153,7 +154,12 @@ public class VotingOnlyNodePluginTests extends ESIntegTestCase {
         expectThrows(
             MasterNotDiscoveredException.class,
             () -> assertThat(
-                clusterAdmin().prepareState().setMasterNodeTimeout("100ms").get().getState().nodes().getMasterNodeId(),
+                clusterAdmin().prepareState()
+                    .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
+                    .get()
+                    .getState()
+                    .nodes()
+                    .getMasterNodeId(),
                 nullValue()
             )
         );


### PR DESCRIPTION
Today various APIs accept both a `TimeValue` and a `String` to specify
the same timeout, with the API implementation taking care of the
conversion from `String` to `TimeValue`. This was convenient for users
of the transport client, but these days it's not necessary. This commit
removes the unnecessary overloads and parsing code and migrates all
callers to creating a proper `TimeValue`.