### PR TITLE
[8.14] Invalidate cross cluster API key docs (#108297)

### DIFF
--- a/docs/reference/rest-api/security/invalidate-api-keys.asciidoc
+++ b/docs/reference/rest-api/security/invalidate-api-keys.asciidoc
@@ -15,9 +15,10 @@ Invalidates one or more API keys.
 [[security-api-invalidate-api-key-prereqs]]
 ==== {api-prereq-title}
 
-* To use this API, you must have at least the `manage_api_key` or the `manage_own_api_key` cluster privilege.
-The `manage_api_key` privilege allows deleting any API keys.
-The `manage_own_api_key` only allows deleting API keys that are owned by the user.
+* To use this API, you must have at least the `manage_security`, `manage_api_key`, or `manage_own_api_key` cluster privilege.
+The `manage_security` privilege allows deleting any API key, including both REST and <<security-api-create-cross-cluster-api-key,cross cluster API keys>>.
+The `manage_api_key` privilege allows deleting any REST API key, but not cross cluster API keys.
+The `manage_own_api_key` only allows deleting REST API keys owned by the user.
 In addition, with the `manage_own_api_key` privilege, an invalidation request must be issued
 in one of the three formats:
 1. Set the parameter `owner=true`


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Invalidate cross cluster API key docs (#108297)