### PR TITLE
[DOCS] Add missing description for `transport_client` reserved role

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -165,7 +165,17 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     new String[] { "transport_client" },
                     null,
                     null,
-                    MetadataUtils.DEFAULT_RESERVED_METADATA
+                    null,
+                    null,
+                    MetadataUtils.DEFAULT_RESERVED_METADATA,
+                    null,
+                    null,
+                    null,
+                    null,
+                    "Grants the privileges required to access the cluster through the Java Transport Client. "
+                        + "The Java Transport Client fetches information about the nodes in the cluster using "
+                        + "the Node Liveness API and the Cluster State API (when sniffing is enabled). "
+                        + "Assign your users this role if they use the Transport Client."
                 )
             ),
             entry("kibana_admin", kibanaAdminUser("kibana_admin", MetadataUtils.DEFAULT_RESERVED_METADATA)),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -3723,6 +3723,15 @@ public class ReservedRolesStoreTests extends ESTestCase {
         assertThat(rolesWithRemoteIndicesPrivileges, containsInAnyOrder("kibana_system", "monitoring_user"));
     }
 
+    /**
+     * Ensures that all reserved roles are self-documented with a brief description.
+     */
+    public void testAllReservedRolesHaveDescription() {
+        for (RoleDescriptor role : ReservedRolesStore.roleDescriptors()) {
+            assertThat("reserved role [" + role.getName() + "] must have description", role.hasDescription(), is(true));
+        }
+    }
+
     private void assertAllIndicesAccessAllowed(Role role, String index) {
         logger.info("index name [{}]", index);
         assertThat(role.indices().allowedIndicesMatcher("indices:foo").test(mockIndexAbstraction(index)), is(true));


### PR DESCRIPTION
This PR adds missing role description for the `transport_client` role, and a test to enforce that all reserved roles are described. The description also serves as self-documentation for roles, thus it is reasonable to make this a requirement for all reserved roles.

Relates to https://github.com/elastic/elasticsearch/pull/108422, which included descriptions for other reserved roles.
