### PR TITLE
[Transform] Remove remote cluster from local test

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -308,11 +308,6 @@ public class ClientTransformIndexerTests extends ESTestCase {
 
     public void testDisablePit() throws InterruptedException {
         TransformConfig.Builder configBuilder = new TransformConfig.Builder(TransformConfigTests.randomTransformConfig());
-        if (randomBoolean()) {
-            // TransformConfigTests.randomTransformConfig never produces remote indices in the source.
-            // We need to explicitly set the remote index here for coverage.
-            configBuilder.setSource(new SourceConfig("remote-cluster:remote-index"));
-        }
         TransformConfig config = configBuilder.build();
 
         boolean pitEnabled = TransformEffectiveSettings.isPitDisabled(config.getSettings()) == false;


### PR DESCRIPTION
This test can fail when we randomly add remote clusters.  We would need to fix our assertion logic, but
`testDisablePitWhenThereIsRemoteIndexInSource` already covers the test case when there is a remote cluster and pit disabled.
