### PR TITLE
Migrate server internalClusterTest to use MockLogAppender.capture

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -250,17 +250,16 @@ public class RolloverIT extends ESIntegTestCase {
         ensureGreen();
         Logger allocationServiceLogger = LogManager.getLogger(AllocationService.class);
 
-        MockLogAppender appender = new MockLogAppender();
-        appender.addExpectation(
-            new MockLogAppender.UnseenEventExpectation(
-                "no related message logged on dry run",
-                AllocationService.class.getName(),
-                Level.INFO,
-                "*test_index*"
-            )
-        );
         final RolloverResponse response;
-        try (var ignored = appender.capturing(AllocationService.class)) {
+        try (var appender = MockLogAppender.capture(AllocationService.class)) {
+            appender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation(
+                    "no related message logged on dry run",
+                    AllocationService.class.getName(),
+                    Level.INFO,
+                    "*test_index*"
+                )
+            );
             response = indicesAdmin().prepareRolloverIndex("test_alias").dryRun(true).get();
             appender.assertAllExpectationsMatched();
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
@@ -68,10 +68,9 @@ public class ShardLockFailureIT extends ESIntegTestCase {
             }
         });
 
-        var mockLogAppender = new MockLogAppender();
         try (
             var ignored1 = internalCluster().getInstance(NodeEnvironment.class, node).shardLock(shardId, "blocked for test");
-            var ignored2 = mockLogAppender.capturing(IndicesClusterStateService.class);
+            var mockLogAppender = MockLogAppender.capture(IndicesClusterStateService.class);
         ) {
             final CountDownLatch countDownLatch = new CountDownLatch(1);
 
@@ -138,10 +137,9 @@ public class ShardLockFailureIT extends ESIntegTestCase {
 
         final var shardId = new ShardId(resolveIndex(indexName), 0);
 
-        var mockLogAppender = new MockLogAppender();
         try (
             var ignored1 = internalCluster().getInstance(NodeEnvironment.class, node).shardLock(shardId, "blocked for test");
-            var ignored2 = mockLogAppender.capturing(IndicesClusterStateService.class);
+            var mockLogAppender = MockLogAppender.capture(IndicesClusterStateService.class);
         ) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -31,7 +31,6 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.IndexSettings;
@@ -649,8 +648,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         reason = "verify the log output on cancelled"
     )
     public void testCancel() throws Exception {
-        MockLogAppender logAppender = new MockLogAppender();
-        try (Releasable ignored = logAppender.capturing(TransportFieldCapabilitiesAction.class)) {
+        try (var logAppender = MockLogAppender.capture(TransportFieldCapabilitiesAction.class)) {
             logAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "clear resources",

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1264,11 +1264,10 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         final String repoName = "test-repo";
         createRepository(repoName, "fs");
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.addExpectation(
-            new MockLogAppender.UnseenEventExpectation("no warnings", BlobStoreRepository.class.getCanonicalName(), Level.WARN, "*")
-        );
-        try (var ignored = mockAppender.capturing(BlobStoreRepository.class)) {
+        try (var mockAppender = MockLogAppender.capture(BlobStoreRepository.class)) {
+            mockAppender.addExpectation(
+                new MockLogAppender.UnseenEventExpectation("no warnings", BlobStoreRepository.class.getCanonicalName(), Level.WARN, "*")
+            );
             final String index1 = "index-1";
             final String index2 = "index-2";
             createIndexWithContent("index-1");

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -162,8 +162,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         value = "org.elasticsearch.snapshots.RestoreService:INFO"
     )
     public void testRestoreLogging() throws IllegalAccessException {
-        final MockLogAppender mockLogAppender = new MockLogAppender();
-        try (var ignored = mockLogAppender.capturing(RestoreService.class)) {
+        try (var mockLogAppender = MockLogAppender.capture(RestoreService.class)) {
             String indexName = "testindex";
             String repoName = "test-restore-snapshot-repo";
             String snapshotName = "test-restore-snapshot";
@@ -899,8 +898,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         index(indexName, "some_id", Map.of("foo", "bar"));
         assertAcked(indicesAdmin().prepareClose(indexName).get());
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(FileRestoreContext.class)) {
+        try (var mockAppender = MockLogAppender.capture(FileRestoreContext.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation("no warnings", FileRestoreContext.class.getCanonicalName(), Level.WARN, "*")
             );

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
@@ -136,9 +136,7 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
         }
         final String primaryNode = internalCluster().startNode(primaryNodeSettings);
 
-        final MockLogAppender mockLogAppender = new MockLogAppender();
-        try (var ignored = mockLogAppender.capturing(BlobStoreRepository.class)) {
-
+        try (var mockLogAppender = MockLogAppender.capture(BlobStoreRepository.class)) {
             MockLogAppender.EventuallySeenEventExpectation snapshotExpectation = new MockLogAppender.EventuallySeenEventExpectation(
                 "snapshot speed over recovery speed",
                 "org.elasticsearch.repositories.blobstore.BlobStoreRepository",

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
@@ -31,9 +31,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
         createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
 
-        final MockLogAppender mockLogAppender = new MockLogAppender();
-
-        try (var ignored = mockLogAppender.capturing(SnapshotsService.class)) {
+        try (var mockLogAppender = MockLogAppender.capture(SnapshotsService.class)) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation(
                     "[does-not-exist]",
@@ -80,10 +78,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
         createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
 
-        final MockLogAppender mockLogAppender = new MockLogAppender();
-
-        try (var ignored = mockLogAppender.capturing(SnapshotsService.class)) {
-
+        try (var mockLogAppender = MockLogAppender.capture(SnapshotsService.class)) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "[test-snapshot]",


### PR DESCRIPTION
relates https://github.com/elastic/elasticsearch/pull/108526