### PR TITLE
[Connector API] Update docs filtering, configuration, delete, scheduling

### DIFF
--- a/docs/reference/connector/apis/delete-connector-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-api.asciidoc
@@ -28,6 +28,9 @@ Note: this action doesn't delete any API key, ingest pipeline or data index asso
 `<connector_id>`::
 (Required, string)
 
+`delete_sync_jobs`::
+(Optional, boolean) A flag indicating if associated sync jobs should be also removed. Defaults to `false`.
+
 [[delete-connector-api-response-codes]]
 ==== {api-response-codes-title}
 
@@ -47,7 +50,12 @@ The following example deletes the connector with ID `my-connector`:
 --------------------------------------------------
 PUT _connector/my-connector
 {
-  "index_name": "search-google-drive",
+  "name": "My Connector",
+  "service_type": "google_drive"
+}
+
+PUT _connector/another-connector
+{
   "name": "My Connector",
   "service_type": "google_drive"
 }
@@ -57,7 +65,7 @@ PUT _connector/my-connector
 
 [source,console]
 ----
-DELETE _connector/my-connector
+DELETE _connector/another-connector?delete_sync_jobs=true
 ----
 
 [source,console-result]
@@ -66,3 +74,5 @@ DELETE _connector/my-connector
     "acknowledged": true
 }
 ----
+
+The following example deletes the connector with ID `another-connector` and its associated sync jobs.

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -6,7 +6,7 @@
 
 preview::[]
 
-Updates a connector's `configuration`, allowing for complete schema modifications or individual value updates within a registered configuration schema.
+Updates a connector's `configuration`, allowing for config value updates within a registered configuration schema.
 
 
 [[update-connector-configuration-api-request]]
@@ -19,7 +19,8 @@ Updates a connector's `configuration`, allowing for complete schema modification
 
 * To sync data using self-managed connectors, you need to deploy the {enterprise-search-ref}/build-connector.html[Elastic connector service] on your own infrastructure. This service runs automatically on Elastic Cloud for native connectors.
 * The `connector_id` parameter should reference an existing connector.
-* The configuration fields definition must be compatible with the specific connector type being used.
+* To update configuration `values`, the connector `configuration` schema must be first registered by a running instance of Elastic connector service.
+* The configuration fields must be compatible with the specific connector configuration schema, refer to {enterprise-search-ref}/connectors-references.html[connectors references] to see supported configuration fields.
 
 [[update-connector-configuration-api-path-params]]
 ==== {api-path-parms-title}
@@ -35,57 +36,7 @@ Updates a connector's `configuration`, allowing for complete schema modification
 (Optional, object) Configuration values for the connector, represented as a mapping of configuration fields to their respective values within a registered schema.
 
 `configuration`::
-(Optional, object) The configuration for the connector. The configuration field is a map where each key represents a specific configuration field name, and the value is a `ConnectorConfiguration` object.
-
-Each `ConnectorConfiguration` object contains the following attributes:
-
-* `category` (Optional, string) The category of the configuration field. This helps in grouping related configurations together in the user interface.
-
-* `default_value` (Required, string | number | bool) The default value for the configuration. This value is used if the value field is empty, applicable only for non-required fields.
-
-* `depends_on` (Required, array of `ConfigurationDependency`) An array of dependencies on other configurations. A field will not be enabled unless these dependencies are met. Each dependency specifies a field key and the required value for the dependency to be considered fulfilled.
-
-* `display` (Required, string) The display type for the UI element that represents this configuration. This defines how the field should be rendered in the user interface. Supported types are: `text`, `textbox`, `textarea`, `numeric`, `toggle` and `dropdown`.
-
-* `label` (Required, string) The display label for the configuration field. This label is shown in the user interface, adjacent to the field.
-
-* `options` (Required, array of `ConfigurationSelectOption`) An array of options for list-type fields. These options are used for inputs in the user interface, each having a label for display and a value.
-
-* `order` (Required, number) The order in which this configuration appears in the user interface. This helps in organizing fields logically.
-
-* `placeholder` (Required, string) Placeholder text for the configuration field. This text is displayed inside the field before a value is entered.
-
-* `required` (Required, boolean) Indicates whether the configuration is mandatory. If true, a value must be provided for the field.
-
-* `sensitive` (Required, boolean) Indicates whether the configuration contains sensitive information. Sensitive fields may be obfuscated in the user interface.
-
-* `tooltip` (Optional, string) Tooltip text providing additional information about the configuration. This text appears when the user hovers over the info icon next to the configuration field.
-
-* `type` (Required, string) The type of the configuration field, such as `str`, `int`, `bool`, `list`. This defines the data type and format of the field's value.
-
-* `ui_restrictions` (Required, array of strings) A list of UI restrictions. These restrictions define where in the user interface this field should be available or restricted.
-
-* `validations` (Required, array of `ConfigurationValidation`) An array of rules for validating the field's value. Each validation specifies a type and a constraint that the field's value must meet.
-
-* `value` (Required, string | number | bool) The current value of the configuration. This is the actual value set for the field and is used by the connector during its operations.
-
-`ConfigurationDependency` represents a dependency that a configuration field has on another field's value. It contains the following attributes:
-
-* `field` (Required, string) The name of the field in the configuration that this dependency relates to.
-
-* `value` (Required, string | number | bool) The required value of the specified field for this dependency to be met.
-
-`ConfigurationSelectOption` defines an option within a selectable configuration field. It contains the following attributes:
-
-* `label` (Required, string) The display label for the option.
-
-* `value` (Required, string) The actual value associated with the option.
-
-`ConfigurationValidation` specifies validation rules for configuration fields. Each ConfigurationValidation instance enforces a specific type of validation based on its type and constraint. It contains the following attributes:
-
-* `constraint` (Required, string | number) The validation constraint. The nature of this constraint depends on the validation type. It could be a numeric value, a list, a regular expression pattern.
-
-* `type` (Required, ConfigurationValidationType) The type of validation to be performed. Possible values include: `less_than`, `greater_than`, `list_type`, `included_in`, `regex` and `unset`.
+(Optional, object) The configuration schema definition for the connector. The configuration field is a map where each key represents a specific configuration field name, and the value is a `ConnectorConfiguration` object. For connector management use `values` to pass config values, `configuration` object is used by Elastic connector service to register the connector configuration schema.
 
 
 [[update-connector-configuration-api-response-codes]]
