### PR TITLE
[TEST] Update version skip for `fields with ignore_malformed`

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -716,8 +716,8 @@ _doc_count:
 ---
 fields with ignore_malformed:
   - requires:
-      cluster_features: ["gte_v8.6.0"]
-      reason: introduced in 8.6.0
+      cluster_features: ["gte_v8.8.0"]
+      reason: support for boolean ignore_malformed was added in 8.8.0
 
   - do:
       indices.create:


### PR DESCRIPTION
Support for boolean field mappers was added in #94121

Fixes #107810
