### PR TITLE
Increase size of big arrays only when there is an actual value in the aggregators

### DIFF
--- a/docs/changelog/107764.yaml
+++ b/docs/changelog/107764.yaml
@@ -1,0 +1,5 @@
+pr: 107764
+summary: Increase size of big arrays only when there is an actual value in the aggregators
+area: Aggregations
+type: enhancement
+issues: []

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/empty_field_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/empty_field_metric.yml
@@ -1,0 +1,142 @@
+setup:
+  - do:
+      indices.create:
+          index: test_1
+          body:
+            mappings:
+              properties:
+                terms_field:
+                  type: keyword
+                int_field:
+                   type : integer
+                double_field:
+                   type : double
+                string_field:
+                   type: keyword
+                geo_point_field:
+                  type: geo_point
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_1
+               _id:    "1"
+           - terms_field: foo
+           - index:
+               _index: test_1
+               _id:    "2"
+           - terms_field: foo
+           - index:
+               _index: test_1
+               _id:    "3"
+           - terms_field: bar
+
+---
+"Basic test":
+
+  - do:
+      search:
+        index: test_1
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_terms:
+              terms:
+                field: terms_field
+                "order":
+                  "_key": "asc"
+              aggs:
+                min_agg:
+                  min:
+                    field: double_field
+                max_agg:
+                  max:
+                    field: double_field
+                avg_agg:
+                  avg:
+                    field: double_field
+                sum_agg:
+                  avg:
+                    field: double_field
+                value_count_agg:
+                  value_count:
+                    field: double_field
+                cardinality_agg:
+                  cardinality:
+                    field: string_field
+                weighted_avg_agg:
+                  weighted_avg:
+                    value:
+                      field: int_field
+                    weight:
+                      field: double_field
+                median_absolute_deviation_agg:
+                  median_absolute_deviation:
+                    field: double_field
+                stats_agg:
+                  stats:
+                    field: double_field
+                extended_stats_agg:
+                  extended_stats:
+                    field: double_field
+                percentiles_agg:
+                  percentiles:
+                    field: double_field
+                    percents: 50
+                geo_bounds_agg:
+                  geo_bounds:
+                    field: geo_point_field
+                geo_centroid_agg:
+                  geo_centroid:
+                    field: geo_point_field
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_terms.buckets.0.key: bar}
+  - match: { aggregations.the_terms.buckets.0.doc_count: 1}
+  - match: { aggregations.the_terms.buckets.0.min_agg.value: null }
+  - match: { aggregations.the_terms.buckets.0.max_agg.value: null }
+  - match: { aggregations.the_terms.buckets.0.avg_agg.value: null }
+  - match: { aggregations.the_terms.buckets.0.sum_agg.value: null }
+  - match: { aggregations.the_terms.buckets.0.value_count_agg.value: 0 }
+  - match: { aggregations.the_terms.buckets.0.cardinality_agg.value: 0 }
+  - match: { aggregations.the_terms.buckets.0.weighted_avg_agg.value: null }
+  - match: { aggregations.the_terms.buckets.0.median_absolute_deviation_agg.value: null }
+  - match: { aggregations.the_terms.buckets.0.stats_agg.min: null }
+  - match: { aggregations.the_terms.buckets.0.stats_agg.max: null }
+  - match: { aggregations.the_terms.buckets.0.stats_agg.avg: null }
+  - match: { aggregations.the_terms.buckets.0.stats_agg.sum: 0.0 }
+  - match: { aggregations.the_terms.buckets.0.extended_stats_agg.min: null }
+  - match: { aggregations.the_terms.buckets.0.extended_stats_agg.max: null }
+  - match: { aggregations.the_terms.buckets.0.extended_stats_agg.avg: null }
+  - match: { aggregations.the_terms.buckets.0.extended_stats_agg.sum: 0.0 }
+  - match: { aggregations.the_terms.buckets.0.extended_stats_agg.sum_of_squares: null }
+  - match: { aggregations.the_terms.buckets.0.percentiles_agg.50: null }
+  - match: { aggregations.the_terms.buckets.0.geo_bounds_agg.top_left: null }
+  - match: { aggregations.the_terms.buckets.0.geo_bounds_agg.bottom_right: null }
+  - match: { aggregations.the_terms.buckets.0.geo_centroid_agg.count: 0 }
+  - match: { aggregations.the_terms.buckets.1.key: foo }
+  - match: { aggregations.the_terms.buckets.1.doc_count: 2 }
+  - match: { aggregations.the_terms.buckets.1.min_agg.value: null }
+  - match: { aggregations.the_terms.buckets.1.max_agg.value: null }
+  - match: { aggregations.the_terms.buckets.1.avg_agg.value: null }
+  - match: { aggregations.the_terms.buckets.1.sum_agg.value: null }
+  - match: { aggregations.the_terms.buckets.1.value_count_agg.value: 0 }
+  - match: { aggregations.the_terms.buckets.1.cardinality_agg.value: 0 }
+  - match: { aggregations.the_terms.buckets.1.weighted_avg_agg.value: null }
+  - match: { aggregations.the_terms.buckets.1.median_absolute_deviation_agg.value: null }
+  - match: { aggregations.the_terms.buckets.1.stats_agg.min: null }
+  - match: { aggregations.the_terms.buckets.1.stats_agg.max: null }
+  - match: { aggregations.the_terms.buckets.1.stats_agg.avg: null }
+  - match: { aggregations.the_terms.buckets.1.stats_agg.sum: 0.0 }
+  - match: { aggregations.the_terms.buckets.1.extended_stats_agg.min: null }
+  - match: { aggregations.the_terms.buckets.1.extended_stats_agg.max: null }
+  - match: { aggregations.the_terms.buckets.1.extended_stats_agg.avg: null }
+  - match: { aggregations.the_terms.buckets.1.extended_stats_agg.sum: 0.0 }
+  - match: { aggregations.the_terms.buckets.1.extended_stats_agg.sum_of_squares: null }
+  - match: { aggregations.the_terms.buckets.1.percentiles_agg.50: null }
+  - match: { aggregations.the_terms.buckets.1.geo_bounds_agg.top_left: null }
+  - match: { aggregations.the_terms.buckets.1.geo_bounds_agg.bottom_right: null }
+  - match: { aggregations.the_terms.buckets.1.geo_centroid_agg.count: 0 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
@@ -67,8 +67,8 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                DoubleHistogram state = getExistingOrNewHistogram(bigArrays(), bucket);
                 if (values.advanceExact(doc)) {
+                    DoubleHistogram state = getExistingOrNewHistogram(bigArrays(), bucket);
                     final int valueCount = values.docValueCount();
                     for (int i = 0; i < valueCount; i++) {
                         state.recordValue(values.nextValue());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
@@ -51,7 +51,7 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
         this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.format = formatter;
-        this.states = context.bigArrays().newObjectArray(0);
+        this.states = context.bigArrays().newObjectArray(1);
         this.keys = keys;
         this.numberOfSignificantValueDigits = numberOfSignificantValueDigits;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
@@ -51,7 +51,7 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
         this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.format = formatter;
-        this.states = context.bigArrays().newObjectArray(1);
+        this.states = context.bigArrays().newObjectArray(0);
         this.keys = keys;
         this.numberOfSignificantValueDigits = numberOfSignificantValueDigits;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -69,8 +69,8 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
                 if (values.advanceExact(doc)) {
+                    TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
                     final int valueCount = values.docValueCount();
                     for (int i = 0; i < valueCount; i++) {
                         state.add(values.nextValue());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -52,7 +52,7 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
         this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.formatter = formatter;
-        this.states = context.bigArrays().newObjectArray(1);
+        this.states = context.bigArrays().newObjectArray(0);
         this.keys = keys;
         this.compression = compression;
         this.executionHint = executionHint;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -52,7 +52,7 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
         this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.formatter = formatter;
-        this.states = context.bigArrays().newObjectArray(0);
+        this.states = context.bigArrays().newObjectArray(1);
         this.keys = keys;
         this.compression = compression;
         this.executionHint = executionHint;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
@@ -65,11 +65,12 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                counts = bigArrays().grow(counts, bucket + 1);
-                sums = bigArrays().grow(sums, bucket + 1);
-                compensations = bigArrays().grow(compensations, bucket + 1);
-
                 if (values.advanceExact(doc)) {
+                    if (bucket >= counts.size()) {
+                        counts = bigArrays().grow(counts, bucket + 1);
+                        sums = bigArrays().grow(sums, bucket + 1);
+                        compensations = bigArrays().grow(compensations, bucket + 1);
+                    }
                     final int valueCount = values.docValueCount();
                     counts.increment(bucket, valueCount);
                     // Compute the sum of double values with Kahan summation algorithm which is more

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
@@ -47,9 +47,9 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
         this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
         final BigArrays bigArrays = context.bigArrays();
-        counts = bigArrays.newLongArray(0, true);
-        sums = bigArrays.newDoubleArray(0, true);
-        compensations = bigArrays.newDoubleArray(0, true);
+        counts = bigArrays.newLongArray(1, true);
+        sums = bigArrays.newDoubleArray(1, true);
+        compensations = bigArrays.newDoubleArray(1, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
@@ -47,9 +47,9 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
         this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
         final BigArrays bigArrays = context.bigArrays();
-        counts = bigArrays.newLongArray(1, true);
-        sums = bigArrays.newDoubleArray(1, true);
-        compensations = bigArrays.newDoubleArray(1, true);
+        counts = bigArrays.newLongArray(0, true);
+        sums = bigArrays.newDoubleArray(0, true);
+        compensations = bigArrays.newDoubleArray(0, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -255,13 +255,13 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
 
         @Override
         public void collect(int doc, long bucketOrd) throws IOException {
-            visitedOrds = bigArrays.grow(visitedOrds, bucketOrd + 1);
-            BitArray bits = visitedOrds.get(bucketOrd);
-            if (bits == null) {
-                bits = new BitArray(maxOrd, bigArrays);
-                visitedOrds.set(bucketOrd, bits);
-            }
             if (values.advanceExact(doc)) {
+                visitedOrds = bigArrays.grow(visitedOrds, bucketOrd + 1);
+                BitArray bits = visitedOrds.get(bucketOrd);
+                if (bits == null) {
+                    bits = new BitArray(maxOrd, bigArrays);
+                    visitedOrds.set(bucketOrd, bits);
+                }
                 for (long ord = values.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = values.nextOrd()) {
                     bits.set((int) ord);
                 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -68,7 +68,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
         assert valuesSourceConfig.hasValues();
         this.valuesSource = valuesSourceConfig.getValuesSource();
         this.precision = precision;
-        this.counts = new HyperLogLogPlusPlus(precision, context.bigArrays(), 1);
+        this.counts = new HyperLogLogPlusPlus(precision, context.bigArrays(), 0);
         this.executionMode = executionMode;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -68,7 +68,7 @@ public class CardinalityAggregator extends NumericMetricsAggregator.SingleValue 
         assert valuesSourceConfig.hasValues();
         this.valuesSource = valuesSourceConfig.getValuesSource();
         this.precision = precision;
-        this.counts = new HyperLogLogPlusPlus(precision, context.bigArrays(), 0);
+        this.counts = new HyperLogLogPlusPlus(precision, context.bigArrays(), 1);
         this.executionMode = executionMode;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -82,21 +82,20 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                if (bucket >= counts.size()) {
-                    final long from = counts.size();
-                    final long overSize = BigArrays.overSize(bucket + 1);
-                    counts = bigArrays().resize(counts, overSize);
-                    sums = bigArrays().resize(sums, overSize);
-                    compensations = bigArrays().resize(compensations, overSize);
-                    mins = bigArrays().resize(mins, overSize);
-                    maxes = bigArrays().resize(maxes, overSize);
-                    sumOfSqrs = bigArrays().resize(sumOfSqrs, overSize);
-                    compensationOfSqrs = bigArrays().resize(compensationOfSqrs, overSize);
-                    mins.fill(from, overSize, Double.POSITIVE_INFINITY);
-                    maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
-                }
-
                 if (values.advanceExact(doc)) {
+                    if (bucket >= counts.size()) {
+                        final long from = counts.size();
+                        final long overSize = BigArrays.overSize(bucket + 1);
+                        counts = bigArrays().resize(counts, overSize);
+                        sums = bigArrays().resize(sums, overSize);
+                        compensations = bigArrays().resize(compensations, overSize);
+                        mins = bigArrays().resize(mins, overSize);
+                        maxes = bigArrays().resize(maxes, overSize);
+                        sumOfSqrs = bigArrays().resize(sumOfSqrs, overSize);
+                        compensationOfSqrs = bigArrays().resize(compensationOfSqrs, overSize);
+                        mins.fill(from, overSize, Double.POSITIVE_INFINITY);
+                        maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
+                    }
                     final int valuesCount = values.docValueCount();
                     counts.increment(bucket, valuesCount);
                     double min = mins.get(bucket);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -57,15 +57,13 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
         this.format = config.format();
         this.sigma = sigma;
         final BigArrays bigArrays = context.bigArrays();
-        counts = bigArrays.newLongArray(1, true);
-        sums = bigArrays.newDoubleArray(1, true);
-        compensations = bigArrays.newDoubleArray(1, true);
-        mins = bigArrays.newDoubleArray(1, false);
-        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-        maxes = bigArrays.newDoubleArray(1, false);
-        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-        sumOfSqrs = bigArrays.newDoubleArray(1, true);
-        compensationOfSqrs = bigArrays.newDoubleArray(1, true);
+        counts = bigArrays.newLongArray(0, true);
+        sums = bigArrays.newDoubleArray(0, true);
+        compensations = bigArrays.newDoubleArray(0, true);
+        mins = bigArrays.newDoubleArray(0, false);
+        maxes = bigArrays.newDoubleArray(0, false);
+        sumOfSqrs = bigArrays.newDoubleArray(0, true);
+        compensationOfSqrs = bigArrays.newDoubleArray(0, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -57,13 +57,15 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
         this.format = config.format();
         this.sigma = sigma;
         final BigArrays bigArrays = context.bigArrays();
-        counts = bigArrays.newLongArray(0, true);
-        sums = bigArrays.newDoubleArray(0, true);
-        compensations = bigArrays.newDoubleArray(0, true);
-        mins = bigArrays.newDoubleArray(0, false);
-        maxes = bigArrays.newDoubleArray(0, false);
-        sumOfSqrs = bigArrays.newDoubleArray(0, true);
-        compensationOfSqrs = bigArrays.newDoubleArray(0, true);
+        counts = bigArrays.newLongArray(1, true);
+        sums = bigArrays.newDoubleArray(1, true);
+        compensations = bigArrays.newDoubleArray(1, true);
+        mins = bigArrays.newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
+        maxes = bigArrays.newDoubleArray(1, false);
+        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
+        sumOfSqrs = bigArrays.newDoubleArray(1, true);
+        compensationOfSqrs = bigArrays.newDoubleArray(1, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
@@ -77,8 +77,8 @@ final class GeoBoundsAggregator extends MetricsAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                growBucket(bucket);
                 if (values.advanceExact(doc)) {
+                    growBucket(bucket);
                     for (int i = 0; i < values.docValueCount(); ++i) {
                         addPoint(values.nextValue(), bucket);
                     }
@@ -91,8 +91,8 @@ final class GeoBoundsAggregator extends MetricsAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                growBucket(bucket);
                 if (values.advanceExact(doc)) {
+                    growBucket(bucket);
                     addPoint(values.pointValue(), bucket);
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
@@ -52,18 +52,12 @@ final class GeoBoundsAggregator extends MetricsAggregator {
         assert valuesSourceConfig.hasValues();
         this.valuesSource = (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource();
         this.wrapLongitude = wrapLongitude;
-        tops = bigArrays().newDoubleArray(1, false);
-        tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
-        bottoms = bigArrays().newDoubleArray(1, false);
-        bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
-        posLefts = bigArrays().newDoubleArray(1, false);
-        posLefts.fill(0, posLefts.size(), Double.POSITIVE_INFINITY);
-        posRights = bigArrays().newDoubleArray(1, false);
-        posRights.fill(0, posRights.size(), Double.NEGATIVE_INFINITY);
-        negLefts = bigArrays().newDoubleArray(1, false);
-        negLefts.fill(0, negLefts.size(), Double.POSITIVE_INFINITY);
-        negRights = bigArrays().newDoubleArray(1, false);
-        negRights.fill(0, negRights.size(), Double.NEGATIVE_INFINITY);
+        tops = bigArrays().newDoubleArray(0, false);
+        bottoms = bigArrays().newDoubleArray(0, false);
+        posLefts = bigArrays().newDoubleArray(0, false);
+        posRights = bigArrays().newDoubleArray(0, false);
+        negLefts = bigArrays().newDoubleArray(0, false);
+        negRights = bigArrays().newDoubleArray(0, false);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregator.java
@@ -52,12 +52,18 @@ final class GeoBoundsAggregator extends MetricsAggregator {
         assert valuesSourceConfig.hasValues();
         this.valuesSource = (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource();
         this.wrapLongitude = wrapLongitude;
-        tops = bigArrays().newDoubleArray(0, false);
-        bottoms = bigArrays().newDoubleArray(0, false);
-        posLefts = bigArrays().newDoubleArray(0, false);
-        posRights = bigArrays().newDoubleArray(0, false);
-        negLefts = bigArrays().newDoubleArray(0, false);
-        negRights = bigArrays().newDoubleArray(0, false);
+        tops = bigArrays().newDoubleArray(1, false);
+        tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
+        bottoms = bigArrays().newDoubleArray(1, false);
+        bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
+        posLefts = bigArrays().newDoubleArray(1, false);
+        posLefts.fill(0, posLefts.size(), Double.POSITIVE_INFINITY);
+        posRights = bigArrays().newDoubleArray(1, false);
+        posRights.fill(0, posRights.size(), Double.NEGATIVE_INFINITY);
+        negLefts = bigArrays().newDoubleArray(1, false);
+        negLefts.fill(0, negLefts.size(), Double.POSITIVE_INFINITY);
+        negRights = bigArrays().newDoubleArray(1, false);
+        negRights.fill(0, negRights.size(), Double.NEGATIVE_INFINITY);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
@@ -65,8 +65,8 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                growBucket(bucket);
                 if (values.advanceExact(doc)) {
+                    growBucket(bucket);
                     final int valueCount = values.docValueCount();
                     // increment by the number of points for this document
                     counts.increment(bucket, valueCount);
@@ -96,8 +96,8 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                growBucket(bucket);
                 if (values.advanceExact(doc)) {
+                    growBucket(bucket);
                     // increment by the number of points for this document
                     counts.increment(bucket, 1);
                     // Compute the sum of double values with Kahan summation algorithm which is more

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
@@ -45,11 +45,11 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         super(name, context, parent, metadata);
         assert valuesSourceConfig.hasValues();
         this.valuesSource = (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource();
-        lonSum = bigArrays().newDoubleArray(1, true);
-        lonCompensations = bigArrays().newDoubleArray(1, true);
-        latSum = bigArrays().newDoubleArray(1, true);
-        latCompensations = bigArrays().newDoubleArray(1, true);
-        counts = bigArrays().newLongArray(1, true);
+        lonSum = bigArrays().newDoubleArray(0, true);
+        lonCompensations = bigArrays().newDoubleArray(0, true);
+        latSum = bigArrays().newDoubleArray(0, true);
+        latCompensations = bigArrays().newDoubleArray(0, true);
+        counts = bigArrays().newLongArray(0, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
@@ -45,11 +45,11 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         super(name, context, parent, metadata);
         assert valuesSourceConfig.hasValues();
         this.valuesSource = (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource();
-        lonSum = bigArrays().newDoubleArray(0, true);
-        lonCompensations = bigArrays().newDoubleArray(0, true);
-        latSum = bigArrays().newDoubleArray(0, true);
-        latCompensations = bigArrays().newDoubleArray(0, true);
-        counts = bigArrays().newLongArray(0, true);
+        lonSum = bigArrays().newDoubleArray(1, true);
+        lonCompensations = bigArrays().newDoubleArray(1, true);
+        latSum = bigArrays().newDoubleArray(1, true);
+        latCompensations = bigArrays().newDoubleArray(1, true);
+        counts = bigArrays().newLongArray(1, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
@@ -85,7 +85,7 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
         this.precision = precision;
         this.maxOrd = maxOrd;
         this.bigArrays = context.bigArrays();
-        this.visitedOrds = bigArrays.newObjectArray(0);
+        this.visitedOrds = bigArrays.newObjectArray(1);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
@@ -269,13 +269,13 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
 
             @Override
             public void collect(int doc, long bucketOrd) throws IOException {
-                visitedOrds = bigArrays.grow(visitedOrds, bucketOrd + 1);
-                BitArray bits = visitedOrds.get(bucketOrd);
-                if (bits == null) {
-                    bits = new BitArray(maxOrd, bigArrays);
-                    visitedOrds.set(bucketOrd, bits);
-                }
                 if (docValues.advanceExact(doc)) {
+                    visitedOrds = bigArrays.grow(visitedOrds, bucketOrd + 1);
+                    BitArray bits = visitedOrds.get(bucketOrd);
+                    if (bits == null) {
+                        bits = new BitArray(maxOrd, bigArrays);
+                        visitedOrds.set(bucketOrd, bits);
+                    }
                     for (long ord = docValues.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = docValues.nextOrd()) {
                         bits.set((int) ord);
                     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GlobalOrdCardinalityAggregator.java
@@ -85,7 +85,7 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
         this.precision = precision;
         this.maxOrd = maxOrd;
         this.bigArrays = context.bigArrays();
-        this.visitedOrds = bigArrays.newObjectArray(1);
+        this.visitedOrds = bigArrays.newObjectArray(0);
     }
 
     @Override
@@ -206,6 +206,7 @@ public class GlobalOrdCardinalityAggregator extends NumericMetricsAggregator.Sin
             // This optimization only applies to top-level cardinality aggregations that apply to fields indexed with an inverted index.
             final Terms indexTerms = aggCtx.getLeafReaderContext().reader().terms(field);
             if (indexTerms != null) {
+                visitedOrds = bigArrays.grow(visitedOrds, 1);
                 BitArray bits = visitedOrds.get(0);
                 final int numNonVisitedOrds = maxOrd - (bits == null ? 0 : (int) bits.cardinality());
                 if (maxOrd <= MAX_FIELD_CARDINALITY_FOR_DYNAMIC_PRUNING || numNonVisitedOrds <= MAX_TERMS_FOR_DYNAMIC_PRUNING) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -85,16 +85,13 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
 
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                if (bucket >= maxes.size()) {
-                    long from = maxes.size();
-                    maxes = bigArrays().grow(maxes, bucket + 1);
-                    maxes.fill(from, maxes.size(), Double.NEGATIVE_INFINITY);
-                }
                 if (values.advanceExact(doc)) {
-                    final double value = values.doubleValue();
-                    double max = maxes.get(bucket);
-                    max = Math.max(max, value);
-                    maxes.set(bucket, max);
+                    if (bucket >= maxes.size()) {
+                        long from = maxes.size();
+                        maxes = bigArrays().grow(maxes, bucket + 1);
+                        maxes.fill(from, maxes.size(), Double.NEGATIVE_INFINITY);
+                    }
+                    maxes.set(bucket, Math.max(maxes.get(bucket), values.doubleValue()));
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -70,8 +70,12 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
                  * There is no parent aggregator (see {@link AggregatorBase#getPointReaderOrNull}
                  * so the ordinal for the bucket is always 0.
                  */
-                maxes = bigArrays().grow(maxes,  1);
-                maxes.set(0, Math.max(Double.NEGATIVE_INFINITY, segMax.doubleValue()));
+                if (maxes.size() == 0) {
+                    maxes = bigArrays().grow(maxes, 1);
+                    maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
+                }
+                assert maxes.size() == 1;
+                maxes.set(0, Math.max(maxes.get(0), segMax.doubleValue()));
                 // the maximum value has been extracted, we don't need to collect hits on this segment.
                 return LeafBucketCollector.NO_OP_COLLECTOR;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -46,7 +46,8 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
         super(name, context, parent, metadata);
         assert config.hasValues();
         this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-        maxes = context.bigArrays().newDoubleArray(0, false);
+        maxes = context.bigArrays().newDoubleArray(1, false);
+        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         this.formatter = config.format();
         this.pointConverter = pointReaderIfAvailable(config);
         if (pointConverter != null) {
@@ -70,12 +71,10 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
                  * There is no parent aggregator (see {@link AggregatorBase#getPointReaderOrNull}
                  * so the ordinal for the bucket is always 0.
                  */
-                if (maxes.size() == 0) {
-                    maxes = bigArrays().resize(maxes, 1);
-                    maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-                }
                 assert maxes.size() == 1;
-                maxes.set(0, Math.max(maxes.get(0), segMax.doubleValue()));
+                double max = maxes.get(0);
+                max = Math.max(max, segMax.doubleValue());
+                maxes.set(0, max);
                 // the maximum value has been extracted, we don't need to collect hits on this segment.
                 return LeafBucketCollector.NO_OP_COLLECTOR;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -70,10 +70,8 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
                  * There is no parent aggregator (see {@link AggregatorBase#getPointReaderOrNull}
                  * so the ordinal for the bucket is always 0.
                  */
-                assert maxes.size() == 1;
-                double max = maxes.get(0);
-                max = Math.max(max, segMax.doubleValue());
-                maxes.set(0, max);
+                maxes = bigArrays().grow(maxes,  1);
+                maxes.set(0, Math.max(Double.NEGATIVE_INFINITY, segMax.doubleValue()));
                 // the maximum value has been extracted, we don't need to collect hits on this segment.
                 return LeafBucketCollector.NO_OP_COLLECTOR;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -46,8 +46,7 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
         super(name, context, parent, metadata);
         assert config.hasValues();
         this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-        maxes = context.bigArrays().newDoubleArray(1, false);
-        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
+        maxes = context.bigArrays().newDoubleArray(0, false);
         this.formatter = config.format();
         this.pointConverter = pointReaderIfAvailable(config);
         if (pointConverter != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -71,7 +71,7 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
                  * so the ordinal for the bucket is always 0.
                  */
                 if (maxes.size() == 0) {
-                    maxes = bigArrays().grow(maxes, 1);
+                    maxes = bigArrays().resize(maxes, 1);
                     maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
                 }
                 assert maxes.size() == 1;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
@@ -87,16 +87,14 @@ public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-
-                valueSketches = bigArrays().grow(valueSketches, bucket + 1);
-
-                TDigestState valueSketch = valueSketches.get(bucket);
-                if (valueSketch == null) {
-                    valueSketch = TDigestState.create(compression, executionHint);
-                    valueSketches.set(bucket, valueSketch);
-                }
-
                 if (values.advanceExact(doc)) {
+                    valueSketches = bigArrays().grow(valueSketches, bucket + 1);
+
+                    TDigestState valueSketch = valueSketches.get(bucket);
+                    if (valueSketch == null) {
+                        valueSketch = TDigestState.create(compression, executionHint);
+                        valueSketches.set(bucket, valueSketch);
+                    }
                     final int valueCount = values.docValueCount();
                     for (int i = 0; i < valueCount; i++) {
                         final double value = values.nextValue();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
@@ -55,7 +55,7 @@ public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.
         this.format = Objects.requireNonNull(format);
         this.compression = compression;
         this.executionHint = executionHint;
-        this.valueSketches = context.bigArrays().newObjectArray(1);
+        this.valueSketches = context.bigArrays().newObjectArray(0);
     }
 
     private boolean hasDataForBucket(long bucketOrd) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
@@ -55,7 +55,7 @@ public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.
         this.format = Objects.requireNonNull(format);
         this.compression = compression;
         this.executionHint = executionHint;
-        this.valueSketches = context.bigArrays().newObjectArray(0);
+        this.valueSketches = context.bigArrays().newObjectArray(1);
     }
 
     private boolean hasDataForBucket(long bucketOrd) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -84,16 +84,13 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
         return new LeafBucketCollectorBase(sub, allValues) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                if (bucket >= mins.size()) {
-                    long from = mins.size();
-                    mins = bigArrays().grow(mins, bucket + 1);
-                    mins.fill(from, mins.size(), Double.POSITIVE_INFINITY);
-                }
                 if (values.advanceExact(doc)) {
-                    final double value = values.doubleValue();
-                    double min = mins.get(bucket);
-                    min = Math.min(min, value);
-                    mins.set(bucket, min);
+                    if (bucket >= mins.size()) {
+                        long from = mins.size();
+                        mins = bigArrays().grow(mins, bucket + 1);
+                        mins.fill(from, mins.size(), Double.POSITIVE_INFINITY);
+                    }
+                    mins.set(bucket, Math.min(mins.get(bucket), values.doubleValue()));
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -72,7 +72,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
                  * so the ordinal for the bucket is always 0.
                  */
                 if (mins.size() == 0) {
-                    mins = bigArrays().grow(mins, 1);
+                    mins = bigArrays().resize(mins, 1);
                     mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
                 }
                 assert mins.size() == 1;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -71,9 +71,8 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
                  * There is no parent aggregator (see {@link MinAggregator#getPointReaderOrNull}
                  * so the ordinal for the bucket is always 0.
                  */
-                double min = mins.get(0);
-                min = Math.min(min, segMin.doubleValue());
-                mins.set(0, min);
+                mins = bigArrays().grow(mins,  1);
+                mins.set(0, Math.min(Double.POSITIVE_INFINITY, segMin.doubleValue()));
                 // the minimum value has been extracted, we don't need to collect hits on this segment.
                 return LeafBucketCollector.NO_OP_COLLECTOR;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -47,7 +47,8 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
         super(name, context, parent, metadata);
         assert config.hasValues();
         this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-        mins = context.bigArrays().newDoubleArray(0, false);
+        mins = context.bigArrays().newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
         this.format = config.format();
         this.pointConverter = pointReaderIfAvailable(config);
         if (pointConverter != null) {
@@ -71,12 +72,9 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
                  * There is no parent aggregator (see {@link MinAggregator#getPointReaderOrNull}
                  * so the ordinal for the bucket is always 0.
                  */
-                if (mins.size() == 0) {
-                    mins = bigArrays().resize(mins, 1);
-                    mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-                }
-                assert mins.size() == 1;
-                mins.set(0, Math.min(mins.get(0), segMin.doubleValue()));
+                double min = mins.get(0);
+                min = Math.min(min, segMin.doubleValue());
+                mins.set(0, min);
                 // the minimum value has been extracted, we don't need to collect hits on this segment.
                 return LeafBucketCollector.NO_OP_COLLECTOR;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -47,8 +47,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
         super(name, context, parent, metadata);
         assert config.hasValues();
         this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-        mins = context.bigArrays().newDoubleArray(1, false);
-        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
+        mins = context.bigArrays().newDoubleArray(0, false);
         this.format = config.format();
         this.pointConverter = pointReaderIfAvailable(config);
         if (pointConverter != null) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -71,8 +71,12 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
                  * There is no parent aggregator (see {@link MinAggregator#getPointReaderOrNull}
                  * so the ordinal for the bucket is always 0.
                  */
-                mins = bigArrays().grow(mins,  1);
-                mins.set(0, Math.min(Double.POSITIVE_INFINITY, segMin.doubleValue()));
+                if (mins.size() == 0) {
+                    mins = bigArrays().grow(mins, 1);
+                    mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
+                }
+                assert mins.size() == 1;
+                mins.set(0, Math.min(mins.get(0), segMin.doubleValue()));
                 // the minimum value has been extracted, we don't need to collect hits on this segment.
                 return LeafBucketCollector.NO_OP_COLLECTOR;
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
@@ -65,19 +65,18 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                if (bucket >= counts.size()) {
-                    final long from = counts.size();
-                    final long overSize = BigArrays.overSize(bucket + 1);
-                    counts = bigArrays().resize(counts, overSize);
-                    sums = bigArrays().resize(sums, overSize);
-                    compensations = bigArrays().resize(compensations, overSize);
-                    mins = bigArrays().resize(mins, overSize);
-                    maxes = bigArrays().resize(maxes, overSize);
-                    mins.fill(from, overSize, Double.POSITIVE_INFINITY);
-                    maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
-                }
-
                 if (values.advanceExact(doc)) {
+                    if (bucket >= counts.size()) {
+                        final long from = counts.size();
+                        final long overSize = BigArrays.overSize(bucket + 1);
+                        counts = bigArrays().resize(counts, overSize);
+                        sums = bigArrays().resize(sums, overSize);
+                        compensations = bigArrays().resize(compensations, overSize);
+                        mins = bigArrays().resize(mins, overSize);
+                        maxes = bigArrays().resize(maxes, overSize);
+                        mins.fill(from, overSize, Double.POSITIVE_INFINITY);
+                        maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
+                    }
                     final int valuesCount = values.docValueCount();
                     counts.increment(bucket, valuesCount);
                     double min = mins.get(bucket);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
@@ -42,11 +42,13 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
         super(name, context, parent, metadata);
         assert config.hasValues();
         this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-        counts = bigArrays().newLongArray(0, true);
-        sums = bigArrays().newDoubleArray(0, true);
-        compensations = bigArrays().newDoubleArray(0, true);
-        mins = bigArrays().newDoubleArray(0, false);
-        maxes = bigArrays().newDoubleArray(0, false);
+        counts = bigArrays().newLongArray(1, true);
+        sums = bigArrays().newDoubleArray(1, true);
+        compensations = bigArrays().newDoubleArray(1, true);
+        mins = bigArrays().newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
+        maxes = bigArrays().newDoubleArray(1, false);
+        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         this.format = config.format();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
@@ -42,13 +42,11 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
         super(name, context, parent, metadata);
         assert config.hasValues();
         this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
-        counts = bigArrays().newLongArray(1, true);
-        sums = bigArrays().newDoubleArray(1, true);
-        compensations = bigArrays().newDoubleArray(1, true);
-        mins = bigArrays().newDoubleArray(1, false);
-        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-        maxes = bigArrays().newDoubleArray(1, false);
-        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
+        counts = bigArrays().newLongArray(0, true);
+        sums = bigArrays().newDoubleArray(0, true);
+        compensations = bigArrays().newDoubleArray(0, true);
+        mins = bigArrays().newDoubleArray(0, false);
+        maxes = bigArrays().newDoubleArray(0, false);
         this.format = config.format();
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -59,10 +59,11 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                sums = bigArrays().grow(sums, bucket + 1);
-                compensations = bigArrays().grow(compensations, bucket + 1);
-
                 if (values.advanceExact(doc)) {
+                    if (bucket >= sums.size()) {
+                        sums = bigArrays().grow(sums, bucket + 1);
+                        compensations = bigArrays().grow(compensations, bucket + 1);
+                    }
                     final int valuesCount = values.docValueCount();
                     // Compute the sum of double values with Kahan summation algorithm which is more
                     // accurate than naive summation.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -43,8 +43,8 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
         assert valuesSourceConfig.hasValues();
         this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
-        sums = bigArrays().newDoubleArray(1, true);
-        compensations = bigArrays().newDoubleArray(1, true);
+        sums = bigArrays().newDoubleArray(0, true);
+        compensations = bigArrays().newDoubleArray(0, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -43,8 +43,8 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
         assert valuesSourceConfig.hasValues();
         this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
-        sums = bigArrays().newDoubleArray(0, true);
-        compensations = bigArrays().newDoubleArray(0, true);
+        sums = bigArrays().newDoubleArray(1, true);
+        compensations = bigArrays().newDoubleArray(1, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -59,8 +59,8 @@ public final class ValueCountAggregator extends NumericMetricsAggregator.SingleV
 
                 @Override
                 public void collect(int doc, long bucket) throws IOException {
-                    counts = bigArrays().grow(counts, bucket + 1);
                     if (values.advanceExact(doc)) {
+                        counts = bigArrays().grow(counts, bucket + 1);
                         counts.increment(bucket, values.docValueCount());
                     }
                 }
@@ -72,8 +72,8 @@ public final class ValueCountAggregator extends NumericMetricsAggregator.SingleV
 
                 @Override
                 public void collect(int doc, long bucket) throws IOException {
-                    counts = bigArrays().grow(counts, bucket + 1);
                     if (values.advanceExact(doc)) {
+                        counts = bigArrays().grow(counts, bucket + 1);
                         counts.increment(bucket, values.docValueCount());
                     }
                 }
@@ -85,8 +85,8 @@ public final class ValueCountAggregator extends NumericMetricsAggregator.SingleV
 
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                counts = bigArrays().grow(counts, bucket + 1);
                 if (values.advanceExact(doc)) {
+                    counts = bigArrays().grow(counts, bucket + 1);
                     counts.increment(bucket, values.docValueCount());
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -48,7 +48,7 @@ public final class ValueCountAggregator extends NumericMetricsAggregator.SingleV
         super(name, aggregationContext, parent, metadata);
         assert valuesSourceConfig.hasValues();
         this.valuesSource = valuesSourceConfig.getValuesSource();
-        counts = bigArrays().newLongArray(1, true);
+        counts = bigArrays().newLongArray(0, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -48,7 +48,7 @@ public final class ValueCountAggregator extends NumericMetricsAggregator.SingleV
         super(name, aggregationContext, parent, metadata);
         assert valuesSourceConfig.hasValues();
         this.valuesSource = valuesSourceConfig.getValuesSource();
-        counts = bigArrays().newLongArray(0, true);
+        counts = bigArrays().newLongArray(1, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
@@ -69,17 +69,18 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
         return new LeafBucketCollectorBase(sub, docValues) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                weights = bigArrays().grow(weights, bucket + 1);
-                valueSums = bigArrays().grow(valueSums, bucket + 1);
-                valueCompensations = bigArrays().grow(valueCompensations, bucket + 1);
-                weightCompensations = bigArrays().grow(weightCompensations, bucket + 1);
-
                 if (docValues.advanceExact(doc) && docWeights.advanceExact(doc)) {
                     if (docWeights.docValueCount() > 1) {
                         throw new IllegalArgumentException(
                             "Encountered more than one weight for a "
                                 + "single document. Use a script to combine multiple weights-per-doc into a single value."
                         );
+                    }
+                    if (bucket >= weights.size()) {
+                        weights = bigArrays().grow(weights, bucket + 1);
+                        valueSums = bigArrays().grow(valueSums, bucket + 1);
+                        valueCompensations = bigArrays().grow(valueCompensations, bucket + 1);
+                        weightCompensations = bigArrays().grow(weightCompensations, bucket + 1);
                     }
                     // There should always be one weight if advanceExact lands us here, either
                     // a real weight or a `missing` weight

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
@@ -48,10 +48,10 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
         assert valuesSources != null;
         this.valuesSources = valuesSources;
         this.format = format;
-        weights = bigArrays().newDoubleArray(0, true);
-        valueSums = bigArrays().newDoubleArray(0, true);
-        valueCompensations = bigArrays().newDoubleArray(0, true);
-        weightCompensations = bigArrays().newDoubleArray(0, true);
+        weights = bigArrays().newDoubleArray(1, true);
+        valueSums = bigArrays().newDoubleArray(1, true);
+        valueCompensations = bigArrays().newDoubleArray(1, true);
+        weightCompensations = bigArrays().newDoubleArray(1, true);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
@@ -48,10 +48,10 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
         assert valuesSources != null;
         this.valuesSources = valuesSources;
         this.format = format;
-        weights = bigArrays().newDoubleArray(1, true);
-        valueSums = bigArrays().newDoubleArray(1, true);
-        valueCompensations = bigArrays().newDoubleArray(1, true);
-        weightCompensations = bigArrays().newDoubleArray(1, true);
+        weights = bigArrays().newDoubleArray(0, true);
+        valueSums = bigArrays().newDoubleArray(0, true);
+        valueCompensations = bigArrays().newDoubleArray(0, true);
+        weightCompensations = bigArrays().newDoubleArray(0, true);
     }
 
     @Override


### PR DESCRIPTION
During aggregation collection, we use BigArrays to hold the values on a compact way for metrics aggregations. We are currently resizing those arrays whenever the collect method is call, regardless if there is an actual value in the provided doc. 
This can be wasteful for sparse fields as we might never have a value but still we are resizng those arrays.

Therefore this commit proposes to move the resize after checking that there is a value in the provided document.