### PR TITLE
[Transform] Use unpooled SearchHits in tests

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -992,7 +992,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
 
     private static Function<SearchRequest, SearchResponse> returnHit() {
         return request -> new SearchResponse(
-            new SearchHits(new SearchHit[] { new SearchHit(1) }, new TotalHits(1L, TotalHits.Relation.EQUAL_TO), 1.0f),
+            SearchHits.unpooled(new SearchHit[] { SearchHit.unpooled(1) }, new TotalHits(1L, TotalHits.Relation.EQUAL_TO), 1.0f),
             // Simulate completely null aggs
             null,
             new Suggest(Collections.emptyList()),

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -88,7 +88,7 @@ import static org.mockito.Mockito.verify;
 public class TransformIndexerStateTests extends ESTestCase {
 
     private static final SearchResponse ONE_HIT_SEARCH_RESPONSE = new SearchResponse(
-        new SearchHits(new SearchHit[] { new SearchHit(1) }, new TotalHits(1L, TotalHits.Relation.EQUAL_TO), 1.0f),
+        SearchHits.unpooled(new SearchHit[] { SearchHit.unpooled(1) }, new TotalHits(1L, TotalHits.Relation.EQUAL_TO), 1.0f),
         // Simulate completely null aggs
         null,
         new Suggest(Collections.emptyList()),


### PR DESCRIPTION
Swapping from `new SearchHits` and `new SearchHit` to `SearchHits.unpooled` and `SearchHit.unpooled`.  This seems to be what every other test is doing.  I made the change both in the test from the issue as well as the test I had copy/pasted the code from :)

Fix #108507
