### PR TITLE
ESQL: Use `required_capability` in CSV spec

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/blog.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/blog.csv-spec
@@ -1,7 +1,7 @@
 # Examples that were published in a blog post
 
 2023-08-08.full-blown-query
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
   FROM employees
 | WHERE still_hired == true

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/boolean.csv-spec
@@ -63,7 +63,7 @@ avg(salary):double | always_false:boolean
 
 
 in
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | keep emp_no, is_rehired, still_hired | where is_rehired in (still_hired, true) | where is_rehired != still_hired;
 ignoreOrder:true
@@ -236,7 +236,7 @@ emp_no:integer |languages:integer |byte2bool:boolean |short2bool:boolean
 ;
 
 mvSort
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 row a = [true, false, true, false] | eval sa = mv_sort(a), sb = mv_sort(a, "DESC");
 
@@ -245,7 +245,7 @@ a:boolean                  | sa:boolean                 | sb:boolean
 ;
 
 mvSortEmp
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 FROM employees
 | eval sd = mv_sort(is_rehired, "DESC"), sa = mv_sort(is_rehired)
@@ -263,7 +263,7 @@ emp_no:integer | is_rehired:boolean       | sa:boolean               | sd:boolea
 ;
 
 mvSlice
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 row a = [true, false, false, true]
 | eval a1 = mv_slice(a, 1), a2 = mv_slice(a, 2, 3);
@@ -273,7 +273,7 @@ a:boolean                  | a1:boolean | a2:boolean
 ;
 
 mvSliceEmp
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(is_rehired, 0)
@@ -290,7 +290,7 @@ emp_no:integer | is_rehired:boolean       | a1:boolean
 ;
 
 values
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -302,7 +302,7 @@ required_feature: esql.agg_values
 ;
 
 valuesGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -323,7 +323,7 @@ still_hired:boolean | first_letter:keyword
 ;
 
 valuesGroupedByOrdinals
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -347,7 +347,7 @@ still_hired:boolean | job_positions:keyword
 ;
 
 implicitCastingEqual
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from employees | where still_hired == "true" | sort emp_no | keep emp_no | limit 1;
 
 emp_no:integer
@@ -355,7 +355,7 @@ emp_no:integer
 ;
 
 implicitCastingNotEqual
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from employees | where still_hired != "true" | sort emp_no | keep emp_no | limit 1;
 
 emp_no:integer
@@ -363,7 +363,7 @@ emp_no:integer
 ;
 
 implicitCastingIn
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from employees | where still_hired in ("true", "false")  | sort emp_no | keep emp_no | limit 1;
 
 emp_no:integer
@@ -371,7 +371,7 @@ emp_no:integer
 ;
 
 implicitCastingInField
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from employees | where false in ("true", still_hired)  | sort emp_no | keep emp_no | limit 1;
 
 emp_no:integer

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/cartesian_multipolygons.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/cartesian_multipolygons.csv-spec
@@ -6,7 +6,7 @@
 # Test against a polygon similar in size to the Bottom Left polygon
 
 whereIntersectsSinglePolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM cartesian_multipolygons
 | WHERE ST_Intersects(shape, TO_CARTESIANSHAPE("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))"))
@@ -25,7 +25,7 @@ id:l | name:keyword            | shape:cartesian_shape
 ;
 
 whereContainsSinglePolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM cartesian_multipolygons
 | WHERE ST_Contains(shape, TO_CARTESIANSHAPE("POLYGON((0.001 0.001, 0.999 0.001, 0.999 0.999, 0.001 0.999, 0.001 0.001))"))
@@ -38,7 +38,7 @@ id:l | name:keyword | shape:cartesian_shape
 ;
 
 whereWithinSinglePolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM cartesian_multipolygons
 | WHERE ST_Within(shape, TO_CARTESIANSHAPE("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))"))
@@ -53,7 +53,7 @@ id:l | name:keyword            | shape:cartesian_shape
 ;
 
 whereDisjointSinglePolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM cartesian_multipolygons
 | WHERE ST_Disjoint(shape, TO_CARTESIANSHAPE("POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))"))
@@ -79,7 +79,7 @@ id:l | name:keyword             | shape:cartesian_shape
 # Test against a polygon smaller in size to the Bottom Left polygon
 
 whereIntersectsSmallerPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM cartesian_multipolygons
 | WHERE ST_Intersects(shape, TO_CARTESIANSHAPE("POLYGON((0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))"))
@@ -98,7 +98,7 @@ id:l | name:keyword | shape:cartesian_shape
 ;
 
 whereContainsSmallerPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM cartesian_multipolygons
 | WHERE ST_Contains(shape, TO_CARTESIANSHAPE("POLYGON((0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))"))
@@ -111,7 +111,7 @@ id:l | name:keyword | shape:cartesian_shape
 ;
 
 whereWithinSmallerPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM cartesian_multipolygons
 | WHERE ST_Within(shape, TO_CARTESIANSHAPE("POLYGON((0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))"))
@@ -123,7 +123,7 @@ id:l | name:keyword | shape:cartesian_shape
 ;
 
 whereDisjointSmallerPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM cartesian_multipolygons
 | WHERE ST_Disjoint(shape, TO_CARTESIANSHAPE("POLYGON((0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.8, 0.2 0.2))"))
@@ -149,7 +149,7 @@ id:l | name:keyword             | shape:cartesian_shape
 # Test against a polygon similar in size to the entire test data
 
 whereIntersectsLargerPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM cartesian_multipolygons
 | WHERE ST_Intersects(shape, TO_CARTESIANSHAPE("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))"))
@@ -180,7 +180,7 @@ id:l | name:keyword            | shape:cartesian_shape
 ;
 
 whereContainsLargerPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM cartesian_multipolygons
 | WHERE ST_Contains(shape, TO_CARTESIANSHAPE("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))"))
@@ -191,7 +191,7 @@ id:l | name:keyword            | shape:cartesian_shape
 ;
 
 whereWithinLargerPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM cartesian_multipolygons
 | WHERE ST_Within(shape, TO_CARTESIANSHAPE("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))"))
@@ -222,7 +222,7 @@ id:l | name:keyword            | shape:cartesian_shape
 ;
 
 whereDisjointLargerPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM cartesian_multipolygons
 | WHERE ST_Disjoint(shape, TO_CARTESIANSHAPE("POLYGON((0 0, 3 0, 3 3, 0 3, 0 0))"))
@@ -236,7 +236,7 @@ id:l | name:keyword            | shape:cartesian_shape
 # Test against a polygon larger than all test data
 
 whereIntersectsEvenLargerPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM cartesian_multipolygons
 | WHERE ST_Intersects(shape, TO_CARTESIANSHAPE("POLYGON((-1 -1, 4 -1, 4 4, -1 4, -1 -1))"))
@@ -267,7 +267,7 @@ id:l | name:keyword            | shape:cartesian_shape
 ;
 
 whereContainsEvenLargerPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM cartesian_multipolygons
 | WHERE ST_Contains(shape, TO_CARTESIANSHAPE("POLYGON((-1 -1, 4 -1, 4 4, -1 4, -1 -1))"))
@@ -278,7 +278,7 @@ id:l | name:keyword            | shape:cartesian_shape
 ;
 
 whereWithinEvenLargerPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM cartesian_multipolygons
 | WHERE ST_Within(shape, TO_CARTESIANSHAPE("POLYGON((-1 -1, 4 -1, 4 4, -1 4, -1 -1))"))
@@ -309,7 +309,7 @@ id:l | name:keyword            | shape:cartesian_shape
 ;
 
 whereDisjointEvenLargerPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM cartesian_multipolygons
 | WHERE ST_Disjoint(shape, TO_CARTESIANSHAPE("POLYGON((-1 -1, 4 -1, 4 4, -1 4, -1 -1))"))

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/conditional.csv-spec
@@ -130,7 +130,7 @@ error_rate:double | hour:date
 
 
 nullOnMultivaluesMathOperation
-required_feature: esql.disable_nullable_opts
+required_capability: disable_nullable_opts
 
 ROW a = 5, b = [ 1, 2 ]| EVAL sum = a + b| LIMIT 1 |  WHERE sum IS NULL;
 warning:Line 1:37: evaluation of [a + b] failed, treating result as null. Only first 20 failures recorded.
@@ -142,7 +142,7 @@ a:integer | b:integer | sum:integer
 
 
 notNullOnMultivaluesMathOperation
-required_feature: esql.disable_nullable_opts
+required_capability: disable_nullable_opts
 
 ROW a = 5, b = [ 1, 2 ]| EVAL sum = a + b| LIMIT 1 |  WHERE sum IS NOT NULL;
 warning:Line 1:37: evaluation of [a + b] failed, treating result as null. Only first 20 failures recorded.
@@ -153,7 +153,7 @@ a:integer | b:integer | sum:integer
 
 
 nullOnMultivaluesComparisonOperation
-required_feature: esql.disable_nullable_opts
+required_capability: disable_nullable_opts
 
 ROW a = 5, b = [ 1, 2 ]| EVAL same = a == b| LIMIT 1 |  WHERE same IS NULL;
 warning:Line 1:38: evaluation of [a == b] failed, treating result as null. Only first 20 failures recorded.
@@ -166,7 +166,7 @@ a:integer | b:integer | same:boolean
 
 
 notNullOnMultivaluesComparisonOperation
-required_feature: esql.disable_nullable_opts
+required_capability: disable_nullable_opts
 
 ROW a = 5, b = [ 1, 2 ]| EVAL same = a == b| LIMIT 1 |  WHERE same IS NOT NULL;
 warning:Line 1:38: evaluation of [a == b] failed, treating result as null. Only first 20 failures recorded.
@@ -177,7 +177,7 @@ a:integer | b:integer | same:boolean
 
 
 notNullOnMultivaluesComparisonOperationWithPartialMatch
-required_feature: esql.disable_nullable_opts
+required_capability: disable_nullable_opts
 
 ROW a = 5, b = [ 5, 2 ]| EVAL same = a == b| LIMIT 1 |  WHERE same IS NOT NULL;
 warning:Line 1:38: evaluation of [a == b] failed, treating result as null. Only first 20 failures recorded.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/convert.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/convert.csv-spec
@@ -1,7 +1,7 @@
 // Conversion-specific tests
 
 convertToBoolean
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW zero=0::boolean, one=1::bool
 ;
 
@@ -10,7 +10,7 @@ false          |true
 ;
 
 convertToInteger
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW zero="0"::integer, one="1"::int
 ;
 
@@ -19,7 +19,7 @@ ROW zero="0"::integer, one="1"::int
 ;
 
 convertToIP
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW ip="1.1.1.1"::ip
 ;
 
@@ -28,7 +28,7 @@ ROW ip="1.1.1.1"::ip
 ;
 
 convertToLong
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW long="-1"::long
 ;
 
