### PR TITLE
Migrate remaining MockLogAppender.capturing to capture

### DIFF
--- a/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
@@ -131,8 +131,7 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
             final IOException ioException = new IOException("fatal");
             when(reader.readLine()).thenThrow(ioException);
             final Logger logger = LogManager.getLogger("testGetMaxMapCountIOException");
-            final MockLogAppender appender = new MockLogAppender();
-            try (var ignored = appender.capturing("testGetMaxMapCountIOException")) {
+            try (var appender = MockLogAppender.capture("testGetMaxMapCountIOException")) {
                 appender.addExpectation(
                     new MessageLoggingExpectation(
                         "expected logged I/O exception",
@@ -152,8 +151,7 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
             reset(reader);
             when(reader.readLine()).thenReturn("eof");
             final Logger logger = LogManager.getLogger("testGetMaxMapCountNumberFormatException");
-            final MockLogAppender appender = new MockLogAppender();
-            try (var ignored = appender.capturing("testGetMaxMapCountNumberFormatException")) {
+            try (var appender = MockLogAppender.capture("testGetMaxMapCountNumberFormatException")) {
                 appender.addExpectation(
                     new MessageLoggingExpectation(
                         "expected logged number format exception",

--- a/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
@@ -61,9 +61,8 @@ public class JULBridgeTests extends ESTestCase {
     private void assertLogged(Runnable loggingCode, LoggingExpectation... expectations) {
         Logger testLogger = LogManager.getLogger("");
         Level savedLevel = testLogger.getLevel();
-        MockLogAppender mockAppender = new MockLogAppender();
 
-        try (var ignored = mockAppender.capturing("")) {
+        try (var mockAppender = MockLogAppender.capture("")) {
             Loggers.setLevel(testLogger, Level.ALL);
             for (var expectation : expectations) {
                 mockAppender.addExpectation(expectation);

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
@@ -117,8 +117,7 @@ public class SettingsFilterTests extends ESTestCase {
 
     private void assertExpectedLogMessages(Consumer<Logger> consumer, MockLogAppender.LoggingExpectation... expectations) {
         Logger testLogger = LogManager.getLogger("org.elasticsearch.test");
-        MockLogAppender appender = new MockLogAppender();
-        try (var ignored = appender.capturing("org.elasticsearch.test")) {
+        try (var appender = MockLogAppender.capture("org.elasticsearch.test")) {
             Arrays.stream(expectations).forEach(appender::addExpectation);
             consumer.accept(testLogger);
             appender.assertAllExpectationsMatched();

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -294,18 +294,6 @@ public class MockLogAppender implements Releasable {
         }
     }
 
-    public Releasable capturing(Class<?>... classes) {
-        this.loggers = Arrays.stream(classes).map(Class::getCanonicalName).toList();
-        addToMockAppenders(this, loggers);
-        return this;
-    }
-
-    public Releasable capturing(String... names) {
-        this.loggers = Arrays.asList(names);
-        addToMockAppenders(this, loggers);
-        return this;
-    }
-
     /**
      * Adds the list of class loggers to this {@link MockLogAppender}.
      *

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -84,17 +84,13 @@ public class MockLogAppender implements Releasable {
         }
     }
 
-    public MockLogAppender() {
+    private MockLogAppender(List<String> loggers) {
         /*
          * We use a copy-on-write array list since log messages could be appended while we are setting up expectations. When that occurs,
          * we would run into a concurrent modification exception from the iteration over the expectations in #append, concurrent with a
          * modification from #addExpectation.
          */
         expectations = new CopyOnWriteArrayList<>();
-    }
-
-    private MockLogAppender(List<String> loggers) {
-        this();
         this.loggers = loggers;
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -35,8 +35,7 @@ public class MockLogAppender implements Releasable {
 
     private static final Map<String, List<MockLogAppender>> mockAppenders = new ConcurrentHashMap<>();
     private static final RealMockAppender parent = new RealMockAppender();
-    // TODO: this can become final once the ctor is made private
-    private List<String> loggers = List.of();
+    private final List<String> loggers;
     private final List<WrappedLoggingExpectation> expectations;
     private volatile boolean isAlive = true;
 

--- a/test/framework/src/test/java/org/elasticsearch/test/MockLogAppenderTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/MockLogAppenderTests.java
@@ -25,9 +25,8 @@ public class MockLogAppenderTests extends ESTestCase {
         });
         logThread.start();
 
-        final var appender = new MockLogAppender();
         for (int i = 0; i < 1000; i++) {
-            try (var ignored = appender.capturing(MockLogAppenderTests.class)) {
+            try (var appender = MockLogAppender.capture(MockLogAppenderTests.class)) {
                 Thread.yield();
             }
         }

--- a/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
+++ b/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
@@ -33,8 +33,7 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
     )
     @Override
     public void test() throws IOException {
-        final MockLogAppender mockLogAppender = new MockLogAppender();
-        try (var ignored = mockLogAppender.capturing(ESClientYamlSuiteTestCaseFailLogIT.class)) {
+        try (var mockLogAppender = MockLogAppender.capture(ESClientYamlSuiteTestCaseFailLogIT.class)) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "message with dump of the test yaml",

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
@@ -47,8 +47,7 @@ public class TransportGetAutoscalingCapacityActionIT extends AutoscalingIntegTes
     }
 
     public void assertCurrentCapacity(long memory, long storage, int nodes) {
-        MockLogAppender appender = new MockLogAppender();
-        try (var ignored = appender.capturing(TransportGetAutoscalingCapacityAction.class)) {
+        try (var appender = MockLogAppender.capture(TransportGetAutoscalingCapacityAction.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "autoscaling capacity response message with " + storage,

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
@@ -133,9 +133,7 @@ public class CcrLicenseIT extends CcrSingleNodeTestCase {
 
     public void testAutoFollowCoordinatorLogsSkippingAutoFollowCoordinationWithNonCompliantLicense() throws Exception {
         final Logger logger = LogManager.getLogger(AutoFollowCoordinator.class);
-        final MockLogAppender appender = new MockLogAppender();
-
-        try (var ignored = appender.capturing(AutoFollowCoordinator.class)) {
+        try (var appender = MockLogAppender.capture(AutoFollowCoordinator.class)) {
             appender.addExpectation(
                 new MockLogAppender.ExceptionSeenEventExpectation(
                     getTestName(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -192,8 +192,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(cache.getClass())) {
+        try (var mockAppender = MockLogAppender.capture(cache.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "[bitset too big]",
@@ -230,8 +229,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(cache.getClass())) {
+        try (var mockAppender = MockLogAppender.capture(cache.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "[cache full]",

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -116,8 +116,7 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
 
         SetStepInfoUpdateTask task = new SetStepInfoUpdateTask(index, policy, currentStepKey, stepInfo);
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(SetStepInfoUpdateTask.class)) {
+        try (var mockAppender = MockLogAppender.capture(SetStepInfoUpdateTask.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "warning",

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -52,9 +52,6 @@ public class TransportGetPipelineActionTests extends ESTestCase {
      * a TransportGetPipelineAction.
      */
     public void testGetPipelineMultipleIDsPartialFailure() throws Exception {
-        // Set up a log appender for detecting log messages
-        final MockLogAppender mockLogAppender = new MockLogAppender();
-
         // Set up a MultiGetResponse
         GetResponse mockResponse = mock(GetResponse.class);
         when(mockResponse.getId()).thenReturn("1");
@@ -66,7 +63,7 @@ public class TransportGetPipelineActionTests extends ESTestCase {
             new MultiGetItemResponse[] { new MultiGetItemResponse(mockResponse, null), new MultiGetItemResponse(null, failure) }
         );
 
-        try (var threadPool = createThreadPool(); var ignored = mockLogAppender.capturing(TransportGetPipelineAction.class)) {
+        try (var threadPool = createThreadPool(); var mockLogAppender = MockLogAppender.capture(TransportGetPipelineAction.class)) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "message",

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
@@ -106,32 +106,28 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             ).getBytes(StandardCharsets.UTF_8)
         );
 
-        MockLogAppender mockAppender = new MockLogAppender();
-        mockAppender.addExpectation(
+        executeLoggingTest(
+            is,
+            Level.INFO,
+            "test_throttling",
             new MockLogAppender.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [5]"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test3",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 4"
-            )
-        );
-        mockAppender.addExpectation(
+            ),
             new MockLogAppender.SeenEventExpectation(
                 "test4",
                 CppLogMessageHandler.class.getName(),
@@ -139,8 +135,6 @@ public class CppLogMessageHandlerTests extends ESTestCase {
                 "[test_throttling] * message 5"
             )
         );
-
-        executeLoggingTest(is, Level.INFO, "test_throttling");
     }
 
     public void testThrottlingSummaryOneRepeat() throws IllegalAccessException, TimeoutException, IOException {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
@@ -64,8 +64,7 @@ public class SearchableSnapshotsRecoverFromSnapshotIntegTests extends BaseSearch
 
         final var newNode = internalCluster().startDataOnlyNode();
 
-        final var mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(ShardSnapshotsService.class)) {
+        try (var mockAppender = MockLogAppender.capture(ShardSnapshotsService.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation(
                     "Error fetching segments file",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -786,13 +786,12 @@ public class SecurityTests extends ESTestCase {
     public void testSecurityRestHandlerInterceptorCanBeInstalled() throws IllegalAccessException {
         final Logger amLogger = LogManager.getLogger(ActionModule.class);
         Loggers.setLevel(amLogger, Level.DEBUG);
-        final MockLogAppender appender = new MockLogAppender();
 
         Settings settings = Settings.builder().put("xpack.security.enabled", false).put("path.home", createTempDir()).build();
         SettingsModule settingsModule = new SettingsModule(Settings.EMPTY);
         ThreadPool threadPool = new TestThreadPool(getTestName());
 
-        try (var ignored = appender.capturing(ActionModule.class)) {
+        try (var appender = MockLogAppender.capture(ActionModule.class)) {
             UsageService usageService = new UsageService();
             Security security = new Security(settings);
 
@@ -838,7 +837,6 @@ public class SecurityTests extends ESTestCase {
         final Logger mockLogger = LogManager.getLogger(Security.class);
         boolean securityEnabled = true;
         Loggers.setLevel(mockLogger, Level.INFO);
-        final MockLogAppender appender = new MockLogAppender();
 
         Settings.Builder settings = Settings.builder().put("path.home", createTempDir());
         if (randomBoolean()) {
@@ -847,7 +845,7 @@ public class SecurityTests extends ESTestCase {
             settings.put("xpack.security.enabled", securityEnabled);
         }
 
-        try (var ignored = appender.capturing(Security.class)) {
+        try (var appender = MockLogAppender.capture(Security.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "message",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -59,8 +59,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     }
 
     public void testLogWhenLicenseProhibitsAuditing() throws Exception {
-        MockLogAppender mockLogAppender = new MockLogAppender();
-        try (var ignored = mockLogAppender.capturing(AuditTrailService.class)) {
+        try (var mockLogAppender = MockLogAppender.capture(AuditTrailService.class)) {
             when(licenseState.getOperationMode()).thenReturn(randomFrom(License.OperationMode.values()));
             if (isAuditingAllowed) {
                 mockLogAppender.addExpectation(
@@ -94,8 +93,7 @@ public class AuditTrailServiceTests extends ESTestCase {
     }
 
     public void testNoLogRecentlyWhenLicenseProhibitsAuditing() throws Exception {
-        MockLogAppender mockLogAppender = new MockLogAppender();
-        try (var ignored = mockLogAppender.capturing(AuditTrailService.class)) {
+        try (var mockLogAppender = MockLogAppender.capture(AuditTrailService.class)) {
             service.nextLogInstantAtomic.set(randomFrom(Instant.now().minus(Duration.ofMinutes(5)), Instant.now()));
             mockLogAppender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -1498,9 +1498,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         IntStream.range(0, cacheSize).forEach(i -> apiKeyAuthCache.put(idPrefix + count.incrementAndGet(), new ListenableFuture<>()));
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
-        final MockLogAppender appender = new MockLogAppender();
 
-        try (var ignored = appender.capturing(ApiKeyService.class)) {
+        try (var appender = MockLogAppender.capture(ApiKeyService.class)) {
             appender.addExpectation(
                 new MockLogAppender.PatternSeenEventExpectation(
                     "evict",
@@ -1559,9 +1558,8 @@ public class ApiKeyServiceTests extends ESTestCase {
 
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
-        final MockLogAppender appender = new MockLogAppender();
 
-        try (var ignored = appender.capturing(ApiKeyService.class)) {
+        try (var appender = MockLogAppender.capture(ApiKeyService.class)) {
             appender.addExpectation(
                 new MockLogAppender.UnseenEventExpectation(
                     "evict",
@@ -1592,9 +1590,8 @@ public class ApiKeyServiceTests extends ESTestCase {
         apiKeyAuthCache.put(randomAlphaOfLength(21), new ListenableFuture<>());
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
-        final MockLogAppender appender = new MockLogAppender();
 
-        try (var ignored = appender.capturing(ApiKeyService.class)) {
+        try (var appender = MockLogAppender.capture(ApiKeyService.class)) {
             // Prepare the warning logging to trigger
             service.getEvictionCounter().add(4500);
             final long thrashingCheckIntervalInSeconds = 300L;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -417,9 +417,7 @@ public class AuthenticationServiceTests extends ESTestCase {
     }
 
     public void testTokenMissing() throws Exception {
-        final MockLogAppender mockAppender = new MockLogAppender();
-
-        try (var ignored = mockAppender.capturing(RealmsAuthenticator.class)) {
+        try (var mockAppender = MockLogAppender.capture(RealmsAuthenticator.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "unlicensed realms",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -480,9 +480,8 @@ public class AuthenticatorChainTests extends ESTestCase {
 
         final Logger logger = LogManager.getLogger(AuthenticatorChain.class);
         Loggers.setLevel(logger, Level.INFO);
-        final MockLogAppender appender = new MockLogAppender();
 
-        try (var ignored = appender.capturing(AuthenticatorChain.class)) {
+        try (var appender = MockLogAppender.capture(AuthenticatorChain.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "run-as",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -205,8 +205,7 @@ public class RealmsAuthenticatorTests extends AbstractAuthenticatorTests {
         final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
         when(request.authenticationFailed(authenticationToken)).thenReturn(e);
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(RealmsAuthenticator.class)) {
+        try (var mockAppender = MockLogAppender.capture(RealmsAuthenticator.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "unlicensed realms",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -935,10 +935,9 @@ public class RealmsTests extends ESTestCase {
         verify(licenseState).enableUsageTracking(Security.CUSTOM_REALMS_FEATURE, "custom_realm_2");
 
         final Logger realmsLogger = LogManager.getLogger(Realms.class);
-        final MockLogAppender appender = new MockLogAppender();
 
         when(licenseState.statusDescription()).thenReturn("mock license");
-        try (var ignored = appender.capturing(Realms.class)) {
+        try (var appender = MockLogAppender.capture(Realms.class)) {
             for (String realmId : List.of("kerberos.kerberos_realm", "type_0.custom_realm_1", "type_1.custom_realm_2")) {
                 appender.addExpectation(
                     new MockLogAppender.SeenEventExpectation(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
@@ -970,7 +970,6 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
     public void testLogIdTokenAndNonce() throws URISyntaxException, BadJOSEException, JOSEException, IllegalAccessException {
         final Logger logger = LogManager.getLogger(OpenIdConnectAuthenticator.class);
-        final MockLogAppender appender = new MockLogAppender();
         Loggers.setLevel(logger, Level.DEBUG);
 
         final RealmConfig config = buildConfig(getBasicRealmSettings().build(), threadContext);
@@ -997,7 +996,7 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
         final Nonce expectedNonce = new Nonce(randomAlphaOfLength(10));
 
-        try (var ignored = appender.capturing(OpenIdConnectAuthenticator.class)) {
+        try (var appender = MockLogAppender.capture(OpenIdConnectAuthenticator.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation("JWT header", logger.getName(), Level.DEBUG, "ID Token Header: " + headerString)
             );
@@ -1058,10 +1057,9 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
         // In addition, capture logs to show that kept alive (TTL) is honored
         final Logger logger = LogManager.getLogger(PoolingNHttpClientConnectionManager.class);
-        final MockLogAppender appender = new MockLogAppender();
         // Note: Setting an org.apache.http logger to DEBUG requires es.insecure_network_trace_enabled=true
         Loggers.setLevel(logger, Level.DEBUG);
-        try (var ignored = appender.capturing(PoolingNHttpClientConnectionManager.class)) {
+        try (var appender = MockLogAppender.capture(PoolingNHttpClientConnectionManager.class)) {
             appender.addExpectation(
                 new MockLogAppender.PatternSeenEventExpectation(
                     "log",
@@ -1202,9 +1200,8 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
         authenticator = new OpenIdConnectAuthenticator(config, getOpConfig(), getDefaultRpConfig(), new SSLService(env), null);
 
         final Logger logger = LogManager.getLogger(OpenIdConnectAuthenticator.class);
-        final MockLogAppender appender = new MockLogAppender();
         Loggers.setLevel(logger, Level.DEBUG);
-        try (var ignored = appender.capturing(OpenIdConnectAuthenticator.class)) {
+        try (var appender = MockLogAppender.capture(OpenIdConnectAuthenticator.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "log",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
@@ -215,8 +215,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             .add(getAttribute(attributeName, attributeFriendlyName, null, List.of("daredevil")));
         SamlToken token = token(signResponse(response));
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(authenticator.getClass())) {
+        try (var mockAppender = MockLogAppender.capture(authenticator.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "attribute name warning",
@@ -240,8 +239,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         assertion.getAttributeStatements().get(0).getAttributes().add(getAttribute(UID_OID, "friendly", null, List.of("daredevil")));
         SamlToken token = token(signResponse(response));
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(authenticator.getClass())) {
+        try (var mockAppender = MockLogAppender.capture(authenticator.getClass())) {
             final SamlAttributes attributes = authenticator.authenticate(token);
             assertThat(attributes, notNullValue());
             mockAppender.assertAllExpectationsMatched();
@@ -261,8 +259,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         SamlToken token = token(signResponse(response));
 
         final Logger samlLogger = LogManager.getLogger(authenticator.getClass());
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(authenticator.getClass())) {
+        try (var mockAppender = MockLogAppender.capture(authenticator.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "attribute name warning",
@@ -866,8 +863,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         String xml = SamlUtils.getXmlContent(response, false);
         final SamlToken token = token(signResponse(xml));
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(authenticator.getClass())) {
+        try (var mockAppender = MockLogAppender.capture(authenticator.getClass())) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "similar audience",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -111,12 +111,9 @@ public class ServiceAccountServiceTests extends ESTestCase {
         final Logger sasLogger = LogManager.getLogger(ServiceAccountService.class);
         Loggers.setLevel(sasLogger, Level.TRACE);
 
-        final MockLogAppender satAppender = new MockLogAppender();
-        final MockLogAppender sasAppender = new MockLogAppender();
-
         try (
-            var ignored1 = satAppender.capturing(ServiceAccountToken.class);
-            var ignored2 = sasAppender.capturing(ServiceAccountService.class)
+            var satAppender = MockLogAppender.capture(ServiceAccountToken.class);
+            var sasAppender = MockLogAppender.capture(ServiceAccountService.class)
         ) {
             // Less than 4 bytes
             satAppender.addExpectation(
@@ -366,8 +363,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
         final Logger sasLogger = LogManager.getLogger(ServiceAccountService.class);
         Loggers.setLevel(sasLogger, Level.TRACE);
 
-        final MockLogAppender appender = new MockLogAppender();
-        try (var ignored = appender.capturing(ServiceAccountService.class)) {
+        try (var appender = MockLogAppender.capture(ServiceAccountService.class)) {
             // non-elastic service account
             final ServiceAccountId accountId1 = new ServiceAccountId(
                 randomValueOtherThan(ElasticServiceAccounts.NAMESPACE, () -> randomAlphaOfLengthBetween(3, 8)),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/LoadAuthorizedIndicesTimeCheckerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/LoadAuthorizedIndicesTimeCheckerTests.java
@@ -192,8 +192,7 @@ public class LoadAuthorizedIndicesTimeCheckerTests extends ESTestCase {
             requestInfo,
             thresholds
         );
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(timerLogger.getName())) {
+        try (var mockAppender = MockLogAppender.capture(timerLogger.getName())) {
             mockAppender.addExpectation(expectation);
             checker.accept(List.of());
             mockAppender.assertAllExpectationsMatched();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -296,8 +296,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             effectiveRoleDescriptors::set
         );
 
-        final MockLogAppender mockAppender = new MockLogAppender();
-        try (var ignored = mockAppender.capturing(RoleDescriptorStore.class)) {
+        try (var mockAppender = MockLogAppender.capture(RoleDescriptorStore.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "disabled role warning",

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/DefaultOperatorPrivilegesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/DefaultOperatorPrivilegesTests.java
@@ -101,10 +101,9 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
 
         // Will mark for the operator user
         final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
-        final MockLogAppender appender = new MockLogAppender();
         Loggers.setLevel(logger, Level.DEBUG);
 
-        try (var ignored = appender.capturing(OperatorPrivileges.class)) {
+        try (var appender = MockLogAppender.capture(OperatorPrivileges.class)) {
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "marking",
@@ -210,10 +209,9 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
         when(xPackLicenseState.isAllowed(Security.OPERATOR_PRIVILEGES_FEATURE)).thenReturn(licensed);
 
         final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
-        final MockLogAppender appender = new MockLogAppender();
         Loggers.setLevel(logger, Level.DEBUG);
 
-        try (var ignored = appender.capturing(OperatorPrivileges.class)) {
+        try (var appender = MockLogAppender.capture(OperatorPrivileges.class)) {
             final RestoreSnapshotRequest restoreSnapshotRequest = mock(RestoreSnapshotRequest.class);
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -175,11 +175,10 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         Files.copy(sampleFile, inUseFile, StandardCopyOption.REPLACE_EXISTING);
 
         final Logger logger = LogManager.getLogger(FileOperatorUsersStore.class);
-        final MockLogAppender appender = new MockLogAppender();
         Loggers.setLevel(logger, Level.TRACE);
 
         try (
-            var ignored = appender.capturing(FileOperatorUsersStore.class);
+            var appender = MockLogAppender.capture(FileOperatorUsersStore.class);
             ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)
         ) {
             appender.addExpectation(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
@@ -14,8 +14,6 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.settings.Settings;
@@ -119,13 +117,10 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
         final SslConfiguration clientSslConfig = sslService.getSSLConfiguration(HTTP_CLIENT_SSL);
         final SSLSocketFactory clientSocketFactory = sslService.sslSocketFactory(clientSslConfig);
 
-        final Logger diagnosticLogger = LogManager.getLogger(DiagnosticTrustManager.class);
-        final MockLogAppender mockAppender = new MockLogAppender();
-
         // Apache clients implement their own hostname checking, but we don't want that.
         // We use a raw socket so we get the builtin JDK checking (which is what we use for transport protocol SSL checks)
         try (
-            var ignored = mockAppender.capturing(DiagnosticTrustManager.class);
+            var mockAppender = MockLogAppender.capture(DiagnosticTrustManager.class);
             MockWebServer webServer = initWebServer(sslService);
             SSLSocket clientSocket = (SSLSocket) clientSocketFactory.createSocket()
         ) {

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -376,8 +376,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         createSnapshot(repoName, "snap", Collections.singletonList(indexName));
 
         String targetNode;
-        final var mockLogAppender = new MockLogAppender();
-        try (var ignored = mockLogAppender.capturing(RecoverySourceHandler.class)) {
+        try (var mockLogAppender = MockLogAppender.capture(RecoverySourceHandler.class)) {
             mockLogAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "expected warn log about restore failure",
@@ -611,8 +610,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
             recoverSnapshotFileRequestReceived.await();
 
-            final var mockLogAppender = new MockLogAppender();
-            try (var ignored = mockLogAppender.capturing(RecoverySourceHandler.class)) {
+            try (var mockLogAppender = MockLogAppender.capture(RecoverySourceHandler.class)) {
                 mockLogAppender.addExpectation(
                     new MockLogAppender.SeenEventExpectation(
                         "expected debug log about restore cancellation",

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -468,8 +468,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         transformAuditor.reset();
         transformAuditor.addExpectation(auditExpectation);
 
-        MockLogAppender mockLogAppender = new MockLogAppender();
-        try (var ignored = mockLogAppender.capturing(checkpointProviderLogger.getName())) {
+        try (var mockLogAppender = MockLogAppender.capture(checkpointProviderLogger.getName())) {
             mockLogAppender.addExpectation(loggingExpectation);
             codeBlock.run();
             mockLogAppender.assertAllExpectationsMatched();


### PR DESCRIPTION
This commit removes the remaining tests constructing a MockLogAppender directly and makes the constructor private.