### PR TITLE
Extend timeout of assertBusy in DeprecationHttpIT for remaining places

### DIFF
--- a/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
+++ b/x-pack/plugin/deprecation/qa/rest/src/javaRestTest/java/org/elasticsearch/xpack/deprecation/DeprecationHttpIT.java
@@ -140,7 +140,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
                 List<Map<String, Object>> documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId());
                 logger.warn(documents);
                 assertThat(documents, hasSize(2));
-            });
+            }, 30, TimeUnit.SECONDS);
         } finally {
             cleanupSettings();
         }
@@ -260,7 +260,7 @@ public class DeprecationHttpIT extends ESRestTestCase {
             var documents = DeprecationTestUtils.getIndexedDeprecations(client(), xOpaqueId);
             logger.warn(documents);
             assertThat(documents, hasSize(headerMatchers.size()));
-        });
+        }, 30, TimeUnit.SECONDS);
     }
 
     public void testDeprecationRouteThrottling() throws Exception {


### PR DESCRIPTION
Checking the sporadic failures since DeprecationHttpIT was enabled again, there wasn't any leaks anymore.
However, there's two places left with the default timeout of assertBusy, causing occasional failures of
```
Expected: a collection with size <2>
     but: collection size was <0>
```

relates to #101596