### PR TITLE
Use assertThatLogger where appropriate

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -343,9 +343,11 @@ public class MockLogAppender implements Releasable {
     /**
      * Executes an action and verifies expectations against the provided logger
      */
-    public static void assertThatLogger(Runnable action, Class<?> loggerOwner, MockLogAppender.LoggingExpectation expectation) {
+    public static void assertThatLogger(Runnable action, Class<?> loggerOwner, MockLogAppender.LoggingExpectation... expectations) {
         try (var mockAppender = MockLogAppender.capture(loggerOwner)) {
-            mockAppender.addExpectation(expectation);
+            for (var expectation : expectations) {
+                mockAppender.addExpectation(expectation);
+            }
             action.run();
             mockAppender.assertAllExpectationsMatched();
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModelTests.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.FieldExpression.FieldValue;
@@ -35,17 +34,16 @@ public class ExpressionModelTests extends ESTestCase {
         ExpressionModel model = new ExpressionModel();
         model.defineField("some_int", randomIntBetween(1, 99));
 
-        doWithLoggingExpectations(
-            List.of(
-                new MockLogAppender.SeenEventExpectation(
-                    "undefined field",
-                    model.getClass().getName(),
-                    Level.DEBUG,
-                    "Attempt to test field [another_field] against value(s) [bork,bork!],"
-                        + " but the field [another_field] does not have a value on this object; known fields are [some_int]"
-                )
-            ),
-            () -> assertThat(model.test("another_field", List.of(new FieldValue("bork"), new FieldValue("bork!"))), is(false))
+        MockLogAppender.assertThatLogger(
+            () -> assertThat(model.test("another_field", List.of(new FieldValue("bork"), new FieldValue("bork!"))), is(false)),
+            ExpressionModel.class,
+            new MockLogAppender.SeenEventExpectation(
+                "undefined field",
+                model.getClass().getName(),
+                Level.DEBUG,
+                "Attempt to test field [another_field] against value(s) [bork,bork!],"
+                    + " but the field [another_field] does not have a value on this object; known fields are [some_int]"
+            )
         );
     }
 
@@ -53,9 +51,10 @@ public class ExpressionModelTests extends ESTestCase {
         ExpressionModel model = new ExpressionModel();
         model.defineField("some_int", randomIntBetween(1, 99));
 
-        doWithLoggingExpectations(
-            List.of(new NoMessagesExpectation()),
-            () -> assertThat(model.test("another_field", List.of(new FieldValue(null))), is(true))
+        MockLogAppender.assertThatLogger(
+            () -> assertThat(model.test("another_field", List.of(new FieldValue(null))), is(true)),
+            ExpressionModel.class,
+            new NoMessagesExpectation()
         );
     }
 
@@ -63,25 +62,16 @@ public class ExpressionModelTests extends ESTestCase {
         ExpressionModel model = new ExpressionModel();
         model.defineField("some_int", randomIntBetween(1, 99));
 
-        doWithLoggingExpectations(
-            List.of(new NoMessagesExpectation()),
-            () -> assertThat(model.test("some_int", List.of(new FieldValue(randomIntBetween(100, 200)))), is(false))
+        MockLogAppender.assertThatLogger(
+            () -> assertThat(model.test("some_int", List.of(new FieldValue(randomIntBetween(100, 200)))), is(false)),
+            ExpressionModel.class,
+            new NoMessagesExpectation()
         );
-    }
-
-    private void doWithLoggingExpectations(List<? extends MockLogAppender.LoggingExpectation> expectations, CheckedRunnable<Exception> body)
-        throws Exception {
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(ExpressionModel.class)) {
-            expectations.forEach(mockAppender::addExpectation);
-            body.run();
-            mockAppender.assertAllExpectationsMatched();
-        }
     }
 
     private class NoMessagesExpectation implements MockLogAppender.LoggingExpectation {
 
-        private List<Message> messages = new ArrayList<>();
+        private final List<Message> messages = new ArrayList<>();
 
         @Override
         public void match(LogEvent event) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
@@ -156,32 +156,28 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             ).getBytes(StandardCharsets.UTF_8)
         );
 
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.addExpectation(
+        executeLoggingTest(
+            is,
+            Level.INFO,
+            "test_throttling",
             new MockLogAppender.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.UnseenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [1]"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 4"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
@@ -189,8 +185,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
                 "[test_throttling] * message 5"
             )
         );
-
-        executeLoggingTest(is, mockAppender, Level.INFO, "test_throttling");
     }
 
     public void testThrottlingSummaryLevelChanges() throws IllegalAccessException, TimeoutException, IOException {
@@ -212,48 +206,40 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             ).getBytes(StandardCharsets.UTF_8)
         );
 
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.addExpectation(
+        executeLoggingTest(
+            is,
+            Level.INFO,
+            "test_throttling",
             new MockLogAppender.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [2]"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test3",
                 CppLogMessageHandler.class.getName(),
                 Level.ERROR,
                 "[test_throttling] * message 3"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test4",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [3]"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test5",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 4"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test6",
                 CppLogMessageHandler.class.getName(),
@@ -261,8 +247,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
                 "[test_throttling] * message 5"
             )
         );
-
-        executeLoggingTest(is, mockAppender, Level.INFO, "test_throttling");
     }
 
     public void testThrottlingLastMessageRepeast() throws IllegalAccessException, TimeoutException, IOException {
@@ -279,16 +263,16 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             ).getBytes(StandardCharsets.UTF_8)
         );
 
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.addExpectation(
+        executeLoggingTest(
+            is,
+            Level.INFO,
+            "test_throttling",
             new MockLogAppender.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
@@ -296,8 +280,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
                 "[test_throttling] * message 2 | repeated [5]"
             )
         );
-
-        executeLoggingTest(is, mockAppender, Level.INFO, "test_throttling");
     }
 
     public void testThrottlingDebug() throws IllegalAccessException, TimeoutException, IOException {
@@ -315,24 +297,22 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             ).getBytes(StandardCharsets.UTF_8)
         );
 
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.addExpectation(
+        executeLoggingTest(
+            is,
+            Level.DEBUG,
+            "test_throttling",
             new MockLogAppender.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.DEBUG,
                 "[test_throttling] * message 6"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.UnseenEventExpectation(
                 "test3",
                 CppLogMessageHandler.class.getName(),
@@ -340,8 +320,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
                 "[test_throttling] * message 1 | repeated [5]"
             )
         );
-
-        executeLoggingTest(is, mockAppender, Level.DEBUG, "test_throttling");
     }
 
     public void testWaitForLogStreamClose() throws IOException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -127,6 +127,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.test.LambdaMatchers.falseWith;
 import static org.elasticsearch.test.LambdaMatchers.trueWith;
