### PR TITLE
[Docs] Add warning of incomplete Kibana support to nested fields

### DIFF
--- a/docs/reference/mapping/types/nested.asciidoc
+++ b/docs/reference/mapping/types/nested.asciidoc
@@ -11,6 +11,8 @@ independently of each other.
 TIP: When ingesting key-value pairs with a large, arbitrary set of keys, you might consider modeling each key-value pair as its own nested document with `key` and `value` fields. Instead, consider using the <<flattened,flattened>> data type, which maps an entire object as a single field and allows for simple searches over its contents.
 Nested documents and queries are typically expensive, so using the `flattened` data type for this use case is a better option.
 
+WARNING: Nested fields have incomplete support in Kibana. While they are visible and searchable in Discover, they cannot be used to build visualizations in Lens.
+
 [[nested-arrays-flattening-objects]]
 ==== How arrays of objects are flattened
 


### PR DESCRIPTION
Adds a warning to the docs of nested fields to indicate incomplete Kibana support.

This is a long standing limitation (https://github.com/elastic/kibana/issues/1084). 

It would be useful to warn users of this gap in support _before_ they are starting to model their data.