### PR TITLE
[8.14] [DOCS] Clarify `retriever` is not API (#108295)

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -1,5 +1,5 @@
 [[retriever]]
-=== Retriever API
+=== Retriever
 
 preview::["This functionality is in technical preview and may be changed or removed in a future release. The syntax will likely change before GA. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [DOCS] Clarify `retriever` is not API (#108295)