### PR TITLE
[8.14] Prevent DLS/FLS if `replication` is assigned (#108600)

### DIFF
--- a/docs/changelog/108600.yaml
+++ b/docs/changelog/108600.yaml
@@ -1,0 +1,15 @@
+pr: 108600
+summary: "Prevent DLS/FLS if `replication` is assigned"
+area: Security
+type: breaking
+issues: [ ]
+breaking:
+  title: "Prevent DLS/FLS if `replication` is assigned"
+  area: REST API
+  details: For cross-cluster API keys, {es} no longer allows specifying document-level security (DLS)
+    or field-level security (FLS) in the `search` field, if `replication` is also specified.
+    {es} likewise blocks the use of any existing cross-cluster API keys that meet this condition.
+  impact: Remove any document-level security (DLS) or field-level security (FLS) definitions from the `search` field
+    for cross-cluster API keys that also have a `replication` field, or create two separate cross-cluster API keys,
+    one for search and one for replication.
+  notable: false

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilder.java
@@ -76,6 +76,9 @@ public class CrossClusterApiKeyRoleDescriptorBuilder {
             clusterPrivileges = CCS_CLUSTER_PRIVILEGE_NAMES;
         } else {
             clusterPrivileges = CCS_AND_CCR_CLUSTER_PRIVILEGE_NAMES;
+            if (search.stream().anyMatch(RoleDescriptor.IndicesPrivileges::isUsingDocumentOrFieldLevelSecurity)) {
+                throw new IllegalArgumentException("search does not support document or field level security if replication is assigned");
+            }
         }
 
         if (replication.stream().anyMatch(RoleDescriptor.IndicesPrivileges::isUsingDocumentOrFieldLevelSecurity)) {
@@ -113,9 +116,9 @@ public class CrossClusterApiKeyRoleDescriptorBuilder {
             throw new IllegalArgumentException("remote indices privileges must be empty");
         }
         final String[] clusterPrivileges = roleDescriptor.getClusterPrivileges();
-        if (false == Arrays.equals(clusterPrivileges, CCS_CLUSTER_PRIVILEGE_NAMES)
-            && false == Arrays.equals(clusterPrivileges, CCR_CLUSTER_PRIVILEGE_NAMES)
-            && false == Arrays.equals(clusterPrivileges, CCS_AND_CCR_CLUSTER_PRIVILEGE_NAMES)) {
+        // must contain either "cross_cluster_search" or "cross_cluster_replication" or both
+        if ((Arrays.asList(clusterPrivileges).contains("cross_cluster_search")
+            || Arrays.asList(clusterPrivileges).contains("cross_cluster_replication")) == false) {
             throw new IllegalArgumentException(
                 "invalid cluster privileges: [" + Strings.arrayToCommaDelimitedString(clusterPrivileges) + "]"
             );
@@ -133,6 +136,43 @@ public class CrossClusterApiKeyRoleDescriptorBuilder {
                 }
             } else if (false == Arrays.equals(privileges, CCS_INDICES_PRIVILEGE_NAMES)) {
                 throw new IllegalArgumentException("invalid indices privileges: [" + Strings.arrayToCommaDelimitedString(privileges));
+            }
+        }
+        // Note: we are skipping the check for document or field level security on search (with replication) here, since validate is called
+        // for instance as part of the Get and Query APIs, which need to continue to handle legacy role descriptors.
+    }
+
+    /**
+     * Pre-GA versions of RCS 2.0 (8.13-) allowed users to use DLS/FLS for "search" when both "search" and "replication" are both defined.
+     * Post-GA versions of RCS 2.0 (8.14+) allow users to use DLS/FLS only when "search" is defined. Defining DLS/FLS when both "search"
+     * and "replication" are defined in not allowed. Legacy here is in reference to pre-GA CCx API keys. This method should only be
+     * called to check the fulfilling cluster's API key role descriptor.
+     */
+    public static void checkForInvalidLegacyRoleDescriptors(String apiKeyId, List<RoleDescriptor> roleDescriptors) {
+        assert roleDescriptors.size() == 1;
+        final var roleDescriptor = roleDescriptors.get(0);
+        final String[] clusterPrivileges = roleDescriptor.getClusterPrivileges();
+        // only need to check if both "search" and "replication" are defined
+        // no need to check for DLS if set of cluster privileges are not the set used pre 8.14
+        final String[] pre8_14ClusterPrivileges = { "cross_cluster_search", "cross_cluster_replication" };
+        final boolean hasBoth = Arrays.equals(clusterPrivileges, pre8_14ClusterPrivileges);
+        if (false == hasBoth) {
+            return;
+        }
+
+        final RoleDescriptor.IndicesPrivileges[] indicesPrivileges = roleDescriptor.getIndicesPrivileges();
+        for (RoleDescriptor.IndicesPrivileges indexPrivilege : indicesPrivileges) {
+            final String[] privileges = indexPrivilege.getPrivileges();
+            final String[] pre8_14IndicesPrivileges = { "read", "read_cross_cluster", "view_index_metadata" };
+            // find the "search" privilege, no need to check for DLS if set of index privileges are not the set used pre 8.14
+            if (Arrays.equals(privileges, pre8_14IndicesPrivileges)) {
+                if (indexPrivilege.isUsingDocumentOrFieldLevelSecurity()) {
+                    throw new IllegalArgumentException(
+                        "Cross cluster API key ["
+                            + apiKeyId
+                            + "] is invalid: search does not support document or field level security if replication is assigned"
+                    );
+                }
             }
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Subject.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Subject.java
@@ -283,7 +283,7 @@ public class Subject {
         final BytesReference limitedByRoleDescriptorsBytes = (BytesReference) metadata.get(API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY);
         assert isEmptyRoleDescriptorsBytes(limitedByRoleDescriptorsBytes)
             : "cross cluster API keys must have empty limited-by role descriptors";
-        return new RoleReference.ApiKeyRoleReference(apiKeyId, roleDescriptorsBytes, RoleReference.ApiKeyRoleType.ASSIGNED);
+        return new RoleReference.ApiKeyRoleReference(apiKeyId, roleDescriptorsBytes, RoleReference.ApiKeyRoleType.ASSIGNED, true);
     }
 
     private RoleReferenceIntersection buildRoleReferencesForCrossClusterAccess() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReference.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReference.java
@@ -81,11 +81,22 @@ public interface RoleReference {
         private final BytesReference roleDescriptorsBytes;
         private final ApiKeyRoleType roleType;
         private RoleKey id = null;
+        private final boolean checkForInvalidLegacyRoleDescriptorsForCrossClusterAccess;
 
         public ApiKeyRoleReference(String apiKeyId, BytesReference roleDescriptorsBytes, ApiKeyRoleType roleType) {
+            this(apiKeyId, roleDescriptorsBytes, roleType, false);
+        }
+
+        public ApiKeyRoleReference(
+            String apiKeyId,
+            BytesReference roleDescriptorsBytes,
+            ApiKeyRoleType roleType,
+            boolean checkForInvalidLegacyRoleDescriptorsForCrossClusterAccess
+        ) {
             this.apiKeyId = apiKeyId;
             this.roleDescriptorsBytes = roleDescriptorsBytes;
             this.roleType = roleType;
+            this.checkForInvalidLegacyRoleDescriptorsForCrossClusterAccess = checkForInvalidLegacyRoleDescriptorsForCrossClusterAccess;
         }
 
         @Override
@@ -115,6 +126,10 @@ public interface RoleReference {
 
         public ApiKeyRoleType getRoleType() {
             return roleType;
+        }
+
+        public boolean checkForInvalidLegacyRoleDescriptorsForCrossClusterAccess() {
+            return checkForInvalidLegacyRoleDescriptorsForCrossClusterAccess;
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilderTests.java
@@ -16,7 +16,9 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 import java.io.IOException;
+import java.util.List;
 
+import static org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder.ROLE_DESCRIPTOR_NAME;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -44,6 +46,60 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("metrics")
                     .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .build() }
+        );
+    }
+
+    public void testBuildForSearchWithDls() throws IOException {
+        final CrossClusterApiKeyRoleDescriptorBuilder access = parseForAccess("""
+            {
+              "search": [
+                {
+                  "names": ["metrics"],
+                  "query": {"term":{"tag":42}}
+                }
+              ]
+            }""");
+
+        final RoleDescriptor roleDescriptor = access.build();
+
+        assertRoleDescriptor(
+            roleDescriptor,
+            new String[] { "cross_cluster_search", "monitor_enrich" },
+            new RoleDescriptor.IndicesPrivileges[] {
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices("metrics")
+                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .query("{\"term\":{\"tag\":42}}")
+                    .build() }
+        );
+    }
+
+    public void testBuildForSearchWithFls() throws IOException {
+        final CrossClusterApiKeyRoleDescriptorBuilder access = parseForAccess("""
+            {
+              "search": [
+                {
+                  "names": ["metrics"],
+                  "field_security": {
+                    "grant": ["*"],
+                    "except": ["private"]
+                  }
+                }
+              ]
+            }""");
+
+        final RoleDescriptor roleDescriptor = access.build();
+
+        assertRoleDescriptor(
+            roleDescriptor,
+            new String[] { "cross_cluster_search", "monitor_enrich" },
+            new RoleDescriptor.IndicesPrivileges[] {
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices("metrics")
+                    .privileges("read", "read_cross_cluster", "view_index_metadata")
+                    .grantedFields("*")
+                    .deniedFields("private")
                     .build() }
         );
     }
@@ -76,15 +132,10 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
             {
               "search": [
                 {
-                  "names": ["metrics"],
-                  "query": {"term":{"tag":42}}
+                  "names": ["metrics"]
                 },
                 {
-                  "names": ["logs"],
-                  "field_security": {
-                    "grant": ["*"],
-                    "except": ["private"]
-                  }
+                  "names": ["logs"]
                 }
               ],
               "replication": [
@@ -104,13 +155,10 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("metrics")
                     .privileges("read", "read_cross_cluster", "view_index_metadata")
-                    .query("{\"term\":{\"tag\":42}}")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("logs")
                     .privileges("read", "read_cross_cluster", "view_index_metadata")
-                    .grantedFields("*")
-                    .deniedFields("private")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("archive")
@@ -118,6 +166,155 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
                     .allowRestrictedIndices(true)
                     .build() }
         );
+    }
+
+    public void testBuildForSearchAndReplicationWithDLSandFLS() throws IOException {
+        // DLS
+        CrossClusterApiKeyRoleDescriptorBuilder access = parseForAccess("""
+            {
+              "search": [
+                {
+                  "names": ["metrics"],
+                  "query": {"term":{"tag":42}}
+                }
+              ],
+              "replication": [
+                {
+                  "names": [ "archive" ]
+                }
+              ]
+            }""");
+
+        IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, access::build);
+        assertThat(
+            exception.getMessage(),
+            containsString("search does not support document or field level security if " + "replication is assigned")
+        );
+
+        // FLS
+        access = parseForAccess("""
+            {
+              "search": [
+                {
+                  "names": ["metrics"],
+                   "field_security": {
+                      "grant": ["*"],
+                      "except": ["private"]
+                  }
+                }
+              ],
+              "replication": [
+                {
+                  "names": [ "archive" ]
+                }
+              ]
+            }""");
+        exception = expectThrows(IllegalArgumentException.class, access::build);
+        assertThat(
+            exception.getMessage(),
+            containsString("search does not support document or field level security if " + "replication is assigned")
+        );
+
+        // DLS and FLS
+        access = parseForAccess("""
+            {
+              "search": [
+                {
+                  "names": ["metrics"],
+                   "query": {"term":{"tag":42}},
+                   "field_security": {
+                      "grant": ["*"],
+                      "except": ["private"]
+                  }
+                }
+              ],
+              "replication": [
+                {
+                  "names": [ "archive" ]
+                }
+              ]
+            }""");
+
+        exception = expectThrows(IllegalArgumentException.class, access::build);
+        assertThat(
+            exception.getMessage(),
+            containsString("search does not support document or field level security if " + "replication is assigned")
+        );
+    }
+
+    public void testCheckForInvalidLegacyRoleDescriptors() {
+        final String[] pre8_14ClusterPrivileges_searchAndReplication = { "cross_cluster_search", "cross_cluster_replication" };
+        final String[] pre8_14ClusterPrivileges_searchOnly = { "cross_cluster_search" };
+        final String[] pre8_14IndexPrivileges = { "read", "read_cross_cluster", "view_index_metadata" };
+        final String[] otherPrivileges = randomArray(1, 5, String[]::new, () -> randomAlphaOfLength(5));
+        String apiKeyId = randomAlphaOfLength(5);
+        RoleDescriptor.IndicesPrivileges pre8_14SearchIndexPrivileges_noDLS = RoleDescriptor.IndicesPrivileges.builder()
+            .indices(randomAlphaOfLength(5))
+            .privileges(pre8_14IndexPrivileges)
+            .build();
+        RoleDescriptor.IndicesPrivileges pre8_14SearchIndexPrivileges_withDLS = RoleDescriptor.IndicesPrivileges.builder()
+            .indices(randomAlphaOfLength(5))
+            .privileges(pre8_14IndexPrivileges)
+            .query("{\"term\":{\"tag\":42}}")
+            .build();
+        RoleDescriptor.IndicesPrivileges otherIndexPrivilege = RoleDescriptor.IndicesPrivileges.builder()
+            .indices(randomAlphaOfLength(5))
+            .privileges(otherPrivileges) // replication has fixed index privileges, but for this test we don't care about the actual values
+            .build();
+
+        // role descriptor emulates pre 8.14 with search and replication with DLS: this is the primary case we are trying to catch
+        RoleDescriptor pre8_14ApiKeyRoleDescriptor_withSearchAndReplication_withDLS = new RoleDescriptor(
+            ROLE_DESCRIPTOR_NAME,
+            pre8_14ClusterPrivileges_searchAndReplication,
+            new RoleDescriptor.IndicesPrivileges[] { pre8_14SearchIndexPrivileges_withDLS, otherIndexPrivilege },
+            null
+        );
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> CrossClusterApiKeyRoleDescriptorBuilder.checkForInvalidLegacyRoleDescriptors(
+                apiKeyId,
+                List.of(pre8_14ApiKeyRoleDescriptor_withSearchAndReplication_withDLS)
+            )
+        );
+        assertThat(
+            exception.getMessage(),
+            equalTo(
+                "Cross cluster API key ["
+                    + apiKeyId
+                    + "] is invalid: search does not support document or field level security if replication is assigned"
+            )
+        );
+        // role descriptor emulates search only with DLS, this could be a valid role descriptor for pre/post 8.14
+        RoleDescriptor apiKeyRoleDescriptor_withSearch_withDLS = new RoleDescriptor(
+            ROLE_DESCRIPTOR_NAME,
+            pre8_14ClusterPrivileges_searchOnly,
+            new RoleDescriptor.IndicesPrivileges[] { pre8_14SearchIndexPrivileges_withDLS },
+            null
+        );
+        noErrorCheckRoleDescriptor(apiKeyRoleDescriptor_withSearch_withDLS);
+
+        // role descriptor emulates search and replication without DLS, this could be a valid role descriptor for pre/post 8.14
+        RoleDescriptor apiKeyRoleDescriptor_withSearchAndReplication_noDLS = new RoleDescriptor(
+            ROLE_DESCRIPTOR_NAME,
+            pre8_14ClusterPrivileges_searchAndReplication,
+            new RoleDescriptor.IndicesPrivileges[] { pre8_14SearchIndexPrivileges_noDLS, otherIndexPrivilege },
+            null
+        );
+        noErrorCheckRoleDescriptor(apiKeyRoleDescriptor_withSearchAndReplication_noDLS);
+
+        // role descriptor that will never have search and replication with DLS but may have other privileges
+        RoleDescriptor notpre8_14_apiKeyRoleDescriptor_withSearchAndReplication_DLS = new RoleDescriptor(
+            ROLE_DESCRIPTOR_NAME,
+            otherPrivileges,
+            new RoleDescriptor.IndicesPrivileges[] { otherIndexPrivilege, otherIndexPrivilege },
+            null
+        );
+        noErrorCheckRoleDescriptor(notpre8_14_apiKeyRoleDescriptor_withSearchAndReplication_DLS);
+    }
+
+    private void noErrorCheckRoleDescriptor(RoleDescriptor roleDescriptor) {
+        // should not raise an exception
+        CrossClusterApiKeyRoleDescriptorBuilder.checkForInvalidLegacyRoleDescriptors(randomAlphaOfLength(5), List.of(roleDescriptor));
     }
 
     public void testExplicitlySpecifyingPrivilegesIsNotAllowed() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilderTests.java
