### PR TITLE
Unmute Azure 3rd party tests

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -50,31 +50,26 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
         System.getProperty("test.azure.container")
     );
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testCreateSnapshot() {
         super.testCreateSnapshot();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testIndexLatest() throws Exception {
         super.testIndexLatest();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testListChildren() {
         super.testListChildren();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testCleanup() throws Exception {
         super.testCleanup();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testReadFromPositionWithLength() {
         super.testReadFromPositionWithLength();
@@ -162,7 +157,6 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
         future.actionGet();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     public void testMultiBlockUpload() throws Exception {
         final BlobStoreRepository repo = getRepository();
         // The configured threshold for this test suite is 1mb

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/azure/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/AzureSnapshotRepoTestKitIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/azure/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/AzureSnapshotRepoTestKitIT.java
@@ -78,7 +78,6 @@ public class AzureSnapshotRepoTestKitIT extends AbstractSnapshotRepoTestKitRestT
         return Settings.builder().put("client", "repository_test_kit").put("container", container).put("base_path", basePath).build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107502")
     @Override
     public void testRepositoryAnalysis() throws Exception {
         super.testRepositoryAnalysis();


### PR DESCRIPTION
Unmute Azure 3rd party tests (again) after re-generating credentials following the updated guide.

Relates: #107928
Fixes: #107720
Fixes: #107502
