### PR TITLE
[Inference API] Add CohereUtilsTests

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereUtilsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/request/cohere/CohereUtilsTests.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.external.request.cohere;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.hamcrest.Matchers.is;
+
+public class CohereUtilsTests extends ESTestCase {
+
+    public void testCreateRequestSourceHeader() {
+        var requestSourceHeader = CohereUtils.createRequestSourceHeader();
+
+        assertThat(requestSourceHeader.getName(), is("Request-Source"));
+        assertThat(requestSourceHeader.getValue(), is("unspecified:elasticsearch"));
+    }
+
+}


### PR DESCRIPTION
While working on Cohere completions I've noticed that there are no tests for `CohereUtils`. Added them with this PR.