### PR TITLE
Fix random limit in AsyncOperatorTests

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -127,7 +127,7 @@ public class AsyncOperatorTests extends ESTestCase {
         intermediateOperators.add(asyncOperator);
         final Iterator<Long> it;
         if (randomBoolean()) {
-            int limit = between(1, ids.size());
+            int limit = between(0, ids.size());
             it = ids.subList(0, limit).iterator();
             intermediateOperators.add(new LimitOperator(limit));
         } else {


### PR DESCRIPTION
Adjust the lower bound to include the case where the number of positions is zero.

Closes #107847