### PR TITLE
Mute ml/inference_crud/Test force delete given model with alias referenced by pipeline

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -658,6 +658,9 @@ setup:
 
 ---
 "Test force delete given model with alias referenced by pipeline":
+  - skip:
+      version: all
+      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/106652"
   - do:
       ml.put_trained_model_alias:
         model_alias: "alias-to-a-classification-model"


### PR DESCRIPTION
Awaits fix https://github.com/elastic/elasticsearch/issues/107505

Muting because it began failing quite often, e.g.
- https://gradle-enterprise.elastic.co/s/vs5c4ha5kdgus
- https://gradle-enterprise.elastic.co/s/macqpmtyuuqii
- https://gradle-enterprise.elastic.co/s/zs2fr6p7w2f6i
- https://gradle-enterprise.elastic.co/s/uutjsebzrau7w
- https://gradle-enterprise.elastic.co/s/jwsitrjbnn5uq
- https://gradle-enterprise.elastic.co/s/slh4t2bjjtciy