### PR TITLE
Unmute SnapshotStatusApisIT#testInfiniteTimeout

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -689,7 +689,6 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107405")
     public void testInfiniteTimeout() throws Exception {
         createRepository("test-repo", "mock");
         createIndex("test-idx", 1, 0);


### PR DESCRIPTION
This test doesn't fail anymore, I've run it 1000 times locally. 


This test got introduced in #107050, and I believe the test got fixed in #107675. Unfortunately, the got muted before #107675 got merged, so I can't confirm that PR actually fixed the test on CI.


