### PR TITLE
Increase startup timeout in packaging tests

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -264,7 +264,7 @@ public class Archives {
             Locale.ROOT,
             """
                 expect - <<EXPECT
-                set timeout 60
+                set timeout 120
                 spawn -ignore HUP %s
                 %s
                 %s


### PR DESCRIPTION
This should help alleviate some packaging tests failures where Elasticsearch simply isn't starting up fast enough.

Closes #108287