### PR TITLE
Block readiness on bad initial FileSettings

### DIFF
--- a/docs/changelog/107804.yaml
+++ b/docs/changelog/107804.yaml
@@ -1,0 +1,6 @@
+pr: 107804
+summary: Block readiness on bad initial `FileSettings`
+area: Infra/Node Lifecycle
+type: bug
+issues:
+ - 107744

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -211,10 +211,9 @@ public class ReadinessClusterIT extends ESIntegTestCase {
         }
     }
 
-    private Tuple<CountDownLatch, AtomicLong> setupClusterStateListenerForError(String node) {
+    private CountDownLatch setupClusterStateListenerForError(String node) {
         ClusterService clusterService = internalCluster().clusterService(node);
         CountDownLatch savedClusterState = new CountDownLatch(1);
-        AtomicLong metadataVersion = new AtomicLong(-1);
         clusterService.addListener(new ClusterStateListener() {
             @Override
             public void clusterChanged(ClusterChangedEvent event) {
@@ -227,13 +226,16 @@ public class ReadinessClusterIT extends ESIntegTestCase {
                         containsString("Missing handler definition for content key [not_cluster_settings]")
                     );
                     clusterService.removeListener(this);
-                    metadataVersion.set(event.state().metadata().version());
                     savedClusterState.countDown();
                 }
             }
         });
 
-        return new Tuple<>(savedClusterState, metadataVersion);
+        // we need this after we setup the listener above, in case the node started and processed
+        // settings before we set our listener to cluster state changes.
+        causeClusterStateUpdate();
+
+        return savedClusterState;
     }
 
     private void writeFileSettings(String json) throws Exception {
@@ -247,7 +249,6 @@ public class ReadinessClusterIT extends ESIntegTestCase {
         logger.info("--> New file settings: [{}]", Strings.format(json, version));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107744")
     public void testNotReadyOnBadFileSettings() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start data node / non master node");
@@ -266,20 +267,46 @@ public class ReadinessClusterIT extends ESIntegTestCase {
         assertMasterNode(internalCluster().nonMasterClient(), masterNode);
         var savedClusterState = setupClusterStateListenerForError(masterNode);
 
-        // we need this after we setup the listener above, in case the node started and processed
-        // settings before we set our listener to cluster state changes.
-        causeClusterStateUpdate();
-
         FileSettingsService masterFileSettingsService = internalCluster().getInstance(FileSettingsService.class, masterNode);
 
         assertTrue(masterFileSettingsService.watching());
         assertFalse(dataFileSettingsService.watching());
 
-        boolean awaitSuccessful = savedClusterState.v1().await(20, TimeUnit.SECONDS);
-        assertTrue(awaitSuccessful);
+        assertTrue(savedClusterState.await(20, TimeUnit.SECONDS));
 
         ReadinessService s = internalCluster().getInstance(ReadinessService.class, internalCluster().getMasterName());
         assertNull(s.boundAddress());
+    }
+
+    public void testReadyAfterRestartWithBadFileSettings() throws Exception {
+        internalCluster().setBootstrapMasterNodeIndex(0);
+        writeFileSettings(testJSON);
+
+        logger.info("--> start data node / non master node");
+        String dataNode = internalCluster().startNode(Settings.builder().put(dataOnlyNode()).put("discovery.initial_state_timeout", "1s"));
+        String masterNode = internalCluster().startMasterOnlyNode();
+
+        assertMasterNode(internalCluster().nonMasterClient(), masterNode);
+        assertBusy(() -> assertTrue("master node ready", internalCluster().getInstance(ReadinessService.class, masterNode).ready()));
+        assertBusy(() -> assertTrue("data node ready", internalCluster().getInstance(ReadinessService.class, dataNode).ready()));
+
+        logger.info("--> stop master node");
+        Settings masterDataPathSettings = internalCluster().dataPathSettings(internalCluster().getMasterName());
+        internalCluster().stopCurrentMasterNode();
+        expectMasterNotFound();
+
+        logger.info("--> write bad file settings before restarting master node");
+        writeFileSettings(testErrorJSON);
+
+        logger.info("--> restart master node");
+        String nextMasterNode = internalCluster().startNode(Settings.builder().put(nonDataNode(masterNode())).put(masterDataPathSettings));
+
+        assertMasterNode(internalCluster().nonMasterClient(), nextMasterNode);
+
+        var savedClusterState = setupClusterStateListenerForError(nextMasterNode);
+        assertTrue(savedClusterState.await(20, TimeUnit.SECONDS));
+
+        assertTrue("master node ready on restart", internalCluster().getInstance(ReadinessService.class, nextMasterNode).ready());
     }
 
     public void testReadyWhenMissingFileSettings() throws Exception {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ReservedStateMetadata.java
@@ -46,6 +46,9 @@ public record ReservedStateMetadata(
     ReservedStateErrorMetadata errorMetadata
 ) implements SimpleDiffable<ReservedStateMetadata>, ToXContentFragment {
 
+    public static final long STATE_VERSION_SNAPSHOT_RESTORE = 0;
+    public static final long STATE_VERSION_EMPTY = -1;
+
     private static final ParseField VERSION = new ParseField("version");
     private static final ParseField HANDLERS = new ParseField("handlers");
     private static final ParseField ERRORS_METADATA = new ParseField("errors");

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -102,7 +102,7 @@ public class FileSettingsService extends MasterNodeFileWatchingService implement
         // We check if the version was reset to 0, and force an update if a file exists. This can happen in situations
         // like snapshot restores.
         ReservedStateMetadata fileSettingsMetadata = clusterState.metadata().reservedStateMetadata().get(NAMESPACE);
-        return fileSettingsMetadata != null && fileSettingsMetadata.version() == 0L;
+        return fileSettingsMetadata != null && fileSettingsMetadata.version() == ReservedStateMetadata.STATE_VERSION_SNAPSHOT_RESTORE;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
@@ -112,7 +112,12 @@ public class ReservedClusterStateService {
         try {
             return stateChunkParser.apply(parser, null);
         } catch (Exception e) {
-            ErrorState errorState = new ErrorState(namespace, -1L, e, ReservedStateErrorMetadata.ErrorKind.PARSING);
+            ErrorState errorState = new ErrorState(
+                namespace,
+                ReservedStateMetadata.STATE_VERSION_EMPTY,
+                e,
+                ReservedStateErrorMetadata.ErrorKind.PARSING
+            );
             updateErrorState(errorState);
             logger.debug("error processing state change request for [{}] with the following errors [{}]", namespace, errorState);
 
@@ -134,7 +139,12 @@ public class ReservedClusterStateService {
         try {
             stateChunk = parse(namespace, parser);
         } catch (Exception e) {
-            ErrorState errorState = new ErrorState(namespace, -1L, e, ReservedStateErrorMetadata.ErrorKind.PARSING);
+            ErrorState errorState = new ErrorState(
+                namespace,
+                ReservedStateMetadata.STATE_VERSION_EMPTY,
+                e,
+                ReservedStateErrorMetadata.ErrorKind.PARSING
+            );
             updateErrorState(errorState);
             logger.debug("error processing state change request for [{}] with the following errors [{}]", namespace, errorState);
 
@@ -148,7 +158,7 @@ public class ReservedClusterStateService {
     }
 
     public void initEmpty(String namespace, ActionListener<ActionResponse.Empty> listener) {
-        var missingVersion = new ReservedStateVersion(-1L, Version.CURRENT);
+        var missingVersion = new ReservedStateVersion(ReservedStateMetadata.STATE_VERSION_EMPTY, Version.CURRENT);
         var emptyState = new ReservedStateChunk(Map.of(), missingVersion);
         updateTaskQueue.submitTask(
             "empty initial cluster state [" + namespace + "]",

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateErrorTask.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateErrorTask.java
@@ -50,8 +50,9 @@ public class ReservedStateErrorTask implements ClusterStateTaskListener {
     static boolean isNewError(ReservedStateMetadata existingMetadata, Long newStateVersion) {
         return (existingMetadata == null
             || existingMetadata.errorMetadata() == null
-            || newStateVersion <= 0 // version will be -1 when we can't even parse the file, it might be 0 on snapshot restore
-            || existingMetadata.errorMetadata().version() < newStateVersion);
+            || existingMetadata.errorMetadata().version() < newStateVersion
+            // version will be -1 (empty) when we can't even parse the file, it might be 0 on snapshot restore
+            || newStateVersion <= ReservedStateMetadata.STATE_VERSION_SNAPSHOT_RESTORE);
     }
 
     static boolean checkErrorVersion(ClusterState currentState, ErrorState errorState) {

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedStateUpdateTask.java
@@ -170,12 +170,12 @@ public class ReservedStateUpdateTask implements ClusterStateTaskListener {
         }
 
         // Version -1 is special, it means "empty"
-        if (reservedStateVersion.version() == -1L) {
+        if (reservedStateVersion.version() == ReservedStateMetadata.STATE_VERSION_EMPTY) {
             return true;
         }
 
         // Version 0 is special, snapshot restores will reset to 0.
-        if (reservedStateVersion.version() <= 0L) {
+        if (reservedStateVersion.version() <= ReservedStateMetadata.STATE_VERSION_SNAPSHOT_RESTORE) {
             logger.warn(
                 () -> format(
                     "Not updating reserved cluster state for namespace [%s], because version [%s] is less or equal to 0",


### PR DESCRIPTION
This PR prevents a new cluster from turning ready if it failed to apply initial FileSettings due to a parsing error. Without any FileSettings applied, despite expecting those, the cluster will likely be in a broken state.

Fixes #107744
