### PR TITLE
[8.14] Correct typo in documentation (#108462)

### DIFF
--- a/docs/reference/tab-widgets/semantic-search/hybrid-search.asciidoc
+++ b/docs/reference/tab-widgets/semantic-search/hybrid-search.asciidoc
@@ -1,7 +1,7 @@
 // tag::elser[]
 
 Hybrid search between a semantic and lexical query can be achieved by using an
-<<rrf-retriever, `rrf` retriever> as part of your search request. Provide a
+<<rrf-retriever, `rrf` retriever>> as part of your search request. Provide a
 `text_expansion` query and a full-text query as
 <<standard-retriever, `standard` retrievers>> for the `rrf` retriever. The `rrf`
 retriever uses <<rrf, reciprocal rank fusion>> to rank the top documents.


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Correct typo in documentation (#108462)