### PR TITLE
[Inference API] Remove unused loggers in request task settings

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/embeddings/AzureOpenAiEmbeddingsRequestTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/embeddings/AzureOpenAiEmbeddingsRequestTaskSettings.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.inference.services.azureopenai.embeddings;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -25,7 +23,6 @@ import static org.elasticsearch.xpack.inference.services.azureopenai.AzureOpenAi
  * @param user a unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse
  */
 public record AzureOpenAiEmbeddingsRequestTaskSettings(@Nullable String user) {
-    private static final Logger logger = LogManager.getLogger(AzureOpenAiEmbeddingsRequestTaskSettings.class);
 
     public static final AzureOpenAiEmbeddingsRequestTaskSettings EMPTY_SETTINGS = new AzureOpenAiEmbeddingsRequestTaskSettings(null);
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/openai/embeddings/OpenAiEmbeddingsRequestTaskSettings.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.inference.services.openai.embeddings;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.ValidationException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.inference.ModelConfigurations;
@@ -25,7 +23,6 @@ import static org.elasticsearch.xpack.inference.services.openai.OpenAiServiceFie
  * @param user a unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse
  */
 public record OpenAiEmbeddingsRequestTaskSettings(@Nullable String user) {
-    private static final Logger logger = LogManager.getLogger(OpenAiEmbeddingsRequestTaskSettings.class);
 
     public static final OpenAiEmbeddingsRequestTaskSettings EMPTY_SETTINGS = new OpenAiEmbeddingsRequestTaskSettings(null);
 


### PR DESCRIPTION
Removed two unused instances of `Logger`.