### PR TITLE
[8.14] [Test] Ignore closed connections on Windows hosts (#108362)

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpClient.java
@@ -40,6 +40,7 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.netty4.NettyAllocator;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
@@ -203,7 +204,11 @@ class Netty4HttpClient implements Closeable {
 
                 @Override
                 public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-                    if (cause instanceof PrematureChannelClosureException || cause instanceof SocketException) {
+                    if (cause instanceof PrematureChannelClosureException
+                        || cause instanceof SocketException
+                        || (cause instanceof IOException
+                            && cause.getMessage() != null
+                            && cause.getMessage().contains("An established connection was aborted by the software in your host machine"))) {
                         // no more requests coming, so fast-forward the latch
                         fastForward();
                     } else {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Test] Ignore closed connections on Windows hosts (#108362)](https://github.com/elastic/elasticsearch/pull/108362)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)