### PR TITLE
Optimise time_series aggregation for single value fields

### DIFF
--- a/docs/changelog/107990.yaml
+++ b/docs/changelog/107990.yaml
@@ -1,0 +1,5 @@
+pr: 107990
+summary: Optimise `time_series` aggregation for single value fields
+area: TSDB
+type: enhancement
+issues: []

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
@@ -122,18 +122,16 @@ public class TimeSeriesAggregator extends BucketsAggregator {
                 SortedNumericDocValues docValues = numericVS.longValues(aggCtx.getLeafReaderContext());
                 dimensionConsumers.put(entry.getKey(), (docId, tsidBuilder) -> {
                     if (docValues.advanceExact(docId)) {
-                        for (int i = 0; i < docValues.docValueCount(); i++) {
-                            tsidBuilder.addLong(fieldName, docValues.nextValue());
-                        }
+                        assert docValues.docValueCount() == 1 : "Dimension field cannot be a multi-valued field";
+                        tsidBuilder.addLong(fieldName, docValues.nextValue());
                     }
                 });
             } else {
                 SortedBinaryDocValues docValues = entry.getValue().bytesValues(aggCtx.getLeafReaderContext());
                 dimensionConsumers.put(entry.getKey(), (docId, tsidBuilder) -> {
                     if (docValues.advanceExact(docId)) {
-                        for (int i = 0; i < docValues.docValueCount(); i++) {
-                            tsidBuilder.addString(fieldName, docValues.nextValue());
-                        }
+                        assert docValues.docValueCount() == 1 : "Dimension field cannot be a multi-valued field";
+                        tsidBuilder.addString(fieldName, docValues.nextValue());
                     }
                 });
             }


### PR DESCRIPTION
Time series dimensions are by definition single value field. Therefore let's take advantage of that property in time-series aggregation and stop trying to iterate over dimension doc values. This change might bring better performance.