### PR TITLE
Use MockLogAppender.capturing

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
@@ -9,9 +9,8 @@
 package org.elasticsearch.transport.netty4;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ESNetty4IntegTestCase;
-import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.MockLogAppender;
@@ -25,21 +24,16 @@ import java.io.IOException;
 public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
 
     private MockLogAppender appender;
+    private Releasable appenderRelease;
 
     public void setUp() throws Exception {
         super.setUp();
         appender = new MockLogAppender();
-        Loggers.addAppender(LogManager.getLogger(ESLoggingHandler.class), appender);
-        Loggers.addAppender(LogManager.getLogger(TransportLogger.class), appender);
-        Loggers.addAppender(LogManager.getLogger(TcpTransport.class), appender);
-        appender.start();
+        appenderRelease = appender.capturing(ESLoggingHandler.class, TransportLogger.class, TcpTransport.class);
     }
 
     public void tearDown() throws Exception {
-        Loggers.removeAppender(LogManager.getLogger(ESLoggingHandler.class), appender);
-        Loggers.removeAppender(LogManager.getLogger(TransportLogger.class), appender);
-        Loggers.removeAppender(LogManager.getLogger(TcpTransport.class), appender);
-        appender.stop();
+        appenderRelease.close();
         super.tearDown();
     }
 

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -203,20 +203,16 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
 
         String stdoutLoggerName = "test_plugin-controller-stdout";
         String stderrLoggerName = "test_plugin-controller-stderr";
-        MockLogAppender stdoutAppender = new MockLogAppender();
-        MockLogAppender stderrAppender = new MockLogAppender();
+        MockLogAppender appender = new MockLogAppender();
         Loggers.setLevel(LogManager.getLogger(stdoutLoggerName), Level.TRACE);
         Loggers.setLevel(LogManager.getLogger(stderrLoggerName), Level.TRACE);
         CountDownLatch messagesLoggedLatch = new CountDownLatch(2);
         if (expectSpawn) {
-            stdoutAppender.addExpectation(new ExpectedStreamMessage(stdoutLoggerName, "I am alive", messagesLoggedLatch));
-            stderrAppender.addExpectation(new ExpectedStreamMessage(stderrLoggerName, "I am an error", messagesLoggedLatch));
+            appender.addExpectation(new ExpectedStreamMessage(stdoutLoggerName, "I am alive", messagesLoggedLatch));
+            appender.addExpectation(new ExpectedStreamMessage(stderrLoggerName, "I am an error", messagesLoggedLatch));
         }
 
