### PR TITLE
MappedActionFilters respect the order field in an ActionFilter

### DIFF
--- a/docs/changelog/107940.yaml
+++ b/docs/changelog/107940.yaml
@@ -1,0 +1,5 @@
+pr: 107940
+summary: '`MappedActionFilters` respect the order field in an `ActionFilter`'
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/support/MappedActionFilters.java
+++ b/server/src/main/java/org/elasticsearch/action/support/MappedActionFilters.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.tasks.Task;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,7 @@ public class MappedActionFilters implements ActionFilter {
         for (var filter : mappedFilters) {
             map.computeIfAbsent(filter.actionName(), k -> new ArrayList<>()).add(filter);
         }
-        map.replaceAll((k, l) -> List.copyOf(l));
+        map.replaceAll((k, l) -> l.stream().sorted(Comparator.comparingInt(ActionFilter::order)).toList());
         this.filtersByAction = Map.copyOf(map);
     }
 

--- a/server/src/test/java/org/elasticsearch/action/support/MappedActionFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/MappedActionFiltersTests.java
@@ -125,7 +125,7 @@ public class MappedActionFiltersTests extends ESTestCase {
 
             @Override
             public int order() {
-                return 0;
+                return 1;
             }
 
             @Override
@@ -141,7 +141,7 @@ public class MappedActionFiltersTests extends ESTestCase {
                 chain.proceed(task, action, request, listener);
             }
         };
-        var actionFilter = new MappedActionFilters(List.of(filter1, filter2));
+        var actionFilter = new MappedActionFilters(randomBoolean() ? List.of(filter1, filter2) : List.of(filter2, filter1));
 
         var chain = new ActionFilterChain<DummyRequest, DummyResponse>() {
             @Override


### PR DESCRIPTION
**Current behaviour**
`MappedActionFilter`s get executed in the order they were added to the list.

**Expected behaviour**
I thought that the `order()` would be used to sort them.

**Details**

The `ActionFilter` interface has an order method which is meant to define the ordering of a list of filters:

https://github.com/elastic/elasticsearch/blob/d6046219ba6f444ae5d4b8ed4eb8912948d38121/server/src/main/java/org/elasticsearch/action/support/ActionFilter.java#L21-L24

This used in `ActionFilters` as well to sort them:

https://github.com/elastic/elasticsearch/blob/d6046219ba6f444ae5d4b8ed4eb8912948d38121/server/src/main/java/org/elasticsearch/action/support/ActionFilters.java#L24

While working with `MappedActionFilters` I noticed that this was not respected but it was preserving the order the filters were provided. I think we should sort them here too using the `order` value and not rely on the caller to properly order them. We could argue that it is even impossible for the caller to properly order them since they are collected from multiple plugins.

https://github.com/elastic/elasticsearch/blob/d6046219ba6f444ae5d4b8ed4eb8912948d38121/server/src/main/java/org/elasticsearch/action/ActionModule.java#L796-L812

**Concerns**
I understand that this change can change the order of the filters and how they have been working so far.

Given that sorting in Java respects the existing ordering, I am speculating that as long as the `order()` of the `MappedActionFilter` returns the same value, this change will not be a breaking one. I checked all the implementations of the `MappedActionFilter` and all of them return `0`, so I do not foresee any side-effects in the way the code currently works.

Any objections?