### PR TITLE
Removing global retention functionality for templates

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
-import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -197,8 +196,7 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
                 builder.startObject();
                 builder.field(NAME.getPreferredName(), componentTemplate.getKey());
                 builder.field(COMPONENT_TEMPLATE.getPreferredName());
-                componentTemplate.getValue()
-                    .toXContent(builder, DataStreamLifecycle.maybeAddEffectiveRetentionParams(params), rolloverConfiguration);
+                componentTemplate.getValue().toXContent(builder, params, rolloverConfiguration);
                 builder.endObject();
             }
             builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
@@ -198,12 +198,7 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
                 builder.field(NAME.getPreferredName(), componentTemplate.getKey());
                 builder.field(COMPONENT_TEMPLATE.getPreferredName());
                 componentTemplate.getValue()
-                    .toXContent(
-                        builder,
-                        DataStreamLifecycle.maybeAddEffectiveRetentionParams(params),
-                        rolloverConfiguration,
-                        globalRetention
-                    );
+                    .toXContent(builder, DataStreamLifecycle.maybeAddEffectiveRetentionParams(params), rolloverConfiguration);
                 builder.endObject();
             }
             builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -197,12 +197,7 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
                 builder.field(NAME.getPreferredName(), indexTemplate.getKey());
                 builder.field(INDEX_TEMPLATE.getPreferredName());
                 indexTemplate.getValue()
-                    .toXContent(
-                        builder,
-                        DataStreamLifecycle.maybeAddEffectiveRetentionParams(params),
-                        rolloverConfiguration,
-                        globalRetention
-                    );
+                    .toXContent(builder, DataStreamLifecycle.maybeAddEffectiveRetentionParams(params), rolloverConfiguration);
                 builder.endObject();
             }
             builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
-import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
@@ -196,8 +195,7 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
                 builder.startObject();
                 builder.field(NAME.getPreferredName(), indexTemplate.getKey());
                 builder.field(INDEX_TEMPLATE.getPreferredName());
