### PR TITLE
[TEST] wait for ILM in testRollupNonTSIndex

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -406,7 +406,11 @@ public class DownsampleActionIT extends ESRestTestCase {
         updatePolicy(client(), index, policy);
 
         try {
-            assertBusy(() -> assertThat(getStepKeyForIndex(client(), index), equalTo(PhaseCompleteStep.finalStep(phaseName).getKey())));
+            assertBusy(
+                () -> assertThat(getStepKeyForIndex(client(), index), equalTo(PhaseCompleteStep.finalStep(phaseName).getKey())),
+                120,
+                TimeUnit.SECONDS
+            );
             String rollupIndex = getRollupIndexName(client(), index, fixedInterval);
             assertNull("Rollup index should not have been created", rollupIndex);
             assertTrue("Source index should not have been deleted", indexExists(index));


### PR DESCRIPTION
look_ahead_time is 1m, need to wait for longer than that.

Related to #103981
