### PR TITLE
Remove ILM access from SLM privileges

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -160,12 +160,7 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> READ_CCR_PATTERN = Set.of(ClusterStateAction.NAME, HasPrivilegesAction.NAME);
     private static final Set<String> MANAGE_ILM_PATTERN = Set.of("cluster:admin/ilm/*");
     private static final Set<String> READ_ILM_PATTERN = Set.of(GetLifecycleAction.NAME, GetStatusAction.NAME);
-    private static final Set<String> MANAGE_SLM_PATTERN = Set.of(
-        "cluster:admin/slm/*",
-        ILMActions.START.name(),
-        ILMActions.STOP.name(),
-        GetStatusAction.NAME
-    );
+    private static final Set<String> MANAGE_SLM_PATTERN = Set.of("cluster:admin/slm/*");
     private static final Set<String> READ_SLM_PATTERN = Set.of(
         GetSLMStatusAction.NAME,
         GetSnapshotLifecycleAction.NAME,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -160,11 +160,7 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> MANAGE_ILM_PATTERN = Set.of("cluster:admin/ilm/*");
     private static final Set<String> READ_ILM_PATTERN = Set.of(GetLifecycleAction.NAME, GetStatusAction.NAME);
     private static final Set<String> MANAGE_SLM_PATTERN = Set.of("cluster:admin/slm/*");
-    private static final Set<String> READ_SLM_PATTERN = Set.of(
-        GetSLMStatusAction.NAME,
-        GetSnapshotLifecycleAction.NAME,
-        GetStatusAction.NAME
-    );
+    private static final Set<String> READ_SLM_PATTERN = Set.of(GetSLMStatusAction.NAME, GetSnapshotLifecycleAction.NAME);
 
     private static final Set<String> MANAGE_SEARCH_APPLICATION_PATTERN = Set.of("cluster:admin/xpack/application/search_application/*");
     private static final Set<String> MANAGE_SEARCH_QUERY_RULES_PATTERN = Set.of("cluster:admin/xpack/query_rules/*");

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -29,7 +29,6 @@ import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.action.XPackInfoAction;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.GetStatusAction;
-import org.elasticsearch.xpack.core.ilm.action.ILMActions;
 import org.elasticsearch.xpack.core.security.action.ActionTypes;
 import org.elasticsearch.xpack.core.security.action.DelegatePkiAuthenticationAction;
 import org.elasticsearch.xpack.core.security.action.apikey.GetApiKeyAction;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
@@ -451,25 +451,27 @@ public class PrivilegeTests extends ESTestCase {
                 "cluster:admin/slm/delete",
                 "cluster:admin/slm/put",
                 "cluster:admin/slm/get",
+                "cluster:admin/slm/execute"
+            );
+            verifyClusterActionDenied(ClusterPrivilegeResolver.MANAGE_SLM,
                 "cluster:admin/ilm/start",
                 "cluster:admin/ilm/stop",
-                "cluster:admin/slm/execute",
-                "cluster:admin/ilm/operation_mode/get"
+                "cluster:admin/ilm/operation_mode/get",
+                "cluster:admin/whatever"
             );
-            verifyClusterActionDenied(ClusterPrivilegeResolver.MANAGE_SLM, "cluster:admin/whatever");
         }
 
         {
             verifyClusterActionAllowed(
                 ClusterPrivilegeResolver.READ_SLM,
                 "cluster:admin/slm/get",
-                "cluster:admin/slm/status",
-                "cluster:admin/ilm/operation_mode/get"
+                "cluster:admin/slm/status"
             );
             verifyClusterActionDenied(
                 ClusterPrivilegeResolver.READ_SLM,
                 "cluster:admin/slm/delete",
                 "cluster:admin/slm/put",
+                "cluster:admin/ilm/operation_mode/get",
                 "cluster:admin/ilm/start",
                 "cluster:admin/ilm/stop",
                 "cluster:admin/slm/execute",

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
@@ -453,7 +453,8 @@ public class PrivilegeTests extends ESTestCase {
                 "cluster:admin/slm/get",
                 "cluster:admin/slm/execute"
             );
-            verifyClusterActionDenied(ClusterPrivilegeResolver.MANAGE_SLM,
+            verifyClusterActionDenied(
+                ClusterPrivilegeResolver.MANAGE_SLM,
                 "cluster:admin/ilm/start",
                 "cluster:admin/ilm/stop",
                 "cluster:admin/ilm/operation_mode/get",
@@ -462,11 +463,7 @@ public class PrivilegeTests extends ESTestCase {
         }
 
         {
-            verifyClusterActionAllowed(
-                ClusterPrivilegeResolver.READ_SLM,
-                "cluster:admin/slm/get",
-                "cluster:admin/slm/status"
-            );
+            verifyClusterActionAllowed(ClusterPrivilegeResolver.READ_SLM, "cluster:admin/slm/get", "cluster:admin/slm/status");
             verifyClusterActionDenied(
                 ClusterPrivilegeResolver.READ_SLM,
                 "cluster:admin/slm/delete",


### PR DESCRIPTION
Starting or stopping SLM used to required starting or stopping ILM. Because of this, the privileges manage_slm and read_slm had the ability to access ILM endpoints. The starting and stopping of SLM is now separate from ILM, thus the privileges no longer need the ability to access ILM endpoints.

Relates to https://github.com/elastic/elasticsearch/issues/94395