### PR TITLE
Add Docs for Azure AI Studio Support for the Inference API

### DIFF
--- a/docs/changelog/108472.yaml
+++ b/docs/changelog/108472.yaml
@@ -1,0 +1,5 @@
+pr: 108472
+summary: Add support for Azure AI Studio embeddings and completions to the inference service.
+area: Machine Learning
+type: feature
+issues: []

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -246,11 +246,11 @@ the same name and the updated API key.
 `target`:::
 (Required, string)
 The target URL of your Azure AI Studio model deployment.
-This can also be found on the overview page for your deployment in the management section of your https://ai.azure.com/[Azure AI Studio] account.
+This can be found on the overview page for your deployment in the management section of your https://ai.azure.com/[Azure AI Studio] account.
 
 `provider`:::
 (Required, string)
-You must provide the model provider for your deployment.
+The model provider for your deployment.
 Note that some providers may support only certain task types.
 Supported providers include:
 
@@ -264,16 +264,17 @@ Supported providers include:
 `endpoint_type`:::
 (Required, string)
 One of `token` or `realtime`.
-This specifies the type of endpoint that is used in your model deployment.
+Specifies the type of endpoint that is used in your model deployment.
 There are https://learn.microsoft.com/en-us/azure/ai-studio/concepts/deployments-overview#billing-for-deploying-and-inferencing-llms-in-azure-ai-studio[two endpoint types available] for deployment through Azure AI Studio.
 "Pay as you go" endpoints are billed per token.
-For these you will need to specify `token` for your `endpoint_type`.
+For these, you must specify `token` for your `endpoint_type`.
 For "real-time" endpoints which are billed per hour of usage, specify `realtime`.
 
 `rate_limit`:::
-(Optional, object) By default, the `azureaistudio` service sets a number of requests per minute rate limit at `240` requests per minute.
+(Optional, object)
+By default, the `azureaistudio` service sets a number of requests at `240` requests per minute.
 This helps to minimize the number of rate limit errors returned from Azure AI Studio.
