### PR TITLE
[8.14] [Bugfix] Connector API - fix status serialisation issue in termquery (#108365)

### DIFF
--- a/docs/changelog/108365.yaml
+++ b/docs/changelog/108365.yaml
@@ -1,0 +1,5 @@
+pr: 108365
+summary: "[Bugfix] Connector API - fix status serialisation issue in termquery"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -823,7 +823,7 @@ public class ConnectorIndexService {
                             Connector.IS_NATIVE_FIELD.getPreferredName(),
                             request.isNative(),
                             Connector.STATUS_FIELD.getPreferredName(),
-                            ConnectorStatus.CONFIGURED
+                            ConnectorStatus.CONFIGURED.toString()
                         )
                     )
 
@@ -969,7 +969,7 @@ public class ConnectorIndexService {
                                 Connector.SERVICE_TYPE_FIELD.getPreferredName(),
                                 request.getServiceType(),
                                 Connector.STATUS_FIELD.getPreferredName(),
-                                newStatus
+                                newStatus.toString()
                             )
                         )
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -266,7 +266,7 @@ public class ConnectorSyncJobIndexService {
 
                         syncJobFieldsToUpdate = Map.of(
                             ConnectorSyncJob.STATUS_FIELD.getPreferredName(),
-                            nextStatus,
+                            nextStatus.toString(),
                             ConnectorSyncJob.CANCELATION_REQUESTED_AT_FIELD.getPreferredName(),
                             now,
                             ConnectorSyncJob.CANCELED_AT_FIELD.getPreferredName(),
@@ -280,7 +280,7 @@ public class ConnectorSyncJobIndexService {
 
                         syncJobFieldsToUpdate = Map.of(
                             ConnectorSyncJob.STATUS_FIELD.getPreferredName(),
-                            nextStatus,
+                            nextStatus.toString(),
                             ConnectorSyncJob.CANCELATION_REQUESTED_AT_FIELD.getPreferredName(),
                             now
                         );
@@ -381,7 +381,10 @@ public class ConnectorSyncJobIndexService {
             }
 
             if (Objects.nonNull(syncStatus)) {
-                TermQueryBuilder syncStatusQuery = new TermQueryBuilder(ConnectorSyncJob.STATUS_FIELD.getPreferredName(), syncStatus);
+                TermQueryBuilder syncStatusQuery = new TermQueryBuilder(
+                    ConnectorSyncJob.STATUS_FIELD.getPreferredName(),
+                    syncStatus.toString()
+                );
                 boolFilterQueryBuilder.must().add(syncStatusQuery);
             }
 
@@ -569,7 +572,7 @@ public class ConnectorSyncJobIndexService {
                             ConnectorSyncJob.ERROR_FIELD.getPreferredName(),
                             error,
                             ConnectorSyncJob.STATUS_FIELD.getPreferredName(),
-                            nextStatus
+                            nextStatus.toString()
                         )
                     );
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [Bugfix] Connector API - fix status serialisation issue in termquery (#108365)