### PR TITLE
ESQL: Add more tests for constant aggregations

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -695,7 +695,7 @@ ca:l|gender:s
 ;
 
 
-countFieldVsAll#[skip:-8.14.99, reason:Fixed count(null) in 8.15]
+countFieldVsAll#[skip:-8.13.99, reason:Fixed count(null) in 8.14]
 from employees | stats ca = count(), cn = count(null), cf = count(gender) by gender | sort gender;
 
 ca:l|cn:l|cf:l|gender:s
@@ -1456,7 +1456,7 @@ rows:l
 6
 ;
 
-countOfConst#[skip:-8.14.99,reason:supported in 8.15]
+countOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s1 = count(1), s2point1 = count(2.1), s_mv = count([-1, 0, 3]) * 3, s_null = count(null), rows = count(*)
 ;
@@ -1465,7 +1465,7 @@ s1:l | s2point1:l | s_mv:l | s_null:l | rows:l
 100  | 100        | 900    | 0        | 100
 ;
 
-countOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+countOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s2point1 = count("two point one"), s_mv = count([-1, 0, 3]), s_null = count(null), rows = count(*) by languages
 | SORT languages
@@ -1576,7 +1576,7 @@ s2point1:d | s_mv:i | languages:i
 2.1        | 3      | null
 ;
 
-medianOfConst#[skip:-8.14.99,reason:supported in 8.15]
+medianOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s1 = median(1), s_mv = median([-1, 0, 1, 3]), s_null = median(null)
 ;
@@ -1585,7 +1585,7 @@ s1:d | s_mv:d | s_null:d
 1.0  | 0.5    | null
 ;
 
-medianOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+medianOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s2point1 = median(2.1), s_mv = median([-1, 0, 1, 3]) by languages
 | SORT languages
@@ -1600,7 +1600,7 @@ s2point1:d | s_mv:d | languages:i
 2.1        | 0.5    | null
 ;
 
-countDistinctOfConst#[skip:-8.14.99,reason:supported in 8.15]
+countDistinctOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s1 = count_distinct(1), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_null = count_distinct(null), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 5) 
 ;
@@ -1609,7 +1609,7 @@ s1:l | s_mv:l | s_null:l | s_param:l
 1    | 4      | 0        | 4
 ;
 
-countDistinctOfConstGrouped#[skip:-8.14.99,reason:supported in 8.15]
+countDistinctOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
 | STATS s2point1 = count_distinct("two point one"), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 8000) by languages
 | SORT languages

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -694,7 +694,6 @@ ca:l|gender:s
 0   |null
 ;
 
-
 countFieldVsAll#[skip:-8.13.99, reason:Fixed count(null) in 8.14]
 from employees | stats ca = count(), cn = count(null), cf = count(gender) by gender | sort gender;
 
@@ -1458,170 +1457,170 @@ rows:l
 
 countOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s1 = count(1), s2point1 = count(2.1), s_mv = count([-1, 0, 3]) * 3, s_null = count(null), rows = count(*)
+| STATS s1 = count(1), s2point1 = count(2.1), s_mv = count([-1, 0, 3]) * 3, s_null = count(null), s_expr = count(1+1), s_expr_null = count(1+null), rows = count(*)
 ;
 
-s1:l | s2point1:l | s_mv:l | s_null:l | rows:l
-100  | 100        | 900    | 0        | 100
+s1:l | s2point1:l | s_mv:l | s_null:l | s_expr:l | s_expr_null:l | rows:l
+100  | 100        | 900    | 0        | 100      | 0             | 100
 ;
 
 countOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s2point1 = count("two point one"), s_mv = count([-1, 0, 3]), s_null = count(null), rows = count(*) by languages
+| STATS s2point1 = count("two point one"), s_mv = count([-1, 0, 3]), s_null = count(null), s_expr = count(1+1), s_expr_null = count(1+null), rows = count(*) by languages
 | SORT languages
 ;
 
-s2point1:l | s_mv:l | s_null:l | rows:l | languages:i
-15         | 45     | 0        | 15     | 1
-19         | 57     | 0        | 19     | 2
-17         | 51     | 0        | 17     | 3
-18         | 54     | 0        | 18     | 4
-21         | 63     | 0        | 21     | 5
-10         | 30     | 0        | 10     | null
+s2point1:l | s_mv:l | s_null:l | s_expr:l | s_expr_null:l | rows:l | languages:i 
+15         | 45     | 0        | 15       | 0             | 15     | 1
+19         | 57     | 0        | 19       | 0             | 19     | 2
+17         | 51     | 0        | 17       | 0             | 17     | 3
+18         | 54     | 0        | 18       | 0             | 18     | 4
+21         | 63     | 0        | 21       | 0             | 21     | 5
+10         | 30     | 0        | 10       | 0             | 10     | null
 ;
 
 sumOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s1 = sum(1), s2point1 = sum(2.1), s_mv = sum([-1, 0, 3]) * 3, s_null = sum(null), rows = count(*)
