### PR TITLE
[8.14] [DOCS] Document `manage_inference` and `monitor_inference` cluster privileges (#108553)

### DIFF
--- a/docs/reference/security/authorization/privileges.asciidoc
+++ b/docs/reference/security/authorization/privileges.asciidoc
@@ -85,6 +85,9 @@ All {Ilm} operations related to managing policies.
 `manage_index_templates`::
 All operations on index templates.
 
+`manage_inference`::
+All operations related to managing {infer}.
+
 `manage_ingest_pipelines`::
 All operations on ingest pipelines.
 
@@ -191,6 +194,9 @@ node info, node and cluster stats, and pending cluster tasks.
 
 `monitor_enrich`::
 All read-only operations related to managing and executing enrich policies.
+
+`monitor_inference`::
+All read-only operations related to {infer}.
 
 `monitor_ml`::
 All read-only {ml} operations, such as getting information about {dfeeds}, jobs,


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [DOCS] Document `manage_inference` and `monitor_inference` cluster privileges (#108553)