@@ -65,7 +65,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
 
         assertRoleDescriptor(
             roleDescriptor,
-            new String[] { "cross_cluster_search", "monitor_enrich" },
+            new String[] { "cross_cluster_search" },
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("metrics")
@@ -93,7 +93,7 @@ public class CrossClusterApiKeyRoleDescriptorBuilderTests extends ESTestCase {
 
         assertRoleDescriptor(
             roleDescriptor,
-            new String[] { "cross_cluster_search", "monitor_enrich" },
+            new String[] { "cross_cluster_search" },
             new RoleDescriptor.IndicesPrivileges[] {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices("metrics")

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptorTests.java
@@ -1261,7 +1261,9 @@ public class RoleDescriptorTests extends ESTestCase {
                 .privileges(CCS_INDICES_PRIVILEGE_NAMES)
                 .indices(generateRandomStringArray(5, randomIntBetween(3, 9), false, false))
                 .allowRestrictedIndices(randomBoolean());
-            randomDlsFls(builder);
+            if (replicationSize == 0) {
+                randomDlsFls(builder);
+            }
             indexPrivileges.add(builder.build());
         }
         for (int i = 0; i < replicationSize; i++) {

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.remotecluster;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpPost;
 import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
@@ -293,7 +292,7 @@ public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCa
     }
 
     protected static Response performRequestWithAdminUser(RestClient targetFulfillingClusterClient, Request request) throws IOException {
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", basicAuthHeaderValue(USER, PASS)));
+        request.setOptions(request.getOptions().toBuilder().addHeader("Authorization", basicAuthHeaderValue(USER, PASS)));
         return targetFulfillingClusterClient.performRequest(request);
     }
 

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityLegacyCrossClusterApiKeysWithDlsFlsIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityLegacyCrossClusterApiKeysWithDlsFlsIT.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.remotecluster;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchResponseUtils;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.util.resource.Resource;
+import org.elasticsearch.test.junit.RunnableTestRuleAdapter;
+import org.elasticsearch.xcontent.ObjectPath;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RemoteClusterSecurityLegacyCrossClusterApiKeysWithDlsFlsIT extends AbstractRemoteClusterSecurityTestCase {
+
+    private static final AtomicReference<Map<String, Object>> API_KEY_MAP_REF = new AtomicReference<>();
+    private static final AtomicReference<Map<String, Object>> CCR_API_KEY_MAP_REF = new AtomicReference<>();
+    private static final AtomicBoolean SSL_ENABLED_REF = new AtomicBoolean();
+    private static final AtomicBoolean NODE1_RCS_SERVER_ENABLED = new AtomicBoolean();
+    private static final AtomicBoolean NODE2_RCS_SERVER_ENABLED = new AtomicBoolean();
+
+    private static final String CCR_USER = "ccr_user";
+
+    static {
+        fulfillingCluster = ElasticsearchCluster.local()
+            .distribution(DistributionType.DEFAULT)
+            .name("fulfilling-cluster")
+            .nodes(3)
+            .module("x-pack-ccr")
+            .apply(commonClusterConfig)
+            .setting("remote_cluster.port", "0")
+            .setting("xpack.security.remote_cluster_server.ssl.enabled", () -> String.valueOf(SSL_ENABLED_REF.get()))
+            .setting("xpack.security.remote_cluster_server.ssl.key", "remote-cluster.key")
+            .setting("xpack.security.remote_cluster_server.ssl.certificate", "remote-cluster.crt")
+            .setting("xpack.security.authc.token.enabled", "true")
+            .keystore("xpack.security.remote_cluster_server.ssl.secure_key_passphrase", "remote-cluster-password")
+            .node(0, spec -> spec.setting("remote_cluster_server.enabled", "true"))
+            .node(1, spec -> spec.setting("remote_cluster_server.enabled", () -> String.valueOf(NODE1_RCS_SERVER_ENABLED.get())))
+            .node(2, spec -> spec.setting("remote_cluster_server.enabled", () -> String.valueOf(NODE2_RCS_SERVER_ENABLED.get())))
+            .build();
+
+        queryCluster = ElasticsearchCluster.local()
+            .name("query-cluster")
+            .apply(commonClusterConfig)
+            .module("x-pack-ccr")
+            .setting("xpack.security.remote_cluster_client.ssl.enabled", () -> String.valueOf(SSL_ENABLED_REF.get()))
+            .setting("xpack.security.remote_cluster_client.ssl.certificate_authorities", "remote-cluster-ca.crt")
+            .setting("xpack.security.authc.token.enabled", "true")
+            .keystore("cluster.remote.my_remote_cluster.credentials", () -> {
+                if (API_KEY_MAP_REF.get() == null) {
+                    final Map<String, Object> apiKeyMap = createCrossClusterAccessApiKey("""
+                        {
+                          "search": [
+                            {
+                                "names": ["shared-metrics"]
+                            }
+                          ],
+                          "replication": [
+                            {
+                                "names": ["shared-metrics"]
+                            }
+                          ]
+                        }""");
+                    API_KEY_MAP_REF.set(apiKeyMap);
+                }
+                return (String) API_KEY_MAP_REF.get().get("encoded");
+            })
+            .keystore("cluster.remote.my_ccr_cluster.credentials", () -> {
+                if (CCR_API_KEY_MAP_REF.get() == null) {
+                    final Map<String, Object> apiKeyMap = createCrossClusterAccessApiKey("""
+                        {
+                          "search": [
+                            {
+                                "names": ["leader-index", "shared-*", "metrics-*"]
+                            }
+                          ],
+                          "replication": [
+                            {
+                                "names": ["leader-index", "shared-*", "metrics-*"]
+                            }
+                          ]
+                        }""");
+                    CCR_API_KEY_MAP_REF.set(apiKeyMap);
+                }
+                return (String) CCR_API_KEY_MAP_REF.get().get("encoded");
+            })
+            .rolesFile(Resource.fromClasspath("roles.yml"))
+            .user(REMOTE_METRIC_USER, PASS.toString(), "read_remote_shared_metrics", false)
+            .user(CCR_USER, PASS.toString(), "ccr_user_role", false)
+            .build();
+    }
+
+    @ClassRule
+    // Use a RuleChain to ensure that fulfilling cluster is started before query cluster
+    // `SSL_ENABLED_REF` is used to control the SSL-enabled setting on the test clusters
+    // We set it here, since randomization methods are not available in the static initialize context above
+    public static TestRule clusterRule = RuleChain.outerRule(new RunnableTestRuleAdapter(() -> {
+        SSL_ENABLED_REF.set(usually());
+        NODE1_RCS_SERVER_ENABLED.set(randomBoolean());
+        NODE2_RCS_SERVER_ENABLED.set(randomBoolean());
+    })).around(fulfillingCluster).around(queryCluster);
+
+    public void testCrossClusterSearchBlockedIfApiKeyInvalid() throws Exception {
+        configureRemoteCluster();
+        final String crossClusterAccessApiKeyId = (String) API_KEY_MAP_REF.get().get("id");
+
+        // Fulfilling cluster
+        {
+            // Spread the shards to all nodes
+            final Request createIndexRequest = new Request("PUT", "shared-metrics");
+            createIndexRequest.setJsonEntity("""
+                {
+                  "settings": {
+                    "number_of_shards": 3,
+                    "number_of_replicas": 0
+                  }
+                }""");
+            assertOK(performRequestAgainstFulfillingCluster(createIndexRequest));
+
+            // Index some documents, so we can attempt to search them from the querying cluster
+            final Request bulkRequest = new Request("POST", "/_bulk?refresh=true");
+            bulkRequest.setJsonEntity(Strings.format("""
+                { "index": { "_index": "shared-metrics" } }
+                { "name": "metric1" }
+                { "index": { "_index": "shared-metrics" } }
+                { "name": "metric2" }
+                { "index": { "_index": "shared-metrics" } }
+                { "name": "metric3" }
+                { "index": { "_index": "shared-metrics" } }
+                { "name": "metric4" }
+                """));
+            assertOK(performRequestAgainstFulfillingCluster(bulkRequest));
+        }
+
+        // Query cluster -- test searching works (the API key is valid)
+        {
+            final var searchRequest = new Request(
+                "GET",
+                String.format(
+                    Locale.ROOT,
+                    "/%s:%s/_search?ccs_minimize_roundtrips=%s",
+                    randomFrom("my_remote_cluster", "my_remote_*"),
+                    randomFrom("shared-metrics", "*"),
+                    randomBoolean()
+                )
+            );
+            final Response response = performRequestWithRemoteMetricUser(searchRequest);
+            assertOK(response);
+            final SearchResponse searchResponse = SearchResponseUtils.parseSearchResponse(responseAsParser(response));
+            try {
+                final List<String> actualIndices = Arrays.stream(searchResponse.getHits().getHits())
+                    .map(SearchHit::getIndex)
+                    .collect(Collectors.toList());
+                assertThat(Set.copyOf(actualIndices), containsInAnyOrder("shared-metrics"));
+            } finally {
+                searchResponse.decRef();
+            }
+        }
+
+        // make API key invalid
+        addDlsQueryToApiKeyDoc(crossClusterAccessApiKeyId);
+
+        // since we updated the API key doc directly, caches need to be clearer manually -- this would also happen during a rolling restart
+        // to the FC, during an upgrade
+        assertOK(performRequestAgainstFulfillingCluster(new Request("POST", "/_security/role/*/_clear_cache")));
+        assertOK(performRequestAgainstFulfillingCluster(new Request("POST", "/_security/api_key/*/_clear_cache")));
+
+        // check that GET still works
+        getCrossClusterApiKeys(crossClusterAccessApiKeyId);
+        // check that query still works
+        validateQueryCrossClusterApiKeys(crossClusterAccessApiKeyId);
+
+        {
+            final var searchRequest = new Request(
+                "GET",
+                String.format(
+                    Locale.ROOT,
+                    "/%s:%s/_search?ccs_minimize_roundtrips=%s",
+                    "my_remote_cluster",
+                    "shared-metrics",
+                    randomBoolean()
+                )
+            );
+            updateClusterSettings(
+                Settings.builder().put("cluster.remote.my_remote_cluster.skip_unavailable", Boolean.toString(true)).build()
+            );
+            final var response = performRequestWithRemoteMetricUser(searchRequest);
+            assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
+            String responseJson = EntityUtils.toString(response.getEntity());
+            assertThat(responseJson, containsString("\"status\":\"skipped\""));
+            assertThat(responseJson, containsString("search does not support document or field level security if replication is assigned"));
+
+            updateClusterSettings(
+                Settings.builder().put("cluster.remote.my_remote_cluster.skip_unavailable", Boolean.toString(false)).build()
+            );
+            final ResponseException ex = expectThrows(ResponseException.class, () -> performRequestWithRemoteMetricUser(searchRequest));
+            assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+            assertThat(
+                ex.getMessage(),
+                containsString("search does not support document or field level security if replication is assigned")
+            );
+        }
+    }
+
+    public void testCrossClusterReplicationBlockedIfApiKeyInvalid() throws Exception {
+        // TODO improve coverage to test:
+        // * auto-follow
+        // * follow successfully, then break key
+        configureRemoteCluster("my_ccr_cluster");
+        final String crossClusterAccessApiKeyId = (String) CCR_API_KEY_MAP_REF.get().get("id");
+
+        // fulfilling cluster
+        {
+            final Request bulkRequest = new Request("POST", "/_bulk?refresh=true");
+            bulkRequest.setJsonEntity(Strings.format("""
+                { "index": { "_index": "leader-index" } }
+                { "name": "doc-1" }
+                { "index": { "_index": "leader-index" } }
+                { "name": "doc-2" }
+                { "index": { "_index": "leader-index" } }
+                { "name": "doc-3" }
+                { "index": { "_index": "leader-index" } }
+                { "name": "doc-4" }
+                { "index": { "_index": "private-index" } }
+                { "name": "doc-5" }
+                """));
+            assertOK(performRequestAgainstFulfillingCluster(bulkRequest));
+        }
+
+        // make API key invalid
+        addDlsQueryToApiKeyDoc(crossClusterAccessApiKeyId);
+        // since we updated the API key doc directly, caches need to be clearer manually -- this would also happen during a rolling restart
+        // to the FC, during an upgrade
+        assertOK(performRequestAgainstFulfillingCluster(new Request("POST", "/_security/role/*/_clear_cache")));
+        assertOK(performRequestAgainstFulfillingCluster(new Request("POST", "/_security/api_key/*/_clear_cache")));
+
+        // query cluster
+        {
+            final String followIndexName = "follower-index";
+            final Request putCcrRequest = new Request("PUT", "/" + followIndexName + "/_ccr/follow?wait_for_active_shards=1");
+            putCcrRequest.setJsonEntity("""
+                {
+                  "remote_cluster": "my_ccr_cluster",
+                  "leader_index": "leader-index"
+                }""");
+
+            final ResponseException ex = expectThrows(ResponseException.class, () -> performRequestWithCcrUser(putCcrRequest));
+            assertThat(
+                ex.getMessage(),
+                containsString("search does not support document or field level security if replication is assigned")
+            );
+            assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addDlsQueryToApiKeyDoc(String crossClusterAccessApiKeyId) throws IOException {
+        Map<String, Object> apiKeyAsMap = getCrossClusterApiKeys(crossClusterAccessApiKeyId);
+        Map<String, Object> roleDescriptors = (Map<String, Object>) apiKeyAsMap.get("role_descriptors");
+        Map<String, Object> crossCluster = (Map<String, Object>) roleDescriptors.get("cross_cluster");
+        List<Map<String, Object>> indices = (List<Map<String, Object>>) crossCluster.get("indices");
+        indices.forEach(index -> {
+            List<String> privileges = (List<String>) index.get("privileges");
+            if (Arrays.equals(privileges.toArray(String[]::new), CrossClusterApiKeyRoleDescriptorBuilder.CCS_INDICES_PRIVILEGE_NAMES)) {
+                index.put("query", "{\"match_all\": {}}");
+                index.put("privileges", List.of("read", "read_cross_cluster", "view_index_metadata")); // ensure privs emulate pre 8.14
+            }
+        });
+        crossCluster.put("cluster", List.of("cross_cluster_search", "cross_cluster_replication")); // ensure privs emulate pre 8.14
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        builder.startObject();
+        builder.field("cross_cluster", crossCluster);
+        builder.endObject();
+        updateApiKey(crossClusterAccessApiKeyId, org.elasticsearch.common.Strings.toString(builder));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getCrossClusterApiKeys(String id) throws IOException {
+        final var request = new Request(HttpGet.METHOD_NAME, "/_security/api_key");
+        request.addParameters(Map.of("id", id));
+
+        Response response = performRequestAgainstFulfillingCluster(request);
+        Map<String, Object> responseMap = entityAsMap(response);
+        List<Map<String, Object>> apiKeys = (List<Map<String, Object>>) responseMap.get("api_keys");
+        assertThat(apiKeys.size(), equalTo(1));
+        assertNotNull(ObjectPath.eval("role_descriptors.cross_cluster", apiKeys.get(0)));
+        return apiKeys.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void validateQueryCrossClusterApiKeys(String id) throws IOException {
+        final var request = new Request(HttpGet.METHOD_NAME, "/_security/_query/api_key");
+        request.setJsonEntity(Strings.format("""
+            {
+              "query": {
+                "ids": {
+                  "values": [
+                    "%s"
+                  ]
+                }
+              }
+            }
+            """, id));
+
+        Response response = performRequestAgainstFulfillingCluster(request);
+        Map<String, Object> responseMap = entityAsMap(response);
+        assertThat(responseMap.get("total"), equalTo(1));
+        assertThat(responseMap.get("count"), equalTo(1));
+        List<Map<String, Object>> apiKeys = (List<Map<String, Object>>) responseMap.get("api_keys");
+        assertThat(apiKeys.size(), equalTo(1));
+        // assumes this method is only called after we manually update the API key doc with the DLS query
+        String query = ObjectPath.eval("role_descriptors.cross_cluster.indices.0.query", apiKeys.get(0));
+        try {
+            assertThat(query, equalTo("{\"match_all\": {}}"));
+        } catch (AssertionError e) {
+            // it's ugly, but the query could be in the 0 or 1 position.
+            query = ObjectPath.eval("role_descriptors.cross_cluster.indices.1.query", apiKeys.get(0));
+            assertThat(query, equalTo("{\"match_all\": {}}"));
+        }
+    }
+
+    private static XContentParser getParser(Response response) throws IOException {
+        final byte[] responseBody = EntityUtils.toByteArray(response.getEntity());
+        return XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, responseBody);
+    }
+
+    static void updateApiKey(String id, String payload) throws IOException {
+        final Request request = new Request("POST", "/.security/_update/" + id + "?refresh=true");
+        request.setJsonEntity(Strings.format("""
+            {
+              "doc": {
+                "role_descriptors": %s
+              }
+            }
+            """, payload));
+        expectWarnings(
+            request,
+            "this request accesses system indices: [.security-7],"
+                + " but in a future major version, direct access to system indices will be prevented by default"
+        );
+        Response response = performRequestAgainstFulfillingCluster(request);
+        assertOK(response);
+    }
+
+    private Response performRequestWithRemoteMetricUser(final Request request) throws IOException {
+        request.setOptions(
+            RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", headerFromRandomAuthMethod(REMOTE_METRIC_USER, PASS))
+        );
+        return client().performRequest(request);
+    }
+
+    static void expectWarnings(Request request, String... expectedWarnings) {
+        final Set<String> expected = Set.of(expectedWarnings);
+        RequestOptions options = request.getOptions().toBuilder().setWarningsHandler(warnings -> {
+            final Set<String> actual = Set.copyOf(warnings);
+            // Return true if the warnings aren't what we expected; the client will treat them as a fatal error.
+            return actual.equals(expected) == false;
+        }).build();
+        request.setOptions(options);
+    }
+
+    private Response performRequestWithCcrUser(final Request request) throws IOException {
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", basicAuthHeaderValue(CCR_USER, PASS)));
+        return client().performRequest(request);
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -144,9 +144,6 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
-import static org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder.CCR_CLUSTER_PRIVILEGE_NAMES;
-import static org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder.CCS_AND_CCR_CLUSTER_PRIVILEGE_NAMES;
-import static org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder.CCS_CLUSTER_PRIVILEGE_NAMES;
 import static org.elasticsearch.xpack.core.security.authz.RoleDescriptor.WORKFLOWS_RESTRICTION_VERSION;
 import static org.elasticsearch.xpack.security.Security.SECURITY_CRYPTO_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.security.support.SecurityIndexManager.Availability.PRIMARY_SHARDS;
@@ -1331,22 +1328,28 @@ public class ApiKeyService {
                 for (ApiKey apiKeyInfo : apiKeyInfos) {
                     assert apiKeyInfo.getType() == ApiKey.Type.CROSS_CLUSTER;
                     assert apiKeyInfo.getRoleDescriptors().size() == 1;
-                    final String[] clusterPrivileges = apiKeyInfo.getRoleDescriptors().iterator().next().getClusterPrivileges();
-                    if (Arrays.equals(clusterPrivileges, CCS_CLUSTER_PRIVILEGE_NAMES)) {
+                    final List<String> clusterPrivileges = Arrays.asList(
+                        apiKeyInfo.getRoleDescriptors().iterator().next().getClusterPrivileges()
+                    );
+
+                    if (clusterPrivileges.contains("cross_cluster_search")
+                        && clusterPrivileges.contains("cross_cluster_replication") == false) {
                         ccsKeys += 1;
-                    } else if (Arrays.equals(clusterPrivileges, CCR_CLUSTER_PRIVILEGE_NAMES)) {
-                        ccrKeys += 1;
-                    } else if (Arrays.equals(clusterPrivileges, CCS_AND_CCR_CLUSTER_PRIVILEGE_NAMES)) {
-                        ccsCcrKeys += 1;
-                    } else {
-                        final String message = "invalid cluster privileges ["
-                            + Strings.arrayToCommaDelimitedString(clusterPrivileges)
-                            + "] for cross-cluster API key ["
-                            + apiKeyInfo.getId()
-                            + "]";
-                        assert false : message;
-                        listener.onFailure(new IllegalStateException(message));
-                    }
+                    } else if (clusterPrivileges.contains("cross_cluster_replication")
+                        && clusterPrivileges.contains("cross_cluster_search") == false) {
+                            ccrKeys += 1;
+                        } else if (clusterPrivileges.contains("cross_cluster_search")
+                            && clusterPrivileges.contains("cross_cluster_replication")) {
+                                ccsCcrKeys += 1;
+                            } else {
+                                final String message = "invalid cluster privileges "
+                                    + clusterPrivileges
+                                    + " for cross-cluster API key ["
+                                    + apiKeyInfo.getId()
+                                    + "]";
+                                assert false : message;
+                                listener.onFailure(new IllegalStateException(message));
+                            }
                 }
                 listener.onResponse(Map.of("total", apiKeyInfos.size(), "ccs", ccsKeys, "ccr", ccrKeys, "ccs_ccr", ccsCcrKeys));
             }, listener::onFailure));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/RoleDescriptorStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/RoleDescriptorStore.java
@@ -17,6 +17,7 @@ import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.xpack.core.common.IteratingActionListener;
+import org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.authz.store.RoleReference;
@@ -107,6 +108,19 @@ public class RoleDescriptorStore implements RoleReferenceResolver {
             || (apiKeyRoleReference.getRoleType() == RoleReference.ApiKeyRoleType.LIMITED_BY
                 && rolesRetrievalResult.getRoleDescriptors().stream().noneMatch(RoleDescriptor::hasRestriction))
             : "there should be zero limited-by role descriptors with restriction and no more than one assigned";
+        // TODO we need unit tests for edge-cases here, for instance, we need to test the REST API keys are never checked for invalid legacy
+        // role descriptors
+        if (apiKeyRoleReference.checkForInvalidLegacyRoleDescriptorsForCrossClusterAccess()) {
+            try {
+                CrossClusterApiKeyRoleDescriptorBuilder.checkForInvalidLegacyRoleDescriptors(
+                    apiKeyRoleReference.getApiKeyId(),
+                    roleDescriptors
+                );
+            } catch (IllegalArgumentException e) {
+                listener.onFailure(e);
+                return;
+            }
+        }
         listener.onResponse(rolesRetrievalResult);
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -6,8 +6,6 @@
  */
 package org.elasticsearch.xpack.security.audit.logfile;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
-
 import io.netty.channel.Channel;
 
 import org.apache.logging.log4j.Level;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.security.audit.logfile;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+
 import io.netty.channel.Channel;
 
 import org.apache.logging.log4j.Level;
@@ -3243,13 +3245,28 @@ public class LoggingAuditTrailTests extends ESTestCase {
                         {
                           "names": [
                             "logs*"
-                          ]
+                          ],
+                          "query": {
+                            "term": {
+                              "tag": 42
+                            }
+                          },
+                          "field_security": {
+                            "grant": [
+                              "*"
+                            ],
+                            "except": [
+                              "private"
+                            ]
+                          }
                         }
                       ]
                     }""",
                 "[{\"cluster\":[\"cross_cluster_search\"],"
                     + "\"indices\":[{\"names\":[\"logs*\"],"
-                    + "\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"]}],"
+                    + "\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"],"
+                    + "\"field_security\":{\"grant\":[\"*\"],\"except\":[\"private\"]},"
+                    + "\"query\":\"{\\\"term\\\":{\\\"tag\\\":42}}\"}],"
                     + "\"applications\":[],\"run_as\":[]}]"
             ),
             new CrossClusterApiKeyAccessWithSerialization(
@@ -3275,20 +3292,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                           {
                             "names": [
                               "logs*"
-                            ],
-                            "query": {
-                              "term": {
-                                "tag": 42
-                              }
-                            },
-                            "field_security": {
-                              "grant": [
-                                "*"
-                              ],
-                              "except": [
-                                "private"
-                              ]
-                            }
+                            ]
                           }
                         ],
                         "replication": [
@@ -3301,8 +3305,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
                         ]
                       }""",
                 "[{\"cluster\":[\"cross_cluster_search\",\"cross_cluster_replication\"],"
-                    + "\"indices\":[{\"names\":[\"logs*\"],\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"],"
-                    + "\"field_security\":{\"grant\":[\"*\"],\"except\":[\"private\"]},\"query\":\"{\\\"term\\\":{\\\"tag\\\":42}}\"},"
+                    + "\"indices\":[{\"names\":[\"logs*\"],\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"]},"
                     + "{\"names\":[\"archive\"],\"privileges\":[\"cross_cluster_replication\",\"cross_cluster_replication_internal\"],"
                     + "\"allow_restricted_indices\":true}],\"applications\":[],\"run_as\":[]}]"
             )

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/50_cross_cluster.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/api_key/50_cross_cluster.yml
@@ -53,14 +53,7 @@ teardown:
             "access": {
               "search": [
                 {
-                  "names": ["logs*"],
-                  "query": {
-                    "term": { "category": "shared" }
-                  },
-                  "field_security": {
-                    "grant": ["*"],
-                    "except": ["private"]
-                  }
+                  "names": ["logs*"]
                 }
               ],
               "replication": [
@@ -123,15 +116,6 @@ teardown:
             "read_cross_cluster",
             "view_index_metadata"
           ],
-          "field_security": {
-            "grant": [
-              "*"
-            ],
-            "except": [
-              "private"
-            ]
-          },
-          "query": "{\"term\":{\"category\":\"shared\"}}",
           "allow_restricted_indices": false
         },
         {
@@ -160,15 +144,6 @@ teardown:
         "names": [
           "logs*"
         ],
-        "field_security": {
-          "grant": [
-            "*"
-          ],
-          "except": [
-            "private"
-          ]
-        },
-        "query": "{\"term\":{\"category\":\"shared\"}}",
         "allow_restricted_indices": false
       }
     ],


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Prevent DLS/FLS if `replication` is assigned (#108600)