### PR TITLE
ESQL: Add Block#lookup method

### DIFF
--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -350,6 +350,33 @@ tasks.named('stringTemplates').configure {
     it.inputFile =  stateInputFile
     it.outputFile = "org/elasticsearch/compute/aggregation/DoubleState.java"
   }
+  // block builders
+  File lookupInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/data/X-Lookup.java.st")
+  template {
+    it.properties = intProperties
+    it.inputFile =  lookupInputFile
+    it.outputFile = "org/elasticsearch/compute/data/IntLookup.java"
+  }
+  template {
+    it.properties = longProperties
+    it.inputFile =  lookupInputFile
+    it.outputFile = "org/elasticsearch/compute/data/LongLookup.java"
+  }
+  template {
+    it.properties = doubleProperties
+    it.inputFile =  lookupInputFile
+    it.outputFile = "org/elasticsearch/compute/data/DoubleLookup.java"
+  }
+  template {
+    it.properties = bytesRefProperties
+    it.inputFile =  lookupInputFile
+    it.outputFile = "org/elasticsearch/compute/data/BytesRefLookup.java"
+  }
+  template {
+    it.properties = booleanProperties
+    it.inputFile =  lookupInputFile
+    it.outputFile = "org/elasticsearch/compute/data/BooleanLookup.java"
+  }
   File arrayStateInputFile = new File("${projectDir}/src/main/java/org/elasticsearch/compute/aggregation/X-ArrayState.java.st")
   template {
     it.properties = intProperties

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanArrayBlock.java
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -110,6 +112,11 @@ final class BooleanArrayBlock extends AbstractArrayBlock implements BooleanBlock
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new BooleanLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBigArrayBlock.java
@@ -9,7 +9,9 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -111,6 +113,11 @@ public final class BooleanBigArrayBlock extends AbstractArrayBlock implements Bo
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new BooleanLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanBlock.java
@@ -11,6 +11,8 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.index.mapper.BlockLoader;
 
 import java.io.IOException;
@@ -37,6 +39,9 @@ public sealed interface BooleanBlock extends Block permits BooleanArrayBlock, Bo
 
     @Override
     BooleanBlock filter(int... positions);
+
+    @Override
+    ReleasableIterator<? extends BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override
     BooleanBlock expand();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanLookup.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanLookup.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Generic {@link Block#lookup} implementation {@link BooleanBlock}s.
+ * This class is generated. Do not edit it.
+ */
+final class BooleanLookup implements ReleasableIterator<BooleanBlock> {
+    private final BooleanBlock values;
+    private final IntBlock positions;
+    private final long targetByteSize;
+    private int position;
+
+    private boolean first;
+    private int valuesInPosition;
+
+    BooleanLookup(BooleanBlock values, IntBlock positions, ByteSizeValue targetBlockSize) {
+        values.incRef();
+        positions.incRef();
+        this.values = values;
+        this.positions = positions;
+        this.targetByteSize = targetBlockSize.getBytes();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return position < positions.getPositionCount();
+    }
+
+    @Override
+    public BooleanBlock next() {
+        try (BooleanBlock.Builder builder = positions.blockFactory().newBooleanBlockBuilder(positions.getTotalValueCount())) {
+            int count = 0;
+            while (position < positions.getPositionCount()) {
+                int start = positions.getFirstValueIndex(position);
+                int end = start + positions.getValueCount(position);
+                valuesInPosition = 0;
+                for (int i = start; i < end; i++) {
+                    copy(builder, positions.getInt(i));
+                }
+                switch (valuesInPosition) {
+                    case 0 -> builder.appendNull();
+                    case 1 -> builder.appendBoolean(first);
+                    default -> builder.endPositionEntry();
+                }
+                position++;
+                // TOOD what if the estimate is super huge? should we break even with less than MIN_TARGET?
+                if (++count > Operator.MIN_TARGET_PAGE_SIZE && builder.estimatedBytes() < targetByteSize) {
+                    break;
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private void copy(BooleanBlock.Builder builder, int valuePosition) {
+        if (valuePosition >= values.getPositionCount()) {
+            return;
+        }
+        int start = values.getFirstValueIndex(valuePosition);
+        int end = start + values.getValueCount(valuePosition);
+        for (int i = start; i < end; i++) {
+            if (valuesInPosition == 0) {
+                first = values.getBoolean(i);
+                valuesInPosition++;
+                continue;
+            }
+            if (valuesInPosition == 1) {
+                builder.beginPositionEntry();
+                builder.appendBoolean(first);
+            }
+            if (valuesInPosition > Block.MAX_LOOKUP) {
+                // TODO replace this with a warning and break
+                throw new IllegalArgumentException("Found a single entry with " + valuesInPosition + " entries");
+            }
+            builder.appendBoolean(values.getBoolean(i));
+            valuesInPosition++;
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values, positions);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BooleanVectorBlock.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -47,6 +49,12 @@ public final class BooleanVectorBlock extends AbstractVectorBlock implements Boo
     @Override
     public BooleanBlock filter(int... positions) {
         return vector.filter(positions).asBlock();
+    }
+
+    @Override
+    public ReleasableIterator<BooleanBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        // TODO optimizations
+        return new BooleanLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -10,7 +10,9 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BytesRefArray;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -114,6 +116,11 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new BytesRefLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -12,6 +12,8 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.index.mapper.BlockLoader;
 
 import java.io.IOException;
@@ -41,6 +43,9 @@ public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, 
 
     @Override
     BytesRefBlock filter(int... positions);
+
+    @Override
+    ReleasableIterator<? extends BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override
     BytesRefBlock expand();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefLookup.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefLookup.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Generic {@link Block#lookup} implementation {@link BytesRefBlock}s.
+ * This class is generated. Do not edit it.
+ */
+final class BytesRefLookup implements ReleasableIterator<BytesRefBlock> {
+    private final BytesRef firstScratch = new BytesRef();
+    private final BytesRef valueScratch = new BytesRef();
+    private final BytesRefBlock values;
+    private final IntBlock positions;
+    private final long targetByteSize;
+    private int position;
+
+    private BytesRef first;
+    private int valuesInPosition;
+
+    BytesRefLookup(BytesRefBlock values, IntBlock positions, ByteSizeValue targetBlockSize) {
+        values.incRef();
+        positions.incRef();
+        this.values = values;
+        this.positions = positions;
+        this.targetByteSize = targetBlockSize.getBytes();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return position < positions.getPositionCount();
+    }
+
+    @Override
+    public BytesRefBlock next() {
+        try (BytesRefBlock.Builder builder = positions.blockFactory().newBytesRefBlockBuilder(positions.getTotalValueCount())) {
+            int count = 0;
+            while (position < positions.getPositionCount()) {
+                int start = positions.getFirstValueIndex(position);
+                int end = start + positions.getValueCount(position);
+                valuesInPosition = 0;
+                for (int i = start; i < end; i++) {
+                    copy(builder, positions.getInt(i));
+                }
+                switch (valuesInPosition) {
+                    case 0 -> builder.appendNull();
+                    case 1 -> builder.appendBytesRef(first);
+                    default -> builder.endPositionEntry();
+                }
+                position++;
+                // TOOD what if the estimate is super huge? should we break even with less than MIN_TARGET?
+                if (++count > Operator.MIN_TARGET_PAGE_SIZE && builder.estimatedBytes() < targetByteSize) {
+                    break;
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private void copy(BytesRefBlock.Builder builder, int valuePosition) {
+        if (valuePosition >= values.getPositionCount()) {
+            return;
+        }
+        int start = values.getFirstValueIndex(valuePosition);
+        int end = start + values.getValueCount(valuePosition);
+        for (int i = start; i < end; i++) {
+            if (valuesInPosition == 0) {
+                first = values.getBytesRef(i, firstScratch);
+                valuesInPosition++;
+                continue;
+            }
+            if (valuesInPosition == 1) {
+                builder.beginPositionEntry();
+                builder.appendBytesRef(first);
+            }
+            if (valuesInPosition > Block.MAX_LOOKUP) {
+                // TODO replace this with a warning and break
+                throw new IllegalArgumentException("Found a single entry with " + valuesInPosition + " entries");
+            }
+            builder.appendBytesRef(values.getBytesRef(i, valueScratch));
+            valuesInPosition++;
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values, positions);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -48,6 +50,12 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
     @Override
     public BytesRefBlock filter(int... positions) {
         return vector.filter(positions).asBlock();
+    }
+
+    @Override
+    public ReleasableIterator<BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        // TODO optimizations
+        return new BytesRefLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleArrayBlock.java
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -110,6 +112,11 @@ final class DoubleArrayBlock extends AbstractArrayBlock implements DoubleBlock {
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new DoubleLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBigArrayBlock.java
@@ -9,7 +9,9 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.DoubleArray;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -111,6 +113,11 @@ public final class DoubleBigArrayBlock extends AbstractArrayBlock implements Dou
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new DoubleLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleBlock.java
@@ -11,6 +11,8 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.index.mapper.BlockLoader;
 
 import java.io.IOException;
@@ -37,6 +39,9 @@ public sealed interface DoubleBlock extends Block permits DoubleArrayBlock, Doub
 
     @Override
     DoubleBlock filter(int... positions);
+
+    @Override
+    ReleasableIterator<? extends DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override
     DoubleBlock expand();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleLookup.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleLookup.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Generic {@link Block#lookup} implementation {@link DoubleBlock}s.
+ * This class is generated. Do not edit it.
+ */
+final class DoubleLookup implements ReleasableIterator<DoubleBlock> {
+    private final DoubleBlock values;
+    private final IntBlock positions;
+    private final long targetByteSize;
+    private int position;
+
+    private double first;
+    private int valuesInPosition;
+
+    DoubleLookup(DoubleBlock values, IntBlock positions, ByteSizeValue targetBlockSize) {
+        values.incRef();
+        positions.incRef();
+        this.values = values;
+        this.positions = positions;
+        this.targetByteSize = targetBlockSize.getBytes();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return position < positions.getPositionCount();
+    }
+
+    @Override
+    public DoubleBlock next() {
+        try (DoubleBlock.Builder builder = positions.blockFactory().newDoubleBlockBuilder(positions.getTotalValueCount())) {
+            int count = 0;
+            while (position < positions.getPositionCount()) {
+                int start = positions.getFirstValueIndex(position);
+                int end = start + positions.getValueCount(position);
+                valuesInPosition = 0;
+                for (int i = start; i < end; i++) {
+                    copy(builder, positions.getInt(i));
+                }
+                switch (valuesInPosition) {
+                    case 0 -> builder.appendNull();
+                    case 1 -> builder.appendDouble(first);
+                    default -> builder.endPositionEntry();
+                }
+                position++;
+                // TOOD what if the estimate is super huge? should we break even with less than MIN_TARGET?
+                if (++count > Operator.MIN_TARGET_PAGE_SIZE && builder.estimatedBytes() < targetByteSize) {
+                    break;
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private void copy(DoubleBlock.Builder builder, int valuePosition) {
+        if (valuePosition >= values.getPositionCount()) {
+            return;
+        }
+        int start = values.getFirstValueIndex(valuePosition);
+        int end = start + values.getValueCount(valuePosition);
+        for (int i = start; i < end; i++) {
+            if (valuesInPosition == 0) {
+                first = values.getDouble(i);
+                valuesInPosition++;
+                continue;
+            }
+            if (valuesInPosition == 1) {
+                builder.beginPositionEntry();
+                builder.appendDouble(first);
+            }
+            if (valuesInPosition > Block.MAX_LOOKUP) {
+                // TODO replace this with a warning and break
+                throw new IllegalArgumentException("Found a single entry with " + valuesInPosition + " entries");
+            }
+            builder.appendDouble(values.getDouble(i));
+            valuesInPosition++;
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values, positions);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/DoubleVectorBlock.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -47,6 +49,12 @@ public final class DoubleVectorBlock extends AbstractVectorBlock implements Doub
     @Override
     public DoubleBlock filter(int... positions) {
         return vector.filter(positions).asBlock();
+    }
+
+    @Override
+    public ReleasableIterator<DoubleBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        // TODO optimizations
+        return new DoubleLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntArrayBlock.java
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -110,6 +112,11 @@ final class IntArrayBlock extends AbstractArrayBlock implements IntBlock {
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new IntLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBigArrayBlock.java
@@ -9,7 +9,9 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.IntArray;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -111,6 +113,11 @@ public final class IntBigArrayBlock extends AbstractArrayBlock implements IntBlo
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new IntLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntBlock.java
@@ -11,6 +11,8 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.index.mapper.BlockLoader;
 
 import java.io.IOException;
@@ -37,6 +39,9 @@ public sealed interface IntBlock extends Block permits IntArrayBlock, IntVectorB
 
     @Override
     IntBlock filter(int... positions);
+
+    @Override
+    ReleasableIterator<? extends IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override
     IntBlock expand();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntLookup.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntLookup.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Generic {@link Block#lookup} implementation {@link IntBlock}s.
+ * This class is generated. Do not edit it.
+ */
+final class IntLookup implements ReleasableIterator<IntBlock> {
+    private final IntBlock values;
+    private final IntBlock positions;
+    private final long targetByteSize;
+    private int position;
+
+    private int first;
+    private int valuesInPosition;
+
+    IntLookup(IntBlock values, IntBlock positions, ByteSizeValue targetBlockSize) {
+        values.incRef();
+        positions.incRef();
+        this.values = values;
+        this.positions = positions;
+        this.targetByteSize = targetBlockSize.getBytes();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return position < positions.getPositionCount();
+    }
+
+    @Override
+    public IntBlock next() {
+        try (IntBlock.Builder builder = positions.blockFactory().newIntBlockBuilder(positions.getTotalValueCount())) {
+            int count = 0;
+            while (position < positions.getPositionCount()) {
+                int start = positions.getFirstValueIndex(position);
+                int end = start + positions.getValueCount(position);
+                valuesInPosition = 0;
+                for (int i = start; i < end; i++) {
+                    copy(builder, positions.getInt(i));
+                }
+                switch (valuesInPosition) {
+                    case 0 -> builder.appendNull();
+                    case 1 -> builder.appendInt(first);
+                    default -> builder.endPositionEntry();
+                }
+                position++;
+                // TOOD what if the estimate is super huge? should we break even with less than MIN_TARGET?
+                if (++count > Operator.MIN_TARGET_PAGE_SIZE && builder.estimatedBytes() < targetByteSize) {
+                    break;
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private void copy(IntBlock.Builder builder, int valuePosition) {
+        if (valuePosition >= values.getPositionCount()) {
+            return;
+        }
+        int start = values.getFirstValueIndex(valuePosition);
+        int end = start + values.getValueCount(valuePosition);
+        for (int i = start; i < end; i++) {
+            if (valuesInPosition == 0) {
+                first = values.getInt(i);
+                valuesInPosition++;
+                continue;
+            }
+            if (valuesInPosition == 1) {
+                builder.beginPositionEntry();
+                builder.appendInt(first);
+            }
+            if (valuesInPosition > Block.MAX_LOOKUP) {
+                // TODO replace this with a warning and break
+                throw new IllegalArgumentException("Found a single entry with " + valuesInPosition + " entries");
+            }
+            builder.appendInt(values.getInt(i));
+            valuesInPosition++;
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values, positions);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/IntVectorBlock.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -47,6 +49,12 @@ public final class IntVectorBlock extends AbstractVectorBlock implements IntBloc
     @Override
     public IntBlock filter(int... positions) {
         return vector.filter(positions).asBlock();
+    }
+
+    @Override
+    public ReleasableIterator<IntBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        // TODO optimizations
+        return new IntLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongArrayBlock.java
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -110,6 +112,11 @@ final class LongArrayBlock extends AbstractArrayBlock implements LongBlock {
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new LongLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBigArrayBlock.java
@@ -9,7 +9,9 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.LongArray;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -111,6 +113,11 @@ public final class LongBigArrayBlock extends AbstractArrayBlock implements LongB
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new LongLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongBlock.java
@@ -11,6 +11,8 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.index.mapper.BlockLoader;
 
 import java.io.IOException;
@@ -37,6 +39,9 @@ public sealed interface LongBlock extends Block permits LongArrayBlock, LongVect
 
     @Override
     LongBlock filter(int... positions);
+
+    @Override
+    ReleasableIterator<? extends LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override
     LongBlock expand();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongLookup.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongLookup.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Generic {@link Block#lookup} implementation {@link LongBlock}s.
+ * This class is generated. Do not edit it.
+ */
+final class LongLookup implements ReleasableIterator<LongBlock> {
+    private final LongBlock values;
+    private final IntBlock positions;
+    private final long targetByteSize;
+    private int position;
+
+    private long first;
+    private int valuesInPosition;
+
+    LongLookup(LongBlock values, IntBlock positions, ByteSizeValue targetBlockSize) {
+        values.incRef();
+        positions.incRef();
+        this.values = values;
+        this.positions = positions;
+        this.targetByteSize = targetBlockSize.getBytes();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return position < positions.getPositionCount();
+    }
+
+    @Override
+    public LongBlock next() {
+        try (LongBlock.Builder builder = positions.blockFactory().newLongBlockBuilder(positions.getTotalValueCount())) {
+            int count = 0;
+            while (position < positions.getPositionCount()) {
+                int start = positions.getFirstValueIndex(position);
+                int end = start + positions.getValueCount(position);
+                valuesInPosition = 0;
+                for (int i = start; i < end; i++) {
+                    copy(builder, positions.getInt(i));
+                }
+                switch (valuesInPosition) {
+                    case 0 -> builder.appendNull();
+                    case 1 -> builder.appendLong(first);
+                    default -> builder.endPositionEntry();
+                }
+                position++;
+                // TOOD what if the estimate is super huge? should we break even with less than MIN_TARGET?
+                if (++count > Operator.MIN_TARGET_PAGE_SIZE && builder.estimatedBytes() < targetByteSize) {
+                    break;
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private void copy(LongBlock.Builder builder, int valuePosition) {
+        if (valuePosition >= values.getPositionCount()) {
+            return;
+        }
+        int start = values.getFirstValueIndex(valuePosition);
+        int end = start + values.getValueCount(valuePosition);
+        for (int i = start; i < end; i++) {
+            if (valuesInPosition == 0) {
+                first = values.getLong(i);
+                valuesInPosition++;
+                continue;
+            }
+            if (valuesInPosition == 1) {
+                builder.beginPositionEntry();
+                builder.appendLong(first);
+            }
+            if (valuesInPosition > Block.MAX_LOOKUP) {
+                // TODO replace this with a warning and break
+                throw new IllegalArgumentException("Found a single entry with " + valuesInPosition + " entries");
+            }
+            builder.appendLong(values.getLong(i));
+            valuesInPosition++;
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values, positions);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/LongVectorBlock.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.compute.data;
 
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -47,6 +49,12 @@ public final class LongVectorBlock extends AbstractVectorBlock implements LongBl
     @Override
     public LongBlock filter(int... positions) {
         return vector.filter(positions).asBlock();
+    }
+
+    @Override
+    public ReleasableIterator<LongBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        // TODO optimizations
+        return new LongLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -10,8 +10,10 @@ package org.elasticsearch.compute.data;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.mapper.BlockLoader;
 
@@ -36,6 +38,11 @@ import java.util.List;
  * the same block at the same time.
  */
 public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, RefCounted, Releasable {
+    /**
+     * The maximum number of values that can be added to one position via lookup.
+     * TODO maybe make this everywhere?
+     */
+    long MAX_LOOKUP = 100_000;
 
     /**
      * {@return an efficient dense single-value view of this block}.
@@ -113,6 +120,33 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
      * TODO: pass BlockFactory
      */
     Block filter(int... positions);
+
+    /**
+     * Builds an Iterator of new {@link Block}s with the same {@link #elementType}
+     * as this Block whose values are copied from positions in this Block. It has the
+     * same number of {@link #getPositionCount() positions} as the {@code positions}
+     * parameter.
+     * <p>
+     *     For example, this this block contained {@code [a, b, [b, c]]}
+     *     and were called with the block {@code [0, 1, 1, [1, 2]]} then the
+     *     result would be {@code [a, b, b, [b, b, c]]}.
+     * </p>
+     * <p>
+     *     This process produces {@code count(this) * count(positions)} values per
+     *     positions which could be quite quite large. Instead of returning a single
+     *     Block, this returns an Iterator of Blocks containing all of the promised
+     *     values.
+     * </p>
+     * <p>
+     *     The returned {@link ReleasableIterator} may retain a reference to {@link Block}s
+     *     inside the {@link Page}. Close it to release those references.
+     * </p>
+     * <p>
+     *     This block is built using the same {@link BlockFactory} as was used to
+     *     build the {@code positions} parameter.
+     * </p>
+     */
+    ReleasableIterator<? extends Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     /**
      * How are multivalued fields ordered?

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -11,6 +11,8 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -73,6 +75,11 @@ final class ConstantNullBlock extends AbstractNonThreadSafeRefCounted
     @Override
     public ConstantNullBlock filter(int... positions) {
         return (ConstantNullBlock) blockFactory().newConstantNullBlock(positions.length);
+    }
+
+    @Override
+    public ReleasableIterator<ConstantNullBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return ReleasableIterator.single((ConstantNullBlock) positions.blockFactory().newConstantNullBlock(positions.getPositionCount()));
     }
 
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/DocBlock.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.compute.data;
 
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -46,6 +48,11 @@ public class DocBlock extends AbstractVectorBlock implements Block {
     @Override
     public Block filter(int... positions) {
         return new DocBlock(asVector().filter(positions));
+    }
+
+    @Override
+    public ReleasableIterator<? extends Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -9,6 +9,8 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -116,6 +118,11 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
                 return builder.mvOrdering(mvOrdering()).build();
             }
         }
+    }
+
+    @Override
+    public ReleasableIterator<BytesRefBlock> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new BytesRefLookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -11,15 +11,16 @@ $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BytesRefArray;
-import org.elasticsearch.core.Releasables;
-
 $else$
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+$endif$
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
-$endif$
 import java.io.IOException;
 import java.util.BitSet;
 
@@ -130,6 +131,11 @@ $endif$
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<$Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new $Type$Lookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-BigArrayBlock.java.st
@@ -9,7 +9,9 @@ package org.elasticsearch.compute.data;
 
 import org.apache.lucene.util.RamUsageEstimator;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.$Array$;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
@@ -111,6 +113,11 @@ public final class $Type$BigArrayBlock extends AbstractArrayBlock implements $Ty
             }
             return builder.mvOrdering(mvOrdering()).build();
         }
+    }
+
+    @Override
+    public ReleasableIterator<$Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        return new $Type$Lookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -14,6 +14,8 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.index.mapper.BlockLoader;
 
 import java.io.IOException;
@@ -57,6 +59,9 @@ $endif$
 
     @Override
     $Type$Block filter(int... positions);
+
+    @Override
+    ReleasableIterator<? extends $Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize);
 
     @Override
     $Type$Block expand();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Lookup.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Lookup.java.st
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.data;
+
+$if(BytesRef)$
+import org.apache.lucene.util.BytesRef;
+$endif$
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Generic {@link Block#lookup} implementation {@link $Type$Block}s.
+ * This class is generated. Do not edit it.
+ */
+final class $Type$Lookup implements ReleasableIterator<$Type$Block> {
+$if(BytesRef)$
+    private final BytesRef firstScratch = new BytesRef();
+    private final BytesRef valueScratch = new BytesRef();
+$endif$
+    private final $Type$Block values;
+    private final IntBlock positions;
+    private final long targetByteSize;
+    private int position;
+
+    private $type$ first;
+    private int valuesInPosition;
+
+    $Type$Lookup($Type$Block values, IntBlock positions, ByteSizeValue targetBlockSize) {
+        values.incRef();
+        positions.incRef();
+        this.values = values;
+        this.positions = positions;
+        this.targetByteSize = targetBlockSize.getBytes();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return position < positions.getPositionCount();
+    }
+
+    @Override
+    public $Type$Block next() {
+        try ($Type$Block.Builder builder = positions.blockFactory().new$Type$BlockBuilder(positions.getTotalValueCount())) {
+            int count = 0;
+            while (position < positions.getPositionCount()) {
+                int start = positions.getFirstValueIndex(position);
+                int end = start + positions.getValueCount(position);
+                valuesInPosition = 0;
+                for (int i = start; i < end; i++) {
+                    copy(builder, positions.getInt(i));
+                }
+                switch (valuesInPosition) {
+                    case 0 -> builder.appendNull();
+                    case 1 -> builder.append$Type$(first);
+                    default -> builder.endPositionEntry();
+                }
+                position++;
+                // TOOD what if the estimate is super huge? should we break even with less than MIN_TARGET?
+                if (++count > Operator.MIN_TARGET_PAGE_SIZE && builder.estimatedBytes() < targetByteSize) {
+                    break;
+                }
+            }
+            return builder.build();
+        }
+    }
+
+    private void copy($Type$Block.Builder builder, int valuePosition) {
+        if (valuePosition >= values.getPositionCount()) {
+            return;
+        }
+        int start = values.getFirstValueIndex(valuePosition);
+        int end = start + values.getValueCount(valuePosition);
+        for (int i = start; i < end; i++) {
+            if (valuesInPosition == 0) {
+$if(BytesRef)$
+                first = values.get$Type$(i, firstScratch);
+$else$
+                first = values.get$Type$(i);
+$endif$
+                valuesInPosition++;
+                continue;
+            }
+            if (valuesInPosition == 1) {
+                builder.beginPositionEntry();
+                builder.append$Type$(first);
+            }
+            if (valuesInPosition > Block.MAX_LOOKUP) {
+                // TODO replace this with a warning and break
+                throw new IllegalArgumentException("Found a single entry with " + valuesInPosition + " entries");
+            }
+$if(BytesRef)$
+            builder.append$Type$(values.get$Type$(i, valueScratch));
+$else$
+            builder.append$Type$(values.get$Type$(i));
+$endif$
+            valuesInPosition++;
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(values, positions);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -10,6 +10,8 @@ package org.elasticsearch.compute.data;
 $if(BytesRef)$
 import org.apache.lucene.util.BytesRef;
 $endif$
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 
 /**
@@ -55,6 +57,12 @@ $endif$
     @Override
     public $Type$Block filter(int... positions) {
         return vector.filter(positions).asBlock();
+    }
+
+    @Override
+    public ReleasableIterator<$Type$Block> lookup(IntBlock positions, ByteSizeValue targetBlockSize) {
+        // TODO optimizations
+        return new $Type$Lookup(this, positions, targetBlockSize);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geo.ShapeTestUtils;
@@ -38,6 +39,7 @@ import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
+import static java.util.Collections.singletonList;
 import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.CARTESIAN;
 import static org.elasticsearch.xpack.ql.util.SpatialCoordinateTypes.GEO;
 import static org.hamcrest.Matchers.containsString;
@@ -47,6 +49,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -192,6 +195,11 @@ public class BasicBlockTests extends ESTestCase {
             int pos = block.getInt(randomPosition(positionCount));
             assertThat(pos, is(block.getInt(pos)));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 2) {
+                assertLookup(block, positions(blockFactory, 1, 2, new int[] { 1, 2 }), List.of(List.of(1), List.of(2), List.of(1, 2)));
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
 
             try (IntBlock.Builder blockBuilder = blockFactory.newIntBlockBuilder(1)) {
                 IntBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -237,6 +245,15 @@ public class BasicBlockTests extends ESTestCase {
             assertThat(value, is(block.getInt(randomPosition(positionCount))));
             assertThat(block.isNull(randomPosition(positionCount)), is(false));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 2) {
+                assertLookup(
+                    block,
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(value), List.of(value), List.of(value, value))
+                );
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
             releaseAndAssertBreaker(block);
         }
     }
@@ -261,6 +278,11 @@ public class BasicBlockTests extends ESTestCase {
             int pos = (int) block.getLong(randomPosition(positionCount));
             assertThat((long) pos, is(block.getLong(pos)));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 2) {
+                assertLookup(block, positions(blockFactory, 1, 2, new int[] { 1, 2 }), List.of(List.of(1L), List.of(2L), List.of(1L, 2L)));
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
 
             try (LongBlock.Builder blockBuilder = blockFactory.newLongBlockBuilder(1)) {
                 LongBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -303,6 +325,15 @@ public class BasicBlockTests extends ESTestCase {
             assertThat(value, is(block.getLong(randomPosition(positionCount))));
             assertThat(block.isNull(randomPosition(positionCount)), is(false));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 2) {
+                assertLookup(
+                    block,
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(value), List.of(value), List.of(value, value))
+                );
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
             releaseAndAssertBreaker(block);
         }
     }
@@ -328,6 +359,11 @@ public class BasicBlockTests extends ESTestCase {
             int pos = (int) block.getDouble(randomPosition(positionCount));
             assertThat((double) pos, is(block.getDouble(pos)));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 2) {
+                assertLookup(block, positions(blockFactory, 1, 2, new int[] { 1, 2 }), List.of(List.of(1d), List.of(2d), List.of(1d, 2d)));
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
 
             try (DoubleBlock.Builder blockBuilder = blockFactory.newDoubleBlockBuilder(1)) {
                 DoubleBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -371,6 +407,15 @@ public class BasicBlockTests extends ESTestCase {
             assertThat(value, is(block.getDouble(positionCount - 1)));
             assertThat(value, is(block.getDouble(randomPosition(positionCount))));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 2) {
+                assertLookup(
+                    block,
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(value), List.of(value), List.of(value, value))
+                );
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
             releaseAndAssertBreaker(block);
         }
     }
@@ -409,6 +454,15 @@ public class BasicBlockTests extends ESTestCase {
             assertions.accept(bytes);
         }
         assertSingleValueDenseBlock(block);
+        if (positionCount > 2) {
+            assertLookup(
+                block,
+                positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+            );
+        }
+        assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+        assertEmptyLookup(blockFactory, block);
 
         try (BytesRefBlock.Builder blockBuilder = blockFactory.newBytesRefBlockBuilder(1)) {
             BytesRefBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -511,6 +565,15 @@ public class BasicBlockTests extends ESTestCase {
             bytes = block.getBytesRef(randomPosition(positionCount), bytes);
             assertThat(bytes, is(value));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 2) {
+                assertLookup(
+                    block,
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(value), List.of(value), List.of(value, value))
+                );
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
             releaseAndAssertBreaker(block);
         }
     }
@@ -537,6 +600,15 @@ public class BasicBlockTests extends ESTestCase {
             assertThat(block.getBoolean(0), is(true));
             assertThat(block.getBoolean(positionCount - 1), is((positionCount - 1) % 10 == 0));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 1) {
+                assertLookup(
+                    block,
+                    positions(blockFactory, 1, 0, new int[] { 1, 0 }),
+                    List.of(List.of(false), List.of(true), List.of(false, true))
+                );
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
 
             try (BooleanBlock.Builder blockBuilder = blockFactory.newBooleanBlockBuilder(1)) {
                 BooleanBlock copy = blockBuilder.copyFrom(block, 0, block.getPositionCount()).build();
@@ -577,6 +649,15 @@ public class BasicBlockTests extends ESTestCase {
             assertThat(block.getBoolean(positionCount - 1), is(value));
             assertThat(block.getBoolean(randomPosition(positionCount)), is(value));
             assertSingleValueDenseBlock(block);
+            if (positionCount > 2) {
+                assertLookup(
+                    block,
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(value), List.of(value), List.of(value, value))
+                );
+            }
+            assertLookup(block, positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, block);
             releaseAndAssertBreaker(block);
         }
     }
@@ -1382,5 +1463,46 @@ public class BasicBlockTests extends ESTestCase {
                 yield new LongBigArrayBlock(values, positionCount, null, new BitSet(), Block.MvOrdering.UNORDERED, blockFactory);
             }
         };
+    }
+
+    static IntBlock positions(BlockFactory blockFactory, Object... positions) {
+        try (IntBlock.Builder builder = blockFactory.newIntBlockBuilder(positions.length)) {
+            for (Object p : positions) {
+                if (p instanceof int[] mv) {
+                    builder.beginPositionEntry();
+                    for (int v : mv) {
+                        builder.appendInt(v);
+                    }
+                    builder.endPositionEntry();
+                    continue;
+                }
+                if (p instanceof Integer v) {
+                    builder.appendInt(v);
+                    continue;
+                }
+                throw new IllegalArgumentException("invalid position: " + p + "(" + p.getClass().getName() + ")");
+            }
+            return builder.build();
+        }
+    }
+
+    static void assertEmptyLookup(BlockFactory blockFactory, Block block) {
+        try (
+            IntBlock positions = positions(blockFactory);
+            ReleasableIterator<? extends Block> lookup = block.lookup(positions, ByteSizeValue.ofKb(100))
+        ) {
+            assertThat(lookup.hasNext(), equalTo(false));
+        }
+    }
+
+    static void assertLookup(Block block, IntBlock positions, List<List<Object>> expected) {
+        try (positions; ReleasableIterator<? extends Block> lookup = block.lookup(positions, ByteSizeValue.ofKb(100))) {
+            assertThat(lookup.hasNext(), equalTo(true));
+            try (Block b = lookup.next()) {
+                assertThat(valuesAtPositions(b, 0, b.getPositionCount()), equalTo(expected));
+                assertThat(b.blockFactory(), sameInstance(positions.blockFactory()));
+            }
+            assertThat(lookup.hasNext(), equalTo(false));
+        }
     }
 }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
@@ -17,8 +17,13 @@ import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.stream.IntStream;
 
+import static java.util.Collections.singletonList;
+import static org.elasticsearch.compute.data.BasicBlockTests.assertEmptyLookup;
+import static org.elasticsearch.compute.data.BasicBlockTests.assertLookup;
+import static org.elasticsearch.compute.data.BasicBlockTests.positions;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -53,6 +58,15 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 }
             });
             BasicBlockTests.assertSingleValueDenseBlock(vector.asBlock());
+            if (positionCount > 1) {
+                assertLookup(
+                    vector.asBlock(),
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+                );
+            }
+            assertLookup(vector.asBlock(), positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, vector.asBlock());
             assertSerialization(block);
             assertThat(vector.toString(), containsString("BooleanBigArrayVector[positions=" + positionCount));
         }
@@ -84,6 +98,15 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 }
             });
             BasicBlockTests.assertSingleValueDenseBlock(vector.asBlock());
+            if (positionCount > 1) {
+                assertLookup(
+                    vector.asBlock(),
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+                );
+            }
+            assertLookup(vector.asBlock(), positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, vector.asBlock());
             assertSerialization(block);
             assertThat(vector.toString(), containsString("IntBigArrayVector[positions=" + positionCount));
         }
@@ -115,6 +138,15 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 }
             });
             BasicBlockTests.assertSingleValueDenseBlock(vector.asBlock());
+            if (positionCount > 1) {
+                assertLookup(
+                    vector.asBlock(),
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+                );
+            }
+            assertLookup(vector.asBlock(), positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, vector.asBlock());
             assertSerialization(block);
             assertThat(vector.toString(), containsString("LongBigArrayVector[positions=" + positionCount));
         }
@@ -146,6 +178,15 @@ public class BigArrayVectorTests extends SerializationTestCase {
                 }
             });
             BasicBlockTests.assertSingleValueDenseBlock(vector.asBlock());
+            if (positionCount > 1) {
+                assertLookup(
+                    vector.asBlock(),
+                    positions(blockFactory, 1, 2, new int[] { 1, 2 }),
+                    List.of(List.of(values[1]), List.of(values[2]), List.of(values[1], values[2]))
+                );
+            }
+            assertLookup(vector.asBlock(), positions(blockFactory, positionCount + 1000), singletonList(null));
+            assertEmptyLookup(blockFactory, vector.asBlock());
             assertSerialization(block);
             assertThat(vector.toString(), containsString("DoubleBigArrayVector[positions=" + positionCount));
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -17,15 +17,20 @@ import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.compute.operator.Operator;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.After;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.IntUnaryOperator;
 import java.util.stream.IntStream;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 public class BlockMultiValuedTests extends ESTestCase {
     @ParametersFactory
@@ -102,6 +107,18 @@ public class BlockMultiValuedTests extends ESTestCase {
 
     public void testFilteredJumbledSubsetThenExpanded() {
         assertFilteredThenExpanded(false, true);
+    }
+
+    public void testLookupFromSingleOnePage() {
+        assertLookup(ByteSizeValue.ofMb(100), between(1, 32), p -> 1);
+    }
+
+    public void testLookupFromManyOnePage() {
+        assertLookup(ByteSizeValue.ofMb(100), between(1, 32), p -> between(1, 5));
+    }
+
+    public void testLookupFromSingleManyPages() {
+        assertLookup(ByteSizeValue.ofBytes(1), between(1, 32), p -> 1);
     }
 
     private void assertFiltered(boolean all, boolean shuffled) {
@@ -210,6 +227,76 @@ public class BlockMultiValuedTests extends ESTestCase {
                 }
             }
             assertThat("Unexpected used in breaker: " + breaker, breaker.getUsed(), equalTo(0L));
+        }
+    }
+
+    private void assertLookup(ByteSizeValue targetBytes, int positionsToCopy, IntUnaryOperator positionsPerPosition) {
+        BlockFactory positionsFactory = blockFactory();
+        int positionCount = randomIntBetween(100, 16 * 1024);
+        var b = BasicBlockTests.randomBlock(blockFactory(), elementType, positionCount, nullAllowed, 0, 100, 0, 0);
+        try (IntBlock.Builder builder = positionsFactory.newIntBlockBuilder(positionsToCopy);) {
+            for (int p = 0; p < positionsToCopy; p++) {
+                int max = positionsPerPosition.applyAsInt(p);
+                switch (max) {
+                    case 0 -> builder.appendNull();
+                    case 1 -> builder.appendInt(between(0, positionCount + 100));
+                    default -> {
+                        builder.beginPositionEntry();
+                        for (int v = 0; v < max; v++) {
+                            builder.appendInt(between(0, positionCount + 100));
+                        }
+                        builder.endPositionEntry();
+                    }
+                }
+            }
+            Block copy = null;
+            int positionOffset = 0;
+            try (
+                IntBlock positions = builder.build();
+                ReleasableIterator<? extends Block> lookup = b.block().lookup(positions, targetBytes);
+            ) {
+                for (int p = 0; p < positions.getPositionCount(); p++) {
+                    if (copy == null || p - positionOffset == copy.getPositionCount()) {
+                        if (copy != null) {
+                            positionOffset += copy.getPositionCount();
+                            copy.close();
+                        }
+                        assertThat(lookup.hasNext(), equalTo(true));
+                        copy = lookup.next();
+                        if (positions.getPositionCount() - positionOffset < Operator.MIN_TARGET_PAGE_SIZE) {
+                            assertThat(copy.getPositionCount(), equalTo(positions.getPositionCount() - positionOffset));
+                        } else {
+                            assertThat(copy.getPositionCount(), greaterThanOrEqualTo(Operator.MIN_TARGET_PAGE_SIZE));
+                        }
+                    }
+                    List<Object> expected = new ArrayList<>();
+                    int start = positions.getFirstValueIndex(p);
+                    int end = start + positions.getValueCount(p);
+                    for (int i = start; i < end; i++) {
+                        int toCopy = positions.getInt(i);
+                        if (toCopy < b.block().getPositionCount()) {
+                            List<Object> v = BasicBlockTests.valuesAtPositions(b.block(), toCopy, toCopy + 1).get(0);
+                            if (v != null) {
+                                expected.addAll(v);
+                            }
+                        }
+                    }
+                    if (expected.isEmpty()) {
+                        assertThat(copy.isNull(p - positionOffset), equalTo(true));
+                    } else {
+                        assertThat(copy.isNull(p - positionOffset), equalTo(false));
+                        assertThat(
+                            BasicBlockTests.valuesAtPositions(copy, p - positionOffset, p + 1 - positionOffset).get(0),
+                            equalTo(expected)
+                        );
+                    }
+                }
+                assertThat(lookup.hasNext(), equalTo(false));
+            } finally {
+                Releasables.close(copy);
+            }
+        } finally {
+            b.block().close();
         }
     }
 }


### PR DESCRIPTION
This adds a method to build a new `Block` by looking up the values in an existing `Block`. Like `BlockHash#lookup` this returns a `ReleasableIterator`. This should allow us to load values using the results of `BlockHash#lookup`.
