### PR TITLE
[ML] Adding manage_inference to the kibana_system role

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -69,6 +69,7 @@ class KibanaOwnedReservedRoleDescriptors {
                 // For Fleet package upgrade
                 "manage_pipeline",
                 "manage_ilm",
+                "manage_inference",
                 // For the endpoint package that ships a transform
                 "manage_transform",
                 InvalidateApiKeyAction.NAME,


### PR DESCRIPTION
This PR adds the `manage_inference` to the `kibana_system` role so the default user can interact with the inference APIs. This came from a discussion around the security assistant not being able to interact with the inference API using the internal elasticsearch user within kibana.  