### PR TITLE
[8.9] Adding docs about scaled_float saturation with long values (#107966)

### DIFF
--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -227,6 +227,18 @@ numeric field can't be both a time series dimension and a time series metric.
     of `scaling_factor` improve accuracy but also increase space requirements.
     This parameter is required.
 
+[[scaled-float-saturation]]
+==== `scaled_float` saturation
+
+`scaled_float` is stored as a single `long` value, which is the product of multiplying the original value by the scaling factor. If the multiplication
+results in a value that is outside the range of a `long`, the value is saturated
+to the minimum or maximum value of a `long`. For example, if the scaling factor
+is +100+ and the value is +92233720368547758.08+, the expected value is +9223372036854775808+.
+However, the value that is stored is +9223372036854775807+, the maximum value for a `long`.
+
+This can lead to unexpected results with <<query-dsl-range-query,range queries>>
+when the scaling factor or provided `float` value are exceptionally large.
+
 [[numeric-synthetic-source]]
 ==== Synthetic `_source`
 


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Adding docs about scaled_float saturation with long values (#107966)