### PR TITLE
[Profiling] Add minimal E2E test for stacktraces

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/profiling/10_basic.yml
@@ -139,6 +139,62 @@ teardown:
   - match: {resources.has_data: true}
 
 ---
+"Test stacktraces agg":
+  # This test mimics the behavior of the first query of the get stacktraces API. In certain environments we have
+  # observed that the stacktrace API returns a count of 2, although we only ever add one document with a count of 1.
+  # As these failures are very rare we start by adding a minimal reproduction that only relies on core ES features
+  # and eliminates any use of profiling-related APIs.
+  - do:
+      search:
+        index: profiling-events-all
+        body:
+          "query": {
+            "bool": {
+              "filter": [
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "2023-11-20",
+                      "lt": "2023-11-21",
+                      "format": "yyyy-MM-dd"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+          size: 0
+          track_total_hits: false
+          aggs:
+            group_by:
+              terms:
+                field: host.id
+                execution_hint: map
+                size: 150000
+              aggs:
+                group_by:
+                  terms:
+                    field: Stacktrace.id
+                    execution_hint: map
+                    size: 150000
+                  aggs:
+                    count:
+                      sum:
+                        field: Stacktrace.count
+            total_count:
+              sum:
+                field: Stacktrace.count
+            min_time:
+              min:
+                field: "@timestamp"
+            max_time:
+              max:
+                field: "@timestamp"
+
+  - match: { aggregations.group_by.buckets.0.group_by.buckets.0.key: "S07KmaoGhvNte78xwwRbZQ" }
+  - match: { aggregations.group_by.buckets.0.group_by.buckets.0.count.value: 1 }
+
+---
 "Test get stacktraces":
   - do:
       profiling.stacktraces:


### PR DESCRIPTION
With this commit we add a new E2E test for retrieving stacktraces without any use of profiling APIs. We add this test because we have observed very rare failures with wrong document counts which we could narrow down to wrong results from the aggregations API but we don't understand the root cause. This test is a first step towards a minimal reproduction that solely relies on core Elasticsearch APIs.
