### PR TITLE
[DOCS] Documents `creating_replicas` param for Health API

### DIFF
--- a/docs/reference/health/health.asciidoc
+++ b/docs/reference/health/health.asciidoc
@@ -302,6 +302,9 @@ details have contents and a structure that is unique to each indicator.
 `creating_primaries`::
     (int) The number of primary shards that are unassigned because they have been very recently created.
 
+`creating_replicas`::
+    (int) The number of replica shards that are unassigned because they have been very recently created. 
+
 `restarting_primaries`::
     (int) The number of primary shards that are relocating because of a node shutdown operation.
 


### PR DESCRIPTION
## Overview

Closes https://github.com/elastic/elasticsearch/issues/108173.

This PR adds documentation to the `creating_replicas` parameter of the Health API.