### PR TITLE
[8.14] [Connector API] Mark connector management APIs as beta in 8.14 (#108004)

### DIFF
--- a/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Cancel connector sync job</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Cancels a connector sync job.
 

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -1,7 +1,7 @@
 [[connector-apis]]
 == Connector APIs
 
-preview::[]
+beta::[]
 
 The connector and sync jobs APIs provide a convenient way to create and manage Elastic {enterprise-search-ref}/connectors.html[connectors^] and sync jobs in an internal index.
 
@@ -29,21 +29,29 @@ You can use these APIs to create, get, delete and update connectors.
 Use the following APIs to manage connectors:
 
 * <<create-connector-api>>
+beta:[]
 * <<delete-connector-api>>
+beta:[]
 * <<get-connector-api>>
+beta:[]
 * <<list-connector-api>>
-* <<check-in-connector-api>>
+beta:[]
 * <<update-connector-api-key-id-api>>
+beta:[]
 * <<update-connector-configuration-api>>
-* <<update-connector-error-api>>
+beta:[]
 * <<update-connector-filtering-api>>
+beta:[]
 * <<update-connector-index-name-api>>
-* <<update-connector-last-sync-api>>
+beta:[]
 * <<update-connector-name-description-api>>
+beta:[]
 * <<update-connector-pipeline-api>>
+beta:[]
 * <<update-connector-scheduling-api>>
+beta:[]
 * <<update-connector-service-type-api>>
-* <<update-connector-status-api>>
+beta:[]
 
 
 [discrete]
@@ -54,38 +62,81 @@ You can use these APIs to create, cancel, delete and update sync jobs.
 
 Use the following APIs to manage sync jobs:
 
-
-* <<cancel-connector-sync-job-api>>
-* <<check-in-connector-sync-job-api>>
 * <<create-connector-sync-job-api>>
+beta:[]
+* <<cancel-connector-sync-job-api>>
+beta:[]
 * <<delete-connector-sync-job-api>>
+beta:[]
 * <<get-connector-sync-job-api>>
+beta:[]
 * <<list-connector-sync-jobs-api>>
+beta:[]
+
+
+[discrete]
+[[service-apis]]
+=== Service APIs
+
+preview::[]
+
+*Connector Service APIs* are a subset of Connector API endpoints, that represent framework-level operations defined in the https://github.com/elastic/connectors/blob/main/docs/CONNECTOR_PROTOCOL.md[Connector Protocol]. These APIs are not intended for direct connector management by users but are there to support the implementation of services that utilize the Conector Protocol to communicate with {es}.
+
+[TIP]
+====
+All Elastic connectors are built using our Python connector framework. The source code is available in the https://github.com/elastic/connectors[elastic/connectors] repository on GitHub.
+====
+
+[discrete]
+[[connector-service-apis]]
+==== Connector Service APIs
+
+* <<check-in-connector-api>>
+preview:[]
+* <<update-connector-error-api>>
+preview:[]
+* <<update-connector-last-sync-api>>
+preview:[]
+* <<update-connector-status-api>>
+preview:[]
+
+[discrete]
+[[sync-job-service-apis]]
+==== Sync Job Service APIs
+
+* <<check-in-connector-sync-job-api>>
+preview:[]
 * <<set-connector-sync-job-error-api>>
+preview:[]
 * <<set-connector-sync-job-stats-api>>
+preview:[]
 
 
-include::cancel-connector-sync-job-api.asciidoc[]
-include::check-in-connector-api.asciidoc[]
-include::check-in-connector-sync-job-api.asciidoc[]
+
 include::create-connector-api.asciidoc[]
-include::create-connector-sync-job-api.asciidoc[]
 include::delete-connector-api.asciidoc[]
-include::delete-connector-sync-job-api.asciidoc[]
 include::get-connector-api.asciidoc[]
-include::get-connector-sync-job-api.asciidoc[]
 include::list-connectors-api.asciidoc[]
-include::list-connector-sync-jobs-api.asciidoc[]
-include::set-connector-sync-job-error-api.asciidoc[]
-include::set-connector-sync-job-stats-api.asciidoc[]
 include::update-connector-api-key-id-api.asciidoc[]
 include::update-connector-configuration-api.asciidoc[]
-include::update-connector-error-api.asciidoc[]
-include::update-connector-filtering-api.asciidoc[]
 include::update-connector-index-name-api.asciidoc[]
-include::update-connector-last-sync-api.asciidoc[]
+include::update-connector-filtering-api.asciidoc[]
 include::update-connector-name-description-api.asciidoc[]
 include::update-connector-pipeline-api.asciidoc[]
 include::update-connector-scheduling-api.asciidoc[]
 include::update-connector-service-type-api.asciidoc[]
+
+include::create-connector-sync-job-api.asciidoc[]
+include::cancel-connector-sync-job-api.asciidoc[]
+include::delete-connector-sync-job-api.asciidoc[]
+include::get-connector-sync-job-api.asciidoc[]
+include::list-connector-sync-jobs-api.asciidoc[]
+
+include::check-in-connector-api.asciidoc[]
+include::update-connector-error-api.asciidoc[]
+include::update-connector-last-sync-api.asciidoc[]
 include::update-connector-status-api.asciidoc[]
+
+include::check-in-connector-sync-job-api.asciidoc[]
+include::set-connector-sync-job-error-api.asciidoc[]
+include::set-connector-sync-job-stats-api.asciidoc[]

--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Create connector</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Creates an Elastic connector.
 Connectors are {es} integrations that bring content from third-party data sources, which can be deployed on {ecloud} or hosted on your own infrastructure:

--- a/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Create connector sync job</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 
 Creates a connector sync job.

--- a/docs/reference/connector/apis/delete-connector-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete connector</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Removes a connector and associated sync jobs.
 This is a destructive action that is not recoverable.

--- a/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Delete connector sync job</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Removes a connector sync job and its associated data.
 This is a destructive action that is not recoverable.

--- a/docs/reference/connector/apis/get-connector-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get connector</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Retrieves the details about a connector.
 

--- a/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Get connector sync job</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Retrieves the details about a connector sync job.
 

--- a/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
+++ b/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>List connector sync jobs</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Returns information about all stored connector sync jobs ordered by their creation date in ascending order.
 

--- a/docs/reference/connector/apis/list-connectors-api.asciidoc
+++ b/docs/reference/connector/apis/list-connectors-api.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>List connectors</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Returns information about all created connectors.
 

--- a/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update connector API key id</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Updates the `api_key_id` and/or `api_key_secret_id` field(s) of a connector, specifying:
 

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update connector configuration</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Updates a connector's `configuration`, allowing for config value updates within a registered configuration schema.
 

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update connector filtering</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Updates the draft `filtering` configuration of a connector and marks the draft validation state as `edited`. The filtering configuration can be activated once validated by the Elastic connector service.
 
@@ -14,6 +14,7 @@ The filtering property is used to configure sync rules (both basic and advanced)
 ==== {api-request-title}
 
 `PUT _connector/<connector_id>/_filtering`
+
 `PUT _connector/<connector_id>/_filtering/_activate`
 
 [[update-connector-filtering-api-prereq]]

--- a/docs/reference/connector/apis/update-connector-index-name-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-index-name-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update connector index name</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Updates the `index_name` field of a connector, specifying the index where the data ingested by the connector is stored.
 

--- a/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update connector name and description</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 
 Updates the `name` and `description` fields of a connector.

--- a/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update connector pipeline</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Updates the `pipeline` configuration of a connector.
 

--- a/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update connector scheduling</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Updates the `scheduling` configuration of a connector.
 

--- a/docs/reference/connector/apis/update-connector-service-type-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-service-type-api.asciidoc
@@ -4,7 +4,7 @@
 <titleabbrev>Update connector service type</titleabbrev>
 ++++
 
-preview::[]
+beta::[]
 
 Updates the `service_type` of a connector.
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [Connector API] Mark connector management APIs as beta in 8.14 (#108004)