### PR TITLE
Avoid using dynamic templates for semantic text fields

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTestCase.java
@@ -29,9 +29,7 @@ public abstract class NonDynamicFieldMapperTestCase extends ESSingleNodeTestCase
     protected abstract String getMapping();
 
     public void testCreateExplicitMappingSucceeds() throws Exception {
-        String mapping = String.format(
-            Locale.ROOT,
-            """
+        String mapping = String.format(Locale.ROOT, """
             {
               "_doc": {
                 "properties": {
@@ -51,8 +49,7 @@ public abstract class NonDynamicFieldMapperTestCase extends ESSingleNodeTestCase
     }
 
     public void testCreateDynamicMappingFails() throws Exception {
-        String mapping =  String.format(
-            Locale.ROOT,"""
+        String mapping = String.format(Locale.ROOT, """
             {
               "_doc": {
                   "dynamic_templates": [
@@ -72,14 +69,13 @@ public abstract class NonDynamicFieldMapperTestCase extends ESSingleNodeTestCase
         Exception exc = expectThrows(Exception.class, () -> req.get());
         assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(exc.getCause().getCause(), instanceOf(MapperParsingException.class));
-        assertThat(exc.getCause().getCause().getMessage(), containsString("["+getTypeName()+"] can't be used in dynamic templates"));
+        assertThat(exc.getCause().getCause().getMessage(), containsString("[" + getTypeName() + "] can't be used in dynamic templates"));
     }
 
     public void testUpdateDynamicMappingFails() throws Exception {
         var resp = client().admin().indices().prepareCreate("test").get();
         assertTrue(resp.isAcknowledged());
-        String mapping =  String.format(
-            Locale.ROOT,"""
+        String mapping = String.format(Locale.ROOT, """
             {
               "_doc": {
                   "dynamic_templates": [
@@ -99,12 +95,11 @@ public abstract class NonDynamicFieldMapperTestCase extends ESSingleNodeTestCase
         Exception exc = expectThrows(Exception.class, () -> req.get());
         assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(exc.getCause().getCause(), instanceOf(MapperParsingException.class));
-        assertThat(exc.getCause().getCause().getMessage(), containsString("["+getTypeName()+"] can't be used in dynamic templates"));
+        assertThat(exc.getCause().getCause().getMessage(), containsString("[" + getTypeName() + "] can't be used in dynamic templates"));
     }
 
     public void testCreateDynamicMappingInIndexTemplateFails() throws Exception {
-        String mapping = String.format(
-            Locale.ROOT,"""
+        String mapping = String.format(Locale.ROOT, """
             {
               "_doc": {
                 "dynamic_templates": [
@@ -128,12 +123,11 @@ public abstract class NonDynamicFieldMapperTestCase extends ESSingleNodeTestCase
         Exception exc = expectThrows(Exception.class, () -> req.get());
         assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(exc.getCause().getCause(), instanceOf(MapperParsingException.class));
-        assertThat(exc.getCause().getCause().getMessage(), containsString("["+getTypeName()+"] can't be used in dynamic templates"));
+        assertThat(exc.getCause().getCause().getMessage(), containsString("[" + getTypeName() + "] can't be used in dynamic templates"));
     }
 
     public void testCreateExplicitMappingInIndexTemplateSucceeds() throws Exception {
-        String mapping =  String.format(
-            Locale.ROOT,"""
+        String mapping = String.format(Locale.ROOT, """
             {
               "_doc": {
                 "properties": {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTestCase.java
@@ -11,49 +11,48 @@ package org.elasticsearch.index.mapper;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequestBuilder;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequestBuilder;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.plugins.MapperPlugin;
-import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xcontent.XContentType;
 
-import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
+import java.util.Locale;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
-public class DynamicFieldMapperTests extends ESSingleNodeTestCase {
-    @Override
-    protected Collection<Class<? extends Plugin>> getPlugins() {
-        return List.of(NonDynamicFieldPlugin.class);
-    }
+public abstract class NonDynamicFieldMapperTestCase extends ESSingleNodeTestCase {
+
+    protected abstract String getTypeName();
+
+    protected abstract String getMapping();
 
     public void testCreateExplicitMappingSucceeds() throws Exception {
-        String mapping = """
+        String mapping = String.format(
+            Locale.ROOT,
+            """
             {
               "_doc": {
                 "properties": {
                   "field": {
-                    "type": "non_dynamic"
+                    %s
                   }
                 }
               }
             }
-            """;
+            """, getMapping());
         var resp = client().admin().indices().prepareCreate("test").setMapping(mapping).get();
         assertTrue(resp.isAcknowledged());
         var mappingsResp = client().admin().indices().prepareGetMappings("test").get();
         var mappingMetadata = mappingsResp.getMappings().get("test");
         var fieldType = XContentMapValues.extractValue("properties.field.type", mappingMetadata.getSourceAsMap());
-        assertThat(fieldType, equalTo(NonDynamicFieldMapper.NAME));
+        assertThat(fieldType, equalTo(getTypeName()));
     }
 
     public void testCreateDynamicMappingFails() throws Exception {
-        String mapping = """
+        String mapping =  String.format(
+            Locale.ROOT,"""
             {
               "_doc": {
                   "dynamic_templates": [
@@ -61,25 +60,26 @@ public class DynamicFieldMapperTests extends ESSingleNodeTestCase {
                       "strings_as_type": {
                         "match_mapping_type": "string",
                         "mapping": {
-                          "type": "non_dynamic"
+                          %s
                         }
                       }
                     }
                   ]
                 }
             }
-            """;
+            """, getMapping());
         CreateIndexRequestBuilder req = client().admin().indices().prepareCreate("test").setMapping(mapping);
         Exception exc = expectThrows(Exception.class, () -> req.get());
         assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(exc.getCause().getCause(), instanceOf(MapperParsingException.class));
-        assertThat(exc.getCause().getCause().getMessage(), containsString("[non_dynamic] can't be used in dynamic templates"));
+        assertThat(exc.getCause().getCause().getMessage(), containsString("["+getTypeName()+"] can't be used in dynamic templates"));
     }
 
     public void testUpdateDynamicMappingFails() throws Exception {
         var resp = client().admin().indices().prepareCreate("test").get();
         assertTrue(resp.isAcknowledged());
-        String mapping = """
+        String mapping =  String.format(
+            Locale.ROOT,"""
             {
               "_doc": {
                   "dynamic_templates": [
@@ -87,23 +87,24 @@ public class DynamicFieldMapperTests extends ESSingleNodeTestCase {
                       "strings_as_type": {
                         "match_mapping_type": "string",
                         "mapping": {
-                          "type": "non_dynamic"
+                            %s
                         }
                       }
                     }
                   ]
                 }
             }
-            """;
+            """, getMapping());
         var req = client().admin().indices().preparePutMapping("test").setSource(mapping, XContentType.JSON);
         Exception exc = expectThrows(Exception.class, () -> req.get());
         assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(exc.getCause().getCause(), instanceOf(MapperParsingException.class));
-        assertThat(exc.getCause().getCause().getMessage(), containsString("[non_dynamic] can't be used in dynamic templates"));
+        assertThat(exc.getCause().getCause().getMessage(), containsString("["+getTypeName()+"] can't be used in dynamic templates"));
     }
 
     public void testCreateDynamicMappingInIndexTemplateFails() throws Exception {
-        String mapping = """
+        String mapping = String.format(
+            Locale.ROOT,"""
             {
               "_doc": {
                 "dynamic_templates": [
@@ -111,14 +112,14 @@ public class DynamicFieldMapperTests extends ESSingleNodeTestCase {
                     "strings_as_type": {
                       "match_mapping_type": "string",
                       "mapping": {
-                        "type": "non_dynamic"
+                        %s
                       }
                     }
                   }
                 ]
               }
             }
-            """;
+            """, getMapping());
         PutIndexTemplateRequestBuilder req = client().admin()
             .indices()
             .preparePutTemplate("template1")
@@ -127,21 +128,22 @@ public class DynamicFieldMapperTests extends ESSingleNodeTestCase {
         Exception exc = expectThrows(Exception.class, () -> req.get());
         assertThat(exc.getCause(), instanceOf(IllegalArgumentException.class));
         assertThat(exc.getCause().getCause(), instanceOf(MapperParsingException.class));
-        assertThat(exc.getCause().getCause().getMessage(), containsString("[non_dynamic] can't be used in dynamic templates"));
+        assertThat(exc.getCause().getCause().getMessage(), containsString("["+getTypeName()+"] can't be used in dynamic templates"));
     }
 
     public void testCreateExplicitMappingInIndexTemplateSucceeds() throws Exception {
-        String mapping = """
+        String mapping =  String.format(
+            Locale.ROOT,"""
             {
               "_doc": {
                 "properties": {
                   "field": {
-                    "type": "non_dynamic"
+                    %s
                   }
                 }
               }
             }
-            """;
+            """, getMapping());
         PutIndexTemplateRequestBuilder req = client().admin()
             .indices()
             .preparePutTemplate("template1")
@@ -155,59 +157,6 @@ public class DynamicFieldMapperTests extends ESSingleNodeTestCase {
         var mappingsResp = client().admin().indices().prepareGetMappings("test1").get();
         var mappingMetadata = mappingsResp.getMappings().get("test1");
         var fieldType = XContentMapValues.extractValue("properties.field.type", mappingMetadata.getSourceAsMap());
-        assertThat(fieldType, equalTo(NonDynamicFieldMapper.NAME));
-    }
-
-    public static class NonDynamicFieldPlugin extends Plugin implements MapperPlugin {
-        public NonDynamicFieldPlugin() {}
-
-        @Override
-        public Map<String, Mapper.TypeParser> getMappers() {
-            return Map.of(NonDynamicFieldMapper.NAME, NonDynamicFieldMapper.PARSER);
-        }
-    }
-
-    private static class NonDynamicFieldMapper extends FieldMapper {
-        private static final String NAME = "non_dynamic";
-
-        private static final TypeParser PARSER = new TypeParser(
-            (n, c) -> new Builder(n),
-            List.of(notFromDynamicTemplates(NAME), notInMultiFields(NAME))
-        );
-
-        private static class Builder extends FieldMapper.Builder {
-            private final Parameter<Map<String, String>> meta = Parameter.metaParam();
-
-            Builder(String name) {
-                super(name);
-            }
-
-            @Override
-            protected Parameter<?>[] getParameters() {
-                return new Parameter<?>[] { meta };
-            }
-
-            @Override
-            public NonDynamicFieldMapper build(MapperBuilderContext context) {
-                return new NonDynamicFieldMapper(name(), new TextFieldMapper.TextFieldType(name(), false, true, meta.getValue()));
-            }
-        }
-
-        private NonDynamicFieldMapper(String simpleName, MappedFieldType mappedFieldType) {
-            super(simpleName, mappedFieldType, MultiFields.empty(), CopyTo.empty());
-        }
-
-        @Override
-        protected String contentType() {
-            return NAME;
-        }
-
-        @Override
-        protected void parseCreateField(DocumentParserContext context) throws IOException {}
-
-        @Override
-        public FieldMapper.Builder getMergeBuilder() {
-            return new Builder(simpleName()).init(this);
-        }
+        assertThat(fieldType, equalTo(getTypeName()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.plugins.Plugin;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class NonDynamicFieldMapperTests extends NonDynamicFieldMapperTestCase {
@@ -27,9 +28,9 @@ public class NonDynamicFieldMapperTests extends NonDynamicFieldMapperTestCase {
     }
 
     protected String getMapping() {
-        return """
-           "type": "%s"
-           """.formatted(NonDynamicFieldMapper.NAME);
+        return String.format(Locale.ROOT, """
+            "type": "%s"
+            """, NonDynamicFieldMapper.NAME);
     }
 
     public static class NonDynamicFieldPlugin extends Plugin implements MapperPlugin {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.plugins.MapperPlugin;
+import org.elasticsearch.plugins.Plugin;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class NonDynamicFieldMapperTests extends NonDynamicFieldMapperTestCase {
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(NonDynamicFieldPlugin.class);
+    }
+
+    protected String getTypeName() {
+        return NonDynamicFieldMapper.NAME;
+    }
+
+    protected String getMapping() {
+        return """
+           "type": "%s"
+           """.formatted(NonDynamicFieldMapper.NAME);
+    }
+
+    public static class NonDynamicFieldPlugin extends Plugin implements MapperPlugin {
+        public NonDynamicFieldPlugin() {}
+
+        @Override
+        public Map<String, Mapper.TypeParser> getMappers() {
+            return Map.of(NonDynamicFieldMapper.NAME, NonDynamicFieldMapper.PARSER);
+        }
+    }
+
+    private static class NonDynamicFieldMapper extends FieldMapper {
+        private static final String NAME = "non_dynamic";
+
+        private static final TypeParser PARSER = new TypeParser(
+            (n, c) -> new Builder(n),
+            List.of(notFromDynamicTemplates(NAME), notInMultiFields(NAME))
+        );
+
+        private static class Builder extends FieldMapper.Builder {
+            private final Parameter<Map<String, String>> meta = Parameter.metaParam();
+
+            Builder(String name) {
+                super(name);
+            }
+
+            @Override
+            protected Parameter<?>[] getParameters() {
+                return new Parameter<?>[] { meta };
+            }
+
+            @Override
+            public NonDynamicFieldMapper build(MapperBuilderContext context) {
+                return new NonDynamicFieldMapper(name(), new TextFieldMapper.TextFieldType(name(), false, true, meta.getValue()));
+            }
+        }
+
+        private NonDynamicFieldMapper(String simpleName, MappedFieldType mappedFieldType) {
+            super(simpleName, mappedFieldType, MultiFields.empty(), CopyTo.empty());
+        }
+
+        @Override
+        protected String contentType() {
+            return NAME;
+        }
+
+        @Override
+        protected void parseCreateField(DocumentParserContext context) throws IOException {}
+
+        @Override
+        public FieldMapper.Builder getMergeBuilder() {
+            return new Builder(simpleName()).init(this);
+        }
+    }
+}

--- a/x-pack/plugin/inference/build.gradle
+++ b/x-pack/plugin/inference/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   compileOnly project(":server")
   compileOnly project(path: xpackModule('core'))
   testImplementation(testArtifact(project(xpackModule('core'))))
+  testImplementation(testArtifact(project(':server')))
   testImplementation(project(':x-pack:plugin:inference:qa:test-service-plugin'))
   testImplementation project(':modules:reindex')
   clusterPlugins project(':x-pack:plugin:inference:qa:test-service-plugin')

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -66,7 +66,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
     public static final TypeParser PARSER = new TypeParser(
         (n, c) -> new Builder(n, c.indexVersionCreated()),
-        notInMultiFields(CONTENT_TYPE)
+        List.of(notInMultiFields(CONTENT_TYPE), notFromDynamicTemplates(CONTENT_TYPE))
     );
 
     public static class Builder extends FieldMapper.Builder {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/Utils.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/Utils.java
@@ -7,10 +7,15 @@
 
 package org.elasticsearch.xpack.inference;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.inference.InferenceServiceExtension;
+import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.xpack.inference.common.Truncator;
 import org.elasticsearch.xpack.inference.external.http.HttpClientManager;
@@ -18,16 +23,31 @@ import org.elasticsearch.xpack.inference.external.http.HttpSettings;
 import org.elasticsearch.xpack.inference.external.http.retry.RetrySettings;
 import org.elasticsearch.xpack.inference.external.http.sender.RequestExecutorServiceSettings;
 import org.elasticsearch.xpack.inference.logging.ThrottlerManager;
+import org.elasticsearch.xpack.inference.mock.TestDenseInferenceServiceExtension;
+import org.elasticsearch.xpack.inference.mock.TestSparseInferenceServiceExtension;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_POOL_NAME;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class Utils {
+public final class Utils {
+
+    private Utils() {
+        throw new UnsupportedOperationException("Utils is a utility class and should not be instantiated");
+    }
+
     public static ClusterService mockClusterServiceEmpty() {
         return mockClusterService(Settings.EMPTY);
     }
@@ -59,5 +79,66 @@ public class Utils {
             false,
             "xpack.inference.utility_thread_pool"
         );
+    }
+
+    public static void storeSparseModel(Client client) throws Exception {
+        Model model = new TestSparseInferenceServiceExtension.TestSparseModel(
+            TestSparseInferenceServiceExtension.TestInferenceService.NAME,
+            new TestSparseInferenceServiceExtension.TestServiceSettings("sparse_model", null, false)
+        );
+        storeModel(client, model);
+    }
+
+    public static void storeDenseModel(Client client, int dimensions, SimilarityMeasure similarityMeasure) throws Exception {
+        Model model = new TestDenseInferenceServiceExtension.TestDenseModel(
+            TestDenseInferenceServiceExtension.TestInferenceService.NAME,
+            new TestDenseInferenceServiceExtension.TestServiceSettings("dense_model", dimensions, similarityMeasure)
+        );
+
+        storeModel(client, model);
+    }
+
+    public static void storeModel(Client client, Model model) throws Exception {
+        ModelRegistry modelRegistry = new ModelRegistry(client);
+
+        AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(listener -> modelRegistry.storeModel(model, listener), storeModelHolder, exceptionHolder);
+
+        assertThat(storeModelHolder.get(), is(true));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+    }
+
+    private static <T> void blockingCall(
+        Consumer<ActionListener<T>> function,
+        AtomicReference<T> response,
+        AtomicReference<Exception> error
+    ) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<T> listener = ActionListener.wrap(r -> {
+            response.set(r);
+            latch.countDown();
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        });
+
+        function.accept(listener);
+        latch.await();
+    }
+
+    public static class TestInferencePlugin extends InferencePlugin {
+        public TestInferencePlugin(Settings settings) {
+            super(settings);
+        }
+
+        @Override
+        public List<InferenceServiceExtension.Factory> getInferenceServiceFactories() {
+            return List.of(
+                TestSparseInferenceServiceExtension.TestInferenceService::new,
+                TestDenseInferenceServiceExtension.TestInferenceService::new
+            );
+        }
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextNonDynamicFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextNonDynamicFieldMapperTests.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -44,10 +45,10 @@ public class SemanticTextNonDynamicFieldMapperTests extends NonDynamicFieldMappe
 
     @Override
     protected String getMapping() {
-        return """
+        return String.format(Locale.ROOT, """
             "type": "%s",
             "inference_id": "%s"
-            """.formatted(SemanticTextFieldMapper.CONTENT_TYPE, TestSparseInferenceServiceExtension.TestInferenceService.NAME);
+            """, SemanticTextFieldMapper.CONTENT_TYPE, TestSparseInferenceServiceExtension.TestInferenceService.NAME);
     }
 
     private void storeSparseModel() throws Exception {

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextNonDynamicFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextNonDynamicFieldMapperTests.java
@@ -7,24 +7,15 @@
 
 package org.elasticsearch.xpack.inference.mapper;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.index.mapper.NonDynamicFieldMapperTests;
-import org.elasticsearch.inference.Model;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.inference.Utils;
 import org.elasticsearch.xpack.inference.mock.TestSparseInferenceServiceExtension;
-import org.elasticsearch.xpack.inference.registry.ModelRegistry;
 import org.junit.Before;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.nullValue;
 
 public class SemanticTextNonDynamicFieldMapperTests extends NonDynamicFieldMapperTests {
 
@@ -49,40 +40,5 @@ public class SemanticTextNonDynamicFieldMapperTests extends NonDynamicFieldMappe
             "type": "%s",
             "inference_id": "%s"
             """, SemanticTextFieldMapper.CONTENT_TYPE, TestSparseInferenceServiceExtension.TestInferenceService.NAME);
-    }
-
-    private void storeSparseModel() throws Exception {
-        Model model = new TestSparseInferenceServiceExtension.TestSparseModel(
-            TestSparseInferenceServiceExtension.TestInferenceService.NAME,
-            new TestSparseInferenceServiceExtension.TestServiceSettings("sparse_model", null, false)
-        );
-        storeModel(model);
-    }
-
-    private void storeModel(Model model) throws Exception {
-        ModelRegistry modelRegistry = new ModelRegistry(client());
-
-        AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
-        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
-
-        blockingCall(listener -> modelRegistry.storeModel(model, listener), storeModelHolder, exceptionHolder);
-
-        assertThat(storeModelHolder.get(), is(true));
-        assertThat(exceptionHolder.get(), is(nullValue()));
-    }
-
-    private <T> void blockingCall(Consumer<ActionListener<T>> function, AtomicReference<T> response, AtomicReference<Exception> error)
-        throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        ActionListener<T> listener = ActionListener.wrap(r -> {
-            response.set(r);
-            latch.countDown();
-        }, e -> {
-            error.set(e);
-            latch.countDown();
-        });
-
-        function.accept(listener);
-        latch.await();
     }
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextNonDynamicFieldMapperTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/mapper/SemanticTextNonDynamicFieldMapperTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.inference.mapper;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.index.mapper.NonDynamicFieldMapperTests;
+import org.elasticsearch.inference.Model;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xpack.inference.Utils;
+import org.elasticsearch.xpack.inference.mock.TestSparseInferenceServiceExtension;
+import org.elasticsearch.xpack.inference.registry.ModelRegistry;
+import org.junit.Before;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class SemanticTextNonDynamicFieldMapperTests extends NonDynamicFieldMapperTests {
+
+    @Before
+    public void setup() throws Exception {
+        Utils.storeSparseModel(client());
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(Utils.TestInferencePlugin.class);
+    }
+
+    @Override
+    protected String getTypeName() {
+        return SemanticTextFieldMapper.CONTENT_TYPE;
+    }
+
+    @Override
+    protected String getMapping() {
+        return """
+            "type": "%s",
+            "inference_id": "%s"
+            """.formatted(SemanticTextFieldMapper.CONTENT_TYPE, TestSparseInferenceServiceExtension.TestInferenceService.NAME);
+    }
+
+    private void storeSparseModel() throws Exception {
+        Model model = new TestSparseInferenceServiceExtension.TestSparseModel(
+            TestSparseInferenceServiceExtension.TestInferenceService.NAME,
+            new TestSparseInferenceServiceExtension.TestServiceSettings("sparse_model", null, false)
+        );
+        storeModel(model);
+    }
+
+    private void storeModel(Model model) throws Exception {
+        ModelRegistry modelRegistry = new ModelRegistry(client());
+
+        AtomicReference<Boolean> storeModelHolder = new AtomicReference<>();
+        AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
+
+        blockingCall(listener -> modelRegistry.storeModel(model, listener), storeModelHolder, exceptionHolder);
+
+        assertThat(storeModelHolder.get(), is(true));
+        assertThat(exceptionHolder.get(), is(nullValue()));
+    }
+
+    private <T> void blockingCall(Consumer<ActionListener<T>> function, AtomicReference<T> response, AtomicReference<Exception> error)
+        throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        ActionListener<T> listener = ActionListener.wrap(r -> {
+            response.set(r);
+            latch.countDown();
+        }, e -> {
+            error.set(e);
+            latch.countDown();
+        });
+
+        function.accept(listener);
+        latch.await();
+    }
+}


### PR DESCRIPTION
Avoids `semantic_text` fields to be used in dynamic templates. 

We need the `semantic_text` fields to be already in the mapping so we can perform inference, so we're disallowing it based on the work done in #107491 .

I've refactored some of the existing tests so we can ensure that the field mapper does comply with the requirements, and created some utilities for dealing with inference services.