### PR TITLE
Mute RestEsqlIT testDoLogWithDebug

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/RestEsqlIT.java
@@ -126,6 +126,7 @@ public class RestEsqlIT extends RestEsqlTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108367")
     public void testDoLogWithDebug() throws IOException {
         try {
             setLoggingLevel("DEBUG");


### PR DESCRIPTION
Muting due to test failure in serverless https://github.com/elastic/elasticsearch/issues/108367