### PR TITLE
Do not start ClusterFormationFailureHelper during shutdown

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -873,7 +873,15 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
             joinAccumulator = joinHelper.new CandidateJoinAccumulator();
 
             peerFinder.activate(coordinationState.get().getLastAcceptedState().nodes());
-            clusterFormationFailureHelper.start();
+
+            // Only start the formation helper if NOT in shutdown.
+            // The shutdown process will disconnect the node from the cluster, and start
+            // rejoining processes, the failure of which we do not want to log about.
+            if (lifecycle.initializedOrStarted()) {
+                clusterFormationFailureHelper.start();
+            } else {
+                logger.info("This node has left the cluster due to shutdown. It is unlikely to successfully rejoin.");
+            }
 
             leaderHeartbeatService.stop();
             leaderChecker.setCurrentNodes(DiscoveryNodes.EMPTY_NODES);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -225,7 +225,7 @@ public class JoinHelper {
         void logWarnWithTimestamp() {
             logger.warn(
                 () -> format(
-                    "last failed join attempt was %s ago, failed to join %s with %s",
+                    "The last failed node-join response was received %s ago. The request was sent to %s, and the request was %s",
                     TimeValue.timeValueMillis(TimeValue.nsecToMSec(System.nanoTime() - timestamp)),
                     destination,
                     joinRequest

--- a/server/src/main/java/org/elasticsearch/common/component/Lifecycle.java
+++ b/server/src/main/java/org/elasticsearch/common/component/Lifecycle.java
@@ -94,6 +94,11 @@ public final class Lifecycle {
         return state == State.CLOSED;
     }
 
+    public boolean initializedOrStarted() {
+        Lifecycle.State state = this.state;
+        return state == State.INITIALIZED || state == State.STARTED;
+    }
+
     public boolean stoppedOrClosed() {
         Lifecycle.State state = this.state;
         return state == State.STOPPED || state == State.CLOSED;

--- a/server/src/test/java/org/elasticsearch/common/component/LifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/common/component/LifecycleTests.java
@@ -61,6 +61,10 @@ public class LifecycleTests extends ESTestCase {
         assertEquals(expectedState == Lifecycle.State.STOPPED, lifecycle.stopped());
         assertEquals(expectedState == Lifecycle.State.CLOSED, lifecycle.closed());
         assertEquals(expectedState == Lifecycle.State.STOPPED || expectedState == Lifecycle.State.CLOSED, lifecycle.stoppedOrClosed());
+        assertEquals(
+            expectedState == Lifecycle.State.INITIALIZED || expectedState == Lifecycle.State.STARTED,
+            lifecycle.initializedOrStarted()
+        );
     }
 
     public void testThreadSafety() {


### PR DESCRIPTION
A node can be disconnected from the cluster during shutdown and attempt to form
a new or rejoin an existing cluster. However, it is misleading to log WARN msgs
because of failure to join a cluster, when shutdown is the cause of the
disconnection and failure is expected. Particularly since it is possible for
the node-join exception to be stale, leftover from a prior, and ultimately
successful, node-join round.

Closes ES-8412