### PR TITLE
apm-data: ignore malformed fields, and too many dynamic fields

### DIFF
--- a/docs/changelog/108444.yaml
+++ b/docs/changelog/108444.yaml
@@ -1,0 +1,5 @@
+pr: 108444
+summary: "Apm-data: ignore malformed fields, and too many dynamic fields"
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@settings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/apm@settings.yaml
@@ -8,3 +8,7 @@ template:
       sort:
         field: "@timestamp"
         order: desc
+    mapping:
+      ignore_malformed: true
+      total_fields:
+        ignore_dynamic_beyond_limit: true

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm@settings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm@settings.yaml
@@ -6,3 +6,9 @@ _meta:
 template:
   settings:
     codec: best_compression
+    mapping:
+      # apm@settings sets `ignore_malformed: true`, but we need
+      # to disable this for metrics since they use synthetic source,
+      # and this combination is incompatible with the
+      # aggregate_metric_double field type.
+      ignore_malformed: false

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 3
+version: 4
 
 component-templates:
   # Data lifecycle.

--- a/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/30_lenient_mappings.yml
+++ b/x-pack/plugin/apm-data/src/yamlRestTest/resources/rest-api-spec/test/30_lenient_mappings.yml
@@ -1,0 +1,100 @@
+---
+setup:
+  - do:
+      cluster.health:
+        wait_for_events: languid
+
+  - do:
+      cluster.put_component_template:
+        name: "logs-apm.app@custom"
+        body:
+          template:
+            settings:
+              mapping:
+                total_fields:
+                  limit: 20
+
+---
+"Test ignore_malformed":
+  - do:
+      bulk:
+        index: traces-apm-testing
+        refresh: true
+        body:
+          # Passing a (non-coercable) string into a numeric field should not
+          # cause an indexing failure; it should just not be indexed.
+          - create: {}
+          - '{"@timestamp": "2017-06-22", "numeric_labels": {"key": "string"}}'
+          - create: {}
+          - '{"@timestamp": "2017-06-22", "numeric_labels": {"key": 123}}'
+
+  - is_false: errors
+
+  - do:
+      search:
+        index: traces-apm-testing
+        body:
+          fields: ["numeric_labels.*", "_ignored"]
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0.fields: {"_ignored": ["numeric_labels.key"]} }
+  - match: { hits.hits.1.fields: {"numeric_labels.key": [123.0]} }
+
+---
+"Test ignore_dynamic_beyond_limit":
+  - do:
+      bulk:
+        index: logs-apm.app.svc1-testing
+        refresh: true
+        body:
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k1": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k2": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k3": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k4": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k5": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k6": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k7": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k8": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k9": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k10": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k11": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k12": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k13": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k14": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k15": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k16": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k17": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k18": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k19": ""}
+          - create: {}
+          - {"@timestamp": "2017-06-22", "k20": ""}
+
+  - is_false: errors
+
+  - do:
+      search:
+        index: logs-apm.app.svc1-testing
+        body:
+          query:
+            term:
+              _ignored:
+                value: k20
+  - length: { hits.hits: 1 }


### PR DESCRIPTION
Enable `ignore_malformed` on all non-metrics APM data streams, and enable `ignore_dynamic_beyond_limit` for all APM data streams. We can enable ignore_malformed on metrics data streams when https://github.com/elastic/elasticsearch/issues/90007 is fixed.

This change means that instead of outright rejecting documents, we will index the documents without indexing those particular malformed fields or dynamic fields exceeding the field limit; these fields will be listed in the `_ignored` meta-field.