### PR TITLE
[8.14] [ci] Add elastic-agent to Windows jobs (#108157)

### DIFF
--- a/.buildkite/hooks/pre-command.bat
+++ b/.buildkite/hooks/pre-command.bat
@@ -18,4 +18,6 @@ set JOB_BRANCH=%BUILDKITE_BRANCH%
 set GRADLE_BUILD_CACHE_USERNAME=vault read -field=username secret/ci/elastic-elasticsearch/migrated/gradle-build-cache
 set GRADLE_BUILD_CACHE_PASSWORD=vault read -field=password secret/ci/elastic-elasticsearch/migrated/gradle-build-cache
 
+bash.exe -c "nohup bash .buildkite/scripts/setup-monitoring.sh </dev/null >/dev/null 2>&1 &"
+
 exit /b 0

--- a/.buildkite/scripts/setup-monitoring.sh
+++ b/.buildkite/scripts/setup-monitoring.sh
@@ -2,23 +2,50 @@
 
 set -euo pipefail
 
+AGENT_VERSION="8.10.1"
+
 ELASTIC_AGENT_URL=$(vault read -field=url secret/ci/elastic-elasticsearch/elastic-agent-token)
 ELASTIC_AGENT_TOKEN=$(vault read -field=token secret/ci/elastic-elasticsearch/elastic-agent-token)
 
-if [[ ! -d /opt/elastic-agent ]]; then
-  sudo mkdir /opt/elastic-agent
-  sudo chown -R buildkite-agent:buildkite-agent /opt/elastic-agent
-  cd /opt/elastic-agent
+ELASTIC_AGENT_DIR=/opt/elastic-agent
+IS_WINDOWS=""
 
-  archive=elastic-agent-8.10.1-linux-x86_64.tar.gz
-  if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
-    archive=elastic-agent-8.10.1-linux-arm64.tar.gz
+# Windows
+if uname -a | grep -q MING; then
+  ELASTIC_AGENT_DIR=/c/elastic-agent
+  IS_WINDOWS="true"
+
+  # Make sudo a no-op on Windows
+  sudo() {
+    "$@"
+  }
+fi
+
+if [[ ! -d $ELASTIC_AGENT_DIR ]]; then
+  sudo mkdir $ELASTIC_AGENT_DIR
+
+  if [[ "$IS_WINDOWS" != "true" ]]; then
+    sudo chown -R buildkite-agent:buildkite-agent $ELASTIC_AGENT_DIR
+  fi
+
+  cd $ELASTIC_AGENT_DIR
+
+  archive="elastic-agent-$AGENT_VERSION-linux-x86_64.tar.gz"
+  if [[ "$IS_WINDOWS" == "true" ]]; then
+    archive="elastic-agent-$AGENT_VERSION-windows-x86_64.zip"
+  elif [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
+    archive="elastic-agent-$AGENT_VERSION-linux-arm64.tar.gz"
   fi
 
   curl -L -O "https://artifacts.elastic.co/downloads/beats/elastic-agent/$archive"
 
-  tar xzf "$archive" --directory=. --strip-components=1
+  if [[ "$IS_WINDOWS" == "true" ]]; then
+    unzip "$archive"
+    mv elastic-agent-*/* .
+  else
+    tar xzf "$archive" --directory=. --strip-components=1
+  fi
 fi
 
-cd /opt/elastic-agent
+cd $ELASTIC_AGENT_DIR
 sudo ./elastic-agent install -f --url="$ELASTIC_AGENT_URL" --enrollment-token="$ELASTIC_AGENT_TOKEN"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[ci] Add elastic-agent to Windows jobs (#108157)](https://github.com/elastic/elasticsearch/pull/108157)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)