### PR TITLE
Optimise histogram aggregations for single value fields

### DIFF
--- a/docs/changelog/107893.yaml
+++ b/docs/changelog/107893.yaml
@@ -1,0 +1,5 @@
+pr: 107893
+summary: Optimise histogram aggregations for single value fields
+area: Aggregations
+type: enhancement
+issues: []

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/AutoDateHistogramAggregator.java
@@ -7,6 +7,8 @@
  */
 package org.elasticsearch.aggregations.bucket.histogram;
 
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.CollectionUtil;
@@ -123,12 +125,16 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
 
     protected abstract LeafBucketCollector getLeafCollector(SortedNumericDocValues values, LeafBucketCollector sub) throws IOException;
 
+    protected abstract LeafBucketCollector getLeafCollector(NumericDocValues values, LeafBucketCollector sub) throws IOException;
+
     @Override
     public final LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) throws IOException {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        return getLeafCollector(valuesSource.longValues(aggCtx.getLeafReaderContext()), sub);
+        final SortedNumericDocValues values = valuesSource.longValues(aggCtx.getLeafReaderContext());
+        final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+        return singleton != null ? getLeafCollector(singleton, sub) : getLeafCollector(values, sub);
     }
 
     protected final InternalAggregation[] buildAggregations(
@@ -249,58 +255,71 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
                         if (rounded == previousRounded) {
                             continue;
                         }
-                        collectValue(doc, rounded);
+                        collectValue(doc, rounded, sub);
                         previousRounded = rounded;
                     }
                 }
+            };
+        }
 
