### PR TITLE
Fix random access reads from ByteArrayIndexInput

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/lucene/store/ByteArrayIndexInput.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/store/ByteArrayIndexInput.java
@@ -35,6 +35,7 @@ public class ByteArrayIndexInput extends IndexInput implements RandomAccessInput
         super(resourceDesc);
         this.bytes = bytes;
         this.offset = offset;
+        this.pos = offset;
         this.length = length;
     }
 
@@ -43,7 +44,7 @@ public class ByteArrayIndexInput extends IndexInput implements RandomAccessInput
 
     @Override
     public long getFilePointer() {
-        return pos;
+        return pos - offset;
     }
 
     @Override
@@ -57,7 +58,7 @@ public class ByteArrayIndexInput extends IndexInput implements RandomAccessInput
         } else if (p > length) {
             throw new EOFException("seek past EOF");
         }
-        return (int) p;
+        return (int) p + offset;
     }
 
     @Override
@@ -108,7 +109,7 @@ public class ByteArrayIndexInput extends IndexInput implements RandomAccessInput
         if (pos >= offset + length) {
             throw new EOFException("seek past EOF");
         }
-        return bytes[offset + pos++];
+        return bytes[pos++];
     }
 
     @Override
@@ -116,14 +117,14 @@ public class ByteArrayIndexInput extends IndexInput implements RandomAccessInput
         if (pos + len > this.offset + length) {
             throw new EOFException("seek past EOF");
         }
-        System.arraycopy(bytes, this.offset + pos, b, offset, len);
+        System.arraycopy(bytes, pos, b, offset, len);
         pos += len;
     }
 
     @Override
     public short readShort() throws IOException {
         try {
-            return (short) BitUtil.VH_LE_SHORT.get(bytes, pos + offset);
+            return (short) BitUtil.VH_LE_SHORT.get(bytes, pos);
         } finally {
             pos += Short.BYTES;
         }
@@ -132,7 +133,7 @@ public class ByteArrayIndexInput extends IndexInput implements RandomAccessInput
     @Override
     public int readInt() throws IOException {
         try {
-            return (int) BitUtil.VH_LE_INT.get(bytes, pos + offset);
+            return (int) BitUtil.VH_LE_INT.get(bytes, pos);
         } finally {
             pos += Integer.BYTES;
         }
@@ -141,7 +142,7 @@ public class ByteArrayIndexInput extends IndexInput implements RandomAccessInput
     @Override
     public long readLong() throws IOException {
         try {
-            return (long) BitUtil.VH_LE_LONG.get(bytes, pos + offset);
+            return (long) BitUtil.VH_LE_LONG.get(bytes, pos);
         } finally {
             pos += Long.BYTES;
         }

--- a/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -79,6 +79,7 @@ public class ESIndexInputTestCase extends ESTestCase {
                         readPos += Long.BYTES;
                         if (indexInput instanceof RandomAccessInput randomAccessInput) {
                             assertEquals(read, randomAccessInput.readLong(indexInput.getFilePointer() - Long.BYTES));
+                            indexInput.seek(readPos);
                         }
                     } else if (length - readPos >= Integer.BYTES && readStrategy <= 1) {
                         int read = indexInput.readInt();
@@ -86,6 +87,7 @@ public class ESIndexInputTestCase extends ESTestCase {
                         readPos += Integer.BYTES;
                         if (indexInput instanceof RandomAccessInput randomAccessInput) {
                             assertEquals(read, randomAccessInput.readInt(indexInput.getFilePointer() - Integer.BYTES));
+                            indexInput.seek(readPos);
                         }
                     } else if (length - readPos >= Short.BYTES && readStrategy <= 2) {
                         short read = indexInput.readShort();
@@ -93,12 +95,14 @@ public class ESIndexInputTestCase extends ESTestCase {
                         readPos += Short.BYTES;
                         if (indexInput instanceof RandomAccessInput randomAccessInput) {
                             assertEquals(read, randomAccessInput.readShort(indexInput.getFilePointer() - Short.BYTES));
+                            indexInput.seek(readPos);
                         }
                     } else {
                         byte read = indexInput.readByte();
                         output[readPos++] = read;
                         if (indexInput instanceof RandomAccessInput randomAccessInput) {
                             assertEquals(read, randomAccessInput.readByte(indexInput.getFilePointer() - 1));
+                            indexInput.seek(readPos);
                         }
                     }
                     break;

--- a/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.common.lucene.store;
 
 import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.RandomAccessInput;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.Settings;
@@ -73,16 +74,32 @@ public class ESIndexInputTestCase extends ESTestCase {
             switch (readStrategy) {
                 case 0, 1, 2, 3:
                     if (length - readPos >= Long.BYTES && readStrategy <= 0) {
-                        ByteBuffer.wrap(output, readPos, Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(indexInput.readLong());
+                        long read = indexInput.readLong();
+                        ByteBuffer.wrap(output, readPos, Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(read);
                         readPos += Long.BYTES;
+                        if (indexInput instanceof RandomAccessInput randomAccessInput) {
+                            assertEquals(read, randomAccessInput.readLong(indexInput.getFilePointer() - Long.BYTES));
+                        }
                     } else if (length - readPos >= Integer.BYTES && readStrategy <= 1) {
-                        ByteBuffer.wrap(output, readPos, Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(indexInput.readInt());
+                        int read = indexInput.readInt();
+                        ByteBuffer.wrap(output, readPos, Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(read);
                         readPos += Integer.BYTES;
+                        if (indexInput instanceof RandomAccessInput randomAccessInput) {
+                            assertEquals(read, randomAccessInput.readInt(indexInput.getFilePointer() - Integer.BYTES));
+                        }
                     } else if (length - readPos >= Short.BYTES && readStrategy <= 2) {
-                        ByteBuffer.wrap(output, readPos, Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).putShort(indexInput.readShort());
+                        short read = indexInput.readShort();
+                        ByteBuffer.wrap(output, readPos, Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).putShort(read);
                         readPos += Short.BYTES;
+                        if (indexInput instanceof RandomAccessInput randomAccessInput) {
+                            assertEquals(read, randomAccessInput.readShort(indexInput.getFilePointer() - Short.BYTES));
+                        }
                     } else {
-                        output[readPos++] = indexInput.readByte();
+                        byte read = indexInput.readByte();
+                        output[readPos++] = read;
+                        if (indexInput instanceof RandomAccessInput randomAccessInput) {
+                            assertEquals(read, randomAccessInput.readByte(indexInput.getFilePointer() - 1));
+                        }
                     }
                     break;
                 case 4:


### PR DESCRIPTION
Fix random access read behavior for ByteArrayIndexInput and enhance our generic test to test random access reads a little if it's a random access input. Also, this adjustment to how `pos` works should maybe come with a mild performance gain.
