### PR TITLE
[Profiling] Add API update reminder for V9

### DIFF
--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetFlamegraphResponse.java
@@ -173,6 +173,7 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         return totalSamples;
     }
 
+    @UpdateForV9 //change casing from Camel Case to Snake Case (requires updates in Kibana as well)
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetFlamegraphResponse.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/action/GetFlamegraphResponse.java
@@ -173,7 +173,7 @@ public class GetFlamegraphResponse extends ActionResponse implements ChunkedToXC
         return totalSamples;
     }
 
-    @UpdateForV9 //change casing from Camel Case to Snake Case (requires updates in Kibana as well)
+    @UpdateForV9 // change casing from Camel Case to Snake Case (requires updates in Kibana as well)
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         return Iterators.concat(


### PR DESCRIPTION
With this commit we add a reminder annotation to change the profiling flamegraph API response from Camel Case to Snake Case (which aligns this API casing with other Elasticsearch APIs).