### PR TITLE
Revert "Make MappedActionFilter its own interface"

### DIFF
--- a/docs/changelog/108187.yaml
+++ b/docs/changelog/108187.yaml
@@ -1,0 +1,5 @@
+pr: 108187
+summary: Revert "Make `MappedActionFilter` its own interface"
+area: Infra/Core
+type: bug
+issues: []

--- a/docs/changelog/108187.yaml
+++ b/docs/changelog/108187.yaml
@@ -1,5 +1,0 @@
-pr: 108187
-summary: Revert "Make `MappedActionFilter` its own interface"
-area: Infra/Core
-type: bug
-issues: []

--- a/server/src/main/java/org/elasticsearch/action/support/MappedActionFilter.java
+++ b/server/src/main/java/org/elasticsearch/action/support/MappedActionFilter.java
@@ -8,31 +8,6 @@
 
 package org.elasticsearch.action.support;
 
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRequest;
-import org.elasticsearch.action.ActionResponse;
-import org.elasticsearch.tasks.Task;
-
-/**
- * An action filter that is run only for a single action.
- *
- * Note: This is an independent interface from {@link ActionFilter} so that it does not
- * have an order. The relative order of executed MappedActionFilter with the same action name
- * is undefined.
- */
-public interface MappedActionFilter {
-    /** Return the name of the action for which this filter should be run */
+public interface MappedActionFilter extends ActionFilter {
     String actionName();
-
-    /**
-     * Enables filtering the execution of an action on the request side, either by sending a response through the
-     * {@link ActionListener} or by continuing the execution through the given {@link ActionFilterChain chain}
-     */
-    <Request extends ActionRequest, Response extends ActionResponse> void apply(
-        Task task,
-        String action,
-        Request request,
-        ActionListener<Response> listener,
-        ActionFilterChain<Request, Response> chain
-    );
 }

--- a/server/src/test/java/org/elasticsearch/action/support/MappedActionFiltersTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/MappedActionFiltersTests.java
@@ -60,6 +60,11 @@ public class MappedActionFiltersTests extends ESTestCase {
             }
 
             @Override
+            public int order() {
+                return 0;
+            }
+
+            @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void apply(
                 Task task,
                 String action,
@@ -96,6 +101,11 @@ public class MappedActionFiltersTests extends ESTestCase {
             }
 
             @Override
+            public int order() {
+                return 0;
+            }
+
+            @Override
             public <Request extends ActionRequest, Response extends ActionResponse> void apply(
                 Task task,
                 String action,
@@ -111,6 +121,11 @@ public class MappedActionFiltersTests extends ESTestCase {
             @Override
             public String actionName() {
                 return "dummyAction";
+            }
+
+            @Override
+            public int order() {
+                return 0;
             }
 
             @Override
@@ -147,6 +162,11 @@ public class MappedActionFiltersTests extends ESTestCase {
             @Override
             public String actionName() {
                 return "dummyAction";
+            }
+
+            @Override
+            public int order() {
+                return 0;
             }
 
             @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/api/filtering/ApiFilteringActionFilter.java
@@ -32,6 +32,11 @@ public abstract class ApiFilteringActionFilter<Res extends ActionResponse> imple
     }
 
     @Override
+    public int order() {
+        return 0;
+    }
+
+    @Override
     public final String actionName() {
         return actionName;
     }


### PR DESCRIPTION
This breaks compilation in serverless. For example: https://gradle-enterprise.elastic.co/s/u3zko6nulfhsa.

Reverts elastic/elasticsearch#107960