@@ -103,7 +54,7 @@ No connector matching `connector_id` could be found.
 [[update-connector-configuration-api-example]]
 ==== {api-examples-title}
 
-The following example updates the `configuration` for the connector with ID `my-connector`:
+The following example configures the `sharepoint_online` connector, you can refer to supported configuration options in [Sharepoint Online connector documentation] or by inspecting registered schema in connector `configuration` field with <<get-connector-api>>.
 
 ////
 [source, console]
@@ -118,35 +69,227 @@ PUT _connector/my-spo-connector
 PUT _connector/my-spo-connector/_configuration
 {
     "configuration": {
+        "tenant_id": {
+          "default_value": null,
+          "depends_on": [],
+          "display": "textbox",
+          "label": "Tenant ID",
+          "options": [],
+          "order": 1,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "",
+          "type": "str",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": ""
+        },
+        "tenant_name": {
+          "default_value": null,
+          "depends_on": [],
+          "display": "textbox",
+          "label": "Tenant name",
+          "options": [],
+          "order": 2,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "",
+          "type": "str",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": ""
+        },
         "client_id": {
-            "default_value": null,
-            "depends_on": [],
-            "display": "text",
-            "label": "Client ID",
-            "options": [],
-            "order": 3,
-            "required": true,
-            "sensitive": false,
-            "tooltip": null,
-            "type": "str",
-            "ui_restrictions": [],
-            "validations": [],
-            "value": null
+          "default_value": null,
+          "depends_on": [],
+          "display": "textbox",
+          "label": "Client ID",
+          "options": [],
+          "order": 3,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "",
+          "type": "str",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": ""
         },
         "secret_value": {
-            "default_value": null,
-            "depends_on": [],
-            "display": "text",
-            "label": "Secret value",
-            "options": [],
-            "order": 4,
-            "required": true,
-            "sensitive": true,
-            "tooltip": null,
-            "type": "str",
-            "ui_restrictions": [],
-            "validations": [],
-            "value": null
+          "default_value": null,
+          "depends_on": [],
+          "display": "textbox",
+          "label": "Secret value",
+          "options": [],
+          "order": 4,
+          "required": true,
+          "sensitive": true,
+          "tooltip": "",
+          "type": "str",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": ""
+        },
+        "site_collections": {
+          "default_value": null,
+          "depends_on": [],
+          "display": "textarea",
+          "label": "Comma-separated list of sites",
+          "options": [],
+          "order": 5,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "A comma-separated list of sites to ingest data from. Use * to include all available sites.",
+          "type": "list",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": ""
+        },
+        "use_text_extraction_service": {
+          "default_value": false,
+          "depends_on": [],
+          "display": "toggle",
+          "label": "Use text extraction service",
+          "options": [],
+          "order": 6,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "Requires a separate deployment of the Elastic Data Extraction Service. Also requires that pipeline settings disable text extraction.",
+          "type": "bool",
+          "ui_restrictions": [
+            "advanced"
+          ],
+          "validations": [],
+          "value": false
+        },
+        "use_document_level_security": {
+          "default_value": false,
+          "depends_on": [],
+          "display": "toggle",
+          "label": "Enable document level security",
+          "options": [],
+          "order": 7,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "Document level security ensures identities and permissions set in Sharepoint Online are maintained in Elasticsearch. This metadata is added to your Elasticsearch documents, so you can control user and group read-access. Access control syncs ensure this metadata is kept up to date.",
+          "type": "bool",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": false
+        },
+        "fetch_drive_item_permissions": {
+          "default_value": true,
+          "depends_on": [
+            {
+              "field": "use_document_level_security",
+              "value": true
+            }
+          ],
+          "display": "toggle",
+          "label": "Fetch drive item permissions",
+          "options": [],
+          "order": 8,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "Enable this option to fetch drive item specific permissions. This setting can increase sync time.",
+          "type": "bool",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": true
+        },
+        "fetch_unique_page_permissions": {
+          "default_value": true,
+          "depends_on": [
+            {
+              "field": "use_document_level_security",
+              "value": true
+            }
+          ],
+          "display": "toggle",
+          "label": "Fetch unique page permissions",
+          "options": [],
+          "order": 9,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "Enable this option to fetch unique page permissions. This setting can increase sync time. If this setting is disabled a page will inherit permissions from its parent site.",
+          "type": "bool",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": true
+        },
+        "fetch_unique_list_permissions": {
+          "default_value": true,
+          "depends_on": [
+            {
+              "field": "use_document_level_security",
+              "value": true
+            }
+          ],
+          "display": "toggle",
+          "label": "Fetch unique list permissions",
+          "options": [],
+          "order": 10,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "Enable this option to fetch unique list permissions. This setting can increase sync time. If this setting is disabled a list will inherit permissions from its parent site.",
+          "type": "bool",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": true
+        },
+        "fetch_unique_list_item_permissions": {
+          "default_value": true,
+          "depends_on": [
+            {
+              "field": "use_document_level_security",
+              "value": true
+            }
+          ],
+          "display": "toggle",
+          "label": "Fetch unique list item permissions",
+          "options": [],
+          "order": 11,
+          "required": true,
+          "sensitive": false,
+          "tooltip": "Enable this option to fetch unique list item permissions. This setting can increase sync time. If this setting is disabled a list item will inherit permissions from its parent site.",
+          "type": "bool",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": true
+        },
+        "enumerate_all_sites": {
+          "default_value": true,
+          "depends_on": [],
+          "display": "toggle",
+          "label": "Enumerate all sites?",
+          "options": [],
+          "order": 6,
+          "required": false,
+          "sensitive": false,
+          "tooltip": "If enabled, sites will be fetched in bulk, then filtered down to the configured list of sites. This is efficient when syncing many sites. If disabled, each configured site will be fetched with an individual request. This is efficient when syncing fewer sites.",
+          "type": "bool",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": true
+        },
+        "fetch_subsites": {
+          "default_value": false,
+          "depends_on": [
+            {
+              "field": "enumerate_all_sites",
+              "value": false
+            }
+          ],
+          "display": "toggle",
+          "label": "Fetch sub-sites of configured sites?",
+          "options": [],
+          "order": 7,
+          "required": false,
+          "sensitive": false,
+          "tooltip": "Whether subsites of the configured site(s) should be automatically fetched.",
+          "type": "bool",
+          "ui_restrictions": [],
+          "validations": [],
+          "value": true
         }
     }
 }
