### PR TITLE
Replace mocks with test implementation in RepositoriesServiceTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.repositories;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
@@ -313,18 +314,11 @@ public class RepositoriesServiceTests extends ESTestCase {
         // 2. repository creation successfully when current node become master node and repository is put again
         var request = new PutRepositoryRequest().name(repoName).type(TestRepository.TYPE);
 
-        repositoriesService.registerRepository(request, new ActionListener<>() {
-            @Override
-            public void onResponse(AcknowledgedResponse acknowledgedResponse) {
-                assertTrue(acknowledgedResponse.isAcknowledged());
-                assertThat(repositoriesService.repository(repoName), isA(TestRepository.class));
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                assert false : e;
-            }
-        });
+        var resultListener = new SubscribableListener<AcknowledgedResponse>();
+        repositoriesService.registerRepository(request, resultListener);
+        var resp = safeAwait(resultListener);
+        assertTrue(resp.isAcknowledged());
+        assertThat(repositoriesService.repository(repoName), isA(TestRepository.class));
     }
 
     private ClusterState createClusterStateWithRepo(String repoName, String repoType) {

--- a/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/RepositoriesServiceTests.java
@@ -316,8 +316,8 @@ public class RepositoriesServiceTests extends ESTestCase {
 
         var resultListener = new SubscribableListener<AcknowledgedResponse>();
         repositoriesService.registerRepository(request, resultListener);
-        var resp = safeAwait(resultListener);
-        assertTrue(resp.isAcknowledged());
+        var response = safeAwait(resultListener);
+        assertTrue(response.isAcknowledged());
         assertThat(repositoriesService.repository(repoName), isA(TestRepository.class));
     }
 


### PR DESCRIPTION
I observed that `testRegisterRepositorySuccessAfterCreationFailed` test never invokes assertion blocks, because listener is not invoked.

There are 2 problems:

1. Test setup used mocks. Mocks interrupt listener chain propagation, so registerRepository never returned Response or Failure.
2. We silently ignore assertions in listener because it is not invoked. Test pass successfully.

PutRepositories method relies on cluster state update. I replace mocked ClusterService and ThreadPool with test implementation of these. Also add blocking call on listener to ensure we get result.

Address [comment](https://github.com/elastic/elasticsearch/pull/108531#pullrequestreview-2051318976) to break down larger PR into smaller pieces in #108531 