### PR TITLE
Simulate should succeed if ignore_missing_pipeline

### DIFF
--- a/docs/changelog/108106.yaml
+++ b/docs/changelog/108106.yaml
@@ -2,5 +2,4 @@ pr: 108106
 summary: Simulate should succeed if `ignore_missing_pipeline`
 area: Ingest Node
 type: bug
-issues: 
- - 107314
+issues: []

--- a/docs/changelog/108106.yaml
+++ b/docs/changelog/108106.yaml
@@ -2,4 +2,5 @@ pr: 108106
 summary: Simulate should succeed if `ignore_missing_pipeline`
 area: Ingest Node
 type: bug
-issues: []
+issues:
+ - 107314

--- a/docs/changelog/108106.yaml
+++ b/docs/changelog/108106.yaml
@@ -2,4 +2,5 @@ pr: 108106
 summary: Simulate should succeed if `ignore_missing_pipeline`
 area: Ingest Node
 type: bug
-issues: []
+issues: 
+ - 107314

--- a/docs/changelog/108106.yaml
+++ b/docs/changelog/108106.yaml
@@ -1,0 +1,5 @@
+pr: 108106
+summary: Simulate should succeed if `ignore_missing_pipeline`
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
@@ -1017,10 +1017,14 @@ teardown:
             ]
           }
   - length: { docs: 1 }
-  - length: { docs.0.processor_results: 1 }
-  - match: { docs.0.processor_results.0.doc._source.outer-field: null }
-  - match: { docs.0.processor_results.0.status: "error" }
+  - length: { docs.0.processor_results: 2 }
+  - match: { docs.0.processor_results.0.doc._source.field1: "123.42 400 <foo>" }
+  - match: { docs.0.processor_results.0.status: "error_ignored" }
   - match: { docs.0.processor_results.0.processor_type: "pipeline" }
-  - match: { docs.0.processor_results.0.error.type: "illegal_argument_exception" }
-  - match: { docs.0.processor_results.0.error.reason: "Pipeline processor configured for non-existent pipeline [missing-inner]" }
+  - match: { docs.0.processor_results.0.ignored_error.error.type: "illegal_argument_exception" }
+  - match: { docs.0.processor_results.0.ignored_error.error.reason: "Pipeline processor configured for non-existent pipeline [missing-inner]" }
+  - match: { docs.0.processor_results.1.doc._source.outer-field: true }
+  - match: { docs.0.processor_results.1.status: "success" }
+  - match: { docs.0.processor_results.1.processor_type: "set" }
+
 

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
@@ -981,3 +981,46 @@ teardown:
   - match: { docs.0.processor_results.0.status: "error" }
   - match: { docs.0.processor_results.0.error.root_cause.0.type: "illegal_argument_exception" }
   - match: { docs.0.processor_results.0.error.root_cause.0.reason: "Pipeline processor configured for non-existent pipeline [____pipeline_doesnot_exist___]" }
+
+---
+"Test verbose simulate with Pipeline Processor and ignore_missing_pipeline":
+  - do:
+      ingest.simulate:
+        verbose: true
+        body: >
+          {
+            "pipeline": {
+              "description": "outer pipeline",
+              "processors": [
+              {
+                "pipeline": {
+                  "name": "missing-inner",
+                  "ignore_missing_pipeline": true
+                }
+              },
+              {
+                "set": {
+                  "field": "outer-field",
+                  "value": true
+                }
+              }
+              ]
+            },
+            "docs": [
+            {
+              "_index": "index",
+              "_id": "id",
+              "_source": {
+                "field1": "123.42 400 <foo>"
+              }
+            }
+            ]
+          }
+  - length: { docs: 1 }
+  - length: { docs.0.processor_results: 1 }
+  - match: { docs.0.processor_results.0.doc._source.outer-field: null }
+  - match: { docs.0.processor_results.0.status: "error" }
+  - match: { docs.0.processor_results.0.processor_type: "pipeline" }
+  - match: { docs.0.processor_results.0.error.type: "illegal_argument_exception" }
+  - match: { docs.0.processor_results.0.error.reason: "Pipeline processor configured for non-existent pipeline [missing-inner]" }
+

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineProcessor.java
@@ -34,6 +34,10 @@ public class PipelineProcessor extends AbstractProcessor {
         this.ingestService = ingestService;
     }
 
+    public boolean isIgnoreMissingPipeline() {
+        return ignoreMissingPipeline;
+    }
+
     @Override
     public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
         String pipelineName = ingestDocument.renderTemplate(this.pipelineTemplate);

--- a/server/src/main/java/org/elasticsearch/ingest/TrackingResultProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/TrackingResultProcessor.java
@@ -83,20 +83,19 @@ public final class TrackingResultProcessor implements Processor {
                         pipelineProcessor.getType(),
                         pipelineProcessor.getTag(),
                         pipelineProcessor.getDescription(),
-                        pipelineProcessor.isIgnoreMissingPipeline()  ? ingestDocument : null,
+                        pipelineProcessor.isIgnoreMissingPipeline() ? ingestDocument : null,
                         e,
                         conditionalWithResult
                     )
                 );
 
-                 if (pipelineProcessor.isIgnoreMissingPipeline()) {
-                     handler.accept(ingestDocument, null);
-                     return;
-                 } else {
-                     throw e;
-                 }
+                if (pipelineProcessor.isIgnoreMissingPipeline()) {
+                    handler.accept(ingestDocument, null);
+                    return;
+                } else {
+                    throw e;
+                }
             }
-
             if (performCycleCheck) {
                 ingestDocumentCopy.executePipeline(pipelineToCall, (result, e) -> {
                     // special handling for pipeline cycle errors

--- a/server/src/main/java/org/elasticsearch/ingest/TrackingResultProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/TrackingResultProcessor.java
@@ -83,12 +83,20 @@ public final class TrackingResultProcessor implements Processor {
                         pipelineProcessor.getType(),
                         pipelineProcessor.getTag(),
                         pipelineProcessor.getDescription(),
+                        pipelineProcessor.isIgnoreMissingPipeline()  ? ingestDocument : null,
                         e,
                         conditionalWithResult
                     )
                 );
-                throw e;
+
+                 if (pipelineProcessor.isIgnoreMissingPipeline()) {
+                     handler.accept(ingestDocument, null);
+                     return;
+                 } else {
+                     throw e;
+                 }
             }
+
             if (performCycleCheck) {
                 ingestDocumentCopy.executePipeline(pipelineToCall, (result, e) -> {
                     // special handling for pipeline cycle errors


### PR DESCRIPTION
Pipeline Processors with non-existing pipelines should succeed (as noop) if ignore_missing_pipeline=true. Currently, this does not work when pipelines are simulated with verbose=true. In this case, an error is returned and no results are shown for subsequent processors. This change allows following processors to run, and changes the status from error to error_ignored.

closes #107314 