### PR TITLE
Optimise frequent item sets aggregation for single value fields

### DIFF
--- a/docs/changelog/108130.yaml
+++ b/docs/changelog/108130.yaml
@@ -1,0 +1,5 @@
+pr: 108130
+summary: Optimise frequent item sets aggregation for single value fields
+area: Machine Learning
+type: enhancement
+issues: []


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/107832, this commit optimize requent item sets aggregation for single value fields.