### PR TITLE
Skip `setIgnoredValues` when there are no ignored values

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -823,7 +823,7 @@ public class ObjectMapper extends Mapper {
             if (objectsWithIgnoredFields == null || objectsWithIgnoredFields.isEmpty()) {
                 return false;
             }
-            ignoredValues = objectsWithIgnoredFields.get(name());
+            ignoredValues = objectsWithIgnoredFields.remove(name());
             hasValue |= ignoredValues != null;
             for (SourceLoader.SyntheticFieldLoader loader : fields) {
                 hasValue |= loader.setIgnoredValues(objectsWithIgnoredFields);

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -820,6 +820,9 @@ public class ObjectMapper extends Mapper {
 
         @Override
         public boolean setIgnoredValues(Map<String, List<IgnoredSourceFieldMapper.NameValue>> objectsWithIgnoredFields) {
+            if (objectsWithIgnoredFields == null || objectsWithIgnoredFields.isEmpty()) {
+                return false;
+            }
             ignoredValues = objectsWithIgnoredFields.get(name());
             hasValue |= ignoredValues != null;
             for (SourceLoader.SyntheticFieldLoader loader : fields) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceLoader.java
@@ -126,7 +126,7 @@ public interface SourceLoader {
             @Override
             public Source source(LeafStoredFieldLoader storedFieldLoader, int docId) throws IOException {
                 // Maps the names of existing objects to lists of ignored fields they contain.
-                Map<String, List<IgnoredSourceFieldMapper.NameValue>> objectsWithIgnoredFields = new HashMap<>();
+                Map<String, List<IgnoredSourceFieldMapper.NameValue>> objectsWithIgnoredFields = null;
 
                 for (Map.Entry<String, List<Object>> e : storedFieldLoader.storedFields().entrySet()) {
                     SyntheticFieldLoader.StoredFieldLoader loader = storedFieldLoaders.get(e.getKey());
@@ -135,12 +135,17 @@ public interface SourceLoader {
                     }
                     if (IgnoredSourceFieldMapper.NAME.equals(e.getKey())) {
                         for (Object value : e.getValue()) {
+                            if (objectsWithIgnoredFields == null) {
+                                objectsWithIgnoredFields = new HashMap<>();
+                            }
                             IgnoredSourceFieldMapper.NameValue nameValue = IgnoredSourceFieldMapper.decode(value);
                             objectsWithIgnoredFields.computeIfAbsent(nameValue.getParentFieldName(), k -> new ArrayList<>()).add(nameValue);
                         }
                     }
                 }
-                loader.setIgnoredValues(objectsWithIgnoredFields);
+                if (objectsWithIgnoredFields != null) {
+                    loader.setIgnoredValues(objectsWithIgnoredFields);
+                }
                 if (docValuesLoader != null) {
                     docValuesLoader.advanceToDoc(docId);
                 }


### PR DESCRIPTION
The current logic iterates over all fields in every doc to check for ignored fields, even when no fields were retrieved from _ignored_source. The fix should address the performance regression we noticed, where `setIgnoredValues` dominates cpu time:

<img width="1417" alt="Screenshot 2024-05-02 at 12 11 01" src="https://github.com/elastic/elasticsearch/assets/131142368/66c5f944-21d4-41b1-955f-9ca434151cbd">

Related to #106825