### PR TITLE
Strengthen locking in `FsBlobContainer` register impl

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/BlobContainer.java
@@ -259,7 +259,7 @@ public interface BlobContainer {
      * @param purpose The purpose of the operation
      * @param key      key of the value to get
      * @param listener a listener, completed with the value read from the register or {@code OptionalBytesReference#MISSING} if the value
-     *                 could not be read due to concurrent activity.
+     *                 could not be read due to concurrent activity (which should not happen).
      */
     default void getRegister(OperationPurpose purpose, String key, ActionListener<OptionalBytesReference> listener) {
         compareAndExchangeRegister(purpose, key, BytesArray.EMPTY, BytesArray.EMPTY, listener);

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -420,15 +420,9 @@ public class FsBlobContainer extends AbstractBlobContainer {
         // Emulate write/write contention as might happen in cloud repositories, at least for the case where the writers are all in this
         // JVM (e.g. for an ESIntegTestCase).
         try (var mutex = writeMutexes.tryAcquire(registerPath)) {
-            if (mutex == null) {
-                return OptionalBytesReference.MISSING;
-            } else {
-                try {
-                    return doUncontendedCompareAndExchangeRegister(registerPath, expected, updated);
-                } finally {
-                    mutex.close();
-                }
-            }
+            return mutex == null
+                ? OptionalBytesReference.MISSING
+                : doUncontendedCompareAndExchangeRegister(registerPath, expected, updated);
         }
     }
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
@@ -713,6 +713,17 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
         }
 
         @Override
+        public void getRegister(OperationPurpose purpose, String key, ActionListener<OptionalBytesReference> listener) {
+            assertPurpose(purpose);
+            final var register = registers.get(key);
+            if (register == null) {
+                listener.onResponse(OptionalBytesReference.EMPTY);
+            } else {
+                listener.onResponse(OptionalBytesReference.of(register.get()));
+            }
+        }
+
+        @Override
         public void compareAndExchangeRegister(
             OperationPurpose purpose,
             String key,

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/ContendedRegisterAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/ContendedRegisterAnalyzeAction.java
@@ -156,7 +156,13 @@ class ContendedRegisterAnalyzeAction extends HandledTransportAction<ContendedReg
         };
 
         if (request.getInitialRead() > request.getRequestCount()) {
-            blobContainer.getRegister(OperationPurpose.REPOSITORY_ANALYSIS, registerName, initialValueListener);
+            blobContainer.getRegister(OperationPurpose.REPOSITORY_ANALYSIS, registerName, initialValueListener.delegateFailure((l, r) -> {
+                if (r.isPresent()) {
+                    l.onResponse(r);
+                } else {
+                    l.onFailure(new IllegalStateException("register read failed due to contention"));
+                }
+            }));
         } else {
             blobContainer.compareAndExchangeRegister(
                 OperationPurpose.REPOSITORY_ANALYSIS,


### PR DESCRIPTION
Expands the JVM-wide mutex to prevent all concurrent operations on
file-based registers, but then introduces an artificial mechanism for
emulating write/write contention within a single JVM.