### PR TITLE
Re-acquire engineMutex during engine reset

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -4233,12 +4233,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
 
                 @Override
                 public void close() throws IOException {
-                    assert Thread.holdsLock(engineMutex);
-
-                    Engine newEngine = newEngineReference.get();
-                    if (newEngine == currentEngineReference.get()) {
-                        // we successfully installed the new engine so do not close it.
-                        newEngine = null;
+                    Engine newEngine;
+                    synchronized (engineMutex) {
+                        newEngine = newEngineReference.get();
+                        if (newEngine == currentEngineReference.get()) {
+                            // we successfully installed the new engine so do not close it.
+                            newEngine = null;
+                        }
                     }
                     IOUtils.close(super::close, newEngine);
                 }


### PR DESCRIPTION
The change in #108145 means that the temporary engine created in
`resetEngineToGlobalCheckpoint()` might now be closed on a thread that
does not hold the `engineMutex`. This commit adds the missing
synchronization.