### PR TITLE
Require 'capabilities' test runner feature if using capabilities check

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/capabilities/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/capabilities/10_basic.yml
@@ -2,6 +2,7 @@
 "Capabilities API":
 
   - requires:
+      test_runner_features: [capabilities]
       capabilities:
         - method: GET
           path: /_capabilities

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ClientYamlTestSuite.java
@@ -299,6 +299,14 @@ public class ClientYamlTestSuite {
                     """, section.getLocation().lineNumber()))
         );
 
+        if (hasCapabilitiesCheck(testSection, setupSection, teardownSection)
+            && false == hasYamlRunnerFeature("capabilities", testSection, setupSection, teardownSection)) {
+            errors = Stream.concat(errors, Stream.of("""
+                attempted to add a [capabilities] check in prerequisites without a corresponding \
+                ["requires": "test_runner_features": "capabilities"] \
+                so runners that do not support [capabilities] checks can skip the test"""));
+        }
+
         return errors;
     }
 
@@ -311,6 +319,16 @@ public class ClientYamlTestSuite {
         return (testSection != null && hasYamlRunnerFeature(feature, testSection.getPrerequisiteSection()))
             || (setupSection != null && hasYamlRunnerFeature(feature, setupSection.getPrerequisiteSection()))
             || (teardownSection != null && hasYamlRunnerFeature(feature, teardownSection.getPrerequisiteSection()));
+    }
+
+    private static boolean hasCapabilitiesCheck(
+        ClientYamlTestSection testSection,
+        SetupSection setupSection,
+        TeardownSection teardownSection
+    ) {
+        return (testSection != null && testSection.getPrerequisiteSection().hasCapabilitiesCheck())
+            || (setupSection != null && setupSection.getPrerequisiteSection().hasCapabilitiesCheck())
+            || (teardownSection != null && teardownSection.getPrerequisiteSection().hasCapabilitiesCheck());
     }
 
     private static boolean hasYamlRunnerFeature(String feature, PrerequisiteSection prerequisiteSection) {

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSection.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.joining;
@@ -506,5 +507,10 @@ public class PrerequisiteSection {
             messageBuilder.append(" unsupported features ").append(yamlRunnerFeatures);
         }
         return messageBuilder.toString();
+    }
+
+    boolean hasCapabilitiesCheck() {
+        return Stream.concat(skipCriteriaList.stream(), requiresCriteriaList.stream())
+            .anyMatch(p -> p instanceof Prerequisites.CapabilitiesPredicate);
     }
 }

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Prerequisites.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/Prerequisites.java
@@ -53,15 +53,17 @@ public class Prerequisites {
             .anyMatch(i -> context.clusterHasFeature(i.clusterFeature()) && context.clusterHasFeature(i.fixedBy()) == false);
     }
 
-    static Predicate<ClientYamlTestExecutionContext> requireCapabilities(List<CapabilitiesCheck> checks) {
+    static CapabilitiesPredicate requireCapabilities(List<CapabilitiesCheck> checks) {
         // requirement not fulfilled if unknown / capabilities API not supported
         return context -> checks.stream().allMatch(check -> checkCapabilities(context, check).orElse(false));
     }
 
-    static Predicate<ClientYamlTestExecutionContext> skipCapabilities(List<CapabilitiesCheck> checks) {
+    static CapabilitiesPredicate skipCapabilities(List<CapabilitiesCheck> checks) {
         // skip if unknown / capabilities API not supported
         return context -> checks.stream().anyMatch(check -> checkCapabilities(context, check).orElse(true));
     }
+
+    interface CapabilitiesPredicate extends Predicate<ClientYamlTestExecutionContext> {}
 
     private static Optional<Boolean> checkCapabilities(ClientYamlTestExecutionContext context, CapabilitiesCheck check) {
         Optional<Boolean> b = context.clusterHasCapabilities(check.method(), check.path(), check.parameters(), check.capabilities());

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSectionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/PrerequisiteSectionTests.java
@@ -636,6 +636,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             "foobar",
             emptyList()
         );
+        assertFalse(section.hasCapabilitiesCheck());
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
         assertFalse(section.skipCriteriaMet(mockContext));
@@ -649,6 +650,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             "foobar",
             emptyList()
         );
+        assertFalse(section.hasCapabilitiesCheck());
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
         when(mockContext.clusterHasFeature("required-feature-1")).thenReturn(true);
@@ -667,6 +669,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             "foobar",
             emptyList()
         );
+        assertFalse(section.hasCapabilitiesCheck());
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
         when(mockContext.clusterHasFeature("required-feature-1")).thenReturn(true);
@@ -684,6 +687,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             "foobar",
             emptyList()
         );
+        assertFalse(section.hasCapabilitiesCheck());
 
         var mockContext = mock(ClientYamlTestExecutionContext.class);
         assertFalse(section.skipCriteriaMet(mockContext));
@@ -717,7 +721,7 @@ public class PrerequisiteSectionTests extends AbstractClientYamlTestFragmentPars
             "required",
             emptyList()
         );
-
+        assertTrue(section.hasCapabilitiesCheck());
         var context = mock(ClientYamlTestExecutionContext.class);
 
         // when the capabilities API is unavailable:


### PR DESCRIPTION
Require 'capabilities' test runner feature if using capabilities check introduced in #108425.

cc @elastic/clients-team 