### PR TITLE
RestSqlIT: Attempt to fix #80089 (7.17 version)

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RestSqlTestCase.java
@@ -98,7 +98,8 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
     }
 
     @After
-    private void cleanup() throws IOException {
+    public void cleanup() throws Exception {
+        waitForPendingTasks(adminClient(), taskName -> taskName.startsWith("indices:data/read/sql/async/get"));
         try {
             deleteTestIndex();
         } catch (ResponseException e) {
@@ -1282,7 +1283,6 @@ public abstract class RestSqlTestCase extends BaseRestSqlTestCase implements Err
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/80089")
     public void testAsyncTextPaginated() throws IOException, InterruptedException {
         final Map<String, String> acceptMap = new HashMap<String, String>() {
             {


### PR DESCRIPTION
This is actually identical to https://github.com/elastic/elasticsearch/pull/107955, and could be done with an automatic back-port, but we wanted to see this running in CI independently for a bit, so I made a separate PR.
