### PR TITLE
[8.14] ESQL: median, count and count_distinct over constants (#107414)

### DIFF
--- a/docs/changelog/107414.yaml
+++ b/docs/changelog/107414.yaml
@@ -1,0 +1,7 @@
+pr: 107414
+summary: "ESQL: median, count and `count_distinct` over constants"
+area: ES|QL
+type: bug
+issues:
+ - 105248
+ - 104900

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -695,13 +695,13 @@ ca:l|gender:s
 ;
 
 
-countFieldVsAll
+countFieldVsAll#[skip:-8.14.99, reason:Fixed count(null) in 8.15]
 from employees | stats ca = count(), cn = count(null), cf = count(gender) by gender | sort gender;
 
 ca:l|cn:l|cf:l|gender:s
-33  |33  |33  |F
-57  |57  |57  |M
-10  |10  |0   |null
+33  |0   |33  |F
+57  |0   |57  |M
+10  |0   |0   |null
 ;
 
 countMultiValue
@@ -1456,6 +1456,30 @@ rows:l
 6
 ;
 
+countOfConst#[skip:-8.14.99,reason:supported in 8.15]
+FROM employees
+| STATS s1 = count(1), s2point1 = count(2.1), s_mv = count([-1, 0, 3]) * 3, s_null = count(null), rows = count(*)
+;
+
+s1:l | s2point1:l | s_mv:l | s_null:l | rows:l
+100  | 100        | 900    | 0        | 100
+;
+
+countOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+FROM employees
+| STATS s2point1 = count("two point one"), s_mv = count([-1, 0, 3]), s_null = count(null), rows = count(*) by languages
+| SORT languages
+;
+
+s2point1:l | s_mv:l | s_null:l | rows:l | languages:i
+15         | 45     | 0        | 15     | 1
+19         | 57     | 0        | 19     | 2
+17         | 51     | 0        | 17     | 3
+18         | 54     | 0        | 18     | 4
+21         | 63     | 0        | 21     | 5
+10         | 30     | 0        | 10     | null
+;
+
 sumOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s1 = sum(1), s2point1 = sum(2.1), s_mv = sum([-1, 0, 3]) * 3, s_null = sum(null), rows = count(*)
@@ -1550,6 +1574,54 @@ s2point1:d | s_mv:i | languages:i
 2.1        | 3      | 4
 2.1        | 3      | 5
 2.1        | 3      | null
+;
+
+medianOfConst#[skip:-8.14.99,reason:supported in 8.15]
+FROM employees
+| STATS s1 = median(1), s_mv = median([-1, 0, 1, 3]), s_null = median(null)
+;
+
+s1:d | s_mv:d | s_null:d
+1.0  | 0.5    | null
+;
+
+medianOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+FROM employees
+| STATS s2point1 = median(2.1), s_mv = median([-1, 0, 1, 3]) by languages
+| SORT languages
+;
+
+s2point1:d | s_mv:d | languages:i
+2.1        | 0.5    | 1
+2.1        | 0.5    | 2
+2.1        | 0.5    | 3
+2.1        | 0.5    | 4
+2.1        | 0.5    | 5
+2.1        | 0.5    | null
+;
+
+countDistinctOfConst#[skip:-8.14.99,reason:supported in 8.15]
+FROM employees
+| STATS s1 = count_distinct(1), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_null = count_distinct(null), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 5) 
+;
+
+s1:l | s_mv:l | s_null:l | s_param:l
+1    | 4      | 0        | 4
+;
+
+countDistinctOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+FROM employees
+| STATS s2point1 = count_distinct("two point one"), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 8000) by languages
+| SORT languages
+;
+
+s2point1:l | s_mv:l | s_param:l | languages:i
+1          | 4      | 4         | 1
+1          | 4      | 4         | 2
+1          | 4      | 4         | 3
+1          | 4      | 4         | 4
+1          | 4      | 4         | 5
+1          | 4      | 4         | null
 ;
 
 evalOverridingKey#[skip:-8.13.1,reason:fixed in 8.13.2]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -695,7 +695,7 @@ ca:l|gender:s
 ;
 
 
