### PR TITLE
[8.14] Add note about license to "Restore an Entire Cluster" docs (#87485)

### DIFF
--- a/docs/reference/snapshot-restore/restore-snapshot.asciidoc
+++ b/docs/reference/snapshot-restore/restore-snapshot.asciidoc
@@ -448,6 +448,10 @@ POST _snapshot/my_repository/my_snapshot_2099.05.06/_restore
 . When the restore operation is complete, resume indexing and restart any
 features you stopped:
 +
+NOTE: When the snapshot is restored, the license that was in use at the time the snapshot
+was taken will be restored as well. If your license has expired since the snapshot was taken,
+you will need to use the <<update-license,Update License API>> to install a current license.
++
 --
 * GeoIP database downloader and ILM history store
 +


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Add note about license to "Restore an Entire Cluster" docs (#87485)](https://github.com/elastic/elasticsearch/pull/87485)

<!--- Backport version: 7.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)