### PR TITLE
[Connector API] Change UpdateConnectorFiltering API to have better defaults

### DIFF
--- a/docs/changelog/108612.yaml
+++ b/docs/changelog/108612.yaml
@@ -1,0 +1,5 @@
+pr: 108612
+summary: "[Connector API] Change `UpdateConnectorFiltering` API to have better defaults"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/60_connector_update_filtering.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/60_connector_update_filtering.yml
@@ -191,16 +191,115 @@ setup:
 ---
 "Update Connector Filtering with value literal - Empty rules":
   - do:
-      catch: "bad_request"
       connector.update_filtering:
         connector_id: test-connector
         body:
           rules: [ ]
 
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { filtering.0.draft.rules.0.id: "DEFAULT" }
+  - match: { filtering.0.draft.rules.0.policy: "include" }
+  - match: { filtering.0.draft.rules.0.rule: "regex" }
+  - match: { filtering.0.draft.rules.0.value: ".*" }
+  - match: { filtering.0.draft.rules.0.field: "_" }
+  - match: { filtering.0.draft.rules.0.order: 0 }
+
+---
+"Update Connector Filtering with with value literal - Only default rule":
+  - do:
+      connector.update_filtering:
+        connector_id: test-connector
+        body:
+          rules:
+            - created_at: "2023-05-25T12:30:00.000Z"
+              field: _
+              id: DEFAULT
+              order: 0
+              policy: include
+              rule: regex
+              updated_at: "2023-05-25T12:30:00.000Z"
+              value: ".*"
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { filtering.0.draft.rules.0.id: "DEFAULT" }
+  - match: { filtering.0.draft.rules.0.policy: "include" }
+  - match: { filtering.0.draft.rules.0.rule: "regex" }
+  - match: { filtering.0.draft.rules.0.value: ".*" }
+  - match: { filtering.0.draft.rules.0.field: "_" }
+  - match: { filtering.0.draft.rules.0.order: 0 }
+
+
+---
+"Update Connector Filtering - Mixed order and default value":
+  - do:
+      connector.update_filtering:
+        connector_id: test-connector
+        body:
+            rules:
+                - created_at: "2023-05-25T12:30:00.000Z"
+                  field: _
+                  id: DEFAULT
+                  order: 5
+                  policy: include
+                  rule: regex
+                  updated_at: "2023-05-25T12:30:00.000Z"
+                  value: ".*"
+                - created_at: "2023-05-25T12:30:00.000Z"
+                  field: my_field
+                  id: MY_RULE
+                  order: 3
+                  policy: exclude
+                  rule: regex
+                  updated_at: "2023-05-25T12:30:00.000Z"
+                  value: "tax-.*"
+                - created_at: "2023-05-25T12:30:00.000Z"
+                  field: my_field
+                  id: MY_RULE_2
+                  order: 0
+                  policy: include
+                  rule: regex
+                  updated_at: "2023-05-25T12:30:00.000Z"
+                  value: "fix-.*"
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  # rules are sorted by order and default rule is always last
+  - match: { filtering.0.draft.rules.0.id: "MY_RULE_2" }
+  - match: { filtering.0.draft.rules.0.policy: "include" }
+  - match: { filtering.0.draft.rules.0.rule: "regex" }
+  - match: { filtering.0.draft.rules.0.value: "fix-.*" }
+  - match: { filtering.0.draft.rules.0.field: "my_field" }
+  - match: { filtering.0.draft.rules.0.order: 0 }
+  - match: { filtering.0.draft.rules.1.id: "MY_RULE" }
+  - match: { filtering.0.draft.rules.1.policy: "exclude" }
+  - match: { filtering.0.draft.rules.1.rule: "regex" }
+  - match: { filtering.0.draft.rules.1.value: "tax-.*" }
+  - match: { filtering.0.draft.rules.1.field: "my_field" }
+  - match: { filtering.0.draft.rules.1.order: 3 }
+  # Make sure default rule has the highest order
+  - match: { filtering.0.draft.rules.2.id: "DEFAULT" }
+  - match: { filtering.0.draft.rules.2.policy: "include" }
+  - match: { filtering.0.draft.rules.2.rule: "regex" }
+  - match: { filtering.0.draft.rules.2.value: ".*" }
+  - match: { filtering.0.draft.rules.2.field: "_" }
+  - match: { filtering.0.draft.rules.2.order: 4 }
+
 ---
 "Update Connector Filtering with value literal - Default rule not present":
   - do:
-      catch: "bad_request"
       connector.update_filtering:
         connector_id: test-connector
         body:
