### PR TITLE
Updating simulate ingest to not use a TransportWriteAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -162,6 +162,7 @@ import org.elasticsearch.action.bulk.SimulateBulkAction;
 import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.bulk.TransportShardBulkAction;
 import org.elasticsearch.action.bulk.TransportSimulateBulkAction;
+import org.elasticsearch.action.bulk.TransportSimulateShardBulkAction;
 import org.elasticsearch.action.delete.TransportDeleteAction;
 import org.elasticsearch.action.explain.TransportExplainAction;
 import org.elasticsearch.action.fieldcaps.TransportFieldCapabilitiesAction;
@@ -714,6 +715,7 @@ public class ActionModule extends AbstractModule {
         actions.register(TransportBulkAction.TYPE, TransportBulkAction.class);
         actions.register(SimulateBulkAction.INSTANCE, TransportSimulateBulkAction.class);
         actions.register(TransportShardBulkAction.TYPE, TransportShardBulkAction.class);
+        actions.register(TransportSimulateShardBulkAction.TYPE, TransportSimulateShardBulkAction.class);
         actions.register(TransportSearchAction.TYPE, TransportSearchAction.class);
         actions.register(TransportSearchScrollAction.TYPE, TransportSearchScrollAction.class);
         actions.register(TransportOpenPointInTimeAction.TYPE, TransportOpenPointInTimeAction.class);

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -14,6 +14,7 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.RoutingMissingException;
 import org.elasticsearch.action.index.IndexRequest;
@@ -349,7 +350,10 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
     }
 
     private void executeBulkShardRequest(BulkShardRequest bulkShardRequest, Releasable releaseOnFinish) {
-        client.executeLocally(TransportShardBulkAction.TYPE, bulkShardRequest, new ActionListener<>() {
+        ActionType<BulkShardResponse> bulkAction = bulkRequest instanceof SimulateBulkRequest
+            ? TransportSimulateShardBulkAction.TYPE
+            : TransportShardBulkAction.TYPE;
+        client.executeLocally(bulkAction, bulkShardRequest, new ActionListener<>() {
 
             // Lazily get the cluster state to avoid keeping it around longer than it is needed
             private ClusterState clusterState = null;

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -70,6 +70,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 
@@ -147,6 +148,36 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         IndexShard primary,
         ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener
     ) {
+        dispatchedShardOperationOnPrimary(
+            request,
+            primary,
+            listener,
+            clusterService,
+            threadPool,
+            updateHelper,
+            mappingUpdatedAction,
+            postWriteRefresh,
+            postWriteAction,
+            documentParsingProvider,
+            ExecutorSelector.getWriteExecutorForShard(threadPool),
+            executorSelector
+        );
+    }
+
+    protected static void dispatchedShardOperationOnPrimary(
+        BulkShardRequest request,
+        IndexShard primary,
+        ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        UpdateHelper updateHelper,
+        MappingUpdatedAction mappingUpdatedAction,
+        PostWriteRefresh postWriteRefresh,
+        Consumer<Runnable> postWriteAction,
+        DocumentParsingProvider documentParsingProvider,
+        BiFunction<ExecutorSelector, IndexShard, Executor> executorFunction,
+        ExecutorSelector executorSelector
+    ) {
         ClusterStateObserver observer = new ClusterStateObserver(clusterService, request.timeout(), logger, threadPool.getThreadContext());
         performOnPrimary(request, primary, updateHelper, threadPool::absoluteTimeInMillis, (update, shardId, mappingListener) -> {
             assert update != null;
@@ -167,7 +198,15 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             public void onTimeout(TimeValue timeout) {
                 mappingUpdateListener.onFailure(new MapperException("timed out while waiting for a dynamic mapping update"));
             }
-        }), listener, executor(primary), postWriteRefresh, postWriteAction, documentParsingProvider);
+        }), listener, executor(primary, executorFunction, executorSelector), postWriteRefresh, postWriteAction, documentParsingProvider);
+    }
+
+    protected static Executor executor(
+        IndexShard shard,
+        BiFunction<ExecutorSelector, IndexShard, Executor> executorFunction,
+        ExecutorSelector executorSelector
+    ) {
+        return executorFunction.apply(executorSelector, shard);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -201,7 +201,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         }), listener, executor(primary, executorFunction, executorSelector), postWriteRefresh, postWriteAction, documentParsingProvider);
     }
 
