### PR TITLE
Revert "[ML] Adding manage_inference to the kibana_system role"

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -69,7 +69,6 @@ class KibanaOwnedReservedRoleDescriptors {
                 // For Fleet package upgrade
                 "manage_pipeline",
                 "manage_ilm",
-                "manage_inference",
                 // For the endpoint package that ships a transform
                 "manage_transform",
                 InvalidateApiKeyAction.NAME,


### PR DESCRIPTION
Reverts elastic/elasticsearch#108262

Accidentally merged the above PR without security's approval. They asked us to revert for now and we'll continue discussing on a new PR.