### PR TITLE
Mute HashLookupOperatorTests testSimpleToString

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AnyOperatorTestCase.java
@@ -68,7 +68,7 @@ public abstract class AnyOperatorTestCase extends ComputeTestCase {
     /**
      * Makes sure the description of {@link #simple} matches the {@link #expectedDescriptionOfSimple}.
      */
-    public final void testSimpleToString() {
+    public void testSimpleToString() {
         try (Operator operator = simple().get(driverContext())) {
             assertThat(operator.toString(), equalTo(expectedToStringOfSimple()));
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HashLookupOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HashLookupOperatorTests.java
@@ -88,4 +88,11 @@ public class HashLookupOperatorTests extends OperatorTestCase {
     protected String expectedToStringOfSimple() {
         return "HashLookup[keys=[foo], hash=PackedValuesBlockHash{groups=[0:LONG], entries=4, size=544b}, mapping=[0]]";
     }
+
+    @Override
+    // when you remove this AwaitsFix, also make this method in the superclass final again
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108045")
+    public void testSimpleToString() {
+        super.testSimpleToString();
+    }
 }


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/108045
