### PR TITLE
ES|QL: Fix WildcardLikeTests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLikeTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLikeTests.java
@@ -58,8 +58,9 @@ public class WildcardLikeTests extends AbstractFunctionTestCase {
         for (DataType type : new DataType[] { DataTypes.KEYWORD, DataTypes.TEXT }) {
             suppliers.add(new TestCaseSupplier(" with " + type.esType(), List.of(type, type), () -> {
                 BytesRef str = new BytesRef(randomAlphaOfLength(5));
-                BytesRef pattern = new BytesRef(randomAlphaOfLength(2));
-                Boolean match = str.utf8ToString().startsWith(pattern.utf8ToString());
+                String patternString = randomAlphaOfLength(2);
+                BytesRef pattern = new BytesRef(patternString + "*");
+                Boolean match = str.utf8ToString().startsWith(patternString);
                 return new TestCaseSupplier.TestCase(
                     List.of(
                         new TestCaseSupplier.TypedData(str, type, "str"),


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/108777
Fixes https://github.com/elastic/elasticsearch/issues/108782

The test succeeded most of the time because `randomString LIKE randomPattern` was false most of the time, but in the construction of the expression we forgot to add a `*` to the random pattern