### PR TITLE
Remove dead code

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -2520,7 +2520,6 @@ public class AuthenticationServiceTests extends ESTestCase {
             true,
             true,
             true,
-            true,
             null,
             concreteSecurityIndexName,
             indexStatus,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/NativeRealmTests.java
@@ -37,7 +37,6 @@ public class NativeRealmTests extends ESTestCase {
             true,
             true,
             true,
-            true,
             null,
             concreteSecurityIndexName,
             indexStatus,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStoreTests.java
@@ -410,7 +410,6 @@ public class NativeRoleMappingStoreTests extends ESTestCase {
             isUpToDate,
             true,
             true,
-            true,
             null,
             concreteSecurityIndexName,
             healthStatus,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -1526,7 +1526,6 @@ public class CompositeRolesStoreTests extends ESTestCase {
             isIndexUpToDate,
             true,
             true,
-            true,
             null,
             concreteSecurityIndexName,
             healthStatus,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreTests.java
@@ -791,7 +791,6 @@ public class NativePrivilegeStoreTests extends ESTestCase {
             isIndexUpToDate,
             true,
             true,
-            true,
             null,
             concreteSecurityIndexName,
             healthStatus,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/CacheInvalidatorRegistryTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/CacheInvalidatorRegistryTests.java
@@ -60,7 +60,6 @@ public class CacheInvalidatorRegistryTests extends ESTestCase {
             true,
             true,
             true,
-            true,
             new SystemIndexDescriptor.MappingsVersion(INTERNAL_MAIN_INDEX_MAPPINGS_FORMAT, 0),
             ".security",
             ClusterHealthStatus.GREEN,


### PR DESCRIPTION
The mapping updates are no longer handled by the security index manager, instead it's now handled by `SystemIndexMappingUpdateService`. 