### PR TITLE
[Inference API] Remove duplicate section in inference api task settings docs

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -79,7 +79,7 @@ Cohere service.
 service.
 * `openai`: specify the `completion` or `text_embedding` task type to use the
 OpenAI service.
-* `azureopenai`: specify the `completion` or `text_embedding` task type to use the Azure OpenAI service.
+* `azureopenai`: specify the `text_embedding` task type to use the Azure OpenAI service.
 * `elasticsearch`: specify the `text_embedding` task type to use the E5
 built-in model or text embedding models uploaded by Eland.
 

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -79,7 +79,7 @@ Cohere service.
 service.
 * `openai`: specify the `completion` or `text_embedding` task type to use the
 OpenAI service.
-* `azureopenai`: specify the `text_embedding` task type to use the Azure OpenAI service.
+* `azureopenai`: specify the `completion` or `text_embedding` task type to use the Azure OpenAI service.
 * `elasticsearch`: specify the `text_embedding` task type to use the E5
 built-in model or text embedding models uploaded by Eland.
 
@@ -268,7 +268,7 @@ used for abuse detection.
 =====
 `return_documents`::
 (Optional, boolean)
-For `cohere` service only. Specify whether to return doc text within the 
+For `cohere` service only. Specify whether to return doc text within the
 results.
 
 `top_n`::
@@ -306,16 +306,6 @@ maximum token length. Defaults to `END`. Valid values are:
 For `openai` and `azureopenai` service only. Specifies the user issuing the
 request, which can be used for abuse detection.
 
-=====
-+
-.`task_settings` for the `completion` task type
-[%collapsible%closed]
-=====
-`user`:::
-(optional, string)
-For `openai` service only. Specifies the user issuing the request, which can be used for abuse detection.
-=====
-
 
 [discrete]
 [[put-inference-api-example]]
@@ -351,11 +341,11 @@ The following example shows how to create an {infer} endpoint called
 
 [source,console]
 ------------------------------------------------------------
-PUT _inference/rerank/cohere-rerank 
+PUT _inference/rerank/cohere-rerank
 {
     "service": "cohere",
     "service_settings": {
-        "api_key": "<API-KEY>", 
+        "api_key": "<API-KEY>",
         "model_id": "rerank-english-v3.0"
     },
     "task_settings": {
@@ -366,7 +356,7 @@ PUT _inference/rerank/cohere-rerank
 ------------------------------------------------------------
 // TEST[skip:TBD]
 
-For more examples, also review the 
+For more examples, also review the
 https://docs.cohere.com/docs/elasticsearch-and-cohere#rerank-search-results-with-cohere-and-elasticsearch[Cohere documentation].
 
 

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -306,7 +306,7 @@ maximum token length. Defaults to `END`. Valid values are:
 For `openai` and `azureopenai` service only. Specifies the user issuing the
 request, which can be used for abuse detection.
 
-
+=====
 [discrete]
 [[put-inference-api-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
^See title. We've two times the same `completion` section in the inference API docs:

<img width="890" alt="image" src="https://github.com/elastic/elasticsearch/assets/26525778/d8fe390e-22f0-41d1-b4c9-7b2e36ea4e10">
