### PR TITLE
[logstash bridge]: bootstrap

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,9 @@ x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/Monito
 x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet @elastic/fleet
 x-pack/plugin/core/src/main/resources/fleet-* @elastic/fleet
 
+# Logstash
+libs/logstash-bridge @elastic/logstash
+
 # Kibana Security
 x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java @elastic/kibana-security
 

--- a/docs/changelog/107973.yaml
+++ b/docs/changelog/107973.yaml
@@ -1,0 +1,5 @@
+pr: 107973
+summary: "[logstash bridge]: bootstrap"
+area: Infra/Core
+type: enhancement
+issues: []

--- a/libs/logstash-bridge/README.md
+++ b/libs/logstash-bridge/README.md
@@ -1,0 +1,5 @@
+## Logstash Bridge
+
+This package contains bridge functionality and API-stability tests to ensure that Logstash's Elastic Integration plugin has access to the minimal subset of Elasticsearch to perform its functions.
+
+If a change is introduced in a separate project that causes this project to fail, please consult with members of @elastic/logstash to chart a path forward.

--- a/libs/logstash-bridge/build.gradle
+++ b/libs/logstash-bridge/build.gradle
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+apply plugin: 'elasticsearch.build'
+
+dependencies {
+  compileOnly project(':server')
+  compileOnly project(':modules:lang-painless')
+  compileOnly project(':modules:lang-painless:spi')
+
+  testImplementation(project(":test:framework")) {
+    exclude group: 'org.elasticsearch', module: 'logstashbridge'
+  }
+}
+
+tasks.named('forbiddenApisMain').configure {
+  replaceSignatureFiles 'jdk-signatures'
+}

--- a/libs/logstash-bridge/src/main/java/module-info.java
+++ b/libs/logstash-bridge/src/main/java/module-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/** Elasticsearch Logstash Bridge. */
+module org.elasticsearch.logstashbridge {
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.grok;
+    requires org.elasticsearch.server;
+    requires org.elasticsearch.painless;
+    requires org.elasticsearch.painless.spi;
+
+    exports org.elasticsearch.logstashbridge;
+}

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/EnvBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/EnvBridge.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+
+import java.nio.file.Path;
+
+public class EnvBridge {
+    private EnvBridge() {}
+
+    public static Environment newEnvironment(final Settings settings, Path configPath) {
+        return new Environment(settings, configPath);
+    }
+}

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/IngestBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/IngestBridge.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.grok.MatcherWatchdog;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.IngestService;
+import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.script.IngestConditionalScript;
+import org.elasticsearch.script.IngestScript;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+
+public class IngestBridge {
+    private IngestBridge() {}
+
+    public static Processor.Parameters newProcessorParameters(
+        final Environment environment,
+        final ScriptService scriptService,
+        final ThreadContext threadContext,
+        final LongSupplier relativeTimeSupplier,
+        final BiFunction<Long, Runnable, Scheduler.ScheduledCancellable> scheduler,
+        final Consumer<Runnable> genericExecutor,
+        final MatcherWatchdog matcherWatchdog
+    ) {
+        return new Processor.Parameters(
+            environment,
+            scriptService,
+            null,
+            threadContext,
+            relativeTimeSupplier,
+            scheduler,
+            null,
+            null,
+            genericExecutor,
+            matcherWatchdog
+        );
+    }
+
+    public static IngestDocument newIngestDocument(Map<String, Object> sourceAndMetadata, Map<String, Object> ingestMetadata) {
+        return new IngestDocument(sourceAndMetadata, ingestMetadata);
+    }
+
+    public ScriptContext<IngestConditionalScript.Factory> ingestConditionalScriptContext() {
+        return IngestConditionalScript.CONTEXT;
+    }
+
+    public ScriptContext<IngestScript.Factory> ingestScriptContext() {
+        return IngestScript.CONTEXT;
+    }
+
+    public static MatcherWatchdog createGrokThreadWatchdog(Environment environment, ThreadPool threadPool) {
+        return IngestService.createGrokThreadWatchdog(environment, threadPool);
+    }
+}

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/LogstashBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/LogstashBridge.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+public class LogstashBridge {
+    private LogstashBridge() {};
+}

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/PainlessPluginBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/PainlessPluginBridge.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.painless.PainlessPlugin;
+import org.elasticsearch.painless.PainlessScriptEngine;
+import org.elasticsearch.painless.spi.Whitelist;
+import org.elasticsearch.script.ScriptContext;
+
+import java.util.List;
+import java.util.Map;
+
+public class PainlessPluginBridge {
+    private PainlessPluginBridge() {}
+
+    public String painlessScriptEngineName() {
+        return PainlessScriptEngine.NAME;
+    }
+
+    public PainlessScriptEngine newPainlessScriptEngine(Settings settings, Map<ScriptContext<?>, List<Whitelist>> contexts) {
+        return new PainlessScriptEngine(settings, contexts);
+    }
+
+    public static List<Whitelist> getPainlessPluginBaseWhitelist() {
+        return List.copyOf(PainlessPlugin.baseWhiteList());
+    }
+}

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ScriptBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ScriptBridge.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.script.ScriptContext;
+import org.elasticsearch.script.ScriptEngine;
+import org.elasticsearch.script.ScriptModule;
+import org.elasticsearch.script.ScriptService;
+
+import java.util.Map;
+import java.util.function.LongSupplier;
+
+public class ScriptBridge {
+    private ScriptBridge() {}
+
+    public static ScriptService newScriptService(
+        Settings settings,
+        Map<String, ScriptEngine> engines,
+        Map<String, ScriptContext<?>> contexts,
+        LongSupplier timeProvider
+    ) {
+        return new ScriptService(settings, engines, contexts, timeProvider);
+    }
+
+    public static Map<String, ScriptContext<?>> coreScriptContexts() {
+        return Map.copyOf(ScriptModule.CORE_CONTEXTS);
+    }
+}

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ThreadPoolBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ThreadPoolBridge.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.threadpool.ThreadPool;
+
+class ThreadPoolBridge {
+    private ThreadPoolBridge() {}
+
+    public static ThreadPool createThreadPool(Settings settings) {
+        return new ThreadPool(settings, MeterRegistry.NOOP);
+    }
+
+}