-        try (
-            var stdoutRelease = stdoutAppender.capturing(stderrLoggerName);
-            var stderrRelease = stderrAppender.capturing(stderrLoggerName)
-        ) {
+        try (var ignore = appender.capturing(stdoutLoggerName, stderrLoggerName)) {
             Spawner spawner = new Spawner();
             spawner.spawnNativeControllers(environment);
 
@@ -234,8 +230,7 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
             } else {
                 assertThat(processes, hasSize(0));
             }
-            stdoutAppender.assertAllExpectationsMatched();
-            stderrAppender.assertAllExpectationsMatched();
+            appender.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -9,8 +9,6 @@
 package org.elasticsearch.snapshots;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
@@ -32,7 +30,6 @@ import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
@@ -1271,10 +1268,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         mockAppender.addExpectation(
             new MockLogAppender.UnseenEventExpectation("no warnings", BlobStoreRepository.class.getCanonicalName(), Level.WARN, "*")
         );
-        mockAppender.start();
-        final Logger logger = LogManager.getLogger(BlobStoreRepository.class);
-        Loggers.addAppender(logger, mockAppender);
-        try {
+        try (var ignored = mockAppender.capturing(BlobStoreRepository.class)) {
             final String index1 = "index-1";
             final String index2 = "index-2";
             createIndexWithContent("index-1");
@@ -1287,9 +1281,6 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
             clusterAdmin().prepareDeleteSnapshot(repoName, snapshot1, snapshot2).get();
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(logger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
@@ -9,9 +9,7 @@
 package org.elasticsearch.snapshots;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.core.Tuple;
@@ -139,9 +137,7 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
         final String primaryNode = internalCluster().startNode(primaryNodeSettings);
 
         final MockLogAppender mockLogAppender = new MockLogAppender();
-        try {
-            mockLogAppender.start();
-            Loggers.addAppender(LogManager.getLogger(BlobStoreRepository.class), mockLogAppender);
+        try (var ignored = mockLogAppender.capturing(BlobStoreRepository.class)) {
 
             MockLogAppender.EventuallySeenEventExpectation snapshotExpectation = new MockLogAppender.EventuallySeenEventExpectation(
                 "snapshot speed over recovery speed",
@@ -175,9 +171,6 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
 
             deleteRepository("test-repo");
             mockLogAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(LogManager.getLogger(BlobStoreRepository.class), mockLogAppender);
-            mockLogAppender.stop();
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
@@ -9,12 +9,10 @@
 package org.elasticsearch.snapshots;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -35,10 +33,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
 
         final MockLogAppender mockLogAppender = new MockLogAppender();
 
-        try {
-            mockLogAppender.start();
-            Loggers.addAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);
-
+        try (var ignored = mockLogAppender.capturing(SnapshotsService.class)) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation(
                     "[does-not-exist]",
@@ -76,8 +71,6 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             awaitNoMoreRunningOperations(); // ensure background file deletion is completed
             mockLogAppender.assertAllExpectationsMatched();
         } finally {
-            Loggers.removeAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);
-            mockLogAppender.stop();
             deleteRepository("test-repo");
         }
     }
@@ -89,9 +82,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
 
         final MockLogAppender mockLogAppender = new MockLogAppender();
 
-        try {
-            mockLogAppender.start();
-            Loggers.addAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);
+        try (var ignored = mockLogAppender.capturing(SnapshotsService.class)) {
 
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
@@ -121,8 +112,6 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
 
             mockLogAppender.assertAllExpectationsMatched();
         } finally {
-            Loggers.removeAppender(LogManager.getLogger(SnapshotsService.class), mockLogAppender);
-            mockLogAppender.stop();
             deleteRepository("test-repo");
         }
     }

--- a/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
@@ -133,22 +132,20 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
             when(reader.readLine()).thenThrow(ioException);
             final Logger logger = LogManager.getLogger("testGetMaxMapCountIOException");
             final MockLogAppender appender = new MockLogAppender();
-            appender.start();
-            appender.addExpectation(
-                new MessageLoggingExpectation(
-                    "expected logged I/O exception",
-                    "testGetMaxMapCountIOException",
-                    Level.WARN,
-                    "I/O exception while trying to read [" + procSysVmMaxMapCountPath + "]",
-                    e -> ioException == e
-                )
-            );
-            Loggers.addAppender(logger, appender);
-            assertThat(check.getMaxMapCount(logger), equalTo(-1L));
-            appender.assertAllExpectationsMatched();
+            try (var ignored = appender.capturing("testGetMaxMapCountIOException")) {
+                appender.addExpectation(
+                    new MessageLoggingExpectation(
+                        "expected logged I/O exception",
+                        "testGetMaxMapCountIOException",
+                        Level.WARN,
+                        "I/O exception while trying to read [" + procSysVmMaxMapCountPath + "]",
+                        e -> ioException == e
+                    )
+                );
+                assertThat(check.getMaxMapCount(logger), equalTo(-1L));
+                appender.assertAllExpectationsMatched();
+            }
             verify(reader).close();
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
         }
 
         {
@@ -156,22 +153,20 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
             when(reader.readLine()).thenReturn("eof");
             final Logger logger = LogManager.getLogger("testGetMaxMapCountNumberFormatException");
             final MockLogAppender appender = new MockLogAppender();
-            appender.start();
-            appender.addExpectation(
-                new MessageLoggingExpectation(
-                    "expected logged number format exception",
-                    "testGetMaxMapCountNumberFormatException",
-                    Level.WARN,
-                    "unable to parse vm.max_map_count [eof]",
-                    e -> e instanceof NumberFormatException && e.getMessage().equals("For input string: \"eof\"")
-                )
-            );
-            Loggers.addAppender(logger, appender);
-            assertThat(check.getMaxMapCount(logger), equalTo(-1L));
-            appender.assertAllExpectationsMatched();
+            try (var ignored = appender.capturing("testGetMaxMapCountNumberFormatException")) {
+                appender.addExpectation(
+                    new MessageLoggingExpectation(
+                        "expected logged number format exception",
+                        "testGetMaxMapCountNumberFormatException",
+                        Level.WARN,
+                        "unable to parse vm.max_map_count [eof]",
+                        e -> e instanceof NumberFormatException && e.getMessage().equals("For input string: \"eof\"")
+                    )
+                );
+                assertThat(check.getMaxMapCount(logger), equalTo(-1L));
+                appender.assertAllExpectationsMatched();
+            }
             verify(reader).close();
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
         }
 
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
@@ -9,12 +9,10 @@
 package org.elasticsearch.cluster.coordination.stateless;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
@@ -85,11 +83,8 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
         final var heartbeatFrequency = TimeValue.timeValueSeconds(randomIntBetween(15, 30));
         final var maxTimeSinceLastHeartbeat = TimeValue.timeValueSeconds(2 * heartbeatFrequency.seconds());
         DiscoveryNodeUtils.create("master");
-        final var logger = LogManager.getLogger(AtomicRegisterPreVoteCollector.class);
         final var appender = new MockLogAppender();
-        appender.start();
-        try {
-            Loggers.addAppender(logger, appender);
+        try (var ignored = appender.capturing(AtomicRegisterPreVoteCollector.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "log emitted when skipping election",
@@ -123,9 +118,6 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
 
             assertThat(startElection.get(), is(false));
             appender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
@@ -9,8 +9,6 @@
 package org.elasticsearch.cluster.routing.allocation;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -23,7 +21,6 @@ import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.allocation.command.AllocationCommands;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.MockLogAppender;
@@ -100,11 +97,8 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
 
         assertTrue(initialState.toString(), initialState.getRoutingNodes().unassigned().isEmpty());
 
-        final Logger allocationServiceLogger = LogManager.getLogger(AllocationService.class);
         final MockLogAppender appender = new MockLogAppender();
-        appender.start();
-        Loggers.addAppender(allocationServiceLogger, appender);
-        try {
+        try (var ignored = appender.capturing(AllocationService.class)) {
             final String dissociationReason = "node left " + randomAlphaOfLength(10);
 
             appender.addExpectation(
@@ -125,9 +119,6 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
             );
 
             appender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(allocationServiceLogger, appender);
-            appender.stop();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
@@ -63,10 +63,8 @@ public class JULBridgeTests extends ESTestCase {
         Level savedLevel = testLogger.getLevel();
         MockLogAppender mockAppender = new MockLogAppender();
 
-        try {
+        try (var ignored = mockAppender.capturing("")) {
             Loggers.setLevel(testLogger, Level.ALL);
-            mockAppender.start();
-            Loggers.addAppender(testLogger, mockAppender);
             for (var expectation : expectations) {
                 mockAppender.addExpectation(expectation);
             }
@@ -74,8 +72,6 @@ public class JULBridgeTests extends ESTestCase {
             mockAppender.assertAllExpectationsMatched();
         } finally {
             Loggers.setLevel(testLogger, savedLevel);
-            Loggers.removeAppender(testLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -8,12 +8,9 @@
 package org.elasticsearch.common.settings;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.logging.DeprecationLogger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.AbstractScopedSettings.SettingUpdater;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -1437,31 +1434,25 @@ public class SettingTests extends ESTestCase {
         final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
 
         final MockLogAppender mockLogAppender = new MockLogAppender();
-        mockLogAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "message",
-                "org.elasticsearch.common.settings.IndexScopedSettings",
-                Level.INFO,
-                "updating [index.refresh_interval] from [20s] to [10s]"
-            ) {
-                @Override
-                public boolean innerMatch(LogEvent event) {
-                    return event.getMarker().getName().equals(" [index1]");
+        try (var ignored = mockLogAppender.capturing(IndexScopedSettings.class)) {
+            mockLogAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "message",
+                    "org.elasticsearch.common.settings.IndexScopedSettings",
+                    Level.INFO,
+                    "updating [index.refresh_interval] from [20s] to [10s]"
+                ) {
+                    @Override
+                    public boolean innerMatch(LogEvent event) {
+                        return event.getMarker().getName().equals(" [index1]");
+                    }
                 }
-            }
-        );
-        mockLogAppender.start();
-        final Logger logger = LogManager.getLogger(IndexScopedSettings.class);
-        try {
-            Loggers.addAppender(logger, mockLogAppender);
+            );
             settings.updateIndexMetadata(
                 newIndexMeta("index1", Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "10s").build())
             );
 
             mockLogAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(logger, mockLogAppender);
-            mockLogAppender.stop();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -116,18 +115,14 @@ public class SettingsFilterTests extends ESTestCase {
         );
     }
 
-    private void assertExpectedLogMessages(Consumer<Logger> consumer, MockLogAppender.LoggingExpectation... expectations)
-        throws IllegalAccessException {
+    private void assertExpectedLogMessages(Consumer<Logger> consumer, MockLogAppender.LoggingExpectation... expectations) {
         Logger testLogger = LogManager.getLogger("org.elasticsearch.test");
         MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(testLogger, appender);
-        try {
+        try (var ignored = appender.capturing("org.elasticsearch.test")) {
             appender.start();
             Arrays.stream(expectations).forEach(appender::addExpectation);
             consumer.accept(testLogger);
             appender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(testLogger, appender);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexingSlowLogTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.logging.ESLogMessage;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.logging.MockAppender;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexingSlowLog.IndexingSlowLogMessage;
 import org.elasticsearch.index.engine.Engine;
@@ -54,6 +55,7 @@ import static org.mockito.Mockito.mock;
 
 public class IndexingSlowLogTests extends ESTestCase {
     static MockAppender appender;
+    static Releasable appenderRelease;
     static Logger testLogger1 = LogManager.getLogger(IndexingSlowLog.INDEX_INDEXING_SLOWLOG_PREFIX + ".index");
 
     @BeforeClass

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -9,8 +9,6 @@
 package org.elasticsearch.ingest;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ResourceNotFoundException;
@@ -42,7 +40,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.TriConsumer;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.util.Maps;
@@ -754,18 +751,17 @@ public class IngestServiceTests extends ESTestCase {
         String id = "_id";
         Pipeline pipeline = ingestService.getPipeline(id);
         assertThat(pipeline, nullValue());
-        ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).build();
+        ClusterState previousClusterState = ClusterState.builder(new ClusterName("_name")).build();
 
         PutPipelineRequest putRequest = new PutPipelineRequest(
             id,
             new BytesArray("{\"description\": \"empty processors\"}"),
             XContentType.JSON
         );
-        ClusterState previousClusterState = clusterState;
-        clusterState = executePut(putRequest, clusterState);
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        mockAppender.addExpectation(
+        ClusterState clusterState = executePut(putRequest, previousClusterState);
+        MockLogAppender.assertThatLogger(
+            () -> ingestService.applyClusterState(new ClusterChangedEvent("", clusterState, previousClusterState)),
+            IngestService.class,
             new MockLogAppender.SeenEventExpectation(
                 "test1",
                 IngestService.class.getCanonicalName(),
@@ -773,15 +769,6 @@ public class IngestServiceTests extends ESTestCase {
                 "failed to update ingest pipelines"
             )
         );
-        Logger ingestLogger = LogManager.getLogger(IngestService.class);
-        Loggers.addAppender(ingestLogger, mockAppender);
-        try {
-            ingestService.applyClusterState(new ClusterChangedEvent("", clusterState, previousClusterState));
-            mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(ingestLogger, mockAppender);
-            mockAppender.stop();
-        }
         pipeline = ingestService.getPipeline(id);
         assertNotNull(pipeline);
         assertThat(pipeline.getId(), equalTo("_id"));

--- a/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
@@ -9,14 +9,12 @@
 package org.elasticsearch.tasks;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.admin.cluster.node.tasks.TaskManagerTestCase;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
@@ -172,10 +170,7 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
             );
 
             MockLogAppender appender = new MockLogAppender();
-            appender.start();
-            resources.add(appender::stop);
-            Loggers.addAppender(LogManager.getLogger(TaskCancellationService.class), appender);
-            resources.add(() -> Loggers.removeAppender(LogManager.getLogger(TaskCancellationService.class), appender));
+            resources.add(appender.capturing(TaskCancellationService.class));
 
             for (MockLogAppender.LoggingExpectation expectation : expectations.apply(childTransportService.getLocalDiscoNode())) {
                 appender.addExpectation(expectation);

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -9,8 +9,6 @@
 package org.elasticsearch.transport;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
@@ -23,7 +21,6 @@ import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.HandlingTimeTracker;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.PageCacheRecycler;
@@ -233,19 +230,16 @@ public class InboundHandlerTests extends ESTestCase {
         // it.
 
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "expected message",
-                EXPECTED_LOGGER_NAME,
-                Level.WARN,
-                "error processing handshake version"
-            )
-        );
-        final Logger inboundHandlerLogger = LogManager.getLogger(InboundHandler.class);
-        Loggers.addAppender(inboundHandlerLogger, mockAppender);
+        try (var ignored = mockAppender.capturing(InboundHandler.class)) {
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "expected message",
+                    EXPECTED_LOGGER_NAME,
+                    Level.WARN,
+                    "error processing handshake version"
+                )
+            );
 
-        try {
             final AtomicBoolean isClosed = new AtomicBoolean();
             channel.addCloseListener(ActionListener.running(() -> assertTrue(isClosed.compareAndSet(false, true))));
 
@@ -268,9 +262,6 @@ public class InboundHandlerTests extends ESTestCase {
             assertTrue(isClosed.get());
             assertNull(channel.getMessageCaptor().get());
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(inboundHandlerLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 
@@ -282,12 +273,9 @@ public class InboundHandlerTests extends ESTestCase {
 
     public void testLogsSlowInboundProcessing() throws Exception {
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        final Logger inboundHandlerLogger = LogManager.getLogger(InboundHandler.class);
-        Loggers.addAppender(inboundHandlerLogger, mockAppender);
 
         handler.setSlowLogThreshold(TimeValue.timeValueMillis(5L));
-        try {
+        try (var ignored = mockAppender.capturing(InboundHandler.class)) {
             final TransportVersion remoteVersion = TransportVersion.current();
 
             mockAppender.addExpectation(
@@ -339,9 +327,6 @@ public class InboundHandlerTests extends ESTestCase {
             handler.inboundMessage(channel, new InboundMessage(responseHeader, ReleasableBytesReference.empty(), () -> {}));
 
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(inboundHandlerLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -9,8 +9,6 @@
 package org.elasticsearch.transport;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
@@ -26,7 +24,6 @@ import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.HandlingTimeTracker;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -537,16 +534,14 @@ public class OutboundHandlerTests extends ESTestCase {
     private static final String EXPECTED_LOGGER_NAME = "org.elasticsearch.transport.OutboundHandler";
 
     public void testSlowLogOutboundMessage() throws Exception {
-        final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        mockAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation("expected message", EXPECTED_LOGGER_NAME, Level.WARN, "sending transport message ")
-        );
-        final Logger outboundHandlerLogger = LogManager.getLogger(OutboundHandler.class);
-        Loggers.addAppender(outboundHandlerLogger, mockAppender);
         handler.setSlowLogThreshold(TimeValue.timeValueMillis(5L));
 
-        try {
+        final MockLogAppender mockAppender = new MockLogAppender();
+        try (var ignored = mockAppender.capturing(OutboundHandler.class)) {
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation("expected message", EXPECTED_LOGGER_NAME, Level.WARN, "sending transport message ")
+            );
+
             final int length = randomIntBetween(1, 100);
             final PlainActionFuture<Void> f = new PlainActionFuture<>();
             handler.sendBytes(new FakeTcpChannel() {
@@ -562,9 +557,6 @@ public class OutboundHandlerTests extends ESTestCase {
             }, new BytesArray(randomByteArrayOfLength(length)), f);
             f.get();
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(outboundHandlerLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -9,14 +9,12 @@
 package org.elasticsearch.transport;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.HandlingTimeTracker;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.network.NetworkUtils;
@@ -574,14 +572,11 @@ public class TcpTransportTests extends ESTestCase {
         Exception exception,
         boolean expectClosed,
         MockLogAppender.LoggingExpectation... expectations
-    ) throws IllegalAccessException {
+    ) {
         final TestThreadPool testThreadPool = new TestThreadPool("test");
         MockLogAppender appender = new MockLogAppender();
 
-        try {
-            appender.start();
-
-            Loggers.addAppender(LogManager.getLogger(TcpTransport.class), appender);
+        try (var ignored = appender.capturing(TcpTransport.class)) {
             for (MockLogAppender.LoggingExpectation expectation : expectations) {
                 appender.addExpectation(expectation);
             }
@@ -621,8 +616,6 @@ public class TcpTransportTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
         } finally {
-            Loggers.removeAppender(LogManager.getLogger(TcpTransport.class), appender);
-            appender.stop();
             ThreadPool.terminate(testThreadPool, 30, TimeUnit.SECONDS);
         }
     }

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -8,13 +8,11 @@
 package org.elasticsearch.transport;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.admin.cluster.stats.ClusterStatsRequest;
 import org.elasticsearch.action.admin.cluster.stats.TransportClusterStatsAction;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -28,21 +26,6 @@ import static org.mockito.Mockito.mock;
 
 @TestLogging(value = "org.elasticsearch.transport.TransportLogger:trace", reason = "to ensure we log network events on TRACE level")
 public class TransportLoggerTests extends ESTestCase {
-
-    private MockLogAppender appender;
-
-    public void setUp() throws Exception {
-        super.setUp();
-        appender = new MockLogAppender();
-        Loggers.addAppender(LogManager.getLogger(TransportLogger.class), appender);
-        appender.start();
-    }
-
-    public void tearDown() throws Exception {
-        Loggers.removeAppender(LogManager.getLogger(TransportLogger.class), appender);
-        appender.stop();
-        super.tearDown();
-    }
 
     public void testLoggingHandler() throws IOException {
         final String writePattern = ".*\\[length: \\d+"
@@ -74,12 +57,15 @@ public class TransportLoggerTests extends ESTestCase {
             readPattern
         );
 
-        appender.addExpectation(writeExpectation);
-        appender.addExpectation(readExpectation);
-        BytesReference bytesReference = buildRequest();
-        TransportLogger.logInboundMessage(mock(TcpChannel.class), bytesReference.slice(6, bytesReference.length() - 6));
-        TransportLogger.logOutboundMessage(mock(TcpChannel.class), bytesReference);
-        appender.assertAllExpectationsMatched();
+        MockLogAppender appender = new MockLogAppender();
+        try (var ignored = appender.capturing(TransportLogger.class)) {
+            appender.addExpectation(writeExpectation);
+            appender.addExpectation(readExpectation);
+            BytesReference bytesReference = buildRequest();
+            TransportLogger.logInboundMessage(mock(TcpChannel.class), bytesReference.slice(6, bytesReference.length() - 6));
+            TransportLogger.logOutboundMessage(mock(TcpChannel.class), bytesReference);
+            appender.assertAllExpectationsMatched();
+        }
     }
 
     private BytesReference buildRequest() throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.transport;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.util.Supplier;
 import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
@@ -29,7 +28,6 @@ import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.CloseableChannel;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkUtils;
@@ -1322,9 +1320,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         );
 
         MockLogAppender appender = new MockLogAppender();
-        try {
-            appender.start();
-            Loggers.addAppender(LogManager.getLogger("org.elasticsearch.transport.TransportService.tracer"), appender);
+        try (var ignored = appender.capturing("org.elasticsearch.transport.TransportService.tracer")) {
 
             ////////////////////////////////////////////////////////////////////////
             // tests for included action type "internal:test"
@@ -1464,9 +1460,6 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             submitRequest(serviceA, nodeB, "internal:testNotSeen", new StringMessageRequest(""), noopResponseHandler).get();
 
             assertBusy(appender::assertAllExpectationsMatched);
-        } finally {
-            Loggers.removeAppender(LogManager.getLogger("org.elasticsearch.transport.TransportService.tracer"), appender);
-            appender.stop();
         }
     }
 

--- a/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
+++ b/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
@@ -11,8 +11,6 @@ package org.elasticsearch.test.rest.yaml;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
@@ -36,10 +34,7 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
     @Override
     public void test() throws IOException {
         final MockLogAppender mockLogAppender = new MockLogAppender();
-        try {
-            mockLogAppender.start();
-            Loggers.addAppender(LogManager.getLogger(ESClientYamlSuiteTestCaseFailLogIT.class), mockLogAppender);
-
+        try (var ignored = mockLogAppender.capturing(ESClientYamlSuiteTestCaseFailLogIT.class)) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "message with dump of the test yaml",
@@ -68,9 +63,6 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
             }
 
             mockLogAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(LogManager.getLogger(ESClientYamlSuiteTestCaseFailLogIT.class), mockLogAppender);
-            mockLogAppender.stop();
         }
     }
 }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.ccr;
 
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -130,6 +132,7 @@ public class CcrLicenseIT extends CcrSingleNodeTestCase {
     }
 
     public void testAutoFollowCoordinatorLogsSkippingAutoFollowCoordinationWithNonCompliantLicense() throws Exception {
+        final Logger logger = LogManager.getLogger(AutoFollowCoordinator.class);
         final MockLogAppender appender = new MockLogAppender();
 
         try (var ignored = appender.capturing(AutoFollowCoordinator.class)) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModelTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.elasticsearch.common.logging.Loggers;
@@ -72,19 +71,11 @@ public class ExpressionModelTests extends ESTestCase {
 
     private void doWithLoggingExpectations(List<? extends MockLogAppender.LoggingExpectation> expectations, CheckedRunnable<Exception> body)
         throws Exception {
-        final Logger modelLogger = LogManager.getLogger(ExpressionModel.class);
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
-            Loggers.addAppender(modelLogger, mockAppender);
+        try (var ignored = mockAppender.capturing(ExpressionModel.class)) {
             expectations.forEach(mockAppender::addExpectation);
-
             body.run();
-
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(modelLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -8,8 +8,6 @@
 package org.elasticsearch.xpack.core.security.authz.accesscontrol;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
@@ -29,7 +27,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BitSet;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.CheckedBiConsumer;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.IndexSettings;
@@ -194,11 +191,8 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        final Logger cacheLogger = LogManager.getLogger(cache.getClass());
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
-            Loggers.addAppender(cacheLogger, mockAppender);
+        try (var ignored = mockAppender.capturing(cache.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "[bitset too big]",
@@ -222,9 +216,6 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
             });
 
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(cacheLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 
@@ -238,11 +229,8 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        final Logger cacheLogger = LogManager.getLogger(cache.getClass());
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
-            Loggers.addAppender(cacheLogger, mockAppender);
+        try (var ignored = mockAppender.capturing(cache.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "[cache full]",
@@ -264,9 +252,6 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
             });
 
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(cacheLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -8,8 +8,6 @@
 package org.elasticsearch.xpack.logstash.action;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -57,16 +55,6 @@ public class TransportGetPipelineActionTests extends ESTestCase {
     public void testGetPipelineMultipleIDsPartialFailure() throws Exception {
         // Set up a log appender for detecting log messages
         final MockLogAppender mockLogAppender = new MockLogAppender();
-        mockLogAppender.addExpectation(
-            new MockLogAppender.SeenEventExpectation(
-                "message",
-                "org.elasticsearch.xpack.logstash.action.TransportGetPipelineAction",
-                Level.INFO,
-                "Could not retrieve logstash pipelines with ids: [2]"
-            )
-        );
-        mockLogAppender.start();
-        final Logger logger = LogManager.getLogger(TransportGetPipelineAction.class);
 
         // Set up a MultiGetResponse
         GetResponse mockResponse = mock(GetResponse.class);
@@ -79,35 +67,41 @@ public class TransportGetPipelineActionTests extends ESTestCase {
             new MultiGetItemResponse[] { new MultiGetItemResponse(mockResponse, null), new MultiGetItemResponse(null, failure) }
         );
 
-        GetPipelineRequest request = new GetPipelineRequest(List.of("1", "2"));
+        try (var threadPool = createThreadPool(); var ignored = mockLogAppender.capturing(TransportGetPipelineAction.class)) {
+            mockLogAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "message",
+                    "org.elasticsearch.xpack.logstash.action.TransportGetPipelineAction",
+                    Level.INFO,
+                    "Could not retrieve logstash pipelines with ids: [2]"
+                )
+            );
 
-        // Set up an ActionListener for the actual test conditions
-        ActionListener<GetPipelineResponse> testActionListener = new ActionListener<>() {
-            @Override
-            public void onResponse(GetPipelineResponse getPipelineResponse) {
-                // check successful pipeline get
-                assertThat(getPipelineResponse, is(notNullValue()));
-                assertThat(getPipelineResponse.pipelines().size(), equalTo(1));
-
-                // check that failed pipeline get is logged
-                mockLogAppender.assertAllExpectationsMatched();
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                // do nothing
-            }
-        };
-
-        try (var threadPool = createThreadPool()) {
             final var client = getMockClient(threadPool, multiGetResponse);
             Loggers.addAppender(logger, mockLogAppender);
             TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
+            GetPipelineRequest request = new GetPipelineRequest(List.of("1", "2"));
+
+            // Set up an ActionListener for the actual test conditions
+            ActionListener<GetPipelineResponse> testActionListener = new ActionListener<>() {
+                @Override
+                public void onResponse(GetPipelineResponse getPipelineResponse) {
+                    // check successful pipeline get
+                    assertThat(getPipelineResponse, is(notNullValue()));
+                    assertThat(getPipelineResponse.pipelines().size(), equalTo(1));
+
+                    // check that failed pipeline get is logged
+                    mockLogAppender.assertAllExpectationsMatched();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // do nothing
+                }
+            };
+
             TransportGetPipelineAction action = new TransportGetPipelineAction(transportService, mock(ActionFilters.class), client);
             action.doExecute(null, request, testActionListener);
-        } finally {
-            Loggers.removeAppender(logger, mockLogAppender);
-            mockLogAppender.stop();
         }
     }
 

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchHit;

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -78,7 +78,6 @@ public class TransportGetPipelineActionTests extends ESTestCase {
             );
 
             final var client = getMockClient(threadPool, multiGetResponse);
-            Loggers.addAppender(logger, mockLogAppender);
             TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor();
             GetPipelineRequest request = new GetPipelineRequest(List.of("1", "2"));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
@@ -105,7 +105,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
         );
 
         MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test1",
@@ -156,7 +155,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
         );
 
         MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test1",
@@ -213,7 +211,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
         );
 
         MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test1",
@@ -281,7 +278,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
         );
 
         MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test1",
@@ -318,7 +314,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
         );
 
         MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
         mockAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation(
                 "test1",
@@ -381,18 +376,16 @@ public class CppLogMessageHandlerTests extends ESTestCase {
 
     private static void executeLoggingTest(InputStream is, MockLogAppender mockAppender, Level level, String jobId) throws IOException {
         Logger cppMessageLogger = LogManager.getLogger(CppLogMessageHandler.class);
-        Loggers.addAppender(cppMessageLogger, mockAppender);
-
         Level oldLevel = cppMessageLogger.getLevel();
         Loggers.setLevel(cppMessageLogger, level);
-        try (CppLogMessageHandler handler = new CppLogMessageHandler(jobId, is)) {
+        try (
+            var ignored = mockAppender.capturing(CppLogMessageHandler.class);
+            CppLogMessageHandler handler = new CppLogMessageHandler(jobId, is)
+        ) {
             handler.tailStream();
+            mockAppender.assertAllExpectationsMatched();
         } finally {
-            Loggers.removeAppender(cppMessageLogger, mockAppender);
             Loggers.setLevel(cppMessageLogger, oldLevel);
-            mockAppender.stop();
         }
-
-        mockAppender.assertAllExpectationsMatched();
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -1510,10 +1510,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
         final MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(logger, appender);
-        appender.start();
 
-        try {
+        try (var ignored = appender.capturing(ApiKeyService.class)) {
             appender.addExpectation(
                 new MockLogAppender.PatternSeenEventExpectation(
                     "evict",
@@ -1556,9 +1554,7 @@ public class ApiKeyServiceTests extends ESTestCase {
             apiKeyAuthCache.invalidateAll();
             appender.assertAllExpectationsMatched();
         } finally {
-            appender.stop();
             Loggers.setLevel(logger, Level.INFO);
-            Loggers.removeAppender(logger, appender);
         }
     }
 
@@ -1575,10 +1571,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
         final MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(logger, appender);
-        appender.start();
 
-        try {
+        try (var ignored = appender.capturing(ApiKeyService.class)) {
             appender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation(
                     "evict",
@@ -1596,9 +1590,7 @@ public class ApiKeyServiceTests extends ESTestCase {
             assertEquals(1, apiKeyAuthCache.count());
             appender.assertAllExpectationsMatched();
         } finally {
-            appender.stop();
             Loggers.setLevel(logger, Level.INFO);
-            Loggers.removeAppender(logger, appender);
         }
     }
 
@@ -1612,10 +1604,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
         final MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(logger, appender);
-        appender.start();
 
-        try {
+        try (var ignored = appender.capturing(ApiKeyService.class)) {
             // Prepare the warning logging to trigger
             service.getEvictionCounter().add(4500);
             final long thrashingCheckIntervalInSeconds = 300L;
@@ -1670,9 +1660,7 @@ public class ApiKeyServiceTests extends ESTestCase {
             apiKeyAuthCache.put(randomAlphaOfLength(23), new ListenableFuture<>());
             appender.assertAllExpectationsMatched();
         } finally {
-            appender.stop();
             Loggers.setLevel(logger, Level.INFO);
-            Loggers.removeAppender(logger, appender);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -7,8 +7,6 @@
 package org.elasticsearch.xpack.security.authc;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.ElasticsearchException;
@@ -33,7 +31,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -420,11 +417,9 @@ public class AuthenticationServiceTests extends ESTestCase {
     }
 
     public void testTokenMissing() throws Exception {
-        final Logger unlicensedRealmsLogger = LogManager.getLogger(RealmsAuthenticator.class);
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
-            Loggers.addAppender(unlicensedRealmsLogger, mockAppender);
+
+        try (var ignored = mockAppender.capturing(RealmsAuthenticator.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "unlicensed realms",
@@ -471,9 +466,6 @@ public class AuthenticationServiceTests extends ESTestCase {
                 service.authenticate("_action", transportRequest, true, listener);
             }
             assertThat(completed.get(), is(true));
-        } finally {
-            Loggers.removeAppender(unlicensedRealmsLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -481,10 +481,8 @@ public class AuthenticatorChainTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(AuthenticatorChain.class);
         Loggers.setLevel(logger, Level.INFO);
         final MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(logger, appender);
-        appender.start();
 
-        try {
+        try (var ignored = appender.capturing(AuthenticatorChain.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "run-as",
@@ -498,9 +496,7 @@ public class AuthenticatorChainTests extends ESTestCase {
             assertThat(future.actionGet(), equalTo(authentication));
             appender.assertAllExpectationsMatched();
         } finally {
-            appender.stop();
             Loggers.setLevel(logger, Level.INFO);
-            Loggers.removeAppender(logger, appender);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -212,13 +212,14 @@ public class RealmsAuthenticatorTests extends AbstractAuthenticatorTests {
                     "unlicensed realms",
                     RealmsAuthenticator.class.getName(),
                     Level.WARN,
-                    "Authentication failed using realms [realm1/realm1,realm2/reaml2]."
+                    "Authentication failed using realms [realm1/realm1,realm2/realm2]."
                         + " Realms [realm3/realm3] were skipped because they are not permitted on the current license"
                 )
             );
             final PlainActionFuture<AuthenticationResult<Authentication>> future = new PlainActionFuture<>();
             realmsAuthenticator.authenticate(context, future);
             assertThat(expectThrows(ElasticsearchSecurityException.class, future::actionGet), is(e));
+            mockAppender.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
@@ -971,8 +971,6 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
     public void testLogIdTokenAndNonce() throws URISyntaxException, BadJOSEException, JOSEException, IllegalAccessException {
         final Logger logger = LogManager.getLogger(OpenIdConnectAuthenticator.class);
         final MockLogAppender appender = new MockLogAppender();
-        appender.start();
-        Loggers.addAppender(logger, appender);
         Loggers.setLevel(logger, Level.DEBUG);
 
         final RealmConfig config = buildConfig(getBasicRealmSettings().build(), threadContext);
@@ -999,7 +997,7 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
         final Nonce expectedNonce = new Nonce(randomAlphaOfLength(10));
 
-        try {
+        try (var ignored = appender.capturing(OpenIdConnectAuthenticator.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation("JWT header", logger.getName(), Level.DEBUG, "ID Token Header: " + headerString)
             );
@@ -1018,8 +1016,6 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
             // The logging message assertion is the only thing we actually care in this test
             appender.assertAllExpectationsMatched();
         } finally {
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
             Loggers.setLevel(logger, (Level) null);
             openIdConnectAuthenticator.close();
         }
@@ -1063,11 +1059,9 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
         // In addition, capture logs to show that kept alive (TTL) is honored
         final Logger logger = LogManager.getLogger(PoolingNHttpClientConnectionManager.class);
         final MockLogAppender appender = new MockLogAppender();
-        appender.start();
-        Loggers.addAppender(logger, appender);
         // Note: Setting an org.apache.http logger to DEBUG requires es.insecure_network_trace_enabled=true
         Loggers.setLevel(logger, Level.DEBUG);
-        try {
+        try (var ignored = appender.capturing(PoolingNHttpClientConnectionManager.class)) {
             appender.addExpectation(
                 new MockLogAppender.PatternSeenEventExpectation(
                     "log",
@@ -1101,8 +1095,6 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
             appender.assertAllExpectationsMatched();
             assertThat(portTested.get(), is(true));
         } finally {
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
             Loggers.setLevel(logger, (Level) null);
             authenticator.close();
             httpServer.stop(1);
@@ -1211,10 +1203,8 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
         final Logger logger = LogManager.getLogger(OpenIdConnectAuthenticator.class);
         final MockLogAppender appender = new MockLogAppender();
-        appender.start();
-        Loggers.addAppender(logger, appender);
         Loggers.setLevel(logger, Level.DEBUG);
-        try {
+        try (var ignored = appender.capturing(OpenIdConnectAuthenticator.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "log",
@@ -1227,8 +1217,6 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
             assertThat(keepAliveStrategy.getKeepAliveDuration(httpResponse, null), equalTo(effectiveTtlInMs));
             appender.assertAllExpectationsMatched();
         } finally {
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
             Loggers.setLevel(logger, (Level) null);
             authenticator.close();
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
@@ -10,7 +10,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.NamedFormatter;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -216,11 +215,8 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             .add(getAttribute(attributeName, attributeFriendlyName, null, List.of("daredevil")));
         SamlToken token = token(signResponse(response));
 
-        final Logger samlLogger = LogManager.getLogger(authenticator.getClass());
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
-            Loggers.addAppender(samlLogger, mockAppender);
+        try (var ignored = mockAppender.capturing(authenticator.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "attribute name warning",
@@ -232,9 +228,6 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             final SamlAttributes attributes = authenticator.authenticate(token);
             assertThat(attributes, notNullValue());
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(samlLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 
@@ -247,17 +240,11 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         assertion.getAttributeStatements().get(0).getAttributes().add(getAttribute(UID_OID, "friendly", null, List.of("daredevil")));
         SamlToken token = token(signResponse(response));
 
-        final Logger samlLogger = LogManager.getLogger(authenticator.getClass());
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
-            Loggers.addAppender(samlLogger, mockAppender);
+        try (var ignored = mockAppender.capturing(authenticator.getClass())) {
             final SamlAttributes attributes = authenticator.authenticate(token);
             assertThat(attributes, notNullValue());
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(samlLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 
@@ -275,9 +262,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
 
         final Logger samlLogger = LogManager.getLogger(authenticator.getClass());
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
-            Loggers.addAppender(samlLogger, mockAppender);
+        try (var ignored = mockAppender.capturing(authenticator.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "attribute name warning",
@@ -297,9 +282,6 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             final SamlAttributes attributes = authenticator.authenticate(token);
             assertThat(attributes, notNullValue());
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(samlLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 
@@ -884,12 +866,8 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         String xml = SamlUtils.getXmlContent(response, false);
         final SamlToken token = token(signResponse(xml));
 
-        final Logger samlLogger = LogManager.getLogger(authenticator.getClass());
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
-            Loggers.addAppender(samlLogger, mockAppender);
-
+        try (var ignored = mockAppender.capturing(authenticator.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "similar audience",
@@ -915,9 +893,6 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             final ElasticsearchSecurityException exception = expectSamlException(() -> authenticator.authenticate(token));
             assertThat(exception.getMessage(), containsString("required audience"));
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(samlLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -111,14 +111,15 @@ public class ServiceAccountServiceTests extends ESTestCase {
         final Logger sasLogger = LogManager.getLogger(ServiceAccountService.class);
         Loggers.setLevel(sasLogger, Level.TRACE);
 
-        final MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(satLogger, appender);
-        Loggers.addAppender(sasLogger, appender);
-        appender.start();
+        final MockLogAppender satAppender = new MockLogAppender();
+        final MockLogAppender sasAppender = new MockLogAppender();
 
-        try {
+        try (
+            var ignored1 = satAppender.capturing(ServiceAccountToken.class);
+            var ignored2 = sasAppender.capturing(ServiceAccountService.class)
+        ) {
             // Less than 4 bytes
-            appender.addExpectation(
+            satAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "less than 4 bytes",
                     ServiceAccountToken.class.getName(),
@@ -128,10 +129,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
             );
             final SecureString bearerString0 = createBearerString(List.of(Arrays.copyOfRange(magicBytes, 0, randomIntBetween(0, 3))));
             assertNull(ServiceAccountService.tryParseToken(bearerString0));
-            appender.assertAllExpectationsMatched();
+            satAppender.assertAllExpectationsMatched();
 
             // Prefix mismatch
-            appender.addExpectation(
+            satAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "prefix mismatch",
                     ServiceAccountToken.class.getName(),
@@ -146,10 +147,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 )
             );
             assertNull(ServiceAccountService.tryParseToken(bearerString1));
-            appender.assertAllExpectationsMatched();
+            satAppender.assertAllExpectationsMatched();
 
             // No colon
-            appender.addExpectation(
+            satAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "no colon",
                     ServiceAccountToken.class.getName(),
@@ -161,10 +162,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 List.of(magicBytes, randomAlphaOfLengthBetween(30, 50).getBytes(StandardCharsets.UTF_8))
             );
             assertNull(ServiceAccountService.tryParseToken(bearerString2));
-            appender.assertAllExpectationsMatched();
+            satAppender.assertAllExpectationsMatched();
 
             // Invalid delimiter for qualified name
-            appender.addExpectation(
+            satAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "invalid delimiter for qualified name",
                     ServiceAccountToken.class.getName(),
@@ -193,10 +194,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 );
                 assertNull(ServiceAccountService.tryParseToken(bearerString3));
             }
-            appender.assertAllExpectationsMatched();
+            satAppender.assertAllExpectationsMatched();
 
             // Invalid token name
-            appender.addExpectation(
+            sasAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "invalid token name",
                     ServiceAccountService.class.getName(),
@@ -217,7 +218,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 )
             );
             assertNull(ServiceAccountService.tryParseToken(bearerString4));
-            appender.assertAllExpectationsMatched();
+            sasAppender.assertAllExpectationsMatched();
 
             // Everything is good
             final String namespace = randomAlphaOfLengthBetween(3, 8);
@@ -241,7 +242,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertThat(parsedToken, equalTo(serviceAccountToken2));
 
             // Invalid magic byte
-            appender.addExpectation(
+            satAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "invalid magic byte again",
                     ServiceAccountToken.class.getName(),
@@ -252,10 +253,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertNull(
                 ServiceAccountService.tryParseToken(new SecureString("AQEAAWVsYXN0aWMvZmxlZXQvdG9rZW4xOnN1cGVyc2VjcmV0".toCharArray()))
             );
-            appender.assertAllExpectationsMatched();
+            satAppender.assertAllExpectationsMatched();
 
             // No colon
-            appender.addExpectation(
+            satAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "no colon again",
                     ServiceAccountToken.class.getName(),
@@ -266,10 +267,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertNull(
                 ServiceAccountService.tryParseToken(new SecureString("AAEAAWVsYXN0aWMvZmxlZXQvdG9rZW4xX3N1cGVyc2VjcmV0".toCharArray()))
             );
-            appender.assertAllExpectationsMatched();
+            satAppender.assertAllExpectationsMatched();
 
             // Invalid qualified name
-            appender.addExpectation(
+            satAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "invalid delimiter for qualified name again",
                     ServiceAccountToken.class.getName(),
@@ -280,10 +281,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertNull(
                 ServiceAccountService.tryParseToken(new SecureString("AAEAAWVsYXN0aWMvZmxlZXRfdG9rZW4xOnN1cGVyc2VjcmV0".toCharArray()))
             );
-            appender.assertAllExpectationsMatched();
+            satAppender.assertAllExpectationsMatched();
 
             // Invalid token name
-            appender.addExpectation(
+            sasAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "invalid token name again",
                     ServiceAccountService.class.getName(),
@@ -294,7 +295,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertNull(
                 ServiceAccountService.tryParseToken(new SecureString("AAEAAWVsYXN0aWMvZmxlZXQvdG9rZW4hOnN1cGVyc2VjcmV0".toCharArray()))
             );
-            appender.assertAllExpectationsMatched();
+            sasAppender.assertAllExpectationsMatched();
 
             // everything is fine
             assertThat(
@@ -310,11 +311,8 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 )
             );
         } finally {
-            appender.stop();
             Loggers.setLevel(satLogger, Level.INFO);
             Loggers.setLevel(sasLogger, Level.INFO);
-            Loggers.removeAppender(satLogger, appender);
-            Loggers.removeAppender(sasLogger, appender);
         }
     }
 
@@ -369,10 +367,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
         Loggers.setLevel(sasLogger, Level.TRACE);
 
         final MockLogAppender appender = new MockLogAppender();
-        Loggers.addAppender(sasLogger, appender);
-        appender.start();
-
-        try {
+        try (var ignored = appender.capturing(ServiceAccountService.class)) {
             // non-elastic service account
             final ServiceAccountId accountId1 = new ServiceAccountId(
                 randomValueOtherThan(ElasticServiceAccounts.NAMESPACE, () -> randomAlphaOfLengthBetween(3, 8)),
@@ -557,9 +552,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             );
             appender.assertAllExpectationsMatched();
         } finally {
-            appender.stop();
             Loggers.setLevel(sasLogger, Level.INFO);
-            Loggers.removeAppender(sasLogger, appender);
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/LoadAuthorizedIndicesTimeCheckerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/LoadAuthorizedIndicesTimeCheckerTests.java
@@ -194,15 +194,11 @@ public class LoadAuthorizedIndicesTimeCheckerTests extends ESTestCase {
             thresholds
         );
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
-        try {
+        try (var ignored = mockAppender.capturing(timerLogger.getName())) {
             Loggers.addAppender(timerLogger, mockAppender);
             mockAppender.addExpectation(expectation);
             checker.accept(List.of());
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(timerLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -7,8 +7,6 @@
 package org.elasticsearch.xpack.security.authz.store;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
@@ -35,7 +33,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -297,10 +294,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         );
 
         final MockLogAppender mockAppender = new MockLogAppender();
-        final Logger logger = LogManager.getLogger(RoleDescriptorStore.class);
-        mockAppender.start();
-        try {
-            Loggers.addAppender(logger, mockAppender);
+        try (var ignored = mockAppender.capturing(RoleDescriptorStore.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "disabled role warning",
@@ -315,9 +309,6 @@ public class CompositeRolesStoreTests extends ESTestCase {
             assertEquals(Role.EMPTY, roleFuture.actionGet());
             assertThat(effectiveRoleDescriptors.get(), empty());
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(logger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/DefaultOperatorPrivilegesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/DefaultOperatorPrivilegesTests.java
@@ -102,11 +102,9 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
         // Will mark for the operator user
         final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
         final MockLogAppender appender = new MockLogAppender();
-        appender.start();
-        Loggers.addAppender(logger, appender);
         Loggers.setLevel(logger, Level.DEBUG);
 
-        try {
+        try (var ignored = appender.capturing(OperatorPrivileges.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "marking",
@@ -122,8 +120,6 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
             );
             appender.assertAllExpectationsMatched();
         } finally {
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
             Loggers.setLevel(logger, (Level) null);
         }
 
@@ -215,11 +211,9 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
 
         final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
         final MockLogAppender appender = new MockLogAppender();
-        appender.start();
-        Loggers.addAppender(logger, appender);
         Loggers.setLevel(logger, Level.DEBUG);
 
-        try {
+        try (var ignored = appender.capturing(OperatorPrivileges.class)) {
             final RestoreSnapshotRequest restoreSnapshotRequest = mock(RestoreSnapshotRequest.class);
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
@@ -233,8 +227,6 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
             verify(restoreSnapshotRequest).skipOperatorOnlyState(licensed);
             appender.assertAllExpectationsMatched();
         } finally {
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
             Loggers.setLevel(logger, (Level) null);
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -176,11 +176,12 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
 
         final Logger logger = LogManager.getLogger(FileOperatorUsersStore.class);
         final MockLogAppender appender = new MockLogAppender();
-        appender.start();
-        Loggers.addAppender(logger, appender);
         Loggers.setLevel(logger, Level.TRACE);
 
-        try (ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)) {
+        try (
+            var ignored = appender.capturing(FileOperatorUsersStore.class);
+            ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)
+        ) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "1st file parsing",
@@ -273,8 +274,6 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             Files.copy(sampleFile, inUseFile, StandardCopyOption.REPLACE_EXISTING);
             assertBusy(() -> assertEquals(4, fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups().size()));
         } finally {
-            Loggers.removeAppender(logger, appender);
-            appender.stop();
             Loggers.setLevel(logger, (Level) null);
         }
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
@@ -18,7 +18,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.DiagnosticTrustManager;
 import org.elasticsearch.common.ssl.SslClientAuthenticationMode;
@@ -122,12 +121,14 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
 
         final Logger diagnosticLogger = LogManager.getLogger(DiagnosticTrustManager.class);
         final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.start();
 
         // Apache clients implement their own hostname checking, but we don't want that.
         // We use a raw socket so we get the builtin JDK checking (which is what we use for transport protocol SSL checks)
-        try (MockWebServer webServer = initWebServer(sslService); SSLSocket clientSocket = (SSLSocket) clientSocketFactory.createSocket()) {
-            Loggers.addAppender(diagnosticLogger, mockAppender);
+        try (
+            var ignored = mockAppender.capturing(DiagnosticTrustManager.class);
+            MockWebServer webServer = initWebServer(sslService);
+            SSLSocket clientSocket = (SSLSocket) clientSocketFactory.createSocket()
+        ) {
 
             String fileName = "/x-pack/plugin/security/build/resources/test/org/elasticsearch/xpack/ssl/SSLErrorMessageTests/ca1.crt"
                 .replace('/', platformFileSeparator());
@@ -168,9 +169,6 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
             // Logging message failures are tricky to debug because you just get a "didn't find match" assertion failure.
             // You should be able to check the log output for the text that was logged and compare to the regex above.
             mockAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(diagnosticLogger, mockAppender);
-            mockAppender.stop();
         }
     }
 

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.snapshotbasedrecoveries.recovery;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.index.IndexCommit;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
@@ -30,7 +29,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.blobstore.OperationPurpose;
 import org.elasticsearch.common.blobstore.support.FilterBlobContainer;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.CancellableThreads;
@@ -378,11 +376,8 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         createSnapshot(repoName, "snap", Collections.singletonList(indexName));
 
         String targetNode;
-        final var recoverySourceHandlerLogger = LogManager.getLogger(RecoverySourceHandler.class);
         final var mockLogAppender = new MockLogAppender();
-        mockLogAppender.start();
-        try {
-            Loggers.addAppender(recoverySourceHandlerLogger, mockLogAppender);
+        try (var ignored = mockLogAppender.capturing(RecoverySourceHandler.class)) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "expected warn log about restore failure",
@@ -398,9 +393,6 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
             ensureGreen();
 
             mockLogAppender.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(recoverySourceHandlerLogger, mockLogAppender);
-            mockLogAppender.stop();
         }
 
         RecoveryState recoveryState = getLatestPeerRecoveryStateForShard(indexName, 0);
@@ -619,11 +611,8 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
             recoverSnapshotFileRequestReceived.await();
 
-            final var recoverySourceHandlerLogger = LogManager.getLogger(RecoverySourceHandler.class);
             final var mockLogAppender = new MockLogAppender();
-            mockLogAppender.start();
-            try {
-                Loggers.addAppender(recoverySourceHandlerLogger, mockLogAppender);
+            try (var ignored = mockLogAppender.capturing(RecoverySourceHandler.class)) {
                 mockLogAppender.addExpectation(
                     new MockLogAppender.SeenEventExpectation(
                         "expected debug log about restore cancellation",
@@ -644,9 +633,6 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                 assertAcked(indicesAdmin().prepareDelete(indexName).get());
 
                 assertBusy(mockLogAppender::assertAllExpectationsMatched);
-            } finally {
-                Loggers.removeAppender(recoverySourceHandlerLogger, mockLogAppender);
-                mockLogAppender.stop();
             }
 
             respondToRecoverSnapshotFile.countDown();

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -462,23 +462,18 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
     }
 
     private void assertExpectation(LoggingExpectation loggingExpectation, AuditExpectation auditExpectation, Runnable codeBlock) {
-        MockLogAppender mockLogAppender = new MockLogAppender();
-        mockLogAppender.start();
-
         Loggers.setLevel(checkpointProviderLogger, Level.DEBUG);
-        mockLogAppender.addExpectation(loggingExpectation);
 
         // always start fresh
         transformAuditor.reset();
         transformAuditor.addExpectation(auditExpectation);
-        try {
-            Loggers.addAppender(checkpointProviderLogger, mockLogAppender);
+
+        MockLogAppender mockLogAppender = new MockLogAppender();
+        try (var ignored = mockLogAppender.capturing(checkpointProviderLogger.getName())) {
+            mockLogAppender.addExpectation(loggingExpectation);
             codeBlock.run();
             mockLogAppender.assertAllExpectationsMatched();
             transformAuditor.assertAllExpectationsMatched();
-        } finally {
-            Loggers.removeAppender(checkpointProviderLogger, mockLogAppender);
-            mockLogAppender.stop();
         }
     }
 


### PR DESCRIPTION
Many uses of MockLogAppender predate the addition of the helper method to create a Releasable for restoring logging, which allows the use of try-with-resource blocks. This commit converts current existing uses of MockLogAppender to use capturing.

relates #106425