### PR TITLE
[8.14] Add known issue for CCS duplicated buckets (#108182)

### DIFF
--- a/docs/reference/release-notes/8.13.0.asciidoc
+++ b/docs/reference/release-notes/8.13.0.asciidoc
@@ -7,6 +7,10 @@ Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 [float]
 === Known issues
 
+* Cross-cluster searches involving nodes upgraded to 8.13.0 and a coordinator node that is running on
+  version 8.12 or earlier can produce duplicate buckets. This occurs when using date_histogram or histogram
+  aggregations (issue: {es-issue}108181[#108181]).
+
 * Due to a bug in the bundled JDK 22 nodes might crash abruptly under high memory pressure.
   We recommend <<jvm-version,downgrading to JDK 21.0.2>> asap to mitigate the issue.
 

--- a/docs/reference/release-notes/8.13.1.asciidoc
+++ b/docs/reference/release-notes/8.13.1.asciidoc
@@ -5,6 +5,11 @@ Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 
 [[bug-8.13.1]]
 [float]
+
+* Cross-cluster searches involving nodes upgraded to 8.13.1 and a coordinator node that is running on
+  version 8.12 or earlier can produce duplicate buckets. This occurs when using date_histogram or histogram
+  aggregations (issue: {es-issue}108181[#108181]).
+
 === Bug fixes
 
 Aggregations::

--- a/docs/reference/release-notes/8.13.2.asciidoc
+++ b/docs/reference/release-notes/8.13.2.asciidoc
@@ -5,6 +5,11 @@ Also see <<breaking-changes-8.13,Breaking changes in 8.13>>.
 
 [[bug-8.13.2]]
 [float]
+
+* Cross-cluster searches involving nodes upgraded to 8.13.2 and a coordinator node that is running on
+  version 8.12 or earlier can produce duplicate buckets. This occurs when using date_histogram or histogram
+  aggregations (issue: {es-issue}108181[#108181]).
+
 === Bug fixes
 
 Aggregations::


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Add known issue for CCS duplicated buckets (#108182)