### PR TITLE
[TEST] Don't test binary field synthetic source with store true

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -255,7 +255,7 @@ public class BinaryFieldMapperTests extends MapperTestCase {
                 b.field("type", "binary").field("doc_values", "true");
 
                 if (rarely()) {
-                    b.field("store", true);
+                    b.field("store", false);
                 }
             }
 


### PR DESCRIPTION
Since synthetic source for binary field is constructed from doc values, binary values are sorted in synthetic source. That leads to a difference in stored fields between original document and document created from synthetic source. Because of that a check in `LuceneTestCase#assertReaderEquals` fails. This check is important and stored field value is not used for synthetic source so this PR disables testing with `store` set to `true`. This is consistent with tests for other fields.

Closes #108010.