### PR TITLE
Allow for null default and max global retention in DataStreamGlobalRetentionTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
@@ -301,7 +301,11 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
             }
             // We check that even if there was no retention provided by the user, the global retention applies
             assertThat(serialized, not(containsString("data_retention")));
-            assertThat(serialized, containsString("effective_retention"));
+            if (globalRetention.getDefaultRetention() != null || globalRetention.getMaxRetention() != null) {
+                assertThat(serialized, containsString("effective_retention"));
+            } else {
+                assertThat(serialized, not(containsString("effective_retention")));
+            }
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
@@ -250,7 +250,11 @@ public class ComposableIndexTemplateTests extends SimpleDiffableSerializationTes
             }
             // We check that even if there was no retention provided by the user, the global retention applies
             assertThat(serialized, not(containsString("data_retention")));
-            assertThat(serialized, containsString("effective_retention"));
+            if (globalRetention.getDefaultRetention() != null || globalRetention.getMaxRetention() != null) {
+                assertThat(serialized, containsString("effective_retention"));
+            } else {
+                assertThat(serialized, not(containsString("effective_retention")));
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetentionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamGlobalRetentionTests.java
@@ -76,9 +76,10 @@ public class DataStreamGlobalRetentionTests extends SimpleDiffableWireSerializat
 
     public static DataStreamGlobalRetention randomGlobalRetention() {
         boolean withDefault = randomBoolean();
+        boolean withMax = randomBoolean();
         return new DataStreamGlobalRetention(
             withDefault == false ? null : TimeValue.timeValueDays(randomIntBetween(1, 1000)),
-            withDefault && randomBoolean() ? null : TimeValue.timeValueDays(randomIntBetween(1000, 2000))
+            withMax == false ? null : TimeValue.timeValueDays(randomIntBetween(1000, 2000))
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamLifecycleTests.java
@@ -135,7 +135,9 @@ public class DataStreamLifecycleTests extends AbstractXContentSerializingTestCas
             } else {
                 assertThat(serialized, containsString("data_retention"));
             }
-            if (lifecycle.isEnabled()) {
+            boolean globalRetentionIsNotNull = globalRetention.getDefaultRetention() != null || globalRetention.getMaxRetention() != null;
+            boolean configuredLifeCycleIsNotNull = lifecycle.getDataRetention() != null && lifecycle.getDataRetention().value() != null;
+            if (lifecycle.isEnabled() && (globalRetentionIsNotNull || configuredLifeCycleIsNotNull)) {
                 assertThat(serialized, containsString("effective_retention"));
             } else {
                 assertThat(serialized, not(containsString("effective_retention")));

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -1794,7 +1794,12 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
             }
             // We check that even if there was no retention provided by the user, the global retention applies
             assertThat(serialized, not(containsString("data_retention")));
-            assertThat(serialized, containsString("effective_retention"));
+            if (globalRetention.getDefaultRetention() != null || globalRetention.getMaxRetention() != null) {
+                assertThat(serialized, containsString("effective_retention"));
+            } else {
+                assertThat(serialized, not(containsString("effective_retention")));
+            }
+
         }
     }
 


### PR DESCRIPTION
DataStreamGlobalRetentionTests.randomGlobalRetention() could never return a DataStreamGlobalRetention that had null for both default and max. This updates it to randomly do that about 1/4 of the time.