### PR TITLE
Trace logging for ESThreadPoolExecutor#remove

### DIFF
--- a/modules/kibana/src/internalClusterTest/java/org/elasticsearch/kibana/KibanaThreadPoolIT.java
+++ b/modules/kibana/src/internalClusterTest/java/org/elasticsearch/kibana/KibanaThreadPoolIT.java
@@ -47,7 +47,10 @@ import static org.hamcrest.Matchers.startsWith;
  * threads that wait on a phaser. This lets us verify that operations on system indices
  * are being directed to other thread pools.</p>
  */
-@TestLogging(reason = "investigate", value = "org.elasticsearch.kibana.KibanaThreadPoolIT:DEBUG")
+@TestLogging(
+    reason = "investigate",
+    value = "org.elasticsearch.kibana.KibanaThreadPoolIT:DEBUG,org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor:TRACE"
+)
 public class KibanaThreadPoolIT extends ESIntegTestCase {
     private static final Logger logger = LogManager.getLogger(KibanaThreadPoolIT.class);
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsThreadPoolExecutor.java
@@ -137,6 +137,12 @@ public class EsThreadPoolExecutor extends ThreadPoolExecutor {
         return b.toString();
     }
 
+    @Override
+    public boolean remove(Runnable task) {
+        logger.trace(() -> "task is removed " + task);
+        return super.remove(task);
+    }
+
     /**
      * Append details about this thread pool to the specified {@link StringBuilder}. All details should be appended as key/value pairs in
      * the form "%s = %s, "


### PR DESCRIPTION
this is just to find out if we ever remove the tasks from the threadPoolExecutor in order to make the Kibana(System) ThreadPool tests reliable

relates https://github.com/elastic/elasticsearch/issues/107625
