### PR TITLE
Extract `ShardBlobsToDelete`

### DIFF
--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.action.support.RefCountingRunnable;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -47,6 +48,7 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 
@@ -56,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -71,6 +74,7 @@ import static org.elasticsearch.repositories.RepositoryDataTests.generateRandomR
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -493,5 +497,42 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
                 .put(Environment.PATH_REPO_SETTING.getKey(), home.resolve("repo").toAbsolutePath())
                 .build()
         );
+    }
+
+    public void testShardBlobsToDelete() {
+        final var repo = setupRepo();
+        final var shardBlobsToDelete = repo.new ShardBlobsToDelete();
+        final var expectedShardGenerations = ShardGenerations.builder();
+        final var expectedBlobsToDelete = new HashSet<String>();
+
+        final var countDownLatch = new CountDownLatch(1);
+        try (var refs = new RefCountingRunnable(countDownLatch::countDown)) {
+            for (int index = between(0, 10); index > 0; index--) {
+                final var indexId = new IndexId(randomIdentifier(), randomUUID());
+                for (int shard = between(1, 3); shard > 0; shard--) {
+                    final var shardId = shard;
+                    final var shardGeneration = new ShardGeneration(randomUUID());
+                    expectedShardGenerations.put(indexId, shard, shardGeneration);
+                    final var blobsToDelete = randomList(10, ESTestCase::randomIdentifier);
+                    final var indexPath = repo.basePath().add("indices").add(indexId.getId()).add(Integer.toString(shard)).buildAsString();
+                    for (final var blobToDelete : blobsToDelete) {
+                        expectedBlobsToDelete.add(indexPath + blobToDelete);
+                    }
+
+                    repo.threadPool()
+                        .generic()
+                        .execute(
+                            ActionRunnable.run(
+                                refs.acquireListener(),
+                                () -> shardBlobsToDelete.addShardDeleteResult(indexId, shardId, shardGeneration, blobsToDelete)
+                            )
+                        );
+                }
+            }
+        }
+        safeAwait(countDownLatch);
+        assertEquals(expectedShardGenerations.build(), shardBlobsToDelete.getUpdatedShardGenerations());
+        shardBlobsToDelete.getBlobPaths().forEachRemaining(s -> assertTrue(expectedBlobsToDelete.remove(s)));
+        assertThat(expectedBlobsToDelete, empty());
     }
 }


### PR DESCRIPTION
Encapsulates this component of the snapshot deletion process so we can
follow up with some optimizations in isolation.

Relates #108278