### PR TITLE
Properly support capabilities checks with mixed version clusters

### DIFF
--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/NodesCapabilitiesUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/NodesCapabilitiesUpgradeIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.upgrades;
+
+import com.carrotsearch.randomizedtesting.annotations.Name;
+
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.core.UpdateForV9;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.List;
+
+@UpdateForV9
+public class NodesCapabilitiesUpgradeIT extends AbstractRollingUpgradeTestCase {
+
+    private static Boolean upgradingBeforeCapabilities;
+
+    public NodesCapabilitiesUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
+        super(upgradedNodes);
+    }
+
+    @Before
+    public void checkBeforeHasNoCapabilities() throws IOException {
+        if (upgradingBeforeCapabilities == null) {
+            // try to do a _capabilities query on a node before we upgrade
+            try {
+                clusterHasCapability("GET", "_capabilities", List.of(), List.of());
+                upgradingBeforeCapabilities = false;
+            } catch (ResponseException e) {
+                if (e.getResponse().getStatusLine().getStatusCode() == 400) {
+                    upgradingBeforeCapabilities = true;
+                } else {
+                    throw e;
+                }
+            }
+        }
+
+        assumeTrue("Only valid when upgrading from versions without capabilities API", upgradingBeforeCapabilities);
+    }
+
+    public void testCapabilitiesReturnsFalsePartiallyUpgraded() {
+        if (isMixedCluster()) {
+
+        }
+    }
+}

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/NodesCapabilitiesUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/NodesCapabilitiesUpgradeIT.java
@@ -52,8 +52,11 @@ public class NodesCapabilitiesUpgradeIT extends AbstractRollingUpgradeTestCase {
             // capabilities checks should either fail (if talking to an old node),
             // or return false as not all nodes have the API (if talking to a new node)
             try {
-                assertThat("Upgraded node should report no capabilities supported",
-                    clusterHasCapability("GET", "_capabilities", List.of(), List.of()), isPresentWith(false));
+                assertThat(
+                    "Upgraded node should report no capabilities supported",
+                    clusterHasCapability("GET", "_capabilities", List.of(), List.of()),
+                    isPresentWith(false)
+                );
             } catch (ResponseException e) {
                 if (e.getResponse().getStatusLine().getStatusCode() != 400) {
                     // throw explicitly to capture exception too

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/capabilities/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/capabilities/10_basic.yml
@@ -1,9 +1,6 @@
 ---
 "Capabilities API":
 
-  - skip:
-      awaits_fix: "https://github.com/elastic/elasticsearch/issues/108509"
-
   - requires:
       capabilities:
         - method: GET

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/capabilities/NodesCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/capabilities/NodesCapabilitiesResponse.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
@@ -37,8 +38,13 @@ public class NodesCapabilitiesResponse extends BaseNodesResponse<NodeCapability>
     }
 
     public Optional<Boolean> isSupported() {
-        // if there are any failures, we don't know if it is fully supported by all nodes in the cluster
-        if (hasFailures() || getNodes().isEmpty()) return Optional.empty();
+        if (hasFailures() || getNodes().isEmpty()) {
+            // there's no nodes in the response (uh? what about ourselves?)
+            // or there's a problem (hopefully transient) talking to one or more nodes.
+            // We don't have enough information to decide if it's supported or not, so return unknown
+            return Optional.empty();
+        }
+
         return Optional.of(getNodes().stream().allMatch(NodeCapability::isSupported));
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/capabilities/NodesCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/capabilities/NodesCapabilitiesResponse.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 

--- a/server/src/main/java/org/elasticsearch/rest/RestFeatures.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestFeatures.java
@@ -12,10 +12,17 @@ import org.elasticsearch.Version;
 import org.elasticsearch.features.FeatureSpecification;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.rest.action.admin.cluster.RestClusterGetSettingsAction;
+import org.elasticsearch.rest.action.admin.cluster.RestNodesCapabilitiesAction;
 
 import java.util.Map;
+import java.util.Set;
 
 public class RestFeatures implements FeatureSpecification {
+    @Override
+    public Set<NodeFeature> getFeatures() {
+        return Set.of(RestNodesCapabilitiesAction.CAPABILITIES_ACTION);
+    }
+
     @Override
     public Map<NodeFeature, Version> getHistoricalFeatures() {
         return Map.of(RestClusterGetSettingsAction.SUPPORTS_GET_SETTINGS_ACTION, Version.V_8_3_0);

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesCapabilitiesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesCapabilitiesAction.java
@@ -11,6 +11,7 @@ package org.elasticsearch.rest.action.admin.cluster;
 import org.elasticsearch.action.admin.cluster.node.capabilities.NodesCapabilitiesRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.Scope;
@@ -25,6 +26,8 @@ import java.util.Set;
 
 @ServerlessScope(Scope.INTERNAL)
 public class RestNodesCapabilitiesAction extends BaseRestHandler {
+
+    public static final NodeFeature CAPABILITIES_ACTION = new NodeFeature("rest.capabilities_action");
 
     @Override
     public List<Route> routes() {


### PR DESCRIPTION
Return `false` when we run capabilities checks on mixed-version clusters. This fixes #108509