### PR TITLE
Make MappedActionFilter its own interface

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/MappedActionFilter.java
+++ b/server/src/main/java/org/elasticsearch/action/support/MappedActionFilter.java
@@ -8,6 +8,31 @@
 
 package org.elasticsearch.action.support;
 
-public interface MappedActionFilter extends ActionFilter {
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.tasks.Task;
+
+/**
+ * An action filter that is run only for a single action.
+ *
+ * Note: This is an independent interface from {@link ActionFilter} so that it does not
+ * have an order. The relative order of executed MappedActionFilter with the same action name
+ * is undefined.
+ */
+public interface MappedActionFilter {
+    /** Return the name of the action for which this filter should be run */
     String actionName();
+
+    /**
+     * Enables filtering the execution of an action on the request side, either by sending a response through the
+     * {@link ActionListener} or by continuing the execution through the given {@link ActionFilterChain chain}
+     */
+    <Request extends ActionRequest, Response extends ActionResponse> void apply(
+        Task task,
+        String action,
+        Request request,
+        ActionListener<Response> listener,
+        ActionFilterChain<Request, Response> chain
+    );
 }

--- a/server/src/test/java/org/elasticsearch/action/support/MappedActionFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/MappedActionFiltersTests.java
@@ -60,11 +60,6 @@ public class MappedActionFiltersTests extends ESTestCase {
             }
 
             @Override
-            public int order() {
-                return 0;
-            }
-
-            @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void apply(
                 Task task,
                 String action,
@@ -101,11 +96,6 @@ public class MappedActionFiltersTests extends ESTestCase {
             }
 
             @Override
-            public int order() {
-                return 0;
-            }
-
-            @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void apply(
                 Task task,
                 String action,
@@ -121,11 +111,6 @@ public class MappedActionFiltersTests extends ESTestCase {
             @Override
             public String actionName() {
                 return "dummyAction";
-            }
-
-            @Override
-            public int order() {
-                return 0;
             }
 
             @Override
@@ -162,11 +147,6 @@ public class MappedActionFiltersTests extends ESTestCase {
             @Override
             public String actionName() {
                 return "dummyAction";
-            }
-
-            @Override
-            public int order() {
-                return 0;
             }
 
             @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
@@ -32,11 +32,6 @@ public abstract class ApiFilteringActionFilter<Res extends ActionResponse> imple
     }
 
     @Override
-    public int order() {
-        return 0;
-    }
-
-    @Override
     public final String actionName() {
         return actionName;
     }


### PR DESCRIPTION
MappedActionFilter is an ActionFilter, but it has no defined order. Yet the order method is still required to be implemented. This commit makes MappedActionFilter its own interface that does not contain order. The apply method is the exact same as ActionFilter, so it still works just as before, but there will be less confusion over whether order is required or applicable.