--- a/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/CoreBridgeTests.java
+++ b/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/CoreBridgeTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.Closeable;
+
+import static org.elasticsearch.logstashbridge.DucktypeMatchers.instancesQuackLike;
+import static org.elasticsearch.logstashbridge.DucktypeMatchers.staticallyQuacksLike;
+
+public class CoreBridgeTests extends ESTestCase {
+
+    public void testTimeValueAPIStability() {
+        interface TimeValueStaticAPI {
+            TimeValue timeValueMillis(long millis);
+        }
+        assertThat(TimeValue.class, staticallyQuacksLike(TimeValueStaticAPI.class));
+    }
+
+    public void testIOUtilsAPIStability() {
+        interface IOUtilsStaticAPI {
+            void closeWhileHandlingException(Iterable<? extends Closeable> objects);
+
+            void closeWhileHandlingException(Closeable closeable);
+        }
+        assertThat(IOUtils.class, staticallyQuacksLike(IOUtilsStaticAPI.class));
+    }
+
+    public void testStringsAPIStability() {
+        interface StringsStaticAPI {
+            String format(String format, Object... args);
+        }
+        assertThat(Strings.class, staticallyQuacksLike(StringsStaticAPI.class));
+    }
+
+    public void testReleasableAPIStability() {
+        interface ReleasableInstanceAPI {
+            void close();
+        }
+        assertThat(Releasable.class, instancesQuackLike(ReleasableInstanceAPI.class));
+    }
+}

