### PR TITLE
[Bugfix] Connector API - fix status serialisation issue in termquery

### DIFF
--- a/docs/changelog/108365.yaml
+++ b/docs/changelog/108365.yaml
@@ -1,0 +1,5 @@
+pr: 108365
+summary: "[Bugfix] Connector API - fix status serialisation issue in termquery"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -823,7 +823,7 @@ public class ConnectorIndexService {
                             Connector.IS_NATIVE_FIELD.getPreferredName(),
                             request.isNative(),
                             Connector.STATUS_FIELD.getPreferredName(),
-                            ConnectorStatus.CONFIGURED
+                            ConnectorStatus.CONFIGURED.toString()
                         )
                     )
 
@@ -969,7 +969,7 @@ public class ConnectorIndexService {
                                 Connector.SERVICE_TYPE_FIELD.getPreferredName(),
                                 request.getServiceType(),
                                 Connector.STATUS_FIELD.getPreferredName(),
-                                newStatus
+                                newStatus.toString()
                             )
                         )
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -266,7 +266,7 @@ public class ConnectorSyncJobIndexService {
 
                         syncJobFieldsToUpdate = Map.of(
                             ConnectorSyncJob.STATUS_FIELD.getPreferredName(),
-                            nextStatus,
+                            nextStatus.toString(),
                             ConnectorSyncJob.CANCELATION_REQUESTED_AT_FIELD.getPreferredName(),
                             now,
                             ConnectorSyncJob.CANCELED_AT_FIELD.getPreferredName(),
@@ -280,7 +280,7 @@ public class ConnectorSyncJobIndexService {
 
                         syncJobFieldsToUpdate = Map.of(
                             ConnectorSyncJob.STATUS_FIELD.getPreferredName(),
-                            nextStatus,
+                            nextStatus.toString(),
                             ConnectorSyncJob.CANCELATION_REQUESTED_AT_FIELD.getPreferredName(),
                             now
                         );
@@ -381,7 +381,10 @@ public class ConnectorSyncJobIndexService {
             }
 
             if (Objects.nonNull(syncStatus)) {
-                TermQueryBuilder syncStatusQuery = new TermQueryBuilder(ConnectorSyncJob.STATUS_FIELD.getPreferredName(), syncStatus);
+                TermQueryBuilder syncStatusQuery = new TermQueryBuilder(
+                    ConnectorSyncJob.STATUS_FIELD.getPreferredName(),
+                    syncStatus.toString()
+                );
                 boolFilterQueryBuilder.must().add(syncStatusQuery);
             }
 
@@ -569,7 +572,7 @@ public class ConnectorSyncJobIndexService {
                             ConnectorSyncJob.ERROR_FIELD.getPreferredName(),
                             error,
                             ConnectorSyncJob.STATUS_FIELD.getPreferredName(),
-                            nextStatus
+                            nextStatus.toString()
                         )
                     );
 


### PR DESCRIPTION
### Bug description

It was reported that a following request:
```
GET _connector/_sync_job?status=pending
```

Can cause internal serialisation failures when running in a multi-node cluster setup or when using a dedicated coordinating node (to force internal serialisation of request)

```
[instance-0000000025] failed to serialize outbound message [Request{indices:data/read/search[phase/query]}{27057855}{false}{false}{false}]
java.lang.IllegalArgumentException: can not write type [class org.elasticsearch.xpack.application.connector.ConnectorSyncStatus]
	at org.elasticsearch.common.io.stream.StreamOutput.writeGenericValue(StreamOutput.java:843) ~[elasticsearch-8.13.2.jar:?]
	at org.elasticsearch.index.query.BaseTermQueryBuilder.doWriteTo(BaseTermQueryBuilder.java:123) ~[elasticsearch-8.13.2.jar:?]
```

The issue is with how the `TermQuery` is serialised when we pass raw `ConnectorSyncStatus status` as an argument to the term query. The `TermQuery` is serialised with [writeGenericOutput](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java#L845) function, and `ConnectorSyncStatus` is not present in the WRITERS ([here](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java#L649)) - as it's not a `GenericNamedWriteable` (and probably shouldn't be).

## Fix

Instead of passing `status` to term query argument, pass `status.toString()` in the `TermQuery` used to handle `status` param in `GET _connector/_sync_job?status=pending` request.

I found a couple of other places where we passed raw enums to Map<String, Object> (for update operations) - I also added `.toString()` to them - although I couldn't reproduce any failures like the one mention above with those operations.

## Validation

I was able to reproduce locally by running a multi-node cluster:
- We can set number of nodes by editing the config [here](https://github.com/elastic/elasticsearch/blob/main/build-tools-internal/src/main/groovy/elasticsearch.run.gradle#L33)
- `./gradlew run` to start the cluster
- The local REST server addresses are `9200`, `9201`, `9202`, ... 

I created the connector and sync job on node `:9200`, and then sent the list sync job request (with sync status param) to other node to force internal serialisation (e.g. :9201), then the request fails. 

With this fix, the request serialises correctly and doesn't fail.


