### PR TITLE
Fix ClassCastException in Significant Terms

### DIFF
--- a/docs/changelog/108429.yaml
+++ b/docs/changelog/108429.yaml
@@ -1,0 +1,6 @@
+pr: 108429
+summary: Fix `ClassCastException` in Significant Terms
+area: Aggregations
+type: bug
+issues:
+ - 108427

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalSignificantTerms.java
@@ -214,6 +214,15 @@ public abstract class InternalSignificantTerms<A extends InternalSignificantTerm
 
             @Override
             public void accept(InternalAggregation aggregation) {
+                /*
+                canLeadReduction here is essentially checking if this shard returned data.  Unmapped shards (that didn't
+                specify a missing value) will be false. Since they didn't return data, we can safely skip them, and
+                doing so prevents us from accidentally taking one as the reference agg for type checking, which would cause
+                shards that actually returned data to fail.
+                 */
+                if (aggregation.canLeadReduction() == false) {
+                    return;
+                }
                 @SuppressWarnings("unchecked")
                 final InternalSignificantTerms<A, B> terms = (InternalSignificantTerms<A, B>) aggregation;
                 if (referenceAgg == null) {


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/108427

Prior to this PR, if a `SignificantTerms` aggregation targeted a field existing on two indices (that were included in the aggregation) but mapped to different field types, the query would fail at reduce time with a somewhat obscure `ClassCastException`.  This change brings the behavior in line with the `Terms` aggregation, which returns a 400 class `IllegalArgumentException` with a useful message in this situation.