### PR TITLE
Remove unused `?master_node_timeout` compat shims

### DIFF
--- a/docs/changelog/108601.yaml
+++ b/docs/changelog/108601.yaml
@@ -1,0 +1,5 @@
+pr: 108601
+summary: Remove unused `?master_node_timeout` compat shims
+area: Distributed
+type: tech debt
+issues: []

--- a/docs/changelog/108601.yaml
+++ b/docs/changelog/108601.yaml
@@ -1,5 +1,0 @@
-pr: 108601
-summary: Remove unused `?master_node_timeout` compat shims
-area: Distributed
-type: tech debt
-issues: []

--- a/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/AcknowledgedRequest.java
@@ -52,11 +52,6 @@ public abstract class AcknowledgedRequest<Request extends MasterNodeRequest<Requ
         this.ackTimeout = Objects.requireNonNull(ackTimeout);
     }
 
-    @Deprecated(forRemoval = true) // just a temporary compatibility shim
-    protected AcknowledgedRequest(TimeValue ackTimeout) {
-        this(MasterNodeRequest.TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT, ackTimeout);
-    }
-
     protected AcknowledgedRequest(StreamInput in) throws IOException {
         super(in);
         this.ackTimeout = in.readTimeValue();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetMlAutoscalingStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetMlAutoscalingStats.java
@@ -45,11 +45,6 @@ public class GetMlAutoscalingStats extends ActionType<Response> {
             this.requestTimeout = Objects.requireNonNull(requestTimeout);
         }
 
-        @Deprecated(forRemoval = true) // temporary compatibility shi
-        public Request(TimeValue timeout) {
-            this(TRAPPY_IMPLICIT_DEFAULT_MASTER_NODE_TIMEOUT, timeout);
-        }
-
         public Request(StreamInput in) throws IOException {
             super(in);
             this.requestTimeout = in.readTimeValue();


### PR DESCRIPTION
These overloads are no longer used so this commit removes them.

Relates #107984