+| STATS s1 = sum(1), s2point1 = sum(2.1), s_mv = sum([-1, 0, 3]) * 3, s_null = sum(null), s_expr = sum(1+1), s_expr_null = sum(1+null), rows = count(*)
 ;
 
-s1:l | s2point1:d | s_mv:l | s_null:d | rows:l
-100  | 210.0      | 600    | null     | 100
+s1:l | s2point1:d | s_mv:l | s_null:d | s_expr:l | s_expr_null:l | rows:l
+100  | 210.0      | 600    | null     | 200      | null          | 100
 ;
 
 sumOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s2point1 = round(sum(2.1), 1), s_mv = sum([-1, 0, 3]), rows = count(*) by languages
+| STATS s2point1 = round(sum(2.1), 1), s_mv = sum([-1, 0, 3]), s_expr = sum(1+1), s_expr_null = sum(1+null), rows = count(*) by languages
 | SORT languages
 ;
 
-s2point1:d | s_mv:l | rows:l | languages:i
-31.5       | 30     | 15     | 1
-39.9       | 38     | 19     | 2
-35.7       | 34     | 17     | 3
-37.8       | 36     | 18     | 4
-44.1       | 42     | 21     | 5
-21.0       | 20     | 10     | null
+s2point1:d | s_mv:l | s_expr:l | s_expr_null:l | rows:l | languages:i
+31.5       | 30     | 30       | null          | 15     | 1
+39.9       | 38     | 38       | null          | 19     | 2
+35.7       | 34     | 34       | null          | 17     | 3
+37.8       | 36     | 36       | null          | 18     | 4
+44.1       | 42     | 42       | null          | 21     | 5
+21.0       | 20     | 20       | null          | 10     | null
 ;
 
 avgOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s1 = avg(1), s_mv = avg([-1, 0, 3]) * 3, s_null = avg(null)
+| STATS s1 = avg(1), s_mv = avg([-1, 0, 3]) * 3, s_null = avg(null), s_expr = avg(1+1), s_expr_null = avg(1+null)
 ;
 
-s1:d | s_mv:d | s_null:d
-1.0  | 2.0    | null
+s1:d | s_mv:d | s_null:d | s_expr:d | s_expr_null:d
+1.0  | 2.0    | null     | 2.0      | null
 ;
 
 avgOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s2point1 = avg(2.1), s_mv = avg([-1, 0, 3]) * 3 by languages
+| STATS s2point1 = avg(2.1), s_mv = avg([-1, 0, 3]) * 3, s_expr = avg(1+1), s_expr_null = avg(1+null) by languages
 | SORT languages
 ;
 
-s2point1:d | s_mv:d | languages:i
-2.1        | 2.0    | 1
-2.1        | 2.0    | 2
-2.1        | 2.0    | 3
-2.1        | 2.0    | 4
-2.1        | 2.0    | 5
-2.1        | 2.0    | null
+s2point1:d | s_mv:d | s_expr:d | s_expr_null:d | languages:i
+2.1        | 2.0    | 2.0      | null          | 1
+2.1        | 2.0    | 2.0      | null          | 2
+2.1        | 2.0    | 2.0      | null          | 3
+2.1        | 2.0    | 2.0      | null          | 4
+2.1        | 2.0    | 2.0      | null          | 5
+2.1        | 2.0    | 2.0      | null          | null
 ;
 
 minOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s1 = min(1), s_mv = min([-1, 0, 3]), s_null = min(null)
+| STATS s1 = min(1), s_mv = min([-1, 0, 3]), s_null = min(null), s_expr = min(1+1), s_expr_null = min(1+null)
 ;
 
-s1:i | s_mv:i | s_null:null
-1    | -1     | null
+s1:i | s_mv:i | s_null:null | s_expr:i | s_expr_null:i
+1    | -1     | null        | 2        | null
 ;
 
 minOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s2point1 = min(2.1), s_mv = min([-1, 0, 3]) by languages
+| STATS s2point1 = min(2.1), s_mv = min([-1, 0, 3]), s_expr = min(1+1), s_expr_null = min(1+null) by languages
 | SORT languages
 ;
 
-s2point1:d | s_mv:i | languages:i
-2.1        | -1     | 1
-2.1        | -1     | 2
-2.1        | -1     | 3
-2.1        | -1     | 4
-2.1        | -1     | 5
-2.1        | -1     | null
+s2point1:d | s_mv:i | s_expr:i | s_expr_null:i | languages:i
+2.1        | -1     | 2        | null          | 1
+2.1        | -1     | 2        | null          | 2
+2.1        | -1     | 2        | null          | 3
+2.1        | -1     | 2        | null          | 4
+2.1        | -1     | 2        | null          | 5
+2.1        | -1     | 2        | null          | null
 ;
 
 maxOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s1 = max(1), s_mv = max([-1, 0, 3]), s_null = max(null)
