### PR TITLE
[ML] Add start model import message

### DIFF
--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelImporter.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.ml.packageloader.action;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
@@ -19,8 +18,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.TaskCancelledException;
-import org.elasticsearch.xpack.core.common.notifications.Level;
-import org.elasticsearch.xpack.core.ml.action.AuditMlNotificationAction;
 import org.elasticsearch.xpack.core.ml.action.PutTrainedModelDefinitionPartAction;
 import org.elasticsearch.xpack.core.ml.action.PutTrainedModelVocabularyAction;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfig;
@@ -59,7 +56,7 @@ class ModelImporter {
         if (Strings.isNullOrEmpty(config.getVocabularyFile()) == false) {
             uploadVocabulary();
 
-            writeDebugNotification(modelId, format("imported model vocabulary [%s]", config.getVocabularyFile()));
+            logger.debug(() -> format("[%s] imported model vocabulary [%s]", modelId, config.getVocabularyFile()));
         }
 
         URI uri = ModelLoaderUtils.resolvePackageLocation(
@@ -151,15 +148,5 @@ class ModelImporter {
         }
 
         client.execute(action, request).actionGet();
-    }
-
-    private void writeDebugNotification(String modelId, String message) {
-        client.execute(
-            AuditMlNotificationAction.INSTANCE,
-            new AuditMlNotificationAction.Request(AuditMlNotificationAction.AuditType.INFERENCE, modelId, message, Level.INFO),
-            ActionListener.noop()
-        );
-
-        logger.debug(() -> format("[%s] %s", modelId, message));
     }
 }

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportLoadTrainedModelPackage.java
@@ -141,6 +141,8 @@ public class TransportLoadTrainedModelPackage extends TransportMasterNodeAction<
         try {
             final long relativeStartNanos = System.nanoTime();
 
+            logAndWriteNotificationAtInfo(auditClient, modelId, "starting model import");
+
             modelImporter.doImport();
 
             final long totalRuntimeNanos = System.nanoTime() - relativeStartNanos;


### PR DESCRIPTION
Adds a `[model_id] starting model import` log message and notification on model download.

The `starting model import` message replaces the `imported model vocabulary` notification. Now we will see a `starting ...` message followed by a `finished...` message instead of the confusing model vocab message

<img width="1247" alt="Screenshot 2024-04-26 at 12 42 45" src="https://github.com/elastic/elasticsearch/assets/2353640/0fbec4ef-0112-43c6-a0fd-d9f98e089b3a">

