### PR TITLE
Dry up byte[] backed AbstractBigArray implementations

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/AbstractBigArray.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 /** Common implementation for array lists that slice data into fixed-size blocks. */
 abstract class AbstractBigArray extends AbstractArray {
 
-    private final PageCacheRecycler recycler;
+    protected final PageCacheRecycler recycler;
     private Recycler.V<?>[] cache;
 
     private final int pageShift;
@@ -93,30 +93,12 @@ abstract class AbstractBigArray extends AbstractArray {
         return array;
     }
 
-    private <T> T registerNewPage(Recycler.V<T> v, int page, int expectedSize) {
+    protected <T> T registerNewPage(Recycler.V<T> v, int page, int expectedSize) {
         cache = grow(cache, page + 1);
         assert cache[page] == null;
         cache[page] = v;
         assert Array.getLength(v.v()) == expectedSize;
         return v.v();
-    }
-
-    protected final byte[] newBytePage(int page) {
-        if (recycler != null) {
-            final Recycler.V<byte[]> v = recycler.bytePage(clearOnResize);
-            return registerNewPage(v, page, PageCacheRecycler.BYTE_PAGE_SIZE);
-        } else {
-            return new byte[PageCacheRecycler.BYTE_PAGE_SIZE];
-        }
-    }
-
-    protected final Object[] newObjectPage(int page) {
-        if (recycler != null) {
-            final Recycler.V<Object[]> v = recycler.objectPage();
-            return registerNewPage(v, page, PageCacheRecycler.OBJECT_PAGE_SIZE);
-        } else {
-            return new Object[PageCacheRecycler.OBJECT_PAGE_SIZE];
-        }
     }
 
     protected final void releasePage(int page) {
@@ -131,40 +113,6 @@ abstract class AbstractBigArray extends AbstractArray {
         if (recycler != null) {
             Releasables.close(cache);
             cache = null;
-        }
-    }
-
-    /**
-     * Fills an array with a value by copying it to itself, increasing copy ranges in each iteration
-     */
-    protected static final void fillBySelfCopy(byte[] page, int fromBytes, int toBytes, int initialCopyBytes) {
-        for (int pos = fromBytes + initialCopyBytes; pos < toBytes;) {
-            int sourceBytesLength = pos - fromBytes; // source bytes available to be copied
-            int copyBytesLength = Math.min(sourceBytesLength, toBytes - pos); // number of bytes to actually copy
-            System.arraycopy(page, fromBytes, page, pos, copyBytesLength);
-            pos += copyBytesLength;
-        }
-    }
-
-    /**
-     * Bulk copies array to paged array
-     */
-    public void set(long index, byte[] buf, int offset, int len, byte[][] pages, int shift) {
-        assert index + len <= size();
-        int pageIndex = pageIndex(index);
-        final int indexInPage = indexInPage(index);
-        if (indexInPage + len <= pageSize()) {
-            System.arraycopy(buf, offset << shift, pages[pageIndex], indexInPage << shift, len << shift);
-        } else {
-            int copyLen = pageSize() - indexInPage;
-            System.arraycopy(buf, offset << shift, pages[pageIndex], indexInPage, copyLen << shift);
-            do {
-                ++pageIndex;
-                offset += copyLen;
-                len -= copyLen;
-                copyLen = Math.min(len, pageSize());
-                System.arraycopy(buf, offset << shift, pages[pageIndex], 0, copyLen << shift);
-            } while (len > copyLen);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/common/util/AbstractBigByteArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/AbstractBigByteArray.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common.util;
+
+import org.elasticsearch.common.recycler.Recycler;
+
+abstract class AbstractBigByteArray extends AbstractBigArray {
+
+    protected byte[][] pages;
+
+    protected AbstractBigByteArray(int pageSize, BigArrays bigArrays, boolean clearOnResize, long size) {
+        super(pageSize, bigArrays, clearOnResize);
+        this.size = size;
+        pages = new byte[numPages(size)][];
+        for (int i = 0; i < pages.length; ++i) {
+            pages[i] = newBytePage(i);
+        }
+    }
+
+    protected final byte[] newBytePage(int page) {
+        if (recycler != null) {
+            final Recycler.V<byte[]> v = recycler.bytePage(clearOnResize);
+            return registerNewPage(v, page, PageCacheRecycler.BYTE_PAGE_SIZE);
+        } else {
+            return new byte[PageCacheRecycler.BYTE_PAGE_SIZE];
+        }
+    }
+
+    /**
+     * Fills an array with a value by copying it to itself, increasing copy ranges in each iteration
+     */
+    protected static void fillBySelfCopy(byte[] page, int fromBytes, int toBytes, int initialCopyBytes) {
+        for (int pos = fromBytes + initialCopyBytes; pos < toBytes;) {
+            int sourceBytesLength = pos - fromBytes; // source bytes available to be copied
+            int copyBytesLength = Math.min(sourceBytesLength, toBytes - pos); // number of bytes to actually copy
+            System.arraycopy(page, fromBytes, page, pos, copyBytesLength);
+            pos += copyBytesLength;
+        }
+    }
+
+    /**
+     * Bulk copies array to paged array
+     */
+    protected void set(long index, byte[] buf, int offset, int len, byte[][] pages, int shift) {
+        assert index + len <= size();
+        int pageIndex = pageIndex(index);
+        final int indexInPage = indexInPage(index);
+        if (indexInPage + len <= pageSize()) {
+            System.arraycopy(buf, offset << shift, pages[pageIndex], indexInPage << shift, len << shift);
+        } else {
+            int copyLen = pageSize() - indexInPage;
+            System.arraycopy(buf, offset << shift, pages[pageIndex], indexInPage, copyLen << shift);
+            do {
+                ++pageIndex;
+                offset += copyLen;
+                len -= copyLen;
+                copyLen = Math.min(len, pageSize());
+                System.arraycopy(buf, offset << shift, pages[pageIndex], 0, copyLen << shift);
+            } while (len > copyLen);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/common/util/BigByteArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigByteArray.java
@@ -26,20 +26,13 @@ import static org.elasticsearch.common.util.PageCacheRecycler.PAGE_SIZE_IN_BYTES
  * Byte array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigByteArray extends AbstractBigArray implements ByteArray {
+final class BigByteArray extends AbstractBigByteArray implements ByteArray {
 
     private static final BigByteArray ESTIMATOR = new BigByteArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
-    private byte[][] pages;
-
     /** Constructor. */
     BigByteArray(long size, BigArrays bigArrays, boolean clearOnResize) {
-        super(BYTE_PAGE_SIZE, bigArrays, clearOnResize);
-        this.size = size;
-        pages = new byte[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newBytePage(i);
-        }
+        super(BYTE_PAGE_SIZE, bigArrays, clearOnResize, size);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigDoubleArray.java
@@ -27,22 +27,15 @@ import static org.elasticsearch.common.util.PageCacheRecycler.DOUBLE_PAGE_SIZE;
  * Double array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigDoubleArray extends AbstractBigArray implements DoubleArray {
+final class BigDoubleArray extends AbstractBigByteArray implements DoubleArray {
 
     private static final BigDoubleArray ESTIMATOR = new BigDoubleArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     static final VarHandle VH_PLATFORM_NATIVE_DOUBLE = MethodHandles.byteArrayViewVarHandle(double[].class, ByteOrder.nativeOrder());
 
-    private byte[][] pages;
-
     /** Constructor. */
     BigDoubleArray(long size, BigArrays bigArrays, boolean clearOnResize) {
-        super(DOUBLE_PAGE_SIZE, bigArrays, clearOnResize);
-        this.size = size;
-        pages = new byte[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newBytePage(i);
-        }
+        super(DOUBLE_PAGE_SIZE, bigArrays, clearOnResize, size);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigFloatArray.java
@@ -22,22 +22,15 @@ import static org.elasticsearch.common.util.PageCacheRecycler.FLOAT_PAGE_SIZE;
  * Float array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigFloatArray extends AbstractBigArray implements FloatArray {
+final class BigFloatArray extends AbstractBigByteArray implements FloatArray {
 
     private static final BigFloatArray ESTIMATOR = new BigFloatArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     static final VarHandle VH_PLATFORM_NATIVE_FLOAT = MethodHandles.byteArrayViewVarHandle(float[].class, ByteOrder.nativeOrder());
 
-    private byte[][] pages;
-
     /** Constructor. */
     BigFloatArray(long size, BigArrays bigArrays, boolean clearOnResize) {
-        super(FLOAT_PAGE_SIZE, bigArrays, clearOnResize);
-        this.size = size;
-        pages = new byte[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newBytePage(i);
-        }
+        super(FLOAT_PAGE_SIZE, bigArrays, clearOnResize, size);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/BigIntArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigIntArray.java
@@ -27,21 +27,14 @@ import static org.elasticsearch.common.util.PageCacheRecycler.INT_PAGE_SIZE;
  * Int array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigIntArray extends AbstractBigArray implements IntArray {
+final class BigIntArray extends AbstractBigByteArray implements IntArray {
     private static final BigIntArray ESTIMATOR = new BigIntArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     static final VarHandle VH_PLATFORM_NATIVE_INT = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.nativeOrder());
 
-    private byte[][] pages;
-
     /** Constructor. */
     BigIntArray(long size, BigArrays bigArrays, boolean clearOnResize) {
-        super(INT_PAGE_SIZE, bigArrays, clearOnResize);
-        this.size = size;
-        pages = new byte[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newBytePage(i);
-        }
+        super(INT_PAGE_SIZE, bigArrays, clearOnResize, size);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/BigLongArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigLongArray.java
@@ -25,22 +25,15 @@ import static org.elasticsearch.common.util.PageCacheRecycler.LONG_PAGE_SIZE;
  * Long array abstraction able to support more than 2B values. This implementation slices data into fixed-sized blocks of
  * configurable length.
  */
-final class BigLongArray extends AbstractBigArray implements LongArray {
+final class BigLongArray extends AbstractBigByteArray implements LongArray {
 
     private static final BigLongArray ESTIMATOR = new BigLongArray(0, BigArrays.NON_RECYCLING_INSTANCE, false);
 
     static final VarHandle VH_PLATFORM_NATIVE_LONG = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.nativeOrder());
 
-    private byte[][] pages;
-
     /** Constructor. */
     BigLongArray(long size, BigArrays bigArrays, boolean clearOnResize) {
-        super(LONG_PAGE_SIZE, bigArrays, clearOnResize);
-        this.size = size;
-        pages = new byte[numPages(size)][];
-        for (int i = 0; i < pages.length; ++i) {
-            pages[i] = newBytePage(i);
-        }
+        super(LONG_PAGE_SIZE, bigArrays, clearOnResize, size);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BigObjectArray.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common.util;
 
 import org.apache.lucene.util.ArrayUtil;
 import org.apache.lucene.util.RamUsageEstimator;
+import org.elasticsearch.common.recycler.Recycler;
 
 import java.util.Arrays;
 
@@ -81,4 +82,12 @@ final class BigObjectArray<T> extends AbstractBigArray implements ObjectArray<T>
         return ESTIMATOR.ramBytesEstimated(size);
     }
 
+    private Object[] newObjectPage(int page) {
+        if (recycler != null) {
+            final Recycler.V<Object[]> v = recycler.objectPage();
+            return registerNewPage(v, page, PageCacheRecycler.OBJECT_PAGE_SIZE);
+        } else {
+            return new Object[PageCacheRecycler.OBJECT_PAGE_SIZE];
+        }
+    }
 }


### PR DESCRIPTION
Dry up the code for all the `byte[]` backed versions of the big array a little. The motivation here (outside of making the code drier now) is to follow-up with possible optimizations for sparsely populated variants of this thing.
