### PR TITLE
[DOCS] clarify that the repo location setting accepts only one value

### DIFF
--- a/docs/reference/snapshot-restore/repository-shared-file-system.asciidoc
+++ b/docs/reference/snapshot-restore/repository-shared-file-system.asciidoc
@@ -33,7 +33,8 @@ in snapshots. Data files are not compressed. Defaults to `true`.
 (Required, string)
 Location of the shared filesystem used to store and retrieve snapshots. This
 location must be registered in the `path.repo` setting on all master and data
-nodes in the cluster.
+nodes in the cluster. 
+Unlike `path.repo`, this setting supports only a single file path.
 
 `max_number_of_snapshots`::
 (Optional, integer)


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/97339 

Clarifies that `location` should be a single value. 

To reviewers: given that multiple values aren't explicitly _rejected_, is `accepts` ok wording? 

To avoid making this issue bigger than it should be, I chose to present the "single value" requirement in contrast to the `path.repo` setting it references. hopefully this will make it so that we don't have to clarify the [entire bug](https://github.com/elastic/elasticsearch/issues/33135) in the docs.
