### PR TITLE
Optimize for single value in ordinals grouping

### DIFF
--- a/docs/changelog/108118.yaml
+++ b/docs/changelog/108118.yaml
@@ -1,0 +1,5 @@
+pr: 108118
+summary: Optimize for single value in ordinals grouping
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/OrdinalsGroupingOperator.java
@@ -531,7 +531,7 @@ public class OrdinalsGroupingOperator implements Operator {
         }
     }
 
-    static abstract class BlockOrdinalsReader {
+    abstract static class BlockOrdinalsReader {
         protected final Thread creationThread;
         protected final BlockFactory blockFactory;
 


### PR DESCRIPTION
This PR introduces two optimizations in the ordinals grouping operator: (1) reading single values from doc values, and (2) enabling the vector path for `addInput`. The query `FROM nyc_taxis | stats avg(total_amount) by rate_code_id | sort rate_code_id` reduced execution time from 3300 ms to 2200 ms.