### PR TITLE
[Data stream lifecycle] Conditionally display effective retention

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -196,7 +197,13 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
                 builder.startObject();
                 builder.field(NAME.getPreferredName(), componentTemplate.getKey());
                 builder.field(COMPONENT_TEMPLATE.getPreferredName());
-                componentTemplate.getValue().toXContent(builder, params, rolloverConfiguration, globalRetention);
+                componentTemplate.getValue()
+                    .toXContent(
+                        builder,
+                        DataStreamLifecycle.maybeAddEffectiveRetentionParams(params),
+                        rolloverConfiguration,
+                        globalRetention
+                    );
                 builder.endObject();
             }
             builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -157,10 +158,6 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
             return indexTemplates;
         }
 
-        public RolloverConfiguration getRolloverConfiguration() {
-            return rolloverConfiguration;
-        }
-
         public DataStreamGlobalRetention getGlobalRetention() {
             return globalRetention;
         }
@@ -199,7 +196,13 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
                 builder.startObject();
                 builder.field(NAME.getPreferredName(), indexTemplate.getKey());
                 builder.field(INDEX_TEMPLATE.getPreferredName());
-                indexTemplate.getValue().toXContent(builder, params, rolloverConfiguration, globalRetention);
+                indexTemplate.getValue()
+                    .toXContent(
+                        builder,
+                        DataStreamLifecycle.maybeAddEffectiveRetentionParams(params),
+                        rolloverConfiguration,
+                        globalRetention
+                    );
                 builder.endObject();
             }
             builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -12,6 +12,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -69,20 +70,8 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
         this.globalRetention = globalRetention;
     }
 
