### PR TITLE
ESQL: Rework integration-only csv testing

### DIFF
--- a/docs/reference/esql/metadata-fields.asciidoc
+++ b/docs/reference/esql/metadata-fields.asciidoc
@@ -34,11 +34,11 @@ like other index fields:
 
 [source.merge.styled,esql]
 ----
-include::{esql-specs}/metadata-IT_tests_only.csv-spec[tag=multipleIndices]
+include::{esql-specs}/metadata.csv-spec[tag=multipleIndices]
 ----
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
-include::{esql-specs}/metadata-IT_tests_only.csv-spec[tag=multipleIndices-result]
+include::{esql-specs}/metadata.csv-spec[tag=multipleIndices-result]
 |===
 
 Similar to index fields, once an aggregation is performed, a
@@ -47,9 +47,9 @@ used as a grouping field:
 
 [source.merge.styled,esql]
 ----
-include::{esql-specs}/metadata-IT_tests_only.csv-spec[tag=metaIndexInAggs]
+include::{esql-specs}/metadata.csv-spec[tag=metaIndexInAggs]
 ----
 [%header.monospaced.styled,format=dsv,separator=|]
 |===
-include::{esql-specs}/metadata-IT_tests_only.csv-spec[tag=metaIndexInAggs-result]
+include::{esql-specs}/metadata.csv-spec[tag=metaIndexInAggs-result]
 |===

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata.csv-spec
@@ -1,5 +1,5 @@
-
-simpleKeep#[skip:-8.12.99]
+simpleKeep
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | sort emp_no | limit 2 | keep emp_no, _index, _version;
 
 emp_no:integer |_index:keyword |_version:long
@@ -7,7 +7,8 @@ emp_no:integer |_index:keyword |_version:long
 10002          |employees      |1
 ;
 
-aliasWithSameName#[skip:-8.12.99]
+aliasWithSameName
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | sort emp_no | limit 2 | eval _index = _index, _version = _version | keep emp_no, _index, _version;
 
 emp_no:integer |_index:keyword |_version:long
@@ -15,16 +16,17 @@ emp_no:integer |_index:keyword |_version:long
 10002          |employees      |1
 ;
 
-inComparison#[skip:-8.12.99]
+inComparison
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | sort emp_no | where _index == "employees" | where _version == 1 | keep emp_no | limit 2;
-
 
 emp_no:integer
 10001
 10002
 ;
 
-metaIndexInAggs#[skip:-8.12.99]
+metaIndexInAggs
+required_feature: esql.metadata_fields
 // tag::metaIndexInAggs[]
 FROM employees METADATA _index, _id
 | STATS max = MAX(emp_no) BY _index
@@ -37,7 +39,8 @@ max:integer |_index:keyword
 // end::metaIndexInAggs-result[]
 ;
 
-metaIndexAliasedInAggs#[skip:-8.12.99]
+metaIndexAliasedInAggs
+required_feature: esql.metadata_fields
 from employees metadata _index | eval _i = _index | stats max = max(emp_no) by _i;
 
 
@@ -45,35 +48,40 @@ max:integer |_i:keyword
 10100       |employees
 ;
 
-metaVersionInAggs#[skip:-8.12.99]
+metaVersionInAggs
+required_feature: esql.metadata_fields
 from employees metadata _version | stats min = min(emp_no) by _version;
 
 min:integer |_version:long
 10001       |1
 ;
 
-metaVersionAliasedInAggs#[skip:-8.12.99]
+metaVersionAliasedInAggs
+required_feature: esql.metadata_fields
 from employees metadata _version | eval _v = _version | stats min = min(emp_no) by _v;
 
 min:integer |_v:long
 10001       |1
 ;
 
-inAggsAndAsGroups#[skip:-8.12.99]
+inAggsAndAsGroups
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | stats max = max(_version) by _index;
 
 max:long |_index:keyword
 1        |employees
 ;
 
-inAggsAndAsGroupsAliased#[skip:-8.12.99]
+inAggsAndAsGroupsAliased
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | eval _i = _index, _v = _version | stats max = max(_v) by _i;
 
 max:long |_i:keyword
 1        |employees
 ;
 
