### PR TITLE
Create a new NodeRequest for every NodesDataTiersUsageTransport use

### DIFF
--- a/docs/changelog/108379.yaml
+++ b/docs/changelog/108379.yaml
@@ -1,0 +1,5 @@
+pr: 108379
+summary: Create a new `NodeRequest` for every `NodesDataTiersUsageTransport` use
+area: Indices APIs
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datatiers/NodesDataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/datatiers/NodesDataTiersUsageTransportAction.java
@@ -90,7 +90,7 @@ public class NodesDataTiersUsageTransportAction extends TransportNodesAction<
 
     @Override
     protected NodeRequest newNodeRequest(NodesRequest request) {
-        return NodeRequest.INSTANCE;
+        return new NodeRequest();
     }
 
     @Override
@@ -175,8 +175,6 @@ public class NodesDataTiersUsageTransportAction extends TransportNodesAction<
     }
 
     public static class NodeRequest extends TransportRequest {
-
-        static final NodeRequest INSTANCE = new NodeRequest();
 
         public NodeRequest(StreamInput in) throws IOException {
             super(in);


### PR DESCRIPTION
This was previously re-using a single instance for the NodeRequest, which can cause:

```
java.lang.AssertionError: Request [ org.elasticsearch.xpack.core.datatiers.NodesDataTiersUsageTransportAction$NodeRequest/WaEyD6eiTRSJSFBG-RCLrg:2055] didn't preserve it parentTaskId
		at org.elasticsearch.server@8.14.0/org.elasticsearch.tasks.TaskManager.register(TaskManager.java:145)
		at org.elasticsearch.server@8.14.0/org.elasticsearch.tasks.TaskManager.register(TaskManager.java:117)
		at org.elasticsearch.server@8.14.0/org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:66)
		at org.elasticsearch.server@8.14.0/org.elasticsearch.transport.TransportService$6.doRun(TransportService.java:1069)
		at org.elasticsearch.server@8.14.0/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:984)
		at org.elasticsearch.server@8.14.0/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
		at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
		at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
		at java.base/java.lang.Thread.run(Thread.java:1570)
```
