### PR TITLE
[Inference API] Update Cohere rate limit link to point to docs instead of blog post

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/cohere/CohereServiceSettings.java
@@ -44,7 +44,7 @@ public class CohereServiceSettings extends FilteredXContentObject implements Ser
     public static final String OLD_MODEL_ID_FIELD = "model";
     public static final String MODEL_ID = "model_id";
     private static final Logger logger = LogManager.getLogger(CohereServiceSettings.class);
-    // The rate limit defined here is pulled for the blog: https://txt.cohere.com/free-developer-tier-announcement/ for the production tier
+    // Production key rate limits for all endpoints: https://docs.cohere.com/docs/going-live#production-key-specifications
     // 10K requests a minute
     private static final RateLimitSettings DEFAULT_RATE_LIMIT_SETTINGS = new RateLimitSettings(10_000);
 


### PR DESCRIPTION
There's now a [page](https://docs.cohere.com/docs/going-live#production-key-specifications), which specifies rate limits. I guess this page gets updates and the blog doesn't, therefore updating the link.