### PR TITLE
Document binary field defauls in TSDB indices

### DIFF
--- a/docs/plugins/mapper-annotated-text.asciidoc
+++ b/docs/plugins/mapper-annotated-text.asciidoc
@@ -157,7 +157,7 @@ of official GA features.
 
 `annotated_text` fields support {ref}/mapping-source-field.html#synthetic-source[synthetic `_source`] if they have
 a {ref}/keyword.html#keyword-synthetic-source[`keyword`] sub-field that supports synthetic
-`_source` or if the `text` field sets `store` to `true`. Either way, it may
+`_source` or if the `annotated_text` field sets `store` to `true`. Either way, it may
 not have {ref}/copy-to.html[`copy_to`].
 
 If using a sub-`keyword` field then the values are sorted in the same way as

--- a/docs/reference/mapping/types/binary.asciidoc
+++ b/docs/reference/mapping/types/binary.asciidoc
@@ -44,7 +44,8 @@ The following parameters are accepted by `binary` fields:
 
     Should the field be stored on disk in a column-stride fashion, so that it
     can later be used for sorting, aggregations, or scripting? Accepts `true`
-    or `false` (default).
+    or `false` (default). This parameter will be automatically set to `true` for TSDB indices
+(indices that have `index.mode` set to `time_series`).
 
 <<mapping-store,`store`>>::
 


### PR DESCRIPTION
Reflects #107739 and fixes a typo i noticed in `annotated_text`.