-inFunction#[skip:-8.12.99]
+inFunction
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | sort emp_no | where length(_index) == length("employees") | where abs(_version) == 1 | keep emp_no | limit 2;
 
 emp_no:integer
@@ -81,14 +89,16 @@ emp_no:integer
 10002
 ;
 
-inArithmetics#[skip:-8.12.99]
+inArithmetics
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | eval i = _version + 2 | stats min = min(emp_no) by i;
 
 min:integer |i:long
 10001       |3
 ;
 
-inSort#[skip:-8.12.99]
+inSort
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | sort _version, _index, emp_no | keep emp_no, _version, _index | limit 2;
 
 emp_no:integer |_version:long |_index:keyword
@@ -96,14 +106,16 @@ emp_no:integer |_version:long |_index:keyword
 10002          |1             |employees
 ;
 
-withMvFunction#[skip:-8.12.99]
+withMvFunction
+required_feature: esql.metadata_fields
 from employees metadata _version | eval i = mv_avg(_version) + 2 | stats min = min(emp_no) by i;
 
 min:integer |i:double
 10001       |3.0
 ;
 
-overwritten#[skip:-8.12.99]
+overwritten
+required_feature: esql.metadata_fields
 from employees metadata _index, _version | sort emp_no | eval _index = 3, _version = "version" | keep emp_no, _index, _version | limit 3;
 
 emp_no:integer |_index:integer |_version:keyword
@@ -112,7 +124,8 @@ emp_no:integer |_index:integer |_version:keyword
 10003          |3              |version
 ;
 
-multipleIndices#[skip:-8.12.99]
+multipleIndices
+required_feature: esql.metadata_fields
 // tag::multipleIndices[]
 FROM ul_logs, apps METADATA _index, _version
 | WHERE id IN (13, 14) AND _version == 1

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFeatures.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/EsqlFeatures.java
@@ -131,6 +131,11 @@ public class EsqlFeatures implements FeatureSpecification {
      */
     public static final NodeFeature STRING_LITERAL_AUTO_CASTING_EXTENDED = new NodeFeature("esql.string_literal_auto_casting_extended");
 
+    /**
+     * Support for metadata fields.
+     */
+    public static final NodeFeature METADATA_FIELDS = new NodeFeature("esql.metadata_fields");
+
     @Override
     public Set<NodeFeature> getFeatures() {
         return Set.of(
@@ -151,7 +156,8 @@ public class EsqlFeatures implements FeatureSpecification {
             CASTING_OPERATOR,
             MV_ORDERING_SORTED_ASCENDING,
             METRICS_COUNTER_FIELDS,
-            STRING_LITERAL_AUTO_CASTING_EXTENDED
+            STRING_LITERAL_AUTO_CASTING_EXTENDED,
+            METADATA_FIELDS
         );
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -73,6 +73,7 @@ import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecution
 import org.elasticsearch.xpack.esql.planner.Mapper;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.esql.planner.TestPhysicalOperationProviders;
+import org.elasticsearch.xpack.esql.plugin.EsqlFeatures;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
 import org.elasticsearch.xpack.esql.stats.DisabledSearchStats;
@@ -216,11 +217,13 @@ public class CsvTests extends ESTestCase {
 
     public final void test() throws Throwable {
         try {
-            /*
-             * We're intentionally not NodeFeatures here because we expect all
-             * of the features to be supported in this unit test.
-             */
             assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, Version.CURRENT));
+
+            /*
+             * The csv tests support all but a few features. The unsupported features
+             * are tested in integration tests.
+             */
+            assumeFalse("metadata fields aren't supported", testCase.requiredFeatures.contains(EsqlFeatures.METADATA_FIELDS.id()));
             doTest();
         } catch (Throwable th) {
             throw reworkException(th);


### PR DESCRIPTION
This reworks the integration-test-only csv testing for `metadata` to use the `required_feature:` syntax instead of the `-IT_tests_only` extension. This is a little more flexible and way nicer on the eyes.