--- a/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/DucktypeMatchers.java
+++ b/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/DucktypeMatchers.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+public class DucktypeMatchers {
+    static QuacksLikeMatcher<Class<?>> instancesQuackLike(final Class<?> ducktypeInterface) {
+        return new QuacksLikeMatcher<>(ducktypeInterface, Function.identity(), false);
+    }
+
+    static QuacksLikeMatcher<Class<?>> staticallyQuacksLike(final Class<?> ducktypeInterface) {
+        return new QuacksLikeMatcher<>(ducktypeInterface, Function.identity(), true);
+    }
+
+    static <T> QuacksLikeMatcher<T> quacksLike(final Class<?> ducktypeInterface) {
+        return new QuacksLikeMatcher<>(ducktypeInterface, T::getClass, false);
+    }
+
+    private static class QuacksLikeMatcher<T> extends TypeSafeMatcher<T> {
+        private final Class<?> ducktypeInterface;
+        private final Function<T, Class<?>> getClass;
+        private final boolean matchStaticMethods;
+
+        QuacksLikeMatcher(Class<?> ducktypeInterface, Function<T, Class<?>> getClass, boolean matchStaticMethods) {
+            assert ducktypeInterface.isInterface() : ducktypeInterface + " is not an interface";
+            assert ducktypeInterface.getInterfaces().length == 0 : ducktypeInterface + " must not extend other interfaces";
+            this.ducktypeInterface = ducktypeInterface;
+            this.getClass = getClass;
+            this.matchStaticMethods = matchStaticMethods;
+        }
+
+        @Override
+        protected boolean matchesSafely(T candidate) {
+            return findMissingMethods(getClass.apply(candidate)).isEmpty();
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            if (matchStaticMethods) {
+                description.appendText("statically ");
+            }
+            description.appendText("quack like ");
+            description.appendText(ducktypeInterface.getName());
+        }
+
+        @Override
+        protected void describeMismatchSafely(T candidate, Description mismatchDescription) {
+            mismatchDescription.appendValueList("missing implementations (", ", ", ")", findMissingMethods(getClass.apply(candidate)));
+        }
+
+        private Set<Method> findMissingMethods(Class<?> candidate) {
+            final Set<Method> missingMethods = new HashSet<>();
+            for (Method method : ducktypeInterface.getMethods()) {
+                try {
+                    Method candidateMethod = candidate.getMethod(method.getName(), method.getParameterTypes());
+                    if (Modifier.isStatic(candidateMethod.getModifiers()) != matchStaticMethods) {
+                        missingMethods.add(method);
+                    }
+                } catch (NoSuchMethodException e) {
+                    missingMethods.add(method);
+                }
+            }
+            return Set.copyOf(missingMethods);
+        }
+    }
+}

--- a/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/IngestBridgeTests.java
+++ b/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/IngestBridgeTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Pipeline;
+import org.elasticsearch.ingest.ValueSource;
+import org.elasticsearch.script.Metadata;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.script.TemplateScript;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import static org.elasticsearch.logstashbridge.DucktypeMatchers.instancesQuackLike;
+import static org.elasticsearch.logstashbridge.DucktypeMatchers.staticallyQuacksLike;
+
+public class IngestBridgeTests extends ESTestCase {
+
+    public void testIngestDocumentAPIStability() throws Exception {
+        interface IngestDocumentInstanceAPI {
+            Metadata getMetadata();
+
+            boolean updateIndexHistory(String index);
+
+            Set<String> getIndexHistory();
+
+            Map<String, Object> getIngestMetadata();
+
+            <T> T getFieldValue(String fieldName, Class<T> type);
+
+            String renderTemplate(TemplateScript.Factory tf);
+
+            void setFieldValue(String fieldName, ValueSource valueSource);
+
+            void removeField(String fieldName);
+
+            void executePipeline(Pipeline pipeline, BiConsumer<IngestDocument, Exception> handler);
+        }
+
+        assertThat(IngestDocument.class, instancesQuackLike(IngestDocumentInstanceAPI.class));
+    }
+
+    public void testConfigurationUtilsAPIStability() throws Exception {
+        interface ConfigurationUtilsStaticAPI {
+            boolean readBooleanProperty(String pType, String pTag, Map<String, Object> config, String propertyName, boolean defaultValue);
+
+            String readStringProperty(String pType, String pTag, Map<String, Object> config, String propertyName, String defaultValue);
+
+            TemplateScript.Factory compileTemplate(
+                String pType,
+                String pTag,
+                String propertyName,
+                String propertyValue,
+                ScriptService scriptService
+            );
+        }
+
+        assertThat(ConfigurationUtils.class, staticallyQuacksLike(ConfigurationUtilsStaticAPI.class));
+    }
+}

