### PR TITLE
[7.17] Fix lingering license warning header

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilter.java
@@ -10,6 +10,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.ipfilter.AbstractRemoteAddressFilter;
 
+import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 
 import java.net.InetSocketAddress;
@@ -19,16 +20,19 @@ class IpFilterRemoteAddressFilter extends AbstractRemoteAddressFilter<InetSocket
 
     private final IPFilter filter;
     private final String profile;
+    private final ThreadContext threadContext;
 
-    IpFilterRemoteAddressFilter(final IPFilter filter, final String profile) {
+    IpFilterRemoteAddressFilter(final IPFilter filter, final String profile, final ThreadContext threadcontext) {
         this.filter = filter;
         this.profile = profile;
+        this.threadContext = threadcontext;
     }
 
     @Override
     protected boolean accept(final ChannelHandlerContext ctx, final InetSocketAddress remoteAddress) throws Exception {
-        // at this stage no auth has happened, so we do not have any principal anyway
-        return filter.accept(profile, remoteAddress);
+        // this prevents thread-context changes to propagate beyond the channel accept test, as netty worker threads are reused
+        try (ThreadContext.StoredContext ignore = threadContext.newStoredContext(false)) {
+            return filter.accept(profile, remoteAddress);
+        }
     }
-
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransport.java
@@ -110,7 +110,11 @@ public class SecurityNetty4HttpServerTransport extends Netty4HttpServerTransport
                 sslEngine.setUseClientMode(false);
                 ch.pipeline().addFirst("ssl", new SslHandler(sslEngine));
             }
