### PR TITLE
Encapsulate IndexShard/IndexService closing in tests

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.index.shard.IndexShardTestCase.closeShardNoCheck;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
@@ -260,7 +261,7 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
                                 IndexShard indexShard = indicesService.getShardOrNull(shardId);
                                 assertNotNull("No shard found for shard " + shardId, indexShard);
                                 logger.info("--> failing shard {} on node {}", shardRequest.shardId(), node);
-                                indexShard.close("test", randomBoolean());
+                                closeShardNoCheck(indexShard, randomBoolean());
                                 failedShards.incrementAndGet();
                             } else {
                                 successfulShards.incrementAndGet();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/GlobalCheckpointListenersIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/GlobalCheckpointListenersIT.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.index.seqno.SequenceNumbers.NO_OPS_PERFORMED;
 import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+import static org.elasticsearch.index.shard.IndexShardTestCase.closeShardNoCheck;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -101,7 +102,7 @@ public class GlobalCheckpointListenersIT extends ESSingleNodeTestCase {
             }
 
         }, null);
-        shard.close("closed", randomBoolean());
+        closeShardNoCheck(shard, randomBoolean());
         assertBusy(() -> assertTrue(invoked.get()));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -93,6 +93,7 @@ import static java.util.Collections.emptySet;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.elasticsearch.action.support.WriteRequest.RefreshPolicy.NONE;
 import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBuilder;
+import static org.elasticsearch.index.shard.IndexShardTestCase.closeShardNoCheck;
 import static org.elasticsearch.index.shard.IndexShardTestCase.getTranslog;
 import static org.elasticsearch.index.shard.IndexShardTestCase.recoverFromStore;
 import static org.elasticsearch.test.LambdaMatchers.falseWith;
@@ -545,7 +546,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         prepareIndex("test").setId("1").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).setRefreshPolicy(IMMEDIATE).get();
 
         CheckedFunction<DirectoryReader, DirectoryReader, IOException> wrapper = directoryReader -> directoryReader;
