### PR TITLE
Docs: move base64 functions under string functions (#107866)

### DIFF
--- a/docs/reference/esql/functions/string-functions.asciidoc
+++ b/docs/reference/esql/functions/string-functions.asciidoc
@@ -10,6 +10,7 @@
 // tag::string_list[]
 * <<esql-concat>>
 * <<esql-ends_with>>
+* <<esql-from_base64>>
 * <<esql-left>>
 * <<esql-length>>
 * <<esql-locate>>
@@ -20,6 +21,7 @@
 * <<esql-split>>
 * <<esql-starts_with>>
 * <<esql-substring>>
+* <<esql-to_base64>>
 * <<esql-to_lower>>
 * <<esql-to_upper>>
 * <<esql-trim>>
@@ -27,6 +29,7 @@
 
 include::concat.asciidoc[]
 include::ends_with.asciidoc[]
+include::layout/from_base64.asciidoc[]
 include::layout/left.asciidoc[]
 include::length.asciidoc[]
 include::layout/locate.asciidoc[]
@@ -37,6 +40,7 @@ include::rtrim.asciidoc[]
 include::split.asciidoc[]
 include::starts_with.asciidoc[]
 include::substring.asciidoc[]
+include::layout/to_base64.asciidoc[]
 include::to_lower.asciidoc[]
 include::to_upper.asciidoc[]
 include::trim.asciidoc[]

--- a/docs/reference/esql/functions/type-conversion-functions.asciidoc
+++ b/docs/reference/esql/functions/type-conversion-functions.asciidoc
@@ -8,8 +8,6 @@
 {esql} supports these type conversion functions:
 
 // tag::type_list[]
-* <<esql-from_base64>>
-* <<esql-to_base64>>
 * <<esql-to_boolean>>
 * <<esql-to_cartesianpoint>>
 * <<esql-to_cartesianshape>>
@@ -27,8 +25,6 @@
 * <<esql-to_version>>
 // end::type_list[]
 
-include::layout/from_base64.asciidoc[]
-include::layout/to_base64.asciidoc[]
 include::to_boolean.asciidoc[]
 include::to_cartesianpoint.asciidoc[]
 include::to_cartesianshape.asciidoc[]


### PR DESCRIPTION
This moves the TO_BASE64 and FROM_BASE64 from the type conversion functions under string functions (they take a string as input and output another string).

(cherry picked from commit 9482673fbe2ac5302e272b29f21fbd34fc2497d0)
