### PR TITLE
Increase size of big arrays only when there is an actual value in the aggregators (Analytics module)

### DIFF
--- a/docs/changelog/107813.yaml
+++ b/docs/changelog/107813.yaml
@@ -1,0 +1,6 @@
+pr: 107813
+summary: Increase size of big arrays only when there is an actual value in the aggregators
+  (Analytics module)
+area: Aggregations
+type: enhancement
+issues: []

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregator.java
@@ -72,8 +72,8 @@ public class BoxplotAggregator extends NumericMetricsAggregator.MultiValue {
             return new LeafBucketCollectorBase(sub, values) {
                 @Override
                 public void collect(int doc, long bucket) throws IOException {
-                    TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
                     if (values.advanceExact(doc)) {
+                        TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
                         final HistogramValue sketch = values.histogram();
                         while (sketch.next()) {
                             state.add(sketch.value(), sketch.count());

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/HistogramRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/HistogramRateAggregator.java
@@ -42,10 +42,11 @@ public class HistogramRateAggregator extends AbstractRateAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                sums = bigArrays().grow(sums, bucket + 1);
-                compensations = bigArrays().grow(compensations, bucket + 1);
-
                 if (values.advanceExact(doc)) {
+
+                    sums = bigArrays().grow(sums, bucket + 1);
+                    compensations = bigArrays().grow(compensations, bucket + 1);
+
                     final HistogramValue sketch = values.histogram();
                     while (sketch.next()) {
                         double sum = sums.get(bucket);

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/NumericRateAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/rate/NumericRateAggregator.java
@@ -70,10 +70,10 @@ public class NumericRateAggregator extends AbstractRateAggregator {
             return new LeafBucketCollectorBase(sub, values) {
                 @Override
                 public void collect(int doc, long bucket) throws IOException {
-                    sums = bigArrays().grow(sums, bucket + 1);
-                    compensations = bigArrays().grow(compensations, bucket + 1);
-
                     if (values.advanceExact(doc)) {
+                        sums = bigArrays().grow(sums, bucket + 1);
+                        compensations = bigArrays().grow(compensations, bucket + 1);
+
                         final int valuesCount = values.docValueCount();
                         // Compute the sum of double values with Kahan summation algorithm which is more
                         // accurate than naive summation.

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/StringStatsAggregator.java
@@ -89,18 +89,17 @@ public class StringStatsAggregator extends MetricsAggregator {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
-                final long overSize = BigArrays.overSize(bucket + 1);
-                if (bucket >= count.size()) {
-                    final long from = count.size();
-                    count = bigArrays().resize(count, overSize);
-                    totalLength = bigArrays().resize(totalLength, overSize);
-                    minLength = bigArrays().resize(minLength, overSize);
-                    maxLength = bigArrays().resize(maxLength, overSize);
-                    minLength.fill(from, overSize, Integer.MAX_VALUE);
-                    maxLength.fill(from, overSize, Integer.MIN_VALUE);
-                }
-
                 if (values.advanceExact(doc)) {
+                    final long overSize = BigArrays.overSize(bucket + 1);
+                    if (bucket >= count.size()) {
+                        final long from = count.size();
+                        count = bigArrays().resize(count, overSize);
+                        totalLength = bigArrays().resize(totalLength, overSize);
+                        minLength = bigArrays().resize(minLength, overSize);
+                        maxLength = bigArrays().resize(maxLength, overSize);
+                        minLength.fill(from, overSize, Integer.MAX_VALUE);
+                        maxLength.fill(from, overSize, Integer.MIN_VALUE);
+                    }
                     final int valuesCount = values.docValueCount();
                     count.increment(bucket, valuesCount);
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
@@ -86,7 +86,7 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
 
         return new LeafBucketCollectorBase(sub, docAValues) {
 
-            private static void processValues(
+            private void processValues(
                 int doc,
                 long bucket,
                 SortedNumericDoubleValues docValues,
@@ -95,6 +95,7 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
                 TTestStatsBuilder builder
             ) throws IOException {
                 if (docValues.advanceExact(doc)) {
+                    builder.grow(bigArrays(), bucket + 1);
                     final int numValues = docValues.docValueCount();
                     for (int i = 0; i < numValues; i++) {
                         builder.addValue(compSum, compSumOfSqr, bucket, docValues.nextValue());
@@ -105,12 +106,10 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (bitsA == null || bitsA.get(doc)) {
-                    a.grow(bigArrays(), bucket + 1);
                     processValues(doc, bucket, docAValues, compSumA, compSumOfSqrA, a);
                 }
                 if (bitsB == null || bitsB.get(doc)) {
                     processValues(doc, bucket, docBValues, compSumB, compSumOfSqrB, b);
-                    b.grow(bigArrays(), bucket + 1);
                 }
             }
         };

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/empty_field_metric.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/empty_field_metric.yml
@@ -1,0 +1,135 @@
+setup:
+  - do:
+      indices.create:
+        index: test_1
+        body:
+          mappings:
+            properties:
+              terms_field:
+                type: keyword
+              date_field:
+                type: date
+              int_field:
+                type : integer
+              double_field:
+                type : double
+              string_field:
+                type: keyword
+              histogram_field:
+                type: histogram
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_1
+              _id:    "1"
+          - terms_field: foo
+            date_field: 2024-01-02
+          - index:
+              _index: test_1
+              _id:    "2"
+          - terms_field: foo
+            date_field: 2024-01-02
+          - index:
+              _index: test_1
+              _id:    "3"
+          - terms_field: bar
+            date_field: 2024-01-01
+
+---
+"Basic test":
+
+  - do:
+      search:
+        index: test_1
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_terms:
+              terms:
+                field: terms_field
+                "order":
+                  "_key": "asc"
+              aggs:
+                boxplot_agg:
+                  boxplot:
+                    field: double_field
+                t_test_agg:
+                  t_test:
+                    a:
+                      field: double_field
+                    b:
+                      field: int_field
+                    type: paired
+                string_stats_agg:
+                  string_stats:
+                    field: string_field
+
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_terms.buckets.0.key: bar}
+  - match: { aggregations.the_terms.buckets.0.doc_count: 1}
+  - exists: aggregations.the_terms.buckets.0.boxplot_agg.min
+  - exists: aggregations.the_terms.buckets.0.boxplot_agg.max
+  - exists: aggregations.the_terms.buckets.0.boxplot_agg.q3
+  - exists: aggregations.the_terms.buckets.0.boxplot_agg.q1
+  - exists: aggregations.the_terms.buckets.0.boxplot_agg.q2
+  - exists: aggregations.the_terms.buckets.0.boxplot_agg.q3
+  - match: { aggregations.the_terms.buckets.0.t_test_agg.value: null }
+  - match: { aggregations.the_terms.buckets.0.string_stats_agg.count: 0 }
+  - match: { aggregations.the_terms.buckets.0.string_stats_agg.min_length: null }
+  - match: { aggregations.the_terms.buckets.0.string_stats_agg.max_length: null }
+  - match: { aggregations.the_terms.buckets.0.string_stats_agg.avg_length: null }
+  - match: { aggregations.the_terms.buckets.0.string_stats_agg.entropy: 0 }
+  - match: { aggregations.the_terms.buckets.1.key: foo}
+  - match: { aggregations.the_terms.buckets.1.doc_count: 2}
+  - exists: aggregations.the_terms.buckets.1.boxplot_agg.min
+  - exists: aggregations.the_terms.buckets.1.boxplot_agg.max
+  - exists: aggregations.the_terms.buckets.1.boxplot_agg.q3
+  - exists: aggregations.the_terms.buckets.1.boxplot_agg.q1
+  - exists: aggregations.the_terms.buckets.1.boxplot_agg.q2
+  - exists: aggregations.the_terms.buckets.1.boxplot_agg.q3
+  - match: { aggregations.the_terms.buckets.1.t_test_agg.value: null }
+  - match: { aggregations.the_terms.buckets.1.string_stats_agg.count: 0 }
+  - match: { aggregations.the_terms.buckets.1.string_stats_agg.min_length: null }
+  - match: { aggregations.the_terms.buckets.1.string_stats_agg.max_length: null }
+  - match: { aggregations.the_terms.buckets.1.string_stats_agg.avg_length: null }
+  - match: { aggregations.the_terms.buckets.1.string_stats_agg.entropy: 0 }
+
+---
+"Rate test":
+
+  - do:
+      search:
+        index: test_1
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_date_hist:
+              date_histogram:
+                field: date_field
+                calendar_interval: day
+                format: yyyy-MM-dd
+              aggs:
+                rate_agg:
+                  rate:
+                    field: double_field
+                rate_hist_agg:
+                  rate:
+                    field: histogram_field
+
+
+  - match: { hits.total: 3 }
+  - length: { hits.hits: 3 }
+  - match: { aggregations.the_date_hist.buckets.0.key_as_string: 2024-01-01 }
+  - match: { aggregations.the_date_hist.buckets.0.doc_count: 1 }
+  - match: { aggregations.the_date_hist.buckets.0.rate_agg.value: 0.0 }
+  - match: { aggregations.the_date_hist.buckets.0.rate_hist_agg.value: 0.0 }
+  - match: { aggregations.the_date_hist.buckets.1.key_as_string: 2024-01-02 }
+  - match: { aggregations.the_date_hist.buckets.1.doc_count: 2 }
+  - match: { aggregations.the_date_hist.buckets.1.rate_agg.value: 0.0 }
+  - match: { aggregations.the_date_hist.buckets.1.rate_hist_agg.value: 0.0 }
+


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/107764 but in the analytics module.

During aggregation collection, we use BigArrays to hold the values on a compact way for metrics aggregations. We are currently resizing those arrays whenever the collect method is call, regardless if there is an actual value in the provided doc.
This can be wasteful for sparse fields as we might never have a value but still we are resizng those arrays.

Therefore this commit proposes to move the resize after checking that there is a value in the provided document.