### PR TITLE
Small refactor of ESQL lucene operator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
@@ -21,7 +21,6 @@ import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.function.Function;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneCountOperator.java
@@ -11,7 +11,6 @@ import org.apache.lucene.search.DocIdStream;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
-import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BooleanBlock;
@@ -41,11 +40,7 @@ public class LuceneCountOperator extends LuceneOperator {
 
     private final LeafCollector leafCollector;
 
-    public static class Factory implements LuceneOperator.Factory {
-        private final DataPartitioning dataPartitioning;
-        private final int taskConcurrency;
-        private final int limit;
-        private final LuceneSliceQueue sliceQueue;
+    public static class Factory extends LuceneOperator.Factory {
 
         public Factory(
             List<? extends ShardContext> contexts,
@@ -54,25 +49,12 @@ public class LuceneCountOperator extends LuceneOperator {
             int taskConcurrency,
             int limit
         ) {
-            this.limit = limit;
-            this.dataPartitioning = dataPartitioning;
-            var weightFunction = weightFunction(queryFunction, ScoreMode.COMPLETE_NO_SCORES);
-            this.sliceQueue = LuceneSliceQueue.create(contexts, weightFunction, dataPartitioning, taskConcurrency);
-            this.taskConcurrency = Math.min(sliceQueue.totalSlices(), taskConcurrency);
+            super(contexts, queryFunction, dataPartitioning, taskConcurrency, limit);
         }
 
         @Override
         public SourceOperator get(DriverContext driverContext) {
             return new LuceneCountOperator(driverContext.blockFactory(), sliceQueue, limit);
-        }
-
-        @Override
-        public int taskConcurrency() {
-            return taskConcurrency;
-        }
-
-        public int limit() {
-            return limit;
         }
 
         @Override
@@ -118,7 +100,7 @@ public class LuceneCountOperator extends LuceneOperator {
     }
 
     @Override
-    public Page getOutput() {
+    protected Page getCheckedOutput() throws IOException {
         if (isFinished()) {
             assert remainingDocs <= 0 : remainingDocs;
             return null;
@@ -170,8 +152,6 @@ public class LuceneCountOperator extends LuceneOperator {
                 }
             }
             return page;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         } finally {
             processingNanos += System.nanoTime() - start;
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -74,7 +74,7 @@ public abstract class LuceneOperator extends SourceOperator {
         this.sliceQueue = sliceQueue;
     }
 
-    protected abstract static class Factory implements SourceOperator.SourceOperatorFactory {
+    public abstract static class Factory implements SourceOperator.SourceOperatorFactory {
         protected final DataPartitioning dataPartitioning;
         protected final int taskConcurrency;
         protected final int limit;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -74,7 +74,6 @@ public abstract class LuceneOperator extends SourceOperator {
         this.sliceQueue = sliceQueue;
     }
 
-
     protected abstract static class Factory implements SourceOperator.SourceOperatorFactory {
         protected final DataPartitioning dataPartitioning;
         protected final int taskConcurrency;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.data.BlockFactory;
+import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.TimeValue;
@@ -34,6 +35,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -72,9 +74,46 @@ public abstract class LuceneOperator extends SourceOperator {
         this.sliceQueue = sliceQueue;
     }
 
-    public interface Factory extends SourceOperator.SourceOperatorFactory {
-        int taskConcurrency();
+
+    protected abstract static class Factory implements SourceOperator.SourceOperatorFactory {
+        protected final DataPartitioning dataPartitioning;
+        protected final int taskConcurrency;
+        protected final int limit;
+        protected final LuceneSliceQueue sliceQueue;
+
+        protected Factory(
+            List<? extends ShardContext> contexts,
+            Function<ShardContext, Query> queryFunction,
+            DataPartitioning dataPartitioning,
+            int taskConcurrency,
+            int limit
+        ) {
+            this.limit = limit;
+            this.dataPartitioning = dataPartitioning;
+            var weightFunction = weightFunction(queryFunction, ScoreMode.COMPLETE_NO_SCORES);
+            this.sliceQueue = LuceneSliceQueue.create(contexts, weightFunction, dataPartitioning, taskConcurrency);
+            this.taskConcurrency = Math.min(sliceQueue.totalSlices(), taskConcurrency);
+        }
+
+        public final int taskConcurrency() {
+            return taskConcurrency;
+        }
+
+        public final int limit() {
+            return limit;
+        }
     }
+
+    @Override
+    public final Page getOutput() {
+        try {
+            return getCheckedOutput();
+        } catch (IOException ioe) {
+            throw new UncheckedIOException(ioe);
+        }
+    }
+
+    protected abstract Page getCheckedOutput() throws IOException;
 
     @Override
     public void close() {}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -10,7 +10,6 @@ package org.elasticsearch.compute.lucene;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
-import org.apache.lucene.search.ScoreMode;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.DocVector;
 import org.elasticsearch.compute.data.IntBlock;
@@ -21,7 +20,6 @@ import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.Releasables;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.function.Function;
 
@@ -37,12 +35,9 @@ public class LuceneSourceOperator extends LuceneOperator {
     private final LeafCollector leafCollector;
     private final int minPageSize;
 
-    public static class Factory implements LuceneOperator.Factory {
-        private final DataPartitioning dataPartitioning;
-        private final int taskConcurrency;
+    public static class Factory extends LuceneOperator.Factory {
+
         private final int maxPageSize;
-        private final int limit;
-        private final LuceneSliceQueue sliceQueue;
 
         public Factory(
             List<? extends ShardContext> contexts,
@@ -52,12 +47,8 @@ public class LuceneSourceOperator extends LuceneOperator {
             int maxPageSize,
             int limit
         ) {
+            super(contexts, queryFunction, dataPartitioning, taskConcurrency, limit);
             this.maxPageSize = maxPageSize;
-            this.limit = limit;
-            this.dataPartitioning = dataPartitioning;
-            var weightFunction = weightFunction(queryFunction, ScoreMode.COMPLETE_NO_SCORES);
-            this.sliceQueue = LuceneSliceQueue.create(contexts, weightFunction, dataPartitioning, taskConcurrency);
-            this.taskConcurrency = Math.min(sliceQueue.totalSlices(), taskConcurrency);
         }
 
         @Override
@@ -65,17 +56,8 @@ public class LuceneSourceOperator extends LuceneOperator {
             return new LuceneSourceOperator(driverContext.blockFactory(), maxPageSize, sliceQueue, limit);
         }
 
-        @Override
-        public int taskConcurrency() {
-            return taskConcurrency;
-        }
-
         public int maxPageSize() {
             return maxPageSize;
-        }
-
-        public int limit() {
-            return limit;
         }
 
         @Override
@@ -123,7 +105,7 @@ public class LuceneSourceOperator extends LuceneOperator {
     }
 
     @Override
-    public Page getOutput() {
+    public Page getCheckedOutput() throws IOException {
         if (isFinished()) {
             assert currentPagePos == 0 : currentPagePos;
             return null;
@@ -162,8 +144,6 @@ public class LuceneSourceOperator extends LuceneOperator {
                 currentPagePos = 0;
             }
             return page;
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         } finally {
             processingNanos += System.nanoTime() - start;
         }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneTopNSourceOperator.java
@@ -13,7 +13,6 @@ import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TopFieldCollector;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.compute.data.BlockFactory;
@@ -28,7 +27,6 @@ import org.elasticsearch.search.sort.SortAndFormats;
 import org.elasticsearch.search.sort.SortBuilder;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -39,13 +37,10 @@ import java.util.stream.Collectors;
  * Source operator that builds Pages out of the output of a TopFieldCollector (aka TopN)
  */
 public final class LuceneTopNSourceOperator extends LuceneOperator {
-    public static final class Factory implements LuceneOperator.Factory {
-        private final int taskConcurrency;
+    public static final class Factory extends LuceneOperator.Factory {
+        ;
         private final int maxPageSize;
         private final List<SortBuilder<?>> sorts;
-        private final int limit;
-        private final DataPartitioning dataPartitioning;
-        private final LuceneSliceQueue sliceQueue;
 
         public Factory(
             List<? extends ShardContext> contexts,
@@ -56,13 +51,9 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
             int limit,
             List<SortBuilder<?>> sorts
         ) {
+            super(contexts, queryFunction, dataPartitioning, taskConcurrency, limit);
             this.maxPageSize = maxPageSize;
             this.sorts = sorts;
-            this.limit = limit;
-            this.dataPartitioning = dataPartitioning;
-            var weightFunction = weightFunction(queryFunction, ScoreMode.TOP_DOCS);
-            this.sliceQueue = LuceneSliceQueue.create(contexts, weightFunction, dataPartitioning, taskConcurrency);
-            this.taskConcurrency = Math.min(sliceQueue.totalSlices(), taskConcurrency);
         }
 
         @Override
@@ -70,17 +61,8 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
             return new LuceneTopNSourceOperator(driverContext.blockFactory(), maxPageSize, sorts, limit, sliceQueue);
         }
 
-        @Override
-        public int taskConcurrency() {
-            return taskConcurrency;
-        }
-
         public int maxPageSize() {
             return maxPageSize;
-        }
-
-        public int limit() {
-            return limit;
         }
 
         @Override
@@ -136,7 +118,7 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
     }
 
     @Override
-    public Page getOutput() {
+    public Page getCheckedOutput() throws IOException {
         if (isFinished()) {
             return null;
         }
@@ -152,7 +134,7 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
         }
     }
 
-    private Page collect() {
+    private Page collect() throws IOException {
         assert doneCollecting == false;
         var scorer = getCurrentOrLoadNextScorer();
         if (scorer == null) {
@@ -169,8 +151,6 @@ public final class LuceneTopNSourceOperator extends LuceneOperator {
         } catch (CollectionTerminatedException cte) {
             // Lucene terminated early the collection (doing topN for an index that's sorted and the topN uses the same sorting)
             scorer.markAsDone();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
         if (scorer.isDone()) {
             var nextScorer = getCurrentOrLoadNextScorer();


### PR DESCRIPTION
This refactor removes duplicated code on all implementations of `LuceneOperator.Factory` by moving the factory from an interface to an abstract class.

In addition it introduces a `getCheckedOutput()` to centralize the catching of IOExceptions thrown by the different implementations of `getOutput()`. Ideally at some point that methods should allow to throw those exceptions.