### PR TITLE
Revert "Format default values of IP ranges to match other range bound"

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/range/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/range/20_synthetic_source.yml
@@ -515,7 +515,7 @@ setup:
         id: "7"
   - match:
       _source:
-        ip_range: { "gte": "0.0.0.0", "lte": "10.10.10.10" }
+        ip_range: { "gte": "::", "lte": "10.10.10.10" }
 
   - do:
       get:

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeType.java
@@ -31,7 +31,6 @@ import org.elasticsearch.lucene.queries.BinaryDocValuesRangeQuery;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -63,26 +62,6 @@ public enum RangeType {
             throws IOException {
             InetAddress address = InetAddresses.forString(parser.text());
             return included ? address : nextDown(address);
-        }
-
-        public Object defaultFrom(Object parsedTo) {
-            if (parsedTo == null) {
-                return minValue();
-            }
-
-            // Make sure that we keep the range inside the same address family.
-            // `minValue()` is always IPv6 so we need to adjust it.
-            return parsedTo instanceof Inet4Address ? InetAddressPoint.decode(new byte[4]) : minValue();
-        }
-
-        public Object defaultTo(Object parsedFrom) {
-            if (parsedFrom == null) {
-                return maxValue();
-            }
-
-            // Make sure that we keep the range inside the same address family.
-            // `maxValue()` is always IPv6 so we need to adjust it.
-            return parsedFrom instanceof Inet4Address ? InetAddressPoint.decode(new byte[] { -1, -1, -1, -1 }) : maxValue();
         }
 
         @Override
@@ -863,14 +842,6 @@ public enum RangeType {
         throws IOException {
         Number value = numberType.parse(parser, coerce);
         return included ? value : (Number) nextDown(value);
-    }
-
-    public Object defaultFrom(Object parsedTo) {
-        return minValue();
-    }
-
-    public Object defaultTo(Object parsedFrom) {
-        return maxValue();
     }
 
     public abstract Object minValue();

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldMapperTests.java
@@ -87,37 +87,6 @@ public class IpRangeFieldMapperTests extends RangeFieldMapperTests {
         }
     }
 
-    @Override
-    public void testNullBounds() throws IOException {
-        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
-            minimalMapping(b);
-            b.field("store", true);
-        }));
-
-        ParsedDocument bothNull = mapper.parse(source(b -> b.startObject("field").nullField("gte").nullField("lte").endObject()));
-        assertThat(storedValue(bothNull), equalTo("[:: : ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]"));
-
-        ParsedDocument onlyFromIPv4 = mapper.parse(
-            source(b -> b.startObject("field").field("gte", rangeValue()).nullField("lte").endObject())
-        );
-        assertThat(storedValue(onlyFromIPv4), equalTo("[192.168.1.7 : 255.255.255.255]"));
-
-        ParsedDocument onlyToIPv4 = mapper.parse(
-            source(b -> b.startObject("field").nullField("gte").field("lte", rangeValue()).endObject())
-        );
-        assertThat(storedValue(onlyToIPv4), equalTo("[0.0.0.0 : 192.168.1.7]"));
-
-        ParsedDocument onlyFromIPv6 = mapper.parse(
-            source(b -> b.startObject("field").field("gte", "2001:db8::").nullField("lte").endObject())
-        );
-        assertThat(storedValue(onlyFromIPv6), equalTo("[2001:db8:: : ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff]"));
-
-        ParsedDocument onlyToIPv6 = mapper.parse(
-            source(b -> b.startObject("field").nullField("gte").field("lte", "2001:db8::").endObject())
-        );
-        assertThat(storedValue(onlyToIPv6), equalTo("[:: : 2001:db8::]"));
-    }
-
     @SuppressWarnings("unchecked")
     public void testValidSyntheticSource() throws IOException {
         CheckedConsumer<XContentBuilder, IOException> mapping = b -> {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -236,14 +236,14 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
         }
     }
 
-    protected static String storedValue(ParsedDocument doc) {
+    private static String storedValue(ParsedDocument doc) {
         assertEquals(3, doc.rootDoc().getFields("field").size());
         List<IndexableField> fields = doc.rootDoc().getFields("field");
         IndexableField storedField = fields.get(2);
         return storedField.stringValue();
     }
 
-    public void testNullBounds() throws IOException {
+    public final void testNullBounds() throws IOException {
 
         // null, null => min, max
         assertNullBounds(b -> b.startObject("field").nullField("gte").nullField("lte").endObject(), true, true);


### PR DESCRIPTION
This reverts commit acb513945b60912dc3e258730da008ac4dd395b4 (a part of #107081). This commit impacts search behaviour for IP range fields and so needs to be reverted.