-If you wish to modify this, set the `requests_per_minute` setting of this object in your service settings:
+To modify this, set the `requests_per_minute` setting of this object in your service settings:
 ```
 "rate_limit": {
     "requests_per_minute": <<number_of_requests>>

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -43,6 +43,7 @@ The following services are available through the {infer} API:
 * Hugging Face
 * OpenAI
 * Azure OpenAI
+* Azure AI Studio
 * Elasticsearch (for built-in models and models uploaded through Eland)
 
 
@@ -80,6 +81,7 @@ service.
 * `openai`: specify the `completion` or `text_embedding` task type to use the
 OpenAI service.
 * `azureopenai`: specify the `completion` or `text_embedding` task type to use the Azure OpenAI service.
+* `azureaistudio`: specify the `completion` or `text_embedding` task type to use the Azure AI Studio service.
 * `elasticsearch`: specify the `text_embedding` task type to use the E5
 built-in model or text embedding models uploaded by Eland.
 
@@ -226,6 +228,59 @@ We recommend using the https://learn.microsoft.com/en-us/azure/ai-services/opena
 
 =====
 +
+.`service_settings` for the `azureaistudio` service
+[%collapsible%closed]
+=====
+
+`api_key`:::
+(Required, string)
+A valid API key of your Azure AI Studio model deployment.
+This key can be found on the overview page for your deployment in the management section of your https://ai.azure.com/[Azure AI Studio] account.
+
+IMPORTANT: You need to provide the API key only once, during the {infer} model
+creation. The <<get-inference-api>> does not retrieve your API key. After
+creating the {infer} model, you cannot change the associated API key. If you
+want to use a different API key, delete the {infer} model and recreate it with
+the same name and the updated API key.
+
+`target`:::
+(Required, string)
+The target URL of your Azure AI Studio model deployment.
+This can also be found on the overview page for your deployment in the management section of your https://ai.azure.com/[Azure AI Studio] account.
+
+`provider`:::
+(Required, string)
+You must provide the model provider for your deployment.
+Note that some providers may support only certain task types.
+Supported providers include:
+
+* `openai` - available for `text_embedding` and `completion` task types
+* `mistral` - available for `completion` task type only
+* `meta` - available for `completion` task type only
+* `microsoft_phi` - available for `completion` task type only
+* `cohere` - available for `text_embedding` and `completion` task types
+* `databricks` - available for `completion` task type only
+
+`endpoint_type`:::
+(Required, string)
+One of `token` or `realtime`.
+This specifies the type of endpoint that is used in your model deployment.
+There are https://learn.microsoft.com/en-us/azure/ai-studio/concepts/deployments-overview#billing-for-deploying-and-inferencing-llms-in-azure-ai-studio[two endpoint types available] for deployment through Azure AI Studio.
+"Pay as you go" endpoints are billed per token.
+For these you will need to specify `token` for your `endpoint_type`.
+For "real-time" endpoints which are billed per hour of usage, specify `realtime`.
+
+`rate_limit`:::
+(Optional, object) By default, the `azureaistudio` service sets a number of requests per minute rate limit at `240` requests per minute.
+This helps to minimize the number of rate limit errors returned from Azure AI Studio.
+If you wish to modify this, set the `requests_per_minute` setting of this object in your service settings:
+```
+"rate_limit": {
+    "requests_per_minute": <<number_of_requests>>
+}
+```
+=====
++
 .`service_settings` for the `elasticsearch` service
 [%collapsible%closed]
 =====
@@ -261,6 +316,31 @@ Settings to configure the {infer} task. These settings are specific to the
 (Optional, string)
 For `openai` service only. Specifies the user issuing the request, which can be
 used for abuse detection.
+
+`temperature`:::
+(Optional, float)
+For the `azureaistudio` service only.
+A number in the range of 0.0 to 2.0 that specifies the sampling temperature to use that controls the apparent creativity of generated completions.
+Should not be used if `top_p` is specified.
+
+`top_p`:::
+(Optional, float)
+For the `azureaistudio` service only.
+A number in the range of 0.0 to 2.0 that is an alternative value to temperature that causes the model to consider the results of the tokens with nucleus sampling probability.
+Should not be used if `temperature` is specified.
+
+`do_sample`:::
+(Optional, float)
+For the `azureaistudio` service only.
+Instructs the inference process to perform sampling or not.
+Has not affect unless `temperature` or `top_p` is specified.
+
+`max_new_tokens`:::
+(Optional, integer)
+For the `azureaistudio` service only.
+Provides a hint for the maximum number of output tokens to be generated.
+Defaults to 64.
+
 =====
 +
 .`task_settings` for the `rerank` task type
@@ -303,7 +383,7 @@ maximum token length. Defaults to `END`. Valid values are:
 
 `user`:::
 (optional, string)
-For `openai` and `azureopenai` service only. Specifies the user issuing the
+For `openai`, `azureopenai` and `azureaistudio` services only. Specifies the user issuing the
 request, which can be used for abuse detection.
 
 =====
@@ -575,3 +655,48 @@ The list of chat completion models that you can choose from in your Azure OpenAI
 
 * https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#gpt-4-and-gpt-4-turbo-models[GPT-4 and GPT-4 Turbo models]
 * https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models#gpt-35[GPT-3.5]
+
+[discrete]
+[[inference-example-azureaistudio]]
+===== Azure AI Studio service
+
+The following example shows how to create an {infer} endpoint called
+`azure_ai_studio_embeddings` to perform a `text_embedding` task type.
+Note that we do not specify a model here, as it is defined already via our Azure AI Studio deployment.
+
+The list of embeddings models that you can choose from in your deployment can be found in the https://ai.azure.com/explore/models?selectedTask=embeddings[Azure AI Studio model explorer].
+
+[source,console]
+------------------------------------------------------------
+PUT _inference/text_embedding/azure_ai_studio_embeddings
+{
+    "service": "azureaistudio",
+    "service_settings": {
+        "api_key": "<api_key>",
+        "target": "<target_uri>",
+        "provider": "<model_provider>",
+        "endpoint_type": "<endpoint_type>"
+    }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+The next example shows how to create an {infer} endpoint called
+`azure_ai_studio_completion` to perform a `completion` task type.
+
+[source,console]
+------------------------------------------------------------
+PUT _inference/completion/azure_ai_studio_completion
+{
+    "service": "azureaistudio",
+    "service_settings": {
+        "api_key": "<api_key>",
+        "target": "<target_uri>",
+        "provider": "<model_provider>",
+        "endpoint_type": "<endpoint_type>"
+    }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+The list of chat completion models that you can choose from in your deployment can be found in the https://ai.azure.com/explore/models?selectedTask=chat-completion[Azure AI Studio model explorer].

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -272,7 +272,7 @@ For "real-time" endpoints which are billed per hour of usage, specify `realtime`
 
 `rate_limit`:::
 (Optional, object)
-By default, the `azureaistudio` service sets a number of requests at `240` requests per minute.
+By default, the `azureaistudio` service sets the number of requests allowed per minute to `240`.
 This helps to minimize the number of rate limit errors returned from Azure AI Studio.
 To modify this, set the `requests_per_minute` setting of this object in your service settings:
 ```

