### PR TITLE
[ci] Move BWC to spot instances, shrink packaging-test-unix instances

### DIFF
--- a/.buildkite/pipelines/periodic-packaging.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.template.yml
@@ -28,7 +28,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: custom-16-32768
+          machineType: n1-standard-8
         env: {}
   - group: packaging-tests-upgrade
     steps: $BWC_STEPS

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -29,7 +29,7 @@ steps:
           provider: gcp
           image: family/elasticsearch-{{matrix.image}}
           diskSizeGb: 350
-          machineType: custom-16-32768
+          machineType: n1-standard-8
         env: {}
   - group: packaging-tests-upgrade
     steps:

--- a/.buildkite/pipelines/periodic.bwc.template.yml
+++ b/.buildkite/pipelines/periodic.bwc.template.yml
@@ -6,5 +6,13 @@
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: $BWC_VERSION
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -10,8 +10,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.0.1
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.1.1 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.1.1#bwcTest
         timeout_in_minutes: 300
@@ -20,8 +29,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.1.1
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.2.1 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.2.1#bwcTest
         timeout_in_minutes: 300
@@ -30,8 +48,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.2.1
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.3.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.3.2#bwcTest
         timeout_in_minutes: 300
@@ -40,8 +67,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.3.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.4.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.4.2#bwcTest
         timeout_in_minutes: 300
@@ -50,8 +86,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.4.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.5.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.5.2#bwcTest
         timeout_in_minutes: 300
@@ -60,8 +105,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.5.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.6.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.6.2#bwcTest
         timeout_in_minutes: 300
@@ -70,8 +124,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.6.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.7.1 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.7.1#bwcTest
         timeout_in_minutes: 300
@@ -80,8 +143,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.7.1
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.8.1 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.8.1#bwcTest
         timeout_in_minutes: 300
@@ -90,8 +162,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.8.1
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.9.3 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.9.3#bwcTest
         timeout_in_minutes: 300
@@ -100,8 +181,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.9.3
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.10.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.10.2#bwcTest
         timeout_in_minutes: 300
@@ -110,8 +200,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.10.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.11.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.11.2#bwcTest
         timeout_in_minutes: 300
@@ -120,8 +219,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.11.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.12.1 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.12.1#bwcTest
         timeout_in_minutes: 300
@@ -130,8 +238,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.12.1
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.13.4 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.13.4#bwcTest
         timeout_in_minutes: 300
@@ -140,8 +257,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.13.4
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.14.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.14.2#bwcTest
         timeout_in_minutes: 300
@@ -150,8 +276,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.14.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.15.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.15.2#bwcTest
         timeout_in_minutes: 300
@@ -160,8 +295,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.15.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.16.3 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.16.3#bwcTest
         timeout_in_minutes: 300
@@ -170,8 +314,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.16.3
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 7.17.21 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v7.17.21#bwcTest
         timeout_in_minutes: 300
@@ -180,8 +333,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 7.17.21
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.0.1 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.0.1#bwcTest
         timeout_in_minutes: 300
@@ -190,8 +352,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.0.1
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.1.3 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.1.3#bwcTest
         timeout_in_minutes: 300
@@ -200,8 +371,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.1.3
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.2.3 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.2.3#bwcTest
         timeout_in_minutes: 300
@@ -210,8 +390,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.2.3
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.3.3 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.3.3#bwcTest
         timeout_in_minutes: 300
@@ -220,8 +409,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.3.3
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.4.3 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.4.3#bwcTest
         timeout_in_minutes: 300
@@ -230,8 +428,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.4.3
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.5.3 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.5.3#bwcTest
         timeout_in_minutes: 300
@@ -240,8 +447,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.5.3
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.6.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.6.2#bwcTest
         timeout_in_minutes: 300
@@ -250,8 +466,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.6.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.7.1 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.7.1#bwcTest
         timeout_in_minutes: 300
@@ -260,8 +485,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.7.1
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.8.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.8.2#bwcTest
         timeout_in_minutes: 300
@@ -270,8 +504,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.8.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.9.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.9.2#bwcTest
         timeout_in_minutes: 300
@@ -280,8 +523,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.9.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.10.4 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.10.4#bwcTest
         timeout_in_minutes: 300
@@ -290,8 +542,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.10.4
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.11.4 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.11.4#bwcTest
         timeout_in_minutes: 300
@@ -300,8 +561,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.11.4
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.12.2 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.12.2#bwcTest
         timeout_in_minutes: 300
@@ -310,8 +580,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.12.2
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.13.3 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.13.3#bwcTest
         timeout_in_minutes: 300
@@ -320,8 +599,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.13.3
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.14.0 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.14.0#bwcTest
         timeout_in_minutes: 300
@@ -330,8 +618,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.14.0
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
       - label: 8.15.0 / bwc
         command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true v8.15.0#bwcTest
         timeout_in_minutes: 300
@@ -340,8 +637,17 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          preemptible: true
         env:
           BWC_VERSION: 8.15.0
+        retry:
+          automatic:
+            - exit_status: "-1"
+              limit: 3
+              signal_reason: none
+            - signal_reason: agent_stop
+              limit: 3
+
   - label: concurrent-search-tests
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dtests.jvm.argline=-Des.concurrent_search=true -Des.concurrent_search=true functionalTests
     timeout_in_minutes: 420


### PR DESCRIPTION
- Move BWC jobs to spot instances, as they are shorter and make for a good test
- Shrink packaging-test-unix instances as nearly the entire job consists of serial tasks with low CPU load