### PR TITLE
Introduce `assertNoSuccessListener` utility

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinValidationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinValidationServiceTests.java
@@ -60,6 +60,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.elasticsearch.action.support.ActionTestUtils.assertNoSuccessListener;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 
@@ -295,17 +296,9 @@ public class JoinValidationServiceTests extends ESTestCase {
                 assertSame(node, joiningNode);
                 assertEquals(JoinValidationService.JOIN_VALIDATE_ACTION_NAME, action);
 
-                final var listener = new ActionListener<TransportResponse>() {
-                    @Override
-                    public void onResponse(TransportResponse transportResponse) {
-                        fail("should not succeed");
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        handleError(requestId, new RemoteTransportException(node.getName(), node.getAddress(), action, e));
-                    }
-                };
+                final ActionListener<TransportResponse> listener = assertNoSuccessListener(
+                    e -> handleError(requestId, new RemoteTransportException(node.getName(), node.getAddress(), action, e))
+                );
 
                 try (var ignored = NamedWriteableRegistryTests.ignoringUnknownNamedWriteables(); var out = new BytesStreamOutput()) {
                     request.writeTo(out);

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -80,6 +80,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
+import static org.elasticsearch.action.support.ActionTestUtils.assertNoSuccessListener;
 import static org.elasticsearch.cluster.service.MasterService.MAX_TASK_DESCRIPTION_CHARS;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
@@ -1041,30 +1042,22 @@ public class MasterServiceTests extends ESTestCase {
                     threadContext.putHeader(testContextHeaderName, testContextHeaderValue);
                     final var expectFailure = randomBoolean();
                     final var taskComplete = new AtomicBoolean();
-                    final var task = new Task(expectFailure, testResponseHeaderValue, new ActionListener<>() {
-                        @Override
-                        public void onResponse(ClusterState clusterState) {
-                            throw new AssertionError("should not succeed");
+                    final var task = new Task(expectFailure, testResponseHeaderValue, assertNoSuccessListener(e -> {
+                        assertEquals(testContextHeaderValue, threadContext.getHeader(testContextHeaderName));
+                        assertEquals(List.of(testResponseHeaderValue), threadContext.getResponseHeaders().get(testResponseHeaderName));
+                        assertThat(e, instanceOf(FailedToCommitClusterStateException.class));
+                        assertThat(e.getMessage(), equalTo(publicationFailedExceptionMessage));
+                        if (expectFailure) {
+                            assertThat(e.getSuppressed().length, greaterThan(0));
+                            var suppressed = e.getSuppressed()[0];
+                            assertThat(suppressed, instanceOf(ElasticsearchException.class));
+                            assertThat(suppressed.getMessage(), equalTo(taskFailedExceptionMessage));
                         }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            assertEquals(testContextHeaderValue, threadContext.getHeader(testContextHeaderName));
-                            assertEquals(List.of(testResponseHeaderValue), threadContext.getResponseHeaders().get(testResponseHeaderName));
-                            assertThat(e, instanceOf(FailedToCommitClusterStateException.class));
-                            assertThat(e.getMessage(), equalTo(publicationFailedExceptionMessage));
-                            if (expectFailure) {
-                                assertThat(e.getSuppressed().length, greaterThan(0));
-                                var suppressed = e.getSuppressed()[0];
-                                assertThat(suppressed, instanceOf(ElasticsearchException.class));
-                                assertThat(suppressed.getMessage(), equalTo(taskFailedExceptionMessage));
-                            }
-                            assertNotNull(publishedState.get());
-                            assertNotSame(stateBeforeFailure, publishedState.get());
-                            assertTrue(taskComplete.compareAndSet(false, true));
-                            publishFailureCountdown.countDown();
-                        }
-                    });
+                        assertNotNull(publishedState.get());
+                        assertNotSame(stateBeforeFailure, publishedState.get());
+                        assertTrue(taskComplete.compareAndSet(false, true));
+                        publishFailureCountdown.countDown();
+                    }));
 
                     queue.submitTask("test", task, null);
                 }

--- a/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/ActionTestUtils.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.fail;
+import static org.elasticsearch.test.ESTestCase.fail;
 
 public class ActionTestUtils {
 
@@ -84,7 +84,7 @@ public class ActionTestUtils {
         return new ActionListener<>() {
             @Override
             public void onResponse(T result) {
-                fail("unexpected success with result [" + result + "]");
+                fail(null, "unexpected success with result [%s] while expecting to handle failure with [%s]", result, consumer);
             }
 
             @Override
@@ -95,7 +95,7 @@ public class ActionTestUtils {
                     if (e2 != e) {
                         e2.addSuppressed(e);
                     }
-                    ESTestCase.fail(e2, "unexpected failure in onFailure");
+                    fail(e2, "unexpected failure in onFailure handler for [%s]", consumer);
                 }
             }
         };

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -61,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonMap;
+import static org.elasticsearch.action.support.ActionTestUtils.assertNoSuccessListener;
 import static org.elasticsearch.common.xcontent.support.XContentMapValues.extractValue;
 import static org.elasticsearch.xpack.ml.DefaultMachineLearningExtension.ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS;
 import static org.hamcrest.Matchers.arrayContaining;
@@ -334,10 +335,7 @@ public class DestinationIndexTests extends ESTestCase {
                 clock,
                 config,
                 ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS,
-                ActionListener.wrap(
-                    response -> fail("should not succeed"),
-                    e -> assertThat(e.getMessage(), Matchers.matchesRegex(finalErrorMessage))
-                )
+                assertNoSuccessListener(e -> assertThat(e.getMessage(), Matchers.matchesRegex(finalErrorMessage)))
             );
 
             return null;
@@ -578,8 +576,7 @@ public class DestinationIndexTests extends ESTestCase {
             clock,
             config,
             ANALYTICS_DEST_INDEX_ALLOWED_SETTINGS,
-            ActionListener.wrap(
-                response -> fail("should not succeed"),
+            assertNoSuccessListener(
                 e -> assertThat(
                     e.getMessage(),
                     equalTo("A field that matches the dest.results_field [ml] already exists; please set a different results_field")


### PR DESCRIPTION
Similar to `assertNoFailureListener`, sometimes we need a listener which
asserts it is not completed successfully.