### PR TITLE
Sort time series indices by time range in GetDataStreams API

### DIFF
--- a/docs/changelog/107967.yaml
+++ b/docs/changelog/107967.yaml
@@ -1,0 +1,6 @@
+pr: 107967
+summary: Sort time series indices by time range in `GetDataStreams` API
+area: TSDB
+type: bug
+issues:
+ - 102088

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
@@ -151,46 +151,64 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
 
             GetDataStreamAction.Response.TimeSeries timeSeries = null;
             if (dataStream.getIndexMode() == IndexMode.TIME_SERIES) {
-                List<Tuple<Instant, Instant>> ranges = new ArrayList<>();
-                Tuple<Instant, Instant> current = null;
-                String previousIndexName = null;
-                for (Index index : dataStream.getIndices()) {
-                    IndexMetadata indexMetadata = metadata.index(index);
-                    if (indexMetadata.getIndexMode() != IndexMode.TIME_SERIES) {
-                        continue;
+                record IndexInfo(String name, Instant timeSeriesStart, Instant timeSeriesEnd) implements Comparable<IndexInfo> {
+                    @Override
+                    public int compareTo(IndexInfo o) {
+                        return Comparator
+                            .comparing(IndexInfo::timeSeriesStart)
+                            .thenComparing(IndexInfo::timeSeriesEnd)
+                            .compare(this, o);
                     }
-                    Instant start = indexMetadata.getTimeSeriesStart();
-                    Instant end = indexMetadata.getTimeSeriesEnd();
-                    if (current == null) {
-                        current = new Tuple<>(start, end);
-                    } else if (current.v2().compareTo(start) == 0) {
-                        current = new Tuple<>(current.v1(), end);
-                    } else if (current.v2().compareTo(start) < 0) {
-                        ranges.add(current);
-                        current = new Tuple<>(start, end);
+                }
+
+                List<Tuple<Instant, Instant>> mergedRanges = new ArrayList<>();
+                Tuple<Instant, Instant> currentMergedRange = null;
+                IndexInfo previous = null;
+
+                // We need indices to be sorted by time series range
+                // to produce temporal ranges.
+                // But it is not enforced in API, so we explicitly sort here.
+                var sortedRanges = dataStream.getIndices().stream()
+                    .map(metadata::index)
+                    .filter(m -> m.getIndexMode() == IndexMode.TIME_SERIES)
+                    .map(m -> new IndexInfo(m.getIndex().getName(), m.getTimeSeriesStart(), m.getTimeSeriesEnd()))
+                    .sorted()
+                    .toList();
+
+                for (var info : sortedRanges) {
+                    Instant start = info.timeSeriesStart();
+                    Instant end = info.timeSeriesEnd();
+
+                    if (currentMergedRange == null) {
+                        currentMergedRange = new Tuple<>(start, end);
+                    } else if (currentMergedRange.v2().compareTo(start) == 0) {
+                        currentMergedRange = new Tuple<>(currentMergedRange.v1(), end);
+                    } else if (currentMergedRange.v2().compareTo(start) < 0) {
+                        mergedRanges.add(currentMergedRange);
+                        currentMergedRange = new Tuple<>(start, end);
                     } else {
                         String message = "previous backing index ["
-                            + previousIndexName
+                            + previous.name()
                             + "] range ["
-                            + current.v1()
+                            + previous.timeSeriesStart()
                             + "/"
-                            + current.v2()
+                            + previous.timeSeriesEnd()
                             + "] range is colliding with current backing ["
-                            + index.getName()
+                            + info.name()
                             + "] index range ["
                             + start
                             + "/"
                             + end
                             + "]";
-                        assert current.v2().compareTo(start) < 0 : message;
+                        assert currentMergedRange.v2().compareTo(start) < 0 : message;
                         LOGGER.warn(message);
                     }
-                    previousIndexName = index.getName();
+                    previous = info;
                 }
-                if (current != null) {
-                    ranges.add(current);
+                if (currentMergedRange != null) {
+                    mergedRanges.add(currentMergedRange);
                 }
-                timeSeries = new GetDataStreamAction.Response.TimeSeries(ranges);
+                timeSeries = new GetDataStreamAction.Response.TimeSeries(mergedRanges);
             }
 
             dataStreamInfos.add(

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
@@ -154,10 +154,7 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
                 record IndexInfo(String name, Instant timeSeriesStart, Instant timeSeriesEnd) implements Comparable<IndexInfo> {
                     @Override
                     public int compareTo(IndexInfo o) {
-                        return Comparator
-                            .comparing(IndexInfo::timeSeriesStart)
-                            .thenComparing(IndexInfo::timeSeriesEnd)
-                            .compare(this, o);
+                        return Comparator.comparing(IndexInfo::timeSeriesStart).thenComparing(IndexInfo::timeSeriesEnd).compare(this, o);
                     }
                 }
 
@@ -168,7 +165,8 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
                 // We need indices to be sorted by time series range
                 // to produce temporal ranges.
                 // But it is not enforced in API, so we explicitly sort here.
-                var sortedRanges = dataStream.getIndices().stream()
+                var sortedRanges = dataStream.getIndices()
+                    .stream()
                     .map(metadata::index)
                     .filter(m -> m.getIndexMode() == IndexMode.TIME_SERIES)
                     .map(m -> new IndexInfo(m.getIndex().getName(), m.getTimeSeriesStart(), m.getTimeSeriesEnd()))

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
@@ -199,7 +199,6 @@ public class GetDataStreamsTransportAction extends TransportMasterNodeReadAction
                             + end
                             + "]";
                         assert currentMergedRange.v2().compareTo(start) < 0 : message;
-                        LOGGER.warn(message);
                     }
                     previous = info;
                 }


### PR DESCRIPTION
Previously this logic assumed that time series indices are sorted by their time series range. This is problematic because data stream APIs don't actually enforce this invariant. As seen in below issues it is possible to add an index to data stream that will break the sort order either manually or via DSL.

This PR simply sorts indices in needed order before working with them. It seems appropriate given that this API is not performance sensitive.

Closes #102088, #106890.