+import static org.elasticsearch.test.MockLogAppender.assertThatLogger;
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.elasticsearch.xpack.security.operator.OperatorPrivileges.NOOP_OPERATOR_PRIVILEGES_SERVICE;
 import static org.elasticsearch.xpack.security.operator.OperatorPrivileges.OPERATOR_PRIVILEGES_ENABLED;
@@ -669,7 +670,7 @@ public class SecurityTests extends ESTestCase {
                 )
             )
             .build();
-        expectLogs(Security.class, Collections.emptyList(), () -> Security.validateForFips(settings));
+        assertThatLogger(() -> Security.validateForFips(settings), Security.class);
     }
 
     public void testValidateForFipsNonFipsCompliantCacheHashAlgoWarningLog() throws IllegalAccessException {
@@ -678,7 +679,7 @@ public class SecurityTests extends ESTestCase {
             .put(XPackSettings.FIPS_MODE_ENABLED.getKey(), true)
             .put(key, randomNonFipsCompliantCacheHash())
             .build();
-        expectLogs(Security.class, List.of(logEventForNonCompliantCacheHash(key)), () -> Security.validateForFips(settings));
+        assertThatLogger(() -> Security.validateForFips(settings), Security.class, logEventForNonCompliantCacheHash(key));
     }
 
     public void testValidateForFipsNonFipsCompliantStoredHashAlgoWarningLog() throws IllegalAccessException {
@@ -687,7 +688,7 @@ public class SecurityTests extends ESTestCase {
             .put(XPackSettings.FIPS_MODE_ENABLED.getKey(), true)
             .put(key, randomNonFipsCompliantStoredHash())
             .build();
-        expectLogs(Security.class, List.of(logEventForNonCompliantStoredHash(key)), () -> Security.validateForFips(settings));
+        assertThatLogger(() -> Security.validateForFips(settings), Security.class, logEventForNonCompliantStoredHash(key));
     }
 
     public void testValidateForMultipleNonFipsCompliantCacheHashAlgoWarningLogs() throws IllegalAccessException {
@@ -698,10 +699,11 @@ public class SecurityTests extends ESTestCase {
             .put(firstKey, randomNonFipsCompliantCacheHash())
             .put(secondKey, randomNonFipsCompliantCacheHash())
             .build();
-        expectLogs(
+        assertThatLogger(
+            () -> Security.validateForFips(settings),
             Security.class,
-            List.of(logEventForNonCompliantCacheHash(firstKey), logEventForNonCompliantCacheHash(secondKey)),
-            () -> Security.validateForFips(settings)
+            logEventForNonCompliantCacheHash(firstKey),
+            logEventForNonCompliantCacheHash(secondKey)
         );
     }
 
@@ -714,15 +716,15 @@ public class SecurityTests extends ESTestCase {
             .put(secondKey, randomNonFipsCompliantCacheHash())
             .put("xpack.security.transport.ssl.keystore.path", "path/to/keystore")
             .build();
-        expectLogs(Security.class, List.of(logEventForNonCompliantCacheHash(firstKey), logEventForNonCompliantCacheHash(secondKey)), () -> {
+        assertThatLogger(() -> {
             final IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> Security.validateForFips(settings));
             assertThat(iae.getMessage(), containsString("JKS Keystores cannot be used in a FIPS 140 compliant JVM"));
-        });
+        }, Security.class, logEventForNonCompliantCacheHash(firstKey), logEventForNonCompliantCacheHash(secondKey));
     }
 
     public void testValidateForFipsNoErrorsOrLogsForDefaultSettings() throws IllegalAccessException {
         final Settings settings = Settings.builder().put(XPackSettings.FIPS_MODE_ENABLED.getKey(), true).build();
-        expectLogs(Security.class, Collections.emptyList(), () -> Security.validateForFips(settings));
+        assertThatLogger(() -> Security.validateForFips(settings), Security.class);
     }
 
     public void testLicenseUpdateFailureHandlerUpdate() throws Exception {
@@ -1152,15 +1154,5 @@ public class SecurityTests extends ESTestCase {
                 + settingKey
                 + "] setting."
         );
-    }
-
-    private void expectLogs(Class<?> clazz, List<MockLogAppender.LoggingExpectation> expected, Runnable runnable)
-        throws IllegalAccessException {
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(clazz)) {
-            expected.forEach(mockAppender::addExpectation);
-            runnable.run();
-            mockAppender.assertAllExpectationsMatched();
-        }
     }
 }


### PR DESCRIPTION
Some tests use MockLogAppender to assert on a single expected logging message. The utility method assertThatLogger handles creating the appender and asserting the expecation. However some other tests want to do the same but with multiple expectations. This commit adjusts assertThatLogger to allow multiple expectations, and converts a few tests that had helper methods that are now obsoleted.
