### PR TITLE
[8.13] Fix random limit in AsyncOperatorTests (#108289)

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/AsyncOperatorTests.java
@@ -127,7 +127,7 @@ public class AsyncOperatorTests extends ESTestCase {
         intermediateOperators.add(asyncOperator);
         final Iterator<Long> it;
         if (randomBoolean()) {
-            int limit = between(1, ids.size());
+            int limit = between(0, ids.size());
             it = ids.subList(0, limit).iterator();
             intermediateOperators.add(new LimitOperator(limit));
         } else {


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Fix random limit in AsyncOperatorTests (#108289)