-        shard.close("simon says", false);
+        closeShardNoCheck(shard);
         AtomicReference<IndexShard> shardRef = new AtomicReference<>();
         List<Exception> failures = new ArrayList<>();
         IndexingOperationListener listener = new IndexingOperationListener() {
@@ -583,7 +584,7 @@ public class IndexShardIT extends ESSingleNodeTestCase {
         try {
             ExceptionsHelper.rethrowAndSuppress(failures);
         } finally {
-            newShard.close("just do it", randomBoolean());
+            closeShardNoCheck(newShard, randomBoolean());
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -83,6 +83,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.action.support.ActionTestUtils.wrapAsRestResponseListener;
+import static org.elasticsearch.index.shard.IndexShardTestCase.closeShardNoCheck;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.array;
@@ -526,7 +527,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         for (IndexService indexService : indicesService) {
             for (IndexShard indexShard : indexService) {
                 if (randomBoolean()) {
-                    indexShard.close("test", randomBoolean());
+                    closeShardNoCheck(indexShard, randomBoolean());
                 } else if (randomBoolean()) {
                     final ShardId shardId = indexShard.shardId();
                     final String[] nodeNames = internalCluster().getNodeNames();

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -113,6 +113,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.index.IndexService.IndexCreationContext.CREATE_INDEX;
+import static org.elasticsearch.index.IndexServiceTests.closeIndexService;
+import static org.elasticsearch.index.shard.IndexShardTestCase.flushAndCloseShardNoCheck;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -240,7 +242,7 @@ public class IndexModuleTests extends ESTestCase {
         IndexService indexService = newIndexService(module);
         assertTrue(indexService.getReaderWrapper() instanceof Wrapper);
         assertSame(indexService.getEngineFactory(), module.getEngineFactory());
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testRegisterIndexStore() throws IOException {
@@ -265,7 +267,7 @@ public class IndexModuleTests extends ESTestCase {
         final IndexService indexService = newIndexService(module);
         assertThat(indexService.getDirectoryFactory(), instanceOf(FooFunction.class));
 
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testDirectoryWrapper() throws IOException {
@@ -311,7 +313,7 @@ public class IndexModuleTests extends ESTestCase {
         assertThat(((WrappedDirectory) directory).shardRouting, sameInstance(shardRouting));
         assertThat(directory, instanceOf(FilterDirectory.class));
 
-        indexService.close("test done", false);
+        closeIndexService(indexService);
     }
 
     public void testOtherServiceBound() throws IOException {
@@ -331,7 +333,7 @@ public class IndexModuleTests extends ESTestCase {
         assertEquals(x.getIndex(), index);
         indexService.getIndexEventListener().beforeIndexRemoved(null, null);
         assertTrue(atomicBoolean.get());
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testListener() throws IOException {
@@ -352,7 +354,7 @@ public class IndexModuleTests extends ESTestCase {
         IndexService indexService = newIndexService(module);
         assertSame(booleanSetting, indexService.getIndexSettings().getScopedSettings().get(booleanSetting.getKey()));
 
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testAddIndexOperationListener() throws IOException {
@@ -383,7 +385,7 @@ public class IndexModuleTests extends ESTestCase {
             l.preIndex(shardId, index);
         }
         assertTrue(executed.get());
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testAddSearchOperationListener() throws IOException {
@@ -409,7 +411,7 @@ public class IndexModuleTests extends ESTestCase {
             l.onNewReaderContext(mock(ReaderContext.class));
         }
         assertTrue(executed.get());
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testAddSimilarity() throws IOException {
@@ -435,7 +437,7 @@ public class IndexModuleTests extends ESTestCase {
         assertThat(similarity, Matchers.instanceOf(TestSimilarity.class));
         assertEquals("my_similarity", similarityService.getSimilarity("my_similarity").name());
         assertEquals("there is a key", ((TestSimilarity) similarity).key);
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testFrozen() {
@@ -496,7 +498,7 @@ public class IndexModuleTests extends ESTestCase {
         );
         IndexService indexService = newIndexService(module);
         assertTrue(indexService.cache().query() instanceof CustomQueryCache);
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
         assertThat(liveQueryCaches, empty());
     }
 
@@ -509,7 +511,7 @@ public class IndexModuleTests extends ESTestCase {
         IndexModule module = createIndexModule(indexSettings, emptyAnalysisRegistry, indexNameExpressionResolver);
         IndexService indexService = newIndexService(module);
         assertTrue(indexService.cache().query() instanceof IndexQueryCache);
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testDisableQueryCacheHasPrecedenceOverForceQueryCache() throws IOException {
@@ -523,7 +525,7 @@ public class IndexModuleTests extends ESTestCase {
         module.forceQueryCacheProvider((a, b) -> new CustomQueryCache(null));
         IndexService indexService = newIndexService(module);
         assertTrue(indexService.cache().query() instanceof DisabledQueryCache);
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
     }
 
     public void testCustomQueryCacheCleanedUpIfIndexServiceCreationFails() {
@@ -644,7 +646,7 @@ public class IndexModuleTests extends ESTestCase {
 
         assertThat(indexService.createRecoveryState(shard, mock(DiscoveryNode.class), mock(DiscoveryNode.class)), is(recoveryState));
 
-        indexService.close("closing", false);
+        closeIndexService(indexService);
     }
 
     public void testIndexCommitListenerIsBound() throws IOException, ExecutionException, InterruptedException {
@@ -694,10 +696,10 @@ public class IndexModuleTests extends ESTestCase {
             ).initialize("_node_id", null, -1);
 
             IndexService indexService = newIndexService(module);
-            closeables.add(() -> indexService.close("close index service at end of test", false));
+            closeables.add(() -> closeIndexService(indexService));
 
             IndexShard indexShard = indexService.createShard(shardRouting, IndexShardTestCase.NOOP_GCP_SYNCER, RetentionLeaseSyncer.EMPTY);
-            closeables.add(() -> indexShard.close("close shard at end of test", true));
+            closeables.add(() -> flushAndCloseShardNoCheck(indexShard));
             indexShard.markAsRecovering("test", new RecoveryState(shardRouting, DiscoveryNodeUtils.create("_node_id", "_node_id"), null));
 
             final PlainActionFuture<Boolean> recoveryFuture = new PlainActionFuture<>();

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -145,7 +145,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertFalse(task.isClosed());
         assertTrue(task.isScheduled());
 
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
         assertFalse("no shards left", task.mustReschedule());
         assertTrue(task.isScheduled());
         task.close();
@@ -222,7 +222,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertTrue(refreshTask.isScheduled());
         assertFalse(refreshTask.isClosed());
 
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
         assertFalse(refreshTask.isScheduled());
         assertTrue(refreshTask.isClosed());
     }
@@ -260,7 +260,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertTrue(fsyncTask.isScheduled());
         assertFalse(fsyncTask.isClosed());
 
-        indexService.close("simon says", false);
+        closeIndexService(indexService);
         assertFalse(fsyncTask.isScheduled());
         assertTrue(fsyncTask.isClosed());
 
@@ -458,5 +458,9 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
             .get();
         indexMetadata = clusterAdmin().prepareState().get().getState().metadata().index("test");
         assertEquals("20s", indexMetadata.getSettings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
+    }
+
+    public static void closeIndexService(IndexService indexService) throws IOException {
+        indexService.close("IndexServiceTests#closeIndexService", false);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineRecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/NoOpEngineRecoveryTests.java
@@ -26,7 +26,7 @@ public class NoOpEngineRecoveryTests extends IndexShardTestCase {
         for (int i = 0; i < nbDocs; i++) {
             indexDoc(indexShard, "_doc", String.valueOf(i));
         }
-        indexShard.close("test", true);
+        flushAndCloseShardNoCheck(indexShard);
 
         final ShardRouting shardRouting = indexShard.routingEntry();
         IndexShard primary = reinitShard(

--- a/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/RecoveryDuringReplicationTests.java
@@ -134,10 +134,10 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
                 new SourceToParse("replica", new BytesArray("{}"), XContentType.JSON)
             );
             shards.promoteReplicaToPrimary(promotedReplica).get();
-            oldPrimary.close("demoted", randomBoolean());
+            closeShardNoCheck(oldPrimary, randomBoolean());
             oldPrimary.store().close();
             shards.removeReplica(remainingReplica);
-            remainingReplica.close("disconnected", false);
+            closeShardNoCheck(remainingReplica);
             remainingReplica.store().close();
             // randomly introduce a conflicting document
             final boolean extra = randomBoolean();
@@ -260,7 +260,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
                 newPrimary.flush(new FlushRequest());
             }
 
-            oldPrimary.close("demoted", false);
+            closeShardNoCheck(oldPrimary);
             oldPrimary.store().close();
 
             IndexShard newReplica = shards.addReplicaWithExistingPath(oldPrimary.shardPath(), oldPrimary.routingEntry().currentNodeId());
@@ -306,7 +306,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
             shards.promoteReplicaToPrimary(newPrimary).get();
             // Recover a replica should rollback the stale documents
             shards.removeReplica(replica);
-            replica.close("recover replica - first time", false);
+            closeShardNoCheck(replica);
             replica.store().close();
             replica = shards.addReplicaWithExistingPath(replica.shardPath(), replica.routingEntry().currentNodeId());
             shards.recoverReplica(replica);
@@ -317,7 +317,7 @@ public class RecoveryDuringReplicationTests extends ESIndexLevelReplicationTestC
             assertThat(replica.getLastSyncedGlobalCheckpoint(), equalTo(replica.seqNoStats().getMaxSeqNo()));
             // Recover a replica again should also rollback the stale documents.
             shards.removeReplica(replica);
-            replica.close("recover replica - second time", false);
+            closeShardNoCheck(replica);
             replica.store().close();
             IndexShard anotherReplica = shards.addReplicaWithExistingPath(replica.shardPath(), replica.routingEntry().currentNodeId());
             shards.recoverReplica(anotherReplica);

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -276,7 +276,7 @@ public class IndexShardTests extends IndexShardTestCase {
         assertNotNull(shardPath);
         // fail shard
         shard.failShard("test shard fail", new CorruptIndexException("", ""));
-        shard.close("do not assert history", false);
+        closeShardNoCheck(shard);
         shard.store().close();
         // check state file still exists
         ShardStateMetadata shardStateMetadata = load(logger, shardPath.getShardStatePath());
@@ -1477,7 +1477,7 @@ public class IndexShardTests extends IndexShardTestCase {
         snapshot = newShard.snapshotStoreMetadata();
         assertThat(snapshot.getSegmentsFile().name(), equalTo("segments_3"));
 
-        newShard.close("test", false);
+        closeShardNoCheck(newShard);
 
         snapshot = newShard.snapshotStoreMetadata();
         assertThat(snapshot.getSegmentsFile().name(), equalTo("segments_3"));
@@ -1766,7 +1766,7 @@ public class IndexShardTests extends IndexShardTestCase {
         AtomicInteger preDelete = new AtomicInteger();
         AtomicInteger postDelete = new AtomicInteger();
         AtomicInteger postDeleteException = new AtomicInteger();
-        shard.close("simon says", true);
+        flushAndCloseShardNoCheck(shard);
         shard = reinitShard(shard, new IndexingOperationListener() {
             @Override
             public Engine.Index preIndex(ShardId shardId, Engine.Index operation) {
@@ -1848,7 +1848,7 @@ public class IndexShardTests extends IndexShardTestCase {
         assertEquals(1, postDelete.get());
         assertEquals(0, postDeleteException.get());
 
-        shard.close("Unexpected close", true);
+        closeShardNoCheck(shard);
         shard.state = IndexShardState.STARTED; // It will generate exception
 
         try {
@@ -4372,7 +4372,7 @@ public class IndexShardTests extends IndexShardTestCase {
         Thread closeShardThread = new Thread(() -> {
             try {
                 safeAwait(readyToCloseLatch);
-                shard.close("testing", false);
+                closeShardNoCheck(shard);
                 // in integration tests, this is done as a listener on IndexService.
                 MockFSDirectoryFactory.checkIndex(logger, shard.store(), shard.shardId);
             } catch (IOException e) {
@@ -4813,7 +4813,7 @@ public class IndexShardTests extends IndexShardTestCase {
         recoveryThread.start();
         try {
             warmerStarted.await();
-            shard.close("testing", false);
+            closeShardNoCheck(shard);
             assertThat(shard.state, equalTo(IndexShardState.CLOSED));
         } finally {
             warmerBlocking.countDown();

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -363,7 +363,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
         for (int i = 0; i < 100; i++) {
             indexDoc(shard, Integer.toString(i), "{\"foo\" : \"bar\"}", XContentType.JSON, null);
         }
-        shard.close("simon says", false);
+        closeShardNoCheck(shard);
         AtomicReference<IndexShard> shardRef = new AtomicReference<>();
         Settings settings = Settings.builder().put("indices.memory.index_buffer_size", "50kb").build();
         Iterable<IndexShard> iterable = () -> (shardRef.get() == null)

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -372,7 +372,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
         DiscoveryNode rNode = DiscoveryNodeUtils.builder("foo").roles(Collections.emptySet()).build();
         IndexShard shard = newStartedShard(false);
         final SeqNoStats seqNoStats = populateRandomData(shard);
-        shard.close("test", false);
+        closeShardNoCheck(shard);
         if (randomBoolean()) {
             shard.store().associateIndexWithNewTranslog(UUIDs.randomBase64UUID());
         } else if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import static org.elasticsearch.index.shard.IndexShardTestCase.closeShardNoCheck;
+
 public class RecoveryStatusTests extends ESSingleNodeTestCase {
     private static final Version MIN_SUPPORTED_LUCENE_VERSION = IndexVersions.MINIMUM_COMPATIBLE.luceneVersion();
 
@@ -71,7 +73,7 @@ public class RecoveryStatusTests extends ESSingleNodeTestCase {
             }
         }
         assertNotNull(expectedFile);
-        indexShard.close("foo", false);// we have to close it here otherwise rename fails since the write.lock is held by the engine
+        closeShardNoCheck(indexShard); // we have to close it here otherwise rename fails since the write.lock is held by the engine
         multiFileWriter.renameAllTempFiles();
         strings = Sets.newHashSet(indexShard.store().directory().listAll());
         assertTrue(strings.toString(), strings.contains("foo.bar"));

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryTests.java
@@ -231,7 +231,7 @@ public class RecoveryTests extends ESIndexLevelReplicationTestCase {
             final String historyUUID = replica.getHistoryUUID();
             Translog.TranslogGeneration translogGeneration = getTranslog(replica).getGeneration();
             shards.removeReplica(replica);
-            replica.close("test", false);
+            closeShardNoCheck(replica);
             IndexWriterConfig iwc = new IndexWriterConfig(null).setCommitOnClose(false)
                 // we don't want merges to happen here - we call maybe merge on the engine
                 // later once we stared it up otherwise we would need to wait for it here
@@ -355,7 +355,7 @@ public class RecoveryTests extends ESIndexLevelReplicationTestCase {
             if (randomBoolean()) {
                 shards.flush();
             }
-            replica.close("test", randomBoolean());
+            closeShardNoCheck(replica, randomBoolean());
             replica.store().close();
             final IndexShard newReplica = shards.addReplicaWithExistingPath(replica.shardPath(), replica.routingEntry().currentNodeId());
             shards.recoverReplica(newReplica);
@@ -472,7 +472,7 @@ public class RecoveryTests extends ESIndexLevelReplicationTestCase {
             }
             shards.syncGlobalCheckpoint();
             shards.promoteReplicaToPrimary(randomFrom(shards.getReplicas())).get();
-            oldPrimary.close("demoted", false);
+            closeShardNoCheck(oldPrimary);
             oldPrimary.store().close();
             oldPrimary = shards.addReplicaWithExistingPath(oldPrimary.shardPath(), oldPrimary.routingEntry().currentNodeId());
             shards.recoverReplica(oldPrimary);

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryRestoreTests.java
@@ -136,7 +136,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
         } finally {
             if (shard != null && shard.state() != IndexShardState.CLOSED) {
                 try {
-                    shard.close("test", false);
+                    closeShardNoCheck(shard);
                 } finally {
                     IOUtils.close(shard.store());
                 }
@@ -205,7 +205,7 @@ public class BlobStoreRepositoryRestoreTests extends IndexShardTestCase {
         } finally {
             if (shard != null && shard.state() != IndexShardState.CLOSED) {
                 try {
-                    shard.close("test", false);
+                    closeShardNoCheck(shard);
                 } finally {
                     IOUtils.close(shard.store());
                 }

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -681,7 +681,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 EngineTestCase.assertAtMostOneLuceneDocumentPerSequenceNumber(engine);
             }
         } finally {
-            IOUtils.close(() -> shard.close("test", false), shard.store());
+            IOUtils.close(() -> closeShardNoCheck(shard), shard.store());
         }
     }
 
@@ -691,6 +691,27 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 closeShard(shard, true);
             }
         }
+    }
+
+    /**
+     * Close an {@link IndexShard}, optionally flushing first, without performing the consistency checks that {@link #closeShard} performs.
+     */
+    public static void closeShardNoCheck(IndexShard indexShard, boolean flushEngine) throws IOException {
+        indexShard.close("IndexShardTestCase#closeShardNoCheck", flushEngine);
+    }
+
+    /**
+     * Close an {@link IndexShard} without flushing or performing the consistency checks that {@link #closeShard} performs.
+     */
+    public static void closeShardNoCheck(IndexShard indexShard) throws IOException {
+        closeShardNoCheck(indexShard, false);
+    }
+
+    /**
+     * Flush and close an {@link IndexShard}, without performing the consistency checks that {@link #closeShard} performs.
+     */
+    public static void flushAndCloseShardNoCheck(IndexShard indexShard) throws IOException {
+        closeShardNoCheck(indexShard, true);
     }
 
     protected void recoverShardFromStore(IndexShard primary) throws IOException {

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -170,7 +170,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                     if (leaderGroup.getReplicas().isEmpty() == false && randomInt(100) < 5) {
                         IndexShard closingReplica = randomFrom(leaderGroup.getReplicas());
                         leaderGroup.removeReplica(closingReplica);
-                        closingReplica.close("test", false);
+                        closeShardNoCheck(closingReplica);
                         closingReplica.store().close();
                     } else if (leaderGroup.getReplicas().isEmpty() == false && rarely()) {
                         IndexShard newPrimary = randomFrom(leaderGroup.getReplicas());

--- a/x-pack/plugin/frozen-indices/src/test/java/org/elasticsearch/index/engine/frozen/FrozenIndexShardTests.java
+++ b/x-pack/plugin/frozen-indices/src/test/java/org/elasticsearch/index/engine/frozen/FrozenIndexShardTests.java
@@ -27,7 +27,7 @@ public class FrozenIndexShardTests extends IndexShardTestCase {
         indexDoc(indexShard, "_doc", "1");
         indexDoc(indexShard, "_doc", "2");
         indexDoc(indexShard, "_doc", "3");
-        indexShard.close("test", true);
+        flushAndCloseShardNoCheck(indexShard);
         final ShardRouting shardRouting = indexShard.routingEntry();
         IndexShard frozenShard = reinitShard(
             indexShard,


### PR DESCRIPTION
Closing an `IndexShard` or an `IndexService` requires some parameters
that are not really important in tests. This commit encapsulates these
calls into utility methods to populate those parameters with sensible
values. Moreover it reduces some unnecessary noise in a follow-up PR
which will make this closing process a little more complicated in
production code without affecting all these tests.

Relates #107952