### PR TITLE
Vector formats in segments supported for all codecs

### DIFF
--- a/docs/changelog/107833.yaml
+++ b/docs/changelog/107833.yaml
@@ -1,6 +1,0 @@
-pr: 107833
-summary: Vector formats in segments supported for all codecs
-area: Search
-type: bug
-issues:
- - 107773

--- a/docs/changelog/107833.yaml
+++ b/docs/changelog/107833.yaml
@@ -1,0 +1,6 @@
+pr: 107833
+summary: Vector formats in segments supported for all codecs
+area: Search
+type: bug
+issues:
+ - 107773

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1135,8 +1135,8 @@ public abstract class Engine implements Closeable {
         KnnVectorsFormat format;
         if (codec instanceof Elasticsearch814Codec esCodec) {
             format = esCodec.getKnnVectorsFormatForField(name);
-        } else if (codec instanceof LegacyPerFieldMapperCodec) {
-            format = ((LegacyPerFieldMapperCodec) codec).getKnnVectorsFormatForField(name);
+        } else if (codec instanceof LegacyPerFieldMapperCodec legacy) {
+            format = legacy.getKnnVectorsFormatForField(name);
         } else {
             format = codec.knnVectorsFormat();
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1133,8 +1133,8 @@ public abstract class Engine implements Closeable {
 
     private static KnnVectorsFormat getKnnVectorsFormatForField(Codec codec, String name) {
         KnnVectorsFormat format;
-        if (codec instanceof Elasticsearch814Codec) {
-            format = ((Elasticsearch814Codec) codec).getKnnVectorsFormatForField(name);
+        if (codec instanceof Elasticsearch814Codec esCodec) {
+            format = esCodec.getKnnVectorsFormatForField(name);
         } else if (codec instanceof LegacyPerFieldMapperCodec) {
             format = ((LegacyPerFieldMapperCodec) codec).getKnnVectorsFormatForField(name);
         } else {


### PR DESCRIPTION
Support not just `PerFieldMapperCodec` when exposing `vector_formats` inside Index Segments API.

see #107216 

closes #107773