### PR TITLE
Ensure all health indicators properly respect the `verbose` flag

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthIndicatorService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthIndicatorService.java
@@ -93,12 +93,14 @@ public class DataStreamLifecycleHealthIndicatorService implements HealthIndicato
                     + " repeatedly encountered errors whilst trying to advance in its lifecycle",
                 createDetails(verbose, dataStreamLifecycleHealthInfo),
                 STAGNATING_INDEX_IMPACT,
-                List.of(
-                    new Diagnosis(
-                        STAGNATING_BACKING_INDICES_DIAGNOSIS_DEF,
-                        List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, affectedIndices))
+                verbose
+                    ? List.of(
+                        new Diagnosis(
+                            STAGNATING_BACKING_INDICES_DIAGNOSIS_DEF,
+                            List.of(new Diagnosis.Resource(Diagnosis.Resource.Type.INDEX, affectedIndices))
+                        )
                     )
-                )
+                    : List.of()
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorService.java
@@ -141,18 +141,18 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
     /**
      * Transforms a CoordinationDiagnosticsService.CoordinationDiagnosticsResult into a HealthIndicatorResult.
      * @param coordinationDiagnosticsResult The CoordinationDiagnosticsResult from the CoordinationDiagnosticsService to be transformed
-     * @param explain If false, the details and user actions returned will be empty
+     * @param verbose If false, the details and user actions returned will be empty
      * @return The HealthIndicatorResult
      */
     // Non-private for testing
     HealthIndicatorResult getHealthIndicatorResult(
         CoordinationDiagnosticsService.CoordinationDiagnosticsResult coordinationDiagnosticsResult,
-        boolean explain
+        boolean verbose
     ) {
         HealthStatus status = HealthStatus.fromCoordinationDiagnosticsStatus(coordinationDiagnosticsResult.status());
-        HealthIndicatorDetails details = getDetails(coordinationDiagnosticsResult.details(), explain);
+        HealthIndicatorDetails details = getDetails(coordinationDiagnosticsResult.details(), verbose);
         Collection<HealthIndicatorImpact> impacts = status.indicatesHealthProblem() ? UNSTABLE_MASTER_IMPACTS : List.of();
-        List<Diagnosis> diagnosis = status.indicatesHealthProblem() ? getUnstableMasterDiagnoses(explain) : List.of();
+        List<Diagnosis> diagnosis = status.indicatesHealthProblem() ? getUnstableMasterDiagnoses(verbose) : List.of();
         return createIndicator(status, coordinationDiagnosticsResult.summary(), details, impacts, diagnosis);
     }
 
@@ -242,12 +242,12 @@ public class StableMasterHealthIndicatorService implements HealthIndicatorServic
      * This method returns the relevant user actions when the master is unstable, linking to some troubleshooting docs and suggesting to
      * contact support.
      *
-     * @param explain If true, the returned list includes UserActions linking to troubleshooting docs and another to contact support,
+     * @param verbose If true, the returned list includes UserActions linking to troubleshooting docs and another to contact support,
      *                otherwise an empty list.
      * @return the relevant user actions when the master is unstable.
      */
