### PR TITLE
Reduce risk for leaks in search execution

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -351,6 +351,7 @@ public abstract class SearchContext implements Releasable {
      * Adds a releasable that will be freed when this context is closed.
      */
     public void addReleasable(Releasable releasable) {   // TODO most Releasables are managed by their callers. We probably don't need this.
+        assert closed.get() == false;
         releasables.add(releasable);
     }
 


### PR DESCRIPTION
Cleaning up one potentially leaky spot (if the phase creation fails we leak the result-consumer and fail tests), add an assertion to the tracking of releasables in the context and removing one redundant variable that makes "leak-free-ness" less obvious.