-            ch.pipeline().addFirst("ip_filter", new IpFilterRemoteAddressFilter(ipFilter, IPFilter.HTTP_PROFILE_NAME));
+            ch.pipeline()
+                .addFirst(
+                    "ip_filter",
+                    new IpFilterRemoteAddressFilter(ipFilter, IPFilter.HTTP_PROFILE_NAME, threadPool.getThreadContext())
+                );
         }
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransport.java
@@ -101,7 +101,7 @@ public class SecurityNetty4ServerTransport extends SecurityNetty4Transport {
 
     private void maybeAddIPFilter(final Channel ch, final String name) {
         if (authenticator != null) {
-            ch.pipeline().addFirst("ipfilter", new IpFilterRemoteAddressFilter(authenticator, name));
+            ch.pipeline().addFirst("ipfilter", new IpFilterRemoteAddressFilter(authenticator, name, threadPool.getThreadContext()));
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/IpFilterRemoteAddressFilterTests.java
@@ -18,10 +18,13 @@ import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.TestUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.xpack.security.Security;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.transport.filter.IPFilter;
+import org.junit.After;
 import org.junit.Before;
 
 import java.net.InetAddress;
@@ -36,6 +39,19 @@ import static org.mockito.Mockito.when;
 
 public class IpFilterRemoteAddressFilterTests extends ESTestCase {
     private IpFilterRemoteAddressFilter handler;
+    private ThreadPool threadPool;
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        this.threadPool = new TestThreadPool(getTestName());
+    }
+
+    @After
+    public void terminate() throws Exception {
+        terminate(threadPool);
+    }
 
     @Before
     public void init() throws Exception {
@@ -80,9 +96,9 @@ public class IpFilterRemoteAddressFilterTests extends ESTestCase {
         }
 
         if (isHttpEnabled) {
-            handler = new IpFilterRemoteAddressFilter(ipFilter, IPFilter.HTTP_PROFILE_NAME);
+            handler = new IpFilterRemoteAddressFilter(ipFilter, IPFilter.HTTP_PROFILE_NAME, threadPool.getThreadContext());
         } else {
-            handler = new IpFilterRemoteAddressFilter(ipFilter, "default");
+            handler = new IpFilterRemoteAddressFilter(ipFilter, "default", threadPool.getThreadContext());
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/Netty4HttpClient.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/Netty4HttpClient.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xpack.security.transport.netty4;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpContentDecompressor;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestEncoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseDecoder;
+import io.netty.handler.codec.http.HttpVersion;
+
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.NettyAllocator;
+
+import java.io.Closeable;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.netty.handler.codec.http.HttpHeaderNames.HOST;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.junit.Assert.fail;
+
+/**
+ * Tiny helper to send http requests over netty.
+ */
+class Netty4HttpClient implements Closeable {
+
+    static Collection<String> returnHttpResponseBodies(Collection<FullHttpResponse> responses) {
+        List<String> list = new ArrayList<>(responses.size());
+        for (FullHttpResponse response : responses) {
+            list.add(response.content().toString(StandardCharsets.UTF_8));
+        }
+        return list;
+    }
+
+    static Collection<String> returnOpaqueIds(Collection<FullHttpResponse> responses) {
+        List<String> list = new ArrayList<>(responses.size());
+        for (HttpResponse response : responses) {
+            list.add(response.headers().get(Task.X_OPAQUE_ID_HTTP_HEADER));
+        }
+        return list;
+    }
+
+    private final Bootstrap clientBootstrap;
+
+    Netty4HttpClient() {
+        clientBootstrap = new Bootstrap().channel(NettyAllocator.getChannelType())
+            .option(ChannelOption.ALLOCATOR, NettyAllocator.getAllocator())
+            .group(new NioEventLoopGroup(1));
+    }
+
+    public List<FullHttpResponse> get(SocketAddress remoteAddress, String... uris) throws InterruptedException {
+        List<HttpRequest> requests = new ArrayList<>(uris.length);
+        for (int i = 0; i < uris.length; i++) {
+            final HttpRequest httpRequest = new DefaultFullHttpRequest(HTTP_1_1, HttpMethod.GET, uris[i]);
+            httpRequest.headers().add(HOST, "localhost");
+            httpRequest.headers().add("X-Opaque-ID", String.valueOf(i));
+            httpRequest.headers().add("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01");
+            requests.add(httpRequest);
+        }
+        return sendRequests(remoteAddress, requests);
+    }
+
+    public final Collection<FullHttpResponse> post(SocketAddress remoteAddress, List<Tuple<String, CharSequence>> urisAndBodies)
+        throws InterruptedException {
+        return processRequestsWithBody(HttpMethod.POST, remoteAddress, urisAndBodies);
+    }
+
+    public final FullHttpResponse send(SocketAddress remoteAddress, FullHttpRequest httpRequest) throws InterruptedException {
+        List<FullHttpResponse> responses = sendRequests(remoteAddress, Collections.singleton(httpRequest));
+        assert responses.size() == 1 : "expected 1 and only 1 http response";
+        return responses.get(0);
+    }
+
+    public final Collection<FullHttpResponse> put(SocketAddress remoteAddress, List<Tuple<String, CharSequence>> urisAndBodies)
+        throws InterruptedException {
+        return processRequestsWithBody(HttpMethod.PUT, remoteAddress, urisAndBodies);
+    }
+
+    private List<FullHttpResponse> processRequestsWithBody(
+        HttpMethod method,
+        SocketAddress remoteAddress,
+        List<Tuple<String, CharSequence>> urisAndBodies
+    ) throws InterruptedException {
+        List<HttpRequest> requests = new ArrayList<>(urisAndBodies.size());
+        for (Tuple<String, CharSequence> uriAndBody : urisAndBodies) {
+            ByteBuf content = Unpooled.copiedBuffer(uriAndBody.v2(), StandardCharsets.UTF_8);
+            HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uriAndBody.v1(), content);
+            request.headers().add(HttpHeaderNames.HOST, "localhost");
+            request.headers().add(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
+            request.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/json");
+            requests.add(request);
+        }
+        return sendRequests(remoteAddress, requests);
+    }
+
+    private synchronized List<FullHttpResponse> sendRequests(final SocketAddress remoteAddress, final Collection<HttpRequest> requests)
+        throws InterruptedException {
+        final CountDownLatch latch = new CountDownLatch(requests.size());
+        final List<FullHttpResponse> content = Collections.synchronizedList(new ArrayList<>(requests.size()));
+
+        clientBootstrap.handler(new CountDownLatchHandler(latch, content));
+
+        ChannelFuture channelFuture = null;
+        try {
+            channelFuture = clientBootstrap.connect(remoteAddress);
+            channelFuture.sync();
+
+            for (HttpRequest request : requests) {
+                channelFuture.channel().writeAndFlush(request);
+            }
+            if (latch.await(30L, TimeUnit.SECONDS) == false) {
+                fail("Failed to get all expected responses.");
+            }
+
+        } finally {
+            if (channelFuture != null) {
+                channelFuture.channel().close().sync();
+            }
+        }
+
+        return content;
+    }
+
+    @Override
+    public void close() {
+        clientBootstrap.config().group().shutdownGracefully().awaitUninterruptibly();
+    }
+
+    /**
+     * helper factory which adds returned data to a list and uses a count down latch to decide when done
+     */
+    private static class CountDownLatchHandler extends ChannelInitializer<SocketChannel> {
+
+        private final CountDownLatch latch;
+        private final Collection<FullHttpResponse> content;
+
+        CountDownLatchHandler(final CountDownLatch latch, final Collection<FullHttpResponse> content) {
+            this.latch = latch;
+            this.content = content;
+        }
+
+        @Override
+        protected void initChannel(SocketChannel ch) {
+            final int maxContentLength = new ByteSizeValue(100, ByteSizeUnit.MB).bytesAsInt();
+            ch.pipeline().addLast(new HttpResponseDecoder());
+            ch.pipeline().addLast(new HttpRequestEncoder());
+            ch.pipeline().addLast(new HttpContentDecompressor());
+            ch.pipeline().addLast(new HttpObjectAggregator(maxContentLength));
+            ch.pipeline().addLast(new SimpleChannelInboundHandler<HttpObject>() {
+                @Override
+                protected void channelRead0(ChannelHandlerContext ctx, HttpObject msg) {
+                    final FullHttpResponse response = (FullHttpResponse) msg;
+                    // We copy the buffer manually to avoid a huge allocation on a pooled allocator. We have
+                    // a test that tracks huge allocations, so we want to avoid them in this test code.
+                    ByteBuf newContent = Unpooled.copiedBuffer(((FullHttpResponse) msg).content());
+                    content.add(response.replace(newContent));
+                    latch.countDown();
+                }
+
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+                    super.exceptionCaught(ctx, cause);
+                    latch.countDown();
+                }
+            });
+        }
+
+    }
+
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/Netty4HttpClient.java.new
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/Netty4HttpClient.java.new
@@ -1,11 +1,32 @@
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
- * 2.0; you may not use this file except in compliance with the Elastic License
- * 2.0.
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
  */
 
 package org.elasticsearch.xpack.security.transport.netty4;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
@@ -13,6 +13,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.DefaultLastHttpContent;
+import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpConstants;
 import io.netty.handler.codec.http.HttpMessage;
 import io.netty.handler.codec.http.HttpMethod;
@@ -23,6 +24,7 @@ import io.netty.util.AsciiString;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchWrapperException;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -48,6 +50,7 @@ import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.SharedGroupFactory;
+import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.ssl.SSLClientAuth;
 import org.elasticsearch.xpack.core.ssl.SSLService;
@@ -56,9 +59,11 @@ import org.elasticsearch.xpack.security.transport.filter.IPFilter;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -66,6 +71,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLEngine;
 
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.transport.Transports.TEST_MOCK_TRANSPORT_THREAD_PREFIX;
 import static org.elasticsearch.xpack.core.XPackSettings.HTTP_SSL_ENABLED;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -73,9 +79,12 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
 public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTransportTestCase {
@@ -841,5 +850,91 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
         } finally {
             testThreadPool.shutdownNow();
         }
+    }
+
+    public void testChannelAcceptorCannotTamperThreadContext() throws Exception {
+        HttpServerTransport.Dispatcher dispatcher = new HttpServerTransport.Dispatcher() {
+            @Override
+            public void dispatchRequest(final RestRequest request, final RestChannel channel, final ThreadContext threadContext) {
+                assertThreadContextNotTampered(threadContext);
+                channel.sendResponse(new BytesRestResponse(OK, BytesRestResponse.TEXT_CONTENT_TYPE, new BytesArray("done")));
+            }
+
+            @Override
+            public void dispatchBadRequest(final RestChannel channel, final ThreadContext threadContext, final Throwable cause) {
+                logger.error(() -> "--> Unexpected bad request [" + FakeRestRequest.requestToString(channel.request()) + "]", cause);
+                throw new AssertionError();
+            }
+        };
+        // there's only one netty worker thread that's reused across client requests
+        Settings settings = Settings.builder().put(Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.getKey(), 1).build();
+        ThreadPool threadPool = new TestThreadPool(TEST_MOCK_TRANSPORT_THREAD_PREFIX);
+        IPFilter ipFilter = mock(IPFilter.class);
+        doAnswer(invocationOnMock -> {
+            assertThreadContextNotTampered(threadPool.getThreadContext());
+            tamperThreadContext(threadPool.getThreadContext());
+            // ideally, the IP filter should pick randomly if to allow the connection or not
+            // but in v7.17, unlike in v8, a closed connection would not return any response
+            // which makes the client timeout and fail the test
+            return true;
+        }).when(ipFilter).accept(any(String.class), any(InetSocketAddress.class));
+        try (
+            Netty4HttpServerTransport transport = Security.getHttpServerTransportWithHeadersValidator(
+                settings,
+                new NetworkService(Collections.emptyList()),
+                BigArrays.NON_RECYCLING_INSTANCE,
+                threadPool,
+                xContentRegistry(),
+                dispatcher,
+                ipFilter,
+                sslService,
+                new SharedGroupFactory(settings),
+                randomClusterSettings(),
+                (httpPreRequest, channel, listener) -> listener.onResponse(null)
+            )
+        ) {
+            transport.start();
+            try (Netty4HttpClient client = new Netty4HttpClient()) {
+                int nRetries = randomIntBetween(1, 3);
+                for (int i = 0; i < nRetries; i++) {
+                    List<FullHttpResponse> responses = client.get(
+                        randomFrom(transport.boundAddress().boundAddresses()).address(),
+                        "/test/url"
+                    );
+                    try {
+                        assertThat(responses, iterableWithSize(1));
+                        assertThat(responses.iterator().next().status(), equalTo(HttpResponseStatus.OK));
+                    } finally {
+                        for (FullHttpResponse response : responses) {
+                            response.release();
+                        }
+                    }
+                }
+            }
+        } finally {
+            threadPool.shutdownNow();
+        }
+    }
+
+    private static void tamperThreadContext(ThreadContext threadContext) {
+        boolean tampered = false;
+        if (randomBoolean()) {
+            threadContext.putHeader(randomAlphaOfLength(16), "tampered with request header");
+            tampered = true;
+        }
+        if (randomBoolean()) {
+            threadContext.putTransient(randomAlphaOfLength(16), "tampered with transient request header");
+            tampered = true;
+        }
+        if (randomBoolean() || tampered == false) {
+            threadContext.addResponseHeader(randomAlphaOfLength(8), "tampered with response header");
+        }
+    }
+
+    private static void assertThreadContextNotTampered(ThreadContext threadContext) {
+        if (false == threadContext.isDefaultContext()) {
+            throw new AssertionError("tampered thread context");
+        }
+        Transports.assertTransportThread();
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
@@ -867,7 +867,10 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
             }
         };
         // there's only one netty worker thread that's reused across client requests
-        Settings settings = Settings.builder().put(Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.getKey(), 1).build();
+        Settings settings = Settings.builder()
+            .put(HttpTransportSettings.SETTING_HTTP_PORT.getKey(), getPortRange())
+            .put(Netty4HttpServerTransport.SETTING_HTTP_WORKER_COUNT.getKey(), 1)
+            .build();
         ThreadPool threadPool = new TestThreadPool(TEST_MOCK_TRANSPORT_THREAD_PREFIX);
         IPFilter ipFilter = mock(IPFilter.class);
         doAnswer(invocationOnMock -> {


### PR DESCRIPTION
Fixes the AcceptChannelHandler#accept mucking with the netty worker thread context.

Fixes https://github.com/elastic/elasticsearch/issues/107573
Backport of https://github.com/elastic/elasticsearch/pull/108031