-                private void collectValue(int doc, long rounded) throws IOException {
-                    long bucketOrd = bucketOrds.add(0, rounded);
-                    if (bucketOrd < 0) { // already seen
-                        bucketOrd = -1 - bucketOrd;
-                        collectExistingBucket(sub, doc, bucketOrd);
-                        return;
+        @Override
+        protected LeafBucketCollector getLeafCollector(NumericDocValues values, LeafBucketCollector sub) {
+            return new LeafBucketCollectorBase(sub, values) {
+                @Override
+                public void collect(int doc, long owningBucketOrd) throws IOException {
+                    assert owningBucketOrd == 0;
+                    if (values.advanceExact(doc)) {
+                        collectValue(doc, preparedRounding.round(values.longValue()), sub);
                     }
-                    collectBucket(sub, doc, bucketOrd);
-                    increaseRoundingIfNeeded(rounded);
-                }
-
-                private void increaseRoundingIfNeeded(long rounded) {
-                    if (roundingIdx >= roundingInfos.length - 1) {
-                        return;
-                    }
-                    min = Math.min(min, rounded);
-                    max = Math.max(max, rounded);
-                    if (bucketOrds.size() <= targetBuckets * roundingInfos[roundingIdx].getMaximumInnerInterval()
-                        && max - min <= targetBuckets * roundingInfos[roundingIdx].getMaximumRoughEstimateDurationMillis()) {
-                        return;
-                    }
-                    do {
-                        LongKeyedBucketOrds oldOrds = bucketOrds;
-                        boolean success = false;
-                        try {
-                            preparedRounding = prepareRounding(++roundingIdx);
-                            long[] mergeMap = new long[Math.toIntExact(oldOrds.size())];
-                            bucketOrds = new LongKeyedBucketOrds.FromSingle(bigArrays());
-                            success = true; // now it is safe to close oldOrds after we finish
-                            LongKeyedBucketOrds.BucketOrdsEnum ordsEnum = oldOrds.ordsEnum(0);
-                            while (ordsEnum.next()) {
-                                long oldKey = ordsEnum.value();
-                                long newKey = preparedRounding.round(oldKey);
-                                long newBucketOrd = bucketOrds.add(0, newKey);
-                                mergeMap[(int) ordsEnum.ord()] = newBucketOrd >= 0 ? newBucketOrd : -1 - newBucketOrd;
-                            }
-                            merge(mergeMap, bucketOrds.size());
-                        } finally {
-                            if (success) {
-                                oldOrds.close();
-                            }
-                        }
-                    } while (roundingIdx < roundingInfos.length - 1
-                        && (bucketOrds.size() > targetBuckets * roundingInfos[roundingIdx].getMaximumInnerInterval()
-                            || max - min > targetBuckets * roundingInfos[roundingIdx].getMaximumRoughEstimateDurationMillis()));
                 }
             };
+        }
+
+        private void collectValue(int doc, long rounded, LeafBucketCollector sub) throws IOException {
+            long bucketOrd = bucketOrds.add(0, rounded);
+            if (bucketOrd < 0) { // already seen
+                bucketOrd = -1 - bucketOrd;
+                collectExistingBucket(sub, doc, bucketOrd);
+                return;
+            }
+            collectBucket(sub, doc, bucketOrd);
+            increaseRoundingIfNeeded(rounded);
+        }
+
+        private void increaseRoundingIfNeeded(long rounded) {
+            if (roundingIdx >= roundingInfos.length - 1) {
+                return;
+            }
+            min = Math.min(min, rounded);
+            max = Math.max(max, rounded);
+            if (bucketOrds.size() <= targetBuckets * roundingInfos[roundingIdx].getMaximumInnerInterval()
+                && max - min <= targetBuckets * roundingInfos[roundingIdx].getMaximumRoughEstimateDurationMillis()) {
+                return;
+            }
+            do {
+                LongKeyedBucketOrds oldOrds = bucketOrds;
+                boolean success = false;
+                try {
+                    preparedRounding = prepareRounding(++roundingIdx);
+                    long[] mergeMap = new long[Math.toIntExact(oldOrds.size())];
+                    bucketOrds = new LongKeyedBucketOrds.FromSingle(bigArrays());
+                    success = true; // now it is safe to close oldOrds after we finish
+                    LongKeyedBucketOrds.BucketOrdsEnum ordsEnum = oldOrds.ordsEnum(0);
+                    while (ordsEnum.next()) {
+                        long oldKey = ordsEnum.value();
+                        long newKey = preparedRounding.round(oldKey);
+                        long newBucketOrd = bucketOrds.add(0, newKey);
+                        mergeMap[(int) ordsEnum.ord()] = newBucketOrd >= 0 ? newBucketOrd : -1 - newBucketOrd;
+                    }
+                    merge(mergeMap, bucketOrds.size());
+                } finally {
+                    if (success) {
+                        oldOrds.close();
+                    }
+                }
+            } while (roundingIdx < roundingInfos.length - 1
+                && (bucketOrds.size() > targetBuckets * roundingInfos[roundingIdx].getMaximumInnerInterval()
+                    || max - min > targetBuckets * roundingInfos[roundingIdx].getMaximumRoughEstimateDurationMillis()));
         }
 
         @Override
@@ -379,8 +398,7 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
          * During collection we use overestimates for how much buckets are save
          * by bumping to the next rounding index. So we end up bumping less
          * aggressively than a "perfect" algorithm. That is fine because we
-         * correct the error when we merge the buckets together all the way
-         * up in {@link InternalAutoDateHistogram#reduceBucket}. In particular,
+         * correct the error when we merge the buckets together. In particular,
          * on final reduce we bump the rounding until it we appropriately
          * cover the date range across all of the results returned by all of
          * the {@link AutoDateHistogramAggregator}s.
@@ -459,77 +477,91 @@ abstract class AutoDateHistogramAggregator extends DeferableBucketAggregator {
                         if (rounded == previousRounded) {
                             continue;
                         }
-                        roundingIdx = collectValue(owningBucketOrd, roundingIdx, doc, rounded);
+                        roundingIdx = collectValue(owningBucketOrd, roundingIdx, doc, rounded, sub);
                         previousRounded = rounded;
                     }
                 }
+            };
+        }
 
