### PR TITLE
Fix listener called twice in compute service

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -705,8 +705,10 @@ public class ComputeService {
             ? Collections.synchronizedList(new ArrayList<>())
             : List.of();
         final var responseHeadersCollector = new ResponseHeadersCollector(transportService.getThreadPool().getThreadContext());
-        listener = ActionListener.runBefore(listener, responseHeadersCollector::finish);
-        try (RefCountingListener refs = new RefCountingListener(listener.map(i -> new ComputeResponse(collectedProfiles)))) {
+        final RefCountingListener listenerRefs = new RefCountingListener(
+            ActionListener.runBefore(listener.map(unused -> new ComputeResponse(collectedProfiles)), responseHeadersCollector::finish)
+        );
+        try (listenerRefs) {
             final AtomicBoolean cancelled = new AtomicBoolean();
             // run compute with target shards
             var internalSink = exchangeService.createSinkHandler(request.sessionId(), request.pragmas().exchangeBufferSize());
@@ -716,16 +718,16 @@ public class ComputeService {
                 internalSink,
                 request.configuration().pragmas().maxConcurrentShardsPerNode(),
                 collectedProfiles,
-                ActionListener.runBefore(cancelOnFailure(task, cancelled, refs.acquire()), responseHeadersCollector::collect)
+                ActionListener.runBefore(cancelOnFailure(task, cancelled, listenerRefs.acquire()), responseHeadersCollector::collect)
             );
             dataNodeRequestExecutor.start();
             // run the node-level reduction
             var externalSink = exchangeService.getSinkHandler(externalId);
             task.addListener(() -> exchangeService.finishSinkHandler(externalId, new TaskCancelledException(task.getReasonCancelled())));
             var exchangeSource = new ExchangeSourceHandler(1, esqlExecutor);
-            exchangeSource.addCompletionListener(refs.acquire());
+            exchangeSource.addCompletionListener(listenerRefs.acquire());
             exchangeSource.addRemoteSink(internalSink::fetchPageAsync, 1);
-            ActionListener<Void> reductionListener = cancelOnFailure(task, cancelled, refs.acquire());
+            ActionListener<Void> reductionListener = cancelOnFailure(task, cancelled, listenerRefs.acquire());
             runCompute(
                 task,
                 new ComputeContext(
@@ -754,7 +756,7 @@ public class ComputeService {
         } catch (Exception e) {
             exchangeService.finishSinkHandler(externalId, e);
             exchangeService.finishSinkHandler(request.sessionId(), e);
-            listener.onFailure(e);
+            listenerRefs.acquire().onFailure(e);
         }
     }
 


### PR DESCRIPTION
I've been running ESQL integration tests along with stress-ng on several dedicated CI instances last week. One problem they found is that a listener gets called twice on cancellation, which trips our assertions, though it doesn't affect correctness. This fix ensures that a sub-listener is notified instead of the main one when exceptions occur.