--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline-widget.asciidoc
@@ -25,6 +25,12 @@
             id="infer-api-ingest-azure-openai">
       Azure OpenAI
     </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-ingest-azure-ai-studio-tab"
+            id="infer-api-ingest-azure-ai-studio">
+      Azure AI Studio
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -66,6 +72,17 @@ include::infer-api-ingest-pipeline.asciidoc[tag=openai]
 ++++
 
 include::infer-api-ingest-pipeline.asciidoc[tag=azure-openai]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-ingest-azure-ai-studio-tab"
+       aria-labelledby="infer-api-ingest-azure-ai-studio"
+       hidden="">
+++++
+
+include::infer-api-ingest-pipeline.asciidoc[tag=azure-ai-studio]
 
 ++++
   </div>

--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline.asciidoc
@@ -112,3 +112,29 @@ PUT _ingest/pipeline/azure_openai_embeddings
 and the `output_field` that will contain the {infer} results.
 
 // end::azure-openai[]
+
+// tag::azure-ai-studio[]
+
+[source,console]
+--------------------------------------------------
+PUT _ingest/pipeline/azure_ai_studio_embeddings
+{
+  "processors": [
+    {
+      "inference": {
+        "model_id": "azure_ai_studio_embeddings", <1>
+        "input_output": { <2>
+          "input_field": "content",
+          "output_field": "content_embedding"
+        }
+      }
+    }
+  ]
+}
+--------------------------------------------------
+<1> The name of the inference endpoint you created by using the
+<<put-inference-api>>, it's referred to as `inference_id` in that step.
+<2> Configuration object that defines the `input_field` for the {infer} process
+and the `output_field` that will contain the {infer} results.
+
+// end::azure-ai-studio[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping-widget.asciidoc
@@ -25,6 +25,12 @@
             id="infer-api-mapping-azure-openai">
       Azure OpenAI
     </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-mapping-azure-ai-studio-tab"
+            id="infer-api-mapping-azure-ai-studio">
+      Azure AI Studio
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -65,6 +71,17 @@ include::infer-api-mapping.asciidoc[tag=openai]
 ++++
 
 include::infer-api-mapping.asciidoc[tag=azure-openai]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-mapping-azure-ai-studio-tab"
+       aria-labelledby="infer-api-mapping-azure-ai-studio"
+       hidden="">
+++++
+
+include::infer-api-mapping.asciidoc[tag=azure-ai-studio]
 
 ++++
   </div>

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
@@ -166,7 +166,7 @@ in the {infer} pipeline configuration in the next step.
 <2> The field to contain the tokens is a `dense_vector` field.
 <3> The output dimensions of the model. This value may be found on the model card in your Azure AI Studio deployment.
 <4> For Azure AI Studio embeddings, the `dot_product` function should be used to
-calculate similarity as Azure OpenAI embeddings are normalised to unit length.
+calculate similarity.
 <5> The name of the field from which to create the dense vector representation.
 In this example, the name of the field is `content`. It must be referenced in
 the {infer} pipeline configuration in the next step.

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping.asciidoc
@@ -139,3 +139,37 @@ the {infer} pipeline configuration in the next step.
 <6> The field type which is text in this example.
 
 // end::azure-openai[]