@@ -160,63 +303,16 @@ DELETE _connector/my-spo-connector
 // TEARDOWN
 ////
 
-This example demonstrates how to register a `sharepoint_online` connector configuration schema. Note: The example does not cover all the necessary configuration fields for operating the Sharepoint Online connector.
-
-[source,console]
-----
-PUT _connector/my-spo-connector/_configuration
-{
-    "configuration": {
-        "client_id": {
-            "default_value": null,
-            "depends_on": [],
-            "display": "text",
-            "label": "Client ID",
-            "options": [],
-            "order": 3,
-            "required": true,
-            "sensitive": false,
-            "tooltip": null,
-            "type": "str",
-            "ui_restrictions": [],
-            "validations": [],
-            "value": null
-        },
-        "secret_value": {
-            "default_value": null,
-            "depends_on": [],
-            "display": "text",
-            "label": "Secret value",
-            "options": [],
-            "order": 4,
-            "required": true,
-            "sensitive": true,
-            "tooltip": null,
-            "type": "str",
-            "ui_restrictions": [],
-            "validations": [],
-            "value": null
-        }
-    }
-}
-----
-
-[source,console-result]
-----
-{
-    "result": "updated"
-}
-----
-
-An example to update configuration values for the `sharepoint_online` connector:
-
 [source,console]
 ----
 PUT _connector/my-spo-connector/_configuration
 {
     "values": {
-        "client_id": "my-client-id",
-        "secret_value": "super-secret-value"
+        "tenant_id": "my-tenant-id",
+        "tenant_name": "my-sharepoint-site",
+        "client_id": "foo",
+        "secret_value": "bar",
+        "site_collections": "*"
     }
 }
 ----
