### PR TITLE
Increase container size for machine dependent heap docker tests

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1011,12 +1011,11 @@ public class DockerTests extends PackagingTestCase {
      * Check that when available system memory is constrained by Docker, the machine-dependant heap sizing
      * logic sets the correct heap size, based on the container limits.
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104786")
     public void test150MachineDependentHeap() throws Exception {
-        final List<String> xArgs = machineDependentHeapTest("942m", List.of());
+        final List<String> xArgs = machineDependentHeapTest("1536m", List.of());
 
-        // This is roughly 0.4 * 942
-        assertThat(xArgs, hasItems("-Xms376m", "-Xmx376m"));
+        // This is roughly 0.5 * 1536
+        assertThat(xArgs, hasItems("-Xms768m", "-Xmx768m"));
     }
 
     /**


### PR DESCRIPTION
We are seeing failures in this test which are presumed to be due to the oomkiller due to the small container memory limit. Let's bump this and hopefully give more breathing room.

Closes https://github.com/elastic/elasticsearch/issues/104786