### PR TITLE
Docs: move STARTS/ENDS_WITH under string functions in the docs (#107867)

### DIFF
--- a/docs/reference/esql/functions/operators.asciidoc
+++ b/docs/reference/esql/functions/operators.asciidoc
@@ -13,11 +13,9 @@ Boolean operators for comparing against one or multiple expressions.
 * <<esql-logical-operators>>
 * <<esql-predicates>>
 * <<esql-cidr_match>>
-* <<esql-ends_with>>
 * <<esql-in-operator>>
 * <<esql-like-operator>>
 * <<esql-rlike-operator>>
-* <<esql-starts_with>>
 // end::op_list[]
 
 include::binary.asciidoc[]
@@ -25,8 +23,6 @@ include::unary.asciidoc[]
 include::logical.asciidoc[]
 include::predicates.asciidoc[]
 include::cidr_match.asciidoc[]
-include::ends_with.asciidoc[]
 include::in.asciidoc[]
 include::like.asciidoc[]
 include::rlike.asciidoc[]
-include::starts_with.asciidoc[]

--- a/docs/reference/esql/functions/string-functions.asciidoc
+++ b/docs/reference/esql/functions/string-functions.asciidoc
@@ -9,6 +9,7 @@
 
 // tag::string_list[]
 * <<esql-concat>>
+* <<esql-ends_with>>
 * <<esql-left>>
 * <<esql-length>>
 * <<esql-locate>>
@@ -17,6 +18,7 @@
 * <<esql-right>>
 * <<esql-rtrim>>
 * <<esql-split>>
+* <<esql-starts_with>>
 * <<esql-substring>>
 * <<esql-to_lower>>
 * <<esql-to_upper>>
@@ -24,6 +26,7 @@
 // end::string_list[]
 
 include::concat.asciidoc[]
+include::ends_with.asciidoc[]
 include::layout/left.asciidoc[]
 include::length.asciidoc[]
 include::layout/locate.asciidoc[]
@@ -32,6 +35,7 @@ include::replace.asciidoc[]
 include::right.asciidoc[]
 include::rtrim.asciidoc[]
 include::split.asciidoc[]
+include::starts_with.asciidoc[]
 include::substring.asciidoc[]
 include::to_lower.asciidoc[]
 include::to_upper.asciidoc[]


### PR DESCRIPTION
This moves the STARTS_WITH and ENDS_with under the strings functions section (as they're not operators).

(cherry picked from commit 31f2fb85dfe0a32ac6f9d8c5a972317195a19806)