-countFieldVsAll#[skip:-8.14.99, reason:Fixed count(null) in 8.15]
+countFieldVsAll#[skip:-8.13.99, reason:Fixed count(null) in 8.14]
 from employees | stats ca = count(), cn = count(null), cf = count(gender) by gender | sort gender;
 
 ca:l|cn:l|cf:l|gender:s
@@ -1456,7 +1456,7 @@ rows:l
 6
 ;
 
-countOfConst#[skip:-8.14.99,reason:supported in 8.15]
+countOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s1 = count(1), s2point1 = count(2.1), s_mv = count([-1, 0, 3]) * 3, s_null = count(null), rows = count(*)
 ;
@@ -1465,7 +1465,7 @@ s1:l | s2point1:l | s_mv:l | s_null:l | rows:l
 100  | 100        | 900    | 0        | 100
 ;
 
-countOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+countOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s2point1 = count("two point one"), s_mv = count([-1, 0, 3]), s_null = count(null), rows = count(*) by languages
 | SORT languages
@@ -1576,7 +1576,7 @@ s2point1:d | s_mv:i | languages:i
 2.1        | 3      | null
 ;
 
-medianOfConst#[skip:-8.14.99,reason:supported in 8.15]
+medianOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s1 = median(1), s_mv = median([-1, 0, 1, 3]), s_null = median(null)
 ;
@@ -1585,7 +1585,7 @@ s1:d | s_mv:d | s_null:d
 1.0  | 0.5    | null
 ;
 
-medianOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+medianOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s2point1 = median(2.1), s_mv = median([-1, 0, 1, 3]) by languages
 | SORT languages
@@ -1600,7 +1600,7 @@ s2point1:d | s_mv:d | languages:i
 2.1        | 0.5    | null
 ;
 
-countDistinctOfConst#[skip:-8.14.99,reason:supported in 8.15]
+countDistinctOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s1 = count_distinct(1), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_null = count_distinct(null), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 5) 
 ;
@@ -1609,7 +1609,7 @@ s1:l | s_mv:l | s_null:l | s_param:l
 1    | 4      | 0        | 4
 ;
 
-countDistinctOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+countDistinctOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s2point1 = count_distinct("two point one"), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 8000) by languages
 | SORT languages

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Count.java
@@ -10,10 +10,15 @@ package org.elasticsearch.xpack.esql.expression.function.aggregate;
 import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountAggregatorFunction;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
+import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvCount;
+import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.Nullability;
 import org.elasticsearch.xpack.ql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.ql.expression.function.aggregate.EnclosedAgg;
