### PR TITLE
[ML] Allow deletion of the ELSER inference service when referenced in ingest

### DIFF
--- a/docs/changelog/108146.yaml
+++ b/docs/changelog/108146.yaml
@@ -1,0 +1,5 @@
+pr: 108146
+summary: Allow deletion of the ELSER inference service when reference in ingest
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elasticsearch/ElasticsearchInternalService.java
@@ -330,9 +330,11 @@ public class ElasticsearchInternalService implements InferenceService {
 
     @Override
     public void stop(String inferenceEntityId, ActionListener<Boolean> listener) {
+        var request = new StopTrainedModelDeploymentAction.Request(inferenceEntityId);
+        request.setForce(true);
         client.execute(
             StopTrainedModelDeploymentAction.INSTANCE,
-            new StopTrainedModelDeploymentAction.Request(inferenceEntityId),
+            request,
             listener.delegateFailureAndWrap((delegatedResponseListener, response) -> delegatedResponseListener.onResponse(Boolean.TRUE))
         );
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserInternalService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/elser/ElserInternalService.java
@@ -246,9 +246,11 @@ public class ElserInternalService implements InferenceService {
 
     @Override
     public void stop(String inferenceEntityId, ActionListener<Boolean> listener) {
+        var request = new StopTrainedModelDeploymentAction.Request(inferenceEntityId);
+        request.setForce(true);
         client.execute(
             StopTrainedModelDeploymentAction.INSTANCE,
-            new StopTrainedModelDeploymentAction.Request(inferenceEntityId),
+            request,
             listener.delegateFailureAndWrap((delegatedResponseListener, response) -> delegatedResponseListener.onResponse(Boolean.TRUE))
         );
     }


### PR DESCRIPTION
Deleting a ELSER inference service that is used in a pipeline fails with a confusing error that mentions `force stop`


```
{
  "error": {
    "root_cause": [
      {
        "type": "status_exception",
        "reason": "Cannot stop deployment [my-elser-model] as it is referenced by ingest processors; use force to stop the deployment"
      }
    ],
    "type": "status_exception",
    "reason": "Cannot stop deployment [my-elser-model] as it is referenced by ingest processors; use force to stop the deployment"
  },
  "status": 409
}
```

The error comes from the ml trained models API, `DELETE _inference` does not have a force option.

### Discuss
The change in this PR sets `force` delete on so that the user isn't blocked by having to delete the pipeline first. An alternative could be to return a different error message saying that the endpoint is used by in an ingest pipeline and requiring the user to delete or edit that pipeline first. 

None of the other inference services makes the check on use in an ingest pipeline, this change brings ELSER in line with the others. If we decide that is wrong then deleting any inference service should check for ingest pipeline usage.


## Reproduce 

```
# Create the ELSER service
PUT _inference/sparse_embedding/my-elser-model
{
  "service": "elser",
  "service_settings": {
    "num_allocations": 1,
    "num_threads": 1
  }
}

# Use it in an ingest pipeline
PUT _ingest/pipeline/elser-p
{
  "processors": [
    {
      "inference": {
        "model_id": "my-elser-model",
        "input_output": [
          {
            "input_field": "title",
            "output_field": "ml.title_embedding.tokens"
          }
        ]
      }
    }
  ]
}

# Then try to delete 
DELETE _inference/sparse_embedding/my-elser-model