+| STATS s1 = max(1), s_mv = max([-1, 0, 3]), s_null = max(null), s_expr = max(1+1), s_expr_null = max(1+null)
 ;
 
-s1:i | s_mv:i | s_null:null
-1    | 3      | null
+s1:i | s_mv:i | s_null:null | s_expr:i | s_expr_null:i
+1    | 3      | null        | 2        | null
 ;
 
 maxOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s2point1 = max(2.1), s_mv = max([-1, 0, 3]) by languages
+| STATS s2point1 = max(2.1), s_mv = max([-1, 0, 3]), s_expr = max(1+1), s_expr_null = max(1+null) by languages
 | SORT languages
 ;
 
-s2point1:d | s_mv:i | languages:i
-2.1        | 3      | 1
-2.1        | 3      | 2
-2.1        | 3      | 3
-2.1        | 3      | 4
-2.1        | 3      | 5
-2.1        | 3      | null
+s2point1:d | s_mv:i | s_expr:i | s_expr_null:i | languages:i
+2.1        | 3      | 2        | null          | 1
+2.1        | 3      | 2        | null          | 2
+2.1        | 3      | 2        | null          | 3
+2.1        | 3      | 2        | null          | 4
+2.1        | 3      | 2        | null          | 5
+2.1        | 3      | 2        | null          | null
 ;
 
 medianOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s1 = median(1), s_mv = median([-1, 0, 1, 3]), s_null = median(null)
+| STATS s1 = median(1), s_mv = median([-1, 0, 1, 3]), s_null = median(null), s_expr = median(1+1), s_expr_null = median(1+null)
 ;
 
-s1:d | s_mv:d | s_null:d
-1.0  | 0.5    | null
+s1:d | s_mv:d | s_null:d | s_expr:d | s_expr_null:d
+1.0  | 0.5    | null     | 2.0      | null
 ;
 
 medianOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s2point1 = median(2.1), s_mv = median([-1, 0, 1, 3]) by languages
+| STATS s2point1 = median(2.1), s_mv = median([-1, 0, 1, 3]), s_expr = median(1+1), s_expr_null = median(1+null) by languages
 | SORT languages
 ;
 
-s2point1:d | s_mv:d | languages:i
-2.1        | 0.5    | 1
-2.1        | 0.5    | 2
-2.1        | 0.5    | 3
-2.1        | 0.5    | 4
-2.1        | 0.5    | 5
-2.1        | 0.5    | null
+s2point1:d | s_mv:d | s_expr:d | s_expr_null:d | languages:i
+2.1        | 0.5    | 2.0      | null          | 1
+2.1        | 0.5    | 2.0      | null          | 2
+2.1        | 0.5    | 2.0      | null          | 3
+2.1        | 0.5    | 2.0      | null          | 4
+2.1        | 0.5    | 2.0      | null          | 5
+2.1        | 0.5    | 2.0      | null          | null
 ;
 
 countDistinctOfConst#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s1 = count_distinct(1), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_null = count_distinct(null), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 5) 
+| STATS s1 = count_distinct(1), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_null = count_distinct(null), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 5), s_expr = count_distinct(1+1), s_expr_null = count_distinct(1+null)
 ;
 
-s1:l | s_mv:l | s_null:l | s_param:l
-1    | 4      | 0        | 4
+s1:l | s_mv:l | s_null:l | s_param:l | s_expr:l | s_expr_null:l
+1    | 4      | 0        | 4         | 1        | 0
 ;
 
 countDistinctOfConstGrouped#[skip:-8.13.99,reason:supported in 8.14]
 FROM employees
-| STATS s2point1 = count_distinct("two point one"), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 8000) by languages
+| STATS s2point1 = count_distinct("two point one"), s_mv = count_distinct([-1, 0, 3, 1, -1, 3]), s_param = count_distinct([-1, 0, 3, 1, -1, 3], 8000), s_expr = count_distinct(1+1), s_expr_null = count_distinct(1+null) by languages
 | SORT languages
 ;
 
-s2point1:l | s_mv:l | s_param:l | languages:i
-1          | 4      | 4         | 1
-1          | 4      | 4         | 2
-1          | 4      | 4         | 3
-1          | 4      | 4         | 4
-1          | 4      | 4         | 5
-1          | 4      | 4         | null
+s2point1:l | s_mv:l | s_param:l | s_expr:l | s_expr_null:l | languages:i
+1          | 4      | 4         | 1        | 0             | 1
+1          | 4      | 4         | 1        | 0             | 2
+1          | 4      | 4         | 1        | 0             | 3
+1          | 4      | 4         | 1        | 0             | 4
+1          | 4      | 4         | 1        | 0             | 5
+1          | 4      | 4         | 1        | 0             | null
 ;
 
 evalOverridingKey#[skip:-8.13.1,reason:fixed in 8.13.2]


### PR DESCRIPTION
Add cases of foldable expressions to the existing csv tests for each
aggregation that supports constants: one that folds to a number, and one
that folds to null.