### PR TITLE
[8.14][TEST] wait for ILM in testRollupNonTSIndex

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -406,7 +406,11 @@ public class DownsampleActionIT extends ESRestTestCase {
         updatePolicy(client(), index, policy);
 
         try {
-            assertBusy(() -> assertThat(getStepKeyForIndex(client(), index), equalTo(PhaseCompleteStep.finalStep(phaseName).getKey())));
+            assertBusy(
+                () -> assertThat(getStepKeyForIndex(client(), index), equalTo(PhaseCompleteStep.finalStep(phaseName).getKey())),
+                120,
+                TimeUnit.SECONDS
+            );
             String rollupIndex = getRollupIndexName(client(), index, fixedInterval);
             assertNull("Rollup index should not have been created", rollupIndex);
             assertTrue("Source index should not have been deleted", indexExists(index));


### PR DESCRIPTION
Backports the following commits to 8.14:

- [TEST] wait for ILM in testRollupNonTSIndex (#107855)