### PR TITLE
[ML] Handle Negative Byte Values when converting to a human-readable string format

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/ByteSizeValue.java
@@ -204,6 +204,14 @@ public class ByteSizeValue implements Writeable, Comparable<ByteSizeValue>, ToXC
         return Strings.format1Decimals(value, suffix);
     }
 
+    public static String bytesToString(long size) {
+        if (size < 0) {
+            size = -size;
+            return "-" + ofBytes(size).toString();
+        }
+        return ofBytes(size).toString();
+    }
+
     public static ByteSizeValue parseBytesSizeValue(String sValue, String settingName) throws ElasticsearchParseException {
         return parseBytesSizeValue(sValue, null, settingName);
     }

--- a/server/src/main/java/org/elasticsearch/index/merge/MergeStats.java
+++ b/server/src/main/java/org/elasticsearch/index/merge/MergeStats.java
@@ -242,7 +242,7 @@ public class MergeStats implements Writeable, ToXContentFragment {
         builder.humanReadableField(Fields.TOTAL_STOPPED_TIME_IN_MILLIS, Fields.TOTAL_STOPPED_TIME, getTotalStoppedTime());
         builder.humanReadableField(Fields.TOTAL_THROTTLED_TIME_IN_MILLIS, Fields.TOTAL_THROTTLED_TIME, getTotalThrottledTime());
         if (builder.humanReadable() && totalBytesPerSecAutoThrottle != -1) {
-            builder.field(Fields.TOTAL_THROTTLE_BYTES_PER_SEC).value(ByteSizeValue.ofBytes(totalBytesPerSecAutoThrottle).toString());
+            builder.field(Fields.TOTAL_THROTTLE_BYTES_PER_SEC).value(ByteSizeValue.bytesToString(totalBytesPerSecAutoThrottle));
         }
         builder.field(Fields.TOTAL_THROTTLE_BYTES_PER_SEC_IN_BYTES, totalBytesPerSecAutoThrottle);
         builder.endObject();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
@@ -425,11 +425,11 @@ class TrainedModelAssignmentRebalancer {
                         + "estimated memory required for this model [{} ({})].",
                     new Object[] {
                         load.getMaxMlMemory(),
-                        ByteSizeValue.ofBytes(load.getMaxMlMemory()).toString(),
+                        ByteSizeValue.bytesToString(load.getMaxMlMemory()),
                         nodeFreeMemory,
-                        ByteSizeValue.ofBytes(nodeFreeMemory).toString(),
+                        ByteSizeValue.bytesToString(nodeFreeMemory),
                         requiredMemory,
-                        ByteSizeValue.ofBytes(requiredMemory).toString() }
+                        ByteSizeValue.bytesToString(requiredMemory) }
                 )
             );
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobNodeSelector.java
@@ -246,11 +246,11 @@ public class JobNodeSelector {
                         + "memory required by existing jobs [%s (%s)], "
                         + "estimated memory required for this job [%s (%s)].",
                     currentLoad.getMaxMlMemory(),
-                    ByteSizeValue.ofBytes(currentLoad.getMaxMlMemory()).toString(),
+                    ByteSizeValue.bytesToString(currentLoad.getMaxMlMemory()),
                     currentLoad.getAssignedJobMemory(),
-                    ByteSizeValue.ofBytes(currentLoad.getAssignedJobMemory()).toString(),
+                    ByteSizeValue.bytesToString(currentLoad.getAssignedJobMemory()),
                     requiredMemoryForJob,
-                    ByteSizeValue.ofBytes(requiredMemoryForJob).toString()
+                    ByteSizeValue.bytesToString(requiredMemoryForJob)
                 );
                 logger.trace(reason);
                 reasons.put(node.getName(), reason);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/output/AutodetectResultProcessor.java
@@ -465,7 +465,7 @@ public class AutodetectResultProcessor {
                         jobId,
                         Messages.getMessage(
                             Messages.JOB_AUDIT_MEMORY_STATUS_HARD_LIMIT_PRE_7_2,
-                            ByteSizeValue.ofBytes(modelSizeStats.getModelBytes()).toString()
+                            ByteSizeValue.bytesToString(modelSizeStats.getModelBytes())
                         )
                     );
                 } else {
@@ -473,8 +473,8 @@ public class AutodetectResultProcessor {
                         jobId,
                         Messages.getMessage(
                             Messages.JOB_AUDIT_MEMORY_STATUS_HARD_LIMIT,
-                            ByteSizeValue.ofBytes(modelSizeStats.getModelBytesMemoryLimit()).toString(),
-                            ByteSizeValue.ofBytes(modelSizeStats.getModelBytesExceeded()).toString()
+                            ByteSizeValue.bytesToString(modelSizeStats.getModelBytesMemoryLimit()),
+                            ByteSizeValue.bytesToString(modelSizeStats.getModelBytesExceeded())
                         )
                     );
                 }


### PR DESCRIPTION
This PR addresses the issue where negative byte values passed to `ByteSizeValue.ofBytes().toString()` result in an `IllegalArgumentException`. The problem was identified in issue #107807, where updating the `number_of_allocations` for a trained model deployment could lead to a negative byte value calculation, causing the update to fail with an error.

**Changes**:
- Introduced a new method `ByteSizeValue.bytesToString(long size)` that correctly handles negative byte values by converting them to a human-readable string format, prefixed with a minus sign if the value is negative.
- Replaced all instances of `ByteSizeValue.ofBytes().toString()` with `ByteSizeValue.bytesToString()` to ensure that negative values are handled gracefully throughout the codebase.