### PR TITLE
[build] [bwc] Add --recurse-submodules to `git fetch`

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
@@ -122,7 +122,7 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
             fetchLatest.dependsOn(addRemoteTaskProvider);
             fetchLatest.getWorkingDir().set(gitExtension.getCheckoutDir());
             // Fetch latest from remotes, including tags, overriding any existing local refs
-            fetchLatest.commandLine("git", "fetch", "--all", "--tags", "--force");
+            fetchLatest.commandLine("git", "fetch", "--all", "--tags", "--force", "--recurse-submodules");
         });
 
         String projectPath = project.getPath();


### PR DESCRIPTION
Make sure we also fetch the latest refs and tags for the projects where `elasticsearch` is a submodule.