### PR TITLE
[8.13] [Connector API][Docs] List supported enum values for the list request (#108557)

### DIFF
--- a/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
+++ b/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
@@ -30,13 +30,13 @@ Returns information about all stored connector sync jobs ordered by their creati
 (Optional, integer) The offset from the first result to fetch. Defaults to `0`.
 
 `status`::
-(Optional, job status) The job status the fetched sync jobs need to have.
+(Optional, job status) A comma-separated list of job statuses to filter the results. Available statuses include: `canceling`, `canceled`, `completed`, `error`, `in_progress`, `pending`, `suspended`.
 
 `connector_id`::
 (Optional, string) The connector id the fetched sync jobs need to have.
 
 `job_type`::
-(Optional, job type) A comma-separated list of job types.
+(Optional, job type) A comma-separated list of job types. Available job types are: `full`, `incremental` and `access_control`.
 
 [[list-connector-sync-jobs-api-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
Backports the following commits to 8.13:
 - [Connector API][Docs] List supported enum values for the list request (#108557)