### PR TITLE
DenseVectorFieldMapper fixed typo

### DIFF
--- a/docs/changelog/108065.yaml
+++ b/docs/changelog/108065.yaml
@@ -1,0 +1,5 @@
+pr: 108065
+summary: '`DenseVectorFieldMapper` fixed typo'
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -1414,7 +1414,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     + name()
                     + "] of type ["
                     + typeName()
-                    + "] doesn't not support indexing multiple values for the same field in the same document"
+                    + "] doesn't support indexing multiple values for the same field in the same document"
             );
         }
         if (Token.VALUE_NULL == context.parser().currentToken()) {


### PR DESCRIPTION
Fix typo in `DenseVectorFieldMapper`.

closes [#108050](https://github.com/elastic/elasticsearch/issues/108050)