### PR TITLE
Fix semantic text for non snapshot tests

### DIFF
--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -4,6 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
@@ -34,6 +36,12 @@ dependencies {
   clusterPlugins project(':x-pack:plugin:inference:qa:test-service-plugin')
 
   api "com.ibm.icu:icu4j:${versions.icu4j}"
+}
+
+if (BuildParams.isSnapshotBuild() == false) {
+  tasks.named("test").configure {
+    systemProperty 'es.semantic_text_feature_flag_enabled', 'true'
+  }
 }
 
 tasks.named('yamlRestTest') {

--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,6 +1,5 @@
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.dra.DraResolvePlugin
-import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -113,12 +112,6 @@ dependencies {
 artifacts {
   // normal es plugins do not publish the jar but we need to since users need it for extensions
   archives tasks.named("jar")
-}
-
-if (BuildParams.isSnapshotBuild() == false) {
-  tasks.named("test").configure {
-    systemProperty 'es.semantic_text_feature_flag_enabled', 'true'
-  }
 }
 
 tasks.register("extractNativeLicenses", Copy) {


### PR DESCRIPTION
Takes back changes done on https://github.com/elastic/elasticsearch/pull/103965, as semantic_text was moved from the ml plugin to the inference plugin.

The same change is applied to the inference gradle file so semantic_text feature flag is active for non-snapshot tests.

Closes https://github.com/elastic/elasticsearch/issues/103966
Related to https://github.com/elastic/elasticsearch/pull/103965

