### PR TITLE
[8.13] Mention alias filters don't apply for get-by-id in docs (#108433)

### DIFF
--- a/docs/reference/alias.asciidoc
+++ b/docs/reference/alias.asciidoc
@@ -287,6 +287,8 @@ POST _aliases
 ----
 // TEST[s/^/PUT my-index-2099.05.06-000001\n/]
 
+NOTE: Filters are only applied when using the <<query-dsl,Query DSL>>, and are not applied when <<docs-get,retrieving a document by ID>>.
+
 [discrete]
 [[alias-routing]]
 === Routing


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Mention alias filters don't apply for get-by-id in docs (#108433)