-    private List<Diagnosis> getUnstableMasterDiagnoses(boolean explain) {
-        if (explain) {
+    private List<Diagnosis> getUnstableMasterDiagnoses(boolean verbose) {
+        if (verbose) {
             return List.of(TROUBLESHOOT_DISCOVERY, TROUBLESHOOT_UNSTABLE_CLUSTER, CONTACT_SUPPORT);
         } else {
             return List.of();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
@@ -984,34 +984,33 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
         }
 
         public HealthIndicatorDetails getDetails(boolean verbose) {
-            if (verbose) {
-                return new SimpleHealthIndicatorDetails(
-                    Map.of(
-                        "unassigned_primaries",
-                        primaries.unassigned,
-                        "initializing_primaries",
-                        primaries.initializing,
-                        "creating_primaries",
-                        primaries.unassigned_new,
-                        "restarting_primaries",
-                        primaries.unassigned_restarting,
-                        "started_primaries",
-                        primaries.started + primaries.relocating,
-                        "unassigned_replicas",
-                        replicas.unassigned,
-                        "initializing_replicas",
-                        replicas.initializing,
-                        "creating_replicas",
-                        replicas.unassigned_new,
-                        "restarting_replicas",
-                        replicas.unassigned_restarting,
-                        "started_replicas",
-                        replicas.started + replicas.relocating
-                    )
-                );
-            } else {
+            if (verbose == false) {
                 return HealthIndicatorDetails.EMPTY;
             }
+            return new SimpleHealthIndicatorDetails(
+                Map.of(
+                    "unassigned_primaries",
+                    primaries.unassigned,
+                    "initializing_primaries",
+                    primaries.initializing,
+                    "creating_primaries",
+                    primaries.unassigned_new,
+                    "restarting_primaries",
+                    primaries.unassigned_restarting,
+                    "started_primaries",
+                    primaries.started + primaries.relocating,
+                    "unassigned_replicas",
+                    replicas.unassigned,
+                    "initializing_replicas",
+                    replicas.initializing,
+                    "creating_replicas",
+                    replicas.unassigned_new,
+                    "restarting_replicas",
+                    replicas.unassigned_restarting,
+                    "started_replicas",
+                    replicas.started + replicas.relocating
+                )
+            );
         }
 
         public List<HealthIndicatorImpact> getImpacts() {

--- a/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/DiskHealthIndicatorService.java
@@ -120,7 +120,7 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             diskHealthAnalyzer.getSymptom(),
             diskHealthAnalyzer.getDetails(verbose),
             diskHealthAnalyzer.getImpacts(),
-            diskHealthAnalyzer.getDiagnoses(maxAffectedResourcesCount)
+            diskHealthAnalyzer.getDiagnoses(verbose, maxAffectedResourcesCount)
         );
     }
 
@@ -357,8 +357,8 @@ public class DiskHealthIndicatorService implements HealthIndicatorService {
             return impacts;
         }
 
-        private List<Diagnosis> getDiagnoses(int size) {
-            if (healthStatus == HealthStatus.GREEN) {
+        private List<Diagnosis> getDiagnoses(boolean verbose, int size) {
+            if (verbose == false || healthStatus == HealthStatus.GREEN) {
                 return List.of();
             }
             List<Diagnosis> diagnosisList = new ArrayList<>();

--- a/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/health/node/ShardsCapacityHealthIndicatorService.java
@@ -123,12 +123,13 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
 
         var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
         return mergeIndicators(
+            verbose,
             calculateFrom(shardLimitsMetadata.maxShardsPerNode(), state, ShardLimitValidator::checkShardLimitForNormalNodes),
             calculateFrom(shardLimitsMetadata.maxShardsPerNodeFrozen(), state, ShardLimitValidator::checkShardLimitForFrozenNodes)
         );
     }
 
-    private HealthIndicatorResult mergeIndicators(StatusResult dataNodes, StatusResult frozenNodes) {
+    private HealthIndicatorResult mergeIndicators(boolean verbose, StatusResult dataNodes, StatusResult frozenNodes) {
         var finalStatus = HealthStatus.merge(Stream.of(dataNodes.status, frozenNodes.status));
         var diagnoses = List.<Diagnosis>of();
         var symptomBuilder = new StringBuilder();
@@ -166,9 +167,9 @@ public class ShardsCapacityHealthIndicatorService implements HealthIndicatorServ
         return createIndicator(
             finalStatus,
             symptomBuilder.toString(),
-            buildDetails(dataNodes.result, frozenNodes.result),
+            verbose ? buildDetails(dataNodes.result, frozenNodes.result) : HealthIndicatorDetails.EMPTY,
             indicatorImpacts,
-            diagnoses
+            verbose ? diagnoses : List.of()
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorService.java
@@ -127,7 +127,7 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
             repositoryHealthAnalyzer.getSymptom(),
             repositoryHealthAnalyzer.getDetails(verbose),
             repositoryHealthAnalyzer.getImpacts(),
-            repositoryHealthAnalyzer.getDiagnoses(maxAffectedResourcesCount)
+            repositoryHealthAnalyzer.getDiagnoses(verbose, maxAffectedResourcesCount)
         );
     }
 
@@ -243,7 +243,10 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
             return IMPACTS;
         }
 
-        public List<Diagnosis> getDiagnoses(int maxAffectedResourcesCount) {
+        public List<Diagnosis> getDiagnoses(boolean verbose, int maxAffectedResourcesCount) {
+            if (verbose == false) {
+                return List.of();
+            }
             var diagnoses = new ArrayList<Diagnosis>();
             if (corruptedRepositories.isEmpty() == false) {
                 diagnoses.add(
@@ -253,10 +256,10 @@ public class RepositoryIntegrityHealthIndicatorService implements HealthIndicato
                     )
                 );
             }
-            if (unknownRepositories.size() > 0) {
+            if (unknownRepositories.isEmpty() == false) {
                 diagnoses.add(createDiagnosis(UNKNOWN_DEFINITION, unknownRepositories, nodesWithUnknownRepos, maxAffectedResourcesCount));
             }
-            if (invalidRepositories.size() > 0) {
+            if (invalidRepositories.isEmpty() == false) {
                 diagnoses.add(createDiagnosis(INVALID_DEFINITION, invalidRepositories, nodesWithInvalidRepos, maxAffectedResourcesCount));
             }
             return diagnoses;

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoryIntegrityHealthIndicatorServiceTests.java
@@ -304,6 +304,29 @@ public class RepositoryIntegrityHealthIndicatorServiceTests extends ESTestCase {
         );
     }
 
+    public void testSkippingFieldsWhenVerboseIsFalse() {
+        var repos = appendToCopy(
+            randomList(1, 10, () -> createRepositoryMetadata("healthy-repo", false)),
+            createRepositoryMetadata("corrupted-repo", true)
+        );
+        var clusterState = createClusterStateWith(new RepositoriesMetadata(repos));
+        var service = createRepositoryIntegrityHealthIndicatorService(clusterState);
+
+        assertThat(
+            service.calculate(false, healthInfo),
+            equalTo(
+                new HealthIndicatorResult(
+                    NAME,
+                    YELLOW,
+                    "Detected [1] corrupted snapshot repository.",
+                    HealthIndicatorDetails.EMPTY,
+                    RepositoryIntegrityHealthIndicatorService.IMPACTS,
+                    List.of()
+                )
+            )
+        );
+    }
+
     private List<Diagnosis> createDiagnoses(
         List<RepositoryMetadata> repos,
         DiscoveryNodes nodes,

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -228,7 +228,7 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
                 "Index Lifecycle Management is not running",
                 createDetails(verbose, ilmMetadata, currentMode),
                 AUTOMATION_DISABLED_IMPACT,
-                List.of(ILM_NOT_RUNNING)
+                verbose ? List.of(ILM_NOT_RUNNING) : List.of()
             );
         } else {
             var stagnatingIndices = stagnatingIndicesFinder.find();
@@ -248,7 +248,7 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
                         + " stayed on the same action longer than expected.",
                     createDetails(verbose, ilmMetadata, currentMode, stagnatingIndices),
                     STAGNATING_INDEX_IMPACT,
-                    createDiagnoses(stagnatingIndices, maxAffectedResourcesCount)
+                    verbose ? createDiagnoses(stagnatingIndices, maxAffectedResourcesCount) : List.of()
                 );
             }
         }


### PR DESCRIPTION
The docs specify that neither details nor diagnoses should be calculated when `verbose` is set to `false`.

Fixes https://github.com/elastic/elasticsearch/issues/108175