### PR TITLE
[8.14] Validate stats formatting in standard InternalStats constructor (#107678)

### DIFF
--- a/docs/changelog/107678.yaml
+++ b/docs/changelog/107678.yaml
@@ -1,0 +1,6 @@
+pr: 107678
+summary: Validate stats formatting in standard `InternalStats` constructor
+area: Aggregations
+type: bug
+issues:
+ - 107671

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/stats_metric_fail_formatting.yml
@@ -1,0 +1,42 @@
+setup:
+  - do:
+      indices.create:
+          index: test_date
+          body:
+            mappings:
+              properties:
+                date_field:
+                   type : date
+                   format: date_hour_minute_second_millis
+
+
+  - do:
+       bulk:
+         refresh: true
+         body:
+           - index:
+               _index: test_date
+               _id:    "1"
+           - date_field: 9999-01-01T00:00:00.000
+           - index:
+               _index: test_date
+               _id:    "2"
+           - date_field: 9999-01-01T00:00:00.000
+
+---
+"fail formatting":
+
+  - skip:
+      version: "- 8.14.99"
+      reason: fixed in 8.15.0
+  - do:
+      catch: /Cannot format stat \[sum\] with format \[DocValueFormat.DateTime\(format\[date_hour_minute_second_millis\] locale\[\], Z, MILLISECONDS\)\]/
+      search:
+        index: test_date
+        body:
+          size: 0
+          aggs:
+            the_stats:
+              stats:
+                field: date_field
+

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -70,6 +70,24 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
         this.sum = sum;
         this.min = min;
         this.max = max;
+        verifyFormattingStats();
+    }
+
+    private void verifyFormattingStats() {
+        if (format != DocValueFormat.RAW) {
+            verifyFormattingStat(Fields.MIN, format, min);
+            verifyFormattingStat(Fields.MAX, format, max);
+            verifyFormattingStat(Fields.AVG, format, getAvg());
+            verifyFormattingStat(Fields.SUM, format, sum);
+        }
+    }
+
+    private static void verifyFormattingStat(String stat, DocValueFormat format, double value) {
+        try {
+            format.format(value);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot format stat [" + stat + "] with format [" + format.toString() + "]", e);
+        }
     }
 
     /**


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Validate stats formatting in standard InternalStats constructor (#107678)