### PR TITLE
Optimise few metric aggregations for single value fields

### DIFF
--- a/docs/changelog/107832.yaml
+++ b/docs/changelog/107832.yaml
@@ -1,0 +1,5 @@
+pr: 107832
+summary: Optimise few metric aggregations for single value fields
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
@@ -9,27 +9,24 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.HdrHistogram.DoubleHistogram;
-import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
 
-abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
+abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator.MultiDoubleValue {
 
     protected final double[] keys;
-    protected final ValuesSource valuesSource;
     protected final DocValueFormat format;
     protected ObjectArray<DoubleHistogram> states;
     protected final int numberOfSignificantValueDigits;
@@ -46,9 +43,8 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, context, parent, metadata);
+        super(name, config, context, parent, metadata);
         assert config.hasValues();
-        this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.format = formatter;
         this.states = context.bigArrays().newObjectArray(1);
@@ -57,26 +53,31 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
     }
 
     @Override
-    public ScoreMode scoreMode() {
-        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
-    }
-
-    @Override
-    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        final SortedNumericDoubleValues values = ((ValuesSource.Numeric) valuesSource).doubleValues(aggCtx.getLeafReaderContext());
+    protected LeafBucketCollector getLeafCollector(SortedNumericDoubleValues values, LeafBucketCollector sub) {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
-                    DoubleHistogram state = getExistingOrNewHistogram(bigArrays(), bucket);
-                    final int valueCount = values.docValueCount();
-                    for (int i = 0; i < valueCount; i++) {
+                    final DoubleHistogram state = getExistingOrNewHistogram(bigArrays(), bucket);
+                    for (int i = 0; i < values.docValueCount(); i++) {
                         state.recordValue(values.nextValue());
                     }
                 }
             }
         };
+    }
 
+    @Override
+    protected LeafBucketCollector getLeafCollector(NumericDoubleValues values, LeafBucketCollector sub) {
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (values.advanceExact(doc)) {
+                    final DoubleHistogram state = getExistingOrNewHistogram(bigArrays(), bucket);
+                    state.recordValue(values.doubleValue());
+                }
+            }
+        };
     }
 
     private DoubleHistogram getExistingOrNewHistogram(final BigArrays bigArrays, long bucket) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -8,27 +8,24 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
 
-abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
+abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggregator.MultiDoubleValue {
 
     protected final double[] keys;
-    protected final ValuesSource valuesSource;
     protected final DocValueFormat formatter;
     protected ObjectArray<TDigestState> states;
     protected final double compression;
@@ -47,9 +44,8 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, context, parent, metadata);
+        super(name, config, context, parent, metadata);
         assert config.hasValues();
-        this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.formatter = formatter;
         this.states = context.bigArrays().newObjectArray(1);
@@ -59,22 +55,28 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
     }
 
     @Override
-    public ScoreMode scoreMode() {
-        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
-    }
-
-    @Override
-    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        final SortedNumericDoubleValues values = ((ValuesSource.Numeric) valuesSource).doubleValues(aggCtx.getLeafReaderContext());
+    protected LeafBucketCollector getLeafCollector(SortedNumericDoubleValues values, final LeafBucketCollector sub) {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
-                    TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
-                    final int valueCount = values.docValueCount();
-                    for (int i = 0; i < valueCount; i++) {
+                    final TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
+                    for (int i = 0; i < values.docValueCount(); i++) {
                         state.add(values.nextValue());
                     }
+                }
+            }
+        };
+    }
+
+    @Override
+    protected LeafBucketCollector getLeafCollector(NumericDoubleValues values, final LeafBucketCollector sub) {
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (values.advanceExact(doc)) {
+                    final TDigestState state = getExistingOrNewHistogram(bigArrays(), bucket);
+                    state.add(values.doubleValue());
                 }
             }
         };

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
@@ -7,28 +7,24 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
 
-class AvgAggregator extends NumericMetricsAggregator.SingleValue {
-
-    final ValuesSource.Numeric valuesSource;
+class AvgAggregator extends NumericMetricsAggregator.SingleDoubleValue {
 
     LongArray counts;
     DoubleArray sums;
@@ -42,9 +38,8 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
         Aggregator parent,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, context, parent, metadata);
+        super(name, valuesSourceConfig, context, parent, metadata);
         assert valuesSourceConfig.hasValues();
-        this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
         final BigArrays bigArrays = context.bigArrays();
         counts = bigArrays.newLongArray(1, true);
@@ -53,43 +48,54 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
     }
 
     @Override
