### PR TITLE
apm-data: increase version for templates

### DIFF
--- a/docs/changelog/108340.yaml
+++ b/docs/changelog/108340.yaml
@@ -1,0 +1,5 @@
+pr: 108340
+summary: "Apm-data: increase version for templates"
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 1
+version: 2
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
I should have done this in https://github.com/elastic/elasticsearch/pull/108227, but forgot. This is necessary to perform an automatic rollover.