-    public Template getResolvedTemplate() {
-        return resolvedTemplate;
-    }
-
-    public Map<String, List<String>> getOverlappingTemplates() {
-        return overlappingTemplates;
-    }
-
     public RolloverConfiguration getRolloverConfiguration() {
         return rolloverConfiguration;
-    }
-
-    public DataStreamGlobalRetention getGlobalRetention() {
-        return globalRetention;
     }
 
     public SimulateIndexTemplateResponse(StreamInput in) throws IOException {
@@ -132,7 +121,12 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
         builder.startObject();
         if (this.resolvedTemplate != null) {
             builder.field(TEMPLATE.getPreferredName());
-            this.resolvedTemplate.toXContent(builder, params, rolloverConfiguration, globalRetention);
+            this.resolvedTemplate.toXContent(
+                builder,
+                DataStreamLifecycle.maybeAddEffectiveRetentionParams(params),
+                rolloverConfiguration,
+                globalRetention
+            );
         }
         if (this.overlappingTemplates != null) {
             builder.startArray(OVERLAPPING.getPreferredName());

--- a/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/GetDataStreamAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.DataStreamAutoShardingEvent;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -546,7 +547,12 @@ public class GetDataStreamAction extends ActionType<GetDataStreamAction.Response
             builder.startObject();
             builder.startArray(DATA_STREAMS_FIELD.getPreferredName());
             for (DataStreamInfo dataStream : dataStreams) {
-                dataStream.toXContent(builder, params, rolloverConfiguration, globalRetention);
+                dataStream.toXContent(
+                    builder,
+                    DataStreamLifecycle.maybeAddEffectiveRetentionParams(params),
+                    rolloverConfiguration,
+                    globalRetention
+                );
             }
             builder.endArray();
             builder.endObject();

--- a/server/src/main/java/org/elasticsearch/action/datastreams/lifecycle/ExplainDataStreamLifecycleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/lifecycle/ExplainDataStreamLifecycleAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
+import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -212,7 +213,12 @@ public class ExplainDataStreamLifecycleAction {
                 return builder;
             }), Iterators.map(indices.iterator(), explainIndexDataLifecycle -> (builder, params) -> {
                 builder.field(explainIndexDataLifecycle.getIndex());
-                explainIndexDataLifecycle.toXContent(builder, outerParams, rolloverConfiguration, globalRetention);
+                explainIndexDataLifecycle.toXContent(
+                    builder,
+                    DataStreamLifecycle.maybeAddEffectiveRetentionParams(outerParams),
+                    rolloverConfiguration,
+                    globalRetention
+                );
                 return builder;
             }), Iterators.single((builder, params) -> {
                 builder.endObject();

--- a/server/src/main/java/org/elasticsearch/action/datastreams/lifecycle/GetDataStreamLifecycleAction.java
+++ b/server/src/main/java/org/elasticsearch/action/datastreams/lifecycle/GetDataStreamLifecycleAction.java
@@ -174,7 +174,12 @@ public class GetDataStreamLifecycleAction {
                 builder.field(NAME_FIELD.getPreferredName(), dataStreamName);
                 if (lifecycle != null) {
                     builder.field(LIFECYCLE_FIELD.getPreferredName());
-                    lifecycle.toXContent(builder, params, rolloverConfiguration, globalRetention);
+                    lifecycle.toXContent(
+                        builder,
+                        org.elasticsearch.cluster.metadata.DataStreamLifecycle.maybeAddEffectiveRetentionParams(params),
+                        rolloverConfiguration,
+                        globalRetention
+                    );
                 }
                 builder.endObject();
                 return builder;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -24,11 +24,13 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.xcontent.AbstractObjectParser;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -353,6 +355,17 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
 
     public static DataStreamLifecycle fromXContent(XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
+    }
+
+    /**
+     * Adds a retention param to signal that this serialisation should include the effective retention metadata
+     */
+    public static ToXContent.Params maybeAddEffectiveRetentionParams(ToXContent.Params params) {
+        boolean shouldAddEffectiveRetention = Objects.equals(params.param(RestRequest.PATH_RESTRICTED), "serverless");
+        return new DelegatingMapParams(
+            Map.of(INCLUDE_EFFECTIVE_RETENTION_PARAM_NAME, Boolean.toString(shouldAddEffectiveRetention)),
+            params
+        );
     }
 
     public static Builder newBuilder(DataStreamLifecycle lifecycle) {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -38,6 +39,7 @@ import java.util.stream.Stream;
 import static org.elasticsearch.cluster.metadata.DataStreamLifecycle.RetentionSource.DATA_STREAM_CONFIGURATION;
 import static org.elasticsearch.cluster.metadata.DataStreamLifecycle.RetentionSource.DEFAULT_GLOBAL_RETENTION;
 import static org.elasticsearch.cluster.metadata.DataStreamLifecycle.RetentionSource.MAX_GLOBAL_RETENTION;
+import static org.elasticsearch.rest.RestRequest.PATH_RESTRICTED;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -340,6 +342,25 @@ public class DataStreamLifecycleTests extends AbstractXContentSerializingTestCas
             );
             assertThat(effectiveDataRetentionWithSource.v1(), equalTo(maxRetentionLessThanDataStream));
             assertThat(effectiveDataRetentionWithSource.v2(), equalTo(MAX_GLOBAL_RETENTION));
+        }
+    }
+
+    public void testEffectiveRetentionParams() {
+        {
+            ToXContent.Params params = DataStreamLifecycle.maybeAddEffectiveRetentionParams(new ToXContent.MapParams(Map.of()));
+            assertThat(params.paramAsBoolean(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAM_NAME, false), equalTo(false));
+        }
+        {
+            ToXContent.Params params = DataStreamLifecycle.maybeAddEffectiveRetentionParams(
+                new ToXContent.MapParams(Map.of(PATH_RESTRICTED, "not-serverless"))
+            );
+            assertThat(params.paramAsBoolean(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAM_NAME, false), equalTo(false));
+        }
+        {
+            ToXContent.Params params = DataStreamLifecycle.maybeAddEffectiveRetentionParams(
+                new ToXContent.MapParams(Map.of(PATH_RESTRICTED, "serverless"))
+            );
+            assertThat(params.paramAsBoolean(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAM_NAME, false), equalTo(true));
         }
     }
 


### PR DESCRIPTION
While the global retention is work in progress, we would like to display the effective retention conditionally. For this reason we added an extra requirement to determine if we are going to add the field in `XContent` serialisation.

A sample yaml test for this could be:
```
---
"Get effective retention from component template":

  - do:
      cluster.put_component_template:
        name: test-component-template
        body:
          template:
            lifecycle:
              data_retention: "10d"
  - is_true: acknowledged

  - do:
      cluster.get_component_template:
        name: test-component-template
  - match: { component_templates.0.component_template.template.lifecycle.effective_retention: "10d" }
  - match: { component_templates.0.component_template.template.lifecycle.retention_determined_by: "data_stream_configuration" }

---
"Get effective retention from index template":

  - do:
      indices.put_index_template:
        name: test-composable-template
        body:
          index_patterns: "my-data-stream"
          template:
            lifecycle:
              data_retention: "10d"
          data_stream: {}
  - is_true: acknowledged

  - do:
      indices.get_index_template:
        name: test-composable-template
  - match: {index_templates.0.index_template.template.lifecycle.effective_retention: "10d"}
  - match: {index_templates.0.index_template.template.lifecycle.retention_determined_by: "data_stream_configuration"}

---
"Get effective retention from data stream":
  - do:
      indices.put_index_template:
        name: ds-template
        body:
          index_patterns: "my-data-stream"
          template:
            lifecycle:
              data_retention: 10d
          data_stream: { }
  - is_true: acknowledged

  - do:
      indices.create_data_stream:
        name: my-data-stream
  - is_true: acknowledged

  - do:
      indices.get_data_lifecycle:
        name: "my-data-stream"

  - match: { data_streams.0.lifecycle.effective_retention: "10d" }
  - match: { data_streams.0.lifecycle.retention_determined_by: "data_stream_configuration" }

  - do:
      indices.get_data_stream:
        name: "my-data-stream"

  - match: { data_streams.0.lifecycle.effective_retention:  "10d" }
  - match: { data_streams.0.lifecycle.retention_determined_by: "data_stream_configuration" }

---
"Get effective retention from simulating index template":

  - do:
      indices.put_index_template:
        name: test
        body:
          index_patterns: te*
          template:
            lifecycle:
              data_retention: "10d"
          data_stream: {}
  - do:
      indices.simulate_index_template:
        name: test

  - match: {template.lifecycle.effective_retention: "10d"}
  - match: {template.lifecycle.retention_determined_by: "data_stream_configuration"}

```