-    public ScoreMode scoreMode() {
-        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
-    }
-
-    @Override
-    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
+    protected LeafBucketCollector getLeafCollector(SortedNumericDoubleValues values, final LeafBucketCollector sub) {
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
-
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
-                    if (bucket >= counts.size()) {
-                        counts = bigArrays().grow(counts, bucket + 1);
-                        sums = bigArrays().grow(sums, bucket + 1);
-                        compensations = bigArrays().grow(compensations, bucket + 1);
-                    }
+                    maybeGrow(bucket);
                     final int valueCount = values.docValueCount();
                     counts.increment(bucket, valueCount);
                     // Compute the sum of double values with Kahan summation algorithm which is more
                     // accurate than naive summation.
-                    double sum = sums.get(bucket);
-                    double compensation = compensations.get(bucket);
-
-                    kahanSummation.reset(sum, compensation);
-
+                    kahanSummation.reset(sums.get(bucket), compensations.get(bucket));
                     for (int i = 0; i < valueCount; i++) {
-                        double value = values.nextValue();
-                        kahanSummation.add(value);
+                        kahanSummation.add(values.nextValue());
                     }
-
                     sums.set(bucket, kahanSummation.value());
                     compensations.set(bucket, kahanSummation.delta());
                 }
             }
         };
