### PR TITLE
SQL: Reenable JdbcCsvSpecIT inWithCompatibleDateTypes

### DIFF
--- a/x-pack/plugin/sql/qa/server/src/main/resources/filter.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/filter.csv-spec
@@ -130,8 +130,7 @@ SELECT COUNT(*), TRUNCATE(emp_no, -2) t FROM test_emp WHERE 'aaabbb' RLIKE 'a{2,
 1              |10100
 ;
 
-// AwaitsFix https://github.com/elastic/elasticsearch/issues/96805
-inWithCompatibleDateTypes-Ignore
+inWithCompatibleDateTypes
 SELECT birth_date FROM test_emp WHERE birth_date IN ({d '1959-07-23'}, CAST('1959-12-25T00:00:00' AS TIMESTAMP), '1964-06-02T00:00:00.000Z') OR birth_date IS NULL ORDER BY birth_date;
 
      birth_date:ts


### PR DESCRIPTION
Reenable org.elasticsearch.xpack.sql.qa.single_node.JdbcCsvSpecIT "test {filter.testInWithCompatibleDateTypes}", no longer reproducible.

The test has been added in 2019 (#47595) and started failing mid-last year (disabled in #96805).
It no longer reproduces on any of the JDK17+. Will reenable, but keep the disabling issue open while monitoring.