@@ -21,12 +26,13 @@ import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
+import org.elasticsearch.xpack.ql.util.StringUtils;
 
 import java.util.List;
 
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 
-public class Count extends AggregateFunction implements EnclosedAgg, ToAggregator {
+public class Count extends AggregateFunction implements EnclosedAgg, ToAggregator, SurrogateExpression {
 
     @FunctionInfo(returnType = "long", description = "Returns the total number (count) of input values.", isAggregation = true)
     public Count(
@@ -86,5 +92,31 @@ public class Count extends AggregateFunction implements EnclosedAgg, ToAggregato
     @Override
     protected TypeResolution resolveType() {
         return EsqlTypeResolutions.isExact(field(), sourceText(), DEFAULT);
+    }
+
+    @Override
+    public Expression surrogate() {
+        var s = source();
+        var field = field();
+
+        if (field.foldable()) {
+            if (field instanceof Literal l) {
+                if (l.value() != null && (l.value() instanceof List<?>) == false) {
+                    // TODO: Normalize COUNT(*), COUNT(), COUNT("foobar"), COUNT(1) as COUNT(*).
+                    // Does not apply to COUNT([1,2,3])
+                    // return new Count(s, new Literal(s, StringUtils.WILDCARD, DataTypes.KEYWORD));
+                    return null;
+                }
+            }
+
+            // COUNT(const) is equivalent to MV_COUNT(const)*COUNT(*) if const is not null; otherwise COUNT(const) == 0.
+            return new Mul(
+                s,
+                new Coalesce(s, new MvCount(s, field), List.of(new Literal(s, 0, DataTypes.INTEGER))),
+                new Count(s, new Literal(s, StringUtils.WILDCARD, DataTypes.KEYWORD))
+            );
+        }
+
+        return null;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Median.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Median.java
@@ -11,6 +11,8 @@ import org.elasticsearch.compute.aggregation.QuantileStates;
 import org.elasticsearch.xpack.esql.expression.SurrogateExpression;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDouble;
+import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMedian;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.expression.Literal;
 import org.elasticsearch.xpack.ql.expression.function.aggregate.AggregateFunction;
@@ -63,6 +65,11 @@ public class Median extends AggregateFunction implements SurrogateExpression {
 
     @Override
     public Expression surrogate() {
-        return new Percentile(source(), field(), new Literal(source(), (int) QuantileStates.MEDIAN, DataTypes.INTEGER));
+        var s = source();
+        var field = field();
+
+        return field.foldable()
+            ? new MvMedian(s, new ToDouble(s, field))
+            : new Percentile(source(), field(), new Literal(source(), (int) QuantileStates.MEDIAN, DataTypes.INTEGER));
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -73,7 +73,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -372,9 +371,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
                 // for the moment support pushing count just for one field
                 List<Stat> stats = tuple.v2();
                 if (stats.size() > 1) {
-                    if (stats.stream().map(Stat::name).collect(Collectors.toSet()).size() > 1) {
-                        return aggregateExec;
-                    }
+                    return aggregateExec;
                 }
 
                 // TODO: handle case where some aggs cannot be pushed down by breaking the aggs into two sources (regular + stats) + union

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -1684,7 +1684,7 @@ public class LogicalPlanOptimizer extends ParameterizedRuleExecutor<LogicalPlan,
      * 1. replaces reference to field attributes with their source
      * 2. in case of Count, aligns the various forms (Count(1), Count(0), Count(), Count(*)) to Count(*)
      */
-    // TODO waiting on https://github.com/elastic/elasticsearch/issues/100634
+    // TODO still needed?
     static class NormalizeAggregate extends Rule<LogicalPlan, LogicalPlan> {
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizerTests.java
@@ -340,7 +340,7 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
         return plan.get();
     }
 
-    // optimized doesn't know yet how to break down different multi count
+    // optimizer doesn't know yet how to break down different multi count
     public void testCountMultipleFieldsWithFilter() {
         var plan = plan("""
             from test
@@ -370,42 +370,17 @@ public class LocalPhysicalPlanOptimizerTests extends MapperServiceTestCase {
         assertThat(expected.toString(), is(esStatsQuery.query().toString()));
     }
 
-    /**
-     * Expected
-     * ProjectExec[[c{r}#3, c{r}#3 AS call, c_literal{r}#7]]
-     * \_LimitExec[1000[INTEGER]]
-     *   \_AggregateExec[[],[COUNT([2a][KEYWORD]) AS c, COUNT(1[INTEGER]) AS c_literal],FINAL,null]
-     *     \_ExchangeExec[[count{r}#18, seen{r}#19, count{r}#20, seen{r}#21],true]
-     *       \_EsStatsQueryExec[test], stats[Stat[name=*, type=COUNT, query=null], Stat[name=*, type=COUNT, query=null]]],
-     *         query[{"esql_single_value":{"field":"emp_no","next":{"range":{"emp_no":{"gt":10010,"boost":1.0}}},
-     *         "source":"emp_no > 10010@2:9"}}][count{r}#23, seen{r}#24, count{r}#25, seen{r}#26], limit[],
-     */
+    // optimizer doesn't know yet how to normalize and deduplicate cout(*), count(), count(1) etc.
     public void testMultiCountAllWithFilter() {
         var plan = plan("""
             from test
             | where emp_no > 10010
             | stats c = count(), call = count(*), c_literal = count(1)
             """, IS_SV_STATS);
-
-        var project = as(plan, ProjectExec.class);
-        var projections = project.projections();
-        assertThat(Expressions.names(projections), contains("c", "call", "c_literal"));
-        var alias = as(projections.get(1), Alias.class);
-        assertThat(Expressions.name(alias.child()), is("c"));
-        var limit = as(project.child(), LimitExec.class);
-        var agg = as(limit.child(), AggregateExec.class);
-        assertThat(agg.getMode(), is(FINAL));
-        assertThat(Expressions.names(agg.aggregates()), contains("c", "c_literal"));
-        var exchange = as(agg.child(), ExchangeExec.class);
-        var esStatsQuery = as(exchange.child(), EsStatsQueryExec.class);
-        assertThat(esStatsQuery.limit(), is(nullValue()));
-        assertThat(Expressions.names(esStatsQuery.output()), contains("count", "seen", "count", "seen"));
-        var source = ((SingleValueQuery.Builder) esStatsQuery.query()).source();
-        var expected = wrapWithSingleQuery(QueryBuilders.rangeQuery("emp_no").gt(10010), "emp_no", source);
-        assertThat(expected.toString(), is(esStatsQuery.query().toString()));
+        assertThat(plan.anyMatch(EsQueryExec.class::isInstance), is(true));
     }
 
-    // optimized doesn't know yet how to break down different multi count
+    // optimizer doesn't know yet how to break down different multi count
     public void testCountFieldsAndAllWithFilter() {
         var plan = plan("""
             from test

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -36,6 +36,8 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Percentile;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroid;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToDouble;
+import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToLong;
 import org.elasticsearch.xpack.esql.expression.function.scalar.convert.ToString;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateExtract;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateFormat;
@@ -55,6 +57,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMax;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMedian;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvMin;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvSum;
+import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Concat;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.LTrim;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.RLike;
@@ -109,6 +112,8 @@ import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.type.EsField;
+import org.elasticsearch.xpack.ql.util.Holder;
+import org.elasticsearch.xpack.ql.util.StringUtils;
 import org.junit.BeforeClass;
 
 import java.lang.reflect.Constructor;
@@ -3653,6 +3658,76 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      * Limit[1000[INTEGER]]
      * \_EsqlProject[[s{r}#3, s_expr{r}#5, s_null{r}#7, w{r}#10]]
      *   \_Project[[s{r}#3, s_expr{r}#5, s_null{r}#7, w{r}#10]]
+     *     \_Eval[[COALESCE(MVCOUNT([1, 2][INTEGER]),0[INTEGER]) * $$COUNT$s$0{r}#26 AS s, COALESCE(MVCOUNT(314.0[DOUBLE] / 100[
+     * INTEGER]),0[INTEGER]) * $$COUNT$s$0{r}#26 AS s_expr, COALESCE(MVCOUNT(null[NULL]),0[INTEGER]) * $$COUNT$s$0{r}#26 AS s_null]]
+     *       \_Aggregate[[w{r}#10],[COUNT(*[KEYWORD]) AS $$COUNT$s$0, w{r}#10]]
+     *         \_Eval[[emp_no{f}#16 % 2[INTEGER] AS w]]
+     *           \_EsRelation[test][_meta_field{f}#22, emp_no{f}#16, first_name{f}#17, ..]
+     */
+    public void testCountOfLiteral() {
+        var plan = plan("""
+            from test
+            | stats s = count([1,2]),
+                    s_expr = count(314.0/100),
+                    s_null = count(null)
+                    by w = emp_no % 2
+            | keep s, s_expr, s_null, w
+            """, SubstitutionOnlyOptimizer.INSTANCE);
+
+        var limit = as(plan, Limit.class);
+        var esqlProject = as(limit.child(), EsqlProject.class);
+        var project = as(esqlProject.child(), Project.class);
+        var eval = as(project.child(), Eval.class);
+        var agg = as(eval.child(), Aggregate.class);
+
+        assertThat(Expressions.names(agg.aggregates()), contains("$$COUNT$s$0", "w"));
+        var countAggLiteral = as(as(Alias.unwrap(agg.aggregates().get(0)), Count.class).field(), Literal.class);
+        assertTrue(countAggLiteral.semanticEquals(new Literal(EMPTY, StringUtils.WILDCARD, DataTypes.KEYWORD)));
+
+        var exprs = eval.fields();
+        // s == mv_count([1,2]) * count(*)
+        var s = as(exprs.get(0), Alias.class);
+        assertThat(s.name(), equalTo("s"));
+        var mul = as(s.child(), Mul.class);
+        var mvCoalesce = as(mul.left(), Coalesce.class);
+        assertThat(mvCoalesce.children().size(), equalTo(2));
+        var mvCount = as(mvCoalesce.children().get(0), MvCount.class);
+        assertThat(mvCount.fold(), equalTo(2));
+        assertThat(mvCoalesce.children().get(1).fold(), equalTo(0));
+        var count = as(mul.right(), ReferenceAttribute.class);
+        assertThat(count.name(), equalTo("$$COUNT$s$0"));
+
+        // s_expr == mv_count(314.0/100) * count(*)
+        var s_expr = as(exprs.get(1), Alias.class);
+        assertThat(s_expr.name(), equalTo("s_expr"));
+        var mul_expr = as(s_expr.child(), Mul.class);
+        var mvCoalesce_expr = as(mul_expr.left(), Coalesce.class);
+        assertThat(mvCoalesce_expr.children().size(), equalTo(2));
+        var mvCount_expr = as(mvCoalesce_expr.children().get(0), MvCount.class);
+        assertThat(mvCount_expr.fold(), equalTo(1));
+        assertThat(mvCoalesce_expr.children().get(1).fold(), equalTo(0));
+        var count_expr = as(mul_expr.right(), ReferenceAttribute.class);
+        assertThat(count_expr.name(), equalTo("$$COUNT$s$0"));
+
+        // s_null == mv_count(null) * count(*)
+        var s_null = as(exprs.get(2), Alias.class);
+        assertThat(s_null.name(), equalTo("s_null"));
+        var mul_null = as(s_null.child(), Mul.class);
+        var mvCoalesce_null = as(mul_null.left(), Coalesce.class);
+        assertThat(mvCoalesce_null.children().size(), equalTo(2));
+        var mvCount_null = as(mvCoalesce_null.children().get(0), MvCount.class);
+        assertThat(mvCount_null.field(), equalTo(NULL));
+        assertThat(mvCoalesce_null.children().get(1).fold(), equalTo(0));
+        var count_null = as(mul_null.right(), ReferenceAttribute.class);
+        assertThat(count_null.name(), equalTo("$$COUNT$s$0"));
+    }
+
+    /**
+     * Expects after running the {@link LogicalPlanOptimizer#substitutions()}:
+     *
+     * Limit[1000[INTEGER]]
+     * \_EsqlProject[[s{r}#3, s_expr{r}#5, s_null{r}#7, w{r}#10]]
+     *   \_Project[[s{r}#3, s_expr{r}#5, s_null{r}#7, w{r}#10]]
      *     \_Eval[[MVSUM([1, 2][INTEGER]) * $$COUNT$s$0{r}#25 AS s, MVSUM(314.0[DOUBLE] / 100[INTEGER]) * $$COUNT$s$0{r}#25 AS s
      * _expr, MVSUM(null[NULL]) * $$COUNT$s$0{r}#25 AS s_null]]
      *       \_Aggregate[[w{r}#10],[COUNT(*[KEYWORD]) AS $$COUNT$s$0, w{r}#10]]
@@ -3676,7 +3751,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         var agg = as(eval.child(), Aggregate.class);
 
         var exprs = eval.fields();
-        // s = count(*) * 3
+        // s == mv_sum([1,2]) * count(*)
         var s = as(exprs.get(0), Alias.class);
         assertThat(s.name(), equalTo("s"));
         var mul = as(s.child(), Mul.class);
@@ -3685,7 +3760,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         var count = as(mul.right(), ReferenceAttribute.class);
         assertThat(count.name(), equalTo("$$COUNT$s$0"));
 
-        // s_expr = count(*) * 3.14
+        // s_expr == mv_sum(314.0/100) * count(*)
         var s_expr = as(exprs.get(1), Alias.class);
         assertThat(s_expr.name(), equalTo("s_expr"));
         var mul_expr = as(s_expr.child(), Mul.class);
@@ -3694,7 +3769,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         var count_expr = as(mul_expr.right(), ReferenceAttribute.class);
         assertThat(count_expr.name(), equalTo("$$COUNT$s$0"));
 
-        // s_null = null
+        // s_null == mv_sum(null) * count(*)
         var s_null = as(exprs.get(2), Alias.class);
         assertThat(s_null.name(), equalTo("s_null"));
         var mul_null = as(s_null.child(), Mul.class);
@@ -3703,22 +3778,43 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         var count_null = as(mul_null.right(), ReferenceAttribute.class);
         assertThat(count_null.name(), equalTo("$$COUNT$s$0"));
 
-        var count_agg = as(Alias.unwrap(agg.aggregates().get(0)), Count.class);
-        assertThat(count_agg.children().get(0), instanceOf(Literal.class));
+        var countAgg = as(Alias.unwrap(agg.aggregates().get(0)), Count.class);
+        assertThat(countAgg.children().get(0), instanceOf(Literal.class));
         var w = as(Alias.unwrap(agg.groupings().get(0)), ReferenceAttribute.class);
         assertThat(w.name(), equalTo("w"));
     }
 
     private record AggOfLiteralTestCase(
-        String aggFunctionName,
-        Class<? extends Expression> substitution,
-        Function<int[], Object> aggMultiValue
+        String aggFunctionTemplate,
+        Function<Expression, Expression> replacementForConstant,
+        Function<int[], Object> aggMultiValue,
+        Function<Double, Object> aggSingleValue
     ) {};
 
     private static List<AggOfLiteralTestCase> AGG_OF_CONST_CASES = List.of(
-        new AggOfLiteralTestCase("avg", MvAvg.class, ints -> ((double) Arrays.stream(ints).sum()) / ints.length),
-        new AggOfLiteralTestCase("min", MvMin.class, ints -> Arrays.stream(ints).min().getAsInt()),
-        new AggOfLiteralTestCase("max", MvMax.class, ints -> Arrays.stream(ints).max().getAsInt())
+        new AggOfLiteralTestCase(
+            "avg({})",
+            constant -> new MvAvg(EMPTY, constant),
+            ints -> ((double) Arrays.stream(ints).sum()) / ints.length,
+            d -> d
+        ),
+        new AggOfLiteralTestCase("min({})", c -> new MvMin(EMPTY, c), ints -> Arrays.stream(ints).min().getAsInt(), d -> d),
+        new AggOfLiteralTestCase("max({})", c -> new MvMax(EMPTY, c), ints -> Arrays.stream(ints).max().getAsInt(), d -> d),
+        new AggOfLiteralTestCase("median({})", c -> new MvMedian(EMPTY, new ToDouble(EMPTY, c)), ints -> {
+            var sortedInts = Arrays.stream(ints).sorted().toArray();
+            int middle = ints.length / 2;
+            double result = ints.length % 2 == 1 ? sortedInts[middle] : (sortedInts[middle] + sortedInts[middle - 1]) / 2.0;
+            return result;
+        }, d -> d),
+        new AggOfLiteralTestCase(
+            "count_distinct({}, 1234)",
+            c -> new ToLong(
+                EMPTY,
+                new Coalesce(EMPTY, new MvCount(EMPTY, new MvDedupe(EMPTY, c)), List.of(new Literal(EMPTY, 0, DataTypes.INTEGER)))
+            ),
+            ints -> Arrays.stream(ints).distinct().count(),
+            d -> 1L
+        )
     );
 
     /**
@@ -3735,13 +3831,21 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      */
     public void testAggOfLiteral() {
         for (AggOfLiteralTestCase testCase : AGG_OF_CONST_CASES) {
-            String query = LoggerMessageFormat.format(null, """
+            String queryTemplate = """
                 from test
-                | stats s = {}([1,2]),
-                        s_expr = {}(314.0/100),
-                        s_null = {}(null)
+                | stats s = {},
+                        s_expr = {},
+                        s_null = {}
                 | keep s, s_expr, s_null
-                """, testCase.aggFunctionName, testCase.aggFunctionName, testCase.aggFunctionName);
+                """;
+            String queryWithoutValues = LoggerMessageFormat.format(
+                null,
+                queryTemplate,
+                testCase.aggFunctionTemplate,
+                testCase.aggFunctionTemplate,
+                testCase.aggFunctionTemplate
+            );
+            String query = LoggerMessageFormat.format(null, queryWithoutValues, "[1,2]", "314.0/100", "null");
 
             var plan = plan(query, SubstitutionOnlyOptimizer.INSTANCE);
 
@@ -3754,16 +3858,7 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
             assertThat(singleRow.length, equalTo(1));
             assertThat(singleRow[0].getPositionCount(), equalTo(1));
 
-            var exprs = eval.fields();
-            var s = as(exprs.get(0), Alias.class);
-            assertThat(s.child(), instanceOf(testCase.substitution));
-            assertThat(s.child().fold(), equalTo(testCase.aggMultiValue.apply(new int[] { 1, 2 })));
-            var s_expr = as(exprs.get(1), Alias.class);
-            assertThat(s_expr.child(), instanceOf(testCase.substitution));
-            assertThat(s_expr.child().fold(), equalTo(3.14));
-            var s_null = as(exprs.get(2), Alias.class);
-            assertThat(s_null.child(), instanceOf(testCase.substitution));
-            assertThat(s_null.child().fold(), equalTo(null));
+            assertAggOfConstExprs(testCase, eval.fields());
         }
     }
 
@@ -3781,14 +3876,22 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
      */
     public void testAggOfLiteralGrouped() {
         for (AggOfLiteralTestCase testCase : AGG_OF_CONST_CASES) {
-            String query = LoggerMessageFormat.format(null, """
+            String queryTemplate = """
                     from test
-                    | stats s = {}([1,2]),
-                            s_expr = {}(314.0/100),
-                            s_null = {}(null)
+                    | stats s = {},
+                            s_expr = {},
+                            s_null = {}
                             by emp_no
                     | keep s, s_expr, s_null, emp_no
-                """, testCase.aggFunctionName, testCase.aggFunctionName, testCase.aggFunctionName);
+                """;
+            String queryWithoutValues = LoggerMessageFormat.format(
+                null,
+                queryTemplate,
+                testCase.aggFunctionTemplate,
+                testCase.aggFunctionTemplate,
+                testCase.aggFunctionTemplate
+            );
+            String query = LoggerMessageFormat.format(null, queryWithoutValues, "[1,2]", "314.0/100", "null");
 
             var plan = plan(query, SubstitutionOnlyOptimizer.INSTANCE);
 
@@ -3799,23 +3902,59 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
             var agg = as(eval.child(), Aggregate.class);
             assertThat(agg.child(), instanceOf(EsRelation.class));
 
-            // Assert exprs
-            var exprs = eval.fields();
-
-            var s = as(exprs.get(0), Alias.class);
-            assertThat(s.child(), instanceOf(testCase.substitution));
-            assertThat(s.child().fold(), equalTo(testCase.aggMultiValue.apply(new int[] { 1, 2 })));
-            var s_expr = as(exprs.get(1), Alias.class);
-            assertThat(s_expr.child(), instanceOf(testCase.substitution));
-            assertThat(s_expr.child().fold(), equalTo(3.14));
-            var s_null = as(exprs.get(2), Alias.class);
-            assertThat(s_null.child(), instanceOf(testCase.substitution));
-            assertThat(s_null.child().fold(), equalTo(null));
-
             // Assert that the aggregate only does the grouping by emp_no
             assertThat(Expressions.names(agg.groupings()), contains("emp_no"));
             assertThat(agg.aggregates().size(), equalTo(1));
+
+            assertAggOfConstExprs(testCase, eval.fields());
         }
+    }
+
+    private static void assertAggOfConstExprs(AggOfLiteralTestCase testCase, List<Alias> exprs) {
+        var s = as(exprs.get(0), Alias.class);
+        assertThat(s.source().toString(), containsString(LoggerMessageFormat.format(null, testCase.aggFunctionTemplate, "[1,2]")));
+        assertEquals(s.child(), testCase.replacementForConstant.apply(new Literal(EMPTY, List.of(1, 2), INTEGER)));
+        assertEquals(s.child().fold(), testCase.aggMultiValue.apply(new int[] { 1, 2 }));
+
+        var s_expr = as(exprs.get(1), Alias.class);
+        assertThat(s_expr.source().toString(), containsString(LoggerMessageFormat.format(null, testCase.aggFunctionTemplate, "314.0/100")));
+        assertEquals(
+            s_expr.child(),
+            testCase.replacementForConstant.apply(new Div(EMPTY, new Literal(EMPTY, 314.0, DOUBLE), new Literal(EMPTY, 100, INTEGER)))
+        );
+        assertEquals(s_expr.child().fold(), testCase.aggSingleValue.apply(3.14));
+
+        var s_null = as(exprs.get(2), Alias.class);
+        assertThat(s_null.source().toString(), containsString(LoggerMessageFormat.format(null, testCase.aggFunctionTemplate, "null")));
+        assertEquals(s_null.child(), testCase.replacementForConstant.apply(NULL));
+        // Cannot just fold as there may be no evaluator for the NULL datatype;
+        // instead we emulate how the optimizer would fold the null value:
+        // it transforms up from the leaves; c.f. FoldNull.
+        assertTrue(oneLeaveIsNull(s_null));
+    }
+
+    private static void assertSubstitutionChain(Expression e, List<Class<? extends Expression>> substitutionChain) {
+        var currentExpression = e;
+
+        for (Class<? extends Expression> currentSubstitution : substitutionChain.subList(0, substitutionChain.size() - 1)) {
+            assertThat(currentExpression, instanceOf(currentSubstitution));
+            assertEquals(currentExpression.children().size(), 1);
+            currentExpression = currentExpression.children().get(0);
+        }
+
+        assertThat(currentExpression, instanceOf(substitutionChain.get(substitutionChain.size() - 1)));
+    }
+
+    private static boolean oneLeaveIsNull(Expression e) {
+        Holder<Boolean> result = new Holder<>(false);
+
+        e.forEachUp(node -> {
+            if (node.children().size() == 0) {
+                result.set(result.get() || Expressions.isNull(node));
+            }
+        });
+
+        return result.get();
     }
 
     public void testEmptyMappingIndex() {


### PR DESCRIPTION
Backports the following commits to 8.14:
 - ESQL: median, count and count_distinct over constants (#107414)