### PR TITLE
Fix thread reinitialize in time-series source operator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
@@ -300,10 +300,14 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
                             queue.pop();
                             newTop = queue.size() > 0 ? queue.top() : null;
                         }
-                        if (newTop != null && newTop.timeSeriesHash.equals(currentTsid) == false) {
-                            newTop.reinitializeIfNeeded(Thread.currentThread());
-                            globalTsidOrd++;
-                            currentTsid = BytesRef.deepCopyOf(newTop.timeSeriesHash);
+                        if (newTop != null) {
+                            if (newTop != leaf) {
+                                newTop.reinitializeIfNeeded(Thread.currentThread());
+                            }
+                            if (newTop.timeSeriesHash.equals(currentTsid) == false) {
+                                globalTsidOrd++;
+                                currentTsid = BytesRef.deepCopyOf(newTop.timeSeriesHash);
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
Currently, we only reinitialize the Lucene internal of the new top if the tsid changes. This isn't enough. We should always ensure the new top is reinitialized if necessary, regardless of tsid.


Closes #108727