### PR TITLE
Fixed overlapping templates warning when adding new template with validation false

### DIFF
--- a/docs/changelog/108494.yaml
+++ b/docs/changelog/108494.yaml
@@ -1,0 +1,6 @@
+pr: 108494
+summary: Fixed overlapping templates warning when adding new template with validation
+  false
+area: Indices APIs
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -597,8 +597,8 @@ public class MetadataIndexTemplateService {
 
         Map<String, List<String>> overlaps = v2TemplateOverlaps(currentState, name, template, validateV2Overlaps);
 
-        overlaps = findConflictingV1Templates(currentState, name, template.indexPatterns());
-        if (overlaps.size() > 0) {
+        overlaps.putAll(findConflictingV1Templates(currentState, name, template.indexPatterns()));
+        if (overlaps.isEmpty() == false) {
             String warning = String.format(
                 Locale.ROOT,
                 "index template [%s] has index patterns %s matching patterns from "

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -653,6 +653,7 @@ public class MetadataIndexTemplateService {
      * @param template the full composable index template object we check for overlaps
      * @param validate should we throw {@link IllegalArgumentException} if conflicts are found or just compute them
      * @return a map of v2 template names to their index patterns for v2 templates that would overlap with the given template
+     * @throws IllegalArgumentException if it detects conflicts and the validate is true
      */
     public static Map<String, List<String>> v2TemplateOverlaps(
         ClusterState currentState,

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -2219,13 +2219,19 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
 
             // when validating is false, we return the conflicts instead of throwing an exception
             var overlaps = MetadataIndexTemplateService.v2TemplateOverlaps(state, "foo2", newTemplate, false);
-
             assertThat(overlaps, allOf(aMapWithSize(1), hasKey("foo")));
+
+            // when adding a template with validating false, we add a critical warning instead of throwing an exception
+            metadataIndexTemplateService.addIndexTemplateV2(state, false, "foo2", newTemplate, false);
+            assertCriticalWarnings(
+                "index template [foo2] has index patterns [abc, baz*] matching patterns from existing older templates"
+                    + " [foo] with patterns (foo => [egg*, baz]); this template [foo2] will take precedence during new index creation"
+            );
 
             // try now the same thing with validation on
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> MetadataIndexTemplateService.v2TemplateOverlaps(state, "foo2", newTemplate, true)
+                () -> metadataIndexTemplateService.addIndexTemplateV2(state, false, "foo2", newTemplate)
             );
             assertThat(
                 e.getMessage(),
@@ -2255,7 +2261,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
                 .build();
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> MetadataIndexTemplateService.v2TemplateOverlaps(state, "foo2", newTemplate, true)
+                () -> metadataIndexTemplateService.addIndexTemplateV2(state, false, "foo2", newTemplate)
             );
             assertThat(
                 e.getMessage(),


### PR DESCRIPTION
When adding a template with validation disabled, we were not detecting correctly all the overlapping v2 templates.

This PR is fixing this and changes the existing test to capture this.