-    protected static Executor executor(
+    private static Executor executor(
         IndexShard shard,
         BiFunction<ExecutorSelector, IndexShard, Executor> executorFunction,
         ExecutorSelector executorSelector

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateShardBulkAction.java
@@ -8,91 +8,65 @@
 
 package org.elasticsearch.action.bulk;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.replication.PostWriteRefresh;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
 import org.elasticsearch.action.update.UpdateHelper;
-import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.ExecutorSelector;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.plugins.internal.DocumentParsingProvider;
+import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.IOException;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 
-/** Performs shard-level bulk (index, delete or update) operations */
-public class TransportSimulateShardBulkAction extends TransportReplicationAction<BulkShardRequest, BulkShardRequest, BulkShardResponse> {
+public class TransportSimulateShardBulkAction extends TransportAction<BulkShardRequest, BulkShardResponse> {
 
     public static final String ACTION_NAME = SimulateBulkAction.NAME + "[s]";
     public static final ActionType<BulkShardResponse> TYPE = new ActionType<>(ACTION_NAME);
 
-    private static final Logger logger = LogManager.getLogger(TransportShardBulkAction.class);
-
     private final UpdateHelper updateHelper;
-
     private final DocumentParsingProvider documentParsingProvider;
-    protected final IndexingPressure indexingPressure;
-    protected final SystemIndices systemIndices;
-    protected final ExecutorSelector executorSelector;
-
-    protected final PostWriteRefresh postWriteRefresh;
+    private final ExecutorSelector executorSelector;
+    private final ThreadPool threadPool;
+    private final ClusterService clusterService;
+    private final IndicesService indicesService;
+    private final PostWriteRefresh postWriteRefresh;
     private final BiFunction<ExecutorSelector, IndexShard, Executor> executorFunction;
 
     @Inject
     public TransportSimulateShardBulkAction(
-        Settings settings,
         TransportService transportService,
         ClusterService clusterService,
         IndicesService indicesService,
         ThreadPool threadPool,
-        ShardStateAction shardStateAction,
         UpdateHelper updateHelper,
         ActionFilters actionFilters,
-        IndexingPressure indexingPressure,
         SystemIndices systemIndices,
         DocumentParsingProvider documentParsingProvider
     ) {
-
-        super(
-            settings,
-            ACTION_NAME,
-            transportService,
-            clusterService,
-            indicesService,
-            threadPool,
-            shardStateAction,
-            actionFilters,
-            BulkShardRequest::new,
-            BulkShardRequest::new,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE,
-            true,
-            false
-        );
+        super(ACTION_NAME, actionFilters, transportService.getTaskManager());
         this.executorFunction = ExecutorSelector.getWriteExecutorForShard(threadPool);
-        this.indexingPressure = indexingPressure;
-        this.systemIndices = systemIndices;
         this.executorSelector = systemIndices.getExecutorSelector();
+        this.threadPool = threadPool;
+        this.clusterService = clusterService;
+        this.indicesService = indicesService;
         this.postWriteRefresh = new PostWriteRefresh(transportService) {
             public void refreshShard(
                 WriteRequest.RefreshPolicy policy,
@@ -108,34 +82,33 @@ public class TransportSimulateShardBulkAction extends TransportReplicationAction
         this.documentParsingProvider = documentParsingProvider;
     }
 
-    private static final TransportRequestOptions TRANSPORT_REQUEST_OPTIONS = TransportRequestOptions.of(
-        null,
-        TransportRequestOptions.Type.BULK
-    );
-
     @Override
-    protected TransportRequestOptions transportOptions() {
-        return TRANSPORT_REQUEST_OPTIONS;
-    }
+    protected void doExecute(Task task, BulkShardRequest request, ActionListener<BulkShardResponse> listener) {
+        IndexShard primary = getPrimaryIndexShard(request);
+        ActionListener<TransportReplicationAction.PrimaryResult<BulkShardRequest, BulkShardResponse>> primaryResultListener =
+            new ActionListener<>() {
+                @Override
+                public void onResponse(
+                    TransportReplicationAction.PrimaryResult<
+                        BulkShardRequest,
+                        BulkShardResponse> bulkShardRequestBulkShardResponsePrimaryResult
+                ) {
+                    listener.onResponse(bulkShardRequestBulkShardResponsePrimaryResult.replicationResponse);
+                }
 
-    @Override
-    protected BulkShardResponse newResponseInstance(StreamInput in) throws IOException {
-        return new BulkShardResponse(in);
-    }
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            };
 
-    @Override
-    protected void shardOperationOnPrimary(
-        BulkShardRequest request,
-        IndexShard primary,
-        ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener
-    ) {
         executorFunction.apply(executorSelector, primary).execute(new ActionRunnable<>(listener) {
             @Override
             protected void doRun() {
                 TransportShardBulkAction.dispatchedShardOperationOnPrimary(
                     request,
                     primary,
-                    listener,
+                    primaryResultListener,
                     clusterService,
                     threadPool,
                     updateHelper,
@@ -147,26 +120,12 @@ public class TransportSimulateShardBulkAction extends TransportReplicationAction
                     executorSelector
                 );
             }
-
-            @Override
-            public boolean isForceExecution() {
-                return true;
-            }
         });
     }
 
-    @Override
-    protected void shardOperationOnReplica(BulkShardRequest request, IndexShard replica, ActionListener<ReplicaResult> listener) {
-        executorFunction.apply(executorSelector, replica).execute(new ActionRunnable<>(listener) {
-            @Override
-            protected void doRun() {
-                // no op
-            }
-
-            @Override
-            public boolean isForceExecution() {
-                return true;
-            }
-        });
+    private IndexShard getPrimaryIndexShard(BulkShardRequest request) {
+        ShardId shardId = clusterService.state().getRoutingTable().shardRoutingTable(request.shardId()).primaryShard().shardId();
+        IndexService indexService = indicesService.indexServiceSafe(shardId.getIndex());
+        return indexService.getShard(shardId.id());
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateShardBulkAction.java
@@ -32,6 +32,10 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+/*
+ * This is the simulate ingest equivalent to TransportShardBulkAction. It only simulates indexing -- no writes are made to shards, and no
+ * refresh is performed.
+ */
 public class TransportSimulateShardBulkAction extends TransportAction<BulkShardRequest, BulkShardResponse> {
 
     public static final String ACTION_NAME = SimulateBulkAction.NAME + "[s]";
@@ -69,7 +73,7 @@ public class TransportSimulateShardBulkAction extends TransportAction<BulkShardR
                 ActionListener<Boolean> listener,
                 @Nullable TimeValue postWriteRefreshTimeout
             ) {
-                // no op
+                // no op because there is no need to refresh since we are not actually writing during a simulation
             }
         };
         this.updateHelper = updateHelper;

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateShardBulkAction.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.bulk;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.support.replication.PostWriteRefresh;
+import org.elasticsearch.action.support.replication.TransportReplicationAction;
+import org.elasticsearch.action.update.UpdateHelper;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexingPressure;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.indices.ExecutorSelector;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.indices.SystemIndices;
+import org.elasticsearch.plugins.internal.DocumentParsingProvider;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportRequestOptions;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.function.BiFunction;
+
+/** Performs shard-level bulk (index, delete or update) operations */
+public class TransportSimulateShardBulkAction extends TransportReplicationAction<BulkShardRequest, BulkShardRequest, BulkShardResponse> {
+
+    public static final String ACTION_NAME = SimulateBulkAction.NAME + "[s]";
+    public static final ActionType<BulkShardResponse> TYPE = new ActionType<>(ACTION_NAME);
+
+    private static final Logger logger = LogManager.getLogger(TransportShardBulkAction.class);
+
+    private final UpdateHelper updateHelper;
+
+    private final DocumentParsingProvider documentParsingProvider;
+    protected final IndexingPressure indexingPressure;
+    protected final SystemIndices systemIndices;
+    protected final ExecutorSelector executorSelector;
+
+    protected final PostWriteRefresh postWriteRefresh;
+    private final BiFunction<ExecutorSelector, IndexShard, Executor> executorFunction;
+
+    @Inject
+    public TransportSimulateShardBulkAction(
+        Settings settings,
+        TransportService transportService,
+        ClusterService clusterService,
+        IndicesService indicesService,
+        ThreadPool threadPool,
+        ShardStateAction shardStateAction,
+        UpdateHelper updateHelper,
+        ActionFilters actionFilters,
+        IndexingPressure indexingPressure,
+        SystemIndices systemIndices,
+        DocumentParsingProvider documentParsingProvider
+    ) {
+
+        super(
+            settings,
+            ACTION_NAME,
+            transportService,
+            clusterService,
+            indicesService,
+            threadPool,
+            shardStateAction,
+            actionFilters,
+            BulkShardRequest::new,
+            BulkShardRequest::new,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE,
+            true,
+            false
+        );
+        this.executorFunction = ExecutorSelector.getWriteExecutorForShard(threadPool);
+        this.indexingPressure = indexingPressure;
+        this.systemIndices = systemIndices;
+        this.executorSelector = systemIndices.getExecutorSelector();
+        this.postWriteRefresh = new PostWriteRefresh(transportService) {
+            public void refreshShard(
+                WriteRequest.RefreshPolicy policy,
+                IndexShard indexShard,
+                @Nullable Translog.Location location,
+                ActionListener<Boolean> listener,
+                @Nullable TimeValue postWriteRefreshTimeout
+            ) {
+                // no op
+            }
+        };
+        this.updateHelper = updateHelper;
+        this.documentParsingProvider = documentParsingProvider;
+    }
+
+    private static final TransportRequestOptions TRANSPORT_REQUEST_OPTIONS = TransportRequestOptions.of(
+        null,
+        TransportRequestOptions.Type.BULK
+    );
+
+    @Override
+    protected TransportRequestOptions transportOptions() {
+        return TRANSPORT_REQUEST_OPTIONS;
+    }
+
+    @Override
+    protected BulkShardResponse newResponseInstance(StreamInput in) throws IOException {
+        return new BulkShardResponse(in);
+    }
+
+    @Override
+    protected void shardOperationOnPrimary(
+        BulkShardRequest request,
+        IndexShard primary,
+        ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener
+    ) {
+        executorFunction.apply(executorSelector, primary).execute(new ActionRunnable<>(listener) {
+            @Override
+            protected void doRun() {
+                dispatchedShardOperationOnPrimary(request, primary, listener);
+            }
+
+            @Override
+            public boolean isForceExecution() {
+                return true;
+            }
+        });
+    }
+
+    @Override
+    protected void shardOperationOnReplica(BulkShardRequest request, IndexShard replica, ActionListener<ReplicaResult> listener) {
+        executorFunction.apply(executorSelector, replica).execute(new ActionRunnable<>(listener) {
+            @Override
+            protected void doRun() {
+                // no op
+            }
+
+            @Override
+            public boolean isForceExecution() {
+                return true;
+            }
+        });
+    }
+
+    protected void dispatchedShardOperationOnPrimary(
+        BulkShardRequest request,
+        IndexShard primary,
+        ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener
+    ) {
+        TransportShardBulkAction.dispatchedShardOperationOnPrimary(
+            request,
+            primary,
+            listener,
+            clusterService,
+            threadPool,
+            updateHelper,
+            null,
+            postWriteRefresh,
+            Runnable::run,
+            documentParsingProvider,
+            ExecutorSelector.getWriteExecutorForShard(threadPool),
+            executorSelector
+        );
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateShardBulkAction.java
@@ -132,7 +132,20 @@ public class TransportSimulateShardBulkAction extends TransportReplicationAction
         executorFunction.apply(executorSelector, primary).execute(new ActionRunnable<>(listener) {
             @Override
             protected void doRun() {
-                dispatchedShardOperationOnPrimary(request, primary, listener);
+                TransportShardBulkAction.dispatchedShardOperationOnPrimary(
+                    request,
+                    primary,
+                    listener,
+                    clusterService,
+                    threadPool,
+                    updateHelper,
+                    null,
+                    postWriteRefresh,
+                    Runnable::run,
+                    documentParsingProvider,
+                    ExecutorSelector.getWriteExecutorForShard(threadPool),
+                    executorSelector
+                );
             }
 
             @Override
@@ -155,26 +168,5 @@ public class TransportSimulateShardBulkAction extends TransportReplicationAction
                 return true;
             }
         });
-    }
-
-    protected void dispatchedShardOperationOnPrimary(
-        BulkShardRequest request,
-        IndexShard primary,
-        ActionListener<PrimaryResult<BulkShardRequest, BulkShardResponse>> listener
-    ) {
-        TransportShardBulkAction.dispatchedShardOperationOnPrimary(
-            request,
-            primary,
-            listener,
-            clusterService,
-            threadPool,
-            updateHelper,
-            null,
-            postWriteRefresh,
-            Runnable::run,
-            documentParsingProvider,
-            ExecutorSelector.getWriteExecutorForShard(threadPool),
-            executorSelector
-        );
     }
 }


### PR DESCRIPTION
Previously, simulate ingest had been using TransportShardBulkAction, a TransportWriteAction, even though it did not actually do any writing or modify any state. This changes it to use the new class TransportSimulateShardBulkAction instead. TransportSimulateShardBulkAction uses the majority of the logic of TransportShardBulkAction through its `dispatchedShardOperationOnPrimary` method, but it does not go through the mechanics of the TransportWriteAction.