+
+// tag::azure-ai-studio[]
+
+[source,console]
+--------------------------------------------------
+PUT azure-ai-studio-embeddings
+{
+  "mappings": {
+    "properties": {
+      "content_embedding": { <1>
+        "type": "dense_vector", <2>
+        "dims": 1536, <3>
+        "element_type": "float",
+        "similarity": "dot_product" <4>
+      },
+      "content": { <5>
+        "type": "text" <6>
+      }
+    }
+  }
+}
+--------------------------------------------------
+<1> The name of the field to contain the generated tokens. It must be referenced
+in the {infer} pipeline configuration in the next step.
+<2> The field to contain the tokens is a `dense_vector` field.
+<3> The output dimensions of the model. This value may be found on the model card in your Azure AI Studio deployment.
+<4> For Azure AI Studio embeddings, the `dot_product` function should be used to
+calculate similarity as Azure OpenAI embeddings are normalised to unit length.
+<5> The name of the field from which to create the dense vector representation.
+In this example, the name of the field is `content`. It must be referenced in
+the {infer} pipeline configuration in the next step.
+<6> The field type which is text in this example.
+
+// end::azure-ai-studio[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-reindex-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-reindex-widget.asciidoc
@@ -25,6 +25,12 @@
             id="infer-api-reindex-azure-openai">
       Azure OpenAI
     </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-reindex-azure-openai-tab"
+            id="infer-api-reindex-azure-openai">
+      Azure AI Studio
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -58,7 +64,6 @@ include::infer-api-reindex.asciidoc[tag=openai]
 
 ++++
   </div>
-  </div>
   <div tabindex="0"
        role="tabpanel"
        id="infer-api-reindex-azure-openai-tab"
@@ -67,6 +72,17 @@ include::infer-api-reindex.asciidoc[tag=openai]
 ++++
 
 include::infer-api-reindex.asciidoc[tag=azure-openai]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-reindex-azure-ai-studio-tab"
+       aria-labelledby="infer-api-reindex-azure-ai-studio"
+       hidden="">
+++++
+
+include::infer-api-reindex.asciidoc[tag=azure-ai-studio]
 
 ++++
   </div>

--- a/docs/reference/tab-widgets/inference-api/infer-api-reindex.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-reindex.asciidoc
@@ -104,3 +104,30 @@ may affect the throughput of the reindexing process. If this happens, change
 `size` to `3` or a similar value in magnitude.
 
 // end::azure-openai[]
+
+// tag::azure-ai-studio[]
+
+[source,console]
+----
+POST _reindex?wait_for_completion=false
+{
+  "source": {
+    "index": "test-data",
+    "size": 50 <1>
+  },
+  "dest": {
+    "index": "azure-ai-studio-embeddings",
+    "pipeline": "azure_ai_studio_embeddings"
+  }
+}
+----
+// TEST[skip:TBD]
+<1> The default batch size for reindexing is 1000. Reducing `size` to a smaller
+number makes the update of the reindexing process quicker which enables you to
+follow the progress closely and detect errors early.
+
+NOTE: Your Azure AI Studio model deployment may have rate limits in place that
+might affect the throughput of the reindexing process. If this happens, change
+`size` to `3` or a similar value in magnitude.
+
+// end::azure-ai-studio[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-requirements-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-requirements-widget.asciidoc
@@ -25,6 +25,12 @@
             id="infer-api-requirements-azure-openai">
       Azure OpenAI
     </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-requirements-azure-ai-studio-tab"
+            id="infer-api-requirements-azure-ai-studio">
+      Azure AI Studio
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -66,6 +72,17 @@ include::infer-api-requirements.asciidoc[tag=openai]
 ++++
 
 include::infer-api-requirements.asciidoc[tag=azure-openai]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-requirements-azure-ai-studio-tab"
+       aria-labelledby="infer-api-requirements-azure-ai-studio"
+       hidden="">
+++++
+
+include::infer-api-requirements.asciidoc[tag=azure-ai-studio]
 
 ++++
   </div>