--- a/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/ScriptBridgeTests.java
+++ b/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/ScriptBridgeTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.script.Metadata;
+import org.elasticsearch.test.ESTestCase;
+
+import java.time.ZonedDateTime;
+
+import static org.elasticsearch.logstashbridge.DucktypeMatchers.instancesQuackLike;
+
+public class ScriptBridgeTests extends ESTestCase {
+
+    public void testMetadataAPIStability() {
+        interface MetadataInstanceAPI {
+            ZonedDateTime getNow();
+
+            String getIndex();
+
+            void setIndex(String index);
+
+            String getId();
+
+            void setId(String id);
+
+            long getVersion();
+
+            void setVersion(long version);
+
+            String getVersionType();
+
+            void setVersionType(String versionType);
+
+            String getRouting();
+
+            void setRouting(String routing);
+        }
+        assertThat(Metadata.class, instancesQuackLike(MetadataInstanceAPI.class));
+    }
+}

--- a/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/ThreadPoolBridgeTests.java
+++ b/libs/logstash-bridge/src/test/java/org/elasticsearch/logstashbridge/ThreadPoolBridgeTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.logstashbridge;
+
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.Scheduler;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.logstashbridge.DucktypeMatchers.instancesQuackLike;
+import static org.elasticsearch.logstashbridge.DucktypeMatchers.staticallyQuacksLike;
+
+public class ThreadPoolBridgeTests extends ESTestCase {
+
+    public void testThreadPoolAPIStability() throws Exception {
+        interface ThreadPoolInstanceAPI {
+            long relativeTimeInMillis();
+
+            long absoluteTimeInMillis();
+
+            ThreadContext getThreadContext();
+
+            Scheduler.ScheduledCancellable schedule(Runnable command, TimeValue delay, Executor executor);
+
+            ExecutorService generic();
+        }
+        assertThat(ThreadPool.class, instancesQuackLike(ThreadPoolInstanceAPI.class));
+
+        interface ThreadPoolStaticAPI {
+            boolean terminate(ThreadPool pool, long timeout, TimeUnit timeUnit);
+        }
+        assertThat(ThreadPool.class, staticallyQuacksLike(ThreadPoolStaticAPI.class));
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -221,6 +221,7 @@ public class BootstrapForTesting {
         addClassCodebase(codebases, "elasticsearch-cli", "org.elasticsearch.cli.Command");
         addClassCodebase(codebases, "elasticsearch-preallocate", "org.elasticsearch.preallocate.Preallocate");
         addClassCodebase(codebases, "elasticsearch-vec", "org.elasticsearch.vec.VectorScorer");
+        addClassCodebase(codebases, "elasticsearch-logstash-bridge", "org.elasticsearch.logstashbridge.LogstashBridge");
         addClassCodebase(codebases, "framework", "org.elasticsearch.test.ESTestCase");
         return codebases;
     }


### PR DESCRIPTION
Adds a new `logstash-bridge` project in `/libs` that:
 - publishes bridge methods for accessing various constructors, static functions, and static fields that are required by Logstash's Elastic Integration Filter (these are _not_ a part of the distributed artifact; the LS plugin will build and use directly)
 - adds "duck type" interface validation tests to ensure that the object methods that Logstash's Elastic Integration Filter rely on maintain a stable API.

## TODO:

 - [ ] hook `:libs:elasticsearch-logstash-bridge:test` into the build/CI, so that when someone breaks an API Logstash relies on we have direct feedback.
 - [ ] map codeowners to a public team
