### PR TITLE
[8.14] Mute AzureStorageCleanupThirdPartyTests

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -50,6 +50,30 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
         System.getProperty("test.azure.container")
     );
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
+    @Override
+    public void testCreateSnapshot() {
+        super.testCreateSnapshot();
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
+    @Override
+    public void testIndexLatest() throws Exception {
+        super.testIndexLatest();
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
+    @Override
+    public void testListChildren() {
+        super.testListChildren();
+    }
+
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
+    @Override
+    public void testCleanup() throws Exception {
+        super.testCleanup();
+    }
+
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
         return pluginList(AzureRepositoryPlugin.class);
@@ -132,6 +156,7 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
         future.actionGet();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     public void testMultiBlockUpload() throws Exception {
         final BlobStoreRepository repo = getRepository();
         // The configured threshold for this test suite is 1mb


### PR DESCRIPTION
Backports the following commits to 8.14:

- Mute AzureStorageCleanupThirdPartyTests (#108117)

Related to #107720