### PR TITLE
Enable Failure Store for Cloud First Testing

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStream.java
@@ -74,7 +74,7 @@ public final class DataStream implements SimpleDiffable<DataStream>, ToXContentO
     public static final TransportVersion ADDED_AUTO_SHARDING_EVENT_VERSION = TransportVersions.DATA_STREAM_AUTO_SHARDING_EVENT;
 
     public static boolean isFailureStoreFeatureFlagEnabled() {
-        return FAILURE_STORE_FEATURE_FLAG.isEnabled();
+        return true;
     }
 
     public static final String BACKING_INDEX_PREFIX = ".ds-";


### PR DESCRIPTION
This PR forces the feature flag for failure store to true so that it can be picked up by cloud first testing infrastructure.

Note: DO NOT MERGE!
This PR is for building cloud images via Elastic CI only.