### PR TITLE
Optimise multiterms aggregation for single value fields

### DIFF
--- a/docs/changelog/107937.yaml
+++ b/docs/changelog/107937.yaml
@@ -1,0 +1,5 @@
+pr: 107937
+summary: Optimise multiterms aggregation for single value fields
+area: Aggregations
+type: enhancement
+issues: []

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregator.java
@@ -7,7 +7,10 @@
 
 package org.elasticsearch.xpack.analytics.multiterms;
 
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.BytesRef;
@@ -20,6 +23,8 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.ObjectArrayPriorityQueue;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.index.fielddata.FieldData;
+import org.elasticsearch.index.fielddata.NumericDoubleValues;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 import org.elasticsearch.search.DocValueFormat;
@@ -376,20 +381,35 @@ class MultiTermsAggregator extends DeferableBucketAggregator {
 
         @Override
         public TermValues getValues(LeafReaderContext ctx) throws IOException {
-            SortedNumericDocValues values = source.longValues(ctx);
+            final SortedNumericDocValues values = source.longValues(ctx);
+            final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+            return singleton != null ? getValues(singleton) : getValues(values);
+        }
+
+        public TermValues getValues(SortedNumericDocValues values) {
             return doc -> {
                 if (values.advanceExact(doc)) {
-                    List<Object> objects = new ArrayList<>();
-                    int valuesCount = values.docValueCount();
+                    final List<Object> objects = new ArrayList<>();
+                    final int valuesCount = values.docValueCount();
                     long previous = Long.MAX_VALUE;
                     for (int i = 0; i < valuesCount; ++i) {
-                        long val = values.nextValue();
+                        final long val = values.nextValue();
                         if (previous != val || i == 0) {
                             objects.add(val);
                             previous = val;
                         }
                     }
                     return objects;
+                } else {
+                    return null;
+                }
+            };
+        }
+
+        public TermValues getValues(NumericDocValues values) {
+            return doc -> {
+                if (values.advanceExact(doc)) {
+                    return List.of(values.longValue());
                 } else {
                     return null;
                 }
@@ -414,20 +434,35 @@ class MultiTermsAggregator extends DeferableBucketAggregator {
 
         @Override
         public TermValues getValues(LeafReaderContext ctx) throws IOException {
-            SortedNumericDoubleValues values = source.doubleValues(ctx);
+            final SortedNumericDoubleValues values = source.doubleValues(ctx);
+            final NumericDoubleValues singleton = FieldData.unwrapSingleton(values);
+            return singleton != null ? getValues(singleton) : getValues(values);
+        }
+
+        public TermValues getValues(SortedNumericDoubleValues values) {
             return doc -> {
                 if (values.advanceExact(doc)) {
-                    List<Object> objects = new ArrayList<>();
-                    int valuesCount = values.docValueCount();
+                    final List<Object> objects = new ArrayList<>();
+                    final int valuesCount = values.docValueCount();
                     double previous = Double.MAX_VALUE;
                     for (int i = 0; i < valuesCount; ++i) {
-                        double val = values.nextValue();
+                        final double val = values.nextValue();
                         if (previous != val || i == 0) {
                             objects.add(val);
                             previous = val;
                         }
                     }
                     return objects;
+                } else {
+                    return null;
+                }
+            };
+        }
+
+        public TermValues getValues(NumericDoubleValues values) {
+            return doc -> {
+                if (values.advanceExact(doc)) {
+                    return List.of(values.doubleValue());
                 } else {
                     return null;
                 }
@@ -453,16 +488,21 @@ class MultiTermsAggregator extends DeferableBucketAggregator {
 
         @Override
         public TermValues getValues(LeafReaderContext ctx) throws IOException {
-            SortedBinaryDocValues values = source.bytesValues(ctx);
+            final SortedBinaryDocValues values = source.bytesValues(ctx);
+            final BinaryDocValues singleton = FieldData.unwrapSingleton(values);
+            return singleton != null ? getValues(singleton) : getValues(values);
+        }
+
+        private TermValues getValues(SortedBinaryDocValues values) {
             return doc -> {
                 if (values.advanceExact(doc)) {
-                    int valuesCount = values.docValueCount();
-                    List<Object> objects = new ArrayList<>(valuesCount);
+                    final int valuesCount = values.docValueCount();
+                    final List<Object> objects = new ArrayList<>(valuesCount);
                     // SortedBinaryDocValues don't guarantee uniqueness so we
                     // need to take care of dups
                     previous.clear();
                     for (int i = 0; i < valuesCount; ++i) {
-                        BytesRef bytes = values.nextValue();
+                        final BytesRef bytes = values.nextValue();
                         if (i > 0 && previous.get().equals(bytes)) {
                             continue;
                         }
@@ -470,6 +510,16 @@ class MultiTermsAggregator extends DeferableBucketAggregator {
                         objects.add(BytesRef.deepCopyOf(bytes));
                     }
                     return objects;
+                } else {
+                    return null;
+                }
+            };
+        }
+
+        private TermValues getValues(BinaryDocValues values) {
+            return doc -> {
+                if (values.advanceExact(doc)) {
+                    return List.of(BytesRef.deepCopyOf(values.binaryValue()));
                 } else {
                     return null;
                 }


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/107832, this commit optimize mulit-terms aggregatios for single value fields.