### PR TITLE
Fix failing mixed cluster test

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -214,13 +214,9 @@ public class SecurityIndexManager implements ClusterStateListener {
      * Get the minimum security index mapping version in the cluster
      */
     private SystemIndexDescriptor.MappingsVersion getMinSecurityIndexMappingVersion(ClusterState clusterState) {
-        var minClusterVersion = clusterState.getMinSystemIndexMappingVersions().get(systemIndexDescriptor.getPrimaryIndex());
-        // Can be null in mixed clusters. This indicates that the cluster state and index needs to be updated with the latest mapping
-        // version from the index descriptor
-        if (minClusterVersion == null) {
-            return systemIndexDescriptor.getMappingsVersion();
-        }
-        return minClusterVersion;
+        SystemIndexDescriptor.MappingsVersion mappingsVersion = clusterState.getMinSystemIndexMappingVersions()
+            .get(systemIndexDescriptor.getPrimaryIndex());
+        return mappingsVersion == null ? new SystemIndexDescriptor.MappingsVersion(1, 0) : mappingsVersion;
     }
 
     @Override


### PR DESCRIPTION
This PR addresses: https://github.com/elastic/elasticsearch/issues/107945

The security profile action origin and internal user is not available before version 8.3.0. The code to handle versioning of the `.security-profile` index was wrong, since it used the latest mapping version from the current node if no mapping version was found in cluster state. This resulted in the latest mappings being applied when an old node was in a cluster instead of sticking to the backwards compatible mapping in the first version.

This changes it back to use the initial backwards compatible version of `.security-profile` mapping. 