### PR TITLE
[8.14] Use direct method mapping for zstd (#108172)

### DIFF
--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaZstdLibrary.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaZstdLibrary.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.nativeaccess.jna;
 
-import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 
@@ -17,27 +16,25 @@ import org.elasticsearch.nativeaccess.lib.ZstdLibrary;
 
 class JnaZstdLibrary implements ZstdLibrary {
 
-    private interface NativeFunctions extends Library {
-        long ZSTD_compressBound(int scrLen);
+    public static class NativeFunctions {
+        public static native long ZSTD_compressBound(int scrLen);
 
-        long ZSTD_compress(Pointer dst, int dstLen, Pointer src, int srcLen, int compressionLevel);
+        public static native long ZSTD_compress(Pointer dst, int dstLen, Pointer src, int srcLen, int compressionLevel);
 
-        boolean ZSTD_isError(long code);
+        public static native boolean ZSTD_isError(long code);
 
-        String ZSTD_getErrorName(long code);
+        public static native String ZSTD_getErrorName(long code);
 
-        long ZSTD_decompress(Pointer dst, int dstLen, Pointer src, int srcLen);
+        public static native long ZSTD_decompress(Pointer dst, int dstLen, Pointer src, int srcLen);
     }
 
-    private final NativeFunctions functions;
-
     JnaZstdLibrary() {
-        this.functions = Native.load("zstd", NativeFunctions.class);
+        Native.register(NativeFunctions.class, "zstd");
     }
 
     @Override
     public long compressBound(int scrLen) {
-        return functions.ZSTD_compressBound(scrLen);
+        return NativeFunctions.ZSTD_compressBound(scrLen);
     }
 
     @Override
@@ -46,7 +43,7 @@ class JnaZstdLibrary implements ZstdLibrary {
         assert src instanceof JnaCloseableByteBuffer;
         var nativeDst = (JnaCloseableByteBuffer) dst;
         var nativeSrc = (JnaCloseableByteBuffer) src;
-        return functions.ZSTD_compress(
+        return NativeFunctions.ZSTD_compress(
             nativeDst.memory.share(dst.buffer().position()),
             dst.buffer().remaining(),
             nativeSrc.memory.share(src.buffer().position()),
@@ -57,12 +54,12 @@ class JnaZstdLibrary implements ZstdLibrary {
 
     @Override
     public boolean isError(long code) {
-        return functions.ZSTD_isError(code);
+        return NativeFunctions.ZSTD_isError(code);
     }
 
     @Override
     public String getErrorName(long code) {
-        return functions.ZSTD_getErrorName(code);
+        return NativeFunctions.ZSTD_getErrorName(code);
     }
 
     @Override
@@ -71,7 +68,7 @@ class JnaZstdLibrary implements ZstdLibrary {
         assert src instanceof JnaCloseableByteBuffer;
         var nativeDst = (JnaCloseableByteBuffer) dst;
         var nativeSrc = (JnaCloseableByteBuffer) src;
-        return functions.ZSTD_decompress(
+        return NativeFunctions.ZSTD_decompress(
             nativeDst.memory.share(dst.buffer().position()),
             dst.buffer().remaining(),
             nativeSrc.memory.share(src.buffer().position()),


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Use direct method mapping for zstd (#108172)