### PR TITLE
[8.14] Remove Beta label for RCS2.0 from 8.14 (#108030)

### DIFF
--- a/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-api-key.asciidoc
@@ -1,8 +1,6 @@
 [[remote-clusters-api-key]]
 === Add remote clusters using API key authentication
 
-beta::[]
-
 API key authentication enables a local cluster to authenticate itself with a
 remote cluster via a <<security-api-create-cross-cluster-api-key,cross-cluster
 API key>>. The API key needs to be created by an administrator of the remote

--- a/docs/reference/modules/cluster/remote-clusters-settings.asciidoc
+++ b/docs/reference/modules/cluster/remote-clusters-settings.asciidoc
@@ -68,7 +68,6 @@ mode are described separately.
 `cluster.remote.<cluster_alias>.credentials` (<<secure-settings,Secure>>, <<reloadable-secure-settings,Reloadable>>)::
 [[remote-cluster-credentials-setting]]
 
-beta:[]
   Per cluster setting for configuring <<remote-clusters-api-key,remote clusters with the API Key based model>>.
   This setting takes the encoded value of a
   <<security-api-create-cross-cluster-api-key,cross-cluster API key>> and must be set

--- a/docs/reference/modules/remote-cluster-network.asciidoc
+++ b/docs/reference/modules/remote-cluster-network.asciidoc
@@ -1,8 +1,6 @@
 [[remote-cluster-network-settings]]
 ==== Advanced remote cluster (API key based model) settings
 
-beta::[]
-
 Use the following advanced settings to configure the remote cluster interface (API key based model)
 independently of the <<transport-settings,transport interface>>. You can also
 configure both interfaces together using the <<common-network-settings,network settings>>.

--- a/docs/reference/modules/remote-clusters.asciidoc
+++ b/docs/reference/modules/remote-clusters.asciidoc
@@ -45,8 +45,7 @@ with either of the connection modes.
 ==== Security models
 
 API key based security model::
-beta:[]
-For clusters on version 8.10 or later, you can use an API key to authenticate
+For clusters on version 8.14 or later, you can use an API key to authenticate
 and authorize cross-cluster operations to a remote cluster. This model offers
 administrators of both the local and the remote cluster fine-grained access
 controls. <<remote-clusters-api-key>>.

--- a/docs/reference/rest-api/security/create-cross-cluster-api-key.asciidoc
+++ b/docs/reference/rest-api/security/create-cross-cluster-api-key.asciidoc
@@ -2,8 +2,6 @@
 [[security-api-create-cross-cluster-api-key]]
 === Create Cross-Cluster API key API
 
-beta::[]
-
 ++++
 <titleabbrev>Create Cross-Cluster API key</titleabbrev>
 ++++

--- a/docs/reference/rest-api/security/create-roles.asciidoc
+++ b/docs/reference/rest-api/security/create-roles.asciidoc
@@ -74,7 +74,7 @@ that begin with `_` are reserved for system usage.
 For more information, see
 <<run-as-privilege>>.
 
-`remote_indices`:: beta:[] (list) A list of remote indices permissions entries.
+`remote_indices`:: (list) A list of remote indices permissions entries.
 +
 --
 NOTE: Remote indices are effective for <<remote-clusters-api-key,remote clusters configured with the API key based model>>.

--- a/docs/reference/rest-api/security/update-cross-cluster-api-key.asciidoc
+++ b/docs/reference/rest-api/security/update-cross-cluster-api-key.asciidoc
@@ -2,8 +2,6 @@
 [[security-api-update-cross-cluster-api-key]]
 === Update Cross-Cluster API key API
 
-beta::[]
-
 ++++
 <titleabbrev>Update Cross-Cluster API key</titleabbrev>
 ++++

--- a/docs/reference/security/authorization/managing-roles.asciidoc
+++ b/docs/reference/security/authorization/managing-roles.asciidoc
@@ -31,8 +31,7 @@ A role is defined by the following JSON structure:
 <4> A list of indices permissions entries. This field is optional (missing `indices`
     privileges effectively mean no index level permissions).
 <5> A list of application privilege entries. This field is optional.
-<6> beta:[]
-    A list of indices permissions entries for
+<6> A list of indices permissions entries for
     <<remote-clusters-api-key,remote clusters configured with the API key based model>>.
     This field is optional (missing `remote_indices` privileges effectively mean
     no index level permissions for any API key based remote clusters).
@@ -164,8 +163,6 @@ no effect, and will not grant any actions in the
 
 [[roles-remote-indices-priv]]
 ==== Remote indices privileges
-
-beta::[]
 
 For <<remote-clusters-api-key,remote clusters configured with the API key based model>>, remote indices privileges
 can be used to specify desired indices privileges for matching remote clusters. The final

--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -21,7 +21,7 @@ Privileges to create snapshots for existing repositories. Can also list and view
 details on existing repositories and snapshots.
 
 `cross_cluster_replication`::
-beta:[] Privileges to connect to <<remote-clusters-api-key,remote clusters configured with the API key based model>>
+Privileges to connect to <<remote-clusters-api-key,remote clusters configured with the API key based model>>
 for cross-cluster replication.
 +
 --
@@ -32,7 +32,7 @@ to manage cross-cluster API keys.
 --
 
 `cross_cluster_search`::
-beta:[] Privileges to connect to <<remote-clusters-api-key,remote clusters configured with the API key based model>>
+Privileges to connect to <<remote-clusters-api-key,remote clusters configured with the API key based model>>
 for cross-cluster search.
 +
 --
@@ -310,13 +310,13 @@ requires the `manage` privilege as well, on both the index and the aliases
 names.
 
 `cross_cluster_replication`::
-beta:[] Privileges to perform cross-cluster replication for indices located on
+Privileges to perform cross-cluster replication for indices located on
 <<remote-clusters-api-key,remote clusters configured with the API key based model>>.
 This privilege should only be used for
 the `privileges` field of <<roles-remote-indices-priv,remote indices privileges>>.
 
 `cross_cluster_replication_internal`::
-beta:[] Privileges to perform supporting actions for cross-cluster replication from
+Privileges to perform supporting actions for cross-cluster replication from
 <<remote-clusters-api-key,remote clusters configured with the API key based model>>.
 +
 --

--- a/docs/reference/security/using-ip-filtering.asciidoc
+++ b/docs/reference/security/using-ip-filtering.asciidoc
@@ -114,8 +114,6 @@ xpack.security.http.filter.deny: _all
 [discrete]
 === Remote cluster (API key based model) filtering
 
-beta::[]
-
 If other clusters connect <<remote-clusters-api-key,using API key
 authentication>> for {ccs} or {ccr}, you may want to have different IP filtering
 for the remote cluster server interface.

--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -2639,8 +2639,6 @@ include::ssl-settings.asciidoc[]
 
 [[remote-cluster-server-tls-ssl-settings]]
 
-beta::[]
-
 :ssl-prefix:             xpack.security.remote_cluster_server
 :component:              Remote cluster server (API key based model)
 :enabled-by-default:
@@ -2654,8 +2652,6 @@ beta::[]
 include::ssl-settings.asciidoc[]
 
 [[remote-cluster-client-tls-ssl-settings]]
-
-beta::[]
 
 :ssl-prefix:             xpack.security.remote_cluster_client
 :component:              Remote cluster client (API key based model)
@@ -2714,12 +2710,12 @@ List of IP addresses to deny for this profile.
 
 `xpack.security.remote_cluster.filter.allow`::
 (<<dynamic-cluster-setting,Dynamic>>)
-beta:[] List of IP addresses to allow just for the
+List of IP addresses to allow just for the
 <<remote-clusters-api-key,remote cluster server configured with the API key based model>>.
 
 `xpack.security.remote_cluster.filter.deny`::
 (<<dynamic-cluster-setting,Dynamic>>)
-beta:[] List of IP addresses to deny just for the remote cluster server configured with
+List of IP addresses to deny just for the remote cluster server configured with
 the <<remote-clusters-api-key,API key based model>>.
 
 include::security-hash-settings.asciidoc[]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Remove Beta label for RCS2.0 from 8.14 (#108030)](https://github.com/elastic/elasticsearch/pull/108030)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)