### PR TITLE
[8.13] [Doc+] Add Secure Connection to Setup CCR Tutorial (#103237)

### DIFF
--- a/docs/reference/ccr/getting-started.asciidoc
+++ b/docs/reference/ccr/getting-started.asciidoc
@@ -90,6 +90,7 @@ image::images/ccr-tutorial-clusters.png[ClusterA contains the leader index and C
 
 To configure a remote cluster from Stack Management in {kib}:
 
+. Set up a <<add-remote-clusters,secure connection>> as needed.
 . Select *Remote Clusters* from the side navigation.
 . Specify the {es} endpoint URL, or the IP address or host name of the remote
 cluster (`ClusterA`) followed by the transport port (defaults to `9300`). For


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Doc+] Add Secure Connection to Setup CCR Tutorial (#103237)