### PR TITLE
Optimise BinaryRangeAggregator for single value fields

### DIFF
--- a/docs/changelog/108016.yaml
+++ b/docs/changelog/108016.yaml
@@ -1,0 +1,5 @@
+pr: 108016
+summary: Optimise `BinaryRangeAggregator` for single value fields
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
@@ -7,9 +7,13 @@
  */
 package org.elasticsearch.search.aggregations.bucket.range;
 
+import org.apache.lucene.index.BinaryDocValues;
+import org.apache.lucene.index.DocValues;
+import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
@@ -130,9 +134,9 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
 
     abstract static class SortedSetRangeLeafCollector extends LeafBucketCollectorBase {
 
-        final long[] froms, tos, maxTos;
-        final SortedSetDocValues values;
-        final LeafBucketCollector sub;
+        private final long[] froms, tos, maxTos;
+        private final DocCollector collector;
+        private final LeafBucketCollector sub;
 
         SortedSetRangeLeafCollector(SortedSetDocValues values, Range[] ranges, LeafBucketCollector sub) throws IOException {
             super(sub, values);
@@ -141,7 +145,23 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
                     throw new IllegalArgumentException("Ranges must be sorted");
                 }
             }
-            this.values = values;
+            final SortedDocValues singleton = DocValues.unwrapSingleton(values);
+            if (singleton != null) {
+                this.collector = (doc, bucket) -> {
+                    if (singleton.advanceExact(doc)) {
+                        collect(doc, singleton.ordValue(), bucket, 0);
+                    }
+                };
+            } else {
+                this.collector = (doc, bucket) -> {
+                    if (values.advanceExact(doc)) {
+                        int lo = 0;
+                        for (long ord = values.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = values.nextOrd()) {
+                            lo = collect(doc, ord, bucket, lo);
+                        }
+                    }
+                };
+            }
             this.sub = sub;
             froms = new long[ranges.length];
             tos = new long[ranges.length]; // inclusive
@@ -174,12 +194,7 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
 
         @Override
         public void collect(int doc, long bucket) throws IOException {
-            if (values.advanceExact(doc)) {
-                int lo = 0;
-                for (long ord = values.nextOrd(); ord != SortedSetDocValues.NO_MORE_ORDS; ord = values.nextOrd()) {
-                    lo = collect(doc, ord, bucket, lo);
-                }
-            }
+            collector.collect(doc, bucket);
         }
 
         private int collect(int doc, long ord, long bucket, int lowBound) throws IOException {
@@ -236,10 +251,10 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
 
     abstract static class SortedBinaryRangeLeafCollector extends LeafBucketCollectorBase {
 
-        final Range[] ranges;
-        final BytesRef[] maxTos;
-        final SortedBinaryDocValues values;
-        final LeafBucketCollector sub;
+        private final Range[] ranges;
+        private final BytesRef[] maxTos;
+        private final DocCollector collector;
+        private final LeafBucketCollector sub;
 
         SortedBinaryRangeLeafCollector(SortedBinaryDocValues values, Range[] ranges, LeafBucketCollector sub) {
             super(sub, values);
@@ -248,7 +263,21 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
                     throw new IllegalArgumentException("Ranges must be sorted");
                 }
             }
-            this.values = values;
+            final BinaryDocValues singleton = FieldData.unwrapSingleton(values);
+            if (singleton != null) {
+                this.collector = (doc, bucket) -> {
+                    if (singleton.advanceExact(doc)) {
+                        collect(doc, singleton.binaryValue(), bucket, 0);
+                    }};
+            } else {
+                this.collector = (doc, bucket) -> {
+                    if (values.advanceExact(doc)) {
+                        for (int i = 0, lo = 0; i < values.docValueCount(); ++i) {
+                            lo = collect(doc, values.nextValue(), bucket, lo);
+                        }
+                    }
+                };
+            }
             this.sub = sub;
             this.ranges = ranges;
             maxTos = new BytesRef[ranges.length];
@@ -266,13 +295,7 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
 
         @Override
         public void collect(int doc, long bucket) throws IOException {
-            if (values.advanceExact(doc)) {
-                final int valuesCount = values.docValueCount();
-                for (int i = 0, lo = 0; i < valuesCount; ++i) {
-                    final BytesRef value = values.nextValue();
-                    lo = collect(doc, value, bucket, lo);
-                }
-            }
+            collector.collect(doc, bucket);
         }
 
         private int collect(int doc, BytesRef value, long bucket, int lowBound) throws IOException {
@@ -325,6 +348,11 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
         }
 
         protected abstract void doCollect(LeafBucketCollector sub, int doc, long bucket) throws IOException;
+    }
+
+    @FunctionalInterface
+    private interface DocCollector {
+        void collect(int doc, long bucket) throws IOException;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/BinaryRangeAggregator.java
@@ -268,7 +268,8 @@ public final class BinaryRangeAggregator extends BucketsAggregator {
                 this.collector = (doc, bucket) -> {
                     if (singleton.advanceExact(doc)) {
                         collect(doc, singleton.binaryValue(), bucket, 0);
-                    }};
+                    }
+                };
             } else {
                 this.collector = (doc, bucket) -> {
                     if (values.advanceExact(doc)) {


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/107832, this commit range aggregations over IP for single value fields.