@@ -229,14 +325,14 @@ PUT _connector/my-spo-connector/_configuration
 ----
 
 
-An example to update single configuration field of the `sharepoint_online` connector. In this case other configuration values won't change:
+An example to update a subset of configuration fields of the `sharepoint_online` connector. In this case other configuration values won't change. It can be useful if you want to e.g. just update the secret value for your connector:
 
 [source,console]
 ----
 PUT _connector/my-spo-connector/_configuration
 {
     "values": {
-        "secret_value": "new-super-secret-value"
+        "secret_value": "foo-bar"
     }
 }
 ----

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -325,7 +325,10 @@ PUT _connector/my-spo-connector/_configuration
 ----
 
 
-An example to update a subset of configuration fields of the `sharepoint_online` connector. In this case other configuration values won't change. It can be useful if you want to e.g. just update the secret value for your connector:
+When you're first setting up your connector you'll need to provide all required configuration details to start running syncs.
+But you can also use this API to only update a subset of fields.
+Here's an example that only updates the `secret_value` field for a `sharepoint_online` connector.
+The other configuration values won't change.
 
 [source,console]
 ----

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -54,7 +54,7 @@ No connector matching `connector_id` could be found.
 [[update-connector-configuration-api-example]]
 ==== {api-examples-title}
 
-The following example configures the `sharepoint_online` connector, you can refer to supported configuration options in [Sharepoint Online connector documentation] or by inspecting registered schema in connector `configuration` field with <<get-connector-api>>.
+The following example configures a `sharepoint_online` connector. Find the supported configuration options in the {enterprise-search-ref}/connectors-sharepoint-online.html[Sharepoint Online connector documentation] or by inspecting the schema in the connector's `configuration` field using the <<get-connector-api>>.
 
 ////
 [source, console]

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -36,7 +36,7 @@ Updates a connector's `configuration`, allowing for config value updates within 
 (Optional, object) Configuration values for the connector, represented as a mapping of configuration fields to their respective values within a registered schema.
 
 `configuration`::
-(Optional, object) The configuration schema definition for the connector. The configuration field is a map where each key represents a specific configuration field name, and the value is a `ConnectorConfiguration` object. For connector management use `values` to pass config values, `configuration` object is used by Elastic connector service to register the connector configuration schema.
+(Optional, object) The configuration schema definition for the connector. The configuration field is a map where each key represents a specific configuration field name, and the value is a `ConnectorConfiguration` object. For connector management use `values` to pass config values. The `configuration` object is used by the Elastic connector service to register the connector configuration schema.
 
 
 [[update-connector-configuration-api-response-codes]]

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -20,7 +20,7 @@ Updates a connector's `configuration`, allowing for config value updates within 
 * To sync data using self-managed connectors, you need to deploy the {enterprise-search-ref}/build-connector.html[Elastic connector service] on your own infrastructure. This service runs automatically on Elastic Cloud for native connectors.
 * The `connector_id` parameter should reference an existing connector.
 * To update configuration `values`, the connector `configuration` schema must be first registered by a running instance of Elastic connector service.
