### PR TITLE
ESQL: Fix bug in hashlookup

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashLookupOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/HashLookupOperator.java
@@ -122,8 +122,13 @@ public class HashLookupOperator extends AbstractPageMappingToIteratorOperator {
     @Override
     protected ReleasableIterator<Page> receive(Page page) {
         Page mapped = page.projectBlocks(blockMapping);
-        page.releaseBlocks();
-        return appendBlocks(mapped, hash.lookup(mapped, BlockFactory.DEFAULT_MAX_BLOCK_PRIMITIVE_ARRAY_SIZE));
+        // TODO maybe this should take an array of Blocks instead?
+        try {
+            // hash.lookup increments any references we need to keep for the iterator
+            return appendBlocks(page, hash.lookup(mapped, BlockFactory.DEFAULT_MAX_BLOCK_PRIMITIVE_ARRAY_SIZE));
+        } finally {
+            mapped.releaseBlocks();
+        }
     }
 
     @Override

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HashLookupOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/HashLookupOperatorTests.java
@@ -8,10 +8,12 @@
 package org.elasticsearch.compute.operator;
 
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.BlockTestUtils;
 import org.elasticsearch.compute.data.IntBlock;
 import org.elasticsearch.compute.data.LongBlock;
 import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.data.TestBlockFactory;
+import org.elasticsearch.core.Tuple;
 import org.hamcrest.Matcher;
 
 import java.util.List;
@@ -28,6 +30,10 @@ public class HashLookupOperatorTests extends OperatorTestCase {
 
     @Override
     protected void assertSimpleOutput(List<Page> input, List<Page> results) {
+        assertSimpleOutput(input, results, 0, 1);
+    }
+
+    private void assertSimpleOutput(List<Page> input, List<Page> results, int keyChannel, int outputChannel) {
         int count = input.stream().mapToInt(Page::getPositionCount).sum();
         assertThat(results.stream().mapToInt(Page::getPositionCount).sum(), equalTo(count));
         int keysIdx = 0;
@@ -39,10 +45,10 @@ public class HashLookupOperatorTests extends OperatorTestCase {
         int p = 0;
         while (p < count) {
             if (keys == null) {
-                keys = input.get(keysIdx++).getBlock(0);
+                keys = input.get(keysIdx++).getBlock(keyChannel);
             }
             if (ords == null) {
-                ords = results.get(ordsIdx++).getBlock(1);
+                ords = results.get(ordsIdx++).getBlock(outputChannel);
             }
             int valueCount = keys.getValueCount(p - keysOffset);
             assertThat(ords.getValueCount(p - ordsOffset), equalTo(valueCount));
@@ -91,5 +97,29 @@ public class HashLookupOperatorTests extends OperatorTestCase {
         return matchesRegex(
             "HashLookup\\[keys=\\[foo], hash=PackedValuesBlockHash\\{groups=\\[0:LONG], entries=4, size=\\d+b}, mapping=\\[0]]"
         );
+    }
+
+    public void testSelectBlocks() {
+        DriverContext context = driverContext();
+        List<Page> input = CannedSourceOperator.collectPages(
+            new TupleBlockSourceOperator(
+                context.blockFactory(),
+                LongStream.range(0, 1000).mapToObj(l -> Tuple.tuple(randomLong(), randomFrom(1L, 7L, 14L, 20L)))
+            )
+        );
+        List<Page> clonedInput = BlockTestUtils.deepCopyOf(input, TestBlockFactory.getNonBreakingInstance());
+        List<Page> results = drive(
+            new HashLookupOperator.Factory(
+                new HashLookupOperator.Key[] {
+                    new HashLookupOperator.Key(
+                        "foo",
+                        TestBlockFactory.getNonBreakingInstance().newLongArrayVector(new long[] { 1, 7, 14, 20 }, 4).asBlock()
+                    ) },
+                new int[] { 1 }
+            ).get(context),
+            input.iterator(),
+            context
+        );
+        assertSimpleOutput(clonedInput, results, 1, 2);
     }
 }


### PR DESCRIPTION
It only worked properly when the keys were the first blocks in the input page - that's unlikely. But that's what the test was running! Surprise! Anyway, this fixes it and adds a test that'd catch the bug.