+    }
+
+    @Override
+    protected LeafBucketCollector getLeafCollector(NumericDoubleValues values, final LeafBucketCollector sub) {
+        final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (values.advanceExact(doc)) {
+                    maybeGrow(bucket);
+                    counts.increment(bucket, 1L);
+                    // Compute the sum of double values with Kahan summation algorithm which is more
+                    // accurate than naive summation.
+                    kahanSummation.reset(sums.get(bucket), compensations.get(bucket));
+                    kahanSummation.add(values.doubleValue());
+                    sums.set(bucket, kahanSummation.value());
+                    compensations.set(bucket, kahanSummation.delta());
+                }
+            }
+        };
+    }
+
+    private void maybeGrow(long bucket) {
+        if (bucket >= counts.size()) {
+            counts = bigArrays().grow(counts, bucket + 1);
+            sums = bigArrays().grow(sums, bucket + 1);
+            compensations = bigArrays().grow(compensations, bucket + 1);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -7,31 +7,28 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xcontent.ParseField;
 
 import java.io.IOException;
 import java.util.Map;
 
-class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
+class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiDoubleValue {
 
     static final ParseField SIGMA_FIELD = new ParseField("sigma");
 
-    final ValuesSource.Numeric valuesSource;
     final DocValueFormat format;
     final double sigma;
 
@@ -51,9 +48,8 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
         double sigma,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, context, parent, metadata);
+        super(name, config, context, parent, metadata);
         assert config.hasValues();
-        this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
         this.format = config.format();
         this.sigma = sigma;
         final BigArrays bigArrays = context.bigArrays();
@@ -69,13 +65,7 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public ScoreMode scoreMode() {
-        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
-    }
-
-    @Override
-    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
+    protected LeafBucketCollector getLeafCollector(SortedNumericDoubleValues values, final LeafBucketCollector sub) {
         final CompensatedSum compensatedSum = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumOfSqr = new CompensatedSum(0, 0);
         return new LeafBucketCollectorBase(sub, values) {
@@ -83,32 +73,15 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
-                    if (bucket >= counts.size()) {
-                        final long from = counts.size();
-                        final long overSize = BigArrays.overSize(bucket + 1);
-                        counts = bigArrays().resize(counts, overSize);
-                        sums = bigArrays().resize(sums, overSize);
-                        compensations = bigArrays().resize(compensations, overSize);
-                        mins = bigArrays().resize(mins, overSize);
-                        maxes = bigArrays().resize(maxes, overSize);
-                        sumOfSqrs = bigArrays().resize(sumOfSqrs, overSize);
-                        compensationOfSqrs = bigArrays().resize(compensationOfSqrs, overSize);
-                        mins.fill(from, overSize, Double.POSITIVE_INFINITY);
-                        maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
-                    }
+                    maybeGrow(bucket);
                     final int valuesCount = values.docValueCount();
                     counts.increment(bucket, valuesCount);
                     double min = mins.get(bucket);
                     double max = maxes.get(bucket);
                     // Compute the sum and sum of squires for double values with Kahan summation algorithm
                     // which is more accurate than naive summation.
-                    double sum = sums.get(bucket);
-                    double compensation = compensations.get(bucket);
-                    compensatedSum.reset(sum, compensation);
-
-                    double sumOfSqr = sumOfSqrs.get(bucket);
-                    double compensationOfSqr = compensationOfSqrs.get(bucket);
-                    compensatedSumOfSqr.reset(sumOfSqr, compensationOfSqr);
+                    compensatedSum.reset(sums.get(bucket), compensations.get(bucket));
+                    compensatedSumOfSqr.reset(sumOfSqrs.get(bucket), compensationOfSqrs.get(bucket));
 
                     for (int i = 0; i < valuesCount; i++) {
                         double value = values.nextValue();
@@ -126,8 +99,54 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
                     maxes.set(bucket, max);
                 }
             }
+        };
+    }
+
+    @Override
+    protected LeafBucketCollector getLeafCollector(NumericDoubleValues values, final LeafBucketCollector sub) {
+        final CompensatedSum compensatedSum = new CompensatedSum(0, 0);
+        return new LeafBucketCollectorBase(sub, values) {
+
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (values.advanceExact(doc)) {
+                    maybeGrow(bucket);
+                    final double value = values.doubleValue();
+                    counts.increment(bucket, 1L);
+                    // Compute the sum and sum of squires for double values with Kahan summation algorithm
+                    // which is more accurate than naive summation.
+                    compensatedSum.reset(sums.get(bucket), compensations.get(bucket));
+                    compensatedSum.add(value);
+                    sums.set(bucket, compensatedSum.value());
+                    compensations.set(bucket, compensatedSum.delta());
+
+                    compensatedSum.reset(sumOfSqrs.get(bucket), compensationOfSqrs.get(bucket));
+                    compensatedSum.add(value * value);
+                    sumOfSqrs.set(bucket, compensatedSum.value());
+                    compensationOfSqrs.set(bucket, compensatedSum.delta());
+
+                    mins.set(bucket, Math.min(mins.get(bucket), value));
+                    maxes.set(bucket, Math.max(maxes.get(bucket), value));
+                }
+            }
 
         };
+    }
+
+    private void maybeGrow(long bucket) {
+        if (bucket >= counts.size()) {
+            final long from = counts.size();
+            final long overSize = BigArrays.overSize(bucket + 1);
+            counts = bigArrays().resize(counts, overSize);
+            sums = bigArrays().resize(sums, overSize);
+            compensations = bigArrays().resize(compensations, overSize);
+            mins = bigArrays().resize(mins, overSize);
+            maxes = bigArrays().resize(maxes, overSize);
+            sumOfSqrs = bigArrays().resize(sumOfSqrs, overSize);
+            compensationOfSqrs = bigArrays().resize(compensationOfSqrs, overSize);
+            mins.fill(from, overSize, Double.POSITIVE_INFINITY);
+            maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregator.java
@@ -8,18 +8,17 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.search.ScoreMode;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
@@ -28,9 +27,8 @@ import java.util.Objects;
 
 import static org.elasticsearch.search.aggregations.metrics.InternalMedianAbsoluteDeviation.computeMedianAbsoluteDeviation;
 
-public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.SingleValue {
+public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.SingleDoubleValue {
 
-    private final ValuesSource.Numeric valuesSource;
     private final DocValueFormat format;
 
     private final double compression;
@@ -49,9 +47,8 @@ public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.
         double compression,
         TDigestExecutionHint executionHint
     ) throws IOException {
-        super(name, context, parent, metadata);
+        super(name, config, context, parent, metadata);
         assert config.hasValues();
-        this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
         this.format = Objects.requireNonNull(format);
         this.compression = compression;
         this.executionHint = executionHint;
@@ -72,37 +69,41 @@ public class MedianAbsoluteDeviationAggregator extends NumericMetricsAggregator.
     }
 
     @Override
-    public ScoreMode scoreMode() {
-        if (valuesSource.needsScores()) {
-            return ScoreMode.COMPLETE;
-        } else {
-            return ScoreMode.COMPLETE_NO_SCORES;
-        }
-    }
-
-    @Override
-    protected LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) throws IOException {
-        final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
-
+    protected LeafBucketCollector getLeafCollector(SortedNumericDoubleValues values, LeafBucketCollector sub) {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
-                    valueSketches = bigArrays().grow(valueSketches, bucket + 1);
-
-                    TDigestState valueSketch = valueSketches.get(bucket);
-                    if (valueSketch == null) {
-                        valueSketch = TDigestState.create(compression, executionHint);
-                        valueSketches.set(bucket, valueSketch);
-                    }
-                    final int valueCount = values.docValueCount();
-                    for (int i = 0; i < valueCount; i++) {
-                        final double value = values.nextValue();
-                        valueSketch.add(value);
+                    final TDigestState valueSketch = getExistingOrNewHistogram(bigArrays(), bucket);
+                    for (int i = 0; i < values.docValueCount(); i++) {
+                        valueSketch.add(values.nextValue());
                     }
                 }
             }
         };
+    }
+
+    @Override
+    protected LeafBucketCollector getLeafCollector(NumericDoubleValues values, LeafBucketCollector sub) {
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (values.advanceExact(doc)) {
+                    final TDigestState valueSketch = getExistingOrNewHistogram(bigArrays(), bucket);
+                    valueSketch.add(values.doubleValue());
+                }
+            }
+        };
+    }
+
+    private TDigestState getExistingOrNewHistogram(final BigArrays bigArrays, long bucket) {
+        valueSketches = bigArrays.grow(valueSketches, bucket + 1);
+        TDigestState state = valueSketches.get(bucket);
+        if (state == null) {
+            state = TDigestState.create(compression, executionHint);
+            valueSketches.set(bucket, state);
+        }
+        return state;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
@@ -7,28 +7,25 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
 
-class StatsAggregator extends NumericMetricsAggregator.MultiValue {
+class StatsAggregator extends NumericMetricsAggregator.MultiDoubleValue {
 
-    final ValuesSource.Numeric valuesSource;
     final DocValueFormat format;
 
     LongArray counts;
@@ -39,9 +36,8 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     StatsAggregator(String name, ValuesSourceConfig config, AggregationContext context, Aggregator parent, Map<String, Object> metadata)
         throws IOException {
-        super(name, context, parent, metadata);
+        super(name, config, context, parent, metadata);
         assert config.hasValues();
-        this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
         counts = bigArrays().newLongArray(1, true);
         sums = bigArrays().newDoubleArray(1, true);
         compensations = bigArrays().newDoubleArray(1, true);
@@ -53,40 +49,20 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
     }
 
     @Override
-    public ScoreMode scoreMode() {
-        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
-    }
-
-    @Override
-    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
+    public LeafBucketCollector getLeafCollector(SortedNumericDoubleValues values, LeafBucketCollector sub) {
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
-
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
-                    if (bucket >= counts.size()) {
-                        final long from = counts.size();
-                        final long overSize = BigArrays.overSize(bucket + 1);
-                        counts = bigArrays().resize(counts, overSize);
-                        sums = bigArrays().resize(sums, overSize);
-                        compensations = bigArrays().resize(compensations, overSize);
-                        mins = bigArrays().resize(mins, overSize);
-                        maxes = bigArrays().resize(maxes, overSize);
-                        mins.fill(from, overSize, Double.POSITIVE_INFINITY);
-                        maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
-                    }
+                    maybeGrow(bucket);
                     final int valuesCount = values.docValueCount();
                     counts.increment(bucket, valuesCount);
                     double min = mins.get(bucket);
                     double max = maxes.get(bucket);
                     // Compute the sum of double values with Kahan summation algorithm which is more
                     // accurate than naive summation.
-                    double sum = sums.get(bucket);
-                    double compensation = compensations.get(bucket);
-                    kahanSummation.reset(sum, compensation);
-
+                    kahanSummation.reset(sums.get(bucket), compensations.get(bucket));
                     for (int i = 0; i < valuesCount; i++) {
                         double value = values.nextValue();
                         kahanSummation.add(value);
@@ -100,6 +76,43 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
                 }
             }
         };
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(NumericDoubleValues values, LeafBucketCollector sub) {
+        final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (values.advanceExact(doc)) {
+                    maybeGrow(bucket);
+                    counts.increment(bucket, 1L);
+                    // Compute the sum of double values with Kahan summation algorithm which is more
+                    // accurate than naive summation.
+                    kahanSummation.reset(sums.get(bucket), compensations.get(bucket));
+                    double value = values.doubleValue();
+                    kahanSummation.add(value);
+                    sums.set(bucket, kahanSummation.value());
+                    compensations.set(bucket, kahanSummation.delta());
+                    mins.set(bucket, Math.min(mins.get(bucket), value));
+                    maxes.set(bucket, Math.max(maxes.get(bucket), value));
+                }
+            }
+        };
+    }
+
+    private void maybeGrow(long bucket) {
+        if (bucket >= counts.size()) {
+            final long from = counts.size();
+            final long overSize = BigArrays.overSize(bucket + 1);
+            counts = bigArrays().resize(counts, overSize);
+            sums = bigArrays().resize(sums, overSize);
+            compensations = bigArrays().resize(compensations, overSize);
+            mins = bigArrays().resize(mins, overSize);
+            maxes = bigArrays().resize(maxes, overSize);
+            mins.fill(from, overSize, Double.POSITIVE_INFINITY);
+            maxes.fill(from, overSize, Double.NEGATIVE_INFINITY);
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -7,26 +7,23 @@
  */
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
-import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
 
-public class SumAggregator extends NumericMetricsAggregator.SingleValue {
+public class SumAggregator extends NumericMetricsAggregator.SingleDoubleValue {
 
-    private final ValuesSource.Numeric valuesSource;
     private final DocValueFormat format;
 
     private DoubleArray sums;
@@ -39,48 +36,58 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
         Aggregator parent,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, context, parent, metadata);
+        super(name, valuesSourceConfig, context, parent, metadata);
         assert valuesSourceConfig.hasValues();
-        this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
         sums = bigArrays().newDoubleArray(1, true);
         compensations = bigArrays().newDoubleArray(1, true);
     }
 
     @Override
-    public ScoreMode scoreMode() {
-        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
-    }
-
-    @Override
-    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
+    protected LeafBucketCollector getLeafCollector(SortedNumericDoubleValues values, final LeafBucketCollector sub) {
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 if (values.advanceExact(doc)) {
-                    if (bucket >= sums.size()) {
-                        sums = bigArrays().grow(sums, bucket + 1);
-                        compensations = bigArrays().grow(compensations, bucket + 1);
-                    }
-                    final int valuesCount = values.docValueCount();
+                    maybeGrow(bucket);
                     // Compute the sum of double values with Kahan summation algorithm which is more
                     // accurate than naive summation.
-                    double sum = sums.get(bucket);
-                    double compensation = compensations.get(bucket);
-                    kahanSummation.reset(sum, compensation);
-
-                    for (int i = 0; i < valuesCount; i++) {
-                        double value = values.nextValue();
-                        kahanSummation.add(value);
+                    kahanSummation.reset(sums.get(bucket), compensations.get(bucket));
+                    for (int i = 0; i < values.docValueCount(); i++) {
+                        kahanSummation.add(values.nextValue());
                     }
-
                     compensations.set(bucket, kahanSummation.delta());
                     sums.set(bucket, kahanSummation.value());
                 }
             }
         };
+    }
+
+    @Override
+    protected LeafBucketCollector getLeafCollector(NumericDoubleValues values, final LeafBucketCollector sub) {
+        final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                if (values.advanceExact(doc)) {
+                    maybeGrow(bucket);
+                    // Compute the sum of double values with Kahan summation algorithm which is more
+                    // accurate than naive summation.
+                    kahanSummation.reset(sums.get(bucket), compensations.get(bucket));
+                    kahanSummation.add(values.doubleValue());
+                    compensations.set(bucket, kahanSummation.delta());
+                    sums.set(bucket, kahanSummation.value());
+                }
+            }
+        };
+    }
+
+    private void maybeGrow(long bucket) {
+        if (bucket >= sums.size()) {
+            sums = bigArrays().grow(sums, bucket + 1);
+            compensations = bigArrays().grow(compensations, bucket + 1);
+        }
     }
 
     @Override


### PR DESCRIPTION
Most of the aggregations that deal with SortedNumericDoubleValues can easily be optimize for single value fields. 

This commit adds two new abstractions for NumericMetricsAggregator which expects implementation for LeafCollectors for single and multi-value fields.  This should give a nice performance boost for single value fields. 

* percentile and percentile ranks aggregations
* avg, sum and median absolute deviation aggregations
* stats, extended stats aggregations. 