### PR TITLE
[TEST] Increase wait time SearchIdleIT#testSearchIdleStats

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
@@ -224,7 +224,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
             .get();
         waitUntil(
             () -> Arrays.stream(indicesAdmin().prepareStats(indexName).get().getShards()).allMatch(ShardStats::isSearchIdle),
-            searchIdleAfter,
+            searchIdleAfter + 1,
             TimeUnit.SECONDS
         );
 


### PR DESCRIPTION
Currently we wait for exactly `searchIdleAfter` seconds. When index gets created it is considered non-idle so that means that for test to pass, it must become idle right after `waitUntil` returns and before `prepareStats`. This PR increases our chances by adding one second to wait.

Closes #101827.