### PR TITLE
Refactor overlapping template v2 validation

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateAction.java
@@ -178,7 +178,7 @@ public class ReservedComposableIndexTemplateAction
 
         // 4. validate for v2 composable template overlaps
         for (var request : composables) {
-            MetadataIndexTemplateService.v2TemplateOverlaps(state, request.name(), request.indexTemplate(), true);
+            MetadataIndexTemplateService.validateV2TemplateOverlaps(state, request.name(), request.indexTemplate());
         }
 
         Set<String> componentEntities = components.stream().map(r -> reservedComponentName(r.name())).collect(Collectors.toSet());


### PR DESCRIPTION
While fixing https://github.com/elastic/elasticsearch/pull/108494, the `ReservedComposableIndexTemplateAction` https://github.com/elastic/elasticsearch/blob/5de04fa3a0a9f33c9469b45a4a2a3b217b1bb8bc/server/src/main/java/org/elasticsearch/action/admin/indices/template/reservedstate/ReservedComposableIndexTemplateAction.java#L135  

```
// We transform in the following order:
// 1. create or update component templates (composable templates depend on them)
// 2. create or update composable index templates (with disabled v2 overlap validation, we might delete some at step 3, while, 2 and 3 cannot be reversed because of data streams)
// 3. delete composable index templates (this will fail on attached data streams, unless we added higher priority one)
// 4. validate for v2 composable template overlaps
// 5. delete component templates (this will check if there are any related composable index templates and fail)
```
is using the `addIndexTemplateV2` to replace a template. By fixing https://github.com/elastic/elasticsearch/pull/108494 we would be adding a warning. 

Considering this is the only place this is being used, this PR refactors the code and keeps the same functionality just better documented.