### PR TITLE
Widen numeric counter types

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/tsdb-mapping.json
@@ -23,6 +23,10 @@
         "bytes_out": {
           "type": "long",
           "time_series_metric": "counter"
+        },
+        "message_in": {
+          "type": "float",
+          "time_series_metric": "counter"
         }
       }
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
@@ -249,7 +249,12 @@ public final class EsqlDataTypes {
     }
 
     public static DataType getCounterType(String typeName) {
-        return fromTypeName("counter_" + typeName);
+        final DataType rootType = widenSmallNumericTypes(fromName(typeName));
+        if (rootType == UNSUPPORTED) {
+            return rootType;
+        }
+        assert rootType == LONG || rootType == INTEGER || rootType == DOUBLE : rootType;
+        return fromTypeName("counter_" + rootType.typeName());
     }
 
     public static boolean isCounterType(DataType dt) {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/AnalyzerTests.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plugin.EsqlPlugin;
 import org.elasticsearch.xpack.esql.session.EsqlIndexResolver;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypeRegistry;
+import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.ql.expression.Alias;
 import org.elasticsearch.xpack.ql.expression.Attribute;
 import org.elasticsearch.xpack.ql.expression.Expressions;
@@ -59,6 +60,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.elasticsearch.xpack.esql.EsqlTestUtils.TEST_VERIFIER;
@@ -69,6 +72,7 @@ import static org.elasticsearch.xpack.esql.analysis.Analyzer.NO_FIELDS;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.analyze;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.analyzer;
 import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.loadMapping;
+import static org.elasticsearch.xpack.esql.analysis.AnalyzerTestUtils.tsdbIndexResolution;
 import static org.elasticsearch.xpack.ql.tree.Source.EMPTY;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -1624,6 +1628,22 @@ public class AnalyzerTests extends ESTestCase {
             query += ", x" + j + " = pow(x" + (j - 1) + ", " + i + ")";
         }
         assertProjection(query + " | keep x*", IntStream.range(0, additionalEvals + 3).mapToObj(v -> "x" + v).toArray(String[]::new));
+    }
+
+    public void testCounterTypes() {
+        var query = "FROM test | KEEP network.* | LIMIT 10";
+        Analyzer analyzer = analyzer(tsdbIndexResolution());
+        LogicalPlan plan = analyze(query, analyzer);
+        var limit = as(plan, Limit.class);
+        var attributes = limit.output().stream().collect(Collectors.toMap(NamedExpression::name, a -> a));
+        assertThat(
+            attributes.keySet(),
+            equalTo(Set.of("network.connections", "network.bytes_in", "network.bytes_out", "network.message_in"))
+        );
+        assertThat(attributes.get("network.connections").dataType(), equalTo(DataTypes.LONG));
+        assertThat(attributes.get("network.bytes_in").dataType(), equalTo(EsqlDataTypes.COUNTER_LONG));
+        assertThat(attributes.get("network.bytes_out").dataType(), equalTo(EsqlDataTypes.COUNTER_LONG));
+        assertThat(attributes.get("network.message_in").dataType(), equalTo(EsqlDataTypes.COUNTER_DOUBLE));
     }
 
     public void testMissingAttributeException_InChainedEval() {


### PR DESCRIPTION
We should widen the numeric root types before converting them into counter types.

Relates #107877