### PR TITLE
Relax block serialization assertion in 8.13

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BigArrayVectorTests.java
@@ -156,7 +156,10 @@ public class BigArrayVectorTests extends SerializationTestCase {
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock, unused -> deserBlock);
             EqualsHashCodeTestUtils.checkEqualsAndHashCode(origBlock.asVector(), unused -> deserBlock.asVector());
             assertThat(deserBlock.asVector(), is(origBlock.asVector()));
-            assertThat(deserBlock.asVector().isConstant(), is(origBlock.asVector().isConstant()));
+            // We can optimize the vector by converting it into a constant vector during serialization.
+            if (origBlock.asVector().isConstant()) {
+                assertTrue(deserBlock.asVector().isConstant());
+            }
         }
     }
 }


### PR DESCRIPTION
In section 8.13, during serialization, we can enable compact forms for blocks/vectors. One of these is converting a single position vector into a constant vector. This change relaxes the assertion, allowing the constant property of a vector to change from false to true during serialization.

Closes #108725