### PR TITLE
[8.13] Fix lingering license warning header (#108031)

### DIFF
--- a/docs/changelog/108031.yaml
+++ b/docs/changelog/108031.yaml
@@ -1,0 +1,6 @@
+pr: 108031
+summary: Fix lingering license warning header
+area: License
+type: bug
+issues:
+ - 107573

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java
@@ -364,7 +364,11 @@ public class Netty4HttpServerTransport extends AbstractHttpServerTransport {
                 ch.pipeline()
                     .addLast(
                         "accept_channel_handler",
-                        new AcceptChannelHandler(acceptChannelPredicate, HttpServerTransport.HTTP_PROFILE_NAME)
+                        new AcceptChannelHandler(
+                            acceptChannelPredicate,
+                            HttpServerTransport.HTTP_PROFILE_NAME,
+                            transport.getThreadPool().getThreadContext()
+                        )
                     );
             }
             if (tlsConfig.isTLSEnabled()) {

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -56,6 +56,7 @@ import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -78,6 +79,12 @@ import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
+<<<<<<< HEAD
+=======
+import org.elasticsearch.transport.Transports;
+import org.elasticsearch.transport.netty4.AcceptChannelHandler;
+import org.elasticsearch.transport.netty4.Netty4Plugin;
+>>>>>>> cf1f83fdde7 (Fix lingering license warning header (#108031))
 import org.elasticsearch.transport.netty4.NettyAllocator;
 import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.transport.netty4.TLSConfig;
@@ -86,6 +93,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -107,10 +115,12 @@ import static org.elasticsearch.rest.RestStatus.BAD_REQUEST;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.rest.RestStatus.UNAUTHORIZED;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -543,6 +553,77 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
                     response.release();
                 }
             }
+        }
+    }
+
+    public void testChannelAcceptorCannotTamperThreadContext() throws Exception {
+        HttpServerTransport.Dispatcher dispatcher = new HttpServerTransport.Dispatcher() {
+            @Override
+            public void dispatchRequest(final RestRequest request, final RestChannel channel, final ThreadContext threadContext) {
+                assertThreadContextNotTampered(threadContext);
+                channel.sendResponse(new RestResponse(OK, RestResponse.TEXT_CONTENT_TYPE, new BytesArray("done")));
+            }
+
+            @Override
+            public void dispatchBadRequest(final RestChannel channel, final ThreadContext threadContext, final Throwable cause) {
+                logger.error(() -> "--> Unexpected bad request [" + FakeRestRequest.requestToString(channel.request()) + "]", cause);
+                throw new AssertionError();
+            }
+        };
+        // there's only one netty worker thread that's reused across client requests
+        Settings settings = Settings.builder()
+            .put(Netty4Plugin.WORKER_COUNT.getKey(), 1)
+            .put(Netty4Plugin.SETTING_HTTP_WORKER_COUNT.getKey(), 0)
+            .build();
+        NioEventLoopGroup group = new NioEventLoopGroup();
+        AtomicBoolean acceptChannel = new AtomicBoolean();
+        try (
+            Netty4HttpServerTransport transport = new Netty4HttpServerTransport(
+                settings,
+                networkService,
+                threadPool,
+                xContentRegistry(),
+                dispatcher,
+                randomClusterSettings(),
+                new SharedGroupFactory(settings),
+                Tracer.NOOP,
+                TLSConfig.noTLS(),
+                new AcceptChannelHandler.AcceptPredicate() {
+                    @Override
+                    public void setBoundAddress(BoundTransportAddress boundHttpTransportAddress) {}
+
+                    @Override
+                    public boolean test(String profile, InetSocketAddress peerAddress) {
+                        assertThreadContextNotTampered(threadPool.getThreadContext());
+                        tamperThreadContext(threadPool.getThreadContext());
+                        return acceptChannel.get();
+                    }
+                },
+                randomFrom((httpPreRequest, channel, listener) -> listener.onResponse(null), null)
+            )
+        ) {
+            transport.start();
+            int nRetries = randomIntBetween(7, 9);
+            for (int i = 0; i < nRetries; i++) {
+                acceptChannel.set(randomBoolean());
+                try (Netty4HttpClient client = new Netty4HttpClient()) {
+                    var responses = client.get(randomFrom(transport.boundAddress().boundAddresses()).address(), "/test/url");
+                    try {
+                        if (acceptChannel.get()) {
+                            assertThat(responses, iterableWithSize(1));
+                            assertThat(responses.iterator().next().status(), equalTo(HttpResponseStatus.OK));
+                        } else {
+                            assertThat(responses, emptyIterable());
+                        }
+                    } finally {
+                        for (FullHttpResponse response : responses) {
+                            response.release();
+                        }
+                    }
+                }
+            }
+        } finally {
+            group.shutdownGracefully().await();
         }
     }
 
@@ -1070,5 +1151,27 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
         }
 
         throw new IllegalArgumentException("Unexpected http method: " + httpMethod);
+    }
+
+    private static void tamperThreadContext(ThreadContext threadContext) {
+        boolean tampered = false;
+        if (randomBoolean()) {
+            threadContext.putHeader(randomAlphaOfLength(16), "tampered with request header");
+            tampered = true;
+        }
+        if (randomBoolean()) {
+            threadContext.putTransient(randomAlphaOfLength(16), "tampered with transient request header");
+            tampered = true;
+        }
+        if (randomBoolean() || tampered == false) {
+            threadContext.addResponseHeader(randomAlphaOfLength(8), "tampered with response header");
+        }
+    }
+
+    private static void assertThreadContextNotTampered(ThreadContext threadContext) {
+        if (false == threadContext.isDefaultContext()) {
+            throw new AssertionError("tampered thread context");
+        }
+        Transports.assertTransportThread();
     }
 }

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -79,12 +79,9 @@ import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
-<<<<<<< HEAD
-=======
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.transport.netty4.AcceptChannelHandler;
 import org.elasticsearch.transport.netty4.Netty4Plugin;
->>>>>>> cf1f83fdde7 (Fix lingering license warning header (#108031))
 import org.elasticsearch.transport.netty4.NettyAllocator;
 import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.transport.netty4.TLSConfig;

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -81,7 +81,6 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.transport.netty4.AcceptChannelHandler;
-import org.elasticsearch.transport.netty4.Netty4Plugin;
 import org.elasticsearch.transport.netty4.NettyAllocator;
 import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.transport.netty4.TLSConfig;
@@ -569,8 +568,8 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
         };
         // there's only one netty worker thread that's reused across client requests
         Settings settings = Settings.builder()
-            .put(Netty4Plugin.WORKER_COUNT.getKey(), 1)
-            .put(Netty4Plugin.SETTING_HTTP_WORKER_COUNT.getKey(), 0)
+            .put(Netty4Transport.WORKER_COUNT.getKey(), 1)
+            .put(Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.getKey(), 0)
             .build();
         NioEventLoopGroup group = new NioEventLoopGroup();
         AtomicBoolean acceptChannel = new AtomicBoolean();

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -81,6 +81,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.transport.netty4.AcceptChannelHandler;
+import org.elasticsearch.transport.netty4.Netty4Transport;
 import org.elasticsearch.transport.netty4.NettyAllocator;
 import org.elasticsearch.transport.netty4.SharedGroupFactory;
 import org.elasticsearch.transport.netty4.TLSConfig;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [Fix lingering license warning header (#108031)](https://github.com/elastic/elasticsearch/pull/108031)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)