### PR TITLE
[7.17] Fix Netty4TransportMultiPortIntegrationIT#testThatTransportClientCanConnect

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/Netty4TransportMultiPortIntegrationIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/Netty4TransportMultiPortIntegrationIT.java
@@ -72,7 +72,7 @@ public class Netty4TransportMultiPortIntegrationIT extends ESNetty4IntegTestCase
             .build();
         // we have to test all the ports that the data node might be bound to
         try (TransportClient transportClient = new MockTransportClient(settings, Arrays.asList(Netty4Plugin.class))) {
-            for (int i = 0; i <= 10; i++) {
+            for (int i = 0; i <= NUMBER_OF_CLIENT_PORTS; i++) {
                 transportClient.addTransportAddress(new TransportAddress(InetAddress.getByName("127.0.0.1"), randomPort + i));
             }
             ClusterHealthResponse response = transportClient.admin().cluster().prepareHealth().get();

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/Netty4TransportMultiPortIntegrationIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/Netty4TransportMultiPortIntegrationIT.java
@@ -72,7 +72,7 @@ public class Netty4TransportMultiPortIntegrationIT extends ESNetty4IntegTestCase
             .build();
         // we have to test all the ports that the data node might be bound to
         try (TransportClient transportClient = new MockTransportClient(settings, Arrays.asList(Netty4Plugin.class))) {
-            for (int i = 0; i <= NUMBER_OF_CLIENT_PORTS; i++) {
+            for (int i = -NUMBER_OF_CLIENT_PORTS; i <= NUMBER_OF_CLIENT_PORTS; i++) {
                 transportClient.addTransportAddress(new TransportAddress(InetAddress.getByName("127.0.0.1"), randomPort + i));
             }
             ClusterHealthResponse response = transportClient.admin().cluster().prepareHealth().get();

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/Netty4TransportMultiPortIntegrationIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/Netty4TransportMultiPortIntegrationIT.java
@@ -72,7 +72,7 @@ public class Netty4TransportMultiPortIntegrationIT extends ESNetty4IntegTestCase
             .build();
         // we have to test all the ports that the data node might be bound to
         try (TransportClient transportClient = new MockTransportClient(settings, Arrays.asList(Netty4Plugin.class))) {
-            for (int i = -NUMBER_OF_CLIENT_PORTS; i <= NUMBER_OF_CLIENT_PORTS; i++) {
+            for (int i = 0; i <= NUMBER_OF_CLIENT_PORTS; i++) {
                 transportClient.addTransportAddress(new TransportAddress(InetAddress.getByName("127.0.0.1"), randomPort + i));
             }
             ClusterHealthResponse response = transportClient.admin().cluster().prepareHealth().get();


### PR DESCRIPTION
#103894 increased the range of available client ports on Windows for a node, but didn't update the range of ports that the transport client test iterates through in trying to connect to the node. 

Both test failures reported in #107757 happened on Windows machines.

See #103894

Resolves #107757

