### PR TITLE
Log running tasks in EsqlDisruptionIT (#108440)

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionIT.java
@@ -121,7 +121,6 @@ public class EsqlActionIT extends AbstractEsqlIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107347")
     public void testFromStatsGroupingAvgWithSort() {
         testFromStatsGroupingAvgImpl("from test | stats avg(count) by data | sort data | limit 2", "data", "avg(count)");
     }


### PR DESCRIPTION
This PR logs tasks that are running after the disruption is cleared,  allowing us to investigate why the disruption tests failed in #107347.

Relates #107347
