### PR TITLE
Removing the @Nullable annotation from DataStreamLifecycle.getEffectiveDataRetentionWithSource()

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamLifecycle.java
@@ -155,9 +155,9 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
 
     /**
      * The least amount of time data should be kept by elasticsearch.
-     * @return the time period or null, null represents that data should never be deleted.
+     * @return A tuple containing the time period or null as v1 (where null represents that data should never be deleted), and the non-null
+     * retention source as v2.
      */
-    @Nullable
     public Tuple<TimeValue, RetentionSource> getEffectiveDataRetentionWithSource(@Nullable DataStreamGlobalRetention globalRetention) {
         // If lifecycle is disabled there is no effective retention
         if (enabled == false) {
@@ -200,6 +200,9 @@ public class DataStreamLifecycle implements SimpleDiffable<DataStreamLifecycle>,
         Tuple<TimeValue, DataStreamLifecycle.RetentionSource> effectiveDataRetentionWithSource = getEffectiveDataRetentionWithSource(
             globalRetention
         );
+        if (effectiveDataRetentionWithSource.v1() == null) {
+            return;
+        }
         String effectiveRetentionStringRep = effectiveDataRetentionWithSource.v1().getStringRep();
         switch (effectiveDataRetentionWithSource.v2()) {
             case DEFAULT_GLOBAL_RETENTION -> HeaderWarning.addWarning(


### PR DESCRIPTION
DataStreamLifecycle.getEffectiveDataRetentionWithSource() was marked as @Nullable. However it cannot ever actually return null. This also updates the javadocs, and fixes one possible place we could get a NullPointerException if DataStreamLifecycle.getEffectiveDataRetentionWithSource()'s returned tuple contained a null in v1.