-                private int collectValue(long owningBucketOrd, int roundingIdx, int doc, long rounded) throws IOException {
-                    long bucketOrd = bucketOrds.add(owningBucketOrd, rounded);
-                    if (bucketOrd < 0) { // already seen
-                        bucketOrd = -1 - bucketOrd;
-                        collectExistingBucket(sub, doc, bucketOrd);
-                        return roundingIdx;
+        @Override
+        protected LeafBucketCollector getLeafCollector(NumericDocValues values, LeafBucketCollector sub) {
+            return new LeafBucketCollectorBase(sub, values) {
+                @Override
+                public void collect(int doc, long owningBucketOrd) throws IOException {
+                    if (values.advanceExact(doc)) {
+                        final int roundingIdx = roundingIndexFor(owningBucketOrd);
+                        final long rounded = preparedRoundings[roundingIdx].round(values.longValue());
+                        collectValue(owningBucketOrd, roundingIdx, doc, rounded, sub);
                     }
-                    collectBucket(sub, doc, bucketOrd);
-                    liveBucketCountUnderestimate = bigArrays().grow(liveBucketCountUnderestimate, owningBucketOrd + 1);
-                    int estimatedBucketCount = liveBucketCountUnderestimate.increment(owningBucketOrd, 1);
-                    return increaseRoundingIfNeeded(owningBucketOrd, estimatedBucketCount, rounded, roundingIdx);
-                }
-
-                /**
-                 * Increase the rounding of {@code owningBucketOrd} using
-                 * estimated, bucket counts, {@link FromMany#rebucket() rebucketing} the all
-                 * buckets if the estimated number of wasted buckets is too high.
-                 */
-                private int increaseRoundingIfNeeded(long owningBucketOrd, int oldEstimatedBucketCount, long newKey, int oldRounding) {
-                    if (oldRounding >= roundingInfos.length - 1) {
-                        return oldRounding;
-                    }
-                    if (mins.size() < owningBucketOrd + 1) {
-                        long oldSize = mins.size();
-                        mins = bigArrays().grow(mins, owningBucketOrd + 1);
-                        mins.fill(oldSize, mins.size(), Long.MAX_VALUE);
-                    }
-                    if (maxes.size() < owningBucketOrd + 1) {
-                        long oldSize = maxes.size();
-                        maxes = bigArrays().grow(maxes, owningBucketOrd + 1);
-                        maxes.fill(oldSize, maxes.size(), Long.MIN_VALUE);
-                    }
-
-                    long min = Math.min(mins.get(owningBucketOrd), newKey);
-                    mins.set(owningBucketOrd, min);
-                    long max = Math.max(maxes.get(owningBucketOrd), newKey);
-                    maxes.set(owningBucketOrd, max);
-                    if (oldEstimatedBucketCount <= targetBuckets * roundingInfos[oldRounding].getMaximumInnerInterval()
-                        && max - min <= targetBuckets * roundingInfos[oldRounding].getMaximumRoughEstimateDurationMillis()) {
-                        return oldRounding;
-                    }
-                    long oldRoughDuration = roundingInfos[oldRounding].roughEstimateDurationMillis;
-                    int newRounding = oldRounding;
-                    int newEstimatedBucketCount;
-                    do {
-                        newRounding++;
-                        double ratio = (double) oldRoughDuration / (double) roundingInfos[newRounding].getRoughEstimateDurationMillis();
-                        newEstimatedBucketCount = (int) Math.ceil(oldEstimatedBucketCount * ratio);
-                    } while (newRounding < roundingInfos.length - 1
-                        && (newEstimatedBucketCount > targetBuckets * roundingInfos[newRounding].getMaximumInnerInterval()
-                            || max - min > targetBuckets * roundingInfos[newRounding].getMaximumRoughEstimateDurationMillis()));
-                    setRounding(owningBucketOrd, newRounding);
-                    mins.set(owningBucketOrd, preparedRoundings[newRounding].round(mins.get(owningBucketOrd)));
-                    maxes.set(owningBucketOrd, preparedRoundings[newRounding].round(maxes.get(owningBucketOrd)));
-                    wastedBucketsOverestimate += oldEstimatedBucketCount - newEstimatedBucketCount;
-                    if (wastedBucketsOverestimate > nextRebucketAt) {
-                        rebucket();
-                        // Bump the threshold for the next rebucketing
-                        wastedBucketsOverestimate = 0;
-                        nextRebucketAt *= 2;
-                    } else {
-                        liveBucketCountUnderestimate.set(owningBucketOrd, newEstimatedBucketCount);
-                    }
-                    return newRounding;
                 }
             };
+        }
+
+        private int collectValue(long owningBucketOrd, int roundingIdx, int doc, long rounded, LeafBucketCollector sub) throws IOException {
+            long bucketOrd = bucketOrds.add(owningBucketOrd, rounded);
+            if (bucketOrd < 0) { // already seen
+                bucketOrd = -1 - bucketOrd;
+                collectExistingBucket(sub, doc, bucketOrd);
+                return roundingIdx;
+            }
+            collectBucket(sub, doc, bucketOrd);
+            liveBucketCountUnderestimate = bigArrays().grow(liveBucketCountUnderestimate, owningBucketOrd + 1);
+            int estimatedBucketCount = liveBucketCountUnderestimate.increment(owningBucketOrd, 1);
+            return increaseRoundingIfNeeded(owningBucketOrd, estimatedBucketCount, rounded, roundingIdx);
+        }
+
+        /**
+         * Increase the rounding of {@code owningBucketOrd} using
+         * estimated, bucket counts, {@link FromMany#rebucket() rebucketing} the all
+         * buckets if the estimated number of wasted buckets is too high.
+         */
+        private int increaseRoundingIfNeeded(long owningBucketOrd, int oldEstimatedBucketCount, long newKey, int oldRounding) {
+            if (oldRounding >= roundingInfos.length - 1) {
+                return oldRounding;
+            }
+            if (mins.size() < owningBucketOrd + 1) {
+                long oldSize = mins.size();
+                mins = bigArrays().grow(mins, owningBucketOrd + 1);
+                mins.fill(oldSize, mins.size(), Long.MAX_VALUE);
+            }
+            if (maxes.size() < owningBucketOrd + 1) {
+                long oldSize = maxes.size();
+                maxes = bigArrays().grow(maxes, owningBucketOrd + 1);
+                maxes.fill(oldSize, maxes.size(), Long.MIN_VALUE);
+            }
+
+            long min = Math.min(mins.get(owningBucketOrd), newKey);
+            mins.set(owningBucketOrd, min);
+            long max = Math.max(maxes.get(owningBucketOrd), newKey);
+            maxes.set(owningBucketOrd, max);
+            if (oldEstimatedBucketCount <= targetBuckets * roundingInfos[oldRounding].getMaximumInnerInterval()
+                && max - min <= targetBuckets * roundingInfos[oldRounding].getMaximumRoughEstimateDurationMillis()) {
+                return oldRounding;
+            }
+            long oldRoughDuration = roundingInfos[oldRounding].roughEstimateDurationMillis;
+            int newRounding = oldRounding;
+            int newEstimatedBucketCount;
+            do {
+                newRounding++;
+                double ratio = (double) oldRoughDuration / (double) roundingInfos[newRounding].getRoughEstimateDurationMillis();
+                newEstimatedBucketCount = (int) Math.ceil(oldEstimatedBucketCount * ratio);
+            } while (newRounding < roundingInfos.length - 1
+                && (newEstimatedBucketCount > targetBuckets * roundingInfos[newRounding].getMaximumInnerInterval()
+                    || max - min > targetBuckets * roundingInfos[newRounding].getMaximumRoughEstimateDurationMillis()));
+            setRounding(owningBucketOrd, newRounding);
+            mins.set(owningBucketOrd, preparedRoundings[newRounding].round(mins.get(owningBucketOrd)));
+            maxes.set(owningBucketOrd, preparedRoundings[newRounding].round(maxes.get(owningBucketOrd)));
+            wastedBucketsOverestimate += oldEstimatedBucketCount - newEstimatedBucketCount;
+            if (wastedBucketsOverestimate > nextRebucketAt) {
+                rebucket();
+                // Bump the threshold for the next rebucketing
+                wastedBucketsOverestimate = 0;
+                nextRebucketAt *= 2;
+            } else {
+                liveBucketCountUnderestimate.set(owningBucketOrd, newEstimatedBucketCount);
+            }
+            return newRounding;
         }
 
         private void rebucket() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregator.java
@@ -9,6 +9,8 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.CollectionUtil;
@@ -285,35 +287,52 @@ class DateHistogramAggregator extends BucketsAggregator implements SizedBucketAg
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        SortedNumericDocValues values = valuesSource.longValues(aggCtx.getLeafReaderContext());
+        final SortedNumericDocValues values = valuesSource.longValues(aggCtx.getLeafReaderContext());
+        final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+        return singleton != null ? getLeafCollector(singleton, sub) : getLeafCollector(values, sub);
+    }
+
+    private LeafBucketCollector getLeafCollector(SortedNumericDocValues values, LeafBucketCollector sub) {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long owningBucketOrd) throws IOException {
                 if (values.advanceExact(doc)) {
-                    int valuesCount = values.docValueCount();
-
                     long previousRounded = Long.MIN_VALUE;
-                    for (int i = 0; i < valuesCount; ++i) {
-                        long value = values.nextValue();
-                        long rounded = preparedRounding.round(value);
+                    for (int i = 0; i < values.docValueCount(); ++i) {
+                        final long rounded = preparedRounding.round(values.nextValue());
                         assert rounded >= previousRounded;
                         if (rounded == previousRounded) {
                             continue;
                         }
-                        if (hardBounds == null || hardBounds.contain(rounded)) {
-                            long bucketOrd = bucketOrds.add(owningBucketOrd, rounded);
-                            if (bucketOrd < 0) { // already seen
-                                bucketOrd = -1 - bucketOrd;
-                                collectExistingBucket(sub, doc, bucketOrd);
-                            } else {
-                                collectBucket(sub, doc, bucketOrd);
-                            }
-                        }
+                        addRoundedValue(rounded, doc, owningBucketOrd, sub);
                         previousRounded = rounded;
                     }
                 }
             }
         };
+    }
+
+    private LeafBucketCollector getLeafCollector(NumericDocValues values, LeafBucketCollector sub) {
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long owningBucketOrd) throws IOException {
+                if (values.advanceExact(doc)) {
+                    addRoundedValue(preparedRounding.round(values.longValue()), doc, owningBucketOrd, sub);
+                }
+            }
+        };
+    }
+
+    private void addRoundedValue(long rounded, int doc, long owningBucketOrd, LeafBucketCollector sub) throws IOException {
+        if (hardBounds == null || hardBounds.contain(rounded)) {
+            long bucketOrd = bucketOrds.add(owningBucketOrd, rounded);
+            if (bucketOrd < 0) { // already seen
+                bucketOrd = -1 - bucketOrd;
+                collectExistingBucket(sub, doc, bucketOrd);
+            } else {
+                collectBucket(sub, doc, bucketOrd);
+            }
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/DateRangeHistogramAggregator.java
@@ -7,13 +7,13 @@
  */
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
+import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.search.ScoreMode;
-import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.search.DocValueFormat;
@@ -117,53 +117,44 @@ class DateRangeHistogramAggregator extends BucketsAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        SortedBinaryDocValues values = valuesSource.bytesValues(aggCtx.getLeafReaderContext());
-        RangeType rangeType = valuesSource.rangeType();
+        // Is it possible for multiple values here? Multiple ranges are encoded into the same BytesRef in the binary doc values
+        final BinaryDocValues values = FieldData.unwrapSingleton(valuesSource.bytesValues(aggCtx.getLeafReaderContext()));
+        assert values != null;
+        final RangeType rangeType = valuesSource.rangeType();
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long owningBucketOrd) throws IOException {
                 if (values.advanceExact(doc)) {
-                    // Is it possible for valuesCount to be > 1 here? Multiple ranges are encoded into the same BytesRef in the binary doc
-                    // values, so it isn't clear what we'd be iterating over.
-                    int valuesCount = values.docValueCount();
-                    assert valuesCount == 1 : "Value count for ranges should always be 1";
                     long previousKey = Long.MIN_VALUE;
-
-                    for (int i = 0; i < valuesCount; i++) {
-                        BytesRef encodedRanges = values.nextValue();
-                        List<RangeFieldMapper.Range> ranges = rangeType.decodeRanges(encodedRanges);
-                        long previousFrom = Long.MIN_VALUE;
-                        for (RangeFieldMapper.Range range : ranges) {
-                            Long from = (Long) range.getFrom();
-                            // The encoding should ensure that this assert is always true.
-                            assert from >= previousFrom : "Start of range not >= previous start";
-                            final Long to = (Long) range.getTo();
-                            final long effectiveFrom = (hardBounds != null && hardBounds.getMin() != null)
-                                ? max(from, hardBounds.getMin())
-                                : from;
-                            final long effectiveTo = (hardBounds != null && hardBounds.getMax() != null)
-                                ? min(to, hardBounds.getMax())
-                                : to;
-                            final long startKey = preparedRounding.round(effectiveFrom);
-                            final long endKey = preparedRounding.round(effectiveTo);
-                            for (long key = max(startKey, previousKey); key <= endKey; key = preparedRounding.nextRoundingValue(key)) {
-                                if (key == previousKey) {
-                                    continue;
-                                }
-                                // Bucket collection identical to NumericHistogramAggregator, could be refactored
-                                long bucketOrd = bucketOrds.add(owningBucketOrd, key);
-                                if (bucketOrd < 0) { // already seen
-                                    bucketOrd = -1 - bucketOrd;
-                                    collectExistingBucket(sub, doc, bucketOrd);
-                                } else {
-                                    collectBucket(sub, doc, bucketOrd);
-                                }
+                    final List<RangeFieldMapper.Range> ranges = rangeType.decodeRanges(values.binaryValue());
+                    long previousFrom = Long.MIN_VALUE;
+                    for (RangeFieldMapper.Range range : ranges) {
+                        Long from = (Long) range.getFrom();
+                        // The encoding should ensure that this assert is always true.
+                        assert from >= previousFrom : "Start of range not >= previous start";
+                        final Long to = (Long) range.getTo();
+                        final long effectiveFrom = (hardBounds != null && hardBounds.getMin() != null)
+                            ? max(from, hardBounds.getMin())
+                            : from;
+                        final long effectiveTo = (hardBounds != null && hardBounds.getMax() != null) ? min(to, hardBounds.getMax()) : to;
+                        final long startKey = preparedRounding.round(effectiveFrom);
+                        final long endKey = preparedRounding.round(effectiveTo);
+                        for (long key = max(startKey, previousKey); key <= endKey; key = preparedRounding.nextRoundingValue(key)) {
+                            if (key == previousKey) {
+                                continue;
                             }
-                            if (endKey > previousKey) {
-                                previousKey = endKey;
+                            // Bucket collection identical to NumericHistogramAggregator, could be refactored
+                            long bucketOrd = bucketOrds.add(owningBucketOrd, key);
+                            if (bucketOrd < 0) { // already seen
+                                bucketOrd = -1 - bucketOrd;
+                                collectExistingBucket(sub, doc, bucketOrd);
+                            } else {
+                                collectBucket(sub, doc, bucketOrd);
                             }
                         }
-
+                        if (endKey > previousKey) {
+                            previousKey = endKey;
+                        }
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/RangeHistogramAggregator.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.search.aggregations.bucket.histogram;
 
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.apache.lucene.index.BinaryDocValues;
+import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
 import org.elasticsearch.index.mapper.RangeType;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
@@ -76,53 +76,46 @@ public class RangeHistogramAggregator extends AbstractHistogramAggregator {
         if (valuesSource == null) {
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
-        final SortedBinaryDocValues values = valuesSource.bytesValues(aggCtx.getLeafReaderContext());
+        // Is it possible for multiple values here? Multiple ranges are encoded into the same BytesRef in the binary doc values
+        final BinaryDocValues values = FieldData.unwrapSingleton(valuesSource.bytesValues(aggCtx.getLeafReaderContext()));
+        assert values != null : "unexpected multi-value binary doc values";
         final RangeType rangeType = valuesSource.rangeType();
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long owningBucketOrd) throws IOException {
                 if (values.advanceExact(doc)) {
-                    // Is it possible for valuesCount to be > 1 here? Multiple ranges are encoded into the same BytesRef in the binary doc
-                    // values, so it isn't clear what we'd be iterating over.
-                    final int valuesCount = values.docValueCount();
-                    assert valuesCount == 1 : "Value count for ranges should always be 1";
                     double previousKey = Double.NEGATIVE_INFINITY;
-
-                    for (int i = 0; i < valuesCount; i++) {
-                        BytesRef encodedRanges = values.nextValue();
-                        List<RangeFieldMapper.Range> ranges = rangeType.decodeRanges(encodedRanges);
-                        double previousFrom = Double.NEGATIVE_INFINITY;
-                        for (RangeFieldMapper.Range range : ranges) {
-                            final Double from = rangeType.doubleValue(range.getFrom());
-                            // The encoding should ensure that this assert is always true.
-                            assert from >= previousFrom : "Start of range not >= previous start";
-                            final Double to = rangeType.doubleValue(range.getTo());
-                            final double effectiveFrom = (hardBounds != null && hardBounds.getMin() != null)
-                                ? Double.max(from, hardBounds.getMin())
-                                : from;
-                            final double effectiveTo = (hardBounds != null && hardBounds.getMax() != null)
-                                ? Double.min(to, hardBounds.getMax())
-                                : to;
-                            final double startKey = Math.floor((effectiveFrom - offset) / interval);
-                            final double endKey = Math.floor((effectiveTo - offset) / interval);
-                            for (double key = Math.max(startKey, previousKey); key <= endKey; key++) {
-                                if (key == previousKey) {
-                                    continue;
-                                }
-                                // Bucket collection identical to NumericHistogramAggregator, could be refactored
-                                long bucketOrd = bucketOrds.add(owningBucketOrd, Double.doubleToLongBits(key));
-                                if (bucketOrd < 0) { // already seen
-                                    bucketOrd = -1 - bucketOrd;
-                                    collectExistingBucket(sub, doc, bucketOrd);
-                                } else {
-                                    collectBucket(sub, doc, bucketOrd);
-                                }
+                    final List<RangeFieldMapper.Range> ranges = rangeType.decodeRanges(values.binaryValue());
+                    double previousFrom = Double.NEGATIVE_INFINITY;
+                    for (RangeFieldMapper.Range range : ranges) {
+                        final Double from = rangeType.doubleValue(range.getFrom());
+                        // The encoding should ensure that this assert is always true.
+                        assert from >= previousFrom : "Start of range not >= previous start";
+                        final Double to = rangeType.doubleValue(range.getTo());
+                        final double effectiveFrom = (hardBounds != null && hardBounds.getMin() != null)
+                            ? Double.max(from, hardBounds.getMin())
+                            : from;
+                        final double effectiveTo = (hardBounds != null && hardBounds.getMax() != null)
+                            ? Double.min(to, hardBounds.getMax())
+                            : to;
+                        final double startKey = Math.floor((effectiveFrom - offset) / interval);
+                        final double endKey = Math.floor((effectiveTo - offset) / interval);
+                        for (double key = Math.max(startKey, previousKey); key <= endKey; key++) {
+                            if (key == previousKey) {
+                                continue;
                             }
-                            if (endKey > previousKey) {
-                                previousKey = endKey;
+                            // Bucket collection identical to NumericHistogramAggregator, could be refactored
+                            long bucketOrd = bucketOrds.add(owningBucketOrd, Double.doubleToLongBits(key));
+                            if (bucketOrd < 0) { // already seen
+                                bucketOrd = -1 - bucketOrd;
+                                collectExistingBucket(sub, doc, bucketOrd);
+                            } else {
+                                collectBucket(sub, doc, bucketOrd);
                             }
                         }
-
+                        if (endKey > previousKey) {
+                            previousKey = endKey;
+                        }
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregator.java
@@ -16,6 +16,8 @@ import org.elasticsearch.common.util.DoubleArray;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
@@ -525,22 +527,37 @@ public class VariableWidthHistogramAggregator extends DeferableBucketAggregator 
             return LeafBucketCollector.NO_OP_COLLECTOR;
         }
         final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
+        final NumericDoubleValues singleton = FieldData.unwrapSingleton(values);
+        return singleton != null ? getLeafCollector(singleton, sub) : getLeafCollector(values, sub);
+    }
+
+    private LeafBucketCollector getLeafCollector(SortedNumericDoubleValues values, LeafBucketCollector sub) {
         return new LeafBucketCollectorBase(sub, values) {
             @Override
             public void collect(int doc, long bucket) throws IOException {
                 assert bucket == 0;
                 if (values.advanceExact(doc)) {
-                    final int valuesCount = values.docValueCount();
                     double prevVal = Double.NEGATIVE_INFINITY;
-                    for (int i = 0; i < valuesCount; ++i) {
+                    for (int i = 0; i < values.docValueCount(); ++i) {
                         double val = values.nextValue();
                         assert val >= prevVal;
                         if (val == prevVal) {
                             continue;
                         }
-
                         collector = collector.collectValue(sub, doc, val);
                     }
+                }
+            }
+        };
+    }
+
+    private LeafBucketCollector getLeafCollector(NumericDoubleValues values, LeafBucketCollector sub) {
+        return new LeafBucketCollectorBase(sub, values) {
+            @Override
+            public void collect(int doc, long bucket) throws IOException {
+                assert bucket == 0;
+                if (values.advanceExact(doc)) {
+                    collector = collector.collectValue(sub, doc, values.doubleValue());
                 }
             }
         };


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/107832, this commit optimize histogram aggregations for single value fields. For example, this change should give a boost of date histograms when not running in query fashion.