@@ -37,7 +37,7 @@ long:long
 ;
 
 convertToLongWithWarning
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW long="1.1.1.1"::long
 ;
 warning:Line 1:10: evaluation of [\"1.1.1.1\"::long] failed, treating result as null. Only first 20 failures recorded.
@@ -48,7 +48,7 @@ null
 ;
 
 convertToDouble
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW zero="0"::double
 ;
 
@@ -57,7 +57,7 @@ ROW zero="0"::double
 ;
 
 convertToString
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW one=1::keyword, two=2::text, three=3::string
 ;
 
@@ -66,7 +66,7 @@ ROW one=1::keyword, two=2::text, three=3::string
 ;
 
 convertToDatetime
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW date="1985-01-01T00:00:00Z"::datetime, zero=0::datetime
 ;
 
@@ -75,7 +75,7 @@ ROW date="1985-01-01T00:00:00Z"::datetime, zero=0::datetime
 ;
 
 convertToVersion
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW ver="1.2.3"::version
 ;
 
@@ -84,7 +84,7 @@ ROW ver="1.2.3"::version
 ;
 
 convertToUnsignedLong
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW zero="0"::unsigned_long, two=abs(-2)::UnsigneD_LOng
 ;
 
@@ -93,7 +93,7 @@ ROW zero="0"::unsigned_long, two=abs(-2)::UnsigneD_LOng
 ;
 
 convertToGeoPoint
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW gp="POINT(0 0)"::geo_point
 ;
 
@@ -102,7 +102,7 @@ POINT (0.0 0.0)
 ;
 
 convertToGeoShape
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW gs="POINT(0 0)"::geo_shape
 ;
 
@@ -111,7 +111,7 @@ POINT (0.0 0.0)
 ;
 
 convertToCartesianPoint
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW cp="POINT(0 0)"::cartesian_point
 ;
 
@@ -120,7 +120,7 @@ POINT (0.0 0.0)
 ;
 
 convertToCartesianShape
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW cs="POINT(0 0)"::cartesian_shape
 ;
 
@@ -129,7 +129,7 @@ POINT (0.0 0.0)
 ;
 
 convertChained
-required_feature: esql.casting_operator
+required_capability: casting_operator
 ROW one=1::STRING::LONG::BOOL
 ;
 
@@ -138,7 +138,7 @@ true
 ;
 
 convertWithIndexMultipleConversionsInSameExpressionAndConversionInFiltering
-required_feature: esql.casting_operator
+required_capability: casting_operator
  FROM employees
 | EVAL en_str=emp_no::STRING, bd=ABS(birth_date::LONG)::STRING
 | KEEP en_str, emp_no, bd, birth_date
@@ -153,7 +153,7 @@ required_feature: esql.casting_operator
 ;
 
 convertWithBoolExpressionAndQualifiedName
-required_feature: esql.casting_operator
+required_capability: casting_operator
  FROM employees
 | EVAL neg = (NOT still_hired)::string, sf = ROUND(height.scaled_float::double, 2)
 | KEEP emp_no, still_hired, neg, sf
@@ -169,7 +169,7 @@ required_feature: esql.casting_operator
 ;
 
 docsCastOperator
-required_feature: esql.casting_operator
+required_capability: casting_operator
 //tag::docsCastOperator[]
 ROW ver = CONCAT(("0"::INT + 1)::STRING, ".2.3")::VERSION
 //end::docsCastOperator[]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/date.csv-spec
@@ -216,7 +216,7 @@ string:keyword                                          |datetime:date
 ;
 
 convertFromUnsignedLong
-required_feature:esql.convert_warn
+required_capability: convert_warn
 
 row ul = [9223372036854775808, 520128000000] | eval dt = to_datetime(ul);
 warning:Line 1:58: evaluation of [to_datetime(ul)] failed, treating result as null. Only first 20 failures recorded.
@@ -357,7 +357,7 @@ date1:date          |         date2:date          |    dd_ms:integer
 ;
 
 evalDateDiffString
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 ROW date1 = TO_DATETIME("2023-12-02T11:00:00.000Z")
 | EVAL dd_ms = DATE_DIFF("microseconds", date1, "2023-12-02T11:00:00.001Z")
@@ -623,7 +623,7 @@ dt:datetime              |plus_post:datetime |plus_pre:datetime
 
 datePlusQuarter
 # "quarter" introduced in 8.15
-required_feature: esql.timespan_abbreviations
+required_capability: timespan_abbreviations
 row dt = to_dt("2100-01-01T01:01:01.000Z")
 | eval plusQuarter = dt + 2 quarters
 ;
@@ -634,7 +634,7 @@ dt:datetime              | plusQuarter:datetime
 
 datePlusAbbreviatedDurations
 # abbreviations introduced in 8.15
-required_feature: esql.timespan_abbreviations
+required_capability: timespan_abbreviations
 row dt = to_dt("2100-01-01T00:00:00.000Z")
 | eval plusDurations = dt + 1 h + 2 min + 2 sec + 1 s + 4 ms
 ;
@@ -645,7 +645,7 @@ dt:datetime              | plusDurations:datetime
 
 datePlusAbbreviatedPeriods
 # abbreviations introduced in 8.15
-required_feature: esql.timespan_abbreviations
+required_capability: timespan_abbreviations
 row dt = to_dt("2100-01-01T00:00:00.000Z")
 | eval plusDurations = dt + 0 yr + 1y + 2 q + 3 mo + 4 w + 3 d
 ;
@@ -855,7 +855,7 @@ date:date                 | year:long
 ;
 
 dateExtractString
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 ROW date = DATE_PARSE("yyyy-MM-dd", "2022-05-06")
 | EVAL year = DATE_EXTRACT("year", "2022-05-06")
@@ -896,7 +896,7 @@ Anneke         |Preusig        |1989-06-02T00:00:00.000Z|1989-06-02
 ;
 
 evalDateFormatString
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 ROW a = 1
 | EVAL df = DATE_FORMAT("YYYY-MM-dd", "1989-06-02T00:00:00.000Z")
@@ -925,7 +925,7 @@ Anneke         |Preusig        |1989-06-02T00:00:00.000Z|1989-01-01T00:00:00.000
 ;
 
 evalDateTruncString
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 ROW a = 1
 | EVAL year_hired = DATE_TRUNC(1 year, "1991-06-26T00:00:00.000Z")
@@ -990,7 +990,7 @@ FROM sample_data
 ;
 
 mvSort
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 row a = ["1985-01-01T00:00:00.000Z", "1986-01-01T00:00:00.000Z", "1987-01-01T00:00:00.000Z"]
 | eval datetime = TO_DATETIME(a)
@@ -1019,7 +1019,7 @@ count:long | age:long
 ;
 
 values
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10003
@@ -1031,7 +1031,7 @@ required_feature: esql.agg_values
 ;
 
 valuesGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -1052,7 +1052,7 @@ required_feature: esql.agg_values
 ;
 
 valuesGroupedByOrdinals
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -1077,7 +1077,7 @@ required_feature: esql.agg_values
 ;
 
 implicitCastingNotEqual
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 from employees | where birth_date != "1957-05-23T00:00:00Z" | keep emp_no, birth_date | sort emp_no | limit 3;
 
 emp_no:integer | birth_date:datetime
@@ -1087,7 +1087,7 @@ emp_no:integer | birth_date:datetime
 ;
 
 implicitCastingLessThanOrEqual
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 from employees | where birth_date <= "1957-05-20T00:00:00Z" | keep emp_no, birth_date | sort emp_no | limit 3;
 
 emp_no:integer | birth_date:datetime
@@ -1097,7 +1097,7 @@ emp_no:integer | birth_date:datetime
 ;
 
 implicitCastingGreaterThan
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 from employees | where birth_date > "1957-05-24T00:00:00Z" | keep emp_no, birth_date | sort emp_no | limit 3;
 
 emp_no:integer | birth_date:datetime

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/enrich.csv-spec
@@ -32,7 +32,7 @@ median_duration:double | env:keyword
 ;
 
 simple
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 // tag::enrich[]
 ROW language_code = "1"  
@@ -47,7 +47,7 @@ language_code:keyword  | language_name:keyword
 ;
 
 enrichOnSimple
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 // tag::enrich_on[]
 ROW a = "1"  
@@ -63,7 +63,7 @@ a:keyword  | language_name:keyword
 
 
 enrichOn
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees  | sort emp_no | limit 1 | eval x = to_string(languages) | enrich languages_policy on x  | keep emp_no, language_name;
 
@@ -73,7 +73,7 @@ emp_no:integer | language_name:keyword
 
 
 enrichOn2
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees | eval x = to_string(languages) | enrich languages_policy on x  | keep emp_no, language_name | sort emp_no | limit 1 ;
 
@@ -83,7 +83,7 @@ emp_no:integer | language_name:keyword
 
 
 simpleSortLimit
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees  | eval x = to_string(languages) | enrich languages_policy on x  | keep emp_no, language_name | sort emp_no | limit 1;
 
@@ -92,7 +92,7 @@ emp_no:integer | language_name:keyword
 ;
 
 with
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees | eval x = to_string(languages) | keep emp_no, x | sort emp_no | limit 1 
 | enrich languages_policy on x with language_name;
@@ -103,7 +103,7 @@ emp_no:integer | x:keyword | language_name:keyword
 
 
 withSimple
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 // tag::enrich_with[]
 ROW a = "1"  
@@ -119,7 +119,7 @@ a:keyword  | language_name:keyword
 
 
 withAlias
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees  | sort emp_no | limit 3 | eval x = to_string(languages) | keep emp_no, x 
 | enrich languages_policy on x with lang = language_name;
@@ -131,7 +131,7 @@ emp_no:integer | x:keyword | lang:keyword
 ;
 
 withAliasSimple
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 // tag::enrich_rename[]
 ROW a = "1"  
@@ -147,7 +147,7 @@ a:keyword  | name:keyword
 
 
 withAliasSort
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees | eval x = to_string(languages) | keep emp_no, x  | sort emp_no | limit 3 
 | enrich languages_policy on x with lang = language_name;
@@ -160,7 +160,7 @@ emp_no:integer | x:keyword | lang:keyword
 
 
 withAliasOverwriteName#[skip:-8.13.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees | sort emp_no
 | eval x = to_string(languages) | enrich languages_policy on x with emp_no = language_name
@@ -172,7 +172,7 @@ French
 ;
 
 withAliasAndPlain
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees  | sort emp_no desc | limit 3 | eval x = to_string(languages) | keep emp_no, x 
 | enrich languages_policy on x with lang = language_name, language_name;
@@ -185,7 +185,7 @@ emp_no:integer | x:keyword | lang:keyword | language_name:keyword
 
 
 withTwoAliasesSameProp
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees  | sort emp_no | limit 1 | eval x = to_string(languages) | keep emp_no, x 
 | enrich languages_policy on x with lang = language_name, lang2 = language_name;
@@ -196,7 +196,7 @@ emp_no:integer | x:keyword | lang:keyword | lang2:keyword
 
 
 redundantWith
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees  | sort emp_no | limit 1 | eval x = to_string(languages) | keep emp_no, x 
 | enrich languages_policy on x with language_name, language_name;
@@ -207,7 +207,7 @@ emp_no:integer | x:keyword | language_name:keyword
 
 
 nullInput
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees  | where emp_no == 10017 | keep emp_no, gender
 | enrich languages_policy on gender with language_name, language_name;
@@ -218,7 +218,7 @@ emp_no:integer | gender:keyword | language_name:keyword
 
  
 constantNullInput
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees  | where emp_no == 10020 | eval x = to_string(languages) | keep emp_no, x 
 | enrich languages_policy on x with language_name, language_name;
@@ -229,7 +229,7 @@ emp_no:integer | x:keyword | language_name:keyword
 
 
 multipleEnrich
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 row a = "1", b = "2", c = "10"  
 | enrich languages_policy on a with a_lang = language_name  
@@ -242,7 +242,7 @@ a:keyword | b:keyword | c:keyword | a_lang:keyword | b_lang:keyword | c_lang:key
 
 
 enrichEval
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 from employees | eval x = to_string(languages) 
 | enrich languages_policy on x with lang = language_name
@@ -258,8 +258,8 @@ emp_no:integer | x:keyword | lang:keyword | language:keyword
 
 
 multivalue
-required_feature: esql.enrich_load
-required_feature: esql.mv_sort
+required_capability: enrich_load
+required_capability: mv_sort
 
 row a = ["1", "2"] | enrich languages_policy on a with a_lang = language_name | eval a_lang = mv_sort(a_lang);  
 
@@ -269,7 +269,7 @@ a:keyword   | a_lang:keyword
 
 
 enrichCidr#[skip:-8.13.99, reason:enrich for cidr added in 8.14.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM sample_data
 | ENRICH client_cidr_policy ON client_ip WITH env
@@ -290,7 +290,7 @@ client_ip:ip | count_env:i | max_env:keyword
 
 
 enrichCidr2#[skip:-8.99.99, reason:ip_range support not added yet]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM sample_data
 | ENRICH client_cidr_policy ON client_ip WITH env, client_cidr
@@ -310,7 +310,7 @@ client_ip:ip | env:keyword               | client_cidr:ip_range
 
 
 enrichAgesStatsYear#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM employees
 | WHERE birth_date > "1960-01-01"
@@ -333,7 +333,7 @@ birth_year:long | age_group:keyword | count:long
 
 
 enrichAgesStatsAgeGroup#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM employees
 | WHERE birth_date IS NOT NULL
@@ -350,7 +350,7 @@ count:long | age_group:keyword
 
 
 enrichHeightsStats#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM employees
 | ENRICH heights_policy ON height WITH height_group = description
@@ -369,7 +369,7 @@ Very Tall      | 2.0        | 2.1        | 20
 
 
 enrichDecadesStats#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM employees
 | ENRICH decades_policy ON birth_date WITH birth_decade = decade, birth_description = description
@@ -390,7 +390,7 @@ null              | 1980          | null                | Radical Eighties   | 4
 
 
 spatialEnrichmentKeywordMatch#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM airports
 | WHERE abbrev == "CPH"
@@ -405,7 +405,7 @@ CPH             |  Copenhagen    |  POINT(12.5683 55.6761)  |  Denmark          
 
 
 spatialEnrichmentGeoMatch#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM airports
 | WHERE abbrev == "CPH"
@@ -420,8 +420,8 @@ CPH             |  Copenhagen    |  POINT(12.5683 55.6761)  |  Denmark          
 
 
 spatialEnrichmentGeoMatchStats#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
-required_feature: esql.enrich_load
-required_feature: esql.mv_warn
+required_capability: enrich_load
+required_capability: mv_warn
 
 FROM airports
 | ENRICH city_boundaries ON city_location WITH airport, region, city_boundary
@@ -437,7 +437,7 @@ POINT(1.396561 24.127649)  |  872         |  88               |  1044
 
 
 spatialEnrichmentKeywordMatchAndSpatialPredicate#[skip:-8.13.99, reason:st_intersects added in 8.14]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM airports
 | ENRICH city_names ON city WITH airport, region, city_boundary
@@ -455,7 +455,7 @@ count:long  |  airport_in_city:boolean
 
 
 spatialEnrichmentKeywordMatchAndSpatialAggregation#[skip:-8.13.99, reason:st_intersects added in 8.14]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM airports
 | ENRICH city_names ON city WITH airport, region, city_boundary
@@ -473,7 +473,7 @@ count:long  |  centroid:geo_point            |  airport_in_city:boolean
 
 
 spatialEnrichmentTextMatch#[skip:-8.13.99, reason:ENRICH extended in 8.14.0]
-required_feature: esql.enrich_load
+required_capability: enrich_load
 
 FROM airports
 | WHERE abbrev == "IDR"

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/eval.csv-spec
@@ -201,7 +201,7 @@ Kyoichi.       |Kyoichi.Maliniak |Kyoichi.MaliniakKyoichi.   |Kyoichi
 ;
 
 roundArrays
-required_feature: esql.disable_nullable_opts
+required_capability: disable_nullable_opts
 
 row a = [1.2], b = [2.4, 7.9] | eval c = round(a), d = round(b), e = round([1.2]), f = round([1.2, 4.6]), g = round([1.14], 1), h = round([1.14], [1, 2]);
 warning:Line 1:56: evaluation of [round(b)] failed, treating result as null. Only first 20 failures recorded.

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
@@ -92,7 +92,7 @@ int:integer |dbl:double
 ;
 
 lessThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change < 1 | keep emp_no, salary_change | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [salary_change < 1] failed, treating result as null. Only first 20 failures recorded.
@@ -108,7 +108,7 @@ emp_no:integer |salary_change:double
 ;
 
 greaterThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change > 1 | keep emp_no, salary_change | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [salary_change > 1] failed, treating result as null. Only first 20 failures recorded.
@@ -124,7 +124,7 @@ emp_no:integer |salary_change:double
 ;
 
 equalToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change == 1.19 | keep emp_no, salary_change | sort emp_no;
 warning:Line 1:24: evaluation of [salary_change == 1.19] failed, treating result as null. Only first 20 failures recorded.
@@ -136,7 +136,7 @@ emp_no:integer |salary_change:double
 ;
 
 equalToOrEqualToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change == 1.19 or salary_change == 7.58 | keep emp_no, salary_change | sort emp_no;
 warning:Line 1:24: evaluation of [salary_change] failed, treating result as null. Only first 20 failures recorded.
@@ -149,7 +149,7 @@ emp_no:integer |salary_change:double
 ;
 
 inMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change in (1.19, 7.58) | keep emp_no, salary_change | sort emp_no;
 warning:Line 1:24: evaluation of [salary_change in (1.19, 7.58)] failed, treating result as null. Only first 20 failures recorded.
@@ -162,7 +162,7 @@ emp_no:integer |salary_change:double
 ;
 
 notLessThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(salary_change < 1) | keep emp_no, salary_change | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [not(salary_change < 1)] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [salary_change < 1] failed, treating result as null. Only first 20 failures recorded.]
