### PR TITLE
Mute KibanaThreadPoolIT#testBlockedThreadPoolsRejectUserRequests

### DIFF
--- a/modules/kibana/src/internalClusterTest/java/org/elasticsearch/kibana/KibanaThreadPoolIT.java
+++ b/modules/kibana/src/internalClusterTest/java/org/elasticsearch/kibana/KibanaThreadPoolIT.java
@@ -107,7 +107,7 @@ public class KibanaThreadPoolIT extends ESIntegTestCase {
             }
         });
     }
-
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107625")
     public void testBlockedThreadPoolsRejectUserRequests() throws Exception {
         assertAcked(client().admin().indices().prepareCreate(USER_INDEX));
 

--- a/modules/kibana/src/internalClusterTest/java/org/elasticsearch/kibana/KibanaThreadPoolIT.java
+++ b/modules/kibana/src/internalClusterTest/java/org/elasticsearch/kibana/KibanaThreadPoolIT.java
@@ -107,6 +107,7 @@ public class KibanaThreadPoolIT extends ESIntegTestCase {
             }
         });
     }
+
     @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/107625")
     public void testBlockedThreadPoolsRejectUserRequests() throws Exception {
         assertAcked(client().admin().indices().prepareCreate(USER_INDEX));


### PR DESCRIPTION
muting as the test is stalling for 20min

https://github.com/elastic/elasticsearch/issues/107625