@@ -213,6 +312,25 @@ setup:
               rule: regex
               updated_at: "2023-05-25T12:30:00.000Z"
               value: "hello-not-default-rule.*"
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { filtering.0.draft.rules.0.id: "MY_RULE" }
+  - match: { filtering.0.draft.rules.0.policy: "exclude" }
+  - match: { filtering.0.draft.rules.0.rule: "regex" }
+  - match: { filtering.0.draft.rules.0.value: "hello-not-default-rule.*" }
+  - match: { filtering.0.draft.rules.0.field: "my_field" }
+  - match: { filtering.0.draft.rules.0.order: 0 }
+  - match: { filtering.0.draft.rules.1.id: "DEFAULT" }
+  - match: { filtering.0.draft.rules.1.policy: "include" }
+  - match: { filtering.0.draft.rules.1.rule: "regex" }
+  - match: { filtering.0.draft.rules.1.value: ".*" }
+  - match: { filtering.0.draft.rules.1.field: "_" }
+  - match: { filtering.0.draft.rules.1.order: 1 }
 
 ---
 "Update Connector Filtering - Connector doesn't exist":

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -63,6 +63,7 @@ import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJob;
 import org.elasticsearch.xpack.application.connector.syncjob.ConnectorSyncJobIndexService;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -76,6 +77,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.application.connector.ConnectorFiltering.fromXContentBytesConnectorFiltering;
+import static org.elasticsearch.xpack.application.connector.ConnectorFiltering.sortFilteringRulesByOrder;
 
 /**
  * A service that manages persistent {@link Connector} configurations.
@@ -615,7 +617,13 @@ public class ConnectorIndexService {
                     ? connectorFilteringSingleton.getDraft().getAdvancedSnippet()
                     : advancedSnippet;
 
-                List<FilteringRule> newDraftRules = rules == null ? connectorFilteringSingleton.getDraft().getRules() : rules;
+                List<FilteringRule> newDraftRules = rules == null
+                    ? connectorFilteringSingleton.getDraft().getRules()
+                    : new ArrayList<>(rules);
+
+                if (rules != null) {
+                    newDraftRules = sortFilteringRulesByOrder(newDraftRules);
+                }
 
                 ConnectorFiltering connectorFilteringWithUpdatedDraft = connectorFilteringSingleton.setDraft(
                     new FilteringRules.Builder().setRules(newDraftRules)

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorFilteringAction.java
@@ -34,7 +34,6 @@ import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
-import static org.elasticsearch.xpack.application.connector.ConnectorFiltering.isDefaultRulePresentInFilteringRules;
 
 public class UpdateConnectorFilteringAction {
 
@@ -101,15 +100,6 @@ public class UpdateConnectorFilteringAction {
             if (filtering == null) {
                 if (rules == null && advancedSnippet == null) {
                     validationException = addValidationError("[advanced_snippet] and [rules] cannot be both [null].", validationException);
-                } else if (rules != null) {
-                    if (rules.isEmpty()) {
-                        validationException = addValidationError("[rules] cannot be an empty list.", validationException);
-                    } else if (isDefaultRulePresentInFilteringRules(rules) == false) {
-                        validationException = addValidationError(
-                            "[rules] need to include the default filtering rule.",
-                            validationException
-                        );
-                    }
                 }
             }
             // If [filtering] is present we don't expect [rules] and [advances_snippet] in the request body

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRule.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/filtering/FilteringRule.java
@@ -203,6 +203,14 @@ public class FilteringRule implements Writeable, ToXContentObject {
         return Objects.hash(createdAt, field, id, order, policy, rule, updatedAt, value);
     }
 
+    public Integer getOrder() {
+        return order;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
     public static class Builder {
 
         private Instant createdAt;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -199,6 +199,7 @@ public final class ConnectorTestUtils {
     public static ConnectorFiltering getRandomConnectorFiltering() {
 
         Instant currentTimestamp = Instant.now();
+        int order = randomInt();
 
         return new ConnectorFiltering.Builder().setActive(
             new FilteringRules.Builder().setAdvancedSnippet(
@@ -212,12 +213,13 @@ public final class ConnectorTestUtils {
                         new FilteringRule.Builder().setCreatedAt(currentTimestamp)
                             .setField(randomAlphaOfLength(10))
                             .setId(randomAlphaOfLength(10))
-                            .setOrder(randomInt())
+                            .setOrder(order)
                             .setPolicy(getRandomFilteringPolicy())
                             .setRule(getRandomFilteringRuleCondition())
                             .setUpdatedAt(currentTimestamp)
                             .setValue(randomAlphaOfLength(10))
-                            .build()
+                            .build(),
+                        ConnectorFiltering.getDefaultFilteringRule(currentTimestamp, order + 1)
                     )
                 )
                 .setFilteringValidationInfo(getRandomFilteringValidationInfo())
@@ -235,12 +237,14 @@ public final class ConnectorTestUtils {
                             new FilteringRule.Builder().setCreatedAt(currentTimestamp)
                                 .setField(randomAlphaOfLength(10))
                                 .setId(randomAlphaOfLength(10))
-                                .setOrder(randomInt())
+                                .setOrder(order)
                                 .setPolicy(getRandomFilteringPolicy())
                                 .setRule(getRandomFilteringRuleCondition())
                                 .setUpdatedAt(currentTimestamp)
                                 .setValue(randomAlphaOfLength(10))
-                                .build()
+                                .build(),
+                            ConnectorFiltering.getDefaultFilteringRule(currentTimestamp, order + 1)
+
                         )
                     )
                     .setFilteringValidationInfo(getRandomFilteringValidationInfo())


### PR DESCRIPTION
This changes validation behaviour for rules to have better defaults instead of throwing. The following cases changed to not throw:

- When "rules" is an empty array, instead of throwing we attach a default rule
- When "rules" have items but doesn't have default rule, we append a default rule.
- Rules array will be ordered and default will be moved as the last

