### PR TITLE
Fix serialization of `JoinStatus#age`

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -196,6 +196,7 @@ public class TransportVersions {
     public static final TransportVersion ROLLUP_USAGE = def(8_653_00_0);
     public static final TransportVersion SECURITY_ROLE_DESCRIPTION = def(8_654_00_0);
     public static final TransportVersion ML_INFERENCE_AZURE_OPENAI_COMPLETIONS = def(8_655_00_0);
+    public static final TransportVersion JOIN_STATUS_AGE_SERIALIZATION = def(8_656_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,


### PR DESCRIPTION
This particular field is being sent in a strange way today. This commit
fixes the wire protocol to use the standard `TimeValue` serialization.