### PR TITLE
[8.14] ES|QL: Fix warnings for number overflow in CSV SPEC tests  (#107745)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
@@ -71,8 +71,8 @@ convertDoubleToUL
 required_feature:esql.convert_warn
 
 row d = 123.4 | eval ul = to_ul(d), overflow = to_ul(1e20);
-warning:Line 1:48: evaluation of [to_ul(1e20)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:48: org.elasticsearch.xpack.ql.InvalidArgumentException: [1.0E20] out of [unsigned_long] range
+warningRegex:Line 1:48: evaluation of \[to_ul\(1e20\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 1:48: org.elasticsearch.xpack.ql.(Invalid|QlIllegal)ArgumentException: \[1.0E20\] out of \[unsigned_long\] range
 
 d:double       |ul:ul      |overflow:ul
 123.4          |123        |null
@@ -130,8 +130,8 @@ convertULToLong
 required_feature:esql.convert_warn
 
 row ul = [9223372036854775807, 9223372036854775808] | eval long = to_long(ul);
-warning:Line 1:67: evaluation of [to_long(ul)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:67: org.elasticsearch.xpack.ql.InvalidArgumentException: [9223372036854775808] out of [long] range
+warningRegex:Line 1:67: evaluation of \[to_long\(ul\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 1:67: org.elasticsearch.xpack.ql.(Invalid|QlIllegal)ArgumentException: \[9223372036854775808\] out of \[long\] range
 
                     ul:ul                 |       long:long
 [9223372036854775807, 9223372036854775808]|9223372036854775807
@@ -173,8 +173,8 @@ convertDoubleToLong
 required_feature:esql.convert_warn
 
 row d = 123.4 | eval d2l = to_long(d), overflow = to_long(1e19);
-warning:Line 1:51: evaluation of [to_long(1e19)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:51: org.elasticsearch.xpack.ql.InvalidArgumentException: [1.0E19] out of [long] range
+warningRegex:Line 1:51: evaluation of \[to_long\(1e19\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 1:51: org.elasticsearch.xpack.ql.(Invalid|QlIllegal)ArgumentException: \[1.0E19\] out of \[long\] range
 
 d:double       |d2l:long      |overflow:long     
 123.4          |123           |null    
@@ -197,8 +197,8 @@ ROW long = [5013792, 2147483647, 501379200000]
 | EVAL int = TO_INTEGER(long)
 // end::to_int-long[]
 ;
-warning:Line 2:14: evaluation of [TO_INTEGER(long)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 2:14: org.elasticsearch.xpack.ql.InvalidArgumentException: [501379200000] out of [integer] range
+warningRegex:Line 2:14: evaluation of \[TO_INTEGER\(long\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 2:14: org.elasticsearch.xpack.ql.(Invalid|QlIllegal)ArgumentException: \[501379200000\] out of \[integer\] range
 
 // tag::to_int-long-result[]
 long:long                           |int:integer
@@ -210,8 +210,8 @@ convertULToInt
 required_feature:esql.convert_warn
 
 row ul = [2147483647, 9223372036854775808] | eval int = to_int(ul);
-warning:Line 1:57: evaluation of [to_int(ul)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:57: org.elasticsearch.xpack.ql.InvalidArgumentException: [9223372036854775808] out of [integer] range
+warningRegex:Line 1:57: evaluation of \[to_int\(ul\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 1:57: org.elasticsearch.xpack.ql.(Invalid|QlIllegal)ArgumentException: \[9223372036854775808\] out of \[integer\] range
 
                     ul:ul        |int:integer
 [2147483647, 9223372036854775808]|2147483647
@@ -257,8 +257,8 @@ convertDoubleToInt
 required_feature:esql.convert_warn
 
 row d = 123.4 | eval d2i = to_integer(d), overflow = to_integer(1e19);
-warning:Line 1:54: evaluation of [to_integer(1e19)] failed, treating result as null. Only first 20 failures recorded.
-warning:Line 1:54: org.elasticsearch.xpack.ql.InvalidArgumentException: [1.0E19] out of [integer] range
+warningRegex:Line 1:54: evaluation of \[to_integer\(1e19\)\] failed, treating result as null. Only first 20 failures recorded.
+warningRegex:Line 1:54: org.elasticsearch.xpack.ql.(Invalid|QlIllegal)ArgumentException: \[1.0E19\] out of \[integer\] range
 
 d:double       |d2i:integer   |overflow:integer
 123.4          |123           |null    
@@ -734,7 +734,7 @@ ROW deg = [90, 180, 270]
 warningWithFromSource
 from employees | sort emp_no | limit 1 | eval x = to_long(emp_no) * 10000000 | eval y = to_int(x) > 1 | keep y;
 warningRegex:Line 1:89: evaluation of \[to_int\(x\)\] failed, treating result as null. Only first 20 failures recorded.
-warningRegex:Line 1:89: org.elasticsearch.xpack.ql.InvalidArgumentException: \[10\d+0000000\] out of \[integer\] range
+warningRegex:Line 1:89: org.elasticsearch.xpack.ql.(Invalid|QlIllegal)ArgumentException: \[10\d+0000000\] out of \[integer\] range
 
 y:boolean
 null
@@ -744,7 +744,7 @@ null
 multipleWarnings
 from employees | sort emp_no | eval x = to_long(emp_no) * 10000000 | where to_int(x) > 1 | keep x | limit 1;
 warningRegex:Line 1:76: evaluation of \[to_int\(x\)\] failed, treating result as null. Only first 20 failures recorded.
-warningRegex:Line 1:76: org.elasticsearch.xpack.ql.InvalidArgumentException: \[10\d+0000000\] out of \[integer\] range
+warningRegex:Line 1:76: org.elasticsearch.xpack.ql.(Invalid|QlIllegal)ArgumentException: \[10\d+0000000\] out of \[integer\] range
 
 x:long
 ;


### PR DESCRIPTION
Backports the following commits to 8.14:
 - ES|QL: Fix warnings for number overflow in CSV SPEC tests  (#107745)