### PR TITLE
Remove redundant results field in RankFeaturePhase

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/RankFeaturePhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/RankFeaturePhase.java
@@ -22,7 +22,6 @@ public final class RankFeaturePhase extends SearchPhase {
 
     private final SearchPhaseContext context;
     private final SearchPhaseResults<SearchPhaseResult> queryPhaseResults;
-    private final SearchPhaseResults<SearchPhaseResult> rankPhaseResults;
 
     private final AggregatedDfs aggregatedDfs;
 
@@ -39,8 +38,6 @@ public final class RankFeaturePhase extends SearchPhase {
         this.context = context;
         this.queryPhaseResults = queryPhaseResults;
         this.aggregatedDfs = aggregatedDfs;
-        this.rankPhaseResults = new ArraySearchPhaseResults<>(context.getNumShards());
-        context.addReleasable(rankPhaseResults);
     }
 
     @Override


### PR DESCRIPTION
The `rankPhaseResults` are never used, just redundantly created and released => remove them.
