### PR TITLE
Fix leaking ArraySearchPhaseResults during node shutdown

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -374,7 +374,16 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
     protected void fork(final Runnable runnable) {
         executor.execute(new AbstractRunnable() {
             @Override
-            public void onFailure(Exception e) {}
+            public void onFailure(Exception e) {
+                logger.error(() -> "unexpected error during [" + task + "]", e);
+                assert false : e;
+            }
+
+            @Override
+            public void onRejection(Exception e) {
+                // avoid leaks during node shutdown by executing on the current thread if the executor shuts down
+                doRun();
+            }
 
             @Override
             protected void doRun() {

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -382,6 +382,7 @@ abstract class AbstractSearchAsyncAction<Result extends SearchPhaseResult> exten
             @Override
             public void onRejection(Exception e) {
                 // avoid leaks during node shutdown by executing on the current thread if the executor shuts down
+                assert e instanceof EsRejectedExecutionException esre && esre.isExecutorShutdown() : e;
                 doRun();
             }
 

--- a/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/AbstractSearchAsyncAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.shard.ShardId;

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlDistributedFailureIT.java
@@ -144,7 +144,6 @@ public class MlDistributedFailureIT extends BaseMlIntegTestCase {
         });
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/104081")
     public void testFullClusterRestart() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(3);
         ensureStableCluster();


### PR DESCRIPTION
We should not quietly ignore exceptions during node shutdown. Lets do what we do on the transport side and just execute on the current thread if forking during shutdown is not possible anymore.

Closes #104361
Closes #103108
Closes #104081
