### PR TITLE
[ML] Revert Key Changes from PR #98139 to Address Deployment Update Failures

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -714,26 +714,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         int numberOfAllocations
     ) {
         // While loading the model in the process we need twice the model size.
-
-        // 1. If ELSER v1 or v2 then 2004MB
-        // 2. If static memory and dynamic memory are not set then 240MB + 2 * model size
-        // 3. Else static memory + dynamic memory * allocations + model size
-
-        // The model size is still added in option 3 to account for the temporary requirement to hold the zip file in memory
-        // in `pytorch_inference`.
-        if (isElserV1Or2Model(modelId)) {
-            return ELSER_1_OR_2_MEMORY_USAGE.getBytes();
-        } else {
-            long baseSize = MEMORY_OVERHEAD.getBytes() + 2 * totalDefinitionLength;
-            if (perDeploymentMemoryBytes == 0 && perAllocationMemoryBytes == 0) {
-                return baseSize;
-            } else {
-                return Math.max(
-                    baseSize,
-                    perDeploymentMemoryBytes + perAllocationMemoryBytes * numberOfAllocations + totalDefinitionLength
-                );
-            }
-        }
+        return isElserV1Or2Model(modelId) ? ELSER_1_OR_2_MEMORY_USAGE.getBytes() : MEMORY_OVERHEAD.getBytes() + 2 * totalDefinitionLength;
     }
 
     private static boolean isElserV1Or2Model(String modelId) {


### PR DESCRIPTION
This PR aims to address the issue reported in #107807, where updating the `number_of_allocations` for a trained model deployment fails due to a regression introduced by PR #98139. The regression causes an incorrect calculation of memory requirements, leading to deployment update failures in high-availability environments.

**Changes**:
- Reverted the changes made to the `org.elasticsearch.xpack.core.ml.action.StartTrainedModelDeploymentAction#estimateMemoryUsageBytes` method by PR #98139.
- Restored the original logic for estimating memory usage that was present before PR #98139, which aligns with the expected behavior and prevents the calculation of negative byte values.

**Testing**:
- Conducted tests to ensure that the `number_of_allocations` can be updated successfully without encountering the previously reported errors.
- Validated that the reverted logic does not reintroduce any previously resolved issues and that it aligns with the expected behavior of the system.

**Documentation**:
- No documentation changes are necessary as this PR restores previous behavior.

**Related issue**: #107807

This PR serves as a temporary fix to the immediate problem affecting users in production environments. It is intended to restore the system's stability while a more comprehensive solution is being developed.

I welcome the community's input on this PR and am open to collaborating on a long-term resolution for the underlying issue.
