### PR TITLE
Allow typed_keys for search application Search API

### DIFF
--- a/docs/changelog/108007.yaml
+++ b/docs/changelog/108007.yaml
@@ -1,0 +1,5 @@
+pr: 108007
+summary: Allow `typed_keys` for search application Search API
+area: Application
+type: feature
+issues: []

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -23,6 +23,11 @@ Unspecified template parameters will be assigned their default values (if applic
 Requires read privileges on the backing alias of the search application.
 
 [[search-application-search-path-params]]
+==== {api-path-parms-title}
+
+`typed_keys`::
+(Optional, Boolean) If `true`, aggregation and suggester names are prefixed
+by their respective types in the response. Defaults to `false`.
 
 [[search-application-search-request-body]]
 ==== {api-request-body-title}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.search.json
@@ -34,6 +34,13 @@
     "body": {
       "description": "Search parameters, including template parameters that override defaults",
       "required": false
+    },
+    "params": {
+      "typed_keys":{
+        "type":"boolean",
+        "default":false,
+        "description": "Specify whether aggregation and suggester names should be prefixed by their respective types in the response"
+      }
     }
   }
 }

--- a/x-pack/plugin/ent-search/qa/rest/roles.yml
+++ b/x-pack/plugin/ent-search/qa/rest/roles.yml
@@ -25,6 +25,7 @@ user:
       "test-index1",
       "test-search-application",
       "test-search-application-1",
+      "test-search-application-with-aggs",
       "test-search-application-with-list",
       "test-search-application-with-list-invalid",
       ".elastic-connectors-v1",

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/search/55_search_application_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/search/55_search_application_search.yml
@@ -112,6 +112,34 @@ setup:
               lang: "mustache"
 
   - do:
+      search_application.put:
+        name: test-search-application-with-aggs
+        body:
+          indices: [ "test-search-index1", "test-search-index2" ]
+          analytics_collection_name: "test-analytics"
+          template:
+            script:
+              source:
+                query:
+                  term:
+                    "{{field_name}}": "{{field_value}}"
+                aggs:
+                  my_agg:
+                    value_count:
+                      field: "field1.keyword"
+              params:
+                field_name: field1
+                field_value: value1
+            dictionary:
+              additionalProperties: false
+              required: [ "field_name" ]
+              properties:
+                field_name:
+                  type: string
+                field_value:
+                  type: string
+
+  - do:
       index:
         index: test-search-index1
         id: doc1
@@ -149,6 +177,11 @@ teardown:
   - do:
       search_application.delete:
         name: test-search-application-with-list-invalid
+        ignore: 404
+
+  - do:
+      search_application.delete:
+        name: test-search-application-with-aggs
         ignore: 404
 
   - do:
@@ -318,3 +351,54 @@ teardown:
               - name: field3
                 boost: 3
 
+---
+"Search Application search with typed keys includes type prefix in aggregation names":
+  - skip:
+      features: headers
+
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      search_application.search:
+        name: test-search-application-with-aggs
+        typed_keys: true
+        body:
+          params:
+            field_name: field2
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "doc1" }
+  - match: { aggregations.value_count#my_agg.value: 1 }
+
+---
+"Search Application search with typed keys set to false returns aggregations without type prefix":
+  - skip:
+      features: headers
+
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      search_application.search:
+        name: test-search-application-with-aggs
+        body:
+          params:
+            field_name: field2
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "doc1" }
+  - match: { aggregations.my_agg.value: 1 }
+
+---
+"Search Application search without typed keys returns aggregations without type prefix":
+  - skip:
+      features: headers
+
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      search_application.search:
+        name: test-search-application-with-aggs
+        body:
+          params:
+            field_name: field2
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "doc1" }
+  - match: { aggregations.my_agg.value: 1 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationAction.java
@@ -14,6 +14,7 @@ import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestRefCountedChunkedToXContentListener;
+import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.xpack.application.EnterpriseSearch;
 import org.elasticsearch.xpack.application.EnterpriseSearchBaseRestHandler;
 import org.elasticsearch.xpack.application.utils.LicenseUtils;
@@ -32,9 +33,7 @@ public class RestQuerySearchApplicationAction extends EnterpriseSearchBaseRestHa
     }
 
     public static final String ENDPOINT_PATH = "/" + EnterpriseSearch.SEARCH_APPLICATION_API_ENDPOINT + "/{name}" + "/_search";
-
-    public static final String TYPED_KEYS_PARAM = "typed_keys";
-    public static final Set<String> RESPONSE_PARAMS = Set.of(TYPED_KEYS_PARAM);
+    public static final Set<String> RESPONSE_PARAMS = Set.of(RestSearchAction.TYPED_KEYS_PARAM);
 
     @Override
     public String getName() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.application.utils.LicenseUtils;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
@@ -31,6 +32,9 @@ public class RestQuerySearchApplicationAction extends EnterpriseSearchBaseRestHa
     }
 
     public static final String ENDPOINT_PATH = "/" + EnterpriseSearch.SEARCH_APPLICATION_API_ENDPOINT + "/{name}" + "/_search";
+
+    public static final String TYPED_KEYS_PARAM = "typed_keys";
+    public static final Set<String> RESPONSE_PARAMS = Set.of(TYPED_KEYS_PARAM);
 
     @Override
     public String getName() {
@@ -55,5 +59,10 @@ public class RestQuerySearchApplicationAction extends EnterpriseSearchBaseRestHa
             RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, restRequest.getHttpChannel());
             cancelClient.execute(QuerySearchApplicationAction.INSTANCE, request, new RestRefCountedChunkedToXContentListener<>(channel));
         };
+    }
+
+    @Override
+    protected Set<String> responseParams() {
+        return RESPONSE_PARAMS;
     }
 }


### PR DESCRIPTION
Allows `typed_keys` in the search application Search API. This is needed for typed clients in order to parse the aggregations response.
These changes are meant to be backported to 8.14.

cc @swallez 