### PR TITLE
Do not use global ordinals strategy if the leaf reader context cannot be obtained

### DIFF
--- a/docs/changelog/108459.yaml
+++ b/docs/changelog/108459.yaml
@@ -1,0 +1,6 @@
+pr: 108459
+summary: Do not use global ordinals strategy if the leaf reader context cannot be
+  obtained
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetCollector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetCollector.java
@@ -177,7 +177,8 @@ public final class FrequentItemSetCollector {
             int pos = items.nextSetBit(0);
             while (pos > 0) {
                 Tuple<Integer, Object> item = transactionStore.getItem(topItemIds.getItemIdAt(pos - 1));
-                assert item.v1() < fields.size() : "item id exceed number of given items, did you configure eclat correctly?";
+                assert item.v1() < fields.size()
+                    : "eclat error: item id (" + item.v1() + ") exceeds the number of given items (" + fields.size() + ")";
                 final Field field = fields.get(item.v1());
                 Object formattedValue = field.formatValue(item.v2());
                 String fieldName = fields.get(item.v1()).getName();
@@ -252,19 +253,20 @@ public final class FrequentItemSetCollector {
         this.topItemIds = topItemIds;
         this.size = size;
         this.min = min;
-        queue = new FrequentItemSetPriorityQueue(size);
-        frequentItemsByCount = Maps.newMapWithExpectedSize(size / 10);
+        this.queue = new FrequentItemSetPriorityQueue(size);
+        this.frequentItemsByCount = Maps.newMapWithExpectedSize(size / 10);
     }
 
     public FrequentItemSet[] finalizeAndGetResults(List<Field> fields) throws IOException {
-        FrequentItemSet[] topFrequentItems = new FrequentItemSet[size()];
+        FrequentItemSet[] topFrequentItems = new FrequentItemSet[queue.size()];
         for (int i = topFrequentItems.length - 1; i >= 0; i--) {
             topFrequentItems[i] = queue.pop().toFrequentItemSet(fields);
         }
         return topFrequentItems;
     }
 
-    public int size() {
+    // Visible for testing
+    int size() {
         return queue.size();
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceAggregator.java
@@ -84,7 +84,7 @@ public abstract class ItemSetMapReduceAggregator<
             ? contextSearcher.createWeight(contextSearcher.rewrite(context.buildQuery(documentFilter)), ScoreMode.COMPLETE_NO_SCORES, 1f)
             : null;
 
-        boolean rewriteBasedOnOrdinals = true;
+        boolean rewriteBasedOnOrdinals = false;
 
         for (var c : configsAndValueFilters) {
             ItemSetMapReduceValueSource e = context.getValuesSourceRegistry()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceAggregator.java
@@ -84,19 +84,17 @@ public abstract class ItemSetMapReduceAggregator<
             ? contextSearcher.createWeight(contextSearcher.rewrite(context.buildQuery(documentFilter)), ScoreMode.COMPLETE_NO_SCORES, 1f)
             : null;
 
-        boolean rewriteBasedOnOrdinals = false;
+        boolean rewriteBasedOnOrdinals = true;
 
-        if (ctx.isPresent()) {
-            for (var c : configsAndValueFilters) {
-                ItemSetMapReduceValueSource e = context.getValuesSourceRegistry()
-                    .getAggregator(registryKey, c.v1())
-                    .build(c.v1(), id++, c.v2(), ordinalOptimization, ctx.get());
-                if (e.getField().getName() != null) {
-                    fields.add(e.getField());
-                    valueSources.add(e);
-                }
-                rewriteBasedOnOrdinals |= e.usesOrdinals();
+        for (var c : configsAndValueFilters) {
+            ItemSetMapReduceValueSource e = context.getValuesSourceRegistry()
+                .getAggregator(registryKey, c.v1())
+                .build(c.v1(), id++, c.v2(), ordinalOptimization, ctx);
+            if (e.getField().getName() != null) {
+                fields.add(e.getField());
+                valueSources.add(e);
             }
+            rewriteBasedOnOrdinals |= e.usesOrdinals();
         }
 
         this.rewriteBasedOnOrdinals = rewriteBasedOnOrdinals;


### PR DESCRIPTION
Global ordinals execution strategy is an optimization that we apply for keyword fields.
However it relies on the leaf reader obtained via:
```
        IndexReader reader = context.searcher().getIndexReader();
```
to be present.
If it is not present, the `FrequentItemSetCollector` code may encounter an `IndexOutOfBoundsException`.
This PR fixes this by not using global ordinals execution strategy if the leaf reader is absent.
This change should not cause significant performance hit as the situation where the reader is absent is usually transient, e.g.: due to index shards not fully initialized yet.