### PR TITLE
Fix BlobCacheUtils.toPageAlignedSize

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheUtils.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheUtils.java
@@ -36,7 +36,7 @@ public class BlobCacheUtils {
      * Rounds the length up so that it is aligned on the next page size (defined by SharedBytes.PAGE_SIZE). For example
      */
     public static long toPageAlignedSize(long length) {
-        int remainder = (int) length % SharedBytes.PAGE_SIZE;
+        int remainder = (int) (length % SharedBytes.PAGE_SIZE);
         if (remainder > 0L) {
             return length + (SharedBytes.PAGE_SIZE - remainder);
         }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/BlobCacheUtilsTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/BlobCacheUtilsTests.java
@@ -23,7 +23,7 @@ public class BlobCacheUtilsTests extends ESTestCase {
     }
 
     public void testToPageAlignedSize() {
-        long value = randomLongBetween(0, Long.MAX_VALUE / 2);
+        long value = randomLongBetween(0, Long.MAX_VALUE - SharedBytes.PAGE_SIZE);
         long expected = ((value - 1) / SharedBytes.PAGE_SIZE + 1) * SharedBytes.PAGE_SIZE;
         assertThat(BlobCacheUtils.toPageAlignedSize(value), Matchers.equalTo(expected));
     }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/BlobCacheUtilsTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/BlobCacheUtilsTests.java
@@ -6,8 +6,10 @@
  */
 package org.elasticsearch.blobcache;
 
+import org.elasticsearch.blobcache.shared.SharedBytes;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
 
 import java.io.EOFException;
 import java.nio.ByteBuffer;
@@ -18,5 +20,11 @@ public class BlobCacheUtilsTests extends ESTestCase {
         final ByteBuffer buffer = ByteBuffer.allocate(randomIntBetween(1, 1025));
         final int remaining = randomIntBetween(1, 1025);
         expectThrows(EOFException.class, () -> BlobCacheUtils.readSafe(BytesArray.EMPTY.streamInput(), buffer, 0, remaining));
+    }
+
+    public void testToPageAlignedSize() {
+        long value = randomLongBetween(0, Long.MAX_VALUE / 2);
+        long expected = ((value - 1) / SharedBytes.PAGE_SIZE + 1) * SharedBytes.PAGE_SIZE;
+        assertThat(BlobCacheUtils.toPageAlignedSize(value), Matchers.equalTo(expected));
     }
 }


### PR DESCRIPTION
toPageAlignedSize could round wrongly when the length did not fit in an integer.
