### PR TITLE
GeoIP tasks should wait longer for master

### DIFF
--- a/docs/changelog/108410.yaml
+++ b/docs/changelog/108410.yaml
@@ -1,0 +1,5 @@
+pr: 108410
+summary: GeoIP tasks should wait longer for master
+area: Ingest Node
+type: bug
+issues: []


### PR DESCRIPTION
Today when creating or removing the GeoIP downloader tasks we use the
default 30s master-node timeout. Yet, for these internal tasks we should
wait forever. This commit extends the timeout.