-* The configuration fields must be compatible with the specific connector configuration schema, refer to {enterprise-search-ref}/connectors-references.html[connectors references] to see supported configuration fields.
+* Make sure configuration fields are compatible with the configuration schema for the third-party data source. Refer to the individual {enterprise-search-ref}/connectors-references.html[connectors references] for details.
 
 [[update-connector-configuration-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -8,7 +8,7 @@ preview::[]
 
 Updates the draft `filtering` configuration of a connector and marks the draft validation state as `edited`. The filtering configuration can be activated once validated by the Elastic connector service.
 
-Learn more about filtering for connectors in the {enterprise-search-ref}/sync-rules.html[sync rules] documentation.
+The filtering property is used to configure sync rules (both basic and advanced) for a connector. Learn more in the {enterprise-search-ref}/sync-rules.html[sync rules documentation].
 
 [[update-connector-filtering-api-request]]
 ==== {api-request-title}

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -184,7 +184,7 @@ PUT _connector/my-sql-connector/_filtering/_validation
 
 Note, you can also update draft `rules` and `advanced_snippet` in a single request.
 
-Once the draft is updated, its validation state is set to `edited`. Connector service will then validate the rules and report the validation state as either `invalid` or `valid`. If the state is `valid`, the draft filtering can be activated with:
+Once the draft is updated, its validation state is set to `edited`. The connector service will then validate the rules and report the validation state as either `invalid` or `valid`. If the state is `valid`, the draft filtering can be activated with:
 
 
 [source,console]

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -6,7 +6,7 @@
 
 preview::[]
 
-Updates the draft `filtering` configuration of a connector and marks the draft validation state as `edited`. The draft filtering can be then activated after a successful validation of the draft by the {enterprise-search-ref}/connectors.html[Elastic connector service].
+Updates the draft `filtering` configuration of a connector and marks the draft validation state as `edited`. The filtering configuration can be activated once validated by the Elastic connector service.
 
 Learn more about filtering for connectors in the {enterprise-search-ref}/sync-rules.html[sync rules] documentation.
 

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -6,19 +6,22 @@
 
 preview::[]
 
+Updates the draft `filtering` configuration of a connector and marks the draft validation state as `edited`. The draft filtering can be then activated after a successful validation of the draft by the {enterprise-search-ref}/connectors.html[Elastic connector service].
 
-Updates the `filtering` configuration of a connector. Learn more about filtering in the {enterprise-search-ref}/sync-rules.html[sync rules] documentation.
+Learn more about filtering for connectors in the {enterprise-search-ref}/sync-rules.html[sync rules] documentation.
 
 [[update-connector-filtering-api-request]]
 ==== {api-request-title}
 
 `PUT _connector/<connector_id>/_filtering`
+`PUT _connector/<connector_id>/_filtering/_activate`
 
 [[update-connector-filtering-api-prereq]]
 ==== {api-prereq-title}
 
 * To sync data using self-managed connectors, you need to deploy the {enterprise-search-ref}/build-connector.html[Elastic connector service] on your own infrastructure. This service runs automatically on Elastic Cloud for native connectors.
 * The `connector_id` parameter should reference an existing connector.
+* Draft filtering needs to be validated by the Elastic connector service before its activation. The `draft.validation.state` needs to be `valid`.
 
 [[update-connector-filtering-api-path-params]]
 ==== {api-path-parms-title}
@@ -30,65 +33,42 @@ Updates the `filtering` configuration of a connector. Learn more about filtering
 [[update-connector-filtering-api-request-body]]
 ==== {api-request-body-title}
 
-`filtering`::
-(Required, array) The filtering configuration for the connector. This configuration determines the set of rules applied for filtering data during syncs.
+`rules`::
+(Optional, array of objects)
+An array of {enterprise-search-ref}/sync-rules.html#sync-rules-basic[basic sync rules], each with the following sub-attributes:
+- `id` (Required, string) +
+A unique identifier for the rule.
+- `policy` (Required, string) +
+Specifies the policy, such as `include` or `exclude`.
+- `field` (Required, string) +
+The field in the document to which this rule applies.
+- `rule` (Required, string) +
+The type of rule, such as `regex`, `starts_with`, `ends_with`, `contains`, `equals`, `<`, `>`, etc.
+- `value` (Required, string) +
+The value to be used in conjunction with the rule for matching the contents of the document's field.
+- `order` (Required, number) +
+The order in which the rules are applied. The first rule to match has its policy applied.
+- `created_at` (Optional, datetime) +
+The timestamp when the rule was added. Defaults to `now` UTC timestamp.
+- `updated_at` (Optional, datetime) +
+The timestamp when the rule was last edited. Defaults to `now` UTC timestamp.
 
-Each entry in the `filtering` array represents a set of filtering rules for a specific data domain and includes the following attributes:
-
-- `domain` (Required, string) +
-Specifies the data domain to which these filtering rules apply.
-
-- `active` (Required, object) +
-Contains the set of rules that are actively used for sync jobs. The `active` object includes:
-
-  * `rules` (Required, array of objects) +
-  An array of individual filtering rule objects, each with the following sub-attributes:
-    ** `id` (Required, string) +
-    A unique identifier for the rule.
-    ** `policy` (Required, string) +
-    Specifies the policy, such as "include" or "exclude".
-    ** `field` (Required, string) +
-    The field in the document to which this rule applies.
-    ** `rule` (Required, string) +
-    The type of rule, such as "regex", "starts_with", "ends_with", "contains", "equals", "<", ">", etc.
-    ** `value` (Required, string) +
-    The value to be used in conjunction with the rule for matching the contents of the document's field.
-    ** `order` (Required, number) +
-    The order in which the rules are applied. The first rule to match has its policy applied.
-    ** `created_at` (Required, datetime) +
-    The timestamp when the rule was added.
-    ** `updated_at` (Required, datetime) +
-    The timestamp when the rule was last edited.
-
-  * `advanced_snippet` (Required, object) +
-  Used for {enterprise-search-ref}/sync-rules.html#sync-rules-advanced[advanced filtering] at query time, with the following sub-attributes:
-    ** `value` (Required, object) +
-    A JSON object passed directly to the connector for advanced filtering.
-    ** `created_at` (Required, datetime) +
-    The timestamp when this JSON object was created.
-    ** `updated_at` (Required, datetime) +
-    The timestamp when this JSON object was last edited.
-
-  * `validation` (Required, object) +
-  Provides validation status for the rules, including:
-    ** `state` (Required, string) +
-    Indicates the validation state: "edited", "valid", or "invalid".
-    ** `errors` (Required, object) +
-    Contains details about any validation errors, with sub-attributes:
-      *** `ids` (Required, string) +
-      The ID(s) of any rules deemed invalid.
-      *** `messages` (Required, string) +
-      Messages explaining what is invalid about the rules.
-
-- `draft` (Required, object) +
-An object identical in structure to the `active` object, but used for drafting and editing filtering rules before they become active.
+`advanced_snippet`::
+(Optional, object)
+Used for {enterprise-search-ref}/sync-rules.html#sync-rules-advanced[advanced filtering] at query time, with the following sub-attributes:
+- `value` (Required, object or array) +
+A JSON object/array passed directly to the connector for advanced filtering.
+- `created_at` (Optional, datetime) +
+The timestamp when this JSON object was created. Defaults to `now` UTC timestamp.
+- `updated_at` (Optional, datetime) +
+The timestamp when this JSON object was last edited. Defaults to `now` UTC timestamp.
 
 
 [[update-connector-filtering-api-response-codes]]
 ==== {api-response-codes-title}
 
 `200`::
-Connector `filtering` field was successfully updated.
+Connector draft filtering was successfully updated.
 
 `400`::
 The `connector_id` was not provided or the request payload was malformed.
@@ -99,80 +79,56 @@ No connector matching `connector_id` could be found.
 [[update-connector-filtering-api-example]]
 ==== {api-examples-title}
 
-The following example updates the `filtering` property for the connector with ID `my-connector`:
+The following example updates the draft {enterprise-search-ref}/sync-rules.html#sync-rules-basic[basic sync rules] for the Google Drive connector with ID `my-g-drive-connector`. All Google Drive files with `.txt` extension will be skipped:
 
 ////
 [source, console]
 --------------------------------------------------
-PUT _connector/my-connector
+PUT _connector/my-g-drive-connector
 {
   "index_name": "search-google-drive",
   "name": "My Connector",
   "service_type": "google_drive"
 }
+
+PUT _connector/my-sql-connector
+{
+  "index_name": "search-sql",
+  "name": "My SQL Connector",
+  "service_type": "google_drive"
+}
+
 --------------------------------------------------
 // TESTSETUP
 
 [source,console]
 --------------------------------------------------
-DELETE _connector/my-connector
+DELETE _connector/my-g-drive-connector
+DELETE _connector/my-sql-connector
 --------------------------------------------------
 // TEARDOWN
 ////
 
 [source,console]
 ----
-PUT _connector/my-connector/_filtering
+PUT _connector/my-g-drive-connector/_filtering
 {
-    "filtering": [
+    "rules": [
+         {
+            "field": "file_extension",
+            "id": "exclude-txt-files",
+            "order": 0,
+            "policy": "exclude",
+            "rule": "equals",
+            "value": "txt"
+        },
         {
-            "active": {
-                "advanced_snippet": {
-                    "created_at": "2023-11-09T15:13:08.231Z",
-                    "updated_at": "2023-11-09T15:13:08.231Z",
-                    "value": {}
-                },
-                "rules": [
-                    {
-                        "created_at": "2023-11-09T15:13:08.231Z",
-                        "field": "_",
-                        "id": "DEFAULT",
-                        "order": 0,
-                        "policy": "include",
-                        "rule": "regex",
-                        "updated_at": "2023-11-09T15:13:08.231Z",
-                        "value": ".*"
-                    }
-                ],
-                "validation": {
-                    "errors": [],
-                    "state": "valid"
-                }
-            },
-            "domain": "DEFAULT",
-            "draft": {
-                "advanced_snippet": {
-                    "created_at": "2023-11-09T15:13:08.231Z",
-                    "updated_at": "2023-11-09T15:13:08.231Z",
-                    "value": {}
-                },
-                "rules": [
-                    {
-                        "created_at": "2023-11-09T15:13:08.231Z",
-                        "field": "_",
-                        "id": "DEFAULT",
-                        "order": 0,
-                        "policy": "include",
-                        "rule": "regex",
-                        "updated_at": "2023-11-09T15:13:08.231Z",
-                        "value": ".*"
-                    }
-                ],
-                "validation": {
-                    "errors": [],
-                    "state": "valid"
-                }
-            }
+            "field": "_",
+            "id": "DEFAULT",
+            "order": 1,
+            "policy": "include",
+            "rule": "regex",
+            "value": ".*"
         }
     ]
 }
@@ -184,3 +140,64 @@ PUT _connector/my-connector/_filtering
     "result": "updated"
 }
 ----
+
+The following example updates the draft {enterprise-search-ref}/sync-rules.html#sync-rules-advanced[advanced sync rules] for the MySQL connector with id `my-sql-connector`.  Advanced sync rules are specific to each connector type. For more details on the syntax and rules specific to the MySQL connector in our example, you can refer to the {enterprise-search-ref}/connectors-mysql.html#connectors-mysql-sync-rules[MySQL connector documentation] .
+
+[source,console]
+----
+PUT _connector/my-sql-connector/_filtering
+{
+    "advanced_snippet": {
+        "value": [{
+            "tables": [
+                "users",
+                "orders"
+            ],
+            "query": "SELECT users.id AS id, orders.order_id AS order_id FROM users JOIN orders ON users.id = orders.user_id"
+        }]
+    }
+}
+----
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----
+
+
+////
+[source, console]
+--------------------------------------------------
+PUT _connector/my-sql-connector/_filtering/_validation
+{
+  "validation": {
+    "state": "valid",
+    "errors": []
+  }
+}
+--------------------------------------------------
+// TEST[continued]
+////
+
+
+Note, you can also update draft `rules` and `advanced_snippet` in a single request.
+
+Once the draft is updated, its validation state is set to `edited`. Connector service will then validate the rules and report the validation state as either `invalid` or `valid`. If the state is `valid`, the draft filtering can be activated with:
+
+
+[source,console]
+----
+PUT _connector/my-sql-connector/_filtering/_activate
+----
+// TEST[continued]
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----
+
+Once filtering rules are activated, they will be applied to all subsequent full or incremental syncs.

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -21,7 +21,7 @@ The filtering property is used to configure sync rules (both basic and advanced)
 
 * To sync data using self-managed connectors, you need to deploy the {enterprise-search-ref}/build-connector.html[Elastic connector service] on your own infrastructure. This service runs automatically on Elastic Cloud for native connectors.
 * The `connector_id` parameter should reference an existing connector.
-* Draft filtering needs to be validated by the Elastic connector service before its activation. The `draft.validation.state` needs to be `valid`.
+* To activate filtering rules, the `draft.validation.state` must be `valid`.
 
 [[update-connector-filtering-api-path-params]]
 ==== {api-path-parms-title}

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -79,7 +79,7 @@ No connector matching `connector_id` could be found.
 [[update-connector-filtering-api-example]]
 ==== {api-examples-title}
 
-The following example updates the draft {enterprise-search-ref}/sync-rules.html#sync-rules-basic[basic sync rules] for the Google Drive connector with ID `my-g-drive-connector`. All Google Drive files with `.txt` extension will be skipped:
+The following example updates the draft {enterprise-search-ref}/sync-rules.html#sync-rules-basic[basic sync rules] for a Google Drive connector with ID `my-g-drive-connector`. All Google Drive files with `.txt` extension will be skipped:
 
 ////
 [source, console]

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -141,7 +141,7 @@ PUT _connector/my-g-drive-connector/_filtering
 }
 ----
 
-The following example updates the draft advanced sync rules for a MySQL connector with id `my-sql-connector`. Advanced sync rules are specific to each connector type. Refer to the references for connectors that support {enterprise-search-ref}/sync-rules.html#sync-rules-advancedl[advanced sync rules] for syntax and examples.
+The following example updates the draft advanced sync rules for a MySQL connector with id `my-sql-connector`. Advanced sync rules are specific to each connector type. Refer to the references for connectors that support {enterprise-search-ref}/sync-rules.html#sync-rules-advanced[advanced sync rules] for syntax and examples.
 
 [source,console]
 ----

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -141,7 +141,7 @@ PUT _connector/my-g-drive-connector/_filtering
 }
 ----
 
