### PR TITLE
Use `wait_for_status` option in `frequent_item_sets_agg` tests

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/frequent_item_sets_agg.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/frequent_item_sets_agg.yml
@@ -7,9 +7,6 @@ setup:
       indices.create:
         index: store
         body:
-          settings:
-            number_of_shards: 1
-            number_of_replicas: 0
           mappings:
             properties:
               features:
@@ -58,9 +55,6 @@ setup:
       indices.create:
         index: store-flattened
         body:
-          settings:
-            number_of_shards: 1
-            number_of_replicas: 0
           mappings:
             properties:
               data:
@@ -96,7 +90,30 @@ setup:
           { "data": {"features": ["rwd", "turbocharger", "autopilot", "pink wheels"], "error_message": "engine overheated"}, "timestamp": 1022137244000 }
           { "index": {} }
           { "data": {"features": ["fwd", "tow-bar", "turbocharger", "pink wheels", "electric mirror", "heated steering wheel", "lane assist", "sunroof", "autopilot", "air condition" ], "error_message": "low tire pressure"}, "timestamp": 1020920854000 }
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.create:
+        index: unavailable-data
+        body:
+          mappings:
+            properties:
+              features:
+                type: keyword
+              error_message:
+                type: keyword
+              timestamp:
+                type: date
+              geo_point:
+                type: geo_point
+              histogram:
+                type: histogram
 
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      cluster.health:
+        wait_for_status: yellow
 
 ---
 "Test frequent item sets array fields":
@@ -550,31 +567,6 @@ setup:
 
 ---
 "Test frequent items on empty index":
-  - skip:
-      features: headers
-
-  - do:
-      headers:
-        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
-      indices.create:
-        index: unavailable-data
-        body:
-          settings:
-            number_of_shards: 1
-            number_of_replicas: 0
-          mappings:
-            properties:
-              features:
-                type: keyword
-              error_message:
-                type: keyword
-              timestamp:
-                type: date
-              geo_point:
-                type: geo_point
-              histogram:
-                type: histogram
-
   - do:
       search:
         index: unavailable-data


### PR DESCRIPTION
Unfortunately, the `number_of_shards` and `number_of_replicas` index settings are not available in serverless.
Hence, I need to revert them.
In order to fix the unavailable shards issue, this PR adds the following section after creating indices:
```
  - do:
      cluster.health:
        wait_for_status: yellow
```

This way the subsequent searches should not fail.

Relates https://github.com/elastic/elasticsearch/issues/106215