### PR TITLE
[7.17] [ci] Shrink platform-support Windows instances (#107912)

### DIFF
--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -49,7 +49,7 @@ steps:
         agents:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
-          machineType: n1-standard-32
+          machineType: n1-standard-16
           diskType: pd-ssd
           diskSizeGb: 350
         env:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Shrink platform-support Windows instances (#107912)](https://github.com/elastic/elasticsearch/pull/107912)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)