### PR TITLE
Document usage of Capabilities API in YAML REST tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
@@ -143,11 +143,12 @@ other test runners to skip tests if they do not support the capabilities API yet
        ... test definitions ...
 ....
 
-Note: If planning to `skip` on capabilities, keep in mind this might lead to unexpected results in _mixed cluster_
-tests. A test is only skipped if all nodes support the requested capabilities, in _mixed clusters_ this might not be
-the case: such a cluster can consist of a mix of nodes where some support respective capabilities and others don't.
-However, in that case, the test is *not* skipped and you might randomly hit one of the nodes that actually supports
-what you intended to skip on. This might break your assumptions and fail the test. 
+*NOTE: If planning to `skip` on capabilities, keep in mind this might lead to unexpected results in _mixed cluster_
+tests!* A test is only skipped if *all* nodes support the requested capabilities, in _mixed clusters_ this might not be
+the case: such a cluster can consist of a mix of nodes where some support respective capabilities and others don't,
+additionally there might even be nodes that do not support the capabilities API at all.
+In such cases the capabilities check will *not* succeed, hence the test is *not* skipped and might randomly hit one
+of the nodes that actually support what you intended to skip on. This might then break your assumptions and fail the test.
 
 Capabilities are declared as part of an implementation of `RestHandler`.
 Override the `supportedQueryParameters` and/or the `supportedCapabilities` methods:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
@@ -93,6 +93,7 @@ then the first entry in the section (after the title) should be called
 
 A `requires` section defines requirements that have to be met in order for tests to run, such as:
 
+- `capabilities` to <<capabilities_check, require API capabilities>>.
 - `cluster_features` to <<cluster_features, require cluster features>>.
 - `test_runner_features` to <<requires_test_runner_features, require test runner features>>.
 
@@ -101,6 +102,7 @@ If `cluster_features` are required, a `reason` must be provided in addition.
 
 A `skip` section, on the other hand, defines certain conditions that, if met, will skip the test, such as:
 
+- `capabilities` to <<capabilities_check, skip if API capabilities are present>>.
 - `cluster_features` to <<cluster_features, skip if cluster features are present>>.
 - `known_issues` to <<skip_known_issues, skip on known issues (based on cluster features)>>.
 - `awaits_fix` to <<skip_awaits_fix, always skip / mute a test due to a pending fix>>.
@@ -114,6 +116,51 @@ Unless only legacy test runner `features` are required, a `reason` must also be 
 `requires` and / or `skip` can also be used at the top level of the file in the `setup` and `teardown` blocks,
 so all the tests in a file will be skipped if either any requirement fails or any skip condition applies regardless
 if defined in `setup` and `teardown`.
+
+[[capabilities_check]]
+=== Require or skip API capabilities
+
+As opposed to <<cluster_features,cluster features>>, which are aimed at doing fast checks internally,
+the capabilities API allows external clients to ask an elasticsearch cluster what it supports in terms of
+particular endpoints, query parameters and other arbitrary capabilities.
+
+Only if every node in the cluster supports the requested path and method with all parameters and capabilities,
+the capabilities check passes successfully. Capabilities checks can be done both for `skip` and `requires`
+prerequisites. In either case, the _capabilities_ test runner feature must be required to allow
+other test runners to skip tests if they do not support the capabilities API yet.
+
+....
+    "Parent":
+     - requires:
+          capabilities:
+            - method: GET
+              path: /_api
+              parameters: [param1, param2]
+              capabilities: [cap1, cap2]
+          test_runner_feature: [capabilities]
+          reason: Capability required to run test
+     - do:
+       ... test definitions ...
+....
+
+Note: If planning to `skip` on capabilities, keep in mind this might lead to unexpected results in _mixed cluster_
+tests. A test is only skipped if all nodes support the requested capabilities, in _mixed clusters_ this might not be
+the case: you might randomly hit a node that actually supports what you intended to skip on.
+
+Capabilities are declared as part of an implementation of `RestHandler`.
+Override the `supportedQueryParameters` and/or the `supportedCapabilities` methods:
+
+....
+@Override
+public Set<String> supportedQueryParameters() {
+  return Set.of("param1", "param2");
+}
+
+@Override
+public Set<String> supportedCapabilities() {
+  return Set.of("cap1", "cap2");
+}
+....
 
 [[cluster_features]]
 === Require or skip cluster features
@@ -295,6 +342,10 @@ Tests that are still using `features` in the `skip` sections should be migrated 
 `test_runner_features` to avoid confusion with recently added cluster features.
 
 ==== Available test runner features
+
+===== `capabilities`
+The runner supports checks against the <<capabilities_check,capabilities API>> in a `skip` or `requires`
+prerequisite section.
 
 ===== `xpack`
 Requires x-pack to be enabled on the `Elasticsearch` instance the rest test is running against

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
@@ -120,8 +120,8 @@ if defined in `setup` and `teardown`.
 [[capabilities_check]]
 === Require or skip API capabilities
 
-As opposed to <<cluster_features,cluster features>>, which are aimed at doing fast checks internally,
-the capabilities API allows external clients to ask an elasticsearch cluster what it supports in terms of
+As opposed to <<cluster_features,cluster features>>, which are aimed at performing checks internal to Elasticsearch,
+the capabilities API allows external clients to ask an Elasticsearch cluster what it supports in terms of
 particular endpoints, query parameters and other arbitrary capabilities.
 
 Only if every node in the cluster supports the requested path and method with all parameters and capabilities,
@@ -145,7 +145,9 @@ other test runners to skip tests if they do not support the capabilities API yet
 
 Note: If planning to `skip` on capabilities, keep in mind this might lead to unexpected results in _mixed cluster_
 tests. A test is only skipped if all nodes support the requested capabilities, in _mixed clusters_ this might not be
-the case: you might randomly hit a node that actually supports what you intended to skip on.
+the case: such a cluster can consist of a mix of nodes where some support respective capabilities and others don't.
+However, in that case, the test is *not* skipped and you might randomly hit one of the nodes that actually supports
+what you intended to skip on. This might break your assumptions and fail the test. 
 
 Capabilities are declared as part of an implementation of `RestHandler`.
 Override the `supportedQueryParameters` and/or the `supportedCapabilities` methods:


### PR DESCRIPTION
Document usage of Capabilities API in YAML REST tests (related to #108425 and #108678).