### PR TITLE
Wait for readiness in docker readiness test

### DIFF
--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/DockerTests.java
@@ -1211,7 +1211,6 @@ public class DockerTests extends PackagingTestCase {
     /**
      * Check that readiness listener works
      */
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108523")
     public void test500Readiness() throws Exception {
         assertFalse(readinessProbe(9399));
         // Disabling security so we wait for green
@@ -1221,7 +1220,8 @@ public class DockerTests extends PackagingTestCase {
         );
         waitForElasticsearch(installation);
         dumpDebug();
-        assertTrue(readinessProbe(9399));
+        // readiness may still take time as file settings are applied into cluster state (even non-existent file settings)
+        assertBusy(() -> assertTrue(readinessProbe(9399)));
     }
 
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/99508")


### PR DESCRIPTION
Previously readiness waited only on a master node being elected. Recently it was also made to wait on file settings being applied. Yet the node may be fully started before those file settings are applied. The test expected readiness was ok after the node finishes starting.

This commit retries the readiness check until it succeeds since readiness state will be updated async to the node finishing starting.

closes #108523