### PR TITLE
Optimize Source.empty() to use singleton instances

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/lookup/EmptySource.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/EmptySource.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.lookup;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.Map;
+
+final class EmptySource implements Source {
+
+    private static final EnumMap<XContentType, EmptySource> values = new EnumMap<>(XContentType.class);
+
+    static {
+        for (XContentType value : XContentType.values()) {
+            values.put(value, new EmptySource(value));
+        }
+    }
+
+    static EmptySource forType(XContentType type) {
+        return values.get(type);
+    }
+
+    private final XContentType type;
+
+    private final BytesReference sourceRef;
+
+    private EmptySource(XContentType type) {
+        this.type = type;
+        try {
+            sourceRef = new BytesArray(
+                BytesReference.toBytes(BytesReference.bytes(new XContentBuilder(type.xContent(), new BytesStreamOutput()).value(Map.of())))
+            );
+        } catch (IOException e) {
+            throw new AssertionError("impossible", e);
+        }
+    }
+
+    @Override
+    public XContentType sourceContentType() {
+        return type;
+    }
+
+    @Override
+    public Map<String, Object> source() {
+        return Map.of();
+    }
+
+    @Override
+    public BytesReference internalSourceRef() {
+        return sourceRef;
+    }
+
+    @Override
+    public Source filter(SourceFilter sourceFilter) {
+        return this;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/lookup/Source.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/Source.java
@@ -74,7 +74,7 @@ public interface Source {
      * An empty Source, represented as an empty map
      */
     static Source empty(XContentType xContentType) {
-        return Source.fromMap(Map.of(), xContentType == null ? XContentType.JSON : xContentType);
+        return EmptySource.forType(xContentType == null ? XContentType.JSON : xContentType);
     }
 
     /**
@@ -148,6 +148,9 @@ public interface Source {
      */
     static Source fromMap(Map<String, Object> map, XContentType xContentType) {
         Map<String, Object> sourceMap = map == null ? Map.of() : map;
+        if (sourceMap.isEmpty()) {
+            return empty(xContentType);
+        }
         return new Source() {
             @Override
             public XContentType sourceContentType() {


### PR DESCRIPTION
The instances returned here are immutable so we can use singletons. We can also be smarter about the way we serialize them to have arrays of the minimal size, e.g. 2 bytes only for JSON instead of a wasteful 1024.
