### PR TITLE
Enable concurrent intra merge for HNSW graphs

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/codec/vectors/ES814HnswScalarQuantizedVectorsFormat.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/vectors/ES814HnswScalarQuantizedVectorsFormat.java
@@ -65,9 +65,6 @@ public final class ES814HnswScalarQuantizedVectorsFormat extends KnnVectorsForma
         }
         this.maxConn = maxConn;
         this.beamWidth = beamWidth;
-        if (numMergeWorkers > 1 && mergeExec == null) {
-            throw new IllegalArgumentException("No executor service passed in when " + numMergeWorkers + " merge workers are requested");
-        }
         if (numMergeWorkers == 1 && mergeExec != null) {
             throw new IllegalArgumentException("No executor service is needed as we'll use single thread to merge");
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchConcurrentMergeScheduler.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
+import java.util.concurrent.Executor;
 
 /**
  * An extension to the {@link ConcurrentMergeScheduler} that provides tracking on merge times, total
@@ -76,6 +77,17 @@ class ElasticsearchConcurrentMergeScheduler extends ConcurrentMergeScheduler {
             return true;
         }
         return super.verbose();
+    }
+
+    // TODO: this is temporarily, remove this override and enable multithreaded merges for all kind of merges
+    @Override
+    public Executor getIntraMergeExecutor(MergePolicy.OneMerge merge) {
+        // Enable multithreaded merges only for force merge operations
+        if (merge.getStoreMergeInfo().mergeMaxNumSegments != -1) {
+            return super.getIntraMergeExecutor(merge);
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -629,7 +629,8 @@ public final class DocumentParser {
 
             DenseVectorFieldMapper.Builder builder = new DenseVectorFieldMapper.Builder(
                 fieldName,
-                context.indexSettings().getIndexVersionCreated()
+                context.indexSettings().getIndexVersionCreated(),
+                context.indexSettings().getMergeSchedulerConfig().getMaxThreadCount()
             );
             DenseVectorFieldMapper denseVectorFieldMapper = builder.build(builderContext);
             context.updateDynamicMappers(fullFieldName, List.of(denseVectorFieldMapper));


### PR DESCRIPTION
apache/lucene#12660 introduced concurrent HNSW merge,
 and apache/lucene#13124 made ConcurrentMergeScheduler
to provide an intra merge executor.

But to enable concurrent intra merge for HNSW graphs we still need to provide numMergeWorker to the codec definition.
This PR does the following:

- provides numMergeWorker to the HNSW vectors codecs definions, where numMergerWorkes set as a node's property of index.merge.scheduler.max_thread_count
- enables concurrent merge only for force merge operations.