-                indexTemplate.getValue()
-                    .toXContent(builder, DataStreamLifecycle.maybeAddEffectiveRetentionParams(params), rolloverConfiguration);
+                indexTemplate.getValue().toXContent(builder, params, rolloverConfiguration);
                 builder.endObject();
             }
             builder.endArray();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -121,12 +121,7 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
         builder.startObject();
         if (this.resolvedTemplate != null) {
             builder.field(TEMPLATE.getPreferredName());
-            this.resolvedTemplate.toXContent(
-                builder,
-                DataStreamLifecycle.maybeAddEffectiveRetentionParams(params),
-                rolloverConfiguration,
-                globalRetention
-            );
+            this.resolvedTemplate.toXContent(builder, DataStreamLifecycle.maybeAddEffectiveRetentionParams(params), rolloverConfiguration);
         }
         if (this.overlappingTemplates != null) {
             builder.startArray(OVERLAPPING.getPreferredName());

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/SimulateIndexTemplateResponse.java
@@ -12,7 +12,6 @@ import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.rollover.RolloverConfiguration;
 import org.elasticsearch.cluster.metadata.DataStreamGlobalRetention;
-import org.elasticsearch.cluster.metadata.DataStreamLifecycle;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -121,7 +120,7 @@ public class SimulateIndexTemplateResponse extends ActionResponse implements ToX
         builder.startObject();
         if (this.resolvedTemplate != null) {
             builder.field(TEMPLATE.getPreferredName());
-            this.resolvedTemplate.toXContent(builder, DataStreamLifecycle.maybeAddEffectiveRetentionParams(params), rolloverConfiguration);
+            this.resolvedTemplate.toXContent(builder, params, rolloverConfiguration);
         }
         if (this.overlappingTemplates != null) {
             builder.startArray(OVERLAPPING.getPreferredName());

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplate.java
@@ -163,21 +163,17 @@ public class ComponentTemplate implements SimpleDiffable<ComponentTemplate>, ToX
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return toXContent(builder, params, null, null);
+        return toXContent(builder, params, null);
     }
 
     /**
      * Converts the component template to XContent and passes the RolloverConditions, when provided, to the template.
      */
-    public XContentBuilder toXContent(
-        XContentBuilder builder,
-        Params params,
-        @Nullable RolloverConfiguration rolloverConfiguration,
-        @Nullable DataStreamGlobalRetention globalRetention
-    ) throws IOException {
+    public XContentBuilder toXContent(XContentBuilder builder, Params params, @Nullable RolloverConfiguration rolloverConfiguration)
+        throws IOException {
         builder.startObject();
         builder.field(TEMPLATE.getPreferredName());
-        this.template.toXContent(builder, params, rolloverConfiguration, globalRetention);
+        this.template.toXContent(builder, params, rolloverConfiguration);
         if (this.version != null) {
             builder.field(VERSION.getPreferredName(), this.version);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -259,23 +259,19 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return toXContent(builder, params, null, null);
+        return toXContent(builder, params, null);
     }
 
     /**
      * Converts the composable index template to XContent and passes the RolloverConditions, when provided, to the template.
      */
-    public XContentBuilder toXContent(
-        XContentBuilder builder,
-        Params params,
-        @Nullable RolloverConfiguration rolloverConfiguration,
-        @Nullable DataStreamGlobalRetention globalRetention
-    ) throws IOException {
+    public XContentBuilder toXContent(XContentBuilder builder, Params params, @Nullable RolloverConfiguration rolloverConfiguration)
+        throws IOException {
         builder.startObject();
         builder.stringListField(INDEX_PATTERNS.getPreferredName(), this.indexPatterns);
         if (this.template != null) {
             builder.field(TEMPLATE.getPreferredName());
-            this.template.toXContent(builder, params, rolloverConfiguration, globalRetention);
+            this.template.toXContent(builder, params, rolloverConfiguration);
         }
         if (this.componentTemplates != null) {
             builder.stringListField(COMPOSED_OF.getPreferredName(), this.componentTemplates);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -213,18 +213,14 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return toXContent(builder, params, null, null);
+        return toXContent(builder, params, null);
     }
 
     /**
      * Converts the template to XContent and passes the RolloverConditions, when provided, to the lifecycle.
      */
-    public XContentBuilder toXContent(
-        XContentBuilder builder,
-        Params params,
-        @Nullable RolloverConfiguration rolloverConfiguration,
-        @Nullable DataStreamGlobalRetention globalRetention
-    ) throws IOException {
+    public XContentBuilder toXContent(XContentBuilder builder, Params params, @Nullable RolloverConfiguration rolloverConfiguration)
+        throws IOException {
         builder.startObject();
         if (this.settings != null) {
             builder.startObject(SETTINGS.getPreferredName());
@@ -254,7 +250,7 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
         }
         if (this.lifecycle != null) {
             builder.field(LIFECYCLE.getPreferredName());
-            lifecycle.toXContent(builder, params, rolloverConfiguration, globalRetention);
+            lifecycle.toXContent(builder, params, rolloverConfiguration, null);
         }
         builder.endObject();
         return builder;

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComponentTemplateTests.java
@@ -291,7 +291,7 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
             RolloverConfiguration rolloverConfiguration = RolloverConfigurationTests.randomRolloverConditions();
             DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionTests.randomGlobalRetention();
             ToXContent.Params withEffectiveRetention = new ToXContent.MapParams(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAMS);
-            template.toXContent(builder, withEffectiveRetention, rolloverConfiguration, globalRetention);
+            template.toXContent(builder, withEffectiveRetention, rolloverConfiguration);
             String serialized = Strings.toString(builder);
             assertThat(serialized, containsString("rollover"));
             for (String label : rolloverConfiguration.resolveRolloverConditions(lifecycle.getEffectiveDataRetention(globalRetention))
@@ -299,13 +299,12 @@ public class ComponentTemplateTests extends SimpleDiffableSerializationTestCase<
                 .keySet()) {
                 assertThat(serialized, containsString(label));
             }
-            // We check that even if there was no retention provided by the user, the global retention applies
+            /*
+             * A template does not have a global retention and the lifecycle has no retention, so there will be no data_retention or
+             * effective_retention.
+             */
             assertThat(serialized, not(containsString("data_retention")));
-            if (globalRetention.getDefaultRetention() != null || globalRetention.getMaxRetention() != null) {
-                assertThat(serialized, containsString("effective_retention"));
-            } else {
-                assertThat(serialized, not(containsString("effective_retention")));
-            }
+            assertThat(serialized, not(containsString("effective_retention")));
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateTests.java
@@ -240,7 +240,7 @@ public class ComposableIndexTemplateTests extends SimpleDiffableSerializationTes
             RolloverConfiguration rolloverConfiguration = RolloverConfigurationTests.randomRolloverConditions();
             DataStreamGlobalRetention globalRetention = DataStreamGlobalRetentionTests.randomGlobalRetention();
             ToXContent.Params withEffectiveRetention = new ToXContent.MapParams(DataStreamLifecycle.INCLUDE_EFFECTIVE_RETENTION_PARAMS);
-            template.toXContent(builder, withEffectiveRetention, rolloverConfiguration, globalRetention);
+            template.toXContent(builder, withEffectiveRetention, rolloverConfiguration);
             String serialized = Strings.toString(builder);
             assertThat(serialized, containsString("rollover"));
             for (String label : rolloverConfiguration.resolveRolloverConditions(lifecycle.getEffectiveDataRetention(globalRetention))
@@ -248,13 +248,12 @@ public class ComposableIndexTemplateTests extends SimpleDiffableSerializationTes
                 .keySet()) {
                 assertThat(serialized, containsString(label));
             }
-            // We check that even if there was no retention provided by the user, the global retention applies
+            /*
+             * A template does not have a global retention and the lifecycle has no retention, so there will be no data_retention or
+             * effective_retention.
+             */
             assertThat(serialized, not(containsString("data_retention")));
-            if (globalRetention.getDefaultRetention() != null || globalRetention.getMaxRetention() != null) {
-                assertThat(serialized, containsString("effective_retention"));
-            } else {
-                assertThat(serialized, not(containsString("effective_retention")));
-            }
+            assertThat(serialized, not(containsString("effective_retention")));
         }
     }
 


### PR DESCRIPTION
Currently, templates (Template, ComonentTemplate, and ComposableIndexTemplate) receive a `globalRetention` object so that (1) when they display the lifecycle we can compute an `effective_retention` for the lifecycle and (2) when they display the rollover config they can accurately display the rollover time. However, this has two problems:
(1) We are exempting system data streams from the global retention settings. Since the template is just a template, and is not applied to a data stream yet, we don't know for sure if it will be applied to a system data stream or to a user data stream
(2) There is an expectation that the fields returned by templates can be updated in a template update. This is not true for retention or rollover time.

This PR stops passing the global retention to templates. Whenever toXContent is called on a lifecycle from a template, null global retention is used. This means that the displayed `effective_retention` and rollover time will be based on whatever retention is configured (or not) in the lifecycle in that template.

Relates to #108038 and #106221