### PR TITLE
[8.13] [Test] Fix AsyncSearchResponse resource leak in security tests (#107809)

### DIFF
--- a/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
+++ b/x-pack/plugin/async-search/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/search/AsyncSearchSecurityIT.java
@@ -223,7 +223,7 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
     private SearchHit[] getSearchHits(String asyncId, String user) throws IOException {
         final Response resp = getAsyncSearch(asyncId, user);
         assertOK(resp);
-        SearchResponse searchResponse = ASYNC_SEARCH_RESPONSE_PARSER.apply(
+        AsyncSearchResponse asyncSearchResponse = ASYNC_SEARCH_RESPONSE_PARSER.apply(
             XContentHelper.createParser(
                 NamedXContentRegistry.EMPTY,
                 LoggingDeprecationHandler.INSTANCE,
@@ -231,11 +231,13 @@ public class AsyncSearchSecurityIT extends ESRestTestCase {
                 XContentType.JSON
             ),
             null
-        ).getSearchResponse();
+        );
+        SearchResponse searchResponse = asyncSearchResponse.getSearchResponse();
         try {
             return searchResponse.getHits().asUnpooled().getHits();
         } finally {
             searchResponse.decRef();
+            asyncSearchResponse.decRef();
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Test] Fix AsyncSearchResponse resource leak in security tests (#107809)