### PR TITLE
ESQL: Docs: Add docs clarifications on DATE_DIFF args (#108301)

### DIFF
--- a/docs/reference/esql/functions/date_diff.asciidoc
+++ b/docs/reference/esql/functions/date_diff.asciidoc
@@ -46,6 +46,12 @@ s|abbreviations
 | nanosecond  | nanoseconds, ns
 |===
 
+Note that while there is an overlap between the function's supported units and
+{esql}'s supported time span literals, these sets are distinct and not
+interchangeable. Similarly, the supported abbreviations are conveniently shared
+with implementations of this function in other established products and not
+necessarily common with the date-time nomenclature used by {es}.
+
 include::types/date_diff.asciidoc[]
 
 *Example*


### PR DESCRIPTION
This adds some clarifications on the time unit strings the function takes as arguments, noting the differences between these and the time span literals, as well as the abbreviations' source.

(cherry picked from commit de725aef80bc72cd0617f0ee27ab81e727d84e71)