-The following example updates the draft {enterprise-search-ref}/sync-rules.html#sync-rules-advanced[advanced sync rules] for the MySQL connector with id `my-sql-connector`.  Advanced sync rules are specific to each connector type. For more details on the syntax and rules specific to the MySQL connector in our example, you can refer to the {enterprise-search-ref}/connectors-mysql.html#connectors-mysql-sync-rules[MySQL connector documentation] .
+The following example updates the draft advanced sync rules for a MySQL connector with id `my-sql-connector`. Advanced sync rules are specific to each connector type. Refer to the references for connectors that support {enterprise-search-ref}/sync-rules.html#sync-rules-advancedl[advanced sync rules] for syntax and examples.
 
 [source,console]
 ----

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -36,31 +36,31 @@ The filtering property is used to configure sync rules (both basic and advanced)
 `rules`::
 (Optional, array of objects)
 An array of {enterprise-search-ref}/sync-rules.html#sync-rules-basic[basic sync rules], each with the following sub-attributes:
-- `id` (Required, string) +
+* `id` (Required, string) +
 A unique identifier for the rule.
-- `policy` (Required, string) +
+* `policy` (Required, string) +
 Specifies the policy, such as `include` or `exclude`.
-- `field` (Required, string) +
+* `field` (Required, string) +
 The field in the document to which this rule applies.
