### PR TITLE
Add more values to estimated sizes for ES|QL field types

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
@@ -106,9 +106,10 @@ public interface EstimatesRowSize {
         return switch (elementType) {
             case BOOLEAN -> 1;
             case BYTES_REF -> switch (dataType.typeName()) {
-                case "ip" -> 16;    // IP addresses, both IPv4 and IPv6, are encoded using 16 bytes.
+                case "ip" -> 16;      // IP addresses, both IPv4 and IPv6, are encoded using 16 bytes.
+                case "version" -> 15; // 8.15.2-SNAPSHOT is 15 bytes, most are shorter, some can be longer
                 case "geo_point", "cartesian_point" -> 21;  // WKB for points is typically 21 bytes.
-                case "geo_shape", "cartesian_shape" -> 100;  // wild estimate for the size of a shape.
+                case "geo_shape", "cartesian_shape" -> 200; // wild estimate, based on some test data (airport_city_boundaries)
                 default -> 50; // wild estimate for the size of a string.
             };
             case DOC -> throw new EsqlIllegalArgumentException("can't load a [doc] with field extraction");

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
@@ -13,7 +13,6 @@ import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
 import org.elasticsearch.xpack.ql.expression.Expression;
 import org.elasticsearch.xpack.ql.type.DataType;
-import org.elasticsearch.xpack.ql.type.DataTypes;
 
 import java.util.List;
 
@@ -106,12 +105,12 @@ public interface EstimatesRowSize {
         ElementType elementType = PlannerUtils.toElementType(dataType);
         return switch (elementType) {
             case BOOLEAN -> 1;
-            case BYTES_REF -> {
-                if (dataType == DataTypes.IP) {
-                    yield 16;
-                }
-                yield 50; // wild estimate for the size of a string.
-            }
+            case BYTES_REF -> switch (dataType.typeName()) {
+                case "ip" -> 16;    // IP addresses, both IPv4 and IPv6, are encoded using 16 bytes.
+                case "geo_point", "cartesian_point" -> 21;  // WKB for points is typically 21 bytes.
+                case "geo_shape", "cartesian_shape" -> 100;  // wild estimate for the size of a shape.
+                default -> 50; // wild estimate for the size of a string.
+            };
             case DOC -> throw new EsqlIllegalArgumentException("can't load a [doc] with field extraction");
             case DOUBLE -> Double.BYTES;
             case INT -> Integer.BYTES;


### PR DESCRIPTION
This is a trivial enhancement to the current guesswork around row estimated sizes for field types.

Previously we only considered IP (16 bytes) and all other BytesRef types were estimated to 50 bytes (assuming mostly strings like KEYWORD). But we know points are 21 bytes (WKB) and shapes are usually much larger, so we've put 21 bytes for points and a wild guess of 100 bytes for shapes.

We could consider also adding Version fields here, as well as doing some actual statistics on shape sizes from the shapes in our integration tests, or in the benchmarks.
