### PR TITLE
Remove ES version from security index

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -9,11 +9,9 @@ package org.elasticsearch.xpack.security.support;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceAlreadyExistsException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
@@ -44,17 +42,15 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_FORMAT_SETTING;
+import static org.elasticsearch.indices.SystemIndexDescriptor.VERSION_META_KEY;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.State.UNRECOVERED_STATE;
 
@@ -214,6 +210,19 @@ public class SecurityIndexManager implements ClusterStateListener {
         stateChangeListeners.remove(listener);
     }
 
+    /**
+     * Get the minimum security index mapping version in the cluster
+     */
+    private SystemIndexDescriptor.MappingsVersion getMinSecurityIndexMappingVersion(ClusterState clusterState) {
+        var minClusterVersion = clusterState.getMinSystemIndexMappingVersions().get(systemIndexDescriptor.getPrimaryIndex());
+        // Can be null in mixed clusters. This indicates that the cluster state and index needs to be updated with the latest mapping
+        // version from the index descriptor
+        if (minClusterVersion == null) {
+            return systemIndexDescriptor.getMappingsVersion();
+        }
+        return minClusterVersion;
+    }
+
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
@@ -231,7 +240,7 @@ public class SecurityIndexManager implements ClusterStateListener {
         final boolean indexAvailableForWrite = available.v1();
         final boolean indexAvailableForSearch = available.v2();
         final boolean mappingIsUpToDate = indexMetadata == null || checkIndexMappingUpToDate(event.state());
-        final Version mappingVersion = oldestIndexMappingVersion(event.state());
+        final SystemIndexDescriptor.MappingsVersion mappingVersion = getMinSecurityIndexMappingVersion(event.state());
         final String concreteIndexName = indexMetadata == null
             ? systemIndexDescriptor.getPrimaryIndex()
             : indexMetadata.getIndex().getName();
@@ -261,7 +270,6 @@ public class SecurityIndexManager implements ClusterStateListener {
             concreteIndexName,
             indexHealth,
             indexState,
-            event.state().nodes().getSmallestNonClientNodeVersion(),
             indexUUID
         );
         this.state = newState;
@@ -317,51 +325,43 @@ public class SecurityIndexManager implements ClusterStateListener {
         return new Tuple<>(allPrimaryShards, searchShards);
     }
 
+    /**
+     * Detect if the mapping in the security index is outdated. If it's outdated it means that whatever is in cluster state is more recent.
+     * There could be several nodes on different ES versions (mixed cluster) supporting different mapping versions, so only return false if
+     * min version in the cluster is more recent than what's in the security index.
+     */
     private boolean checkIndexMappingUpToDate(ClusterState clusterState) {
-        final Version minimumNonClientNodeVersion = clusterState.nodes().getSmallestNonClientNodeVersion();
-        final SystemIndexDescriptor descriptor = systemIndexDescriptor.getDescriptorCompatibleWith(minimumNonClientNodeVersion);
+        // Get descriptor compatible with the min version in the cluster
+        final SystemIndexDescriptor descriptor = systemIndexDescriptor.getDescriptorCompatibleWith(
+            getMinSecurityIndexMappingVersion(clusterState)
+        );
         if (descriptor == null) {
             return false;
         }
-
-        /*
-         * The method reference looks wrong here, but it's just counter-intuitive. It expands to:
-         *
-         *     mappingVersion -> descriptor.getMappingVersion().onOrBefore(mappingVersion)
-         *
-         * ...which is true if the mappings have been updated.
-         */
-        return checkIndexMappingVersionMatches(clusterState, descriptor.getMappingsNodeVersion()::onOrBefore);
+        return descriptor.getMappingsVersion().version() <= loadIndexMappingVersion(systemIndexDescriptor.getAliasName(), clusterState);
     }
 
-    private boolean checkIndexMappingVersionMatches(ClusterState clusterState, Predicate<Version> predicate) {
-        return checkIndexMappingVersionMatches(this.systemIndexDescriptor.getAliasName(), clusterState, logger, predicate);
-    }
-
-    public static boolean checkIndexMappingVersionMatches(
-        String indexName,
-        ClusterState clusterState,
-        Logger logger,
-        Predicate<Version> predicate
-    ) {
-        return loadIndexMappingVersions(indexName, clusterState, logger).stream().allMatch(predicate);
-    }
-
-    private Version oldestIndexMappingVersion(ClusterState clusterState) {
-        final Set<Version> versions = loadIndexMappingVersions(systemIndexDescriptor.getAliasName(), clusterState, logger);
-        return versions.stream().min(Version::compareTo).orElse(null);
-    }
-
-    private static Set<Version> loadIndexMappingVersions(String aliasName, ClusterState clusterState, Logger logger) {
-        Set<Version> versions = new HashSet<>();
+    private static int loadIndexMappingVersion(String aliasName, ClusterState clusterState) {
         IndexMetadata indexMetadata = resolveConcreteIndex(aliasName, clusterState.metadata());
         if (indexMetadata != null) {
             MappingMetadata mappingMetadata = indexMetadata.mapping();
             if (mappingMetadata != null) {
-                versions.add(readMappingVersion(aliasName, mappingMetadata, logger));
+                return readMappingVersion(aliasName, mappingMetadata);
             }
         }
-        return versions;
+        return 0;
+    }
+
+    private static int readMappingVersion(String indexName, MappingMetadata mappingMetadata) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> meta = (Map<String, Object>) mappingMetadata.sourceAsMap().get("_meta");
+        if (meta == null) {
+            logger.info("Missing _meta field in mapping [{}] of index [{}]", mappingMetadata.type(), indexName);
+            throw new IllegalStateException("Cannot read managed_index_mappings_version string in index " + indexName);
+        }
+        // If null, no value has been set in the index yet, so return 0 to trigger put mapping
+        final Integer value = (Integer) meta.get(VERSION_META_KEY);
+        return value == null ? 0 : value;
     }
 
     /**
@@ -378,21 +378,6 @@ public class SecurityIndexManager implements ClusterStateListener {
             return metadata.index(indices.get(0));
         }
         return null;
-    }
-
-    private static Version readMappingVersion(String indexName, MappingMetadata mappingMetadata, Logger logger) {
-        try {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> meta = (Map<String, Object>) mappingMetadata.sourceAsMap().get("_meta");
-            if (meta == null) {
-                logger.info("Missing _meta field in mapping [{}] of index [{}]", mappingMetadata.type(), indexName);
-                throw new IllegalStateException("Cannot read security-version string in index " + indexName);
-            }
-            return Version.fromString((String) meta.get(SECURITY_VERSION_STRING));
-        } catch (ElasticsearchParseException e) {
-            logger.error(() -> "Cannot parse the mapping for index [" + indexName + "]", e);
-            throw new ElasticsearchException("Cannot parse the mapping for index [{}]", e, indexName);
-        }
     }
 
     /**
@@ -440,12 +425,10 @@ public class SecurityIndexManager implements ClusterStateListener {
                 );
             } else if (state.indexExists() == false) {
                 assert state.concreteIndexName != null;
-                final SystemIndexDescriptor descriptorForVersion = systemIndexDescriptor.getDescriptorCompatibleWith(
-                    state.minimumNodeVersion
-                );
+                final SystemIndexDescriptor descriptorForVersion = systemIndexDescriptor.getDescriptorCompatibleWith(state.mappingVersion);
 
                 if (descriptorForVersion == null) {
-                    final String error = systemIndexDescriptor.getMinimumNodeVersionMessage("create index");
+                    final String error = systemIndexDescriptor.getMinimumMappingsVersionMessage("create index");
                     consumer.accept(new IllegalStateException(error));
                 } else {
                     logger.info(
@@ -491,11 +474,10 @@ public class SecurityIndexManager implements ClusterStateListener {
                     );
                 }
             } else if (state.mappingUpToDate == false) {
-                final SystemIndexDescriptor descriptorForVersion = systemIndexDescriptor.getDescriptorCompatibleWith(
-                    state.minimumNodeVersion
-                );
+                final SystemIndexDescriptor descriptorForVersion = systemIndexDescriptor.getDescriptorCompatibleWith(state.mappingVersion);
+
                 if (descriptorForVersion == null) {
-                    final String error = systemIndexDescriptor.getMinimumNodeVersionMessage("updating mapping");
+                    final String error = systemIndexDescriptor.getMinimumMappingsVersionMessage("updating mapping");
                     consumer.accept(new IllegalStateException(error));
                 } else {
                     logger.info(
@@ -549,17 +531,16 @@ public class SecurityIndexManager implements ClusterStateListener {
      * State of the security index.
      */
     public static class State {
-        public static final State UNRECOVERED_STATE = new State(null, false, false, false, false, null, null, null, null, null, null);
+        public static final State UNRECOVERED_STATE = new State(null, false, false, false, false, null, null, null, null, null);
         public final Instant creationTime;
         public final boolean isIndexUpToDate;
         public final boolean indexAvailableForSearch;
         public final boolean indexAvailableForWrite;
         public final boolean mappingUpToDate;
-        public final Version mappingVersion;
+        public final SystemIndexDescriptor.MappingsVersion mappingVersion;
         public final String concreteIndexName;
         public final ClusterHealthStatus indexHealth;
         public final IndexMetadata.State indexState;
-        public final Version minimumNodeVersion;
         public final String indexUUID;
 
         public State(
@@ -568,11 +549,10 @@ public class SecurityIndexManager implements ClusterStateListener {
             boolean indexAvailableForSearch,
             boolean indexAvailableForWrite,
             boolean mappingUpToDate,
-            Version mappingVersion,
+            SystemIndexDescriptor.MappingsVersion mappingVersion,
             String concreteIndexName,
             ClusterHealthStatus indexHealth,
             IndexMetadata.State indexState,
-            Version minimumNodeVersion,
             String indexUUID
         ) {
             this.creationTime = creationTime;
@@ -584,7 +564,6 @@ public class SecurityIndexManager implements ClusterStateListener {
             this.concreteIndexName = concreteIndexName;
             this.indexHealth = indexHealth;
             this.indexState = indexState;
-            this.minimumNodeVersion = minimumNodeVersion;
             this.indexUUID = indexUUID;
         }
 
@@ -601,8 +580,7 @@ public class SecurityIndexManager implements ClusterStateListener {
                 && Objects.equals(mappingVersion, state.mappingVersion)
                 && Objects.equals(concreteIndexName, state.concreteIndexName)
                 && indexHealth == state.indexHealth
-                && indexState == state.indexState
-                && Objects.equals(minimumNodeVersion, state.minimumNodeVersion);
+                && indexState == state.indexState;
         }
 
         public boolean indexExists() {
@@ -619,8 +597,7 @@ public class SecurityIndexManager implements ClusterStateListener {
                 mappingUpToDate,
                 mappingVersion,
                 concreteIndexName,
-                indexHealth,
-                minimumNodeVersion
+                indexHealth
             );
         }
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecuritySystemIndices.java
@@ -38,7 +38,7 @@ import static org.elasticsearch.xpack.security.support.SecurityIndexManager.SECU
 public class SecuritySystemIndices {
 
     public static final int INTERNAL_MAIN_INDEX_FORMAT = 6;
-    private static final int INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT = 1;
+    public static final int INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT = 1;
     private static final int INTERNAL_TOKENS_INDEX_FORMAT = 7;
     private static final int INTERNAL_TOKENS_INDEX_MAPPINGS_FORMAT = 1;
     private static final int INTERNAL_PROFILE_INDEX_FORMAT = 8;
@@ -53,6 +53,15 @@ public class SecuritySystemIndices {
     public static final String SECURITY_PROFILE_ALIAS = ".security-profile";
     public static final Version VERSION_SECURITY_PROFILE_ORIGIN = Version.V_8_3_0;
     public static final NodeFeature SECURITY_PROFILE_ORIGIN_FEATURE = new NodeFeature("security.security_profile_origin");
+
+    /**
+     * Security managed index mappings used to be updated based on the product version. They are now updated based on per-index mappings
+     * versions. However, older nodes will still look for a product version in the mappings metadata, so we have to put <em>something</em>
+     * in that field that will allow the older node to realise that the mappings are ahead of what it knows about. The easiest solution is
+     * to hardcode 8.14.0 in this field, because any node from 8.14.0 onwards should be using per-index mappings versions to determine
+     * whether mappings are up-to-date.
+     */
+    public static final String BWC_MAPPINGS_VERSION = "8.14.0";
 
     private static final Logger logger = LogManager.getLogger(SecuritySystemIndices.class);
 
@@ -119,7 +128,7 @@ public class SecuritySystemIndices {
             .setSettings(getMainIndexSettings())
             .setAliasName(SECURITY_MAIN_ALIAS)
             .setIndexFormat(INTERNAL_MAIN_INDEX_FORMAT)
-            .setVersionMetaKey("security-version")
+            .setVersionMetaKey(SECURITY_VERSION_STRING)
             .setOrigin(SECURITY_ORIGIN)
             .setThreadPools(ExecutorNames.CRITICAL_SYSTEM_INDEX_THREAD_POOLS)
             .build();
@@ -146,7 +155,7 @@ public class SecuritySystemIndices {
             builder.startObject();
             {
                 builder.startObject("_meta");
-                builder.field(SECURITY_VERSION_STRING, Version.CURRENT.toString());
+                builder.field(SECURITY_VERSION_STRING, BWC_MAPPINGS_VERSION); // Only needed for BWC with pre-8.15.0 nodes
                 builder.field(SystemIndexDescriptor.VERSION_META_KEY, INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT);
                 builder.endObject();
 
@@ -632,7 +641,7 @@ public class SecuritySystemIndices {
             builder.startObject();
             {
                 builder.startObject("_meta");
-                builder.field(SECURITY_VERSION_STRING, Version.CURRENT);
+                builder.field(SECURITY_VERSION_STRING, BWC_MAPPINGS_VERSION); // Only needed for BWC with pre-8.15.0 nodes
                 builder.field(SystemIndexDescriptor.VERSION_META_KEY, INTERNAL_TOKENS_INDEX_MAPPINGS_FORMAT);
                 builder.endObject();
 
@@ -844,7 +853,7 @@ public class SecuritySystemIndices {
             builder.startObject();
             {
                 builder.startObject("_meta");
-                builder.field(SECURITY_VERSION_STRING, Version.CURRENT.toString());
+                builder.field(SECURITY_VERSION_STRING, BWC_MAPPINGS_VERSION); // Only needed for BWC with pre-8.15.0 nodes
                 builder.field(SystemIndexDescriptor.VERSION_META_KEY, mappingsVersion);
                 builder.endObject();
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -2525,7 +2525,6 @@ public class AuthenticationServiceTests extends ESTestCase {
             concreteSecurityIndexName,
             indexStatus,
             IndexMetadata.State.OPEN,
-            null,
             "my_uuid"
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmTests.java
@@ -42,7 +42,6 @@ public class NativeRealmTests extends ESTestCase {
             concreteSecurityIndexName,
             indexStatus,
             IndexMetadata.State.OPEN,
-            null,
             "my_uuid"
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
@@ -415,7 +415,6 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
             concreteSecurityIndexName,
             healthStatus,
             IndexMetadata.State.OPEN,
-            null,
             "my_uuid"
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -1531,7 +1531,6 @@ public class CompositeRolesStoreTests extends ESTestCase {
             concreteSecurityIndexName,
             healthStatus,
             IndexMetadata.State.OPEN,
-            null,
             "my_uuid"
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -796,7 +796,6 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             concreteSecurityIndexName,
             healthStatus,
             IndexMetadata.State.OPEN,
-            null,
             "my_uuid"
         );
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativeRolesStoreTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.UnassignedInfo.Reason;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
@@ -35,6 +36,7 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.license.XPackLicenseState;
@@ -65,6 +67,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -482,6 +485,7 @@ public class NativeRolesStoreTests extends ESTestCase {
         }
 
         Index index = metadata.index(securityIndexName).getIndex();
+
         ShardRouting shardRouting = ShardRouting.newUnassigned(
             new ShardId(index, 0),
             true,
@@ -506,6 +510,13 @@ public class NativeRolesStoreTests extends ESTestCase {
         ClusterState clusterState = ClusterState.builder(new ClusterName(NativeRolesStoreTests.class.getName()))
             .metadata(metadata)
             .routingTable(routingTable)
+            .putCompatibilityVersions(
+                "test",
+                new CompatibilityVersions(
+                    TransportVersion.current(),
+                    Map.of(".security-7", new SystemIndexDescriptor.MappingsVersion(1, 0))
+                )
+            )
             .build();
 
         return clusterState;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/CacheInvalidatorRegistryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/CacheInvalidatorRegistryTests.java
@@ -7,9 +7,9 @@
 
 package org.elasticsearch.xpack.security.support;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.security.support.CacheInvalidatorRegistry.CacheInvalidator;
 import org.junit.Before;
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
+import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -60,11 +61,10 @@ public class CacheInvalidatorRegistryTests extends ESTestCase {
             true,
             true,
             true,
-            Version.CURRENT,
+            new SystemIndexDescriptor.MappingsVersion(INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT, 0),
             ".security",
             ClusterHealthStatus.GREEN,
             IndexMetadata.State.OPEN,
-            null,
             "my_uuid"
         );
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityIndexManagerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecurityIndexManagerTests.java
@@ -7,7 +7,7 @@
 package org.elasticsearch.xpack.security.support;
 
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.Version;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -33,6 +33,7 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.version.CompatibilityVersions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
@@ -56,11 +57,13 @@ import org.junit.Before;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -75,15 +78,17 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public class SecurityIndexManagerTests extends ESTestCase {
-
     private static final ClusterName CLUSTER_NAME = new ClusterName("security-index-manager-tests");
     private static final ClusterState EMPTY_CLUSTER_STATE = new ClusterState.Builder(CLUSTER_NAME).build();
     private SystemIndexDescriptor descriptorSpy;
+    private ThreadPool threadPool;
     private SecurityIndexManager manager;
+
+    private int putMappingRequestCount = 0;
 
     @Before
     public void setUpManager() {
-        final ThreadPool threadPool = mock(ThreadPool.class);
+        threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         when(threadPool.generic()).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
 
@@ -97,6 +102,7 @@ public class SecurityIndexManagerTests extends ESTestCase {
                 ActionListener<Response> listener
             ) {
                 if (request instanceof PutMappingRequest) {
+                    putMappingRequestCount++;
                     listener.onResponse((Response) AcknowledgedResponse.of(true));
                 }
             }
@@ -383,7 +389,7 @@ public class SecurityIndexManagerTests extends ESTestCase {
 
         // Ensure that the mappings for the index are out-of-date, so that the security index manager will
         // attempt to update them.
-        String previousVersion = getPreviousVersion(Version.CURRENT);
+        int previousVersion = INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT - 1;
 
         // State recovered with index, with mappings with a prior version
         ClusterState.Builder clusterStateBuilder = createClusterState(
@@ -394,31 +400,31 @@ public class SecurityIndexManagerTests extends ESTestCase {
             getMappings(previousVersion)
         );
         manager.clusterChanged(event(markShardsAvailable(clusterStateBuilder)));
-
         manager.prepareIndexIfNeededThenExecute(prepareException::set, () -> prepareRunnableCalled.set(true));
 
         assertThat(prepareRunnableCalled.get(), is(true));
         assertThat(prepareException.get(), nullValue());
+        // Verify that the client to send put mapping was used
+        assertThat(putMappingRequestCount, equalTo(1));
     }
 
     /**
      * Check that the security index manager will refuse to update mappings on an index
-     * if the corresponding {@link SystemIndexDescriptor} requires a higher node version
+     * if the corresponding {@link SystemIndexDescriptor} requires a higher mapping version
      * that the cluster's current minimum version.
      */
-    public void testCannotUpdateIndexMappingsWhenMinNodeVersionTooLow() {
+    public void testCannotUpdateIndexMappingsWhenMinMappingVersionTooLow() {
         final AtomicBoolean prepareRunnableCalled = new AtomicBoolean(false);
         final AtomicReference<Exception> prepareException = new AtomicReference<>(null);
 
         // Hard-code a failure here.
-        doReturn("Nope").when(descriptorSpy).getMinimumNodeVersionMessage(anyString());
-        doReturn(null).when(descriptorSpy).getDescriptorCompatibleWith(eq(Version.CURRENT));
+        doReturn("Nope").when(descriptorSpy).getMinimumMappingsVersionMessage(anyString());
+        doReturn(null).when(descriptorSpy).getDescriptorCompatibleWith(eq(new SystemIndexDescriptor.MappingsVersion(1, 0)));
 
         // Ensure that the mappings for the index are out-of-date, so that the security index manager will
         // attempt to update them.
-        String previousVersion = getPreviousVersion(Version.CURRENT);
+        int previousVersion = INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT - 1;
 
-        // State recovered with index, with mappings with a prior version
         ClusterState.Builder clusterStateBuilder = createClusterState(
             TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
             SecuritySystemIndices.SECURITY_MAIN_ALIAS,
@@ -435,6 +441,55 @@ public class SecurityIndexManagerTests extends ESTestCase {
         assertThat(exception, not(nullValue()));
         assertThat(exception, instanceOf(IllegalStateException.class));
         assertThat(exception.getMessage(), equalTo("Nope"));
+        // Verify that the client to send put mapping was never used
+        assertThat(putMappingRequestCount, equalTo(0));
+    }
+
+    /**
+     * Check that the security index manager will not update mappings on an index if the mapping version wasn't bumped
+     */
+    public void testNoUpdateWhenIndexMappingsVersionNotBumped() {
+        final AtomicBoolean prepareRunnableCalled = new AtomicBoolean(false);
+        final AtomicReference<Exception> prepareException = new AtomicReference<>(null);
+
+        ClusterState.Builder clusterStateBuilder = createClusterState(
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
+            SecuritySystemIndices.SECURITY_MAIN_ALIAS,
+            SecuritySystemIndices.INTERNAL_MAIN_INDEX_FORMAT,
+            IndexMetadata.State.OPEN,
+            getMappings(INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT)
+        );
+        manager.clusterChanged(event(markShardsAvailable(clusterStateBuilder)));
+        manager.prepareIndexIfNeededThenExecute(prepareException::set, () -> prepareRunnableCalled.set(true));
+
+        assertThat(prepareRunnableCalled.get(), is(true));
+        assertThat(prepareException.get(), is(nullValue()));
+        // Verify that the client to send put mapping was never used
+        assertThat(putMappingRequestCount, equalTo(0));
+    }
+
+    /**
+     * Check that the security index manager will not update mappings on an index if there is no mapping version in cluster state
+     */
+    public void testNoUpdateWhenNoIndexMappingsVersionInClusterState() {
+        final AtomicBoolean prepareRunnableCalled = new AtomicBoolean(false);
+        final AtomicReference<Exception> prepareException = new AtomicReference<>(null);
+
+        ClusterState.Builder clusterStateBuilder = createClusterState(
+            TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7,
+            SecuritySystemIndices.SECURITY_MAIN_ALIAS,
+            SecuritySystemIndices.INTERNAL_MAIN_INDEX_FORMAT,
+            IndexMetadata.State.OPEN,
+            getMappings(INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT),
+            Map.of()
+        );
+        manager.clusterChanged(event(markShardsAvailable(clusterStateBuilder)));
+        manager.prepareIndexIfNeededThenExecute(prepareException::set, () -> prepareRunnableCalled.set(true));
+
+        assertThat(prepareRunnableCalled.get(), is(true));
+        assertThat(prepareException.get(), is(nullValue()));
+        // Verify that the client to send put mapping was never used
+        assertThat(putMappingRequestCount, equalTo(0));
     }
 
     public void testListenerNotCalledBeforeStateNotRecovered() {
@@ -567,12 +622,32 @@ public class SecurityIndexManagerTests extends ESTestCase {
         IndexMetadata.State state,
         String mappings
     ) {
+        return createClusterState(
+            indexName,
+            aliasName,
+            format,
+            state,
+            mappings,
+            Map.of(indexName, new SystemIndexDescriptor.MappingsVersion(1, 0))
+        );
+    }
+
+    private static ClusterState.Builder createClusterState(
+        String indexName,
+        String aliasName,
+        int format,
+        IndexMetadata.State state,
+        String mappings,
+        Map<String, SystemIndexDescriptor.MappingsVersion> compatibilityVersions
+    ) {
         IndexMetadata.Builder indexMeta = getIndexMetadata(indexName, aliasName, format, state, mappings);
 
         Metadata.Builder metadataBuilder = new Metadata.Builder();
         metadataBuilder.put(indexMeta);
 
-        return ClusterState.builder(state()).metadata(metadataBuilder.build());
+        return ClusterState.builder(state())
+            .metadata(metadataBuilder.build())
+            .putCompatibilityVersions("test", new CompatibilityVersions(TransportVersion.current(), compatibilityVersions));
     }
 
     private ClusterState markShardsAvailable(ClusterState.Builder clusterStateBuilder) {
@@ -614,17 +689,21 @@ public class SecurityIndexManagerTests extends ESTestCase {
     }
 
     private static String getMappings() {
-        return getMappings(Version.CURRENT.toString());
+        return getMappings(INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT);
     }
 
-    private static String getMappings(String version) {
+    private static String getMappings(Integer version) {
         try {
             final XContentBuilder builder = jsonBuilder();
 
             builder.startObject();
             {
                 builder.startObject("_meta");
-                builder.field("security-version", version);
+                if (version != null) {
+                    builder.field(SystemIndexDescriptor.VERSION_META_KEY, version);
+                }
+                // This is expected to be ignored
+                builder.field("security-version", "8.13.0");
                 builder.endObject();
 
                 builder.field("dynamic", "strict");
@@ -642,13 +721,5 @@ public class SecurityIndexManagerTests extends ESTestCase {
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to build index mappings", e);
         }
-    }
-
-    private String getPreviousVersion(Version version) {
-        if (version.minor == 0) {
-            return version.major - 1 + ".99.0";
-        }
-
-        return version.major + "." + (version.minor - 1) + ".0";
     }
 }


### PR DESCRIPTION
This PR removes the use of ES version in the `_meta` field of the mappings for the security system indices (`.security`, `.security-tokens`, `.security-profile`)

To be able to support versionless upgrades of Serverless Elasticsearch, `Version.CURRENT` as an indicator of if something like a system index mapping should be updated or not is no longer sufficient. Instead, the version of a system index needs to be tracked separately from the ES version and bumped if the mapping needs to be updated. 

The `MappingVersion` of the security index is already tracked in the `_meta` information of the mapping, so this PR only switches over to use that and removes the old code. 

We still need to keep the old key around to prevent pre-8.15 and post-8.15 nodes fighting and causing repeated mappings updates in mixed-version clusters. The pre-8.15 nodes will replace the mappings if the `version` field is not present, on the assumption that the mappings are _really_ old.

To reduce use of the `Version.CURRENT` constant this PR changes the `version` field in the security index mappings metadata to be hardcoded as `8.15.0`. Pre-8.15 nodes will see _all_ nodes from 8.15.0 onwards as 8.15.0 for the purposes of determining whether security index mappings need updating. However, that still works as, from the older node's perspective, it means "newer than I understand".