### PR TITLE
Very minor update to check-running.asciidoc

### DIFF
--- a/docs/reference/setup/install/check-running.asciidoc
+++ b/docs/reference/setup/install/check-running.asciidoc
@@ -5,7 +5,7 @@ You can test that your {es} node is running by sending an HTTPS request to port
 
 ["source","sh",subs="attributes"]
 ----
-curl --cacert {es-conf}{slash}certs{slash}http_ca.crt -u elastic:$ELASTIC_PASSWORD https://localhost:9200 <1>
+sudo curl --cacert {es-conf}{slash}certs{slash}http_ca.crt -u elastic:$ELASTIC_PASSWORD https://localhost:9200 <1>
 ----
 // NOTCONSOLE
 <1> Ensure that you use `https` in your call, or the request will fail.


### PR DESCRIPTION
if simply following the install instructions, you need sudo to access http_ca.crt. Somewhat OTT use of sudo, perhaps, but it has been used plenty in the steps directly above. 