### PR TITLE
Handle PIT Id as `BytesReference` instead of `String`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/CCSPointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/CCSPointInTimeIT.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.TimeValue;
@@ -92,7 +93,7 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
             indices.add(randomFrom("*", "local_*", "local_test"));
         }
         indices.add(randomFrom("*:*", "remote_cluster:*", "remote_cluster:remote_test"));
-        String pitId = openPointInTime(indices.toArray(new String[0]), TimeValue.timeValueMinutes(2));
+        BytesReference pitId = openPointInTime(indices.toArray(new String[0]), TimeValue.timeValueMinutes(2));
         try {
             if (randomBoolean()) {
                 localClient.prepareIndex("local_test").setId("local_new").setSource().get();
@@ -162,7 +163,7 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
         request.keepAlive(TimeValue.timeValueMinutes(2));
         request.indexFilter(new RangeQueryBuilder("@timestamp").gte("2023-12-15"));
         final OpenPointInTimeResponse response = client().execute(TransportOpenPointInTimeAction.TYPE, request).actionGet();
-        String pitId = response.getPointInTimeId();
+        BytesReference pitId = response.getPointInTimeId();
 
         if (randomBoolean()) {
             localClient.prepareIndex("local_test").setId("local_new").setSource().get();
@@ -252,7 +253,7 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
             indices.add(randomFrom("*", "local_*", "local_test"));
         }
         indices.add(randomFrom("*:*", "remote_cluster:*", "remote_cluster:remote_test"));
-        String pitId = openPointInTime(indices.toArray(new String[0]), TimeValue.timeValueMinutes(2));
+        BytesReference pitId = openPointInTime(indices.toArray(new String[0]), TimeValue.timeValueMinutes(2));
         try {
             if (randomBoolean()) {
                 localClient.prepareIndex("local_test").setId("local_new").setSource().get();
@@ -308,13 +309,13 @@ public class CCSPointInTimeIT extends AbstractMultiClustersTestCase {
         assertFalse(cluster.isTimedOut());
     }
 
-    private String openPointInTime(String[] indices, TimeValue keepAlive) {
+    private BytesReference openPointInTime(String[] indices, TimeValue keepAlive) {
         OpenPointInTimeRequest request = new OpenPointInTimeRequest(indices).keepAlive(keepAlive);
         final OpenPointInTimeResponse response = client().execute(TransportOpenPointInTimeAction.TYPE, request).actionGet();
         return response.getPointInTimeId();
     }
 
-    private void closePointInTime(String readerId) {
+    private void closePointInTime(BytesReference readerId) {
         client().execute(TransportClosePointInTimeAction.TYPE, new ClosePointInTimeRequest(readerId)).actionGet();
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
@@ -525,7 +526,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                         // do nothing
                     }
                 }
-                String pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openRequest).actionGet().getPointInTimeId();
+                BytesReference pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openRequest).actionGet().getPointInTimeId();
                 try {
                     assertResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)).setProfile(true), response -> {
                         var profileResults = response.getProfileResults();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/QueryRewriteContextIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/QueryRewriteContextIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.TransportClosePointInTimeAction;
 import org.elasticsearch.action.search.TransportOpenPointInTimeAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -136,7 +137,7 @@ public class QueryRewriteContextIT extends ESIntegTestCase {
         assertResolvedIndices(prepareSearch("test*"), Set.of("test*"), Set.of(indices), r -> {});
         assertResolvedIndices(prepareSearch("alias"), Set.of("alias"), Set.of(indices), r -> {});
 
-        final String pointInTimeId = openPointInTime(indices, TimeValue.timeValueMinutes(2));
+        final BytesReference pointInTimeId = openPointInTime(indices, TimeValue.timeValueMinutes(2));
         try {
             final PointInTimeBuilder pointInTimeBuilder = new PointInTimeBuilder(pointInTimeId);
             assertResolvedIndices(prepareSearch().setPointInTime(pointInTimeBuilder), Set.of(indices), Set.of(indices), r -> {});
@@ -190,13 +191,13 @@ public class QueryRewriteContextIT extends ESIntegTestCase {
         );
     }
 
-    private String openPointInTime(String[] indices, TimeValue keepAlive) {
+    private BytesReference openPointInTime(String[] indices, TimeValue keepAlive) {
         OpenPointInTimeRequest request = new OpenPointInTimeRequest(indices).keepAlive(keepAlive);
         OpenPointInTimeResponse response = client().execute(TransportOpenPointInTimeAction.TYPE, request).actionGet();
         return response.getPointInTimeId();
     }
 
-    private void closePointInTime(String pointInTimeId) {
+    private void closePointInTime(BytesReference pointInTimeId) {
         ClosePointInTimeResponse response = client().execute(
             TransportClosePointInTimeAction.TYPE,
             new ClosePointInTimeRequest(pointInTimeId)

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
@@ -452,7 +453,7 @@ public class SearchAfterIT extends ESIntegTestCase {
             }
         }
         // search_after with sort with point in time
-        String pitID;
+        BytesReference pitID;
         {
             OpenPointInTimeRequest openPITRequest = new OpenPointInTimeRequest("test").keepAlive(TimeValue.timeValueMinutes(5));
             pitID = client().execute(TransportOpenPointInTimeAction.TYPE, openPITRequest).actionGet().getPointInTimeId();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/slice/SearchSliceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/slice/SearchSliceIT.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportClosePointInTimeAction;
 import org.elasticsearch.action.search.TransportOpenPointInTimeAction;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.Scroll;
@@ -205,7 +206,7 @@ public class SearchSliceIT extends ESIntegTestCase {
             // Open point-in-time reader
             OpenPointInTimeRequest request = new OpenPointInTimeRequest("test").keepAlive(TimeValue.timeValueSeconds(10));
             OpenPointInTimeResponse response = client().execute(TransportOpenPointInTimeAction.TYPE, request).actionGet();
-            String pointInTimeId = response.getPointInTimeId();
+            BytesReference pointInTimeId = response.getPointInTimeId();
 
             // Test sort on document IDs
             assertSearchSlicesWithPointInTime(field, ShardDocSortField.NAME, pointInTimeId, max, numDocs);
@@ -217,7 +218,13 @@ public class SearchSliceIT extends ESIntegTestCase {
         }
     }
 
-    private void assertSearchSlicesWithPointInTime(String sliceField, String sortField, String pointInTimeId, int numSlice, int numDocs) {
+    private void assertSearchSlicesWithPointInTime(
+        String sliceField,
+        String sortField,
+        BytesReference pointInTimeId,
+        int numSlice,
+        int numDocs
+    ) {
         int totalResults = 0;
         List<String> keys = new ArrayList<>();
         for (int id = 0; id < numSlice; id++) {

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -184,7 +184,7 @@ public class TransportVersions {
     public static final TransportVersion ADD_RESOURCE_ALREADY_UPLOADED_EXCEPTION = def(8_643_00_0);
     public static final TransportVersion ESQL_MV_ORDERING_SORTED_ASCENDING = def(8_644_00_0);
     public static final TransportVersion ESQL_PAGE_MAPPING_TO_ITERATOR = def(8_645_00_0);
-    public static final TransportVersion COMPACT_PIT_ID = def(8_646_00_0);
+    public static final TransportVersion BINARY_PIT_ID = def(8_646_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -184,6 +184,7 @@ public class TransportVersions {
     public static final TransportVersion ADD_RESOURCE_ALREADY_UPLOADED_EXCEPTION = def(8_643_00_0);
     public static final TransportVersion ESQL_MV_ORDERING_SORTED_ASCENDING = def(8_644_00_0);
     public static final TransportVersion ESQL_PAGE_MAPPING_TO_ITERATOR = def(8_645_00_0);
+    public static final TransportVersion COMPACT_PIT_ID = def(8_646_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.search.TransportSearchAction.SearchTimeProvider;
 import org.elasticsearch.action.support.TransportActions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
@@ -661,7 +662,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
         SearchResponseSections internalSearchResponse,
         ShardSearchFailure[] failures,
         String scrollId,
-        String searchContextId
+        BytesReference searchContextId
     ) {
         int numSuccess = successfulOps.get();
         int numFailures = failures.length;
@@ -693,7 +694,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
             raisePhaseFailure(new SearchPhaseExecutionException("", "Shard failures", null, failures));
         } else {
             final String scrollId = request.scroll() != null ? TransportSearchHelper.buildScrollId(queryResults) : null;
-            final String searchContextId;
+            final BytesReference searchContextId;
             if (buildPointInTimeFromSearchResults()) {
                 searchContextId = SearchContextId.encode(queryResults.asList(), aliasFilter, minTransportVersion);
             } else {

--- a/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeResponse.java
@@ -9,34 +9,36 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Objects;
 
 public final class OpenPointInTimeResponse extends ActionResponse implements ToXContentObject {
-    private final String pointInTimeId;
+    private final BytesReference pointInTimeId;
 
-    public OpenPointInTimeResponse(String pointInTimeId) {
+    public OpenPointInTimeResponse(BytesReference pointInTimeId) {
         this.pointInTimeId = Objects.requireNonNull(pointInTimeId, "Point in time parameter must be not null");
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(pointInTimeId);
+        out.writeBytesReference(pointInTimeId);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("id", pointInTimeId);
+        builder.field("id", Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(pointInTimeId)));
         builder.endObject();
         return builder;
     }
 
-    public String getPointInTimeId() {
+    public BytesReference getPointInTimeId() {
         return pointInTimeId;
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
@@ -8,15 +8,12 @@
 
 package org.elasticsearch.action.search;
 
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.Maps;
@@ -27,10 +24,7 @@ import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.transport.RemoteClusterAware;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -61,26 +55,21 @@ public final class SearchContextId {
         return contextIds.contains(contextId);
     }
 
-    public static String encode(
+    public static BytesReference encode(
         List<SearchPhaseResult> searchPhaseResults,
         Map<String, AliasFilter> aliasFilter,
         TransportVersion version
     ) {
-        final BytesReference bytesReference;
-        try (var encodedStreamOutput = new BytesStreamOutput()) {
-            try (var out = new OutputStreamStreamOutput(Base64.getUrlEncoder().wrap(encodedStreamOutput))) {
-                out.setTransportVersion(version);
-                TransportVersion.writeVersion(version, out);
-                out.writeCollection(searchPhaseResults, SearchContextId::writeSearchPhaseResult);
-                out.writeMap(aliasFilter, StreamOutput::writeWriteable);
-            }
-            bytesReference = encodedStreamOutput.bytes();
+        try (var out = new BytesStreamOutput()) {
+            out.setTransportVersion(version);
+            TransportVersion.writeVersion(version, out);
+            out.writeCollection(searchPhaseResults, SearchContextId::writeSearchPhaseResult);
+            out.writeMap(aliasFilter, StreamOutput::writeWriteable);
+            return out.bytes();
         } catch (IOException e) {
             assert false : e;
             throw new IllegalArgumentException(e);
         }
-        final BytesRef bytesRef = bytesReference.toBytesRef();
-        return new String(bytesRef.bytes, bytesRef.offset, bytesRef.length, StandardCharsets.ISO_8859_1);
     }
 
     private static void writeSearchPhaseResult(StreamOutput out, SearchPhaseResult searchPhaseResult) throws IOException {
@@ -89,11 +78,8 @@ public final class SearchContextId {
         new SearchContextIdForNode(target.getClusterAlias(), target.getNodeId(), searchPhaseResult.getContextId()).writeTo(out);
     }
 
-    public static SearchContextId decode(NamedWriteableRegistry namedWriteableRegistry, String id) {
-        try (
-            var decodedInputStream = Base64.getUrlDecoder().wrap(new ByteArrayInputStream(id.getBytes(StandardCharsets.ISO_8859_1)));
-            var in = new NamedWriteableAwareStreamInput(new InputStreamStreamInput(decodedInputStream), namedWriteableRegistry)
-        ) {
+    public static SearchContextId decode(NamedWriteableRegistry namedWriteableRegistry, BytesReference id) {
+        try (var in = new NamedWriteableAwareStreamInput(id.streamInput(), namedWriteableRegistry)) {
             final TransportVersion version = TransportVersion.readVersion(in);
             in.setTransportVersion(version);
             final Map<ShardId, SearchContextIdForNode> shards = Collections.unmodifiableMap(
@@ -110,11 +96,8 @@ public final class SearchContextId {
         }
     }
 
-    public static String[] decodeIndices(String id) {
-        try (
-            var decodedInputStream = Base64.getUrlDecoder().wrap(new ByteArrayInputStream(id.getBytes(StandardCharsets.ISO_8859_1)));
-            var in = new InputStreamStreamInput(decodedInputStream)
-        ) {
+    public static String[] decodeIndices(BytesReference id) {
+        try (var in = id.streamInput()) {
             final TransportVersion version = TransportVersion.readVersion(in);
             in.setTransportVersion(version);
             final Map<ShardId, SearchContextIdForNode> shards = Collections.unmodifiableMap(

--- a/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchResponse.java
@@ -13,6 +13,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -39,6 +40,7 @@ import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -75,7 +77,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
     private final Boolean terminatedEarly;
     private final int numReducePhases;
     private final String scrollId;
-    private final String pointInTimeId;
+    private final BytesReference pointInTimeId;
     private final int totalShards;
     private final int successfulShards;
     private final int skippedShards;
@@ -109,7 +111,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         scrollId = in.readOptionalString();
         tookInMillis = in.readVLong();
         skippedShards = in.readVInt();
-        pointInTimeId = in.readOptionalString();
+        pointInTimeId = in.readOptionalBytesReference();
     }
 
     public SearchResponse(
@@ -156,7 +158,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         long tookInMillis,
         ShardSearchFailure[] shardFailures,
         Clusters clusters,
-        String pointInTimeId
+        BytesReference pointInTimeId
     ) {
         this(
             searchResponseSections.hits,
@@ -192,7 +194,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         long tookInMillis,
         ShardSearchFailure[] shardFailures,
         Clusters clusters,
-        String pointInTimeId
+        BytesReference pointInTimeId
     ) {
         this.hits = hits;
         hits.incRef();
@@ -349,7 +351,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
     /**
      * Returns the encoded string of the search context that the search request is used to executed
      */
-    public String pointInTimeId() {
+    public BytesReference pointInTimeId() {
         return pointInTimeId;
     }
 
@@ -419,7 +421,10 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
             builder.field(SCROLL_ID.getPreferredName(), scrollId);
         }
         if (pointInTimeId != null) {
-            builder.field(POINT_IN_TIME_ID.getPreferredName(), pointInTimeId);
+            builder.field(
+                POINT_IN_TIME_ID.getPreferredName(),
+                Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(pointInTimeId))
+            );
         }
         builder.field(TOOK.getPreferredName(), tookInMillis);
         builder.field(TIMED_OUT.getPreferredName(), isTimedOut());
@@ -462,7 +467,7 @@ public class SearchResponse extends ActionResponse implements ChunkedToXContentO
         out.writeOptionalString(scrollId);
         out.writeVLong(tookInMillis);
         out.writeVInt(skippedShards);
-        out.writeOptionalString(pointInTimeId);
+        out.writeOptionalBytesReference(pointInTimeId);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
@@ -9,6 +9,8 @@
 package org.elasticsearch.search.builder;
 
 import org.elasticsearch.action.search.SearchContextId;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -22,6 +24,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Objects;
 
 /**
@@ -35,7 +38,7 @@ public final class PointInTimeBuilder implements Writeable, ToXContentFragment {
 
     static {
         PARSER = new ObjectParser<>(SearchSourceBuilder.POINT_IN_TIME.getPreferredName(), XContentParams::new);
-        PARSER.declareString((params, id) -> params.encodedId = id, ID_FIELD);
+        PARSER.declareString((params, id) -> params.encodedId = new BytesArray(Base64.getUrlDecoder().decode(id)), ID_FIELD);
         PARSER.declareField(
             (params, keepAlive) -> params.keepAlive = keepAlive,
             (p, c) -> TimeValue.parseTimeValue(p.text(), KEEP_ALIVE_FIELD.getPreferredName()),
@@ -45,32 +48,32 @@ public final class PointInTimeBuilder implements Writeable, ToXContentFragment {
     }
 
     private static final class XContentParams {
-        private String encodedId;
+        private BytesReference encodedId;
         private TimeValue keepAlive;
     }
 
-    private final String encodedId;
+    private final BytesReference encodedId;
     private transient SearchContextId searchContextId; // lazily decoded from the encodedId
     private TimeValue keepAlive;
 
-    public PointInTimeBuilder(String pitID) {
+    public PointInTimeBuilder(BytesReference pitID) {
         this.encodedId = Objects.requireNonNull(pitID, "Point in time ID must be provided");
     }
 
     public PointInTimeBuilder(StreamInput in) throws IOException {
-        encodedId = in.readString();
+        encodedId = in.readBytesReference();
         keepAlive = in.readOptionalTimeValue();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(encodedId);
+        out.writeBytesReference(encodedId);
         out.writeOptionalTimeValue(keepAlive);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(ID_FIELD.getPreferredName(), encodedId);
+        builder.field(ID_FIELD.getPreferredName(), Base64.getEncoder().encodeToString(BytesReference.toBytes(encodedId)));
         if (keepAlive != null) {
             builder.field(KEEP_ALIVE_FIELD.getPreferredName(), keepAlive.getStringRep());
         }
@@ -88,7 +91,7 @@ public final class PointInTimeBuilder implements Writeable, ToXContentFragment {
     /**
      * Returns the encoded id of this point in time
      */
-    public String getEncodedId() {
+    public BytesReference getEncodedId() {
         return encodedId;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
@@ -73,7 +73,7 @@ public final class PointInTimeBuilder implements Writeable, ToXContentFragment {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.field(ID_FIELD.getPreferredName(), Base64.getEncoder().encodeToString(BytesReference.toBytes(encodedId)));
+        builder.field(ID_FIELD.getPreferredName(), Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(encodedId)));
         if (keepAlive != null) {
             builder.field(KEEP_ALIVE_FIELD.getPreferredName(), keepAlive.getStringRep());
         }

--- a/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/PointInTimeBuilder.java
@@ -62,7 +62,7 @@ public final class PointInTimeBuilder implements Writeable, ToXContentFragment {
     }
 
     public PointInTimeBuilder(StreamInput in) throws IOException {
-        if (in.getTransportVersion().onOrAfter(TransportVersions.COMPACT_PIT_ID)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersions.BINARY_PIT_ID)) {
             encodedId = in.readBytesReference();
         } else {
             encodedId = new BytesArray(Base64.getUrlDecoder().decode(in.readString()));
@@ -72,7 +72,7 @@ public final class PointInTimeBuilder implements Writeable, ToXContentFragment {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        if (out.getTransportVersion().onOrAfter(TransportVersions.COMPACT_PIT_ID)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersions.BINARY_PIT_ID)) {
             out.writeBytesReference(encodedId);
         } else {
             out.writeString(Base64.getUrlEncoder().encodeToString(BytesReference.toBytes(encodedId)));

--- a/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ShardSearchRequest.java
@@ -440,7 +440,7 @@ public class ShardSearchRequest extends TransportRequest implements IndicesReque
             // of shard-level search requests. However, we need to assign as a dummy PIT instead of null as we verify PIT for
             // slice requests on data nodes.
             source = source.shallowCopy();
-            source.pointInTimeBuilder(new PointInTimeBuilder(""));
+            source.pointInTimeBuilder(new PointInTimeBuilder(BytesArray.EMPTY));
         }
         this.source = source;
     }

--- a/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
+++ b/server/src/test/java/org/elasticsearch/action/search/MockSearchPhaseContext.java
@@ -10,6 +10,8 @@ package org.elasticsearch.action.search;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
@@ -83,7 +85,9 @@ public final class MockSearchPhaseContext implements SearchPhaseContext {
     @Override
     public void sendSearchResponse(SearchResponseSections internalSearchResponse, AtomicArray<SearchPhaseResult> queryResults) {
         String scrollId = getRequest().scroll() != null ? TransportSearchHelper.buildScrollId(queryResults) : null;
-        String searchContextId = getRequest().pointInTimeBuilder() != null ? TransportSearchHelper.buildScrollId(queryResults) : null;
+        BytesReference searchContextId = getRequest().pointInTimeBuilder() != null
+            ? new BytesArray(TransportSearchHelper.buildScrollId(queryResults))
+            : null;
         var existing = searchResponse.getAndSet(
             new SearchResponse(
                 internalSearchResponse,

--- a/server/src/test/java/org/elasticsearch/action/search/RestOpenPointInTimeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/RestOpenPointInTimeActionTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.search;
 
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -30,7 +31,7 @@ public class RestOpenPointInTimeActionTests extends RestActionTestCase {
         verifyingClient.setExecuteVerifier(((actionType, transportRequest) -> {
             assertThat(transportRequest, instanceOf(OpenPointInTimeRequest.class));
             transportRequests.add((OpenPointInTimeRequest) transportRequest);
-            return new OpenPointInTimeResponse("n/a");
+            return new OpenPointInTimeResponse(new BytesArray("n/a"));
         }));
         {
             RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)

--- a/server/src/test/java/org/elasticsearch/action/search/SearchContextIdTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchContextIdTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.index.query.IdsQueryBuilder;
@@ -64,7 +65,7 @@ public class SearchContextIdTests extends ESTestCase {
                 aliasFilters.put(result.getSearchShardTarget().getShardId().getIndex().getUUID(), aliasFilter);
             }
         }
-        final String id = SearchContextId.encode(queryResults.asList(), aliasFilters, version);
+        final BytesReference id = SearchContextId.encode(queryResults.asList(), aliasFilters, version);
         final SearchContextId context = SearchContextId.decode(namedWriteableRegistry, id);
         assertThat(context.shards().keySet(), hasSize(3));
         assertThat(context.aliasFilter(), equalTo(aliasFilters));

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -347,7 +347,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
             // Reader context with scroll
             SearchRequest searchRequest = new SearchRequest().source(
                 new SearchSourceBuilder().pointInTimeBuilder(
-                    new PointInTimeBuilder(new BytesArray(Base64.getEncoder().encode("id".getBytes(StandardCharsets.UTF_8))))
+                    new PointInTimeBuilder(new BytesArray(Base64.getUrlEncoder().encode("id".getBytes(StandardCharsets.UTF_8))))
                 )
             ).scroll(TimeValue.timeValueMillis(randomIntBetween(1, 100)));
             ActionRequestValidationException validationErrors = searchRequest.validate();

--- a/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchRequestTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.util.ArrayUtils;
@@ -39,7 +40,9 @@ import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.VersionUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 import static java.util.Collections.emptyMap;
@@ -343,7 +346,9 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         {
             // Reader context with scroll
             SearchRequest searchRequest = new SearchRequest().source(
-                new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("id"))
+                new SearchSourceBuilder().pointInTimeBuilder(
+                    new PointInTimeBuilder(new BytesArray(Base64.getEncoder().encode("id".getBytes(StandardCharsets.UTF_8))))
+                )
             ).scroll(TimeValue.timeValueMillis(randomIntBetween(1, 100)));
             ActionRequestValidationException validationErrors = searchRequest.validate();
             assertNotNull(validationErrors);
@@ -517,7 +522,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
                 new SearchSourceBuilder().rankBuilder(new TestRankBuilder(100))
                     .query(QueryBuilders.termQuery("field", "term"))
                     .knnSearch(List.of(new KnnSearchBuilder("vector", new float[] { 0f }, 10, 100, null)))
-                    .pointInTimeBuilder(new PointInTimeBuilder("test"))
+                    .pointInTimeBuilder(new PointInTimeBuilder(new BytesArray("test")))
             );
             ActionRequestValidationException validationErrors = searchRequest.validate();
             assertNotNull(validationErrors);
@@ -550,7 +555,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         }
         {
             SearchRequest searchRequest = new SearchRequest("test").source(
-                new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(""))
+                new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(BytesArray.EMPTY))
             );
             ActionRequestValidationException validationErrors = searchRequest.validate();
             assertNotNull(validationErrors);
@@ -562,7 +567,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         }
         {
             SearchRequest searchRequest = new SearchRequest().indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED)
-                .source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("")));
+                .source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(BytesArray.EMPTY)));
             ActionRequestValidationException validationErrors = searchRequest.validate();
             assertNotNull(validationErrors);
             assertEquals(1, validationErrors.validationErrors().size());
@@ -570,7 +575,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         }
         {
             SearchRequest searchRequest = new SearchRequest().routing("route1")
-                .source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("")));
+                .source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(BytesArray.EMPTY)));
             ActionRequestValidationException validationErrors = searchRequest.validate();
             assertNotNull(validationErrors);
             assertEquals(1, validationErrors.validationErrors().size());
@@ -578,7 +583,7 @@ public class SearchRequestTests extends AbstractSearchTestCase {
         }
         {
             SearchRequest searchRequest = new SearchRequest().preference("pref1")
-                .source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("")));
+                .source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(BytesArray.EMPTY)));
             ActionRequestValidationException validationErrors = searchRequest.validate();
             assertNotNull(validationErrors);
             assertEquals(1, validationErrors.validationErrors().size());

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -44,6 +44,8 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -1841,7 +1843,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         }
         indicesAdmin().prepareRefresh("test").get();
 
-        String pitId = client().execute(
+        BytesReference pitId = client().execute(
             TransportOpenPointInTimeAction.TYPE,
             new OpenPointInTimeRequest("test").keepAlive(TimeValue.timeValueMinutes(10))
         ).actionGet().getPointInTimeId();
@@ -1863,7 +1865,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         for (ShardSearchRequest shardRequest : shardRequests) {
             assertNotNull(shardRequest.source());
             assertNotNull(shardRequest.source().pointInTimeBuilder());
-            assertThat(shardRequest.source().pointInTimeBuilder().getEncodedId(), equalTo(""));
+            assertThat(shardRequest.source().pointInTimeBuilder().getEncodedId(), equalTo(BytesArray.EMPTY));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/search/builder/PointInTimeBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/PointInTimeBuilderTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.builder;
 
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -27,7 +28,7 @@ public class PointInTimeBuilderTests extends AbstractXContentSerializingTestCase
 
     @Override
     protected PointInTimeBuilder createTestInstance() {
-        final PointInTimeBuilder pointInTime = new PointInTimeBuilder(randomAlphaOfLength(20));
+        final PointInTimeBuilder pointInTime = new PointInTimeBuilder(new BytesArray(randomAlphaOfLength(20)));
         if (randomBoolean()) {
             pointInTime.setKeepAlive(randomTimeValue());
         }

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -448,7 +448,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         @SuppressWarnings("unchecked")
         Map<String, Object> pit = (Map<String, Object>) sourceAsMap.get("pit");
         assertEquals(
-            new String(Base64.getEncoder().encode("id".getBytes(StandardCharsets.UTF_8)), StandardCharsets.ISO_8859_1),
+            new String(Base64.getUrlEncoder().encode("id".getBytes(StandardCharsets.UTF_8)), StandardCharsets.ISO_8859_1),
             pit.get("id")
         );
         if (keepAlive != null) {

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.admin.cluster.stats.SearchUsageStats;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -62,6 +63,8 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -436,7 +439,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         XContentType xContentType = randomFrom(XContentType.values());
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         TimeValue keepAlive = randomBoolean() ? TimeValue.timeValueHours(1) : null;
-        searchSourceBuilder.pointInTimeBuilder(new PointInTimeBuilder("id").setKeepAlive(keepAlive));
+        searchSourceBuilder.pointInTimeBuilder(new PointInTimeBuilder(new BytesArray("id")).setKeepAlive(keepAlive));
         XContentBuilder builder = XContentFactory.contentBuilder(xContentType);
         searchSourceBuilder.toXContent(builder, ToXContent.EMPTY_PARAMS);
         BytesReference bytes = BytesReference.bytes(builder);
@@ -444,7 +447,10 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         assertEquals(1, sourceAsMap.size());
         @SuppressWarnings("unchecked")
         Map<String, Object> pit = (Map<String, Object>) sourceAsMap.get("pit");
-        assertEquals("id", pit.get("id"));
+        assertEquals(
+            new String(Base64.getEncoder().encode("id".getBytes(StandardCharsets.UTF_8)), StandardCharsets.ISO_8859_1),
+            pit.get("id")
+        );
         if (keepAlive != null) {
             assertEquals("1h", pit.get("keep_alive"));
             assertEquals(2, pit.size());
@@ -771,7 +777,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         // these are not correct runtime mappings but they are counted compared to empty object
         searchSourceBuilder.runtimeMappings(Collections.singletonMap("field", "keyword"));
         searchSourceBuilder.knnSearch(List.of(new KnnSearchBuilder("field", new float[] {}, 2, 5, null)));
-        searchSourceBuilder.pointInTimeBuilder(new PointInTimeBuilder("pitid"));
+        searchSourceBuilder.pointInTimeBuilder(new PointInTimeBuilder(new BytesArray("pitid")));
         searchSourceBuilder.docValueField("field");
         searchSourceBuilder.storedField("field");
         searchSourceBuilder.explain(true);

--- a/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/slice/SliceBuilderTests.java
@@ -21,6 +21,7 @@ import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -97,7 +98,7 @@ public class SliceBuilderTests extends ESTestCase {
 
     private ShardSearchRequest createPointInTimeRequest(int shardIndex, int numShards) {
         SearchRequest searchRequest = new SearchRequest().allowPartialSearchResults(true)
-            .source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder("1m")));
+            .source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(new BytesArray("1m"))));
         return new ShardSearchRequest(
             OriginalIndices.NONE,
             searchRequest,

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -383,7 +383,7 @@ public class RandomSearchRequestGenerator {
         }
         if (randomBoolean()) {
             PointInTimeBuilder pit = new PointInTimeBuilder(
-                new BytesArray(Base64.getEncoder().encode(randomAlphaOfLengthBetween(3, 10).getBytes(StandardCharsets.UTF_8)))
+                new BytesArray(Base64.getUrlEncoder().encode(randomAlphaOfLengthBetween(3, 10).getBytes(StandardCharsets.UTF_8)))
             );
             if (randomBoolean()) {
                 pit.setKeepAlive(TimeValue.timeValueMinutes(randomIntBetween(1, 60)));

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.common.xcontent.XContentHelper;
@@ -44,7 +45,9 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -379,7 +382,9 @@ public class RandomSearchRequestGenerator {
             builder.collapse(randomCollapseBuilder.get());
         }
         if (randomBoolean()) {
-            PointInTimeBuilder pit = new PointInTimeBuilder(randomAlphaOfLengthBetween(3, 10));
+            PointInTimeBuilder pit = new PointInTimeBuilder(
+                new BytesArray(Base64.getEncoder().encode(randomAlphaOfLengthBetween(3, 10).getBytes(StandardCharsets.UTF_8)))
+            );
             if (randomBoolean()) {
                 pit.setKeepAlive(TimeValue.timeValueMinutes(randomIntBetween(1, 60)));
             }

--- a/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.text.Text;
@@ -52,6 +53,7 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -201,7 +203,7 @@ public enum SearchResponseUtils {
         int totalShards = -1;
         int skippedShards = 0; // 0 for BWC
         String scrollId = null;
-        String searchContextId = null;
+        BytesReference searchContextId = null;
         List<ShardSearchFailure> failures = new ArrayList<>();
         SearchResponse.Clusters clusters = SearchResponse.Clusters.EMPTY;
         for (XContentParser.Token token = parser.nextToken(); token != XContentParser.Token.END_OBJECT; token = parser.nextToken()) {
@@ -211,7 +213,7 @@ public enum SearchResponseUtils {
                 if (SearchResponse.SCROLL_ID.match(currentFieldName, parser.getDeprecationHandler())) {
                     scrollId = parser.text();
                 } else if (SearchResponse.POINT_IN_TIME_ID.match(currentFieldName, parser.getDeprecationHandler())) {
-                    searchContextId = parser.text();
+                    searchContextId = new BytesArray(Base64.getDecoder().decode(parser.text()));
                 } else if (SearchResponse.TOOK.match(currentFieldName, parser.getDeprecationHandler())) {
                     tookInMillis = parser.longValue();
                 } else if (SearchResponse.TIMED_OUT.match(currentFieldName, parser.getDeprecationHandler())) {

--- a/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/SearchResponseUtils.java
@@ -213,7 +213,7 @@ public enum SearchResponseUtils {
                 if (SearchResponse.SCROLL_ID.match(currentFieldName, parser.getDeprecationHandler())) {
                     scrollId = parser.text();
                 } else if (SearchResponse.POINT_IN_TIME_ID.match(currentFieldName, parser.getDeprecationHandler())) {
-                    searchContextId = new BytesArray(Base64.getDecoder().decode(parser.text()));
+                    searchContextId = new BytesArray(Base64.getUrlDecoder().decode(parser.text()));
                 } else if (SearchResponse.TOOK.match(currentFieldName, parser.getDeprecationHandler())) {
                     tookInMillis = parser.longValue();
                 } else if (SearchResponse.TIMED_OUT.match(currentFieldName, parser.getDeprecationHandler())) {

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchIntegTestCase.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
@@ -239,7 +240,7 @@ public abstract class AsyncSearchIntegTestCase extends ESIntegTestCase {
         int numFailures,
         int progressStep
     ) throws Exception {
-        final String pitId;
+        final BytesReference pitId;
         final SubmitAsyncSearchRequest request;
         if (randomBoolean()) {
             OpenPointInTimeRequest openPIT = new OpenPointInTimeRequest(indexName).keepAlive(TimeValue.timeValueMinutes(between(5, 10)));

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClient.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.TransportClosePointInTimeAction;
 import org.elasticsearch.action.search.TransportOpenPointInTimeAction;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.get.GetResult;
@@ -44,7 +45,7 @@ import static org.elasticsearch.xpack.ql.util.ActionListeners.map;
 // search and multi-search hence the code repetition
 public class PITAwareQueryClient extends BasicQueryClient {
 
-    private String pitId;
+    private BytesReference pitId;
     private final TimeValue keepAlive;
     private final QueryBuilder filter;
 
@@ -114,7 +115,10 @@ public class PITAwareQueryClient extends BasicQueryClient {
     }
 
     // listener handing the extraction of new PIT and closing in case of exceptions
-    private <Response> ActionListener<Response> pitListener(Function<Response, String> pitIdExtractor, ActionListener<Response> listener) {
+    private <Response> ActionListener<Response> pitListener(
+        Function<Response, BytesReference> pitIdExtractor,
+        ActionListener<Response> listener
+    ) {
         return wrap(r -> {
             // get pid
             pitId = pitIdExtractor.apply(r);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sample/CircuitBreakerTests.java
@@ -22,6 +22,8 @@ import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.TestCircuitBreaker;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -192,7 +194,7 @@ public class CircuitBreakerTests extends ESTestCase {
 
     private class ESMockClient extends NoOpClient {
         protected final CircuitBreaker circuitBreaker;
-        private final String pitId = "test_pit_id";
+        private final BytesReference pitId = new BytesArray("test_pit_id");
 
         ESMockClient(ThreadPool threadPool, CircuitBreaker circuitBreaker) {
             super(threadPool);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClientTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/search/PITAwareQueryClientTests.java
@@ -21,6 +21,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -179,7 +181,7 @@ public class PITAwareQueryClientTests extends ESTestCase {
      */
     private class ESMockClient extends NoOpClient {
         private final QueryBuilder filter;
-        private final String pitId = "test_pit_id";
+        private final BytesReference pitId = new BytesArray("test_pit_id");
         private boolean openedPIT = false;
         private int searchRequestsRemainingCount;
 

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -29,6 +29,8 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.breaker.TestCircuitBreaker;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -370,7 +372,7 @@ public class CircuitBreakerTests extends ESTestCase {
         protected final CircuitBreaker circuitBreaker;
         // private final String pitId;
         private int searchRequestsRemainingCount;
-        private final String pitId = "test_pit_id";
+        private final BytesReference pitId = new BytesArray("test_pit_id");
 
         ESMockClient(ThreadPool threadPool, CircuitBreaker circuitBreaker, int searchRequestsRemainingCount) {
             super(threadPool);

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateStalePrimaryAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationCommand;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
@@ -230,7 +231,9 @@ public class FrozenIndexIT extends ESIntegTestCase {
         final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest(indexName).indicesOptions(
             IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED
         ).keepAlive(TimeValue.timeValueMinutes(2));
-        final String pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openPointInTimeRequest).actionGet().getPointInTimeId();
+        final BytesReference pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openPointInTimeRequest)
+            .actionGet()
+            .getPointInTimeId();
         try {
             assertNoFailuresAndResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)), searchResponse -> {
                 assertThat(searchResponse.pointInTimeId(), equalTo(pitId));
@@ -277,7 +280,9 @@ public class FrozenIndexIT extends ESIntegTestCase {
             IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED
         ).keepAlive(TimeValue.timeValueMinutes(2));
 
-        final String pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openPointInTimeRequest).actionGet().getPointInTimeId();
+        final BytesReference pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openPointInTimeRequest)
+            .actionGet()
+            .getPointInTimeId();
         try {
             indicesAdmin().prepareDelete("index-1").get();
             // Return partial results if allow partial search result is allowed
@@ -312,7 +317,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
             final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").indicesOptions(
                 IndicesOptions.strictExpandOpenAndForbidClosed()
             ).keepAlive(TimeValue.timeValueMinutes(2));
-            final String pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openPointInTimeRequest)
+            final BytesReference pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openPointInTimeRequest)
                 .actionGet()
                 .getPointInTimeId();
             try {
@@ -329,7 +334,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
             final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").keepAlive(
                 TimeValue.timeValueMinutes(2)
             );
-            final String pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openPointInTimeRequest)
+            final BytesReference pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openPointInTimeRequest)
                 .actionGet()
                 .getPointInTimeId();
             try {

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.RecoverySource;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
@@ -83,7 +84,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         return pluginList(FrozenIndices.class, LocalStateCompositeXPackPlugin.class);
     }
 
-    String openReaders(TimeValue keepAlive, String... indices) {
+    BytesReference openReaders(TimeValue keepAlive, String... indices) {
         OpenPointInTimeRequest request = new OpenPointInTimeRequest(indices).indicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED)
             .keepAlive(keepAlive);
         final OpenPointInTimeResponse response = client().execute(TransportOpenPointInTimeAction.TYPE, request).actionGet();
@@ -145,7 +146,7 @@ public class FrozenIndexTests extends ESSingleNodeTestCase {
         }
         client().prepareClearScroll().addScrollId(searchResponse.getScrollId()).get();
 
-        String pitId = openReaders(TimeValue.timeValueMinutes(1), indexName);
+        BytesReference pitId = openReaders(TimeValue.timeValueMinutes(1), indexName);
         try {
             for (int from = 0; from < 3; from++) {
                 assertResponse(

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.search.TransportClosePointInTimeAction;
 import org.elasticsearch.action.search.TransportOpenPointInTimeAction;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexService;
@@ -141,7 +142,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
         final OpenPointInTimeRequest openRequest = new OpenPointInTimeRequest(indexName).indicesOptions(
             IndicesOptions.STRICT_EXPAND_OPEN_FORBID_CLOSED
         ).keepAlive(TimeValue.timeValueMinutes(2));
-        final String pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openRequest).actionGet().getPointInTimeId();
+        final BytesReference pitId = client().execute(TransportOpenPointInTimeAction.TYPE, openRequest).actionGet().getPointInTimeId();
         try {
             assertNoFailuresAndResponse(prepareSearch().setPointInTime(new PointInTimeBuilder(pitId)), resp -> {
                 assertThat(resp.pointInTimeId(), equalTo(pitId));

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheMaintenanceService.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/BlobStoreCacheMaintenanceService.java
@@ -38,6 +38,7 @@ import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -484,7 +485,7 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
             });
         }
 
-        private static ActionListener<Void> closingPitBefore(Client client, String pointInTimeId, ActionListener<Void> listener) {
+        private static ActionListener<Void> closingPitBefore(Client client, BytesReference pointInTimeId, ActionListener<Void> listener) {
             return new ActionListener<>() {
                 @Override
                 public void onResponse(Void unused) {
@@ -498,7 +499,7 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
             };
         }
 
-        private static void closePit(Client client, String pointInTimeId, Runnable onCompletion) {
+        private static void closePit(Client client, BytesReference pointInTimeId, Runnable onCompletion) {
             client.execute(TransportClosePointInTimeAction.TYPE, new ClosePointInTimeRequest(pointInTimeId), new ActionListener<>() {
                 @Override
                 public void onResponse(ClosePointInTimeResponse response) {
@@ -522,14 +523,14 @@ public class BlobStoreCacheMaintenanceService implements ClusterStateListener {
          * The maintenance task, once it has opened its PIT and started running so that it has all the state it needs to do its job.
          */
         private class RunningPeriodicMaintenanceTask implements Runnable {
-            private final String pointInTimeId;
+            private final BytesReference pointInTimeId;
             private final RefCountingListener listeners;
             private final Instant expirationTime;
             private final Map<String, Set<String>> existingSnapshots;
             private final Set<String> existingRepositories;
 
             RunningPeriodicMaintenanceTask(
-                String pointInTimeId,
+                BytesReference pointInTimeId,
                 ActionListener<Void> listener,
                 Instant expirationTime,
                 Map<String, Set<String>> existingSnapshots,

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -27,6 +27,7 @@ import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.client.internal.Requests;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -1303,7 +1304,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         }
         refresh();
 
-        String pitId = openPointInTime("user1", TimeValue.timeValueMinutes(1), "test");
+        BytesReference pitId = openPointInTime("user1", TimeValue.timeValueMinutes(1), "test");
         SearchResponse response = null;
         try {
             for (int from = 0; from < numVisible; from++) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.action.termvectors.TermVectorsResponse;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.client.internal.Requests;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -1157,7 +1158,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         }
     }
 
-    static String openPointInTime(String userName, TimeValue keepAlive, String... indices) {
+    static BytesReference openPointInTime(String userName, TimeValue keepAlive, String... indices) {
         OpenPointInTimeRequest request = new OpenPointInTimeRequest(indices).keepAlive(keepAlive);
         final OpenPointInTimeResponse response = client().filterWithHeader(
             Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue(userName, USERS_PASSWD))
@@ -1178,7 +1179,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
         }
         refresh("test");
 
-        String pitId = openPointInTime("user1", TimeValue.timeValueMinutes(1), "test");
+        BytesReference pitId = openPointInTime("user1", TimeValue.timeValueMinutes(1), "test");
         try {
             for (int from = 0; from < numDocs; from++) {
                 assertResponse(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -94,6 +94,8 @@ import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -942,7 +944,7 @@ public class AuthorizationServiceTests extends ESTestCase {
     }
 
     public void testUserWithNoRolesCanClosePointInTime() {
-        final ClosePointInTimeRequest closePointInTimeRequest = new ClosePointInTimeRequest(randomAlphaOfLength(8));
+        final ClosePointInTimeRequest closePointInTimeRequest = new ClosePointInTimeRequest(new BytesArray(randomAlphaOfLength(8)));
         final Authentication authentication = createAuthentication(new User("test user"));
         mockEmptyMetadata();
         final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
@@ -3641,7 +3643,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         }
     }
 
-    private static String createEncodedPIT(Index index) {
+    private static BytesReference createEncodedPIT(Index index) {
         DiscoveryNode node1 = DiscoveryNodeUtils.create("node_1");
         TestSearchPhaseResult testSearchPhaseResult1 = new TestSearchPhaseResult(new ShardSearchContextId("a", 1), node1);
         testSearchPhaseResult1.setSearchShardTarget(

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -160,7 +160,7 @@ public class Querier {
             TransportOpenPointInTimeAction.TYPE,
             openPitRequest,
             listener.delegateFailureAndWrap((delegate, openPointInTimeResponse) -> {
-                String pitId = openPointInTimeResponse.getPointInTimeId();
+                BytesReference pitId = openPointInTimeResponse.getPointInTimeId();
                 search.indicesOptions(SearchRequest.DEFAULT_INDICES_OPTIONS);
                 search.indices(Strings.EMPTY_ARRAY);
                 search.source().pointInTimeBuilder(new PointInTimeBuilder(pitId));
@@ -176,14 +176,14 @@ public class Querier {
         );
     }
 
-    private static void closePointInTimeAfterError(Client client, String pointInTimeId, Exception e, ActionListener<?> listener) {
+    private static void closePointInTimeAfterError(Client client, BytesReference pointInTimeId, Exception e, ActionListener<?> listener) {
         closePointInTime(client, pointInTimeId, wrap(r -> listener.onFailure(e), closeError -> {
             e.addSuppressed(closeError);
             listener.onFailure(e);
         }));
     }
 
-    public static void closePointInTime(Client client, String pointInTimeId, ActionListener<Boolean> listener) {
+    public static void closePointInTime(Client client, BytesReference pointInTimeId, ActionListener<Boolean> listener) {
         if (pointInTimeId != null) {
             // request should not be made with the parent task assigned because the parent task might already be canceled
             client = client instanceof ParentTaskAssigningClient wrapperClient ? wrapperClient.unwrap() : client;

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/CancellationTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/analysis/CancellationTests.java
@@ -22,6 +22,8 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.tasks.TaskCancelHelper;
 import org.elasticsearch.tasks.TaskCancelledException;
@@ -171,7 +173,7 @@ public class CancellationTests extends ESTestCase {
         ClusterService mockClusterService = mockClusterService(nodeId);
 
         String[] indices = new String[] { "endgame" };
-        String pitId = randomAlphaOfLength(10);
+        BytesReference pitId = new BytesArray(randomAlphaOfLength(10));
 
         // Emulation of field capabilities
         FieldCapabilitiesResponse fieldCapabilitiesResponse = mock(FieldCapabilitiesResponse.class);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -450,7 +451,7 @@ class ClientTransformIndexer extends TransformIndexer {
             return;
         }
 
-        String oldPit = pit.getEncodedId();
+        BytesReference oldPit = pit.getEncodedId();
 
         ClosePointInTimeRequest closePitRequest = new ClosePointInTimeRequest(oldPit);
         ClientHelper.executeWithHeadersAsync(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.CompositeBytesReference;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -172,7 +173,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
             );
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals("the_pit_id+", response.pointInTimeId());
+                assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
             });
 
             assertEquals(1L, client.getPitContextCounter());
@@ -185,15 +186,15 @@ public class ClientTransformIndexerTests extends ESTestCase {
             assertEquals(0L, client.getPitContextCounter());
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals("the_pit_id+", response.pointInTimeId());
+                assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
             });
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals("the_pit_id++", response.pointInTimeId());
+                assertEquals(new BytesArray("the_pit_id++"), response.pointInTimeId());
             });
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals("the_pit_id+++", response.pointInTimeId());
+                assertEquals(new BytesArray("the_pit_id+++"), response.pointInTimeId());
             });
 
             assertEquals(1L, client.getPitContextCounter());
@@ -202,15 +203,15 @@ public class ClientTransformIndexerTests extends ESTestCase {
             assertEquals(0L, client.getPitContextCounter());
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals("the_pit_id+", response.pointInTimeId());
+                assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
             });
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals("the_pit_id++", response.pointInTimeId());
+                assertEquals(new BytesArray("the_pit_id++"), response.pointInTimeId());
             });
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
-                assertEquals("the_pit_id+++", response.pointInTimeId());
+                assertEquals(new BytesArray("the_pit_id+++"), response.pointInTimeId());
             });
 
             assertEquals(1L, client.getPitContextCounter());
@@ -358,7 +359,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
             this.<SearchResponse>assertAsync(listener -> indexer.doNextSearch(0, listener), response -> {
                 if (pitEnabled) {
-                    assertEquals("the_pit_id+", response.pointInTimeId());
+                    assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
                 } else {
                     assertNull(response.pointInTimeId());
                 }
@@ -371,7 +372,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
                 if (pitEnabled) {
                     assertNull(response.pointInTimeId());
                 } else {
-                    assertEquals("the_pit_id+", response.pointInTimeId());
+                    assertEquals(new BytesArray("the_pit_id+"), response.pointInTimeId());
                 }
             });
         }
@@ -507,7 +508,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
                 // throw search context missing for the 4th run
                 if (searchRequest.pointInTimeBuilder() != null
-                    && "the_pit_id+++".equals(searchRequest.pointInTimeBuilder().getEncodedId())) {
+                    && new BytesArray("the_pit_id+++").equals(searchRequest.pointInTimeBuilder().getEncodedId())) {
                     listener.onFailure(new SearchContextMissingException(new ShardSearchContextId("sc_missing", 42)));
                 } else {
                     ActionListener.respondAndRelease(
@@ -534,7 +535,7 @@ public class ClientTransformIndexerTests extends ESTestCase {
                             SearchResponse.Clusters.EMPTY,
                             // copy the pit from the request
                             searchRequest.pointInTimeBuilder() != null
-                                ? new BytesArray(searchRequest.pointInTimeBuilder().getEncodedId().utf8ToString() + "+")
+                                ? CompositeBytesReference.of(searchRequest.pointInTimeBuilder().getEncodedId(), new BytesArray("+"))
                                 : null
                         )
                     );


### PR DESCRIPTION
Handling the PIT id as a `BytesReference` instead of as base64 encoded string saves about a third of network traffic for these. We know that PIT ids can be a significant source of traffic so the savings are well worth it. Also, this saves cycles and memory on all nodes involved. A follow-up here would be exploring to slice these IDs out of network buffer instead of copying them to reduce memory usage and large allocations.