-- `rule` (Required, string) +
+* `rule` (Required, string) +
 The type of rule, such as `regex`, `starts_with`, `ends_with`, `contains`, `equals`, `<`, `>`, etc.
-- `value` (Required, string) +
+* `value` (Required, string) +
 The value to be used in conjunction with the rule for matching the contents of the document's field.
-- `order` (Required, number) +
+* `order` (Required, number) +
 The order in which the rules are applied. The first rule to match has its policy applied.
-- `created_at` (Optional, datetime) +
+* `created_at` (Optional, datetime) +
 The timestamp when the rule was added. Defaults to `now` UTC timestamp.
-- `updated_at` (Optional, datetime) +
+* `updated_at` (Optional, datetime) +
 The timestamp when the rule was last edited. Defaults to `now` UTC timestamp.
 
 `advanced_snippet`::
 (Optional, object)
 Used for {enterprise-search-ref}/sync-rules.html#sync-rules-advanced[advanced filtering] at query time, with the following sub-attributes:
-- `value` (Required, object or array) +
+* `value` (Required, object or array) +
 A JSON object/array passed directly to the connector for advanced filtering.
-- `created_at` (Optional, datetime) +
+* `created_at` (Optional, datetime) +
 The timestamp when this JSON object was created. Defaults to `now` UTC timestamp.
