### PR TITLE
[Transform] Retry Destination IndexNotFoundException

### DIFF
--- a/docs/changelog/108394.yaml
+++ b/docs/changelog/108394.yaml
@@ -1,0 +1,6 @@
+pr: 108394
+summary: Handle `IndexNotFoundException`
+area: Transform
+type: bug
+issues:
+ - 107263

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -193,11 +193,11 @@ class ClientTransformIndexer extends TransformIndexer {
 
         for (BulkItemResponse item : bulkResponse.getItems()) {
             if (item.isFailed()) {
-                var exception = item.getFailure().getCause().getClass();
-                if (IndexNotFoundException.class.isAssignableFrom(exception)) {
+                var exceptionClass = item.getFailure().getCause().getClass();
+                if (IndexNotFoundException.class.isAssignableFrom(exceptionClass)) {
                     context.setShouldRecreateDestinationIndex(true);
                 }
-                deduplicatedFailures.putIfAbsent(exception.getSimpleName(), item);
+                deduplicatedFailures.putIfAbsent(exceptionClass.getSimpleName(), item);
                 failureCount++;
             }
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -193,7 +193,11 @@ class ClientTransformIndexer extends TransformIndexer {
 
         for (BulkItemResponse item : bulkResponse.getItems()) {
             if (item.isFailed()) {
-                deduplicatedFailures.putIfAbsent(item.getFailure().getCause().getClass().getSimpleName(), item);
+                var exception = item.getFailure().getCause().getClass();
+                if (IndexNotFoundException.class.isAssignableFrom(exception)) {
+                    context.setShouldRecreateDestinationIndex(true);
+                }
+                deduplicatedFailures.putIfAbsent(exception.getSimpleName(), item);
                 failureCount++;
             }
         }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformContext.java
@@ -45,6 +45,7 @@ public class TransformContext {
     private volatile Instant changesLastDetectedAt;
     private volatile Instant lastSearchTime;
     private volatile boolean shouldStopAtCheckpoint = false;
+    private volatile boolean shouldRecreateDestinationIndex = false;
     private volatile AuthorizationState authState;
     private volatile int pageSize = 0;
 
@@ -172,6 +173,14 @@ public class TransformContext {
 
     public void setShouldStopAtCheckpoint(boolean shouldStopAtCheckpoint) {
         this.shouldStopAtCheckpoint = shouldStopAtCheckpoint;
+    }
+
+    public boolean shouldRecreateDestinationIndex() {
+        return shouldRecreateDestinationIndex;
+    }
+
+    public void setShouldRecreateDestinationIndex(boolean shouldRecreateDestinationIndex) {
+        this.shouldRecreateDestinationIndex = shouldRecreateDestinationIndex;
     }
 
     public AuthorizationState getAuthState() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
@@ -69,7 +69,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         assertNull(ExceptionRootCauseFinder.getFirstIrrecoverableExceptionFromBulkResponses(bulkItemResponses.values()));
     }
 
-    private Map<Integer, BulkItemResponse> bulkItemResponses(Exception... exceptions) {
+    private static Map<Integer, BulkItemResponse> bulkItemResponses(Exception... exceptions) {
         var id = new AtomicInteger(1);
         return Arrays.stream(exceptions)
             .map(exception -> new BulkItemResponse.Failure("the_index", "id", exception))

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/utils/ExceptionRootCauseFinderTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.MapperException;
 import org.elasticsearch.index.shard.ShardId;
@@ -27,116 +28,27 @@ import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentLocation;
 
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class ExceptionRootCauseFinderTests extends ESTestCase {
 
     public void testGetFirstIrrecoverableExceptionFromBulkResponses() {
-        Map<Integer, BulkItemResponse> bulkItemResponses = new HashMap<>();
-
-        int id = 1;
-        // 1
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure(
-                    "the_index",
-                    "id",
-                    new DocumentParsingException(XContentLocation.UNKNOWN, "document parsing error")
-                )
-            )
-        );
-        // 2
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure("the_index", "id", new ResourceNotFoundException("resource not found error"))
-            )
-        );
-        // 3
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure("the_index", "id", new IllegalArgumentException("illegal argument error"))
-            )
-        );
-        // 4 not irrecoverable
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure("the_index", "id", new EsRejectedExecutionException("es rejected execution"))
-            )
-        );
-        // 5 not irrecoverable
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure("the_index", "id", new TranslogException(new ShardId("the_index", "uid", 0), "translog error"))
-            )
-        );
-        // 6
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure(
-                    "the_index",
-                    "id",
-                    new ElasticsearchSecurityException("Authentication required", RestStatus.UNAUTHORIZED)
-                )
-            )
-        );
-        // 7
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure(
-                    "the_index",
-                    "id",
-                    new ElasticsearchSecurityException("current license is non-compliant for [transform]", RestStatus.FORBIDDEN)
-                )
-            )
-        );
-        // 8 not irrecoverable
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure(
-                    "the_index",
-                    "id",
-                    new ElasticsearchSecurityException("overloaded, to many requests", RestStatus.TOO_MANY_REQUESTS)
-                )
-            )
-        );
-        // 9 not irrecoverable
-        bulkItemResponses.put(
-            id,
-            BulkItemResponse.failure(
-                id++,
-                OpType.INDEX,
-                new BulkItemResponse.Failure(
-                    "the_index",
-                    "id",
-                    new ElasticsearchSecurityException("internal error", RestStatus.INTERNAL_SERVER_ERROR)
-                )
-            )
+        Map<Integer, BulkItemResponse> bulkItemResponses = bulkItemResponses(
+            new DocumentParsingException(XContentLocation.UNKNOWN, "document parsing error"),
+            new ResourceNotFoundException("resource not found error"),
+            new IllegalArgumentException("illegal argument error"),
+            new EsRejectedExecutionException("es rejected execution"),
+            new TranslogException(new ShardId("the_index", "uid", 0), "translog error"),
+            new ElasticsearchSecurityException("Authentication required", RestStatus.UNAUTHORIZED),
+            new ElasticsearchSecurityException("current license is non-compliant for [transform]", RestStatus.FORBIDDEN),
+            new ElasticsearchSecurityException("overloaded, to many requests", RestStatus.TOO_MANY_REQUESTS),
+            new ElasticsearchSecurityException("internal error", RestStatus.INTERNAL_SERVER_ERROR),
+            new IndexNotFoundException("some missing index")
         );
 
         assertFirstException(bulkItemResponses.values(), DocumentParsingException.class, "document parsing error");
@@ -157,6 +69,14 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         assertNull(ExceptionRootCauseFinder.getFirstIrrecoverableExceptionFromBulkResponses(bulkItemResponses.values()));
     }
 
