### PR TITLE
ESQL: Add key names to description of hash lookup

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/OperatorTests.java
@@ -370,7 +370,13 @@ public class OperatorTests extends MapperServiceTestCase {
                 var driver = new Driver(
                     driverContext,
                     new SequenceLongBlockSourceOperator(driverContext.blockFactory(), values, 100),
-                    List.of(new HashLookupOperator(driverContext.blockFactory(), new Block[] { primesBlock }, new int[] { 0 })),
+                    List.of(
+                        new HashLookupOperator(
+                            driverContext.blockFactory(),
+                            new HashLookupOperator.Key[] { new HashLookupOperator.Key("primes", primesBlock) },
+                            new int[] { 0 }
+                        )
+                    ),
                     new PageConsumerOperator(page -> {
                         try {
                             BlockTestUtils.readInto(actualValues, page.getBlock(0));

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HashLookupOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HashLookupOperatorTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.operator;
 
-import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.TestBlockFactory;
@@ -31,18 +30,22 @@ public class HashLookupOperatorTests extends OperatorTestCase {
     @Override
     protected Operator.OperatorFactory simple() {
         return new HashLookupOperator.Factory(
-            new Block[] { TestBlockFactory.getNonBreakingInstance().newLongArrayVector(new long[] { 7, 14, 20 }, 3).asBlock() },
+            new HashLookupOperator.Key[] {
+                new HashLookupOperator.Key(
+                    "foo",
+                    TestBlockFactory.getNonBreakingInstance().newLongArrayVector(new long[] { 7, 14, 20 }, 3).asBlock()
+                ) },
             new int[] { 0 }
         );
     }
 
     @Override
     protected String expectedDescriptionOfSimple() {
-        return "HashLookup[keys=[{type=LONG, positions=3, size=96b}], mapping=[0]]";
+        return "HashLookup[keys=[{name=foo, type=LONG, positions=3, size=96b}], mapping=[0]]";
     }
 
     @Override
     protected String expectedToStringOfSimple() {
-        return "HashLookup[hash=PackedValuesBlockHash{groups=[0:LONG], entries=3, size=536b}, mapping=[0]]";
+        return "HashLookup[keys=[foo], hash=PackedValuesBlockHash{groups=[0:LONG], entries=3, size=536b}, mapping=[0]]";
     }
 }


### PR DESCRIPTION
When I was debugging further work on our new hash stuff I found myself really wanting the key names on the `description` and `toString` of the hash lookup operator. This adds it.
