### PR TITLE
Fix G1 JDK bug workaround

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -27,62 +27,64 @@ final class SystemJvmOptions {
         boolean isHotspot = sysprops.getOrDefault("sun.management.compiler", "").contains("HotSpot");
         String libraryPath = findLibraryPath(sysprops);
 
-        return Stream.of(
-            /*
-             * Cache ttl in seconds for positive DNS lookups noting that this overrides the JDK security property networkaddress.cache.ttl;
-             * can be set to -1 to cache forever.
-             */
-            "-Des.networkaddress.cache.ttl=60",
-            /*
-             * Cache ttl in seconds for negative DNS lookups noting that this overrides the JDK security property
-             * networkaddress.cache.negative ttl; set to -1 to cache forever.
-             */
-            "-Des.networkaddress.cache.negative.ttl=10",
-            // Allow to set the security manager.
-            "-Djava.security.manager=allow",
-            // pre-touch JVM emory pages during initialization
-            "-XX:+AlwaysPreTouch",
-            // explicitly set the stack size
-            "-Xss1m",
-            // set to headless, just in case,
-            "-Djava.awt.headless=true",
-            // ensure UTF-8 encoding by default (e.g., filenames)
-            "-Dfile.encoding=UTF-8",
-            // use our provided JNA always versus the system one
-            "-Djna.nosys=true",
-            /*
-             * Turn off a JDK optimization that throws away stack traces for common exceptions because stack traces are important for
-             * debugging.
-             */
-            "-XX:-OmitStackTraceInFastThrow",
-            // flags to configure Netty
-            "-Dio.netty.noUnsafe=true",
-            "-Dio.netty.noKeySetOptimization=true",
-            "-Dio.netty.recycler.maxCapacityPerThread=0",
-            // log4j 2
-            "-Dlog4j.shutdownHookEnabled=false",
-            "-Dlog4j2.disable.jmx=true",
-            "-Dlog4j2.formatMsgNoLookups=true",
-            /*
-             * Due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise time/date
-             * parsing will break in an incompatible way for some date patterns and locales.
-             */
-            "-Djava.locale.providers=SPI,COMPAT",
-            /*
-             * Temporarily suppress illegal reflective access in searchable snapshots shared cache preallocation; this is temporary while we
-             * explore alternatives. See org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate.
-             */
-            "--add-opens=java.base/java.io=org.elasticsearch.preallocate",
-            "--add-opens=org.apache.lucene.core/org.apache.lucene.store=org.elasticsearch.vec",
-            maybeEnableNativeAccess(),
-            maybeOverrideDockerCgroup(distroType),
-            maybeSetActiveProcessorCount(nodeSettings),
-            maybeWorkaroundG1Bug(),
-            setReplayFile(distroType, isHotspot),
-            "-Djava.library.path=" + libraryPath,
-            "-Djna.library.path=" + libraryPath,
-            // Pass through distribution type
-            "-Des.distribution.type=" + distroType
+        return Stream.concat(
+            Stream.of(
+                /*
+                 * Cache ttl in seconds for positive DNS lookups noting that this overrides the JDK security property networkaddress.cache.ttl;
+                 * can be set to -1 to cache forever.
+                 */
+                "-Des.networkaddress.cache.ttl=60",
+                /*
+                 * Cache ttl in seconds for negative DNS lookups noting that this overrides the JDK security property
+                 * networkaddress.cache.negative ttl; set to -1 to cache forever.
+                 */
+                "-Des.networkaddress.cache.negative.ttl=10",
+                // Allow to set the security manager.
+                "-Djava.security.manager=allow",
+                // pre-touch JVM emory pages during initialization
+                "-XX:+AlwaysPreTouch",
+                // explicitly set the stack size
+                "-Xss1m",
+                // set to headless, just in case,
+                "-Djava.awt.headless=true",
+                // ensure UTF-8 encoding by default (e.g., filenames)
+                "-Dfile.encoding=UTF-8",
+                // use our provided JNA always versus the system one
+                "-Djna.nosys=true",
+                /*
+                 * Turn off a JDK optimization that throws away stack traces for common exceptions because stack traces are important for
+                 * debugging.
+                 */
+                "-XX:-OmitStackTraceInFastThrow",
+                // flags to configure Netty
+                "-Dio.netty.noUnsafe=true",
+                "-Dio.netty.noKeySetOptimization=true",
+                "-Dio.netty.recycler.maxCapacityPerThread=0",
+                // log4j 2
+                "-Dlog4j.shutdownHookEnabled=false",
+                "-Dlog4j2.disable.jmx=true",
+                "-Dlog4j2.formatMsgNoLookups=true",
+                /*
+                 * Due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise time/date
+                 * parsing will break in an incompatible way for some date patterns and locales.
+                 */
+                "-Djava.locale.providers=SPI,COMPAT",
+                /*
+                 * Temporarily suppress illegal reflective access in searchable snapshots shared cache preallocation; this is temporary while we
+                 * explore alternatives. See org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate.
+                 */
+                "--add-opens=java.base/java.io=org.elasticsearch.preallocate",
+                "--add-opens=org.apache.lucene.core/org.apache.lucene.store=org.elasticsearch.vec",
+                maybeEnableNativeAccess(),
+                maybeOverrideDockerCgroup(distroType),
+                maybeSetActiveProcessorCount(nodeSettings),
+                setReplayFile(distroType, isHotspot),
+                "-Djava.library.path=" + libraryPath,
+                "-Djna.library.path=" + libraryPath,
+                // Pass through distribution type
+                "-Des.distribution.type=" + distroType
+            ),
+            maybeWorkaroundG1Bug()
         ).filter(e -> e.isEmpty() == false).collect(Collectors.toList());
     }
 
@@ -141,12 +143,12 @@ final class SystemJvmOptions {
     /*
      * Only affects 22 and 22.0.1, see https://bugs.openjdk.org/browse/JDK-8329528
      */
-    private static String maybeWorkaroundG1Bug() {
+    private static Stream<String> maybeWorkaroundG1Bug() {
         Runtime.Version v = Runtime.version();
         if (v.feature() == 22 && v.update() <= 1) {
-            return "-XX:+UnlockDiagnosticVMOptions -XX:G1NumCollectionsKeepPinned=10000000";
+            return Stream.of("-XX:+UnlockDiagnosticVMOptions", "-XX:G1NumCollectionsKeepPinned=10000000");
         }
-        return "";
+        return Stream.of();
     }
 
     private static String findLibraryPath(Map<String, String> sysprops) {

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -30,8 +30,8 @@ final class SystemJvmOptions {
         return Stream.concat(
             Stream.of(
                 /*
-                 * Cache ttl in seconds for positive DNS lookups noting that this overrides the JDK security property networkaddress.cache.ttl;
-                 * can be set to -1 to cache forever.
+                 * Cache ttl in seconds for positive DNS lookups noting that this overrides the JDK security property
+                 * networkaddress.cache.ttl can be set to -1 to cache forever.
                  */
                 "-Des.networkaddress.cache.ttl=60",
                 /*
@@ -70,8 +70,8 @@ final class SystemJvmOptions {
                  */
                 "-Djava.locale.providers=SPI,COMPAT",
                 /*
-                 * Temporarily suppress illegal reflective access in searchable snapshots shared cache preallocation; this is temporary while we
-                 * explore alternatives. See org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate.
+                 * Temporarily suppress illegal reflective access in searchable snapshots shared cache preallocation; this is temporary
+                 * while we explore alternatives. See org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate.
                  */
                 "--add-opens=java.base/java.io=org.elasticsearch.preallocate",
                 "--add-opens=org.apache.lucene.core/org.apache.lucene.store=org.elasticsearch.vec",


### PR DESCRIPTION
The workaround requires to JDK args, but SystemJvmOptions actually operates on individual JDK args. This commit adjusts SystemJvmOptions to allow adding sets of jdk args together.