### PR TITLE
Remove ram.percent from CAT Node default columns

### DIFF
--- a/docs/changelog/108465.yaml
+++ b/docs/changelog/108465.yaml
@@ -1,0 +1,5 @@
+pr: 108465
+summary: Remove `ram.percent` from CAT Node default columns
+area: Stats
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestNodesAction.java
@@ -155,7 +155,7 @@ public class RestNodesAction extends AbstractCatAction {
         table.addCell("heap.percent", "alias:hp,heapPercent;text-align:right;desc:used heap ratio");
         table.addCell("heap.max", "default:false;alias:hm,heapMax;text-align:right;desc:max configured heap");
         table.addCell("ram.current", "default:false;alias:rc,ramCurrent;text-align:right;desc:used machine memory");
-        table.addCell("ram.percent", "alias:rp,ramPercent;text-align:right;desc:used machine memory ratio");
+        table.addCell("ram.percent", "default:false;alias:rp,ramPercent;text-align:right;desc:used machine memory ratio");
         table.addCell("ram.max", "default:false;alias:rm,ramMax;text-align:right;desc:total machine memory");
         table.addCell("file_desc.current", "default:false;alias:fdc,fileDescriptorCurrent;text-align:right;desc:used file descriptors");
         table.addCell(


### PR DESCRIPTION
👋 @dakrone as follow-up to your closing https://github.com/elastic/elasticsearch/issues/32393 yesterday, could we consider a smaller win to reduce the symptom surface area of removing `ram.percent` from the default columns of [CAT Nodes](https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-nodes.html)? Support (at least) encourages users to ignore it entirely and focus on `heap.percent` (which already is default). 