-- `updated_at` (Optional, datetime) +
+* `updated_at` (Optional, datetime) +
 The timestamp when this JSON object was last edited. Defaults to `now` UTC timestamp.
 
 

--- a/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
@@ -32,13 +32,13 @@ Updates the `scheduling` configuration of a connector.
 `scheduling`::
 (Required, object) The scheduling configuration for the connector. This configuration determines frequency of synchronization operations for the connector.
 
-The scheduling configuration includes the following attributes, each represented as a `ScheduleConfig` object:
+The scheduling configuration includes the following attributes, each represented as a `ScheduleConfig` object. If the `scheduling` object does not include all schedule types, only those provided will be updated; the others will remain unchanged.
 
-- `access_control` (Required, `ScheduleConfig` object) Defines the schedule for synchronizing access control settings of the connector.
+- `access_control` (Optional, `ScheduleConfig` object) Defines the schedule for synchronizing access control settings of the connector.
 
-- `full` (Required, `ScheduleConfig` object) Defines the schedule for a full content syncs.
+- `full` (Optional, `ScheduleConfig` object) Defines the schedule for a full content syncs.
 
-- `incremental` (Required, `ScheduleConfig` object) Defines the schedule for incremental content syncs.
+- `incremental` (Optional, `ScheduleConfig` object) Defines the schedule for incremental content syncs.
 
 Each `ScheduleConfig` object includes the following sub-attributes:
 
@@ -99,6 +99,28 @@ PUT _connector/my-connector/_scheduling
         "incremental": {
             "enabled": false,
             "interval": "0 30 0 * * ?"
+        }
+    }
+}
+----
+
+[source,console-result]
+----
+{
+    "result": "updated"
+}
+----
+
+The following example updates `full` sync schedule only, other schedule types remain unchanged:
+
+[source,console]
+----
+PUT _connector/my-connector/_scheduling
+{
+    "scheduling": {
+        "full": {
+            "enabled": true,
+            "interval": "0 10 0 * * ?"
         }
     }
 }


### PR DESCRIPTION
### Changes

A couple of docs improvements, add new content about `filtering`, `scheduling` and `delete` endpoints. 

Make update `configuration` endpoint a bit more hands-on, hide content that is confusing to users. 