### PR TITLE
Annotated text fields are stored by default with synthetic source

### DIFF
--- a/docs/changelog/107922.yaml
+++ b/docs/changelog/107922.yaml
@@ -1,0 +1,6 @@
+pr: 107922
+summary: Feature/annotated text store defaults
+area: Mapping
+type: enhancement
+issues:
+ - 107734

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -563,7 +563,12 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), builder.indexCreatedVersion, builder.analyzers.indexAnalyzers, builder.isSyntheticSourceEnabledViaIndexMode).init(this);
+        return new Builder(
+            simpleName(),
+            builder.indexCreatedVersion,
+            builder.analyzers.indexAnalyzers,
+            builder.isSyntheticSourceEnabledViaIndexMode
+        ).init(this);
     }
 
     @Override

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
@@ -29,7 +29,7 @@ public class AnnotatedTextFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType fieldType = new AnnotatedTextFieldMapper.Builder("field", IndexVersion.current(), createDefaultIndexAnalyzers())
+        MappedFieldType fieldType = new AnnotatedTextFieldMapper.Builder("field", IndexVersion.current(), createDefaultIndexAnalyzers(), false)
             .build(MapperBuilderContext.root(false, false))
             .fieldType();
 

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldTypeTests.java
@@ -29,9 +29,12 @@ public class AnnotatedTextFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFetchSourceValue() throws IOException {
-        MappedFieldType fieldType = new AnnotatedTextFieldMapper.Builder("field", IndexVersion.current(), createDefaultIndexAnalyzers(), false)
-            .build(MapperBuilderContext.root(false, false))
-            .fieldType();
+        MappedFieldType fieldType = new AnnotatedTextFieldMapper.Builder(
+            "field",
+            IndexVersion.current(),
+            createDefaultIndexAnalyzers(),
+            false
+        ).build(MapperBuilderContext.root(false, false)).fieldType();
 
         assertEquals(List.of("value"), fetchSourceValue(fieldType, "value"));
         assertEquals(List.of("42"), fetchSourceValue(fieldType, 42L));


### PR DESCRIPTION
This change follows existing implementation for text field.

Closes #107734.