### PR TITLE
Workaround G1 bug for JDK 22 and 22.0.1 (#108571)

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -94,3 +94,6 @@
 
 # JDK 9+ GC logging
 9-:-Xlog:gc*,gc+age=trace,safepoint:file=@loggc@:utctime,pid,tags:filecount=32,filesize=64m
+
+# workaround G1 bug, see https://bugs.openjdk.org/browse/JDK-8329528
+22:-XX:+UnlockDiagnosticVMOptions -XX:G1NumCollectionsKeepPinned=10000000

--- a/docs/changelog/108571.yaml
+++ b/docs/changelog/108571.yaml
@@ -1,0 +1,5 @@
+pr: 108571
+summary: Workaround G1 bug for JDK 22 and 22.0.1
+area: Infra/CLI
+type: bug
+issues: []


### PR DESCRIPTION
See https://bugs.openjdk.org/browse/JDK-8329528. The applied workaround was suggested on the linked issue, and was tested and confirmed to avoid the G1 bug.