--- a/docs/reference/tab-widgets/inference-api/infer-api-requirements.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-requirements.asciidoc
@@ -26,3 +26,10 @@ You can apply for access to Azure OpenAI by completing the form at https://aka.m
 * An embedding model deployed in https://oai.azure.com/[Azure OpenAI Studio].
 
 // end::azure-openai[]
+
+// tag::azure-ai-studio[]
+* An https://azure.microsoft.com/free/cognitive-services?azure-portal=true[Azure subscription]
+* Access to https://ai.azure.com/[Azure AI Studio]
+* A deployed https://ai.azure.com/explore/models?selectedTask=embeddings[embeddings] or https://ai.azure.com/explore/models?selectedTask=chat-completion[chat completion] model.
+
+// end::azure-ai-studio[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-search-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search-widget.asciidoc
@@ -25,6 +25,12 @@
             id="infer-api-search-azure-openai">
       Azure OpenAI
     </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-search-azure-ai-studio-tab"
+            id="infer-api-search-azure-ai-studio">
+      Azure AI Studio
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -66,6 +72,16 @@ include::infer-api-search.asciidoc[tag=openai]
 ++++
 
 include::infer-api-search.asciidoc[tag=azure-openai]
+
+++++
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-search-azure-ai-studio-tab"
+       aria-labelledby="infer-api-search-azure-ai-studio"
+       hidden="">
+++++
+
+include::infer-api-search.asciidoc[tag=azure-ai-studio]
 
 ++++
   </div>

--- a/docs/reference/tab-widgets/inference-api/infer-api-search-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search-widget.asciidoc
@@ -74,6 +74,7 @@ include::infer-api-search.asciidoc[tag=openai]
 include::infer-api-search.asciidoc[tag=azure-openai]
 
 ++++
+  </div>
   <div tabindex="0"
        role="tabpanel"
        id="infer-api-search-azure-ai-studio-tab"

--- a/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search.asciidoc
@@ -237,7 +237,7 @@ GET azure-openai-embeddings/_search
 // TEST[skip:TBD]
 
 As a result, you receive the top 10 documents that are closest in meaning to the
-query from the `openai-embeddings` index sorted by their proximity to the query:
+query from the `azure-openai-embeddings` index sorted by their proximity to the query:
 
 [source,consol-result]
 --------------------------------------------------
@@ -275,3 +275,68 @@ query from the `openai-embeddings` index sorted by their proximity to the query:
 // NOTCONSOLE
 
 // end::azure-openai[]
