### PR TITLE
[8.14] Reduce parallelism for yaml and java esql rest tests (#107890)

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/build.gradle
@@ -40,6 +40,7 @@ BuildParams.bwcVersions.withWireCompatible(supportedVersion) { bwcVersion, baseN
     usesBwcDistribution(bwcVersion)
     systemProperty("tests.old_cluster_version", bwcVersion)
     systemProperty("tests.version_parameter_unsupported", versionUnsupported(bwcVersion))
+    maxParallelForks = 1
   }
 
   def yamlRestTest = tasks.register("v${bwcVersion}#yamlRestTest", StandaloneRestIntegTestTask) {


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Reduce parallelism for yaml and java esql rest tests (#107890)