### PR TITLE
Fix Bucket ordering for partial reduction in date histogram and histogram aggregation

### DIFF
--- a/docs/changelog/108184.yaml
+++ b/docs/changelog/108184.yaml
@@ -1,0 +1,7 @@
+pr: 108184
+summary: Fix Bucket ordering for partial reduction in date histogram and histogram
+  aggregation
+area: Aggregations
+type: bug
+issues:
+ - 108181

--- a/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/AggregationsIT.java
+++ b/qa/ccs-rolling-upgrade-remote-cluster/src/test/java/org/elasticsearch/upgrades/AggregationsIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.upgrades;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.Version;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * This test ensure aggregation compatibility in cross cluster search
+ */
+public class AggregationsIT extends ESRestTestCase {
+
+    private static final String CLUSTER_ALIAS = "remote_cluster";
+    private static final String localIndex = "test_bwc_index";
+    private static final String remoteIndex = "test_bwc_remote_index";
+    private static int docs;
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        return true;
+    }
+
+    static List<SearchStatesIT.Node> getNodes(RestClient restClient) throws IOException {
+        Response response = restClient.performRequest(new Request("GET", "_nodes"));
+        ObjectPath objectPath = ObjectPath.createFromResponse(response);
+        final Map<String, Object> nodeMap = objectPath.evaluate("nodes");
+        final List<SearchStatesIT.Node> nodes = new ArrayList<>();
+        for (String id : nodeMap.keySet()) {
+            final String name = objectPath.evaluate("nodes." + id + ".name");
+            final Version version = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
+            final String transportAddress = objectPath.evaluate("nodes." + id + ".transport.publish_address");
+            final String httpAddress = objectPath.evaluate("nodes." + id + ".http.publish_address");
+            final Map<String, Object> attributes = objectPath.evaluate("nodes." + id + ".attributes");
+            nodes.add(new SearchStatesIT.Node(id, name, version, transportAddress, httpAddress, attributes));
+        }
+        return nodes;
+    }
+
+    static List<HttpHost> parseHosts(String props) {
+        final String address = System.getProperty(props);
+        assertNotNull("[" + props + "] is not configured", address);
+        String[] stringUrls = address.split(",");
+        List<HttpHost> hosts = new ArrayList<>(stringUrls.length);
+        for (String stringUrl : stringUrls) {
+            int portSeparator = stringUrl.lastIndexOf(':');
+            if (portSeparator < 0) {
+                throw new IllegalArgumentException("Illegal cluster url [" + stringUrl + "]");
+            }
+            String host = stringUrl.substring(0, portSeparator);
+            int port = Integer.parseInt(stringUrl.substring(portSeparator + 1));
+            hosts.add(new HttpHost(host, port, "http"));
+        }
+        assertThat("[" + props + "] is empty", hosts, not(empty()));
+        return hosts;
+    }
+
+    static RestClient newLocalClient() {
+        return RestClient.builder(randomFrom(parseHosts("tests.rest.cluster"))).build();
+    }
+
+    static RestClient newRemoteClient() {
+        return RestClient.builder(randomFrom(parseHosts("tests.rest.remote_cluster"))).build();
+    }
+
+    @Before
+    private void configureClusters() throws Exception {
+        if (docs == 0) {
+            try (RestClient localClient = newLocalClient(); RestClient remoteClient = newRemoteClient()) {
+                configureRemoteClusters(localClient, getNodes(remoteClient));
+                docs = between(10, 100);
+                createindex(localClient, localIndex);
+                createindex(remoteClient, remoteIndex);
+            }
+        }
+    }
+
+    @After
+    private void clearClusters() throws Exception {
+        try (RestClient localClient = newLocalClient(); RestClient remoteClient = newRemoteClient()) {
+            deleteIndex(localClient, localIndex);
+            deleteIndex(remoteClient, remoteIndex);
+            docs = 0;
+        }
+    }
+
+    private void createindex(RestClient client, String index) throws IOException {
+        final String mapping = """
+             "properties": {
+               "date": { "type": "date" },
+               "number": { "type": "integer" }
+             }
+            """;
+        createIndex(client, index, Settings.EMPTY, mapping);
+        for (int i = 0; i < docs; i++) {
+            Request createDoc = new Request("POST", "/" + index + "/_doc/id_" + i);
+            createDoc.setJsonEntity(Strings.format("""
+                { "date": %s, "number": %s }
+                """, i * 1000 * 60, i));
+            assertOK(client.performRequest(createDoc));
+        }
+        refresh(client, index);
+    }
+
+    private static void configureRemoteClusters(RestClient localClient, List<SearchStatesIT.Node> remoteNodes) throws Exception {
+        final String remoteClusterSettingPrefix = "cluster.remote." + CLUSTER_ALIAS + ".";
+        final Settings remoteConnectionSettings;
+        final List<String> seeds = remoteNodes.stream()
+            .filter(n -> n.attributes().containsKey("gateway"))
+            .map(n -> n.transportAddress())
+            .collect(Collectors.toList());
+        remoteConnectionSettings = Settings.builder()
+            .putNull(remoteClusterSettingPrefix + "proxy_address")
+            .put(remoteClusterSettingPrefix + "mode", "sniff")
+            .putList(remoteClusterSettingPrefix + "seeds", seeds)
+            .build();
+        updateClusterSettings(localClient, remoteConnectionSettings);
+        assertBusy(() -> {
+            final Response resp = localClient.performRequest(new Request("GET", "/_remote/info"));
+            assertOK(resp);
+            final ObjectPath objectPath = ObjectPath.createFromResponse(resp);
+            assertNotNull(objectPath.evaluate(CLUSTER_ALIAS));
+            assertTrue(objectPath.evaluate(CLUSTER_ALIAS + ".connected"));
+        }, 60, TimeUnit.SECONDS);
+    }
+
+    public void testDateHistogram() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            try (RestClient localClient = newLocalClient()) {
+                String in = URLEncoder.encode(localIndex + ",remote_cluster:" + remoteIndex, StandardCharsets.UTF_8);
+                Request request = new Request("POST", "/" + in + "/_search");
+                request.setJsonEntity(
+                    "{\"aggs\": { \"hist\": { \"date_histogram\": { \"field\": \"date\", \"calendar_interval\": \"minute\" }}}}"
+                );
+                ObjectPath response = ObjectPath.createFromResponse(localClient.performRequest(request));
+                assertEquals(docs, response.evaluateArraySize("aggregations.hist.buckets"));
+                for (int j = 0; j < docs; j++) {
+                    assertEquals(2, (int) response.evaluate("aggregations.hist.buckets." + j + ".doc_count"));
+                }
+            }
+        }
+    }
+
+    public void testHistogram() throws Exception {
+        for (int i = 0; i < 3; i++) {
+            try (RestClient localClient = newLocalClient()) {
+                String in = URLEncoder.encode(localIndex + ",remote_cluster:" + remoteIndex, StandardCharsets.UTF_8);
+                Request request = new Request("POST", "/" + in + "/_search");
+                request.setJsonEntity("{\"aggs\": { \"hist\": { \"histogram\": { \"field\": \"number\", \"interval\": 1 }}}}");
+                ObjectPath response = ObjectPath.createFromResponse(localClient.performRequest(request));
+                assertEquals(docs, response.evaluateArraySize("aggregations.hist.buckets"));
+                for (int j = 0; j < docs; j++) {
+                    assertEquals(2, (int) response.evaluate("aggregations.hist.buckets." + j + ".doc_count"));
+                }
+            }
+        }
+    }
+}