@@ -178,7 +178,7 @@ emp_no:integer |salary_change:double
 ;
 
 notGreaterThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(salary_change > 1) | keep emp_no, salary_change | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [not(salary_change > 1)] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [salary_change > 1] failed, treating result as null. Only first 20 failures recorded.]
@@ -194,7 +194,7 @@ emp_no:integer |salary_change:double
 ;
 
 notEqualToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(salary_change == 1.19) | keep emp_no, salary_change | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [not(salary_change == 1.19)] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [salary_change == 1.19] failed, treating result as null. Only first 20 failures recorded.]
@@ -241,7 +241,7 @@ row a = [1.1, 2.1, 2.1] | eval da = mv_dedupe(a);
 ;
 
 mvSliceEmp
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change, 0, 1)
@@ -436,7 +436,7 @@ ROW deg = [90.0, 180.0, 270.0]
 ;
 
 mvSort
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 row a = [4.0, 2.0, -3.0, 2.0] | eval sa = mv_sort(a), sd = mv_sort(a, "DESC");
 
@@ -445,7 +445,7 @@ a:double              | sa:double             | sd:double
 ;
 
 mvSortEmp
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 FROM employees
 | eval sd = mv_sort(salary_change, "DESC"), sa = mv_sort(salary_change)
@@ -467,7 +467,7 @@ emp_no:integer | salary_change:double    | sa:double               | sd:double
 ;
 
 values
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -479,7 +479,7 @@ required_feature: esql.agg_values
 ;
 
 valuesGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -500,7 +500,7 @@ required_feature: esql.agg_values
 ;
 
 valuesGroupedByOrdinals
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/from.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/from.csv-spec
@@ -130,7 +130,7 @@ c:l | name:k
 ;
 
 convertFromDatetimeWithOptions
-required_feature: esql.from_options
+required_capability: from_options
 
 // tag::convertFromDatetimeWithOptions[]
   FROM employees OPTIONS "allow_no_indices"="false","preference"="_local"

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ints.csv-spec
@@ -1,7 +1,7 @@
 // Integral types-specific tests
 
 inLongAndInt
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where avg_worked_seconds in (372957040, salary_change.long, 236703986) | where emp_no in (10017, emp_no - 1) | keep emp_no, avg_worked_seconds;
 warning:Line 1:24: evaluation of [avg_worked_seconds in (372957040, salary_change.long, 236703986)] failed, treating result as null. Only first 20 failures recorded.
@@ -68,7 +68,7 @@ long:long                    |ul:ul
 ;
 
 convertDoubleToUL
-required_feature:esql.convert_warn
+required_capability: convert_warn
 
 row d = 123.4 | eval ul = to_ul(d), overflow = to_ul(1e20);
 warningRegex:Line 1:48: evaluation of \[to_ul\(1e20\)\] failed, treating result as null. Only first 20 failures recorded.
@@ -127,7 +127,7 @@ int:integer       |long:long
 ;
 
 convertULToLong
-required_feature:esql.convert_warn
+required_capability: convert_warn
 
 row ul = [9223372036854775807, 9223372036854775808] | eval long = to_long(ul);
 warningRegex:Line 1:67: evaluation of \[to_long\(ul\)\] failed, treating result as null. Only first 20 failures recorded.
@@ -170,7 +170,7 @@ str1:keyword |str2:keyword |str3:keyword |long1:long  |long2:long |long3:long
 ;
 
 convertDoubleToLong
-required_feature:esql.convert_warn
+required_capability: convert_warn
 
 row d = 123.4 | eval d2l = to_long(d), overflow = to_long(1e19);
 warningRegex:Line 1:51: evaluation of \[to_long\(1e19\)\] failed, treating result as null. Only first 20 failures recorded.
@@ -190,7 +190,7 @@ int:integer       |ii:integer
 ;
 
 convertLongToInt
-required_feature:esql.convert_warn
+required_capability: convert_warn
 
 // tag::to_int-long[]
 ROW long = [5013792, 2147483647, 501379200000]
@@ -207,7 +207,7 @@ long:long                           |int:integer
 ;
 
 convertULToInt
-required_feature:esql.convert_warn
+required_capability: convert_warn
 
 row ul = [2147483647, 9223372036854775808] | eval int = to_int(ul);
 warningRegex:Line 1:57: evaluation of \[to_int\(ul\)\] failed, treating result as null. Only first 20 failures recorded.
@@ -239,7 +239,7 @@ int_str:keyword  |int_dbl_str:keyword |is2i:integer|ids2i:integer
 ;
 
 convertStringToIntFail#[skip:-8.13.99, reason:warning changed in 8.14]
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 row str1 = "2147483647.2", str2 = "2147483648", non = "no number" | eval i1 = to_integer(str1), i2 = to_integer(str2), noi = to_integer(non);
 warning:Line 1:79: evaluation of [to_integer(str1)] failed, treating result as null. Only first 20 failures recorded.
@@ -254,7 +254,7 @@ str1:keyword   |str2:keyword   |non:keyword    |i1:integer     |i2:integer     |
 ;
 
 convertDoubleToInt
-required_feature:esql.convert_warn
+required_capability: convert_warn
 
 row d = 123.4 | eval d2i = to_integer(d), overflow = to_integer(1e19);
 warningRegex:Line 1:54: evaluation of \[to_integer\(1e19\)\] failed, treating result as null. Only first 20 failures recorded.
@@ -265,7 +265,7 @@ d:double       |d2i:integer   |overflow:integer
 ;
 
 lessThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change.int < 1 | keep emp_no, salary_change.int | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [salary_change.int < 1] failed, treating result as null. Only first 20 failures recorded.
@@ -281,7 +281,7 @@ emp_no:integer |salary_change.int:integer
 ;
 
 greaterThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change.int > 1 | keep emp_no, salary_change.int | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [salary_change.int > 1] failed, treating result as null. Only first 20 failures recorded.
@@ -297,7 +297,7 @@ emp_no:integer |salary_change.int:integer
 ;
 
 equalToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change.int == 0 | keep emp_no, salary_change.int | sort emp_no;
 warning:Line 1:24: evaluation of [salary_change.int == 0] failed, treating result as null. Only first 20 failures recorded.
@@ -312,7 +312,7 @@ emp_no:integer |salary_change.int:integer
 ;
 
 equalToOrEqualToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change.int == 1 or salary_change.int == 8 | keep emp_no, salary_change.int | sort emp_no;
 warning:Line 1:24: evaluation of [salary_change.int] failed, treating result as null. Only first 20 failures recorded.
@@ -325,7 +325,7 @@ emp_no:integer |salary_change.int:integer
 ;
 
 inMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where salary_change.int in (1, 7) | keep emp_no, salary_change.int | sort emp_no;
 warning:Line 1:24: evaluation of [salary_change.int in (1, 7)] failed, treating result as null. Only first 20 failures recorded.
@@ -338,7 +338,7 @@ emp_no:integer |salary_change.int:integer
 ;
 
 notLessThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(salary_change.int < 1) | keep emp_no, salary_change.int | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [not(salary_change.int < 1)] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [salary_change.int < 1] failed, treating result as null. Only first 20 failures recorded.]
@@ -354,7 +354,7 @@ emp_no:integer |salary_change.int:integer
 ;
 
 notGreaterThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(salary_change.int > 1) | keep emp_no, salary_change.int | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [not(salary_change.int > 1)] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [salary_change.int > 1] failed, treating result as null. Only first 20 failures recorded.]
@@ -370,7 +370,7 @@ emp_no:integer |salary_change.int:integer
 ;
 
 notEqualToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(salary_change.int == 1) | keep emp_no, salary_change.int | sort emp_no | limit 5;
 warning:Line 1:24: evaluation of [not(salary_change.int == 1)] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [salary_change.int == 1] failed, treating result as null. Only first 20 failures recorded.]
@@ -417,7 +417,7 @@ row a = [1, 2, 2, 3] | eval da = mv_dedupe(a);
 ;
 
 mvSort
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 // tag::mv_sort[]
 ROW a = [4, 2, -3, 2]
@@ -432,7 +432,7 @@ a:integer     | sa:integer    | sd:integer
 ;
 
 mvSortEmpInt
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 FROM employees
 | eval sd = mv_sort(salary_change.int, "DESC"), sa = mv_sort(salary_change.int)
@@ -454,7 +454,7 @@ emp_no:integer | salary_change.int:integer | sa:integer    | sd:integer
 ;
 
 mvSortEmpLong
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 FROM employees
 | eval sd = mv_sort(salary_change.long, "DESC"), sa = mv_sort(salary_change.long)
@@ -476,7 +476,7 @@ emp_no:integer | salary_change.long:long | sa:long        | sd:long
 ;
 
 mvSlice
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 // tag::mv_slice_positive[]
 row a = [1, 2, 2, 3]
@@ -490,7 +490,7 @@ a:integer    | a1:integer | a2:integer
 ;
 
 mvSliceNegativeOffset
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 // tag::mv_slice_negative[]
 row a = [1, 2, 2, 3]
@@ -504,7 +504,7 @@ a:integer    | a1:integer | a2:integer
 ;
 
 mvSliceSingle
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 row a = 1
 | eval a1 = mv_slice(a, 0);
@@ -514,7 +514,7 @@ a:integer | a1:integer
 ;
 
 mvSliceOutOfBound
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 row a = [1, 2, 2, 3]
 | eval a1 = mv_slice(a, 4), a2 = mv_slice(a, 2, 6), a3 = mv_slice(a, 4, 6);