+
+// tag::azure-ai-studio[]
+
+[source,console]
+--------------------------------------------------
+GET azure-ai-studio-embeddings/_search
+{
+  "knn": {
+    "field": "content_embedding",
+    "query_vector_builder": {
+      "text_embedding": {
+        "model_id": "azure_ai_studio_embeddings",
+        "model_text": "Calculate fuel cost"
+      }
+    },
+    "k": 10,
+    "num_candidates": 100
+  },
+  "_source": [
+    "id",
+    "content"
+  ]
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+
+As a result, you receive the top 10 documents that are closest in meaning to the
+query from the `azure-ai-studio-embeddings` index sorted by their proximity to the query:
+
+[source,consol-result]
+--------------------------------------------------
+"hits": [
+      {
+        "_index": "azure-ai-studio-embeddings",
+        "_id": "DDd5OowBHxQKHyc3TDSC",
+        "_score": 0.83704096,
+        "_source": {
+          "id": 862114,
+          "body": "How to calculate fuel cost for a road trip. By Tara Baukus Mello • Bankrate.com. Dear Driving for Dollars, My family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost.It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes.y family is considering taking a long road trip to finish off the end of the summer, but I'm a little worried about gas prices and our overall fuel cost. It doesn't seem easy to calculate since we'll be traveling through many states and we are considering several routes."
+        }
+      },
+      {
+        "_index": "azure-ai-studio-embeddings",
+        "_id": "ajd5OowBHxQKHyc3TDSC",
+        "_score": 0.8345704,
+        "_source": {
+          "id": 820622,
+          "body": "Home Heating Calculator. Typically, approximately 50% of the energy consumed in a home annually is for space heating. When deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important.This calculator can help you estimate the cost of fuel for different heating appliances.hen deciding on a heating system, many factors will come into play: cost of fuel, installation cost, convenience and life style are all important. This calculator can help you estimate the cost of fuel for different heating appliances."
+        }
+      },
+      {
+        "_index": "azure-ai-studio-embeddings",
+        "_id": "Djd5OowBHxQKHyc3TDSC",
+        "_score": 0.8327426,
+        "_source": {
+          "id": 8202683,
+          "body": "Fuel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel.If you are paying $4 per gallon, the trip would cost you $200.Most boats have much larger gas tanks than cars.uel is another important cost. This cost will depend on your boat, how far you travel, and how fast you travel. A 33-foot sailboat traveling at 7 knots should be able to travel 300 miles on 50 gallons of diesel fuel."
+        }
+      },
+      (...)
+    ]
+--------------------------------------------------
+// NOTCONSOLE
+
+// end::azure-ai-studio[]

--- a/docs/reference/tab-widgets/inference-api/infer-api-task-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task-widget.asciidoc
@@ -25,6 +25,12 @@
             id="infer-api-task-azure-openai">
       Azure OpenAI
     </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="infer-api-task-azure-ai-studio-tab"
+            id="infer-api-task-azure-ai-studio">
+      Azure AI Studio
+    </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
@@ -66,6 +72,17 @@ include::infer-api-task.asciidoc[tag=openai]
 ++++
 
 include::infer-api-task.asciidoc[tag=azure-openai]
+
+++++
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="infer-api-task-azure-ai-studio-tab"
+       aria-labelledby="infer-api-task-azure-ai-studio"
+       hidden="">
+++++
+
+include::infer-api-task.asciidoc[tag=azure-ai-studio]
 
 ++++
   </div>

--- a/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-task.asciidoc
@@ -118,8 +118,42 @@ The <<get-inference-api>> does not return this information.
 <3> The name our your Azure resource.
 <4> The id of your deployed model.
 
-NOTE: When using this model the recommended similarity measure to use in the
+NOTE: It may take a few minutes for your model's deployment to become available
+after it is created. If you try and create the model as above and receive a
+`404` error message, wait a few minutes and try again.
+Also, when using this model the recommended similarity measure to use in the
 `dense_vector` field mapping is `dot_product`.
-In the case of Azure OpenAI models, the embeddings are normalized to unit length in which case the `dot_product` and the `cosine` measures are equivalent.
+In the case of Azure OpenAI models, the embeddings are normalized to unit
+length in which case the `dot_product` and the `cosine` measures are equivalent.
 
 // end::azure-openai[]
+
+// tag::azure-ai-studio[]
+
+[source,console]
+------------------------------------------------------------
+PUT _inference/text_embedding/azure_ai_studio_embeddings <1>
+{
+    "service": "azureaistudio",
+    "service_settings": {
+        "api_key": "<api_key>", <2>
+        "target": "<target_uri>", <3>
+        "provider": "<provider>", <4>
+        "endpoint_type": "<endpoint_type>" <5>
+    }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+<1> The task type is `text_embedding` in the path and the `inference_id` which is the unique identifier of the {infer} endpoint is `azure_ai_studio_embeddings`.
+<2> The API key for accessing your Azure AI Studio deployed model. You can find this on your model deployment's overview page.
+<3> The target URI for accessing your Azure AI Studio deployed model. You can find this on your model deployment's overview page.
+<4> The model provider, such as `cohere` or `openai`.
+<5> The deployed endpoint type. This can be `token` (for "pay as you go" deployments), or `realtime` for real-time deployment endpoints.
+
+NOTE: It may take a few minutes for your model's deployment to become available
+after it is created. If you try and create the model as above and receive a
+`404` error message, wait a few minutes and try again.
+Also, when using this model the recommended similarity measure to use in the
+`dense_vector` field mapping is `dot_product`.
+
+// end::azure-ai-studio[]


### PR DESCRIPTION
Add docs for the Azure AI Studio embeddings and chat completion task type (from https://github.com/elastic/elasticsearch/pull/108472)

Also updates the [Semantic Search tutorial](https://www.elastic.co/guide/en/elasticsearch/reference/master/semantic-search-inference.html) to add in Azure AI Studio as well.