### PR TITLE
Make ingest byte stat names more descriptive

### DIFF
--- a/docs/changelog/108786.yaml
+++ b/docs/changelog/108786.yaml
@@ -1,0 +1,5 @@
+pr: 108786
+summary: Make ingest byte stat names more descriptive
+area: Ingest Node
+type: enhancement
+issues: []

--- a/docs/reference/cluster/cluster-info.asciidoc
+++ b/docs/reference/cluster/cluster-info.asciidoc
@@ -207,14 +207,14 @@ pipeline.
 (integer)
 Total number of failed operations for the ingest pipeline.
 
-`ingested_in_bytes`::
+`ingested_as_first_pipeline_in_bytes`::
 (Optional, integer)
 Total number of bytes of all documents ingested by the pipeline.
 This field is only present on pipelines which are the first to process a document.
 Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after
 a reroute processor, or pipelines in pipeline processors.
 
-`produced_in_bytes`::
+`produced_as_first_pipeline_in_bytes`::
 (Optional, integer)
 Total number of bytes of all documents produced by the pipeline.
 This field is only present on pipelines which are the first to process a document.

--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -2643,14 +2643,14 @@ pipeline.
 (integer)
 Total number of failed operations for the ingest pipeline.
 
-`ingested_in_bytes`::
+`ingested_as_first_pipeline_in_bytes`::
 (Optional, integer)
 Total number of bytes of all documents ingested by the pipeline.
 This field is only present on pipelines which are the first to process a document.
 Thus, it is not present on pipelines which only serve as a final pipeline after a default pipeline, a pipeline run after
 a reroute processor, or pipelines in pipeline processors.
 
-`produced_in_bytes`::
+`produced_as_first_pipeline_in_bytes`::
 (Optional, integer)
 Total number of bytes of all documents produced by the pipeline.
 This field is only present on pipelines which are the first to process a document.

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/15_info_ingest.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/15_info_ingest.yml
@@ -90,8 +90,8 @@ teardown:
   - gte: { ingest.pipelines.ingest_info_pipeline.time_in_millis: 0 }
   - match: { ingest.pipelines.ingest_info_pipeline.current: 0 }
   - match: { ingest.pipelines.ingest_info_pipeline.failed: 0 }
-  - gt: { ingest.pipelines.ingest_info_pipeline.ingested_in_bytes: 0 }
-  - gt: { ingest.pipelines.ingest_info_pipeline.produced_in_bytes: 0 }
+  - gt: { ingest.pipelines.ingest_info_pipeline.ingested_as_first_pipeline_in_bytes: 0 }
+  - gt: { ingest.pipelines.ingest_info_pipeline.produced_as_first_pipeline_in_bytes: 0 }
 
   # Processors section
   - is_true: ingest.pipelines.ingest_info_pipeline.processors.0.set
@@ -129,8 +129,8 @@ teardown:
       cluster.info:
         target: [ ingest ]
   - match: { ingest.pipelines.pipeline-1.failed: 1 }
-  - gt: { ingest.pipelines.pipeline-1.ingested_in_bytes: 0 }
-  - match: { ingest.pipelines.pipeline-1.produced_in_bytes: 0 }
+  - gt: { ingest.pipelines.pipeline-1.ingested_as_first_pipeline_in_bytes: 0 }
+  - match: { ingest.pipelines.pipeline-1.produced_as_first_pipeline_in_bytes: 0 }
 
 ---
 "Test drop processor":
@@ -156,8 +156,8 @@ teardown:
   - do:
       cluster.info:
         target: [ ingest ]
-  - gt: { ingest.pipelines.pipeline-1.ingested_in_bytes: 0 }
-  - match: { ingest.pipelines.pipeline-1.produced_in_bytes: 0 }
+  - gt: { ingest.pipelines.pipeline-1.ingested_as_first_pipeline_in_bytes: 0 }
+  - match: { ingest.pipelines.pipeline-1.produced_as_first_pipeline_in_bytes: 0 }
 
 ---
 "Test that pipeline processor has byte stats recorded in first pipeline":
@@ -211,11 +211,11 @@ teardown:
   - do:
       cluster.info:
         target: [ ingest ]
