### PR TITLE
Docs: move base64 functions under string functions

### DIFF
--- a/docs/reference/esql/functions/string-functions.asciidoc
+++ b/docs/reference/esql/functions/string-functions.asciidoc
@@ -9,6 +9,7 @@
 
 // tag::string_list[]
 * <<esql-concat>>
+* <<esql-from_base64>>
 * <<esql-left>>
 * <<esql-length>>
 * <<esql-locate>>
@@ -18,12 +19,14 @@
 * <<esql-rtrim>>
 * <<esql-split>>
 * <<esql-substring>>
+* <<esql-to_base64>>
 * <<esql-to_lower>>
 * <<esql-to_upper>>
 * <<esql-trim>>
 // end::string_list[]
 
 include::layout/concat.asciidoc[]
+include::layout/from_base64.asciidoc[]
 include::layout/left.asciidoc[]
 include::layout/length.asciidoc[]
 include::layout/locate.asciidoc[]
@@ -33,6 +36,7 @@ include::layout/right.asciidoc[]
 include::layout/rtrim.asciidoc[]
 include::layout/split.asciidoc[]
 include::layout/substring.asciidoc[]
+include::layout/to_base64.asciidoc[]
 include::layout/to_lower.asciidoc[]
 include::layout/to_upper.asciidoc[]
 include::layout/trim.asciidoc[]

--- a/docs/reference/esql/functions/type-conversion-functions.asciidoc
+++ b/docs/reference/esql/functions/type-conversion-functions.asciidoc
@@ -8,8 +8,6 @@
 {esql} supports these type conversion functions:
 
 // tag::type_list[]
-* <<esql-from_base64>>
-* <<esql-to_base64>>
 * <<esql-to_boolean>>
 * <<esql-to_cartesianpoint>>
 * <<esql-to_cartesianshape>>
@@ -27,8 +25,6 @@
 * <<esql-to_version>>
 // end::type_list[]
 
-include::layout/from_base64.asciidoc[]
-include::layout/to_base64.asciidoc[]
 include::layout/to_boolean.asciidoc[]
 include::layout/to_cartesianpoint.asciidoc[]
 include::layout/to_cartesianshape.asciidoc[]


### PR DESCRIPTION
This moves the TO_BASE64 and FROM_BASE64 from the type conversion functions under string functions (they take a string as input and output another string).
