### PR TITLE
[DOCS] Add crosslink to retrievers overview

### DIFF
--- a/docs/reference/search/retriever.asciidoc
+++ b/docs/reference/search/retriever.asciidoc
@@ -12,6 +12,11 @@ allows for complex behavior to be depicted in a tree-like structure, called
 the retriever tree, to better clarify the order of operations that occur
 during a search.
 
+[TIP]
+====
+Refer to <<retrievers-overview>> for a high level overview of the retrievers abstraction.
+====
+
 The following retrievers are available:
 
 `standard`::


### PR DESCRIPTION
Link to https://www.elastic.co/guide/en/elasticsearch/reference/master/retrievers-overview.html from API reference