-  - gt: { ingest.pipelines.pipeline-1.ingested_in_bytes: 0 }
-  - set: { ingest.pipelines.pipeline-1.ingested_in_bytes: ingest_bytes }
-  - gt: { ingest.pipelines.pipeline-1.produced_in_bytes: $ingest_bytes }
-  - match: { ingest.pipelines.pipeline-2.ingested_in_bytes: null }
-  - match: { ingest.pipelines.pipeline-2.produced_in_bytes: null }
+  - gt: { ingest.pipelines.pipeline-1.ingested_as_first_pipeline_in_bytes: 0 }
+  - set: { ingest.pipelines.pipeline-1.ingested_as_first_pipeline_in_bytes: ingest_bytes }
+  - gt: { ingest.pipelines.pipeline-1.produced_as_first_pipeline_in_bytes: $ingest_bytes }
+  - match: { ingest.pipelines.pipeline-2.ingested_as_first_pipeline_in_bytes: null }
+  - match: { ingest.pipelines.pipeline-2.produced_as_first_pipeline_in_bytes: null }
 
 ---
 "Test that final pipeline has byte stats recorded in first pipeline":
@@ -264,11 +264,11 @@ teardown:
   - do:
       cluster.info:
         target: [ ingest ]
-  - gt: { ingest.pipelines.pipeline-1.ingested_in_bytes: 0 }
-  - set: { ingest.pipelines.pipeline-1.ingested_in_bytes: ingest_bytes }
-  - gt: { ingest.pipelines.pipeline-1.produced_in_bytes: $ingest_bytes }
-  - match: { ingest.pipelines.pipeline-2.ingested_in_bytes: null }
-  - match: { ingest.pipelines.pipeline-2.produced_in_bytes: null }
+  - gt: { ingest.pipelines.pipeline-1.ingested_as_first_pipeline_in_bytes: 0 }
+  - set: { ingest.pipelines.pipeline-1.ingested_as_first_pipeline_in_bytes: ingest_bytes }
+  - gt: { ingest.pipelines.pipeline-1.produced_as_first_pipeline_in_bytes: $ingest_bytes }
+  - match: { ingest.pipelines.pipeline-2.ingested_as_first_pipeline_in_bytes: null }
+  - match: { ingest.pipelines.pipeline-2.produced_as_first_pipeline_in_bytes: null }
 
 
 ---
@@ -330,8 +330,8 @@ teardown:
   - do:
       cluster.info:
         target: [ ingest ]
-  - gt: { ingest.pipelines.pipeline-1.ingested_in_bytes: 0 }
-  - set: { ingest.pipelines.pipeline-1.ingested_in_bytes: ingest_bytes }
-  - gt: { ingest.pipelines.pipeline-1.produced_in_bytes: $ingest_bytes }
-  - match: { ingest.pipelines.pipeline-2.ingested_in_bytes: null }
-  - match: { ingest.pipelines.pipeline-2.produced_in_bytes: null }
+  - gt: { ingest.pipelines.pipeline-1.ingested_as_first_pipeline_in_bytes: 0 }
+  - set: { ingest.pipelines.pipeline-1.ingested_as_first_pipeline_in_bytes: ingest_bytes }
+  - gt: { ingest.pipelines.pipeline-1.produced_as_first_pipeline_in_bytes: $ingest_bytes }
+  - match: { ingest.pipelines.pipeline-2.ingested_as_first_pipeline_in_bytes: null }
+  - match: { ingest.pipelines.pipeline-2.produced_as_first_pipeline_in_bytes: null }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -286,8 +286,8 @@ public record IngestStats(Stats totalStats, List<PipelineStat> pipelineStats, Ma
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             if (bytesIngested > 0 || bytesProduced > 0) {
-                builder.field("ingested_in_bytes", bytesIngested);
-                builder.field("produced_in_bytes", bytesProduced);
+                builder.field("ingested_as_first_pipeline_in_bytes", bytesIngested);
+                builder.field("produced_as_first_pipeline_in_bytes", bytesProduced);
             }
             return builder;
         }


### PR DESCRIPTION
Current ingest byte stat fields could easily be confused. Add more descriptive name to make it clear they do not count all docs processed by the pipeline

Related to https://github.com/elastic/elasticsearch/pull/107240