### PR TITLE
Adding a wait-for-status parameter to the health_report API

### DIFF
--- a/docs/changelog/107963.yaml
+++ b/docs/changelog/107963.yaml
@@ -1,0 +1,6 @@
+pr: 107963
+summary: Adding a wait-for-status parameter to the `health_report` API
+area: Health
+type: enhancement
+issues:
+ - 107796

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -1,3 +1,4 @@
+
 [[health-api]]
 === Health API
 ++++
@@ -97,6 +98,11 @@ for health status set `verbose` to `false` to disable the more expensive analysi
     As a diagnosis can return multiple types of affected resources this parameter will limit the number of resources returned for each type to the configured value (e.g. a diagnosis could return
     `1000` affected indices and `1000` affected nodes).
     Defaults to `1000`.
+
+`wait_for_status`::
+(Optional, string) One of `green`, `yellow` or `red`. Will wait until the status of
+the cluster changes to the one provided or better, i.e. `green` > `yellow` > `red`.
+By default, will not wait for any status.
 
 [role="child_attributes"]
 [[health-api-response-body]]

--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -1,4 +1,3 @@
-
 [[health-api]]
 === Health API
 ++++

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/health_report.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/health_report.json
@@ -47,6 +47,15 @@
         "type": "int",
         "description": "Limit the number of affected resources the health API returns",
         "default": 1000
+      },
+      "wait_for_status":{
+        "type":"enum",
+        "options":[
+          "green",
+          "yellow",
+          "red"
+        ],
+        "description":"Wait until cluster is in a specific state"
       }
     }
   }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -5,7 +5,8 @@
       reason: "health was added in 8.2.0, master_is_stable in 8.4.0, and REST API updated in 8.7"
 
   - do:
-      health_report: { }
+      health_report:
+        wait_for_status: green
 
   - is_true: cluster_name
   - match:   { status: "green" }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -1,8 +1,9 @@
 ---
 "cluster health basic test":
   - skip:
-      version: "- 8.6.99"
-      reason: "health was added in 8.2.0, master_is_stable in 8.4.0, and REST API updated in 8.7"
+      version: "- 8.14.99"
+      reason: "health was added in 8.2.0, master_is_stable in 8.4.0, and REST API updated in 8.7. But this was not stable until
+      wait_for_status was added in 8.15.0"
 
   - do:
       health_report:

--- a/server/src/main/java/org/elasticsearch/health/RestGetHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/health/RestGetHealthAction.java
@@ -18,6 +18,7 @@ import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
@@ -45,6 +46,10 @@ public class RestGetHealthAction extends BaseRestHandler {
         boolean verbose = request.paramAsBoolean(VERBOSE_PARAM, true);
         int size = request.paramAsInt(SIZE_PARAM, 1000);
         GetHealthAction.Request getHealthRequest = new GetHealthAction.Request(indicatorName, verbose, size);
+        String waitForStatus = request.param("wait_for_status");
+        if (waitForStatus != null) {
+            getHealthRequest.waitForStatus(HealthStatus.valueOf(waitForStatus.toUpperCase(Locale.ROOT)));
+        }
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).execute(
             GetHealthAction.INSTANCE,
             getHealthRequest,


### PR DESCRIPTION
This adds a `wait-for-status` parameter to the health_report API, much like the one already in the [cluster health API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html#cluster-health-api-query-params). This is mainly useful in integration tests, where we want to wait until the cluster is in a known state before proceeding. For a multi-node cluster it can take a little time for the health node to come up and start reporting.
Closes #107796