### PR TITLE
Enable concurrent profiling

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -2172,12 +2172,12 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
     }
 
     public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinality) {
-        if (profile) return false;
-
         if (sorts != null) {
             // the implicit sorting is by _score, which supports parallel collection
             for (SortBuilder<?> sortBuilder : sorts) {
-                if (sortBuilder.supportsParallelCollection() == false) return false;
+                if (sortBuilder.supportsParallelCollection() == false) {
+                    return false;
+                }
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/builder/SearchSourceBuilderTests.java
@@ -996,7 +996,7 @@ public class SearchSourceBuilderTests extends AbstractSearchTestCase {
         {
             SearchSourceBuilder searchSourceBuilder = newSearchSourceBuilder.get();
             searchSourceBuilder.profile(true);
-            assertFalse(searchSourceBuilder.supportsParallelCollection(fieldCardinality));
+            assertTrue(searchSourceBuilder.supportsParallelCollection(fieldCardinality));
         }
     }
 


### PR DESCRIPTION
Concurrent search execution has been disabled so far whenever profile is on. In practice, there are scenarios for which we can't really disable concurrency, because concurrency is not always based on slices. That makes it more important to address the concurrency issues in the profiler and enable concurrent profiling across the board.