+    private Map<Integer, BulkItemResponse> bulkItemResponses(Exception... exceptions) {
+        var id = new AtomicInteger(1);
+        return Arrays.stream(exceptions)
+            .map(exception -> new BulkItemResponse.Failure("the_index", "id", exception))
+            .map(failure -> BulkItemResponse.failure(id.get(), OpType.INDEX, failure))
+            .collect(Collectors.toMap(response -> id.getAndIncrement(), Function.identity()));
+    }
+
     public void testIsIrrecoverable() {
         assertFalse(ExceptionRootCauseFinder.isExceptionIrrecoverable(new MapperException("mappings problem")));
         assertFalse(ExceptionRootCauseFinder.isExceptionIrrecoverable(new TaskCancelledException("cancelled task")));
@@ -174,6 +94,7 @@ public class ExceptionRootCauseFinderTests extends ESTestCase {
         assertTrue(
             ExceptionRootCauseFinder.isExceptionIrrecoverable(new DocumentParsingException(new XContentLocation(1, 2), "parse error"))
         );
+        assertTrue(ExceptionRootCauseFinder.isExceptionIrrecoverable(new IndexNotFoundException("some missing index")));
     }
 
     private static void assertFirstException(Collection<BulkItemResponse> bulkItemResponses, Class<?> expectedClass, String message) {


### PR DESCRIPTION
An Index can be removed from its previous shard in the middle of a Transform run.  Ideally, this happens as part of the Delete API, and the Transform has already been stopped, but in the case that it isn't, we want to retry the checkpoint.

If the Transform had been stopped, the retry will move the Indexer into a graceful shutdown.

If the Transform had not been stopped, the retry will check if the Index exists or recreate the Index if it does not exist.

This is currently how unattended Transforms work, and this change will make it so regular Transforms can also auto-recover from this error.

Fix #107263

