### PR TITLE
ecs@mappings: reduce scope for ecs_geo_point

### DIFF
--- a/docs/changelog/108349.yaml
+++ b/docs/changelog/108349.yaml
@@ -1,0 +1,6 @@
+pr: 108349
+summary: "Ecs@mappings: reduce scope for `ecs_geo_point`"
+area: Data streams
+type: bug
+issues:
+ - 108338

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/EcsLogsDataStreamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/EcsLogsDataStreamIT.java
@@ -201,12 +201,12 @@ public class EcsLogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
                       "host": {
                         "cpu": {
                           "usage": 0.68
-                        }
-                      },
-                      "geo": {
-                        "location": {
-                          "lon": -73.614830,
-                          "lat": 45.505918
+                        },
+                        "geo": {
+                          "location": {
+                            "lon": -73.614830,
+                            "lat": 45.505918
+                          }
                         }
                       },
                       "data_stream": {
@@ -414,7 +414,7 @@ public class EcsLogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
                 getValueFromPath(properties, List.of("host", "properties", "cpu", "properties", "usage", "scaling_factor")),
                 is(1000.0)
             );
-            assertThat(getValueFromPath(properties, List.of("geo", "properties", "location", "type")), is("geo_point"));
+            assertThat(getValueFromPath(properties, List.of("host", "properties", "geo", "properties", "location", "type")), is("geo_point"));
             assertThat(getValueFromPath(properties, List.of("data_stream", "properties", "dataset", "type")), is("constant_keyword"));
             assertThat(getValueFromPath(properties, List.of("data_stream", "properties", "namespace", "type")), is("constant_keyword"));
             assertThat(getValueFromPath(properties, List.of("data_stream", "properties", "type", "type")), is("constant_keyword"));

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/EcsLogsDataStreamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/EcsLogsDataStreamIT.java
@@ -414,7 +414,10 @@ public class EcsLogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
                 getValueFromPath(properties, List.of("host", "properties", "cpu", "properties", "usage", "scaling_factor")),
                 is(1000.0)
             );
-            assertThat(getValueFromPath(properties, List.of("host", "properties", "geo", "properties", "location", "type")), is("geo_point"));
+            assertThat(
+                getValueFromPath(properties, List.of("host", "properties", "geo", "properties", "location", "type")),
+                is("geo_point")
+            );
             assertThat(getValueFromPath(properties, List.of("data_stream", "properties", "dataset", "type")), is("constant_keyword"));
             assertThat(getValueFromPath(properties, List.of("data_stream", "properties", "namespace", "type")), is("constant_keyword"));
             assertThat(getValueFromPath(properties, List.of("data_stream", "properties", "type", "type")), is("constant_keyword"));

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/LogsDataStreamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/LogsDataStreamIT.java
@@ -463,7 +463,6 @@ public class LogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
                       {
                         "@timestamp": "2023-06-12",
                         "start_timestamp": "2023-06-08",
-                        "location" : "POINT (-71.34 41.12)",
                         "test": "flattened",
                         "test.start_timestamp": "not a date",
                         "test.start-timestamp": "not a date",
@@ -497,7 +496,7 @@ public class LogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
                         "vulnerability.score.version": "2.0",
                         "vulnerability.textual_score": "bad",
                         "host.cpu.usage": 0.68,
-                        "geo.location": [-73.614830, 45.505918],
+                        "host.geo.location": [-73.614830, 45.505918],
                         "data_stream.dataset": "nginx.access",
                         "data_stream.namespace": "production",
                         "data_stream.custom": "whatever",
@@ -521,8 +520,7 @@ public class LogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
               },
               "fields": [
                 "data_stream.type",
-                "location",
-                "geo.location",
+                "host.geo.location",
                 "test.start-timestamp",
                 "test.start_timestamp",
                 "vulnerability.textual_score"
@@ -537,14 +535,9 @@ public class LogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
         // verify that data_stream.type has the correct constant_keyword value
         assertThat(fields.get("data_stream.type"), is(List.of("logs")));
         // verify geo_point subfields evaluation
-        assertThat(((List<Map<String, Object>>) fields.get("location")).get(0).get("type"), is("Point"));
-        List<Double> coordinates = ((List<Map<String, List<Double>>>) fields.get("location")).get(0).get("coordinates");
-        assertThat(coordinates.size(), is(2));
-        assertThat(coordinates.get(0), equalTo(-71.34));
-        assertThat(coordinates.get(1), equalTo(41.12));
-        List<Object> geoLocation = (List<Object>) fields.get("geo.location");
+        List<Object> geoLocation = (List<Object>) fields.get("host.geo.location");
         assertThat(((Map<String, Object>) geoLocation.get(0)).get("type"), is("Point"));
-        coordinates = ((Map<String, List<Double>>) geoLocation.get(0)).get("coordinates");
+        List<Double> coordinates = ((Map<String, List<Double>>) geoLocation.get(0)).get("coordinates");
         assertThat(coordinates.size(), is(2));
         assertThat(coordinates.get(0), equalTo(-73.614830));
         assertThat(coordinates.get(1), equalTo(45.505918));
@@ -612,8 +605,7 @@ public class LogsDataStreamIT extends DisabledSecurityDataStreamTestCase {
         assertThat(getValueFromPath(properties, List.of("vulnerability.textual_score", "type")), is("float"));
         assertThat(getValueFromPath(properties, List.of("host.cpu.usage", "type")), is("scaled_float"));
         assertThat(getValueFromPath(properties, List.of("host.cpu.usage", "scaling_factor")), is(1000.0));
-        assertThat(getValueFromPath(properties, List.of("location", "type")), is("geo_point"));
-        assertThat(getValueFromPath(properties, List.of("geo.location", "type")), is("geo_point"));
+        assertThat(getValueFromPath(properties, List.of("host.geo.location", "type")), is("geo_point"));
         assertThat(getValueFromPath(properties, List.of("data_stream.dataset", "type")), is("constant_keyword"));
         assertThat(getValueFromPath(properties, List.of("data_stream.namespace", "type")), is("constant_keyword"));
         assertThat(getValueFromPath(properties, List.of("data_stream.type", "type")), is("constant_keyword"));

--- a/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ecs@mappings.json
@@ -189,8 +189,7 @@
               "type": "geo_point"
             },
             "path_match": [
-              "location",
-              "*.location"
+              "*.geo.location"
             ]
           }
         },

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/LegacyStackTemplateRegistry.java
@@ -43,7 +43,7 @@ public class LegacyStackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 4;
+    public static final int REGISTRY_VERSION = 5;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
 

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -47,7 +47,7 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
-    public static final int REGISTRY_VERSION = 9;
+    public static final int REGISTRY_VERSION = 10;
 
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.stack.template.version";
     public static final Setting<Boolean> STACK_TEMPLATES_ENABLED = Setting.boolSetting(


### PR DESCRIPTION
Match on the path `*.geo.location`, rather than `location` or `*.location`. All ECS fields match `*.geo.location`, and this reduces the chances of matching non-ECS fields that happen to end in "location".

Fixes https://github.com/elastic/elasticsearch/issues/108338