### PR TITLE
Add number of nodes accessor to test cluster handle

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterHandle.java
@@ -66,6 +66,11 @@ public class DefaultLocalClusterHandle implements LocalClusterHandle {
     }
 
     @Override
+    public int getNumNodes() {
+        return nodes.size();
+    }
+
+    @Override
     public void start() {
         if (started.getAndSet(true) == false) {
             LOGGER.info("Starting Elasticsearch test cluster '{}'", name);

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalElasticsearchCluster.java
@@ -55,6 +55,11 @@ public class DefaultLocalElasticsearchCluster<S extends LocalClusterSpec, H exte
     }
 
     @Override
+    public int getNumNodes() {
+        return handle.getNumNodes();
+    }
+
+    @Override
     public void start() {
         checkHandle();
         handle.start();

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -16,6 +16,12 @@ import org.elasticsearch.test.cluster.util.Version;
 import java.io.InputStream;
 
 public interface LocalClusterHandle extends ClusterHandle {
+
+    /**
+     * Returns the number of nodes that are part of this cluster.
+     */
+    int getNumNodes();
+
     /**
      * Stops the node at a given index.
      * @param index of the node to stop


### PR DESCRIPTION
Local test clusters have several methods allowing interaction with nodes by ordinal number. However, there is currently no way to know how mnany nodes were actually configured for the cluster. This commit adds an accessor for the number of nodes the cluster handle knows about.