### PR TITLE
Use direct method mapping for zstd

### DIFF
--- a/docs/changelog/108172.yaml
+++ b/docs/changelog/108172.yaml
@@ -1,7 +1,0 @@
-pr: 108172
-summary: Use direct method mapping for zstd
-area: Infra/Core
-type: bug
-issues:
- - 107504
- - 107770

--- a/docs/changelog/108172.yaml
+++ b/docs/changelog/108172.yaml
@@ -1,0 +1,7 @@
+pr: 108172
+summary: Use direct method mapping for zstd
+area: Infra/Core
+type: bug
+issues:
+ - 107504
+ - 107770

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaZstdLibrary.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaZstdLibrary.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.nativeaccess.jna;
 
-import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaZstdLibrary.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaZstdLibrary.java
@@ -17,27 +17,25 @@ import org.elasticsearch.nativeaccess.lib.ZstdLibrary;
 
 class JnaZstdLibrary implements ZstdLibrary {
 
-    private interface NativeFunctions extends Library {
-        long ZSTD_compressBound(int scrLen);
+    public static class NativeFunctions {
+        public static native long ZSTD_compressBound(int scrLen);
 
-        long ZSTD_compress(Pointer dst, int dstLen, Pointer src, int srcLen, int compressionLevel);
+        public static native long ZSTD_compress(Pointer dst, int dstLen, Pointer src, int srcLen, int compressionLevel);
 
-        boolean ZSTD_isError(long code);
+        public static native boolean ZSTD_isError(long code);
 
-        String ZSTD_getErrorName(long code);
+        public static native String ZSTD_getErrorName(long code);
 
-        long ZSTD_decompress(Pointer dst, int dstLen, Pointer src, int srcLen);
+        public static native long ZSTD_decompress(Pointer dst, int dstLen, Pointer src, int srcLen);
     }
 
-    private final NativeFunctions functions;
-
     JnaZstdLibrary() {
-        this.functions = Native.load("zstd", NativeFunctions.class);
+        Native.register(NativeFunctions.class, "zstd");
     }
 
     @Override
     public long compressBound(int scrLen) {
-        return functions.ZSTD_compressBound(scrLen);
+        return NativeFunctions.ZSTD_compressBound(scrLen);
     }
 
     @Override
@@ -46,7 +44,7 @@ class JnaZstdLibrary implements ZstdLibrary {
         assert src instanceof JnaCloseableByteBuffer;
         var nativeDst = (JnaCloseableByteBuffer) dst;
         var nativeSrc = (JnaCloseableByteBuffer) src;
-        return functions.ZSTD_compress(
+        return NativeFunctions.ZSTD_compress(
             nativeDst.memory.share(dst.buffer().position()),
             dst.buffer().remaining(),
             nativeSrc.memory.share(src.buffer().position()),
@@ -57,12 +55,12 @@ class JnaZstdLibrary implements ZstdLibrary {
 
     @Override
     public boolean isError(long code) {
-        return functions.ZSTD_isError(code);
+        return NativeFunctions.ZSTD_isError(code);
     }
 
     @Override
     public String getErrorName(long code) {
-        return functions.ZSTD_getErrorName(code);
+        return NativeFunctions.ZSTD_getErrorName(code);
     }
 
     @Override
@@ -71,7 +69,7 @@ class JnaZstdLibrary implements ZstdLibrary {
         assert src instanceof JnaCloseableByteBuffer;
         var nativeDst = (JnaCloseableByteBuffer) dst;
         var nativeSrc = (JnaCloseableByteBuffer) src;
-        return functions.ZSTD_decompress(
+        return NativeFunctions.ZSTD_decompress(
             nativeDst.memory.share(dst.buffer().position()),
             dst.buffer().remaining(),
             nativeSrc.memory.share(src.buffer().position()),


### PR DESCRIPTION
JNA supports two types of mapping to native methods, proxying and direct method mapping. Proxying is nicer for unit testing, but unfortunately the proxied methods are lazily loaded. NativeAccess expects that methods are linked during static init, before SecurityManager is initialized. For any native methods called after security manager init, the proxied method will fail.

This commit changes the zstd bindings to use direct method mapping so that calling zstd methods does not fail when using JNA (pre Java 21).

closes #107504
closes #107770