### PR TITLE
[8.14] Validate model_id is required when using the learning_to_rank rescorer (#107743)

### DIFF
--- a/docs/changelog/107743.yaml
+++ b/docs/changelog/107743.yaml
@@ -1,0 +1,5 @@
+pr: 107743
+summary: Validate `model_id` is required when using the `learning_to_rank` rescorer
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilder.java
@@ -40,6 +40,7 @@ public class LearningToRankRescorerBuilder extends RescorerBuilder<LearningToRan
     static {
         PARSER.declareString(Builder::setModelId, MODEL_FIELD);
         PARSER.declareObject(Builder::setParams, (p, c) -> p.map(), PARAMS_FIELD);
+        PARSER.declareRequiredFieldSet(MODEL_FIELD.getPreferredName());
     }
 
     public static LearningToRankRescorerBuilder fromXContent(XContentParser parser, LearningToRankService learningToRankService) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilderSerializationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilderSerializationTests.java
@@ -33,7 +33,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.LearningToRankConfigTests.randomLearningToRankConfig;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 
@@ -55,6 +57,22 @@ public class LearningToRankRescorerBuilderSerializationTests extends AbstractBWC
                 }
             }
         }
+    }
+
+    public void testModelIdIsRequired() throws IOException {
+        XContentBuilder jsonBuilder = jsonBuilder().startObject();
+        if (randomBoolean()) {
+            jsonBuilder.field("params", randomParams());
+        }
+        jsonBuilder.endObject();
+
+        XContentParser parser = createParser(jsonBuilder);
+
+        Exception e = assertThrows(
+            IllegalArgumentException.class,
+            () -> LearningToRankRescorerBuilder.fromXContent(parser, mock(LearningToRankService.class))
+        );
+        assertThat(e.getMessage(), containsString("Required one of fields [model_id], but none were specified."));
     }
 
     @Override


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Validate model_id is required when using the learning_to_rank rescorer (#107743)