### PR TITLE
[8.14] Unmute Azure 3rd party tests (#108336)

### DIFF
--- a/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
+++ b/modules/repository-azure/src/internalClusterTest/java/org/elasticsearch/repositories/azure/AzureStorageCleanupThirdPartyTests.java
@@ -50,25 +50,21 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
         System.getProperty("test.azure.container")
     );
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testCreateSnapshot() {
         super.testCreateSnapshot();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testIndexLatest() throws Exception {
         super.testIndexLatest();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testListChildren() {
         super.testListChildren();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     @Override
     public void testCleanup() throws Exception {
         super.testCleanup();
@@ -156,7 +152,6 @@ public class AzureStorageCleanupThirdPartyTests extends AbstractThirdPartyReposi
         future.actionGet();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107720")
     public void testMultiBlockUpload() throws Exception {
         final BlobStoreRepository repo = getRepository();
         // The configured threshold for this test suite is 1mb

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/azure/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/AzureSnapshotRepoTestKitIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/azure/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/AzureSnapshotRepoTestKitIT.java
@@ -77,4 +77,9 @@ public class AzureSnapshotRepoTestKitIT extends AbstractSnapshotRepoTestKitRestT
 
         return Settings.builder().put("client", "repository_test_kit").put("container", container).put("base_path", basePath).build();
     }
+
+    @Override
+    public void testRepositoryAnalysis() throws Exception {
+        super.testRepositoryAnalysis();
+    }
 }

--- a/x-pack/plugin/snapshot-repo-test-kit/qa/azure/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/AzureSnapshotRepoTestKitIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/azure/src/javaRestTest/java/org/elasticsearch/repositories/blobstore/testkit/AzureSnapshotRepoTestKitIT.java
@@ -77,9 +77,4 @@ public class AzureSnapshotRepoTestKitIT extends AbstractSnapshotRepoTestKitRestT
 
         return Settings.builder().put("client", "repository_test_kit").put("container", container).put("base_path", basePath).build();
     }
-
-    @Override
-    public void testRepositoryAnalysis() throws Exception {
-        super.testRepositoryAnalysis();
-    }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Unmute Azure 3rd party tests (#108336)](https://github.com/elastic/elasticsearch/pull/108336)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)