### PR TITLE
[8.14] Remove leading is_ prefix from Enterprise geoip docs (#108518)

### DIFF
--- a/docs/changelog/108518.yaml
+++ b/docs/changelog/108518.yaml
@@ -1,0 +1,5 @@
+pr: 108518
+summary: Remove leading is_ prefix from Enterprise geoip docs
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -483,22 +483,22 @@ public final class GeoIpProcessor extends AbstractProcessor {
                     }
                 }
                 case HOSTING_PROVIDER -> {
-                    geoData.put("is_hosting_provider", isHostingProvider);
+                    geoData.put("hosting_provider", isHostingProvider);
                 }
                 case TOR_EXIT_NODE -> {
-                    geoData.put("is_tor_exit_node", isTorExitNode);
+                    geoData.put("tor_exit_node", isTorExitNode);
                 }
                 case ANONYMOUS_VPN -> {
-                    geoData.put("is_anonymous_vpn", isAnonymousVpn);
+                    geoData.put("anonymous_vpn", isAnonymousVpn);
                 }
                 case ANONYMOUS -> {
-                    geoData.put("is_anonymous", isAnonymous);
+                    geoData.put("anonymous", isAnonymous);
                 }
                 case PUBLIC_PROXY -> {
-                    geoData.put("is_public_proxy", isPublicProxy);
+                    geoData.put("public_proxy", isPublicProxy);
                 }
                 case RESIDENTIAL_PROXY -> {
-                    geoData.put("is_residential_proxy", isResidentialProxy);
+                    geoData.put("residential_proxy", isResidentialProxy);
                 }
             }
         }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorTests.java
@@ -373,12 +373,12 @@ public class GeoIpProcessorTests extends ESTestCase {
         location.put("lon", -1.25);
         assertThat(geoData.get("location"), equalTo(location));
         assertThat(geoData.get("network"), equalTo("2.125.160.216/29"));
-        assertThat(geoData.get("is_hosting_provider"), equalTo(false));
-        assertThat(geoData.get("is_tor_exit_node"), equalTo(false));
-        assertThat(geoData.get("is_anonymous_vpn"), equalTo(false));
-        assertThat(geoData.get("is_anonymous"), equalTo(false));
-        assertThat(geoData.get("is_public_proxy"), equalTo(false));
-        assertThat(geoData.get("is_residential_proxy"), equalTo(false));
+        assertThat(geoData.get("hosting_provider"), equalTo(false));
+        assertThat(geoData.get("tor_exit_node"), equalTo(false));
+        assertThat(geoData.get("anonymous_vpn"), equalTo(false));
+        assertThat(geoData.get("anonymous"), equalTo(false));
+        assertThat(geoData.get("public_proxy"), equalTo(false));
+        assertThat(geoData.get("residential_proxy"), equalTo(false));
     }
 
     public void testAddressIsNotInTheDatabase() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Remove leading is_ prefix from Enterprise geoip docs (#108518)