### PR TITLE
Validate `ICSS.onClusterStateShardsClosed` calls

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -174,6 +174,7 @@ public final class IndicesStore implements ClusterStateListener, Closeable {
                     switch (shardDeletionCheckResult) {
                         case FOLDER_FOUND_CAN_DELETE:
                             indicesClusterStateService.onClusterStateShardsClosed(
+                                event.state().version(),
                                 () -> deleteShardIfExistElseWhere(event.state(), indexShardRoutingTable)
                             );
                             break;

--- a/test/framework/src/main/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/cluster/AbstractIndicesClusterStateServiceTestCase.java
@@ -428,7 +428,7 @@ public abstract class AbstractIndicesClusterStateServiceTestCase extends ESTestC
 
     public static void awaitIndexShardCloseAsyncTasks(IndicesClusterStateService indicesClusterStateService) {
         final var latch = new CountDownLatch(1);
-        indicesClusterStateService.onClusterStateShardsClosed(latch::countDown);
+        indicesClusterStateService.onClusterStateShardsClosed(-1, latch::countDown);
         safeAwait(latch);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -465,9 +465,8 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
     }
 
     protected void awaitIndexShardCloseAsyncTasks() {
-        // ES-8334 TODO build this wait into the relevant APIs (especially, delete-index and close-index)
         final var latch = new CountDownLatch(1);
-        getInstanceFromNode(IndicesClusterStateService.class).onClusterStateShardsClosed(latch::countDown);
+        getInstanceFromNode(IndicesClusterStateService.class).onClusterStateShardsClosed(-1, latch::countDown);
         safeAwait(latch);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -2582,12 +2582,11 @@ public final class InternalTestCluster extends TestCluster {
     }
 
     public void awaitIndexShardCloseAsyncTasks() {
-        // ES-8334 TODO build this wait into the relevant APIs (especially, delete-index and close-index)
         final var latch = new CountDownLatch(1);
         try (var refs = new RefCountingRunnable(latch::countDown)) {
             for (final var nodeAndClient : nodes.values()) {
                 final var ref = refs.acquire();
-                getInstanceFromNode(IndicesClusterStateService.class, nodeAndClient.node()).onClusterStateShardsClosed(ref::close);
+                getInstanceFromNode(IndicesClusterStateService.class, nodeAndClient.node()).onClusterStateShardsClosed(-1, ref::close);
             }
         }
         safeAwait(latch);


### PR DESCRIPTION
This method kinda only makes sense in the context of applying a specific
cluster state, so with this commit we validate that the subscription
matches the expected state.

Also removes a couple of other TODOs that we've decided not to do.

Relates #108145