### PR TITLE
Deprecate `writeEnum`/`readEnum`

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -1296,14 +1296,20 @@ public abstract class StreamInput extends InputStream {
 
     /**
      * Reads an enum with type E that was serialized based on the value of its ordinal
+     * @deprecated give each {@link Writeable} enum an {@code byte id} member
+     *             and serialize that
      */
+    @Deprecated
     public <E extends Enum<E>> E readEnum(Class<E> enumClass) throws IOException {
         return readEnum(enumClass, enumClass.getEnumConstants());
     }
 
     /**
      * Reads an optional enum with type E that was serialized based on the value of its ordinal
+     * @deprecated give each {@link Writeable} enum an {@code byte id} member
+     *             and serialize that
      */
+    @Deprecated
     @Nullable
     public <E extends Enum<E>> E readOptionalEnum(Class<E> enumClass) throws IOException {
         if (readBoolean()) {
@@ -1313,6 +1319,12 @@ public abstract class StreamInput extends InputStream {
         }
     }
 
+    /**
+     * Read an enum.
+     * @deprecated give each {@link Writeable} enum an {@code byte id} member
+     *             and serialize that
+     */
+    @Deprecated
     private <E extends Enum<E>> E readEnum(Class<E> enumClass, E[] values) throws IOException {
         int ordinal = readVInt();
         if (ordinal < 0 || ordinal >= values.length) {

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -1113,7 +1113,10 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes an enum with type E based on its ordinal value
+     * @deprecated give each {@link Writeable} enum an {@code byte id} member
+     *             and serialize that
      */
+    @Deprecated
     public <E extends Enum<E>> void writeEnum(E enumValue) throws IOException {
         assert enumValue instanceof XContentType == false : "XContentHelper#writeTo should be used for XContentType serialisation";
         writeVInt(enumValue.ordinal());
@@ -1121,7 +1124,10 @@ public abstract class StreamOutput extends OutputStream {
 
     /**
      * Writes an optional enum with type E based on its ordinal value
+     * @deprecated give each {@link Writeable} enum an {@code byte id} member
+     *             and serialize that
      */
+    @Deprecated
     public <E extends Enum<E>> void writeOptionalEnum(@Nullable E enumValue) throws IOException {
         if (enumValue == null) {
             writeBoolean(false);


### PR DESCRIPTION
We've been moving away from serializing java `enum`s using their ordinals for a long time because:
1. Changing the order of the enums breaks wire compatibility
2. Adding wire compatibility is difficult if the object itself doens't implement it's own serialization.
3. It's not obvious to a reader that the enum even is serialized.

I think those are the three main reasons we stopped doing this. I remember we mostly advised folks to make a `byte id` field and serialize that using method in the enum itself. That solves the problems - the presence of the `implements Writeable` and the serialization methods shows the reader that the enum does indeed go over the wire. It's an extra bunch of code, but the signal "we serialize this" is pretty darn nice.