@@ -524,7 +524,7 @@ a:integer    | a1:integer | a2:integer | a3:integer
 ;
 
 mvSliceEmpInt
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change.int, 0, 1)
@@ -541,7 +541,7 @@ emp_no:integer | salary_change.int:integer | a1:integer
 ;
 
 mvSliceEmpIntSingle
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change.int, 1)
@@ -558,7 +558,7 @@ emp_no:integer | salary_change.int:integer | a1:integer
 ;
 
 mvSliceEmpIntEndOutOfBound
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change.int, 1, 4)
@@ -575,7 +575,7 @@ emp_no:integer | salary_change.int:integer | a1:integer
 ;
 
 mvSliceEmpIntOutOfBound
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change.int, 2, 4)
@@ -592,7 +592,7 @@ emp_no:integer | salary_change.int:integer | a1:integer
 ;
 
 mvSliceEmpIntStartOutOfBoundNegative
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change.int, -5, -2)
@@ -609,7 +609,7 @@ emp_no:integer | salary_change.int:integer | a1:integer
 ;
 
 mvSliceEmpIntOutOfBoundNegative
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change.int, -5, -3)
@@ -626,7 +626,7 @@ emp_no:integer | salary_change.int:integer | a1:integer
 ;
 
 mvSliceEmpLong
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change.long, 0, 1)
@@ -750,7 +750,7 @@ x:long
 ;
 
 valuesLong
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -762,7 +762,7 @@ required_feature: esql.agg_values
 ;
 
 valuesLongGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -783,7 +783,7 @@ required_feature: esql.agg_values
 ;
 
 valuesLongGroupedByOrdinals
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -807,7 +807,7 @@ required_feature: esql.agg_values
 ;
 
 valuesInt
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -819,7 +819,7 @@ required_feature: esql.agg_values
 ;
 
 valuesIntGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -840,7 +840,7 @@ l:integer | first_letter:keyword
 ;
 
 valuesIntGroupedByOrdinals
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -864,7 +864,7 @@ required_feature: esql.agg_values
 ;
 
 valuesShort
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -876,7 +876,7 @@ required_feature: esql.agg_values
 ;
 
 valuesShortGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -897,7 +897,7 @@ l:integer | first_letter:keyword
 ;
 
 valuesShortGroupedByOrdinals
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/ip.csv-spec
@@ -16,7 +16,7 @@ eth2           |epsilon        |[fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece
 ;
 
 equals
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | sort host, card | where ip0 == ip1 | keep card, host, ip0, ip1;
 warning:Line 1:38: evaluation of [ip0 == ip1] failed, treating result as null. Only first 20 failures recorded.
@@ -60,7 +60,7 @@ eth2           |epsilon        |[fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece
 ;
 
 lessThan
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | sort host, card, ip1 | where ip0 < ip1 | keep card, host, ip0, ip1;
 warning:Line 1:43: evaluation of [ip0 < ip1] failed, treating result as null. Only first 20 failures recorded.
@@ -73,7 +73,7 @@ lo0            |gamma          |fe80::cae2:65ff:fece:feb9|fe81::cae2:65ff:fece:f
 ;
 
 notEquals
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | sort host, card, ip1 | where ip0 != ip1 | keep card, host, ip0, ip1;
 warning:Line 1:43: evaluation of [ip0 != ip1] failed, treating result as null. Only first 20 failures recorded.
@@ -125,7 +125,7 @@ null           |[127.0.0.1, 127.0.0.2, 127.0.0.3]
 ;
 
 conditional
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | keep eq, ip0, ip1;
 ignoreOrder:true
@@ -146,7 +146,7 @@ fe80::cae2:65ff:fece:fec1                             |[fe80::cae2:65ff:fece:feb
 ;
 
 in
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | where eq in (ip0, ip1) | keep card, host, ip0, ip1, eq;
 ignoreOrder:true
@@ -168,7 +168,7 @@ eth0           |epsilon        |[fe80::cae2:65ff:fece:feb9, fe80::cae2:65ff:fece
 
 
 inWithWarningsRegex#[skip:-8.13.99, reason:regex warnings in tests introduced in v 8.14.0]
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | eval eq=case(ip0==ip1, ip0, ip1) | where eq in (ip0, ip1) | keep card, host, ip0, ip1, eq;
 ignoreOrder:true
@@ -188,7 +188,7 @@ eth0           |epsilon        |[fe80::cae2:65ff:fece:feb9, fe80::cae2:65ff:fece
 ;
 
 cidrMatchSimple
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where cidr_match(ip1, "127.0.0.2/32") | keep card, host, ip0, ip1;
 warning:Line 1:20: evaluation of [cidr_match(ip1, \"127.0.0.2/32\")] failed, treating result as null. Only first 20 failures recorded.
@@ -199,7 +199,7 @@ eth1           |beta           |127.0.0.1      |127.0.0.2
 ;
 
 cidrMatchNullField
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where cidr_match(ip0, "127.0.0.2/32") is null | keep card, host, ip0, ip1;
 ignoreOrder:true
@@ -213,7 +213,7 @@ eth2           |epsilon        |[fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece
 ;
 
 cdirMatchMultipleArgs
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 //tag::cdirMatchMultipleArgs[]
 FROM hosts 
@@ -233,7 +233,7 @@ eth0           |gamma          |fe80::cae2:65ff:fece:feb9|127.0.0.3
 ;
 
 cidrMatchFunctionArg
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where cidr_match(ip1, concat("127.0.0.2", "/32"), "127.0.0.3/32") | keep card, host, ip0, ip1;
 ignoreOrder:true
@@ -246,7 +246,7 @@ eth0           |gamma          |fe80::cae2:65ff:fece:feb9|127.0.0.3
 ;
 
 cidrMatchFieldArg
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | eval cidr="127.0.0.2" | where cidr_match(ip1, cidr, "127.0.0.3/32") | keep card, host, ip0, ip1;
 ignoreOrder:true
@@ -294,7 +294,7 @@ eth0           |beta           |127.0.0.1  |::1
 ;
 
 pushDownIPWithIn
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where ip1 in (to_ip("::1"), to_ip("127.0.0.1")) | keep card, host, ip0, ip1;
 ignoreOrder:true
@@ -308,7 +308,7 @@ eth0           |beta           |127.0.0.1   |::1
 ;
 
 pushDownIPWithComparision
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where ip1 > to_ip("127.0.0.1") | keep card, ip1;
 ignoreOrder:true
@@ -324,7 +324,7 @@ eth0           |fe80::cae2:65ff:fece:fec1
 ;
 
 mvSort
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 FROM hosts
 | eval sd = mv_sort(ip1, "DESC"), sa = mv_sort(ip1)
@@ -342,7 +342,7 @@ epsilon      | [fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece:fec0] | [fe81::c
 ;
 
 mvSlice
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from hosts
 | where host == "epsilon"
@@ -358,7 +358,7 @@ epsilon      | [fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece:fec0] | [fe81::c
 ;
 
 mvSlice
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from hosts
 | where host == "epsilon"
@@ -374,7 +374,7 @@ epsilon      | [fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece:fec0] | [fe81::c
 ;
 
 mvZip
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from hosts
 | eval zip = mv_zip(to_string(description), to_string(ip0), "@@")
@@ -392,7 +392,7 @@ epsilon      | null                          | null                             
 ;
 
 values
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM hosts
 | STATS ip0=MV_SORT(VALUES(ip0))
@@ -403,7 +403,7 @@ required_feature: esql.agg_values
 ;
 
 valuesGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM hosts
 | EVAL host=SUBSTRING(host, 0, 1)
@@ -419,7 +419,7 @@ fe80::cae2:65ff:fece:feb9 | g
 ;
 
 valuesGroupedByOrdinals
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM hosts
 | STATS ip0=MV_SORT(VALUES(ip0)) BY host
@@ -434,7 +434,7 @@ fe80::cae2:65ff:fece:feb9 | gamma
 ;
 
 implictCastingEqual
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from hosts | where mv_first(ip0) == "127.0.0.1" | keep host, ip0 | sort host;
 
 host:keyword | ip0:ip
@@ -445,7 +445,7 @@ beta         | 127.0.0.1
 ;
 
 implictCastingNotEqual
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from hosts | where mv_first(ip0) != "127.0.0.1" | keep host, ip0 | sort host, ip0 | limit 3;
 
 host:keyword | ip0:ip
@@ -455,7 +455,7 @@ epsilon      | [fe81::cae2:65ff:fece:feb9, fe82::cae2:65ff:fece:fec0]
 ;
 
 implictCastingGreaterThan
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from hosts | where mv_first(ip0) > "127.0.0.1" | keep host, ip0 | sort host, ip0 | limit 3;
 
 host:keyword | ip0:ip
@@ -465,7 +465,7 @@ gamma        | fe80::cae2:65ff:fece:feb9
 ;
 
 implictCastingLessThanOrEqual
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from hosts | where mv_first(ip0) <= "127.0.0.1" | keep host, ip0 | sort host, ip0 | limit 3;
 
 host:keyword | ip0:ip
@@ -475,7 +475,7 @@ beta         | 127.0.0.1
 ;
 
 implictCastingIn
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from hosts | where mv_first(ip0) in ( "127.0.0.1", "::1") | keep host, ip0 | sort host, ip0;
 
 host:keyword | ip0:ip

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/math.csv-spec
@@ -201,7 +201,7 @@ height:double | s:double
 ;
 
 powSalarySquared
-required_feature: esql.pow_double
+required_capability: pow_double
 
 from employees | eval s = pow(to_long(salary) - 75000, 2) + 10000 | keep salary, s | sort salary desc | limit 4;
 
@@ -618,7 +618,7 @@ base:double | exponent:integer | result:double
 ;
 
 powIntInt
-required_feature: esql.pow_double
+required_capability: pow_double
 
 ROW base = 2, exponent = 2
 | EVAL s = POW(base, exponent)
@@ -629,7 +629,7 @@ base:integer | exponent:integer | s:double
 ;
 
 powIntIntPlusInt
-required_feature: esql.pow_double
+required_capability: pow_double
 
 row s = 1 + pow(2, 2);
 
@@ -645,7 +645,7 @@ s:double
 ;
 
 powIntUL
-required_feature: esql.pow_double
+required_capability: pow_double
 
 row x = pow(1, 9223372036854775808);
 
@@ -654,7 +654,7 @@ x:double
 ;
 
 powLongUL
-required_feature: esql.pow_double
+required_capability: pow_double
 
 row x = to_long(1) | eval x = pow(x, 9223372036854775808);
 
@@ -663,7 +663,7 @@ x:double
 ;
 
 powUnsignedLongUL
-required_feature: esql.pow_double
+required_capability: pow_double
 
 row x = to_ul(1) | eval x = pow(x, 9223372036854775808);
 
@@ -688,7 +688,7 @@ null
 ;
 
 powULInt
-required_feature: esql.pow_double
+required_capability: pow_double
 
 row x = pow(to_unsigned_long(9223372036854775807), 1);
 
@@ -697,7 +697,7 @@ x:double
 ;
 
 powULIntOverrun
-required_feature: esql.pow_double
+required_capability: pow_double
 
 ROW x = POW(9223372036854775808, 2)
 ;
@@ -719,7 +719,7 @@ x:double
 ;
 
 powULLong
-required_feature: esql.pow_double
+required_capability: pow_double
 
 row x = to_long(10) | eval x = pow(to_unsigned_long(10), x);
 
@@ -728,7 +728,7 @@ x:double
 ;
 
 powULLongOverrun
-required_feature: esql.pow_double
+required_capability: pow_double
 
 row x = to_long(100) | eval x = pow(to_unsigned_long(10), x);
 
@@ -1414,7 +1414,7 @@ Anneke         |Preusig        |1.56           |1.56
 ;
 
 evalAbsString
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 ROW number = -1.0
 | EVAL abs_number = ABS("10.0")
@@ -1425,7 +1425,7 @@ number:double  | abs_number:double
 ;
 
 functionUnderArithmeticOperationAggString
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 ROW a = 1
 | eval x = date_trunc(1 month, "2024-11-22") + 2 days, y = x + 3 days
@@ -1437,7 +1437,7 @@ count():long | y:date
 ;
 
 functionUnderArithmeticOperationString
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 from employees
 | eval x = date_trunc(1 month, "2024-11-22") + 2 days, y = x + 3 days

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/metadata.csv-spec
@@ -1,5 +1,5 @@
 simpleKeep
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | sort emp_no | limit 2 | keep emp_no, _index, _version;
 
 emp_no:integer |_index:keyword |_version:long
@@ -8,7 +8,7 @@ emp_no:integer |_index:keyword |_version:long
 ;
 
 aliasWithSameName
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | sort emp_no | limit 2 | eval _index = _index, _version = _version | keep emp_no, _index, _version;
 
 emp_no:integer |_index:keyword |_version:long
@@ -17,7 +17,7 @@ emp_no:integer |_index:keyword |_version:long
 ;
 
 inComparison
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | sort emp_no | where _index == "employees" | where _version == 1 | keep emp_no | limit 2;
 
 emp_no:integer
@@ -26,7 +26,7 @@ emp_no:integer
 ;
 
 metaIndexInAggs
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 // tag::metaIndexInAggs[]
 FROM employees METADATA _index, _id
 | STATS max = MAX(emp_no) BY _index
@@ -40,7 +40,7 @@ max:integer |_index:keyword
 ;
 
 metaIndexAliasedInAggs
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index | eval _i = _index | stats max = max(emp_no) by _i;
 
 
@@ -49,7 +49,7 @@ max:integer |_i:keyword
 ;
 
 metaVersionInAggs
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _version | stats min = min(emp_no) by _version;
 
 min:integer |_version:long
@@ -57,7 +57,7 @@ min:integer |_version:long
 ;
 
 metaVersionAliasedInAggs
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _version | eval _v = _version | stats min = min(emp_no) by _v;
 
 min:integer |_v:long
@@ -65,7 +65,7 @@ min:integer |_v:long
 ;
 
 inAggsAndAsGroups
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | stats max = max(_version) by _index;
 
 max:long |_index:keyword
@@ -73,7 +73,7 @@ max:long |_index:keyword
 ;
 
 inAggsAndAsGroupsAliased
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | eval _i = _index, _v = _version | stats max = max(_v) by _i;
 
 max:long |_i:keyword
@@ -81,7 +81,7 @@ max:long |_i:keyword
 ;
 
 inFunction
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | sort emp_no | where length(_index) == length("employees") | where abs(_version) == 1 | keep emp_no | limit 2;
 
 emp_no:integer
@@ -90,7 +90,7 @@ emp_no:integer
 ;
 
 inArithmetics
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | eval i = _version + 2 | stats min = min(emp_no) by i;
 
 min:integer |i:long
@@ -98,7 +98,7 @@ min:integer |i:long
 ;
 
 inSort
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | sort _version, _index, emp_no | keep emp_no, _version, _index | limit 2;
 
 emp_no:integer |_version:long |_index:keyword
@@ -107,7 +107,7 @@ emp_no:integer |_version:long |_index:keyword
 ;
 
 withMvFunction
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _version | eval i = mv_avg(_version) + 2 | stats min = min(emp_no) by i;
 
 min:integer |i:double
@@ -115,7 +115,7 @@ min:integer |i:double
 ;
 
 overwritten
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 from employees metadata _index, _version | sort emp_no | eval _index = 3, _version = "version" | keep emp_no, _index, _version | limit 3;
 
 emp_no:integer |_index:integer |_version:keyword
@@ -125,7 +125,7 @@ emp_no:integer |_index:integer |_version:keyword
 ;
 
 multipleIndices
-required_feature: esql.metadata_fields
+required_capability: metadata_fields
 // tag::multipleIndices[]
 FROM ul_logs, apps METADATA _index, _version
 | WHERE id IN (13, 14) AND _version == 1

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -3,7 +3,7 @@
 ###############################################
 
 convertFromStringQuantize
-required_feature: esql.spatial_points
+required_capability: spatial_points
 
 row wkt = "POINT(42.97109629958868 14.7552534006536)"
 | eval pt = to_geopoint(wkt);
@@ -13,7 +13,7 @@ POINT(42.97109629958868 14.7552534006536) |POINT(42.97109629958868 14.7552534006
 ;
 
 convertFromString
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 // tag::to_geopoint-str[]
 ROW wkt = "POINT(42.97109630194 14.7552534413725)"
@@ -28,7 +28,7 @@ wkt:keyword                              |pt:geo_point
 ;
 
 convertFromStringArray
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 row wkt = ["POINT(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)"]
 | eval pt = to_geopoint(wkt);
@@ -38,7 +38,7 @@ wkt:keyword                                                                     
 ;
 
 centroidFromStringNested
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 row wkt = "POINT(42.97109629958868 14.7552534006536)"
 | STATS c = ST_CENTROID_AGG(TO_GEOPOINT(wkt));
@@ -48,7 +48,7 @@ POINT(42.97109629958868 14.7552534006536)
 ;
 
 centroidFromString1
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 ROW wkt = ["POINT(42.97109629958868 14.7552534006536)"]
 | MV_EXPAND wkt
@@ -60,7 +60,7 @@ POINT(42.97109629958868 14.7552534006536)
 ;
 
 centroidFromString2
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 ROW wkt = ["POINT(42.97109629958868 14.7552534006536)", "POINT(75.80929149873555 22.72774917539209)"]
 | MV_EXPAND wkt
@@ -72,7 +72,7 @@ POINT(59.390193899162114 18.741501288022846)
 ;
 
 centroidFromString3
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 ROW wkt = ["POINT(42.97109629958868 14.7552534006536)", "POINT(75.80929149873555 22.72774917539209)", "POINT(-0.030548143003023033 24.37553649504829)"]
 | MV_EXPAND wkt
@@ -84,7 +84,7 @@ POINT(39.58327988510707 20.619513023697994)
 ;
 
 centroidFromString4
-required_feature: esql.st_x_y
+required_capability: st_x_y
 
 ROW wkt = ["POINT(42.97109629958868 14.7552534006536)", "POINT(75.80929149873555 22.72774917539209)", "POINT(-0.030548143003023033 24.37553649504829)"]
 | MV_EXPAND wkt
@@ -97,7 +97,7 @@ POINT(39.58327988510707 20.619513023697994) | 39.58327988510707 | 20.61951302369
 ;
 
 stXFromString
-required_feature: esql.st_x_y
+required_capability: st_x_y
 
 // tag::st_x_y[]
 ROW point = TO_GEOPOINT("POINT(42.97109629958868 14.7552534006536)")
@@ -112,7 +112,7 @@ POINT(42.97109629958868 14.7552534006536)  | 42.97109629958868 | 14.755253400653
 ;
 
 simpleLoad
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 FROM airports | WHERE scalerank == 9 | SORT abbrev | WHERE length(name) > 12;
 
@@ -132,7 +132,7 @@ ZAH             |  Zāhedān         |  POINT(60.8628 29.4964)  |  Iran         
 ;
 
 stXFromAirportsSupportsNull
-required_feature: esql.st_x_y
+required_capability: st_x_y
 
 FROM airports
 | EVAL x = FLOOR(ABS(ST_X(city_location))/200), y = FLOOR(ABS(ST_Y(city_location))/100)
@@ -149,7 +149,7 @@ c:long  | x:double  | y:double
 # Tests for ST_CENTROID on GEO_POINT type
 
 centroidFromAirports
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 // tag::st_centroid_agg-airports[]
 FROM airports
@@ -164,7 +164,7 @@ POINT(-0.030548143003023033 24.37553649504829)
 ;
 
 centroidFromAirportsNested
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | STATS centroid=ST_CENTROID_AGG(TO_GEOPOINT(location))
@@ -175,7 +175,7 @@ POINT (-0.03054810272375508 24.37553651570554)
 ;
 
 centroidFromAirportsCount
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | STATS centroid=ST_CENTROID_AGG(location), count=COUNT()
@@ -186,7 +186,7 @@ POINT(-0.030548143003023033 24.37553649504829) | 891
 ;
 
 centroidFromAirportsCountGrouped
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | STATS centroid=ST_CENTROID_AGG(location), count=COUNT() BY scalerank
@@ -205,7 +205,7 @@ POINT(1.2588642098541771 24.379140841774642)  | 63         | 2
 ;
 
 centroidFromAirportsFiltered
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | WHERE scalerank == 9
@@ -217,7 +217,7 @@ POINT(83.27726172452623 28.99289782286029) | 33
 ;
 
 centroidFromAirportsCountGroupedCentroid
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | STATS centroid=ST_CENTROID_AGG(location), count=COUNT() BY scalerank
@@ -229,7 +229,7 @@ POINT (7.572387259169772 26.836561792945492) | 891
 ;
 
 centroidFromAirportsCountCityLocations
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | STATS centroid=ST_CENTROID_AGG(city_location), count=COUNT()
@@ -240,7 +240,7 @@ POINT (1.3965610809060276 24.127649406297987) | 891
 ;
 
 centroidFromAirportsCountGroupedCountry
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | STATS centroid=ST_CENTROID_AGG(city_location), count=COUNT() BY country
@@ -269,7 +269,7 @@ POINT (70.7946499697864 30.69746997440234)     | 10         | Pakistan
 ;
 
 centroidFromAirportsFilteredCountry
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | WHERE country == "United States"
@@ -281,7 +281,7 @@ POINT (-97.3333946136801 38.07953176370194) | 129
 ;
 
 centroidFromAirportsCountGroupedCountryCentroid
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | STATS centroid=ST_CENTROID_AGG(city_location), count=COUNT() BY country
@@ -293,7 +293,7 @@ POINT (17.55538044598613 18.185558743854063)  | 891
 ;
 
 centroidFromAirportsCountryCount
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | STATS airports=ST_CENTROID_AGG(location), cities=ST_CENTROID_AGG(city_location), count=COUNT()
@@ -304,7 +304,7 @@ POINT(-0.030548143003023033 24.37553649504829) | POINT (1.3965610809060276 24.12
 ;
 
 centroidFromAirportsFilteredAndSorted
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | WHERE scalerank == 9
@@ -318,7 +318,7 @@ POINT(78.73736493755132 26.761841227998957) | 12
 ;
 
 centroidFromAirportsAfterMvExpand
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | MV_EXPAND type
@@ -330,7 +330,7 @@ POINT(2.121611400672094 24.559172889205755) | 933
 ;
 
 centroidFromAirportsGroupedAfterMvExpand
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | MV_EXPAND type
@@ -350,7 +350,7 @@ POINT(1.2588642098541771 24.379140841774642)  | 63         | 2
 ;
 
 centroidFromAirportsGroupedAfterMvExpandFiltered
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | WHERE scalerank == 9
@@ -363,7 +363,7 @@ POINT(83.16847535921261 28.79002037679311)    | 40         | 9
 ;
 
 centroidFromAirportsAfterMvExpandFiltered
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | WHERE scalerank == 9
@@ -376,7 +376,7 @@ POINT(83.16847535921261 28.79002037679311)    | 40
 ;
 
 centroidFromAirportsAfterKeywordPredicateCountryUK
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports
 | WHERE country == "United Kingdom"
@@ -388,7 +388,7 @@ POINT (-2.597342072712148 54.33551226578214)    | 17
 ;
 
 centroidFromAirportsAfterIntersectsPredicateCountryUK
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports
 | WHERE ST_INTERSECTS(location, TO_GEOSHAPE("POLYGON((1.2305 60.8449, -1.582 61.6899, -10.7227 58.4017, -7.1191 55.3291, -7.9102 54.2139, -5.4492 54.0078, -5.2734 52.3756, -7.8223 49.6676, -5.0977 49.2678, 0.9668 50.5134, 2.5488 52.1065, 2.6367 54.0078, -0.9668 56.4625, 1.2305 60.8449))"))
@@ -400,7 +400,7 @@ POINT (-2.597342072712148 54.33551226578214)    | 17
 ;
 
 centroidFromAirportsAfterContainsPredicateCountryUK
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports
 | WHERE ST_CONTAINS(TO_GEOSHAPE("POLYGON((1.2305 60.8449, -1.582 61.6899, -10.7227 58.4017, -7.1191 55.3291, -7.9102 54.2139, -5.4492 54.0078, -5.2734 52.3756, -7.8223 49.6676, -5.0977 49.2678, 0.9668 50.5134, 2.5488 52.1065, 2.6367 54.0078, -0.9668 56.4625, 1.2305 60.8449))"), location)
@@ -412,7 +412,7 @@ POINT (-2.597342072712148 54.33551226578214)    | 17
 ;
 
 centroidFromAirportsAfterWithinPredicateCountryUK
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports
 | WHERE ST_WITHIN(location, TO_GEOSHAPE("POLYGON((1.2305 60.8449, -1.582 61.6899, -10.7227 58.4017, -7.1191 55.3291, -7.9102 54.2139, -5.4492 54.0078, -5.2734 52.3756, -7.8223 49.6676, -5.0977 49.2678, 0.9668 50.5134, 2.5488 52.1065, 2.6367 54.0078, -0.9668 56.4625, 1.2305 60.8449))"))
@@ -424,7 +424,7 @@ POINT (-2.597342072712148 54.33551226578214)    | 17
 ;
 
 intersectsAfterCentroidFromAirportsAfterKeywordPredicateCountryUK
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports
 | WHERE country == "United Kingdom"
@@ -443,7 +443,7 @@ POINT (-2.597342072712148 54.33551226578214)    | 17         | true             
 ;
 
 centroidFromAirportsAfterIntersectsEvalExpression
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports
 | EVAL in_uk = ST_INTERSECTS(location, TO_GEOSHAPE("POLYGON((1.2305 60.8449, -1.582 61.6899, -10.7227 58.4017, -7.1191 55.3291, -7.9102 54.2139, -5.4492 54.0078, -5.2734 52.3756, -7.8223 49.6676, -5.0977 49.2678, 0.9668 50.5134, 2.5488 52.1065, 2.6367 54.0078, -0.9668 56.4625, 1.2305 60.8449))"))
@@ -461,7 +461,7 @@ POINT (0.04453958108176276 23.74658354606057)  |  873         |  false          
 ;
 
 centroidFromAirportsAfterIntersectsPredicate
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports
 | WHERE ST_INTERSECTS(location, TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))"))
@@ -473,7 +473,7 @@ POINT (42.97109629958868 14.7552534006536)    | 1
 ;
 
 centroidFromAirportsAfterIntersectsCompoundPredicate
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports
 | WHERE scalerank == 9 AND ST_INTERSECTS(location, TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))")) AND country == "Yemen"
@@ -488,7 +488,7 @@ POINT (42.97109629958868 14.7552534006536)    | 1
 # Tests for ST_INTERSECTS on GEO_POINT type
 
 pointIntersectsLiteralPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 // tag::st_intersects-airports[]
 FROM airports
@@ -503,7 +503,7 @@ HOD             |  Al Ḩudaydah     |  POINT(42.9511 14.8022)  |  Yemen        
 ;
 
 pointIntersectsLiteralPolygonReversed
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports
 | WHERE ST_INTERSECTS(TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))"), location)
@@ -514,7 +514,7 @@ HOD             |  Al Ḩudaydah     |  POINT(42.9511 14.8022)  |  Yemen        
 ;
 
 literalPointIntersectsLiteralPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -528,7 +528,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPointIntersectsLiteralPolygonReversed
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -542,7 +542,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPointIntersectsLiteralPolygonOneRow
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW intersects = ST_INTERSECTS(TO_GEOPOINT("POINT(0 0)"), TO_GEOSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"))
 ;
@@ -552,7 +552,7 @@ true
 ;
 
 cityInCityBoundary
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airport_city_boundaries
 | EVAL in_city = ST_INTERSECTS(city_location, city_boundary)
@@ -568,7 +568,7 @@ cardinality:k  |  in_city:boolean
 ;
 
 cityNotInCityBoundaryBiggest
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airport_city_boundaries
 | WHERE NOT ST_INTERSECTS(city_location, city_boundary)
@@ -583,7 +583,7 @@ SYX             |  Sanya Phoenix Int'l  |  Sanya        |  POINT(109.5036 18.253
 ;
 
 airportCityLocationPointIntersection
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_mp
 | WHERE ST_INTERSECTS(location, city_location)
@@ -594,7 +594,7 @@ XXX             |  Atlantis      |  POINT(0 0)              |  Atlantis         
 ;
 
 airportCityLocationPointIntersectionCentroid
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_mp
 | WHERE ST_INTERSECTS(location, city_location)
@@ -609,7 +609,7 @@ POINT (0 0)         | POINT (0 0)              |  1
 # Tests for ST_DISJOINT on GEO_POINT type
 
 literalPolygonDisjointLiteralPoint
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -623,7 +623,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPointDisjointLiteralPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -637,7 +637,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPolygonDisjointLiteralPointOneRow
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 ROW disjoint = ST_DISJOINT(TO_GEOSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"), TO_GEOPOINT("POINT(0 0)"))
 ;
@@ -647,7 +647,7 @@ false
 ;
 
 literalPointDisjointLiteralPolygonOneRow
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 ROW disjoint = ST_DISJOINT(TO_GEOPOINT("POINT(-1 0)"), TO_GEOSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"))
 ;
@@ -657,7 +657,7 @@ true
 ;
 
 pointDisjointLiteralPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM airports
 | WHERE ST_DISJOINT(location, TO_GEOSHAPE("POLYGON((-10 -60, 120 -60, 120 60, -10 60, -10 -60))"))
@@ -679,7 +679,7 @@ x:double  |  y:double  |  count:long
 ;
 
 airportCityLocationPointDisjointCentroid
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM airports_mp
 | WHERE ST_DISJOINT(location, city_location)
@@ -694,7 +694,7 @@ POINT (67.8581917192787 24.02956652920693) | POINT (67.81638333333332 24.0489999
 # Tests for ST_CONTAINS on GEO_POINT type
 
 literalPolygonContainsLiteralPoint
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -708,7 +708,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPointDoesNotContainLiteralPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -720,7 +720,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPolygonContainsLiteralPointOneRow
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW contains = ST_CONTAINS(TO_GEOSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"), TO_GEOPOINT("POINT(0 0)"))
 ;
@@ -730,7 +730,7 @@ true
 ;
 
 literalPointDoesNotContainLiteralPolygonOneRow
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW contains = ST_CONTAINS(TO_GEOPOINT("POINT(0 0)"), TO_GEOSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"))
 ;
@@ -740,7 +740,7 @@ false
 ;
 
 pointContainsLiteralPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports
 | WHERE ST_CONTAINS(location, TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))"))
@@ -750,7 +750,7 @@ abbrev:keyword  |  city:keyword    |  city_location:geo_point |  country:keyword
 ;
 
 pointContainedInLiteralPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports
 | WHERE ST_CONTAINS(TO_GEOSHAPE("POLYGON((42 14, 43 14, 43 15, 42 15, 42 14))"), location)
@@ -761,7 +761,7 @@ HOD             |  Al Ḩudaydah     |  POINT(42.9511 14.8022)  |  Yemen        
 ;
 
 airportCityLocationPointContains
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_mp
 | WHERE ST_CONTAINS(location, city_location)
@@ -772,7 +772,7 @@ XXX             |  Atlantis      |  POINT(0 0)              |  Atlantis         
 ;
 
 airportCityLocationPointContainsCentroid
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_mp
 | WHERE ST_CONTAINS(location, city_location)
@@ -787,7 +787,7 @@ POINT (0 0)         | POINT (0 0)              |  1
 # Tests for ST_WITHIN on GEO_POINT type
 
 literalPolygonNotWithinLiteralPoint
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -799,7 +799,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPointWithinLiteralPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -813,7 +813,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPolygonNotWithinLiteralPointOneRow
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW within = ST_WITHIN(TO_GEOSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"), TO_GEOPOINT("POINT(0 0)"))
 ;
@@ -823,7 +823,7 @@ false
 ;
 
 literalPointWithinLiteralPolygonOneRow
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW within = ST_WITHIN(TO_GEOPOINT("POINT(0 0)"), TO_GEOSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"))
 ;
@@ -833,7 +833,7 @@ true
 ;
 
 pointWithinLiteralPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 // tag::st_within-airports[]
 FROM airports
@@ -848,7 +848,7 @@ HOD             |  Al Ḩudaydah     |  POINT(42.9511 14.8022)  |  Yemen        
 ;
 
 airportCityLocationPointWithin
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_mp
 | WHERE ST_WITHIN(location, city_location)
@@ -859,7 +859,7 @@ XXX             |  Atlantis      |  POINT(0 0)              |  Atlantis         
 ;
 
 airportCityLocationPointWithinCentroid
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_mp
 | WHERE ST_WITHIN(location, city_location)
@@ -874,7 +874,7 @@ POINT (0 0)         | POINT (0 0)              |  1
 # Tests for Equality and casting with GEO_POINT
 
 geoPointEquals
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 // tag::to_geopoint-equals[]
 ROW wkt = ["POINT(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)"]
@@ -891,7 +891,7 @@ wkt:keyword                              |pt:geo_point
 ;
 
 geoPointNotEquals
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 // tag::to_geopoint-not-equals[]
 ROW wkt = ["POINT(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)"]
@@ -908,7 +908,7 @@ wkt:keyword                               |pt:geo_point
 ;
 
 convertFromStringParseError
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 // tag::to_geopoint-str-parse-error[]
 row wkt = ["POINTX(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)", "POINT(111)"]
@@ -936,7 +936,7 @@ wkt:keyword                               |pt:geo_point
 ###############################################
 
 convertCartesianFromString
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 // tag::to_cartesianpoint-str[]
 ROW wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"]
@@ -953,7 +953,7 @@ wkt:keyword               |pt:cartesian_point
 ;
 
 convertCartesianFromStringArray
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 row wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"]
 | eval pt = to_cartesianpoint(wkt);
@@ -963,7 +963,7 @@ wkt:keyword                                           |pt:cartesian_point
 ;
 
 centroidCartesianFromStringNested
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 row wkt = "POINT(4297.10986328125 -1475.530029296875)"
 | STATS c = ST_CENTROID_AGG(TO_CARTESIANPOINT(wkt));
@@ -973,7 +973,7 @@ POINT(4297.10986328125 -1475.530029296875)
 ;
 
 centroidFromCartesianString1
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 ROW wkt = ["POINT(4297.10986328125 -1475.530029296875)"]
 | MV_EXPAND wkt
@@ -985,7 +985,7 @@ POINT(4297.10986328125 -1475.530029296875)
 ;
 
 centroidFromCartesianString2
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 ROW wkt = ["POINT(4297.10986328125 -1475.530029296875)", "POINT(7580.93017578125 2272.77001953125)"]
 | MV_EXPAND wkt
@@ -997,7 +997,7 @@ POINT(5939.02001953125 398.6199951171875)
 ;
 
 centroidFromCartesianString3
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 ROW wkt = ["POINT(4297.10986328125 -1475.530029296875)", "POINT(7580.93017578125 2272.77001953125)", "POINT(-30.548143003023033 2437.553649504829)"]
 | MV_EXPAND wkt
@@ -1009,7 +1009,7 @@ POINT(3949.163965353159 1078.2645465797348)
 ;
 
 stXFromCartesianString
-required_feature: esql.st_x_y
+required_capability: st_x_y
 
 ROW point = TO_CARTESIANPOINT("POINT(4297.10986328125 -1475.530029296875)")
 | EVAL x =  ST_X(point), y = ST_Y(point)
@@ -1020,7 +1020,7 @@ POINT(4297.10986328125 -1475.530029296875)  | 4297.10986328125 | -1475.530029296
 ;
 
 simpleCartesianLoad
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 FROM airports_web | WHERE scalerank == 9 | SORT abbrev | WHERE length(name) > 12;
 
@@ -1039,7 +1039,7 @@ ZAH            | POINT (6779435.866395892 3436280.545331025)   | Zahedan Int'l  
 # Tests for ST_CENTROID on CARTESIAN_POINT type
 
 cartesianCentroidFromAirports
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports_web
 | STATS centroid=ST_CENTROID_AGG(location);
@@ -1049,7 +1049,7 @@ POINT(-266681.67563861894 3053301.5120195406)
 ;
 
 cartesianCentroidFromAirportsNested
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports_web
 | STATS centroid=ST_CENTROID_AGG(TO_CARTESIANPOINT(location));
@@ -1059,7 +1059,7 @@ POINT (-266681.66530554957 3053301.506061676)
 ;
 
 cartesianCentroidFromAirportsCount
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports_web
 | STATS centroid=ST_CENTROID_AGG(location), count=COUNT()
@@ -1070,7 +1070,7 @@ POINT(-266681.67563861894 3053301.5120195406) | 849
 ;
 
 cartesianCentroidFromAirportsCountGrouped
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports_web
 | STATS centroid=ST_CENTROID_AGG(location), count=COUNT() BY scalerank
@@ -1089,7 +1089,7 @@ POINT(140136.12878224207 3081220.7881944445)  | 63         | 2
 ;
 
 cartesianCentroidFromAirportsFiltered
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports_web
 | WHERE scalerank == 9
@@ -1101,7 +1101,7 @@ POINT(9289013.153846154 3615537.0533353365) | 26
 ;
 
 cartesianCentroidFromAirportsFilteredAndSorted
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports_web
 | WHERE scalerank == 9
@@ -1115,7 +1115,7 @@ POINT(9003597.4375 3429344.0078125) | 8
 ;
 
 cartesianCentroidFromAirportsCountGroupedCentroid
-required_feature: esql.st_centroid_agg
+required_capability: st_centroid_agg
 
 FROM airports_web
 | STATS centroid=ST_CENTROID_AGG(location), count=COUNT() BY scalerank
@@ -1130,7 +1130,7 @@ POINT (726480.0130685265 3359566.331716279) | 849
 # Tests for ST_INTERSECTS on CARTESIAN_POINT type
 
 cartesianCentroidFromAirportsAfterIntersectsPredicate
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANSHAPE("POLYGON((4700000 1600000, 4800000 1600000, 4800000 1700000, 4700000 1700000, 4700000 1600000))"))
@@ -1142,7 +1142,7 @@ POINT (4783520.5 1661010.0)  | 1
 ;
 
 cartesianPointIntersectsPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANSHAPE("POLYGON((4700000 1600000, 4800000 1600000, 4800000 1700000, 4700000 1700000, 4700000 1600000))"))
@@ -1153,7 +1153,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 literalCartesianPointIntersectsPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -1167,7 +1167,7 @@ wkt:keyword   | pt:cartesian_point
 ;
 
 cartesianPointIntersectsPointShape
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANSHAPE("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1178,7 +1178,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 cartesianPointIntersectsPoint
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANPOINT("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1189,7 +1189,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 cartesianPointIntersectsMultiPoint
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANSHAPE("MULTIPOINT(4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096)"))
@@ -1202,7 +1202,7 @@ CPH            | POINT (1408119.2975413958 7484813.53657096)  | Copenhagen     |
 ;
 
 cartesianPointIntersectsLineString
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANSHAPE("LINESTRING(4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096)"))
@@ -1215,7 +1215,7 @@ CPH            | POINT (1408119.2975413958 7484813.53657096)  | Copenhagen     |
 ;
 
 cartesianPointIntersectsMultiLineString
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANSHAPE("MULTILINESTRING((4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096),(1408119.2975413958 7484813.53657096, 1996039.722208033 8322469.9470024165))"))
@@ -1229,7 +1229,7 @@ ARN            | POINT(1996039.722208033 8322469.9470024165)  | Arlanda        |
 ;
 
 cartesianPointIntersectsPointShapeWithCentroid
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANSHAPE("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1241,7 +1241,7 @@ POINT (4783520.5 1661010.0) | 1
 ;
 
 cartesianPointIntersectsPointWithCentroid
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANPOINT("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1253,7 +1253,7 @@ POINT (4783520.5 1661010.0) | 1
 ;
 
 cartesianPointIntersectsLiteralPolygonCount
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_INTERSECTS(location, TO_CARTESIANSHAPE("POLYGON((0 -60000000, 120000000 -60000000, 120000000 60000000, 0 60000000, 0 -60000000))"))
@@ -1268,7 +1268,7 @@ count:long
 # Tests for ST_DISJOINT on CARTESIAN_POINT type
 
 literalPolygonDisjointLiteralCartesianPoint
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -1282,7 +1282,7 @@ wkt:keyword     | pt:cartesian_point
 ;
 
 literalCartesianPointDisjointLiteralPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -1296,7 +1296,7 @@ wkt:keyword     | pt:cartesian_point
 ;
 
 literalPolygonDisjointLiteralCartesianPointOneRow
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 ROW disjoint = ST_DISJOINT(TO_CARTESIANSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"), TO_CARTESIANPOINT("POINT(0 0)"))
 ;
@@ -1306,7 +1306,7 @@ false
 ;
 
 literalCartesianPointDisjointLiteralPolygonOneRow
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 ROW disjoint = ST_DISJOINT(TO_CARTESIANPOINT("POINT(-1 0)"), TO_CARTESIANSHAPE("POLYGON((0 -1, 1 -1, 1 1, 0 1, 0 -1))"))
 ;
@@ -1316,7 +1316,7 @@ true
 ;
 
 cartesianPointDisjointLiteralPolygonCount
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM airports_web
 | WHERE ST_DISJOINT(location, TO_CARTESIANSHAPE("POLYGON((0 -60000000, 120000000 -60000000, 120000000 60000000, 0 60000000, 0 -60000000))"))
@@ -1328,7 +1328,7 @@ count:long
 ;
 
 cartesianPointIntersectsDisjointLiteralPolygonCount
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM airports_web
 | EVAL intersects = ST_INTERSECTS(location, TO_CARTESIANSHAPE("POLYGON((0 -60000000, 120000000 -60000000, 120000000 60000000, 0 60000000, 0 -60000000))"))
@@ -1344,7 +1344,7 @@ false               |  true              |  405
 ;
 
 cartesianPointDisjointLiteralPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM airports_web
 | WHERE ST_DISJOINT(location, TO_CARTESIANSHAPE("POLYGON((0 -60000000, 120000000 -60000000, 120000000 60000000, 0 60000000, 0 -60000000))"))
@@ -1365,7 +1365,7 @@ x:double  |  y:double  |  count:long
 ;
 
 cartesianPointDisjointEmptyGeometry
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM airports_web
 | WHERE ST_DISJOINT(location, TO_CARTESIANSHAPE("LINESTRING()"))
@@ -1380,7 +1380,7 @@ count:long
 ;
 
 cartesianPointDisjointInvalidGeometry
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM airports_web
 | WHERE ST_DISJOINT(location, TO_CARTESIANSHAPE("Invalid Geometry"))
@@ -1398,7 +1398,7 @@ count:long
 # Tests for ST_CONTAINS on CARTESIAN_POINT type
 
 cartesianCentroidFromAirportsAfterPolygonContainsPointPredicate
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_web
 | WHERE ST_CONTAINS(TO_CARTESIANSHAPE("POLYGON((4700000 1600000, 4800000 1600000, 4800000 1700000, 4700000 1700000, 4700000 1600000))"), location)
@@ -1410,7 +1410,7 @@ POINT (4783520.5 1661010.0)  | 1
 ;
 
 cartesianPolygonContainsPointPredicate
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_web
 | WHERE ST_CONTAINS(TO_CARTESIANSHAPE("POLYGON((4700000 1600000, 4800000 1600000, 4800000 1700000, 4700000 1700000, 4700000 1600000))"), location)
@@ -1421,7 +1421,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 literalCartesianPolygonContainsPointPredicate
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -1435,7 +1435,7 @@ wkt:keyword   | pt:cartesian_point
 ;
 
 cartesianCentroidFromAirportsAfterPointContainsPolygonPredicate
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANSHAPE("POLYGON((4700000 1600000, 4800000 1600000, 4800000 1700000, 4700000 1700000, 4700000 1600000))"))
@@ -1447,7 +1447,7 @@ POINT (NaN NaN)              | 0
 ;
 
 cartesianPointContainsPolygonPredicate
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANSHAPE("POLYGON((4700000 1600000, 4800000 1600000, 4800000 1700000, 4700000 1700000, 4700000 1600000))"))
@@ -1457,7 +1457,7 @@ abbrev:keyword | location:cartesian_point                     |  name:text     |
 ;
 
 literalCartesianPointContainsPolygonPredicate
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -1469,7 +1469,7 @@ wkt:keyword   | pt:cartesian_point
 ;
 
 cartesianPointContainsPointShape
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANSHAPE("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1480,7 +1480,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 cartesianPointContainsPoint
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANPOINT("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1491,7 +1491,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 cartesianPointContainsMultiPoint
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANSHAPE("MULTIPOINT(4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096)"))
@@ -1502,7 +1502,7 @@ abbrev:keyword | location:cartesian_point                     | name:text      |
 ;
 
 cartesianPointContainsLineString
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANSHAPE("LINESTRING(4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096)"))
@@ -1513,7 +1513,7 @@ abbrev:keyword | location:cartesian_point                     | name:text      |
 ;
 
 cartesianPointContainsMultiLineString
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANSHAPE("MULTILINESTRING((4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096),(1408119.2975413958 7484813.53657096, 1996039.722208033 8322469.9470024165))"))
@@ -1524,7 +1524,7 @@ abbrev:keyword | location:cartesian_point                     | name:text      |
 ;
 
 cartesianPointContainsPointShapeWithCentroid
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANSHAPE("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1536,7 +1536,7 @@ POINT (4783520.5 1661010.0) | 1
 ;
 
 cartesianPointContainsPointWithCentroid
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_CONTAINS(location, TO_CARTESIANPOINT("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1551,7 +1551,7 @@ POINT (4783520.5 1661010.0) | 1
 # Tests for ST_WITHIN on CARTESIAN_POINT type
 
 cartesianCentroidFromAirportsAfterWithinPredicate
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANSHAPE("POLYGON((4700000 1600000, 4800000 1600000, 4800000 1700000, 4700000 1700000, 4700000 1600000))"))
@@ -1563,7 +1563,7 @@ POINT (4783520.5 1661010.0)  | 1
 ;
 
 cartesianPointWithinPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANSHAPE("POLYGON((4700000 1600000, 4800000 1600000, 4800000 1700000, 4700000 1700000, 4700000 1600000))"))
@@ -1574,7 +1574,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 literalCartesianPointWithinPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -1588,7 +1588,7 @@ wkt:keyword   | pt:cartesian_point
 ;
 
 cartesianPointWithinPointShape
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANSHAPE("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1599,7 +1599,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 cartesianPointWithinPoint
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANPOINT("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1610,7 +1610,7 @@ HOD            | POINT (4783520.559160681 1661010.0197476079) | Hodeidah Int'l |
 ;
 
 cartesianPointWithinMultiPoint
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANSHAPE("MULTIPOINT(4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096)"))
@@ -1623,7 +1623,7 @@ CPH            | POINT (1408119.2975413958 7484813.53657096)  | Copenhagen     |
 ;
 
 cartesianPointWithinLineString
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANSHAPE("LINESTRING(4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096)"))
@@ -1636,7 +1636,7 @@ CPH            | POINT (1408119.2975413958 7484813.53657096)  | Copenhagen     |
 ;
 
 cartesianPointWithinMultiLineString
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANSHAPE("MULTILINESTRING((4783520.559160681 1661010.0197476079, 1408119.2975413958 7484813.53657096),(1408119.2975413958 7484813.53657096, 1996039.722208033 8322469.9470024165))"))
@@ -1650,7 +1650,7 @@ ARN            | POINT(1996039.722208033 8322469.9470024165)  | Arlanda        |
 ;
 
 cartesianPointWithinPointShapeWithCentroid
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANSHAPE("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1662,7 +1662,7 @@ POINT (4783520.5 1661010.0) | 1
 ;
 
 cartesianPointWithinPointWithCentroid
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | WHERE ST_WITHIN(location, TO_CARTESIANPOINT("POINT(4783520.559160681 1661010.0197476079)"))
@@ -1677,7 +1677,7 @@ POINT (4783520.5 1661010.0) | 1
 # Tests for Equality and casting with GEO_POINT
 
 cartesianPointEquals
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 // tag::to_cartesianpoint-equals[]
 ROW wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"]
@@ -1694,7 +1694,7 @@ wkt:keyword               |pt:cartesian_point
 ;
 
 cartesianPointNotEquals
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 // tag::to_cartesianpoint-not-equals[]
 ROW wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"]
@@ -1711,7 +1711,7 @@ wkt:keyword              |pt:cartesian_point
 ;
 
 convertCartesianFromStringParseError
-required_feature: esql.spatial_points_from_source
+required_capability: spatial_points_from_source
 
 // tag::to_cartesianpoint-str-parse-error[]
 row wkt = ["POINTX(4297.11 -1475.53)", "POINT(7580.93 2272.77)", "POINT(111)"]

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial_shapes.csv-spec
@@ -3,7 +3,7 @@
 #
 
 convertFromString
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 // tag::to_geoshape-str[]
 ROW wkt = "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"
@@ -18,7 +18,7 @@ wkt:keyword                                     | geom:geo_shape
 ;
 
 convertFromStringArray
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 row wkt = ["POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))", "POINT(75.8092915005895 22.727749187571)"]
 | eval pt = to_geoshape(wkt);
@@ -28,7 +28,7 @@ wkt:keyword                                                                     
 ;
 
 convertFromStringViaPoint
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 ROW wkt = "POINT (30 10)"
 | EVAL point = TO_GEOPOINT(wkt)
@@ -41,7 +41,7 @@ wkt:keyword     | point:geo_point | shape:geo_shape
 
 # need to work out how to upload WKT
 simpleLoad
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 FROM countries_bbox | WHERE id == "ISL";
 
@@ -50,7 +50,7 @@ ISL|Iceland|BBOX(-24.538400, -13.499446, 66.536100, 63.390000)
 ;
 
 simpleLoadPointsAsShapes
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 FROM airports
 | WHERE abbrev == "CPH" OR abbrev == "VLC"
@@ -80,7 +80,7 @@ CPH             |  Københavns Kommune  |  POINT(12.5683 55.6761)  |  Copenhagen
 # Tests for ST_INTERSECTS with GEO_SHAPE
 
 pointIntersectsLiteralPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports
 | EVAL location = TO_GEOSHAPE(location)
@@ -93,7 +93,7 @@ HOD            | Hodeidah Int'l | POINT(42.97109630194 14.7552534413725) | Yemen
 ;
 
 polygonIntersectsLiteralPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airport_city_boundaries
 | WHERE ST_INTERSECTS(city_boundary, TO_GEOSHAPE("POLYGON((109.4 18.1, 109.6 18.1, 109.6 18.3, 109.4 18.3, 109.4 18.1))"))
@@ -106,7 +106,7 @@ SYX            | Sanya Phoenix Int'l  | 天涯区       | Sanya        | POINT(1
 ;
 
 pointIntersectsLiteralPolygonReversed
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports
 | EVAL location = TO_GEOSHAPE(location)
@@ -119,7 +119,7 @@ HOD            | Hodeidah Int'l | POINT(42.97109630194 14.7552534413725) | Yemen
 ;
 
 literalPointIntersectsLiteralPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -133,7 +133,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPointIntersectsLiteralPolygonReversed
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -147,7 +147,7 @@ wkt:keyword   | pt:geo_point
 ;
 
 literalPointAsShapeIntersectsLiteralPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -161,7 +161,7 @@ wkt:keyword   | pt:geo_shape
 ;
 
 literalPointAsShapeIntersectsLiteralPolygonReversed
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -175,7 +175,7 @@ wkt:keyword   | pt:geo_shape
 ;
 
 shapeIntersectsLiteralPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM countries_bbox
 | WHERE ST_INTERSECTS(shape, TO_GEOSHAPE("POLYGON((29 -30, 31 -30, 31 -27.3, 29 -27.3, 29 -30))"))
@@ -189,7 +189,7 @@ LSO        | Lesotho      | BBOX(27.013973, 29.455554, -28.570691, -30.650527)
 ;
 
 literalPolygonIntersectsLiteralPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POLYGON((-20 60, -6 60, -6 66, -20 66, -20 60))", "POLYGON((20 60, 6 60, 6 66, 20 66, 20 60))"]
 | EVAL other = TO_GEOSHAPE("POLYGON((-15 64, -10 64, -10 66, -15 66, -15 64))")
@@ -204,7 +204,7 @@ wkt:keyword                                       | shape:geo_shape             
 ;
 
 literalPolygonIntersectsLiteralPolygonOneRow
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW intersects = ST_INTERSECTS(TO_GEOSHAPE("POLYGON((-20 60, -6 60, -6 66, -20 66, -20 60))"), TO_GEOSHAPE("POLYGON((-15 64, -10 64, -10 66, -15 66, -15 64))"))
 ;
@@ -217,7 +217,7 @@ true
 # Tests for ST_DISJOINT with GEO_SHAPE
 
 polygonDisjointLiteralPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 // tag::st_disjoint-airport_city_boundaries[]
 FROM airport_city_boundaries
@@ -238,7 +238,7 @@ ACA            | General Juan N Alvarez Int'l | Acapulco de Juárez | Acapulco d
 # Tests for ST_CONTAINS and ST_WITHIN with GEO_SHAPE
 
 polygonContainsLiteralPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 // tag::st_contains-airport_city_boundaries[]
 FROM airport_city_boundaries
@@ -255,7 +255,7 @@ SYX            | Sanya Phoenix Int'l  | 天涯区       | Sanya        | POINT(1
 ;
 
 polygonWithinLiteralPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 // tag::st_within-airport_city_boundaries[]
 FROM airport_city_boundaries
@@ -275,7 +275,7 @@ SYX            | Sanya Phoenix Int'l  | 天涯区       | Sanya        | POINT(1
 # Tests for Equality and casting with GEO_SHAPE
 
 geo_shapeEquals
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 ROW wkt = ["POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))", "POINT(75.8092915005895 22.727749187571)"]
 | MV_EXPAND wkt
@@ -288,7 +288,7 @@ wkt:keyword                              |pt:geo_shape
 ;
 
 geo_shapeNotEquals
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 ROW wkt = ["POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))", "POINT(75.8092915005895 22.727749187571)"]
 | MV_EXPAND wkt
@@ -301,7 +301,7 @@ wkt:keyword                               |pt:geo_shape
 ;
 
 convertFromStringParseError
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 row wkt = ["POINTX(42.97109630194 14.7552534413725)", "POINT(75.8092915005895 22.727749187571)", "POINT(111)"]
 | mv_expand wkt
@@ -323,7 +323,7 @@ wkt:keyword                               |pt:geo_shape
 #
 
 convertCartesianShapeFromString
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 // tag::to_cartesianshape-str[]
 ROW wkt = ["POINT(4297.11 -1475.53)", "POLYGON ((3339584.72 1118889.97, 4452779.63 4865942.27, 2226389.81 4865942.27, 1113194.90 2273030.92, 3339584.72 1118889.97))"]
@@ -340,7 +340,7 @@ wkt:keyword               |geom:cartesian_shape
 ;
 
 convertCartesianFromStringArray
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 row wkt = ["POLYGON ((3339584.72 1118889.97, 4452779.63 4865942.27, 2226389.81 4865942.27, 1113194.90 2273030.92, 3339584.72 1118889.97))", "POINT(7580.93 2272.77)"]
 | eval pt = to_cartesianshape(wkt);
@@ -350,7 +350,7 @@ wkt:keyword                                                                     
 ;
 
 convertCartesianFromStringViaPoint
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 ROW wkt = "POINT (3010 -1010)"
 | EVAL point = TO_CARTESIANPOINT(wkt)
@@ -363,7 +363,7 @@ wkt:keyword          | point:cartesian_point | shape:cartesian_shape
 
 # need to work out how to upload WKT
 simpleCartesianShapeLoad
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 FROM countries_bbox_web | WHERE id == "ISL";
 
@@ -372,7 +372,7 @@ ISL|Iceland|BBOX(-2731602.192501422, -1502751.454502109, 1.0025136653899286E7, 9
 ;
 
 simpleLoadCartesianPointsAsShapes
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 FROM airports_web
 | WHERE abbrev == "CPH" OR abbrev == "VLC"
@@ -389,7 +389,7 @@ abbrev:keyword | name:text    | scalerank:integer | type:keyword | location:cart
 # Tests for ST_INTERSECTS with CARTESIAN_SHAPE
 
 cartesianPointIntersectsPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM airports_web
 | EVAL location = TO_CARTESIANSHAPE(location)
@@ -402,7 +402,7 @@ HOD            | Hodeidah Int'l | POINT (4783520.559160681 1661010.0197476079) |
 ;
 
 literalCartesianPointIntersectsPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POINT(1 1)", "POINT(-1 -1)", "POINT(-1 1)", "POINT(1 -1)"]
 | MV_EXPAND wkt
@@ -416,7 +416,7 @@ wkt:keyword   | pt:cartesian_shape
 ;
 
 cartesianShapeIntersectsPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 FROM countries_bbox_web
 | WHERE ST_INTERSECTS(shape, TO_CARTESIANSHAPE("POLYGON((3100000 -3400000, 3500000 -3400000, 3500000 -3150000, 3100000 -3150000, 3100000 -3400000))"))
@@ -430,7 +430,7 @@ LSO        | Lesotho      | BBOX(3007181.718244638, 3278977.271857335, -3321117.
 ;
 
 literalCartesianPolygonIntersectsPolygon
-required_feature: esql.st_intersects
+required_capability: st_intersects
 
 ROW wkt = ["POLYGON((-2000 6000, -600 6000, -600 6600, -2000 6600, -2000 6000))", "POLYGON((2000 6000, 600 6000, 600 6600, 2000 6600, 2000 6000))"]
 | MV_EXPAND wkt
@@ -447,7 +447,7 @@ wkt:keyword                                                           | shape:ca
 # Tests for ST_DISJOINT with CARTESIAN_SHAPE
 
 cartesianPolygonDisjointLiteralPolygon
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM countries_bbox_web
 | WHERE ST_DISJOINT(shape, TO_CARTESIANSHAPE("POLYGON((3100000 -3400000, 3500000 -3400000, 3500000 -3150000, 3100000 -3150000, 3100000 -3400000))"))
@@ -460,7 +460,7 @@ ZWE        | Zimbabwe     | BBOX (2809472.180051312, 3681512.6693309383, -176035
 ;
 
 cartesianPolygonDisjointEmptyGeometry
-required_feature: esql.st_disjoint
+required_capability: st_disjoint
 
 FROM countries_bbox_web
 | WHERE ST_DISJOINT(shape, TO_CARTESIANSHAPE("LINESTRING()"))
@@ -478,7 +478,7 @@ count:long
 # Tests for ST_CONTAINS and ST_WITHIN with CARTESIAN_SHAPE
 
 cartesianShapeContainsPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM countries_bbox_web
 | WHERE ST_CONTAINS(shape, TO_CARTESIANSHAPE("POLYGON((3100000 -3400000, 3500000 -3400000, 3500000 -3150000, 3100000 -3150000, 3100000 -3400000))"))
@@ -490,7 +490,7 @@ ZAF        | South Africa | BBOX(1834915.5679635953, 4218142.412200545, -2527908
 ;
 
 cartesianShapeWithinPolygon
-required_feature: esql.st_contains_within
+required_capability: st_contains_within
 
 FROM countries_bbox_web
 | WHERE ST_WITHIN(shape, TO_CARTESIANSHAPE("POLYGON((1800000 -2500000, 4300000 -2500000, 4300000 -6000000, 1800000 -6000000, 1800000 -2500000))"))
@@ -507,7 +507,7 @@ LSO        | Lesotho      | BBOX(3007181.718244638, 3278977.271857335, -3321117.
 # Tests for Equality and casting with CARTESIAN_SHAPE
 
 cartesianshapeEquals
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 ROW wkt = ["POLYGON ((3339584.72 1118889.97, 4452779.63 4865942.27, 2226389.81 4865942.27, 1113194.90 2273030.92, 3339584.72 1118889.97))", "POINT(7580.93 2272.77)"]
 | MV_EXPAND wkt
@@ -520,7 +520,7 @@ wkt:keyword               |pt:cartesian_shape
 ;
 
 cartesianShapeNotEquals
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 ROW wkt = ["POLYGON ((3339584.72 1118889.97, 4452779.63 4865942.27, 2226389.81 4865942.27, 1113194.90 2273030.92, 3339584.72 1118889.97))", "POINT(7580.93 2272.77)"]
 | MV_EXPAND wkt
@@ -533,7 +533,7 @@ wkt:keyword              |pt:cartesian_shape
 ;
 
 convertCartesianShapeFromStringParseError
-required_feature: esql.spatial_shapes
+required_capability: spatial_shapes
 
 row wkt = ["POINTX(4297.11 -1475.53)", "POINT(7580.93 2272.77)", "POINT(111)"]
 | mv_expand wkt

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/string.csv-spec
@@ -71,7 +71,7 @@ emp_no:integer | last_name:keyword | gender:keyword | f_l:boolean
 ;
 
 stringCast
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 ROW a = 1 | eval ss = substring("abcd", "2"), l = left("abcd", "2"), r = right("abcd", "2");
 
@@ -80,7 +80,7 @@ a:integer | ss:keyword | l:keyword | r:keyword
 ;
 
 stringCastEmp
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 from employees
 | eval ss = substring(first_name, "2")
@@ -330,7 +330,7 @@ emp_no:integer | name:keyword
 
 // Note: no matches in MV returned
 in
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where job_positions in ("Internship", first_name) | keep emp_no, job_positions;
 ignoreOrder:true
@@ -522,7 +522,7 @@ emp_no:integer |positions:keyword                                               
 ;
 
 lessThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where job_positions < "C" | keep emp_no, job_positions | sort emp_no;
 warning:Line 1:24: evaluation of [job_positions < \"C\"] failed, treating result as null. Only first 20 failures recorded.
@@ -535,7 +535,7 @@ emp_no:integer |job_positions:keyword
 ;
 
 greaterThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where job_positions > "C" | keep emp_no, job_positions | sort emp_no | limit 6;
 warning:Line 1:24: evaluation of [job_positions > \"C\"] failed, treating result as null. Only first 20 failures recorded.
@@ -552,7 +552,7 @@ emp_no:integer |job_positions:keyword
 ;
 
 equalToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where job_positions == "Accountant" | keep emp_no, job_positions | sort emp_no;
 warning:Line 1:24: evaluation of [job_positions == \"Accountant\"] failed, treating result as null. Only first 20 failures recorded.
@@ -564,7 +564,7 @@ emp_no:integer |job_positions:keyword
 ;
 
 equalToOrEqualToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where job_positions == "Accountant" or job_positions == "Tech Lead" | keep emp_no, job_positions | sort emp_no;
 warning:Line 1:24: evaluation of [job_positions] failed, treating result as null. Only first 20 failures recorded.
@@ -577,7 +577,7 @@ emp_no:integer |job_positions:keyword
 ;
 
 inMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where job_positions in ("Accountant", "Tech Lead") | keep emp_no, job_positions | sort emp_no;
 warning:Line 1:24: evaluation of [job_positions in (\"Accountant\", \"Tech Lead\")] failed, treating result as null. Only first 20 failures recorded.
@@ -590,7 +590,7 @@ emp_no:integer |job_positions:keyword
 ;
 
 notLessThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(job_positions < "C") | keep emp_no, job_positions | sort emp_no | limit 6;
 warning:Line 1:24: evaluation of [not(job_positions < \"C\")] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [job_positions < \"C\"] failed, treating result as null. Only first 20 failures recorded.]
@@ -607,7 +607,7 @@ emp_no:integer |job_positions:keyword
 ;
 
 notGreaterThanMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(job_positions > "C") | keep emp_no, job_positions | sort emp_no | limit 6;
 warning:Line 1:24: evaluation of [not(job_positions > \"C\")] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [job_positions > \"C\"] failed, treating result as null. Only first 20 failures recorded.]
@@ -620,7 +620,7 @@ emp_no:integer |job_positions:keyword
 ;
 
 notEqualToMultivalue
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from employees | where not(job_positions == "Accountant") | keep emp_no, job_positions | sort emp_no | limit 6;
 warning:Line 1:24: evaluation of [not(job_positions == \"Accountant\")] failed, treating result as null. Only first 20 failures recorded.#[Emulated:Line 1:28: evaluation of [job_positions == \"Accountant\"] failed, treating result as null. Only first 20 failures recorded.]
@@ -745,7 +745,7 @@ ROW a=[10, 9, 8]
 ;
 
 mvSort
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 row a = ["Mon", "Tues", "Wed", "Thu", "Fri"] | eval sa = mv_sort(a), sd = mv_sort(a, "DESC");
 
@@ -754,7 +754,7 @@ a:keyword                            | sa:keyword                 | sd:keyword
 ;
 
 mvSortEmp
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 FROM employees
 | eval sd = mv_sort(job_positions, "DESC"), sa = mv_sort(job_positions)
@@ -772,7 +772,7 @@ emp_no:integer | job_positions:keyword                                          
 ;
 
 mvSliceCast
-required_feature: esql.string_literal_auto_casting
+required_capability: string_literal_auto_casting
 
 ROW a = ["1", "2", "3", "4"]
 | eval a1 = mv_slice(a, "0", "1");
@@ -782,7 +782,7 @@ a:keyword            | a1:keyword
 ;
 
 mvSliceEmp
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval a1 = mv_slice(salary_change.keyword, 0, 1)
@@ -799,7 +799,7 @@ emp_no:integer | salary_change.keyword:keyword | a1:keyword
 ;
 
 mvZip
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 // tag::mv_zip[]
 ROW a = ["x", "y", "z"], b = ["1", "2"]
@@ -815,7 +815,7 @@ a:keyword | b:keyword | c:keyword
 ;
 
 mvZipEmp
-required_feature: esql.mv_sort
+required_capability: mv_sort
 
 from employees
 | eval full_name = mv_zip(first_name, last_name, " "), full_name_2 = mv_zip(last_name, first_name), jobs = mv_zip(job_positions, salary_change.keyword, "#")
@@ -842,7 +842,7 @@ beta             | Kubernetes cluster       | [beta k8s server, beta k8s server2
 ;
 
 lengthOfText
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where host=="epsilon" | eval l1 = length(host_group), l2 = length(description) | keep l1, l2;
 ignoreOrder:true
@@ -856,7 +856,7 @@ null                   | 19
 ;
 
 startsWithText
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where host=="epsilon" | eval l1 = starts_with(host_group, host), l2 = starts_with(description, host) | keep l1, l2;
 ignoreOrder:true
@@ -870,7 +870,7 @@ false                  | null
 ;
 
 substringOfText
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where host=="epsilon" | eval l1 = substring(host_group, 0, 5), l2 = substring(description, 0, 5) | keep l1, l2;
 ignoreOrder:true
@@ -884,7 +884,7 @@ Gatew                  | null
 ;
 
 concatOfText
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where host == "epsilon" | eval l1 = concat(host, "/", host_group), l2 = concat(host_group, "/", description) | sort l1 |  keep l1, l2;
 warning:Line 1:86: evaluation of [concat(host_group, \"/\", description)] failed, treating result as null. Only first 20 failures recorded.
@@ -1150,7 +1150,7 @@ a:keyword           | upper:keyword         | lower:keyword
 ;
 
 values
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM employees
 | WHERE emp_no <= 10009
@@ -1162,7 +1162,7 @@ required_feature: esql.agg_values
 ;
 
 valuesGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
 // tag::values-grouped[]
   FROM employees
@@ -1314,7 +1314,7 @@ min(f_l):integer | max(f_l):integer | job_positions:keyword
 ;
 
 locateWarnings#[skip:-8.13.99,reason:new string function added in 8.14]
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from hosts | where host=="epsilon" | eval l1 = locate(host_group, "ate"), l2 = locate(description, "ate") | keep l1, l2;
 ignoreOrder:true
@@ -1328,7 +1328,7 @@ null       | 0
 ;
 
 base64Encode#[skip:-8.13.99,reason:new base64 function added in 8.14]
-required_feature: esql.base64_decode_encode
+required_capability: base64_decode_encode
 
 // tag::to_base64[]
 row a = "elastic" 
@@ -1343,7 +1343,7 @@ elastic   | ZWxhc3RpYw==
 ;
 
 base64Decode#[skip:-8.13.99,reason:new base64 function added in 8.14]
-required_feature: esql.base64_decode_encode
+required_capability: base64_decode_encode
 
 // tag::from_base64[]
 row a = "ZWxhc3RpYw==" 
@@ -1358,7 +1358,7 @@ ZWxhc3RpYw== | elastic
 ;
 
 base64EncodeDecodeEmp#[skip:-8.13.99,reason:new base64 function added in 8.14]
-required_feature: esql.base64_decode_encode
+required_capability: base64_decode_encode
 
 from employees
 | where emp_no < 10032 and emp_no > 10027

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unsigned_long.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/unsigned_long.csv-spec
@@ -46,7 +46,7 @@ from ul_logs | sort bytes_in desc nulls last, id | limit 12;
 ;
 
 filterPushDownGT
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from ul_logs | where bytes_in >= to_ul(74330435873664882) | sort bytes_in | eval div = bytes_in / to_ul(pow(10., 15)) | keep bytes_in, div, id | limit 12;
 warning:Line 1:22: evaluation of [bytes_in >= to_ul(74330435873664882)] failed, treating result as null. Only first 20 failures recorded.
@@ -68,7 +68,7 @@ warning:Line 1:22: java.lang.IllegalArgumentException: single-value function enc
 ;
 
 filterPushDownRange
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from ul_logs | where bytes_in >= to_ul(74330435873664882) | where bytes_in <= to_ul(316080452389500167)  | sort bytes_in | eval div = bytes_in / to_ul(pow(10., 15)) | keep bytes_in, div, id | limit 12;
 warning:Line 1:22: evaluation of [bytes_in >= to_ul(74330435873664882)] failed, treating result as null. Only first 20 failures recorded.
@@ -84,7 +84,7 @@ warning:#[Emulated:Line 1:67: java.lang.IllegalArgumentException: single-value f
 ;
 
 filterPushDownIn
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 // TODO: testing framework doesn't perform implicit conversion to UL of given values, needs explicit conversion
 from ul_logs | where bytes_in in (to_ul(74330435873664882), to_ul(154551962150890564), to_ul(195161570976258241)) | sort bytes_in | keep bytes_in, id;
@@ -98,7 +98,7 @@ warning:Line 1:22: java.lang.IllegalArgumentException: single-value function enc
 ;
 
 filterOnFieldsEquality
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from ul_logs | where bytes_in == bytes_out;
 warning:Line 1:22: evaluation of [bytes_in == bytes_out] failed, treating result as null. Only first 20 failures recorded.
@@ -109,7 +109,7 @@ warning:Line 1:22: java.lang.IllegalArgumentException: single-value function enc
 ;
 
 filterOnFieldsInequality
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from ul_logs | sort id | where bytes_in < bytes_out | eval b_in = bytes_in / to_ul(pow(10.,15)), b_out = bytes_out / to_ul(pow(10.,15)) | limit 5;
 warning:Line 1:32: evaluation of [bytes_in < bytes_out] failed, treating result as null. Only first 20 failures recorded.
@@ -140,7 +140,7 @@ from ul_logs | stats c = count(bytes_in) by bytes_in | sort c desc, bytes_in des
 ;
 
 case
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 from ul_logs | where case(bytes_in == to_ul(154551962150890564), true, false);
 warning:Line 1:27: evaluation of [bytes_in == to_ul(154551962150890564)] failed, treating result as null. Only first 20 failures recorded.
@@ -151,7 +151,7 @@ warning:Line 1:27: java.lang.IllegalArgumentException: single-value function enc
 ;
 
 toDegrees
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 FROM ul_logs | WHERE bytes_in == bytes_out | EVAL deg = TO_DEGREES(bytes_in) | KEEP bytes_in, deg
 ;
@@ -163,7 +163,7 @@ warning:Line 1:22: java.lang.IllegalArgumentException: single-value function enc
 ;
 
 toRadians
-required_feature: esql.mv_warn
+required_capability: mv_warn
 
 FROM ul_logs | WHERE bytes_in == bytes_out | EVAL rad = TO_RADIANS(bytes_in) | KEEP bytes_in, rad
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/version.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/version.csv-spec
@@ -312,7 +312,7 @@ null       | null      | null            | 11    | 0     | 1.3.0  | 0.1     | no
 ;
 
 values
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM apps
 | STATS version=MV_SORT(VALUES(version))
@@ -323,7 +323,7 @@ required_feature: esql.agg_values
 ;
 
 valuesGrouped
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM apps
 | EVAL name=SUBSTRING(name, 0, 1)
@@ -348,7 +348,7 @@ version:version | name:keyword
 ;
 
 valuesGroupedByOrdinals
-required_feature: esql.agg_values
+required_capability: agg_values
 
   FROM apps
 | STATS version=MV_SORT(VALUES(version)) BY name
@@ -372,7 +372,7 @@ version:version | name:keyword
 ;
 
 implictCastingEqual
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from apps | where version == "1.2.3.4" | sort name | keep name, version;
 
 name:keyword | version:version
@@ -381,7 +381,7 @@ hhhhh        | 1.2.3.4
 ;
 
 implictCastingNotEqual
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from apps | where version != "1.2.3.4" | sort name, version | keep name, version | limit 2;
 
 name:keyword | version:version
@@ -390,7 +390,7 @@ bbbbb        | 2.1
 ;
 
 implictCastingGreaterThan
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from apps | where version > "1.2.3.4" | sort name, version | keep name, version | limit 2;
 
 name:keyword | version:version
@@ -399,7 +399,7 @@ ccccc        | 2.3.4
 ;
 
 implictCastingLessThanOrEqual
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from apps | where version <= "1.2.3.4" | sort name, version | keep name, version | limit 2;
 
 name:keyword | version:version
@@ -408,7 +408,7 @@ aaaaa        | 1.2.3.4
 ;
 
 implictCastingIn
-required_feature: esql.string_literal_auto_casting_extended
+required_capability: string_literal_auto_casting_extended
 from apps | where version in ( "1.2.3.4", "bad" ) | sort name | keep name, version;
 
 name:keyword | version:version

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/CsvSpecReader.java
@@ -43,8 +43,8 @@ public final class CsvSpecReader {
                 if (line.startsWith(SCHEMA_PREFIX)) {
                     assertThat("Early schema already declared " + earlySchema, earlySchema.length(), is(0));
                     earlySchema.append(line.substring(SCHEMA_PREFIX.length()).trim());
-                } else if (line.toLowerCase(Locale.ROOT).startsWith("required_feature:")) {
-                    requiredCapabilities.add(line.substring("required_feature:".length()).trim().replace("esql.", ""));
+                } else if (line.toLowerCase(Locale.ROOT).startsWith("required_capability:")) {
+                    requiredCapabilities.add(line.substring("required_capability:".length()).trim());
                 } else {
                     if (line.endsWith(";")) {
                         // pick up the query


### PR DESCRIPTION
This renames `required_feature` to `required_capability` because we're now using the newlt built `capabilities` API.
