### PR TITLE
[Profiling] Use synthetic source for events and metrics

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
@@ -22,7 +22,7 @@
     },
     "mappings": {
       "_source": {
-        "enabled": false
+        "mode": "synthetic"
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},

--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-metrics.json
@@ -17,7 +17,7 @@
     },
     "mappings": {
       "_source": {
-        "enabled": false
+        "mode": "synthetic"
       },
       "_meta": {
         "index-template-version": ${xpack.profiling.template.version},

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
@@ -48,12 +48,13 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 5: Add optional component template '<idx-name>@custom' to all index templates that reference component templates
     // version 6: Added 'host.arch' keyword mapping to profiling-hosts
     // version 7: Added 'host.type', 'cloud.provider', 'cloud.region' keyword mappings to profiling-hosts
-    public static final int INDEX_TEMPLATE_VERSION = 7;
+    // version 8: Changed from disabled _source to synthetic _source for profiling-events-* and profiling-metrics
+    public static final int INDEX_TEMPLATE_VERSION = 8;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
-    public static final int PROFILING_EVENTS_VERSION = 2;
+    public static final int PROFILING_EVENTS_VERSION = 3;
     public static final int PROFILING_EXECUTABLES_VERSION = 1;
-    public static final int PROFILING_METRICS_VERSION = 1;
+    public static final int PROFILING_METRICS_VERSION = 2;
     public static final int PROFILING_HOSTS_VERSION = 2;
     public static final int PROFILING_STACKFRAMES_VERSION = 1;
     public static final int PROFILING_STACKTRACES_VERSION = 1;


### PR DESCRIPTION
We could find no additional storage overhead any more (a nice improvement to ~2 years ago when we decided against synthetic source and for disabling source).
