### PR TITLE
Fix Create a snapshot spec

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -54,6 +54,8 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot_1
         wait_for_completion: true
+        body: |
+          {"index_settings": {"index.routing.rebalance.enable": "none"}}
 
   - do:
       indices.recovery:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/snapshot.restore/10_basic.yml
@@ -54,8 +54,9 @@ setup:
         repository: test_repo_restore_1
         snapshot: test_snapshot_1
         wait_for_completion: true
-        body: |
-          {"index_settings": {"index.routing.rebalance.enable": "none"}}
+        body:
+          "index_settings":
+            "index.routing.rebalance.enable": "none"
 
   - do:
       indices.recovery:


### PR DESCRIPTION
Prior to this change the shard might have been moved after restoring. As a result we were getting an array with 2 recoveries (SNAPSHOT and PEER). This change ensures the shard is not moved after restoring snapshot.

Closes: #94354