### PR TITLE
[8.14] [DOCS] Fix stored_fields parameter description (#98385) (#108445)

### DIFF
--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -1062,8 +1062,8 @@ end::stats[]
 
 tag::stored_fields[]
 `stored_fields`::
-(Optional, Boolean) If `true`, retrieves the document fields stored in the
-index rather than the document `_source`. Defaults to `false`.
+(Optional, string)
+A comma-separated list of <<mapping-store,`stored fields`>> to include in the response.
 end::stored_fields[]
 
 tag::sync[]


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [DOCS] Fix stored_fields parameter description (#98385) (#108445)