--- a/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/HistogramIT.java
+++ b/qa/mixed-cluster/src/test/java/org/elasticsearch/backwards/HistogramIT.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.backwards;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
+
+import java.io.IOException;
+
+/**
+ * Test that index enough data to trigger concurrency.
+ */
+public class HistogramIT extends ESRestTestCase {
+
+    private static final String index = "idx";
+    private static final int numBuckets = 1000;
+    private static final int docsPerBuckets = 1000;
+
+    private int indexDocs(int numDocs, int id) throws Exception {
+        final Request request = new Request("POST", "/_bulk");
+        final StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < numDocs; ++i) {
+            Object[] args = new Object[] { index, id++, i * 1000 * 60, i };
+            builder.append(Strings.format("""
+                { "index" : { "_index" : "%s", "_id": "%s" } }
+                {"date" : %s, "number" : %s }
+                """, args));
+        }
+        request.setJsonEntity(builder.toString());
+        assertOK(client().performRequest(request));
+        return id;
+    }
+
+    public void testWithConcurrency() throws Exception {
+        final String mapping = """
+             "properties": {
+               "date": { "type": "date" },
+               "number": { "type": "integer" }
+             }
+            """;
+        final Settings.Builder settings = Settings.builder()
+            .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 3)
+            .put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 0);
+        createIndex(index, settings.build(), mapping);
+        // We want to trigger concurrency so we need to index enough documents
+        int id = 1;
+        for (int i = 0; i < docsPerBuckets; i++) {
+            id = indexDocs(numBuckets, id);
+            refreshAllIndices();
+        }
+        // Check date histogram
+        assertDateHistogram();
+        // Check histogram
+        assertHistogram();
+    }
+
+    private void assertDateHistogram() throws IOException {
+        final Request request = new Request("POST", index + "/_search");
+        request.setJsonEntity("""
+            {
+              "aggs": {
+                "hist": {
+                  "date_histogram": {
+                    "field": "date",
+                    "calendar_interval": "minute"
+                  }
+                }
+              }
+            }""");
+        final Response response = client().performRequest(request);
+        assertOK(response);
+        ObjectPath o = ObjectPath.createFromResponse(response);
+        assertEquals(numBuckets, o.evaluateArraySize("aggregations.hist.buckets"));
+        for (int j = 0; j < numBuckets; j++) {
+            assertEquals(docsPerBuckets, (int) o.evaluate("aggregations.hist.buckets." + j + ".doc_count"));
+        }
+    }
+
+    private void assertHistogram() throws IOException {
+        final Request request = new Request("POST", index + "/_search");
+        request.setJsonEntity("""
+            {
+              "aggs": {
+                "hist": {
+                  "histogram": {
+                    "field": "number",
+                    "interval": "1"
+                  }
+                }
+              }
+            }""");
+        final Response response = client().performRequest(request);
+        assertOK(response);
+        ObjectPath o = ObjectPath.createFromResponse(response);
+        assertEquals(numBuckets, o.evaluateArraySize("aggregations.hist.buckets"));
+        for (int j = 0; j < numBuckets; j++) {
+            assertEquals(docsPerBuckets, (int) o.evaluate("aggregations.hist.buckets." + j + ".doc_count"));
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -456,8 +456,8 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
             @Override
             public InternalAggregation get() {
                 List<Bucket> reducedBuckets = reducer.get();
+                reducedBuckets.sort(Comparator.comparingLong(b -> b.key));
                 if (reduceContext.isFinalReduce()) {
-                    reducedBuckets.sort(Comparator.comparingLong(b -> b.key));
                     if (minDocCount == 0) {
                         addEmptyBuckets(reducedBuckets, reduceContext);
                     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -399,8 +399,8 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
             @Override
             public InternalAggregation get() {
                 List<Bucket> reducedBuckets = reducer.get();
+                reducedBuckets.sort(Comparator.comparingDouble(b -> b.key));
                 if (reduceContext.isFinalReduce()) {
-                    reducedBuckets.sort(Comparator.comparingDouble(b -> b.key));
                     if (minDocCount == 0) {
                         addEmptyBuckets(reducedBuckets, reduceContext);
                     }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1735,6 +1735,10 @@ public abstract class ESRestTestCase extends ESTestCase {
         return createIndex(client, name, settings, null, null);
     }
 
+    protected static CreateIndexResponse createIndex(RestClient client, String name, Settings settings, String mapping) throws IOException {
+        return createIndex(client, name, settings, mapping, null);
+    }
+
     protected static CreateIndexResponse createIndex(String name, Settings settings, String mapping) throws IOException {
         return createIndex(name, settings, mapping, null);
     }


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/105359. we changed the bucket ordering for partial reduces which causes issues when the output is shared with a node running on an older version. This PR reorders the output to the expected order for previous versions.

fixes https://github.com/elastic/elasticsearch/issues/108181