### PR TITLE
[8.14] Increase startup timeout in packaging tests (#108487)

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Archives.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/util/Archives.java
@@ -264,7 +264,7 @@ public class Archives {
             Locale.ROOT,
             """
                 expect - <<EXPECT
-                set timeout 60
+                set timeout 120
                 spawn -ignore HUP %s
                 %s
                 %s


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Increase startup timeout in packaging tests (#108487)