### PR TITLE
Add BlockHash for 3 BytesRefs

### DIFF
--- a/docs/changelog/108165.yaml
+++ b/docs/changelog/108165.yaml
@@ -1,0 +1,5 @@
+pr: 108165
+summary: Add `BlockHash` for 3 `BytesRefs`
+area: ES|QL
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
@@ -56,20 +56,25 @@ public final class Int3Hash extends AbstractHash {
      * Get the id associated with <code>key</code> or -1 if the key is not contained in the hash.
      */
     public long find(int key1, int key2, int key3) {
-        final long slot = slot(hash(key1, key2, key3), mask);
-        for (long index = slot;; index = nextSlot(index, mask)) {
+        long index = slot(hash(key1, key2, key3), mask);
+        while (true) {
             final long id = id(index);
-            long keyOffset = 3 * id;
-            if (id == -1 || (keys.get(keyOffset) == key1 && keys.get(keyOffset + 1) == key2 && keys.get(keyOffset + 2) == key3)) {
+            if (id == -1) {
                 return id;
+            } else {
+                long keyOffset = 3 * id;
+                if ((keys.get(keyOffset) == key1 && keys.get(keyOffset + 1) == key2 && keys.get(keyOffset + 2) == key3)) {
+                    return id;
+                }
             }
+            index = nextSlot(index, mask);
         }
     }
 
     private long set(int key1, int key2, int key3, long id) {
         assert size < maxSize;
-        final long slot = slot(hash(key1, key2, key3), mask);
-        for (long index = slot;; index = nextSlot(index, mask)) {
+        long index = slot(hash(key1, key2, key3), mask);
+        while (true) {
             final long curId = id(index);
             if (curId == -1) { // means unset
                 id(index, id);
@@ -82,6 +87,7 @@ public final class Int3Hash extends AbstractHash {
                     return -1 - curId;
                 }
             }
+            index = nextSlot(index, mask);
         }
     }
 
@@ -94,14 +100,15 @@ public final class Int3Hash extends AbstractHash {
     }
 
     private void reset(int key1, int key2, int key3, long id) {
-        final long slot = slot(hash(key1, key2, key3), mask);
-        for (long index = slot;; index = nextSlot(index, mask)) {
+        long index = slot(hash(key1, key2, key3), mask);
+        while (true) {
             final long curId = id(index);
             if (curId == -1) { // means unset
                 id(index, id);
                 append(id, key1, key2, key3);
                 break;
             }
+            index = nextSlot(index, mask);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.apache.lucene.util.hppc.BitMixer;
+import org.elasticsearch.core.Releasables;
+
+/**
+ * Specialized hash table implementation similar to BytesRefHash that maps
+ * three int values to ids. Collisions are resolved with open addressing and
+ * linear probing, growth is smooth thanks to {@link BigArrays} and capacity
+ * is always a multiple of 3 for faster identification of buckets.
+ * This class is not thread-safe.
+ */
+// IDs are internally stored as id + 1 so that 0 encodes for an empty slot
+public final class Int3Hash extends AbstractHash {
+    private IntArray keys;
+
+    // Constructor with configurable capacity and default maximum load factor.
+    public Int3Hash(long capacity, BigArrays bigArrays) {
+        this(capacity, DEFAULT_MAX_LOAD_FACTOR, bigArrays);
+    }
+
+    // Constructor with configurable capacity and load factor.
+    public Int3Hash(long capacity, float maxLoadFactor, BigArrays bigArrays) {
+        super(capacity, maxLoadFactor, bigArrays);
+        try {
+            // `super` allocates a big array so we have to `close` if we fail here or we'll leak it.
+            keys = bigArrays.newIntArray(3 * capacity, false);
+        } finally {
+            if (keys == null) {
+                close();
+            }
+        }
+    }
+
+    public int getKey1(long id) {
+        return keys.get(3 * id);
+    }
+
+    public int getKey2(long id) {
+        return keys.get(3 * id + 1);
+    }
+
+    public int getKey3(long id) {
+        return keys.get(3 * id + 2);
+    }
+
+    /**
+     * Get the id associated with <code>key</code> or -1 if the key is not contained in the hash.
+     */
+    public long find(int key1, int key2, int key3) {
+        final long slot = slot(hash(key1, key2, key3), mask);
+        for (long index = slot;; index = nextSlot(index, mask)) {
+            final long id = id(index);
+            long keyOffset = 3 * id;
+            if (id == -1 || (keys.get(keyOffset) == key1 && keys.get(keyOffset + 1) == key2 && keys.get(keyOffset + 2) == key3)) {
+                return id;
+            }
+        }
+    }
+
+    private long set(int key1, int key2, int key3, long id) {
+        assert size < maxSize;
+        final long slot = slot(hash(key1, key2, key3), mask);
+        for (long index = slot;; index = nextSlot(index, mask)) {
+            final long curId = id(index);
+            if (curId == -1) { // means unset
+                id(index, id);
+                append(id, key1, key2, key3);
+                ++size;
+                return id;
+            } else {
+                long keyOffset = 3 * curId;
+                if (keys.get(keyOffset) == key1 && keys.get(keyOffset + 1) == key2 && keys.get(keyOffset + 2) == key3) {
+                    return -1 - curId;
+                }
+            }
+        }
+    }
+
+    private void append(long id, int key1, int key2, int key3) {
+        long keyOffset = 3 * id;
+        keys = bigArrays.grow(keys, keyOffset + 3);
+        keys.set(keyOffset, key1);
+        keys.set(keyOffset + 1, key2);
+        keys.set(keyOffset + 2, key3);
+    }
+
+    private void reset(int key1, int key2, int key3, long id) {
+        final long slot = slot(hash(key1, key2, key3), mask);
+        for (long index = slot;; index = nextSlot(index, mask)) {
+            final long curId = id(index);
+            if (curId == -1) { // means unset
+                id(index, id);
+                append(id, key1, key2, key3);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Try to add {@code key}. Return its newly allocated id if it wasn't in
+     * the hash table yet, or {@code -1-id} if it was already present in
+     * the hash table.
+     */
+    public long add(int key1, int key2, int key3) {
+        if (size >= maxSize) {
+            assert size == maxSize;
+            grow();
+        }
+        assert size < maxSize;
+        return set(key1, key2, key3, size);
+    }
+
+    @Override
+    protected void removeAndAdd(long index) {
+        final long id = id(index, -1);
+        assert id >= 0;
+        long keyOffset = id * 3;
+        final int key1 = keys.set(keyOffset, 0);
+        final int key2 = keys.set(keyOffset + 1, 0);
+        final int key3 = keys.set(keyOffset + 2, 0);
+        reset(key1, key2, key3, id);
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(keys, super::close);
+    }
+
+    static long hash(long key1, long key2, long key3) {
+        return 31L * (31L * BitMixer.mix(key1) + BitMixer.mix(key2)) + BitMixer.mix(key3);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/common/util/Int3HashTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/Int3HashTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class Int3HashTests extends ESTestCase {
+    private BigArrays randombigArrays() {
+        return new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), new NoneCircuitBreakerService());
+    }
+
+    private Int3Hash randomHash() {
+        // Test high load factors to make sure that collision resolution works fine
+        final float maxLoadFactor = 0.6f + randomFloat() * 0.39f;
+        return new Int3Hash(randomIntBetween(0, 100), maxLoadFactor, randombigArrays());
+    }
+
+    public void testSimple() {
+        try (Int3Hash hash = randomHash()) {
+            assertThat(hash.add(0, 0, 0), equalTo(0L));
+            assertThat(hash.add(0, 0, 1), equalTo(1L));
+            assertThat(hash.add(0, 1, 1), equalTo(2L));
+            assertThat(hash.add(1, 0, 0), equalTo(3L));
+            assertThat(hash.add(1, 0, 1), equalTo(4L));
+
+            assertThat(hash.add(0, 0, 0), equalTo(-1L));
+            assertThat(hash.add(0, 0, 1), equalTo(-2L));
+            assertThat(hash.add(1, 0, 1), equalTo(-5L));
+
+            assertThat(hash.getKey1(0), equalTo(0));
+            assertThat(hash.getKey2(0), equalTo(0));
+            assertThat(hash.getKey3(0), equalTo(0));
+            assertThat(hash.getKey1(4), equalTo(1));
+            assertThat(hash.getKey2(4), equalTo(0));
+            assertThat(hash.getKey3(4), equalTo(1));
+        }
+    }
+
+    public void testDuel() {
+        try (Int3Hash hash = randomHash()) {
+            int iters = scaledRandomIntBetween(100, 100000);
+            Key[] values = randomArray(1, iters, Key[]::new, () -> new Key(randomInt(), randomInt(), randomInt()));
+            Map<Key, Integer> keyToId = new HashMap<>();
+            List<Key> idToKey = new ArrayList<>();
+            for (int i = 0; i < iters; ++i) {
+                Key key = randomFrom(values);
+                if (keyToId.containsKey(key)) {
+                    assertEquals(-1 - keyToId.get(key), hash.add(key.key1, key.key2, key.key3));
+                } else {
+                    assertEquals(keyToId.size(), hash.add(key.key1, key.key2, key.key3));
+                    keyToId.put(key, keyToId.size());
+                    idToKey.add(key);
+                }
+            }
+
+            assertEquals(keyToId.size(), hash.size());
+            for (Map.Entry<Key, Integer> entry : keyToId.entrySet()) {
+                assertEquals(entry.getValue().longValue(), hash.find(entry.getKey().key1, entry.getKey().key2, entry.getKey().key3));
+            }
+
+            assertEquals(idToKey.size(), hash.size());
+            for (long i = 0; i < hash.capacity(); i++) {
+                long id = hash.id(i);
+                if (id >= 0) {
+                    Key key = idToKey.get((int) id);
+                    assertEquals(key.key1, hash.getKey1(id));
+                    assertEquals(key.key2, hash.getKey2(id));
+                    assertEquals(key.key3, hash.getKey3(id));
+                }
+            }
+
+            for (long i = 0; i < hash.size(); i++) {
+                Key key = idToKey.get((int) i);
+                assertEquals(key.key1, hash.getKey1(i));
+                assertEquals(key.key2, hash.getKey2(i));
+                assertEquals(key.key3, hash.getKey3(i));
+            }
+        }
+    }
+
+    public void testAllocation() {
+        MockBigArrays.assertFitsIn(ByteSizeValue.ofBytes(256), bigArrays -> new Int3Hash(1, bigArrays));
+    }
+
+    record Key(int key1, int key2, int key3) {
+
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -88,8 +88,9 @@ final class BytesRefBlockHash extends BlockHash {
     }
 
     IntBlock add(BytesRefBlock block) {
-        if (block instanceof OrdinalBytesRefBlock ordinalsBlock) {
-            return addOrdinalsBlock(ordinalsBlock);
+        var ordinals = block.asOrdinals();
+        if (ordinals != null) {
+            return addOrdinalsBlock(ordinals);
         }
         MultivalueDedupe.HashResult result = new MultivalueDedupeBytesRef(block).hashAdd(blockFactory, hash);
         seenNull |= result.sawNull();

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/aggregation/blockhash/BytesRefBlockHash.java
@@ -22,6 +22,7 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupe;
 import org.elasticsearch.compute.operator.mvdedupe.MultivalueDedupeBytesRef;
@@ -87,6 +88,9 @@ final class BytesRefBlockHash extends BlockHash {
     }
 
     IntBlock add(BytesRefBlock block) {
+        if (block instanceof OrdinalBytesRefBlock ordinalsBlock) {
+            return addOrdinalsBlock(ordinalsBlock);
+        }
         MultivalueDedupe.HashResult result = new MultivalueDedupeBytesRef(block).hashAdd(blockFactory, hash);
         seenNull |= result.sawNull();
         return result.ords();
@@ -106,6 +110,38 @@ final class BytesRefBlockHash extends BlockHash {
             return ReleasableIterator.single(lookup(castBlock));
         }
         return ReleasableIterator.single(lookup(vector));
+    }
+
+    private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock inputBlock) {
+        var inputOrds = inputBlock.getOrdinalsBlock();
+        try (
+            var builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount());
+            var hashOrds = add(inputBlock.getDictionaryVector())
+        ) {
+            for (int i = 0; i < inputOrds.getPositionCount(); i++) {
+                int valueCount = inputOrds.getValueCount(i);
+                int firstIndex = inputOrds.getFirstValueIndex(i);
+                switch (valueCount) {
+                    case 0 -> {
+                        builder.appendInt(0);
+                        seenNull = true;
+                    }
+                    case 1 -> {
+                        int ord = hashOrds.getInt(inputOrds.getInt(firstIndex));
+                        builder.appendInt(ord);
+                    }
+                    default -> {
+                        builder.beginPositionEntry();
+                        for (int v = 0; v < valueCount; v++) {
+                            int ord = hashOrds.getInt(inputOrds.getInt(firstIndex + i));
+                            builder.appendInt(ord);
+                        }
+                        builder.endPositionEntry();
+                    }
+                }
+            }
+            return builder.build();
+        }
     }
 
     private IntBlock lookup(BytesRefVector vector) {

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayBlock.java
@@ -89,6 +89,11 @@ final class BytesRefArrayBlock extends AbstractArrayBlock implements BytesRefBlo
     }
 
     @Override
+    public OrdinalBytesRefBlock asOrdinals() {
+        return null;
+    }
+
+    @Override
     public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
         return vector.getBytesRef(valueIndex, dest);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefArrayVector.java
@@ -59,6 +59,11 @@ final class BytesRefArrayVector extends AbstractVector implements BytesRefVector
     }
 
     @Override
+    public OrdinalBytesRefVector asOrdinals() {
+        return null;
+    }
+
+    @Override
     public BytesRef getBytesRef(int position, BytesRef dest) {
         return values.get(position, dest);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -41,6 +41,12 @@ public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, 
     @Override
     BytesRefVector asVector();
 
+    /**
+     * Returns an ordinal BytesRef block if this block is backed by a dictionary and ordinals;
+     * otherwise, returns null. Callers must not release this block as no extra reference is retained by this method.
+     */
+    OrdinalBytesRefBlock asOrdinals();
+
     @Override
     BytesRefBlock filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefBlock.java
@@ -42,8 +42,8 @@ public sealed interface BytesRefBlock extends Block permits BytesRefArrayBlock, 
     BytesRefVector asVector();
 
     /**
-     * Returns an ordinal BytesRef block if this block is backed by a dictionary and ordinals;
-     * otherwise, returns null. Callers must not release this block as no extra reference is retained by this method.
+     * Returns an ordinal bytesref block if this block is backed by a dictionary and ordinals; otherwise,
+     * returns null. Callers must not release the returned block as no extra reference is retained by this method.
      */
     OrdinalBytesRefBlock asOrdinals();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -26,8 +26,8 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
     BytesRefBlock asBlock();
 
     /**
-     * Returns an ordinal BytesRef vector if this vector is backed by a dictionary and ordinals;
-     * otherwise, returns null. Callers must not release this vector as no extra reference is retained by this method.
+     * Returns an ordinal BytesRef vector if this vector is backed by a dictionary and ordinals; otherwise,
+     * returns null. Callers must not release the returned vector as no extra reference is retained by this method.
      */
     OrdinalBytesRefVector asOrdinals();
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVector.java
@@ -25,6 +25,12 @@ public sealed interface BytesRefVector extends Vector permits ConstantBytesRefVe
     @Override
     BytesRefBlock asBlock();
 
+    /**
+     * Returns an ordinal BytesRef vector if this vector is backed by a dictionary and ordinals;
+     * otherwise, returns null. Callers must not release this vector as no extra reference is retained by this method.
+     */
+    OrdinalBytesRefVector asOrdinals();
+
     @Override
     BytesRefVector filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -33,6 +33,16 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
     }
 
     @Override
+    public OrdinalBytesRefBlock asOrdinals() {
+        var ordinals = vector.asOrdinals();
+        if (ordinals != null) {
+            return new OrdinalBytesRefBlock(ordinals.getOrdinalsVector().asBlock(), ordinals.getDictionaryVector());
+        } else {
+            return null;
+        }
+    }
+
+    @Override
     public BytesRef getBytesRef(int valueIndex, BytesRef dest) {
         return vector.getBytesRef(valueIndex, dest);
     }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/BytesRefVectorBlock.java
@@ -36,7 +36,7 @@ public final class BytesRefVectorBlock extends AbstractVectorBlock implements By
     public OrdinalBytesRefBlock asOrdinals() {
         var ordinals = vector.asOrdinals();
         if (ordinals != null) {
-            return new OrdinalBytesRefBlock(ordinals.getOrdinalsVector().asBlock(), ordinals.getDictionaryVector());
+            return ordinals.asBlock();
         } else {
             return null;
         }

--- a/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/generated-src/org/elasticsearch/compute/data/ConstantBytesRefVector.java
@@ -36,6 +36,11 @@ final class ConstantBytesRefVector extends AbstractVector implements BytesRefVec
     }
 
     @Override
+    public OrdinalBytesRefVector asOrdinals() {
+        return null;
+    }
+
+    @Override
     public BytesRefVector filter(int... positions) {
         return blockFactory().newConstantBytesRefVector(value, positions.length);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BlockHash.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @see BytesRefHash
  */
 public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
-    permits BooleanBlockHash, BytesRefBlockHash, DoubleBlockHash, IntBlockHash, LongBlockHash,   //
+    permits BooleanBlockHash, BytesRefBlockHash, DoubleBlockHash, IntBlockHash, LongBlockHash, BytesRef3BlockHash, //
     NullBlockHash, PackedValuesBlockHash, BytesRefLongBlockHash, LongLongBlockHash, TimeSeriesBlockHash {
 
     protected final BlockFactory blockFactory;
@@ -94,6 +94,9 @@ public abstract sealed class BlockHash implements Releasable, SeenGroupIds //
     public static BlockHash build(List<GroupSpec> groups, BlockFactory blockFactory, int emitBatchSize, boolean allowBrokenOptimizations) {
         if (groups.size() == 1) {
             return newForElementType(groups.get(0).channel(), groups.get(0).elementType(), blockFactory);
+        }
+        if (groups.size() == 3 && groups.stream().allMatch(g -> g.elementType == ElementType.BYTES_REF)) {
+            return new BytesRef3BlockHash(blockFactory, groups.get(0).channel, groups.get(1).channel, groups.get(2).channel, emitBatchSize);
         }
         if (allowBrokenOptimizations && groups.size() == 2) {
             var g1 = groups.get(0);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRef3BlockHash.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/BytesRef3BlockHash.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation.blockhash;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BitArray;
+import org.elasticsearch.common.util.Int3Hash;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BytesRefBlock;
+import org.elasticsearch.compute.data.BytesRefVector;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.core.ReleasableIterator;
+import org.elasticsearch.core.Releasables;
+
+import java.util.Locale;
+
+/**
+ * Maps three {@link BytesRefBlock}s to group ids.
+ */
+final class BytesRef3BlockHash extends BlockHash {
+    private final int emitBatchSize;
+    private final int channel1;
+    private final int channel2;
+    private final int channel3;
+    private final BytesRefBlockHash hash1;
+    private final BytesRefBlockHash hash2;
+    private final BytesRefBlockHash hash3;
+    private final Int3Hash finalHash;
+
+    BytesRef3BlockHash(BlockFactory blockFactory, int channel1, int channel2, int channel3, int emitBatchSize) {
+        super(blockFactory);
+        this.emitBatchSize = emitBatchSize;
+        this.channel1 = channel1;
+        this.channel2 = channel2;
+        this.channel3 = channel3;
+        boolean success = false;
+        try {
+            this.hash1 = new BytesRefBlockHash(channel1, blockFactory);
+            this.hash2 = new BytesRefBlockHash(channel2, blockFactory);
+            this.hash3 = new BytesRefBlockHash(channel3, blockFactory);
+            this.finalHash = new Int3Hash(1, blockFactory.bigArrays());
+            success = true;
+        } finally {
+            if (success == false) {
+                close();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(hash1, hash2, hash3, finalHash);
+    }
+
+    @Override
+    public void add(Page page, GroupingAggregatorFunction.AddInput addInput) {
+        BytesRefBlock b1 = page.getBlock(channel1);
+        BytesRefBlock b2 = page.getBlock(channel2);
+        BytesRefBlock b3 = page.getBlock(channel3);
+        BytesRefVector v1 = b1.asVector();
+        BytesRefVector v2 = b2.asVector();
+        BytesRefVector v3 = b3.asVector();
+        if (v1 != null && v2 != null && v3 != null) {
+            addVectors(v1, v2, v3, addInput);
+        } else {
+            try (IntBlock k1 = hash1.add(b1); IntBlock k2 = hash2.add(b2); IntBlock k3 = hash3.add(b3)) {
+                try (AddWork work = new AddWork(k1, k2, k3, addInput)) {
+                    work.add();
+                }
+            }
+        }
+    }
+
+    private void addVectors(BytesRefVector v1, BytesRefVector v2, BytesRefVector v3, GroupingAggregatorFunction.AddInput addInput) {
+        final int positionCount = v1.getPositionCount();
+        try (IntVector.Builder ordsBuilder = blockFactory.newIntVectorFixedBuilder(positionCount)) {
+            // TODO: enable ordinal vectors in BytesRefBlockHash
+            try (IntVector k1 = hash1.add(v1); IntVector k2 = hash2.add(v2); IntVector k3 = hash3.add(v3)) {
+                for (int p = 0; p < positionCount; p++) {
+                    long ord = hashOrdToGroup(finalHash.add(k1.getInt(p), k2.getInt(p), k3.getInt(p)));
+                    ordsBuilder.appendInt(Math.toIntExact(ord));
+                }
+            }
+            try (IntVector ords = ordsBuilder.build()) {
+                addInput.add(0, ords);
+            }
+        }
+    }
+
+    private class AddWork extends AbstractAddBlock {
+        final IntBlock b1;
+        final IntBlock b2;
+        final IntBlock b3;
+
+        AddWork(IntBlock b1, IntBlock b2, IntBlock b3, GroupingAggregatorFunction.AddInput addInput) {
+            super(blockFactory, emitBatchSize, addInput);
+            this.b1 = b1;
+            this.b2 = b2;
+            this.b3 = b3;
+        }
+
+        void add() {
+            int positionCount = b1.getPositionCount();
+            for (int i = 0; i < positionCount; i++) {
+                int v1 = b1.getValueCount(i);
+                int v2 = b2.getValueCount(i);
+                int v3 = b3.getValueCount(i);
+                int first1 = b1.getFirstValueIndex(i);
+                int first2 = b2.getFirstValueIndex(i);
+                int first3 = b3.getFirstValueIndex(i);
+                if (v1 == 1 && v2 == 1 && v3 == 1) {
+                    long ord = hashOrdToGroup(finalHash.add(b1.getInt(first1), b2.getInt(first2), b3.getInt(first3)));
+                    ords.appendInt(Math.toIntExact(ord));
+                    addedValue(i);
+                    continue;
+                }
+                ords.beginPositionEntry();
+                for (int i1 = 0; i1 < v1; i1++) {
+                    int k1 = b1.getInt(first1 + i1);
+                    for (int i2 = 0; i2 < v2; i2++) {
+                        int k2 = b2.getInt(first2 + i2);
+                        for (int i3 = 0; i3 < v3; i3++) {
+                            int k3 = b3.getInt(first3 + i3);
+                            long ord = hashOrdToGroup(finalHash.add(k1, k2, k3));
+                            ords.appendInt(Math.toIntExact(ord));
+                            addedValueInMultivaluePosition(i);
+                        }
+                    }
+                }
+                ords.endPositionEntry();
+            }
+            emitOrds();
+        }
+    }
+
+    @Override
+    public ReleasableIterator<IntBlock> lookup(Page page, ByteSizeValue targetBlockSize) {
+        throw new UnsupportedOperationException("TODO");
+    }
+
+    @Override
+    public Block[] getKeys() {
+        final int positions = (int) finalHash.size();
+        final BytesRef scratch = new BytesRef();
+        final BytesRefBlock[] outputBlocks = new BytesRefBlock[3];
+        try {
+            try (BytesRefBlock.Builder b1 = blockFactory.newBytesRefBlockBuilder(positions)) {
+                for (int i = 0; i < positions; i++) {
+                    int k1 = finalHash.getKey1(i);
+                    if (k1 == 0) {
+                        b1.appendNull();
+                    } else {
+                        b1.appendBytesRef(hash1.hash.get(k1 - 1, scratch));
+                    }
+                }
+                outputBlocks[0] = b1.build();
+            }
+            try (BytesRefBlock.Builder b2 = blockFactory.newBytesRefBlockBuilder(positions)) {
+                for (int i = 0; i < positions; i++) {
+                    int k2 = finalHash.getKey2(i);
+                    if (k2 == 0) {
+                        b2.appendNull();
+                    } else {
+                        b2.appendBytesRef(hash2.hash.get(k2 - 1, scratch));
+                    }
+                }
+                outputBlocks[1] = b2.build();
+            }
+            try (BytesRefBlock.Builder b3 = blockFactory.newBytesRefBlockBuilder(positions)) {
+                for (int i = 0; i < positions; i++) {
+                    int k3 = finalHash.getKey3(i);
+                    if (k3 == 0) {
+                        b3.appendNull();
+                    } else {
+                        b3.appendBytesRef(hash3.hash.get(k3 - 1, scratch));
+                    }
+                }
+                outputBlocks[2] = b3.build();
+            }
+            return outputBlocks;
+        } finally {
+            if (outputBlocks[outputBlocks.length - 1] == null) {
+                Releasables.close(outputBlocks);
+            }
+        }
+    }
+
+    @Override
+    public BitArray seenGroupIds(BigArrays bigArrays) {
+        return new Range(0, Math.toIntExact(finalHash.size())).seenGroupIds(bigArrays);
+    }
+
+    @Override
+    public IntVector nonEmpty() {
+        return IntVector.range(0, Math.toIntExact(finalHash.size()), blockFactory);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            Locale.ROOT,
+            "BytesRef3BlockHash{keys=[channel1=%d, channel2=%d, channel3=%d], entries=%d}",
+            channel1,
+            channel2,
+            channel3,
+            finalHash.size()
+        );
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -27,6 +27,7 @@ import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.OrdinalBytesRefBlock;
 $elseif(double)$
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -125,6 +126,11 @@ $endif$
     }
 
     IntBlock add($Type$Block block) {
+$if(BytesRef)$
+        if (block instanceof OrdinalBytesRefBlock ordinalsBlock) {
+            return addOrdinalsBlock(ordinalsBlock);
+        }
+$endif$
         MultivalueDedupe.HashResult result = new MultivalueDedupe$Type$(block).hashAdd(blockFactory, hash);
         seenNull |= result.sawNull();
         return result.ords();
@@ -145,6 +151,40 @@ $endif$
         }
         return ReleasableIterator.single(lookup(vector));
     }
+
+$if(BytesRef)$
+    private IntBlock addOrdinalsBlock(OrdinalBytesRefBlock inputBlock) {
+        var inputOrds = inputBlock.getOrdinalsBlock();
+        try (
+            var builder = blockFactory.newIntBlockBuilder(inputOrds.getPositionCount());
+            var hashOrds = add(inputBlock.getDictionaryVector())
+        ) {
+            for (int i = 0; i < inputOrds.getPositionCount(); i++) {
+                int valueCount = inputOrds.getValueCount(i);
+                int firstIndex = inputOrds.getFirstValueIndex(i);
+                switch (valueCount) {
+                    case 0 -> {
+                        builder.appendInt(0);
+                        seenNull = true;
+                    }
+                    case 1 -> {
+                        int ord = hashOrds.getInt(inputOrds.getInt(firstIndex));
+                        builder.appendInt(ord);
+                    }
+                    default -> {
+                        builder.beginPositionEntry();
+                        for (int v = 0; v < valueCount; v++) {
+                            int ord = hashOrds.getInt(inputOrds.getInt(firstIndex + i));
+                            builder.appendInt(ord);
+                        }
+                        builder.endPositionEntry();
+                    }
+                }
+            }
+            return builder.build();
+        }
+    }
+$endif$
 
     private IntBlock lookup($Type$Vector vector) {
 $if(BytesRef)$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/blockhash/X-BlockHash.java.st
@@ -127,8 +127,9 @@ $endif$
 
     IntBlock add($Type$Block block) {
 $if(BytesRef)$
-        if (block instanceof OrdinalBytesRefBlock ordinalsBlock) {
-            return addOrdinalsBlock(ordinalsBlock);
+        var ordinals = block.asOrdinals();
+        if (ordinals != null) {
+            return addOrdinalsBlock(ordinals);
         }
 $endif$
         MultivalueDedupe.HashResult result = new MultivalueDedupe$Type$(block).hashAdd(blockFactory, hash);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -43,6 +43,11 @@ final class ConstantNullBlock extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
+    public OrdinalBytesRefBlock asOrdinals() {
+        return null;
+    }
+
+    @Override
     public boolean isNull(int position) {
         return true;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullVector.java
@@ -34,6 +34,12 @@ public final class ConstantNullVector extends AbstractVector implements BooleanV
     }
 
     @Override
+    public OrdinalBytesRefVector asOrdinals() {
+        assert false : "null vector";
+        throw new UnsupportedOperationException("null vector");
+    }
+
+    @Override
     public ConstantNullVector filter(int... positions) {
         assert false : "null vector";
         throw new UnsupportedOperationException("null vector");

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -81,6 +81,11 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
     }
 
     @Override
+    public OrdinalBytesRefBlock asOrdinals() {
+        return this;
+    }
+
+    @Override
     public BytesRefBlock filter(int... positions) {
         if (positions.length * ordinals.getTotalValueCount() >= bytes.getPositionCount() * ordinals.getPositionCount()) {
             OrdinalBytesRefBlock result = null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -78,8 +78,8 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
-    public BytesRefBlock asBlock() {
-        return new BytesRefVectorBlock(this);
+    public OrdinalBytesRefBlock asBlock() {
+        return new OrdinalBytesRefBlock(ordinals.asBlock(), bytes);
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefVector.java
@@ -83,6 +83,19 @@ public final class OrdinalBytesRefVector extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
+    public OrdinalBytesRefVector asOrdinals() {
+        return this;
+    }
+
+    public IntVector getOrdinalsVector() {
+        return ordinals;
+    }
+
+    public BytesRefVector getDictionaryVector() {
+        return bytes;
+    }
+
+    @Override
     public BytesRefVector filter(int... positions) {
         if (positions.length >= ordinals.getPositionCount()) {
             OrdinalBytesRefVector result = null;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayBlock.java.st
@@ -96,6 +96,13 @@ final class $Type$ArrayBlock extends AbstractArrayBlock implements $Type$Block {
         return null;
     }
 
+$if(BytesRef)$
+    @Override
+    public OrdinalBytesRefBlock asOrdinals() {
+        return null;
+    }
+$endif$
+
     @Override
 $if(BytesRef)$
     public BytesRef getBytesRef(int valueIndex, BytesRef dest) {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ArrayVector.java.st
@@ -109,6 +109,13 @@ $endif$
 
 $if(BytesRef)$
     @Override
+    public OrdinalBytesRefVector asOrdinals() {
+        return null;
+    }
+$endif$
+
+$if(BytesRef)$
+    @Override
     public BytesRef getBytesRef(int position, BytesRef dest) {
         return values.get(position, dest);
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -57,6 +57,14 @@ $endif$
     @Override
     $Type$Vector asVector();
 
+$if(BytesRef)$
+    /**
+     * Returns an ordinal BytesRef block if this block is backed by a dictionary and ordinals;
+     * otherwise, returns null. Callers must not release this block as no extra reference is retained by this method.
+     */
+    OrdinalBytesRefBlock asOrdinals();
+$endif$
+
     @Override
     $Type$Block filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Block.java.st
@@ -59,8 +59,8 @@ $endif$
 
 $if(BytesRef)$
     /**
-     * Returns an ordinal BytesRef block if this block is backed by a dictionary and ordinals;
-     * otherwise, returns null. Callers must not release this block as no extra reference is retained by this method.
+     * Returns an ordinal bytesref block if this block is backed by a dictionary and ordinals; otherwise,
+     * returns null. Callers must not release the returned block as no extra reference is retained by this method.
      */
     OrdinalBytesRefBlock asOrdinals();
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-ConstantVector.java.st
@@ -46,6 +46,13 @@ $endif$
         return new $Type$VectorBlock(this);
     }
 
+$if(BytesRef)$
+    @Override
+    public OrdinalBytesRefVector asOrdinals() {
+        return null;
+    }
+$endif$
+
     @Override
     public $Type$Vector filter(int... positions) {
         return blockFactory().newConstant$Type$Vector(value, positions.length);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -45,8 +45,8 @@ $endif$
 
 $if(BytesRef)$
     /**
-     * Returns an ordinal BytesRef vector if this vector is backed by a dictionary and ordinals;
-     * otherwise, returns null. Callers must not release this vector as no extra reference is retained by this method.
+     * Returns an ordinal BytesRef vector if this vector is backed by a dictionary and ordinals; otherwise,
+     * returns null. Callers must not release the returned vector as no extra reference is retained by this method.
      */
     OrdinalBytesRefVector asOrdinals();
 $endif$

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-Vector.java.st
@@ -43,6 +43,14 @@ $endif$
     @Override
     $Type$Block asBlock();
 
+$if(BytesRef)$
+    /**
+     * Returns an ordinal BytesRef vector if this vector is backed by a dictionary and ordinals;
+     * otherwise, returns null. Callers must not release this vector as no extra reference is retained by this method.
+     */
+    OrdinalBytesRefVector asOrdinals();
+$endif$
+
     @Override
     $Type$Vector filter(int... positions);
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -39,7 +39,7 @@ $if(BytesRef)$
     public OrdinalBytesRefBlock asOrdinals() {
         var ordinals = vector.asOrdinals();
         if (ordinals != null) {
-            return new OrdinalBytesRefBlock(ordinals.getOrdinalsVector().asBlock(), ordinals.getDictionaryVector());
+            return ordinals.asBlock();
         } else {
             return null;
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/X-VectorBlock.java.st
@@ -34,6 +34,18 @@ public final class $Type$VectorBlock extends AbstractVectorBlock implements $Typ
         return vector;
     }
 
+$if(BytesRef)$
+    @Override
+    public OrdinalBytesRefBlock asOrdinals() {
+        var ordinals = vector.asOrdinals();
+        if (ordinals != null) {
+            return new OrdinalBytesRefBlock(ordinals.getOrdinalsVector().asBlock(), ordinals.getDictionaryVector());
+        } else {
+            return null;
+        }
+    }
+$endif$
+
     @Override
 $if(BytesRef)$
     public BytesRef getBytesRef(int valueIndex, BytesRef dest) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashRandomizedTests.java
@@ -207,7 +207,9 @@ public class BlockHashRandomizedTests extends ESTestCase {
                     assertMap(keyList, keyMatcher);
                 }
 
-                if (blockHash instanceof LongLongBlockHash == false && blockHash instanceof BytesRefLongBlockHash == false) {
+                if (blockHash instanceof LongLongBlockHash == false
+                    && blockHash instanceof BytesRefLongBlockHash == false
+                    && blockHash instanceof BytesRef3BlockHash == false) {
                     assertLookup(blockFactory, expectedOrds, types, blockHash, oracle);
                 }
             } finally {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -1222,7 +1222,9 @@ public class BlockHashTests extends ESTestCase {
                 }
                 called[0] = true;
                 callback.accept(ordsAndKeys);
-                if (hash instanceof LongLongBlockHash == false && hash instanceof BytesRefLongBlockHash == false) {
+                if (hash instanceof LongLongBlockHash == false
+                    && hash instanceof BytesRefLongBlockHash == false
+                    && hash instanceof BytesRef3BlockHash == false) {
                     try (ReleasableIterator<IntBlock> lookup = hash.lookup(new Page(values), ByteSizeValue.ofKb(between(1, 100)))) {
                         assertThat(lookup.hasNext(), equalTo(true));
                         try (IntBlock ords = lookup.next()) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -21,12 +21,14 @@ import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BooleanBlock;
 import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.DoubleBlock;
+import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.MockBlockFactory;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.TestBlockFactory;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.ReleasableIterator;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
@@ -43,6 +45,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -1105,6 +1108,97 @@ public class BlockHashTests extends ESTestCase {
         }, blockFactory.newLongArrayVector(values, values.length).asBlock(), blockFactory.newConstantNullBlock(values.length));
     }
 
+    public void test3BytesRefs() {
+        final Page page;
+        final int positions = randomIntBetween(1, 1000);
+        final boolean generateVector = randomBoolean();
+        try (
+            BytesRefBlock.Builder builder1 = blockFactory.newBytesRefBlockBuilder(positions);
+            BytesRefBlock.Builder builder2 = blockFactory.newBytesRefBlockBuilder(positions);
+            BytesRefBlock.Builder builder3 = blockFactory.newBytesRefBlockBuilder(positions)
+        ) {
+            List<BytesRefBlock.Builder> builders = List.of(builder1, builder2, builder3);
+            for (int p = 0; p < positions; p++) {
+                for (BytesRefBlock.Builder builder : builders) {
+                    int valueCount = generateVector ? 1 : between(0, 3);
+                    switch (valueCount) {
+                        case 0 -> builder.appendNull();
+                        case 1 -> builder.appendBytesRef(new BytesRef(Integer.toString(between(1, 100))));
+                        default -> {
+                            builder.beginPositionEntry();
+                            for (int v = 0; v < valueCount; v++) {
+                                builder.appendBytesRef(new BytesRef(Integer.toString(between(1, 100))));
+                            }
+                            builder.endPositionEntry();
+                        }
+                    }
+                }
+            }
+            page = new Page(builder1.build(), builder2.build(), builder3.build());
+        }
+        final int emitBatchSize = between(positions, 10 * 1024);
+        var groupSpecs = List.of(
+            new BlockHash.GroupSpec(0, ElementType.BYTES_REF),
+            new BlockHash.GroupSpec(1, ElementType.BYTES_REF),
+            new BlockHash.GroupSpec(2, ElementType.BYTES_REF)
+        );
+        record Output(int offset, IntBlock block, IntVector vector) implements Releasable {
+            @Override
+            public void close() {
+                Releasables.close(block, vector);
+            }
+        }
+        List<Output> output1 = new ArrayList<>();
+        List<Output> output2 = new ArrayList<>();
+        try (
+            BlockHash hash1 = new BytesRef3BlockHash(blockFactory, 0, 1, 2, emitBatchSize);
+            BlockHash hash2 = new PackedValuesBlockHash(groupSpecs, blockFactory, emitBatchSize)
+        ) {
+            hash1.add(page, new GroupingAggregatorFunction.AddInput() {
+                @Override
+                public void add(int positionOffset, IntBlock groupIds) {
+                    groupIds.incRef();
+                    output1.add(new Output(positionOffset, groupIds, null));
+                }
+
+                @Override
+                public void add(int positionOffset, IntVector groupIds) {
+                    groupIds.incRef();
+                    output1.add(new Output(positionOffset, null, groupIds));
+                }
+            });
+            hash2.add(page, new GroupingAggregatorFunction.AddInput() {
+                @Override
+                public void add(int positionOffset, IntBlock groupIds) {
+                    groupIds.incRef();
+                    output2.add(new Output(positionOffset, groupIds, null));
+                }
+
+                @Override
+                public void add(int positionOffset, IntVector groupIds) {
+                    groupIds.incRef();
+                    output2.add(new Output(positionOffset, null, groupIds));
+                }
+            });
+            assertThat(output1.size(), equalTo(output1.size()));
+            for (int i = 0; i < output1.size(); i++) {
+                Output o1 = output1.get(i);
+                Output o2 = output2.get(i);
+                assertThat(o1.offset, equalTo(o2.offset));
+                if (o1.vector != null) {
+                    assertThat(o1.vector, either(equalTo(o2.vector)).or(equalTo(o2.block.asVector())));
+                } else {
+                    assertNull(o2.vector);
+                    assertThat(o1.block, equalTo(o2.block));
+                }
+            }
+        } finally {
+            Releasables.close(output1);
+            Releasables.close(output2);
+            page.releaseBlocks();
+        }
+    }
+
     record OrdsAndKeys(String description, int positionOffset, IntBlock ords, Block[] keys, IntVector nonEmpty) {}
 
     /**
@@ -1202,7 +1296,9 @@ public class BlockHashTests extends ESTestCase {
                 add(positionOffset, groupIds.asBlock());
             }
         });
-        if (blockHash instanceof LongLongBlockHash == false && blockHash instanceof BytesRefLongBlockHash == false) {
+        if (blockHash instanceof LongLongBlockHash == false
+            && blockHash instanceof BytesRefLongBlockHash == false
+            && blockHash instanceof BytesRef3BlockHash == false) {
             Block[] keys = blockHash.getKeys();
             try (ReleasableIterator<IntBlock> lookup = blockHash.lookup(new Page(keys), ByteSizeValue.ofKb(between(1, 100)))) {
                 while (lookup.hasNext()) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.compute.data.Block;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockStreamInput;
+import org.elasticsearch.compute.data.BytesRefBlock;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.IntVector;
@@ -250,9 +251,10 @@ public class EnrichLookupService {
     ) {
         Block inputBlock = inputPage.getBlock(0);
         final IntBlock selectedPositions;
-        if (inputBlock instanceof OrdinalBytesRefBlock ordinalBytesRefBlock) {
-            inputBlock = ordinalBytesRefBlock.getDictionaryVector().asBlock();
-            selectedPositions = ordinalBytesRefBlock.getOrdinalsBlock();
+        final OrdinalBytesRefBlock ordinalsBytesRefBlock;
+        if (inputBlock instanceof BytesRefBlock bytesRefBlock && (ordinalsBytesRefBlock = bytesRefBlock.asOrdinals()) != null) {
+            inputBlock = ordinalsBytesRefBlock.getDictionaryVector().asBlock();
+            selectedPositions = ordinalsBytesRefBlock.getOrdinalsBlock();
             selectedPositions.mustIncRef();
         } else {
             selectedPositions = IntVector.range(0, inputBlock.getPositionCount(), blockFactory).asBlock();


### PR DESCRIPTION
This change introduces a specialized BlockHash for 3 BytesRefs. Unlike other specialized BlockHashes, this BlockHash should handle nulls and multivalues properly. While not intended as a showcase, it can illustrate the performance enhancements of ESQL on multi-term aggregations over the search API in our benchmark. This change is expected to reduce the execution time of multi-term aggregations from 2054ms to 1178ms.