### PR TITLE
[ESQL] Apply SimplifyComparisonArithmetics tests from SQL

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -4431,8 +4431,8 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         doTestSimplifyComparisonArithmetics("2 * integer > 4", "integer", GT, 2);
 
         // TODO: These aren't passing
-        // doTestSimplifyComparisonArithmetics("float / 2.0 > 4.0", "float", GT, 8d);
-        // doTestSimplifyComparisonArithmetics("2.0 / float < 4.0", "float", GT, .5);
+        doTestSimplifyComparisonArithmetics("float / 2.0 > 4.0", "float", GT, 8d);
+        doTestSimplifyComparisonArithmetics("2.0 / float < 4.0", "float", GT, .5);
     }
 
     public void testSimplifyComparisonArithmeticWithMultipleOps() {


### PR DESCRIPTION
Work in Progress

Relates to https://github.com/elastic/elasticsearch/pull/108200

@astefan found some tests for the `SimplifyComparisonArithmetics` optimization I'm trying to migrate in the linked PR, however these tests are quite complex so I wanted to pull them out into their own PR.  The tests in question come from `OptimizerRunTests` in the SQL plugin.  They are full optimizer stack tests, meaning they apply the entire set of optimization rules, not just `SimplifyComparisonArithmetics`.

As you can see, many of these tests are failing against the ES|QL optimizer stack.  This is not entirely surprising, since the tests are written assuming the SQL optimizer stack, which is not identical.  Please note that this PR is testing only changes - I haven't touched the code being exercised by these tests, so these failures reflect the state of the code as it exists in main.

It's not clear to me what we should do about this, so I'm posting it for feedback.  I can do some comparative tracing and figure out which rule differences are causing the failures, but I don't know that we gain anything from that.  Alternatively, we can change or drop these tests to conform to the optimizers we do use in ES|QL, but that seems like we lose the coverage we're trying to get with these.

/cc @costin , @alex-spies , and @fang-xing-esql 