### PR TITLE
Rename MockLogAppender to MockLog

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
@@ -12,7 +12,7 @@ import org.apache.logging.log4j.Level;
 import org.elasticsearch.ESNetty4IntegTestCase;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportLogger;
@@ -22,11 +22,11 @@ import java.io.IOException;
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, scope = ESIntegTestCase.Scope.TEST)
 public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
 
-    private MockLogAppender appender;
+    private MockLog appender;
 
     public void setUp() throws Exception {
         super.setUp();
-        appender = MockLogAppender.capture(ESLoggingHandler.class, TransportLogger.class, TcpTransport.class);
+        appender = MockLog.capture(ESLoggingHandler.class, TransportLogger.class, TcpTransport.class);
     }
 
     public void tearDown() throws Exception {
@@ -45,14 +45,14 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
             + ", version: .*"
             + ", action: cluster:monitor/nodes/stats\\[n\\]\\]"
             + " WRITE: \\d+B";
-        final MockLogAppender.LoggingExpectation writeExpectation = new MockLogAppender.PatternSeenEventExpectation(
+        final MockLog.LoggingExpectation writeExpectation = new MockLog.PatternSeenEventExpectation(
             "hot threads request",
             TransportLogger.class.getCanonicalName(),
             Level.TRACE,
             writePattern
         );
 
-        final MockLogAppender.LoggingExpectation flushExpectation = new MockLogAppender.SeenEventExpectation(
+        final MockLog.LoggingExpectation flushExpectation = new MockLog.SeenEventExpectation(
             "flush",
             ESLoggingHandler.class.getCanonicalName(),
             Level.TRACE,
@@ -66,7 +66,7 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
             + ", action: cluster:monitor/nodes/stats\\[n\\]\\]"
             + " READ: \\d+B";
 
-        final MockLogAppender.LoggingExpectation readExpectation = new MockLogAppender.PatternSeenEventExpectation(
+        final MockLog.LoggingExpectation readExpectation = new MockLog.PatternSeenEventExpectation(
             "hot threads request",
             TransportLogger.class.getCanonicalName(),
             Level.TRACE,
@@ -83,7 +83,7 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
     @TestLogging(value = "org.elasticsearch.transport.TcpTransport:DEBUG", reason = "to ensure we log connection events on DEBUG level")
     public void testConnectionLogging() throws IOException {
         appender.addExpectation(
-            new MockLogAppender.PatternSeenEventExpectation(
+            new MockLog.PatternSeenEventExpectation(
                 "open connection log",
                 TcpTransport.class.getCanonicalName(),
                 Level.DEBUG,
@@ -91,7 +91,7 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
             )
         );
         appender.addExpectation(
-            new MockLogAppender.PatternSeenEventExpectation(
+            new MockLog.PatternSeenEventExpectation(
                 "close connection log",
                 TcpTransport.class.getCanonicalName(),
                 Level.DEBUG,

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
@@ -22,15 +22,15 @@ import java.io.IOException;
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, scope = ESIntegTestCase.Scope.TEST)
 public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
 
-    private MockLog appender;
+    private MockLog mockLog;
 
     public void setUp() throws Exception {
         super.setUp();
-        appender = MockLog.capture(ESLoggingHandler.class, TransportLogger.class, TcpTransport.class);
+        mockLog = MockLog.capture(ESLoggingHandler.class, TransportLogger.class, TcpTransport.class);
     }
 
     public void tearDown() throws Exception {
-        appender.close();
+        mockLog.close();
         super.tearDown();
     }
 
@@ -73,16 +73,16 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
             readPattern
         );
 
-        appender.addExpectation(writeExpectation);
-        appender.addExpectation(flushExpectation);
-        appender.addExpectation(readExpectation);
+        mockLog.addExpectation(writeExpectation);
+        mockLog.addExpectation(flushExpectation);
+        mockLog.addExpectation(readExpectation);
         client().admin().cluster().prepareNodesStats().get(TimeValue.timeValueSeconds(10));
-        appender.assertAllExpectationsMatched();
+        mockLog.assertAllExpectationsMatched();
     }
 
     @TestLogging(value = "org.elasticsearch.transport.TcpTransport:DEBUG", reason = "to ensure we log connection events on DEBUG level")
     public void testConnectionLogging() throws IOException {
-        appender.addExpectation(
+        mockLog.addExpectation(
             new MockLog.PatternSeenEventExpectation(
                 "open connection log",
                 TcpTransport.class.getCanonicalName(),
@@ -90,7 +90,7 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
                 ".*opened transport connection \\[[1-9][0-9]*\\] to .*"
             )
         );
-        appender.addExpectation(
+        mockLog.addExpectation(
             new MockLog.PatternSeenEventExpectation(
                 "close connection log",
                 TcpTransport.class.getCanonicalName(),
@@ -102,6 +102,6 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
         final String nodeName = internalCluster().startNode();
         internalCluster().stopNode(nodeName);
 
-        appender.assertAllExpectationsMatched();
+        mockLog.assertAllExpectationsMatched();
     }
 }

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.plugins.Platforms;
 import org.elasticsearch.plugins.PluginTestUtil;
 import org.elasticsearch.test.GraalVMThreadsFilter;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -66,10 +66,10 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
     static {
         // normally done by ESTestCase, but need here because spawner depends on logging
         LogConfigurator.loadLog4jPlugins();
-        MockLogAppender.init();
+        MockLog.init();
     }
 
-    static class ExpectedStreamMessage implements MockLogAppender.LoggingExpectation {
+    static class ExpectedStreamMessage implements MockLog.LoggingExpectation {
         final String expectedLogger;
         final String expectedMessage;
         final CountDownLatch matched;
@@ -210,7 +210,7 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         Loggers.setLevel(LogManager.getLogger(stderrLoggerName), Level.TRACE);
         CountDownLatch messagesLoggedLatch = new CountDownLatch(2);
 
-        try (var appender = MockLogAppender.capture(stdoutLoggerName, stderrLoggerName)) {
+        try (var appender = MockLog.capture(stdoutLoggerName, stderrLoggerName)) {
             if (expectSpawn) {
                 appender.addExpectation(new ExpectedStreamMessage(stdoutLoggerName, "I am alive", messagesLoggedLatch));
                 appender.addExpectation(new ExpectedStreamMessage(stderrLoggerName, "I am an error", messagesLoggedLatch));

--- a/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
+++ b/qa/no-bootstrap-tests/src/test/java/org/elasticsearch/bootstrap/SpawnerNoBootstrapTests.java
@@ -210,10 +210,10 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
         Loggers.setLevel(LogManager.getLogger(stderrLoggerName), Level.TRACE);
         CountDownLatch messagesLoggedLatch = new CountDownLatch(2);
 
-        try (var appender = MockLog.capture(stdoutLoggerName, stderrLoggerName)) {
+        try (var mockLog = MockLog.capture(stdoutLoggerName, stderrLoggerName)) {
             if (expectSpawn) {
-                appender.addExpectation(new ExpectedStreamMessage(stdoutLoggerName, "I am alive", messagesLoggedLatch));
-                appender.addExpectation(new ExpectedStreamMessage(stderrLoggerName, "I am an error", messagesLoggedLatch));
+                mockLog.addExpectation(new ExpectedStreamMessage(stdoutLoggerName, "I am alive", messagesLoggedLatch));
+                mockLog.addExpectation(new ExpectedStreamMessage(stderrLoggerName, "I am an error", messagesLoggedLatch));
             }
 
             Spawner spawner = new Spawner();
@@ -233,7 +233,7 @@ public class SpawnerNoBootstrapTests extends LuceneTestCase {
             } else {
                 assertThat(processes, is(empty()));
             }
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -35,7 +35,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -251,9 +251,9 @@ public class RolloverIT extends ESIntegTestCase {
         Logger allocationServiceLogger = LogManager.getLogger(AllocationService.class);
 
         final RolloverResponse response;
-        try (var appender = MockLogAppender.capture(AllocationService.class)) {
+        try (var appender = MockLog.capture(AllocationService.class)) {
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "no related message logged on dry run",
                     AllocationService.class.getName(),
                     Level.INFO,

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -251,8 +251,8 @@ public class RolloverIT extends ESIntegTestCase {
         Logger allocationServiceLogger = LogManager.getLogger(AllocationService.class);
 
         final RolloverResponse response;
-        try (var appender = MockLog.capture(AllocationService.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(AllocationService.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "no related message logged on dry run",
                     AllocationService.class.getName(),
@@ -261,7 +261,7 @@ public class RolloverIT extends ESIntegTestCase {
                 )
             );
             response = indicesAdmin().prepareRolloverIndex("test_alias").dryRun(true).get();
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
 
         assertThat(response.getOldIndex(), equalTo("test_index-1"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
@@ -42,7 +42,7 @@ import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -387,9 +387,9 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             )
             .get();
 
-        try (var dryRunMockLog = MockLogAppender.capture(TransportClusterRerouteAction.class)) {
+        try (var dryRunMockLog = MockLog.capture(TransportClusterRerouteAction.class)) {
             dryRunMockLog.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "no completed message logged on dry run",
                     TransportClusterRerouteAction.class.getName(),
                     Level.INFO,
@@ -411,9 +411,9 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             dryRunMockLog.assertAllExpectationsMatched();
         }
 
-        try (var allocateMockLog = MockLogAppender.capture(TransportClusterRerouteAction.class)) {
+        try (var allocateMockLog = MockLog.capture(TransportClusterRerouteAction.class)) {
             allocateMockLog.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "message for first allocate empty primary",
                     TransportClusterRerouteAction.class.getName(),
                     Level.INFO,
@@ -421,7 +421,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
                 )
             );
             allocateMockLog.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "no message for second allocate empty primary",
                     TransportClusterRerouteAction.class.getName(),
                     Level.INFO,

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -138,8 +138,8 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
             Arrays.asList(getTestTransportPlugin(), MockHttpTransport.TestPlugin.class),
             Function.identity()
         );
-        try (var mockAppender = MockLog.capture(JoinHelper.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(JoinHelper.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation("test", JoinHelper.class.getCanonicalName(), Level.INFO, "failed to join") {
 
                     @Override
@@ -159,7 +159,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
             other.beforeTest(random());
             final ClusterState first = internalCluster().getInstance(ClusterService.class).state();
             assertThat(first.nodes().getSize(), equalTo(1));
-            assertBusy(mockAppender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
         } finally {
             other.close();
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -18,7 +18,7 @@ import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 import org.elasticsearch.test.MockHttpTransport;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.NodeConfigurationSource;
 import org.elasticsearch.transport.RemoteTransportException;
 import org.elasticsearch.transport.TransportService;
@@ -138,9 +138,9 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
             Arrays.asList(getTestTransportPlugin(), MockHttpTransport.TestPlugin.class),
             Function.identity()
         );
-        try (var mockAppender = MockLogAppender.capture(JoinHelper.class)) {
+        try (var mockAppender = MockLog.capture(JoinHelper.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation("test", JoinHelper.class.getCanonicalName(), Level.INFO, "failed to join") {
+                new MockLog.SeenEventExpectation("test", JoinHelper.class.getCanonicalName(), Level.INFO, "failed to join") {
 
                     @Override
                     public boolean innerMatch(final LogEvent event) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
@@ -22,7 +22,7 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.concurrent.CountDownLatch;
@@ -70,11 +70,11 @@ public class ShardLockFailureIT extends ESIntegTestCase {
 
         try (
             var ignored1 = internalCluster().getInstance(NodeEnvironment.class, node).shardLock(shardId, "blocked for test");
-            var mockLogAppender = MockLogAppender.capture(IndicesClusterStateService.class);
+            var mockLogAppender = MockLog.capture(IndicesClusterStateService.class);
         ) {
             final CountDownLatch countDownLatch = new CountDownLatch(1);
 
-            mockLogAppender.addExpectation(new MockLogAppender.LoggingExpectation() {
+            mockLogAppender.addExpectation(new MockLog.LoggingExpectation() {
                 int debugMessagesSeen = 0;
                 int warnMessagesSeen = 0;
 
@@ -139,10 +139,10 @@ public class ShardLockFailureIT extends ESIntegTestCase {
 
         try (
             var ignored1 = internalCluster().getInstance(NodeEnvironment.class, node).shardLock(shardId, "blocked for test");
-            var mockLogAppender = MockLogAppender.capture(IndicesClusterStateService.class);
+            var mockLogAppender = MockLog.capture(IndicesClusterStateService.class);
         ) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "timeout message",
                     "org.elasticsearch.indices.cluster.IndicesClusterStateService",
                     Level.WARN,

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
@@ -70,11 +70,11 @@ public class ShardLockFailureIT extends ESIntegTestCase {
 
         try (
             var ignored1 = internalCluster().getInstance(NodeEnvironment.class, node).shardLock(shardId, "blocked for test");
-            var mockLogAppender = MockLog.capture(IndicesClusterStateService.class);
+            var mockLog = MockLog.capture(IndicesClusterStateService.class);
         ) {
             final CountDownLatch countDownLatch = new CountDownLatch(1);
 
-            mockLogAppender.addExpectation(new MockLog.LoggingExpectation() {
+            mockLog.addExpectation(new MockLog.LoggingExpectation() {
                 int debugMessagesSeen = 0;
                 int warnMessagesSeen = 0;
 
@@ -108,7 +108,7 @@ public class ShardLockFailureIT extends ESIntegTestCase {
             ensureYellow(indexName);
             assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
             assertEquals(ClusterHealthStatus.YELLOW, clusterAdmin().prepareHealth(indexName).get().getStatus());
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
 
         ensureGreen(indexName);
@@ -139,9 +139,9 @@ public class ShardLockFailureIT extends ESIntegTestCase {
 
         try (
             var ignored1 = internalCluster().getInstance(NodeEnvironment.class, node).shardLock(shardId, "blocked for test");
-            var mockLogAppender = MockLog.capture(IndicesClusterStateService.class);
+            var mockLog = MockLog.capture(IndicesClusterStateService.class);
         ) {
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "timeout message",
                     "org.elasticsearch.indices.cluster.IndicesClusterStateService",
@@ -153,7 +153,7 @@ public class ShardLockFailureIT extends ESIntegTestCase {
             );
 
             updateIndexSettings(Settings.builder().putNull(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name"), indexName);
-            assertBusy(mockLogAppender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
             final var clusterHealthResponse = clusterAdmin().prepareHealth(indexName)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(TimeValue.timeValueSeconds(10))

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -54,7 +54,7 @@ import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.DummyQueryBuilder;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.xcontent.ObjectParser;
@@ -648,9 +648,9 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         reason = "verify the log output on cancelled"
     )
     public void testCancel() throws Exception {
-        try (var logAppender = MockLogAppender.capture(TransportFieldCapabilitiesAction.class)) {
+        try (var logAppender = MockLog.capture(TransportFieldCapabilitiesAction.class)) {
             logAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "clear resources",
                     TransportFieldCapabilitiesAction.class.getCanonicalName(),
                     Level.TRACE,

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -648,8 +648,8 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         reason = "verify the log output on cancelled"
     )
     public void testCancel() throws Exception {
-        try (var logAppender = MockLog.capture(TransportFieldCapabilitiesAction.class)) {
-            logAppender.addExpectation(
+        try (var mockLog = MockLog.capture(TransportFieldCapabilitiesAction.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "clear resources",
                     TransportFieldCapabilitiesAction.class.getCanonicalName(),
@@ -681,7 +681,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
                 }
             }, 30, TimeUnit.SECONDS);
             cancellable.cancel();
-            assertBusy(logAppender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
             logger.info("--> waiting for field-caps tasks to be cancelled");
             assertBusy(() -> {
                 List<TaskInfo> tasks = clusterAdmin().prepareListTasks()

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -56,7 +56,7 @@ import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
 import org.elasticsearch.test.InternalTestCluster;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.disruption.BusyMasterServiceDisruption;
 import org.elasticsearch.test.disruption.ServiceDisruptionScheme;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -1264,9 +1264,9 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         final String repoName = "test-repo";
         createRepository(repoName, "fs");
 
-        try (var mockAppender = MockLogAppender.capture(BlobStoreRepository.class)) {
+        try (var mockAppender = MockLog.capture(BlobStoreRepository.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation("no warnings", BlobStoreRepository.class.getCanonicalName(), Level.WARN, "*")
+                new MockLog.UnseenEventExpectation("no warnings", BlobStoreRepository.class.getCanonicalName(), Level.WARN, "*")
             );
             final String index1 = "index-1";
             final String index2 = "index-2";

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -1264,8 +1264,8 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         final String repoName = "test-repo";
         createRepository(repoName, "fs");
 
-        try (var mockAppender = MockLog.capture(BlobStoreRepository.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(BlobStoreRepository.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation("no warnings", BlobStoreRepository.class.getCanonicalName(), Level.WARN, "*")
             );
             final String index1 = "index-1";
@@ -1279,7 +1279,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
             createSnapshot(repoName, snapshot2, List.of(index2));
 
             clusterAdmin().prepareDeleteSnapshot(repoName, snapshot1, snapshot2).get();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -162,7 +162,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         value = "org.elasticsearch.snapshots.RestoreService:INFO"
     )
     public void testRestoreLogging() throws IllegalAccessException {
-        try (var mockLogAppender = MockLog.capture(RestoreService.class)) {
+        try (var mockLog = MockLog.capture(RestoreService.class)) {
             String indexName = "testindex";
             String repoName = "test-restore-snapshot-repo";
             String snapshotName = "test-restore-snapshot";
@@ -171,7 +171,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             String restoredIndexName = indexName + "-restored";
             String expectedValue = "expected";
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "not seen start of snapshot restore",
                     "org.elasticsearch.snapshots.RestoreService",
@@ -180,7 +180,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 )
             );
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "not seen completion of snapshot restore",
                     "org.elasticsearch.snapshots.RestoreService",
@@ -207,7 +207,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             assertThat(restoreSnapshotResponse.status(), equalTo(RestStatus.ACCEPTED));
             ensureGreen(restoredIndexName);
             assertThat(client.prepareGet(restoredIndexName, docId).get().isExists(), equalTo(true));
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -898,8 +898,8 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         index(indexName, "some_id", Map.of("foo", "bar"));
         assertAcked(indicesAdmin().prepareClose(indexName).get());
 
-        try (var mockAppender = MockLog.capture(FileRestoreContext.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(FileRestoreContext.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation("no warnings", FileRestoreContext.class.getCanonicalName(), Level.WARN, "*")
             );
 
@@ -909,7 +909,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
                 .setWaitForCompletion(true)
                 .get();
             assertEquals(0, restoreSnapshotResponse.getRestoreInfo().failedShards());
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -29,7 +29,7 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.blobstore.FileRestoreContext;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xcontent.XContentFactory;
 
@@ -162,7 +162,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         value = "org.elasticsearch.snapshots.RestoreService:INFO"
     )
     public void testRestoreLogging() throws IllegalAccessException {
-        try (var mockLogAppender = MockLogAppender.capture(RestoreService.class)) {
+        try (var mockLogAppender = MockLog.capture(RestoreService.class)) {
             String indexName = "testindex";
             String repoName = "test-restore-snapshot-repo";
             String snapshotName = "test-restore-snapshot";
@@ -172,7 +172,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             String expectedValue = "expected";
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "not seen start of snapshot restore",
                     "org.elasticsearch.snapshots.RestoreService",
                     Level.INFO,
@@ -181,7 +181,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
             );
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "not seen completion of snapshot restore",
                     "org.elasticsearch.snapshots.RestoreService",
                     Level.INFO,
@@ -898,9 +898,9 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         index(indexName, "some_id", Map.of("foo", "bar"));
         assertAcked(indicesAdmin().prepareClose(indexName).get());
 
-        try (var mockAppender = MockLogAppender.capture(FileRestoreContext.class)) {
+        try (var mockAppender = MockLog.capture(FileRestoreContext.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation("no warnings", FileRestoreContext.class.getCanonicalName(), Level.WARN, "*")
+                new MockLog.UnseenEventExpectation("no warnings", FileRestoreContext.class.getCanonicalName(), Level.WARN, "*")
             );
 
             final RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(repoName, snapshotName)

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
@@ -16,7 +16,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.Collections;
@@ -136,8 +136,8 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
         }
         final String primaryNode = internalCluster().startNode(primaryNodeSettings);
 
-        try (var mockLogAppender = MockLogAppender.capture(BlobStoreRepository.class)) {
-            MockLogAppender.EventuallySeenEventExpectation snapshotExpectation = new MockLogAppender.EventuallySeenEventExpectation(
+        try (var mockLogAppender = MockLog.capture(BlobStoreRepository.class)) {
+            MockLog.EventuallySeenEventExpectation snapshotExpectation = new MockLog.EventuallySeenEventExpectation(
                 "snapshot speed over recovery speed",
                 "org.elasticsearch.repositories.blobstore.BlobStoreRepository",
                 Level.WARN,
@@ -148,7 +148,7 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
             if (nodeBandwidthSettingsSet) snapshotExpectation.setExpectSeen();
             mockLogAppender.addExpectation(snapshotExpectation);
 
-            MockLogAppender.SeenEventExpectation restoreExpectation = new MockLogAppender.SeenEventExpectation(
+            MockLog.SeenEventExpectation restoreExpectation = new MockLog.SeenEventExpectation(
                 "snapshot restore speed over recovery speed",
                 "org.elasticsearch.repositories.blobstore.BlobStoreRepository",
                 Level.WARN,

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
@@ -136,7 +136,7 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
         }
         final String primaryNode = internalCluster().startNode(primaryNodeSettings);
 
-        try (var mockLogAppender = MockLog.capture(BlobStoreRepository.class)) {
+        try (var mockLog = MockLog.capture(BlobStoreRepository.class)) {
             MockLog.EventuallySeenEventExpectation snapshotExpectation = new MockLog.EventuallySeenEventExpectation(
                 "snapshot speed over recovery speed",
                 "org.elasticsearch.repositories.blobstore.BlobStoreRepository",
@@ -146,7 +146,7 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
                     + "rate limit will be superseded by the recovery rate limit"
             );
             if (nodeBandwidthSettingsSet) snapshotExpectation.setExpectSeen();
-            mockLogAppender.addExpectation(snapshotExpectation);
+            mockLog.addExpectation(snapshotExpectation);
 
             MockLog.SeenEventExpectation restoreExpectation = new MockLog.SeenEventExpectation(
                 "snapshot restore speed over recovery speed",
@@ -156,7 +156,7 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
                     + "the effective recovery rate limit [indices.recovery.max_bytes_per_sec=100mb] per second, thus the repository "
                     + "rate limit will be superseded by the recovery rate limit"
             );
-            mockLogAppender.addExpectation(restoreExpectation);
+            mockLog.addExpectation(restoreExpectation);
 
             createRepository(
                 "test-repo",
@@ -168,7 +168,7 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
             );
 
             deleteRepository("test-repo");
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
@@ -16,7 +16,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.mockstore.MockRepository;
 import org.elasticsearch.test.ClusterServiceUtils;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -31,9 +31,9 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
         createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
 
-        try (var mockLogAppender = MockLogAppender.capture(SnapshotsService.class)) {
+        try (var mockLogAppender = MockLog.capture(SnapshotsService.class)) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "[does-not-exist]",
                     SnapshotsService.class.getName(),
                     Level.INFO,
@@ -42,7 +42,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             );
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "[deleting test-snapshot]",
                     SnapshotsService.class.getName(),
                     Level.INFO,
@@ -51,7 +51,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             );
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "[test-snapshot deleted]",
                     SnapshotsService.class.getName(),
                     Level.INFO,
@@ -78,9 +78,9 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
         createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
 
-        try (var mockLogAppender = MockLogAppender.capture(SnapshotsService.class)) {
+        try (var mockLogAppender = MockLog.capture(SnapshotsService.class)) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "[test-snapshot]",
                     SnapshotsService.class.getName(),
                     Level.WARN,

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotsServiceIT.java
@@ -31,8 +31,8 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
         createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
 
-        try (var mockLogAppender = MockLog.capture(SnapshotsService.class)) {
-            mockLogAppender.addExpectation(
+        try (var mockLog = MockLog.capture(SnapshotsService.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "[does-not-exist]",
                     SnapshotsService.class.getName(),
@@ -41,7 +41,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
                 )
             );
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "[deleting test-snapshot]",
                     SnapshotsService.class.getName(),
@@ -50,7 +50,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
                 )
             );
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "[test-snapshot deleted]",
                     SnapshotsService.class.getName(),
@@ -67,7 +67,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             assertThat(startDeleteSnapshot("test-repo", "test-snapshot").actionGet().isAcknowledged(), is(true));
 
             awaitNoMoreRunningOperations(); // ensure background file deletion is completed
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             deleteRepository("test-repo");
         }
@@ -78,8 +78,8 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         createIndexWithRandomDocs("test-index", randomIntBetween(1, 42));
         createSnapshot("test-repo", "test-snapshot", List.of("test-index"));
 
-        try (var mockLogAppender = MockLog.capture(SnapshotsService.class)) {
-            mockLogAppender.addExpectation(
+        try (var mockLog = MockLog.capture(SnapshotsService.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "[test-snapshot]",
                     SnapshotsService.class.getName(),
@@ -105,7 +105,7 @@ public class SnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
                 assertThat(e.getCause().getMessage(), containsString("exception after block"));
             }
 
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             deleteRepository("test-repo");
         }

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -60,7 +60,7 @@ import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -495,10 +495,10 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         request.decRef();
         assertTrue(request.hasReferences());
 
-        MockLogAppender.assertThatLogger(
+        MockLog.assertThatLogger(
             () -> setState(clusterService, ClusterStateCreationUtils.state(localNode, localNode, allNodes)),
             ClusterApplierService.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "listener log",
                 ClusterApplierService.class.getCanonicalName(),
                 Level.TRACE,

--- a/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -131,7 +131,7 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
             final IOException ioException = new IOException("fatal");
             when(reader.readLine()).thenThrow(ioException);
             final Logger logger = LogManager.getLogger("testGetMaxMapCountIOException");
-            try (var appender = MockLogAppender.capture("testGetMaxMapCountIOException")) {
+            try (var appender = MockLog.capture("testGetMaxMapCountIOException")) {
                 appender.addExpectation(
                     new MessageLoggingExpectation(
                         "expected logged I/O exception",
@@ -151,7 +151,7 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
             reset(reader);
             when(reader.readLine()).thenReturn("eof");
             final Logger logger = LogManager.getLogger("testGetMaxMapCountNumberFormatException");
-            try (var appender = MockLogAppender.capture("testGetMaxMapCountNumberFormatException")) {
+            try (var appender = MockLog.capture("testGetMaxMapCountNumberFormatException")) {
                 appender.addExpectation(
                     new MessageLoggingExpectation(
                         "expected logged number format exception",
@@ -169,7 +169,7 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
 
     }
 
-    private static class MessageLoggingExpectation implements MockLogAppender.LoggingExpectation {
+    private static class MessageLoggingExpectation implements MockLog.LoggingExpectation {
 
         private boolean saw = false;
 

--- a/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/MaxMapCountCheckTests.java
@@ -131,8 +131,8 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
             final IOException ioException = new IOException("fatal");
             when(reader.readLine()).thenThrow(ioException);
             final Logger logger = LogManager.getLogger("testGetMaxMapCountIOException");
-            try (var appender = MockLog.capture("testGetMaxMapCountIOException")) {
-                appender.addExpectation(
+            try (var mockLog = MockLog.capture("testGetMaxMapCountIOException")) {
+                mockLog.addExpectation(
                     new MessageLoggingExpectation(
                         "expected logged I/O exception",
                         "testGetMaxMapCountIOException",
@@ -142,7 +142,7 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
                     )
                 );
                 assertThat(check.getMaxMapCount(logger), equalTo(-1L));
-                appender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
             verify(reader).close();
         }
@@ -151,8 +151,8 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
             reset(reader);
             when(reader.readLine()).thenReturn("eof");
             final Logger logger = LogManager.getLogger("testGetMaxMapCountNumberFormatException");
-            try (var appender = MockLog.capture("testGetMaxMapCountNumberFormatException")) {
-                appender.addExpectation(
+            try (var mockLog = MockLog.capture("testGetMaxMapCountNumberFormatException")) {
+                mockLog.addExpectation(
                     new MessageLoggingExpectation(
                         "expected logged number format exception",
                         "testGetMaxMapCountNumberFormatException",
@@ -162,7 +162,7 @@ public class MaxMapCountCheckTests extends AbstractBootstrapCheckTestCase {
                     )
                 );
                 assertThat(check.getMaxMapCount(logger), equalTo(-1L));
-                appender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
             verify(reader).close();
         }

--- a/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -353,10 +353,10 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         for (DiscoveryNode disconnectedNode : disconnectedNodes) {
             transportService.disconnectFromNode(disconnectedNode);
         }
-        try (var appender = MockLog.capture(NodeConnectionsService.class)) {
+        try (var mockLog = MockLog.capture(NodeConnectionsService.class)) {
             for (DiscoveryNode targetNode : targetNodes) {
                 if (disconnectedNodes.contains(targetNode)) {
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.SeenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -364,7 +364,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                             "connecting to " + targetNode
                         )
                     );
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.SeenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -373,7 +373,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                         )
                     );
                 } else {
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.UnseenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -381,7 +381,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                             "connecting to " + targetNode
                         )
                     );
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.UnseenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -393,7 +393,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             }
 
             runTasksUntil(deterministicTaskQueue, CLUSTER_NODE_RECONNECT_INTERVAL_SETTING.get(Settings.EMPTY).millis());
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
 
         for (DiscoveryNode disconnectedNode : disconnectedNodes) {
@@ -406,10 +406,10 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             transportService.disconnectFromNode(disconnectedNode);
         }
 
-        try (var appender = MockLog.capture(NodeConnectionsService.class)) {
+        try (var mockLog = MockLog.capture(NodeConnectionsService.class)) {
             for (DiscoveryNode targetNode : targetNodes) {
                 if (disconnectedNodes.contains(targetNode) && newTargetNodes.get(targetNode.getId()) != null) {
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.SeenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -417,7 +417,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                             "connecting to " + targetNode
                         )
                     );
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.SeenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -426,7 +426,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                         )
                     );
                 } else {
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.UnseenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -434,7 +434,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                             "connecting to " + targetNode
                         )
                     );
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.UnseenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -444,7 +444,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                     );
                 }
                 if (newTargetNodes.get(targetNode.getId()) == null) {
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.SeenEventExpectation(
                             "disconnected from " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -455,7 +455,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                 }
             }
             for (DiscoveryNode targetNode : newTargetNodes) {
-                appender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.UnseenEventExpectation(
                         "disconnected from " + targetNode,
                         "org.elasticsearch.cluster.NodeConnectionsService",
@@ -464,7 +464,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                     )
                 );
                 if (targetNodes.get(targetNode.getId()) == null) {
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.SeenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -472,7 +472,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                             "connecting to " + targetNode
                         )
                     );
-                    appender.addExpectation(
+                    mockLog.addExpectation(
                         new MockLog.SeenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
@@ -486,7 +486,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             service.disconnectFromNodesExcept(newTargetNodes);
             service.connectToNodes(newTargetNodes, () -> {});
             deterministicTaskQueue.runAllRunnableTasks();
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -353,11 +353,11 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         for (DiscoveryNode disconnectedNode : disconnectedNodes) {
             transportService.disconnectFromNode(disconnectedNode);
         }
-        try (var appender = MockLogAppender.capture(NodeConnectionsService.class)) {
+        try (var appender = MockLog.capture(NodeConnectionsService.class)) {
             for (DiscoveryNode targetNode : targetNodes) {
                 if (disconnectedNodes.contains(targetNode)) {
                     appender.addExpectation(
-                        new MockLogAppender.SeenEventExpectation(
+                        new MockLog.SeenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -365,7 +365,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                         )
                     );
                     appender.addExpectation(
-                        new MockLogAppender.SeenEventExpectation(
+                        new MockLog.SeenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -374,7 +374,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                     );
                 } else {
                     appender.addExpectation(
-                        new MockLogAppender.UnseenEventExpectation(
+                        new MockLog.UnseenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -382,7 +382,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                         )
                     );
                     appender.addExpectation(
-                        new MockLogAppender.UnseenEventExpectation(
+                        new MockLog.UnseenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -406,11 +406,11 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             transportService.disconnectFromNode(disconnectedNode);
         }
 
-        try (var appender = MockLogAppender.capture(NodeConnectionsService.class)) {
+        try (var appender = MockLog.capture(NodeConnectionsService.class)) {
             for (DiscoveryNode targetNode : targetNodes) {
                 if (disconnectedNodes.contains(targetNode) && newTargetNodes.get(targetNode.getId()) != null) {
                     appender.addExpectation(
-                        new MockLogAppender.SeenEventExpectation(
+                        new MockLog.SeenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -418,7 +418,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                         )
                     );
                     appender.addExpectation(
-                        new MockLogAppender.SeenEventExpectation(
+                        new MockLog.SeenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -427,7 +427,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                     );
                 } else {
                     appender.addExpectation(
-                        new MockLogAppender.UnseenEventExpectation(
+                        new MockLog.UnseenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -435,7 +435,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                         )
                     );
                     appender.addExpectation(
-                        new MockLogAppender.UnseenEventExpectation(
+                        new MockLog.UnseenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -445,7 +445,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                 }
                 if (newTargetNodes.get(targetNode.getId()) == null) {
                     appender.addExpectation(
-                        new MockLogAppender.SeenEventExpectation(
+                        new MockLog.SeenEventExpectation(
                             "disconnected from " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -456,7 +456,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             }
             for (DiscoveryNode targetNode : newTargetNodes) {
                 appender.addExpectation(
-                    new MockLogAppender.UnseenEventExpectation(
+                    new MockLog.UnseenEventExpectation(
                         "disconnected from " + targetNode,
                         "org.elasticsearch.cluster.NodeConnectionsService",
                         Level.DEBUG,
@@ -465,7 +465,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                 );
                 if (targetNodes.get(targetNode.getId()) == null) {
                     appender.addExpectation(
-                        new MockLogAppender.SeenEventExpectation(
+                        new MockLog.SeenEventExpectation(
                             "connecting to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,
@@ -473,7 +473,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
                         )
                     );
                     appender.addExpectation(
-                        new MockLogAppender.SeenEventExpectation(
+                        new MockLog.SeenEventExpectation(
                             "connected to " + targetNode,
                             "org.elasticsearch.cluster.NodeConnectionsService",
                             Level.DEBUG,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.gateway.ClusterStateUpdaters;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -143,11 +143,11 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
             cluster.stabilise();
             final var clusterNode = cluster.getAnyLeader();
 
-            try (var mockAppender = MockLogAppender.capture(Coordinator.class, Coordinator.CoordinatorPublication.class)) {
+            try (var mockAppender = MockLog.capture(Coordinator.class, Coordinator.CoordinatorPublication.class)) {
 
                 clusterNode.disconnect();
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "write heartbeat failure",
                         Coordinator.class.getCanonicalName(),
                         Level.WARN,
@@ -160,7 +160,7 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
 
                 coordinatorStrategy.disruptElections = true;
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "acquire term failure",
                         Coordinator.class.getCanonicalName(),
                         Level.WARN,
@@ -173,7 +173,7 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
 
                 coordinatorStrategy.disruptPublications = true;
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "verify term failure",
                         Coordinator.CoordinatorPublication.class.getCanonicalName(),
                         Level.WARN,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -143,10 +143,10 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
             cluster.stabilise();
             final var clusterNode = cluster.getAnyLeader();
 
-            try (var mockAppender = MockLog.capture(Coordinator.class, Coordinator.CoordinatorPublication.class)) {
+            try (var mockLog = MockLog.capture(Coordinator.class, Coordinator.CoordinatorPublication.class)) {
 
                 clusterNode.disconnect();
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "write heartbeat failure",
                         Coordinator.class.getCanonicalName(),
@@ -155,11 +155,11 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
                     )
                 );
                 cluster.runFor(HEARTBEAT_FREQUENCY.get(Settings.EMPTY).millis(), "warnings");
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
                 clusterNode.heal();
 
                 coordinatorStrategy.disruptElections = true;
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "acquire term failure",
                         Coordinator.class.getCanonicalName(),
@@ -168,11 +168,11 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
                     )
                 );
                 cluster.runFor(DEFAULT_ELECTION_DELAY, "warnings");
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
                 coordinatorStrategy.disruptElections = false;
 
                 coordinatorStrategy.disruptPublications = true;
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "verify term failure",
                         Coordinator.CoordinatorPublication.class.getCanonicalName(),
@@ -181,7 +181,7 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
                     )
                 );
                 cluster.runFor(DEFAULT_ELECTION_DELAY + DEFAULT_CLUSTER_STATE_UPDATE_DELAY, "publication warnings");
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
                 coordinatorStrategy.disruptPublications = false;
             }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -19,7 +19,7 @@ import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportService;
@@ -650,9 +650,9 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
     }
 
     public void testBootstrapStateLogging() {
-        try (var mockAppender = MockLogAppender.capture(ClusterBootstrapService.class)) {
+        try (var mockAppender = MockLog.capture(ClusterBootstrapService.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "fresh node message",
                     ClusterBootstrapService.class.getCanonicalName(),
                     Level.INFO,
@@ -679,7 +679,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
             final String infoMessagePattern = """
                 this node is locked into cluster UUID [test-uuid] and will not attempt further cluster bootstrapping""";
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "bootstrapped node message",
                     ClusterBootstrapService.class.getCanonicalName(),
                     Level.INFO,
@@ -700,7 +700,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
                 https://www.elastic.co/guide/en/elasticsearch/reference/*/important-settings.html#initial_master_nodes""";
 
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "bootstrapped node message if bootstrapping still configured",
                     ClusterBootstrapService.class.getCanonicalName(),
                     Level.WARN,
@@ -721,7 +721,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
             mockAppender.assertAllExpectationsMatched();
 
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "bootstrapped node message if bootstrapping still configured",
                     ClusterBootstrapService.class.getCanonicalName(),
                     Level.WARN,
@@ -738,7 +738,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
             mockAppender.assertAllExpectationsMatched();
 
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "bootstrapped node message if discovery type is single node ",
                     ClusterBootstrapService.class.getCanonicalName(),
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -650,8 +650,8 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
     }
 
     public void testBootstrapStateLogging() {
-        try (var mockAppender = MockLog.capture(ClusterBootstrapService.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(ClusterBootstrapService.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "fresh node message",
                     ClusterBootstrapService.class.getCanonicalName(),
@@ -674,11 +674,11 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
                 }
             ).logBootstrapState(metadataBuilder.build());
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             final String infoMessagePattern = """
                 this node is locked into cluster UUID [test-uuid] and will not attempt further cluster bootstrapping""";
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "bootstrapped node message",
                     ClusterBootstrapService.class.getCanonicalName(),
@@ -691,7 +691,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
                 throw new AssertionError("should not be called");
             }).logBootstrapState(Metadata.builder().clusterUUID("test-uuid").clusterUUIDCommitted(true).build());
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             final var warningMessagePattern = """
                 this node is locked into cluster UUID [test-uuid] but [cluster.initial_master_nodes] is set to [node1, node2]; \
@@ -699,7 +699,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
                 for further information see \
                 https://www.elastic.co/guide/en/elasticsearch/reference/*/important-settings.html#initial_master_nodes""";
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "bootstrapped node message if bootstrapping still configured",
                     ClusterBootstrapService.class.getCanonicalName(),
@@ -718,9 +718,9 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
                 }
             ).logBootstrapState(Metadata.builder().clusterUUID("test-uuid").clusterUUIDCommitted(true).build());
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "bootstrapped node message if bootstrapping still configured",
                     ClusterBootstrapService.class.getCanonicalName(),
@@ -735,9 +735,9 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
                 deterministicTaskQueue.advanceTime();
             }
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "bootstrapped node message if discovery type is single node ",
                     ClusterBootstrapService.class.getCanonicalName(),
@@ -756,7 +756,7 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
                 }
             ).logBootstrapState(Metadata.builder().clusterUUID("test-uuid").clusterUUIDCommitted(true).build());
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -26,7 +26,7 @@ import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -109,12 +109,12 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         final long startTimeMillis = deterministicTaskQueue.getCurrentTimeMillis();
         clusterFormationFailureHelper.start();
 
-        try (var mockLogAppender = MockLogAppender.capture(ClusterFormationFailureHelper.class)) {
+        try (var mockLogAppender = MockLog.capture(ClusterFormationFailureHelper.class)) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation("master not discovered", LOGGER_NAME, Level.WARN, "master not discovered")
+                new MockLog.SeenEventExpectation("master not discovered", LOGGER_NAME, Level.WARN, "master not discovered")
             );
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "troubleshooting link",
                     LOGGER_NAME,
                     Level.WARN,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -109,11 +109,11 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         final long startTimeMillis = deterministicTaskQueue.getCurrentTimeMillis();
         clusterFormationFailureHelper.start();
 
-        try (var mockLogAppender = MockLog.capture(ClusterFormationFailureHelper.class)) {
-            mockLogAppender.addExpectation(
+        try (var mockLog = MockLog.capture(ClusterFormationFailureHelper.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation("master not discovered", LOGGER_NAME, Level.WARN, "master not discovered")
             );
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "troubleshooting link",
                     LOGGER_NAME,
@@ -133,7 +133,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
             }
             assertThat(warningCount.get(), is(1L));
             assertThat(deterministicTaskQueue.getCurrentTimeMillis() - startTimeMillis, is(expectedDelayMillis));
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
 
         while (warningCount.get() < 5) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -39,7 +39,7 @@ import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.monitor.NodeHealthService;
 import org.elasticsearch.monitor.StatusInfo;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
@@ -1226,9 +1226,9 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             List<ClusterNode> addedNodes = cluster.addNodes(randomIntBetween(1, 2));
             final long previousClusterStateVersion = cluster.getAnyLeader().getLastAppliedClusterState().version();
 
-            try (var mockAppender = MockLogAppender.capture(JoinHelper.class, Coordinator.class)) {
+            try (var mockAppender = MockLog.capture(JoinHelper.class, Coordinator.class)) {
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "failed to join",
                         JoinHelper.class.getCanonicalName(),
                         Level.INFO,
@@ -1236,7 +1236,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     )
                 );
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "failed to ping",
                         Coordinator.class.getCanonicalName(),
                         Level.WARN,
@@ -1362,9 +1362,9 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
 
             cluster1.clusterNodes.add(newNode);
 
-            try (var mockAppender = MockLogAppender.capture(JoinHelper.class)) {
+            try (var mockAppender = MockLog.capture(JoinHelper.class)) {
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation("test1", JoinHelper.class.getCanonicalName(), Level.INFO, "*failed to join*")
+                    new MockLog.SeenEventExpectation("test1", JoinHelper.class.getCanonicalName(), Level.INFO, "*failed to join*")
                 );
                 cluster1.runFor(DEFAULT_STABILISATION_TIME, "failing join validation");
                 mockAppender.assertAllExpectationsMatched();
@@ -1400,9 +1400,9 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             final var leader = cluster.getAnyLeader();
             leader.addActionBlock(TransportService.HANDSHAKE_ACTION_NAME);
 
-            try (var mockAppender = MockLogAppender.capture(Coordinator.class, JoinHelper.class)) {
+            try (var mockAppender = MockLog.capture(Coordinator.class, JoinHelper.class)) {
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "connect-back failure",
                         Coordinator.class.getCanonicalName(),
                         Level.WARN,
@@ -1411,7 +1411,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                             + "] but could not connect back to the joining node"
                     )
                 );
-                mockAppender.addExpectation(new MockLogAppender.LoggingExpectation() {
+                mockAppender.addExpectation(new MockLog.LoggingExpectation() {
                     boolean matched = false;
 
                     @Override
@@ -1692,8 +1692,8 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             }
 
             for (int i = scaledRandomIntBetween(1, 10); i >= 0; i--) {
-                try (var mockLogAppender = MockLogAppender.capture(ClusterFormationFailureHelper.class)) {
-                    mockLogAppender.addExpectation(new MockLogAppender.LoggingExpectation() {
+                try (var mockLogAppender = MockLog.capture(ClusterFormationFailureHelper.class)) {
+                    mockLogAppender.addExpectation(new MockLog.LoggingExpectation() {
                         final Set<DiscoveryNode> nodesLogged = new HashSet<>();
 
                         @Override
@@ -1760,8 +1760,8 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             cluster.stabilise();
 
             for (int i = scaledRandomIntBetween(1, 10); i >= 0; i--) {
-                try (var mockLogAppender = MockLogAppender.capture(Coordinator.class)) {
-                    mockLogAppender.addExpectation(new MockLogAppender.LoggingExpectation() {
+                try (var mockLogAppender = MockLog.capture(Coordinator.class)) {
+                    mockLogAppender.addExpectation(new MockLog.LoggingExpectation() {
                         String loggedClusterUuid;
 
                         @Override
@@ -1803,10 +1803,10 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             cluster.stabilise();
             final ClusterNode brokenNode = cluster.getAnyNodeExcept(cluster.getAnyLeader());
 
-            try (var mockLogAppender = MockLogAppender.capture(Coordinator.CoordinatorPublication.class, LagDetector.class)) {
+            try (var mockLogAppender = MockLog.capture(Coordinator.CoordinatorPublication.class, LagDetector.class)) {
 
                 mockLogAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "publication info message",
                         Coordinator.CoordinatorPublication.class.getCanonicalName(),
                         Level.INFO,
@@ -1819,7 +1819,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                 );
 
                 mockLogAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "publication warning",
                         Coordinator.CoordinatorPublication.class.getCanonicalName(),
                         Level.WARN,
@@ -1832,7 +1832,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                 );
 
                 mockLogAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "lag warning",
                         LagDetector.class.getCanonicalName(),
                         Level.WARN,
@@ -1844,7 +1844,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                 );
 
                 mockLogAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "hot threads from lagging node",
                         LagDetector.class.getCanonicalName(),
                         Level.DEBUG,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1228,12 +1228,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
 
             try (var mockLog = MockLog.capture(JoinHelper.class, Coordinator.class)) {
                 mockLog.addExpectation(
-                    new MockLog.SeenEventExpectation(
-                        "failed to join",
-                        JoinHelper.class.getCanonicalName(),
-                        Level.INFO,
-                        "*failed to join*"
-                    )
+                    new MockLog.SeenEventExpectation("failed to join", JoinHelper.class.getCanonicalName(), Level.INFO, "*failed to join*")
                 );
                 mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -1226,8 +1226,8 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             List<ClusterNode> addedNodes = cluster.addNodes(randomIntBetween(1, 2));
             final long previousClusterStateVersion = cluster.getAnyLeader().getLastAppliedClusterState().version();
 
-            try (var mockAppender = MockLog.capture(JoinHelper.class, Coordinator.class)) {
-                mockAppender.addExpectation(
+            try (var mockLog = MockLog.capture(JoinHelper.class, Coordinator.class)) {
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "failed to join",
                         JoinHelper.class.getCanonicalName(),
@@ -1235,7 +1235,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                         "*failed to join*"
                     )
                 );
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "failed to ping",
                         Coordinator.class.getCanonicalName(),
@@ -1244,7 +1244,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     )
                 );
                 cluster.runFor(10000, "failing joins");
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
 
             assertTrue(addedNodes.stream().allMatch(ClusterNode::isCandidate));
@@ -1362,12 +1362,12 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
 
             cluster1.clusterNodes.add(newNode);
 
-            try (var mockAppender = MockLog.capture(JoinHelper.class)) {
-                mockAppender.addExpectation(
+            try (var mockLog = MockLog.capture(JoinHelper.class)) {
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation("test1", JoinHelper.class.getCanonicalName(), Level.INFO, "*failed to join*")
                 );
                 cluster1.runFor(DEFAULT_STABILISATION_TIME, "failing join validation");
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
             assertEquals(0, newNode.getLastAppliedClusterState().version());
 
@@ -1400,8 +1400,8 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             final var leader = cluster.getAnyLeader();
             leader.addActionBlock(TransportService.HANDSHAKE_ACTION_NAME);
 
-            try (var mockAppender = MockLog.capture(Coordinator.class, JoinHelper.class)) {
-                mockAppender.addExpectation(
+            try (var mockLog = MockLog.capture(Coordinator.class, JoinHelper.class)) {
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "connect-back failure",
                         Coordinator.class.getCanonicalName(),
@@ -1411,7 +1411,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                             + "] but could not connect back to the joining node"
                     )
                 );
-                mockAppender.addExpectation(new MockLog.LoggingExpectation() {
+                mockLog.addExpectation(new MockLog.LoggingExpectation() {
                     boolean matched = false;
 
                     @Override
@@ -1468,7 +1468,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     defaultMillis(DISCOVERY_FIND_PEERS_INTERVAL_SETTING) + 8 * DEFAULT_DELAY_VARIABILITY,
                     "allowing time for join attempt"
                 );
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
 
             leader.clearActionBlocks();
@@ -1692,8 +1692,8 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             }
 
             for (int i = scaledRandomIntBetween(1, 10); i >= 0; i--) {
-                try (var mockLogAppender = MockLog.capture(ClusterFormationFailureHelper.class)) {
-                    mockLogAppender.addExpectation(new MockLog.LoggingExpectation() {
+                try (var mockLog = MockLog.capture(ClusterFormationFailureHelper.class)) {
+                    mockLog.addExpectation(new MockLog.LoggingExpectation() {
                         final Set<DiscoveryNode> nodesLogged = new HashSet<>();
 
                         @Override
@@ -1725,7 +1725,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                         }
                     });
                     cluster.runFor(warningDelayMillis + DEFAULT_DELAY_VARIABILITY, "waiting for warning to be emitted");
-                    mockLogAppender.assertAllExpectationsMatched();
+                    mockLog.assertAllExpectationsMatched();
                 }
             }
 
@@ -1760,8 +1760,8 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             cluster.stabilise();
 
             for (int i = scaledRandomIntBetween(1, 10); i >= 0; i--) {
-                try (var mockLogAppender = MockLog.capture(Coordinator.class)) {
-                    mockLogAppender.addExpectation(new MockLog.LoggingExpectation() {
+                try (var mockLog = MockLog.capture(Coordinator.class)) {
+                    mockLog.addExpectation(new MockLog.LoggingExpectation() {
                         String loggedClusterUuid;
 
                         @Override
@@ -1778,7 +1778,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                         }
                     });
                     cluster.runFor(warningDelayMillis + DEFAULT_DELAY_VARIABILITY, "waiting for warning to be emitted");
-                    mockLogAppender.assertAllExpectationsMatched();
+                    mockLog.assertAllExpectationsMatched();
                 }
             }
         }
@@ -1803,9 +1803,9 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             cluster.stabilise();
             final ClusterNode brokenNode = cluster.getAnyNodeExcept(cluster.getAnyLeader());
 
-            try (var mockLogAppender = MockLog.capture(Coordinator.CoordinatorPublication.class, LagDetector.class)) {
+            try (var mockLog = MockLog.capture(Coordinator.CoordinatorPublication.class, LagDetector.class)) {
 
-                mockLogAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "publication info message",
                         Coordinator.CoordinatorPublication.class.getCanonicalName(),
@@ -1818,7 +1818,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     )
                 );
 
-                mockLogAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "publication warning",
                         Coordinator.CoordinatorPublication.class.getCanonicalName(),
@@ -1831,7 +1831,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     )
                 );
 
-                mockLogAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "lag warning",
                         LagDetector.class.getCanonicalName(),
@@ -1843,7 +1843,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     )
                 );
 
-                mockLogAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "hot threads from lagging node",
                         LagDetector.class.getCanonicalName(),
@@ -1879,7 +1879,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
                     "waiting for messages to be emitted"
                 );
 
-                mockLogAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorVotingConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorVotingConfigurationTests.java
@@ -458,8 +458,8 @@ public class CoordinatorVotingConfigurationTests extends AbstractCoordinatorTest
         value = "org.elasticsearch.cluster.coordination.ClusterBootstrapService:INFO"
     )
     public void testClusterUUIDLogging() {
-        try (var mockAppender = MockLog.capture(ClusterBootstrapService.class); var cluster = new Cluster(randomIntBetween(1, 3))) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(ClusterBootstrapService.class); var cluster = new Cluster(randomIntBetween(1, 3))) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "fresh node message",
                     ClusterBootstrapService.class.getCanonicalName(),
@@ -470,10 +470,10 @@ public class CoordinatorVotingConfigurationTests extends AbstractCoordinatorTest
 
             cluster.runRandomly();
             cluster.stabilise();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             final var restartingNode = cluster.getAnyNode();
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "restarted node message",
                     ClusterBootstrapService.class.getCanonicalName(),
@@ -486,7 +486,7 @@ public class CoordinatorVotingConfigurationTests extends AbstractCoordinatorTest
             restartingNode.close();
             cluster.clusterNodes.replaceAll(cn -> cn == restartingNode ? cn.restartedNode() : cn);
             cluster.stabilise();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorVotingConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorVotingConfigurationTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.discovery.DiscoveryModule;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.HashSet;
@@ -458,9 +458,9 @@ public class CoordinatorVotingConfigurationTests extends AbstractCoordinatorTest
         value = "org.elasticsearch.cluster.coordination.ClusterBootstrapService:INFO"
     )
     public void testClusterUUIDLogging() {
-        try (var mockAppender = MockLogAppender.capture(ClusterBootstrapService.class); var cluster = new Cluster(randomIntBetween(1, 3))) {
+        try (var mockAppender = MockLog.capture(ClusterBootstrapService.class); var cluster = new Cluster(randomIntBetween(1, 3))) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "fresh node message",
                     ClusterBootstrapService.class.getCanonicalName(),
                     Level.INFO,
@@ -474,7 +474,7 @@ public class CoordinatorVotingConfigurationTests extends AbstractCoordinatorTest
 
             final var restartingNode = cluster.getAnyNode();
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "restarted node message",
                     ClusterBootstrapService.class.getCanonicalName(),
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ElectionSchedulerFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ElectionSchedulerFactoryTests.java
@@ -51,14 +51,14 @@ public class ElectionSchedulerFactoryTests extends ESTestCase {
         final AtomicBoolean electionStarted = new AtomicBoolean();
 
         try (
-            var appender = MockLog.capture(ElectionSchedulerFactory.class);
+            var mockLog = MockLog.capture(ElectionSchedulerFactory.class);
             var ignored1 = electionSchedulerFactory.startElectionScheduler(
                 initialGracePeriod,
                 () -> assertTrue(electionStarted.compareAndSet(false, true))
             )
         ) {
 
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "no zero retries message",
                     ElectionSchedulerFactory.class.getName(),
@@ -68,7 +68,7 @@ public class ElectionSchedulerFactoryTests extends ESTestCase {
             );
             for (int i : new int[] { 10, 20, 990 }) {
                 // the test may stop after 1000 attempts, so might not report the 1000th failure; it definitely reports the 990th tho.
-                appender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         i + " retries message",
                         ElectionSchedulerFactory.class.getName(),
@@ -123,7 +123,7 @@ public class ElectionSchedulerFactoryTests extends ESTestCase {
                 lastElectionFinishTime = thisElectionStartTime + duration;
             }
 
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
         deterministicTaskQueue.runAllTasks();
         assertFalse(electionStarted.get());

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ElectionSchedulerFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ElectionSchedulerFactoryTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -51,7 +51,7 @@ public class ElectionSchedulerFactoryTests extends ESTestCase {
         final AtomicBoolean electionStarted = new AtomicBoolean();
 
         try (
-            var appender = MockLogAppender.capture(ElectionSchedulerFactory.class);
+            var appender = MockLog.capture(ElectionSchedulerFactory.class);
             var ignored1 = electionSchedulerFactory.startElectionScheduler(
                 initialGracePeriod,
                 () -> assertTrue(electionStarted.compareAndSet(false, true))
@@ -59,7 +59,7 @@ public class ElectionSchedulerFactoryTests extends ESTestCase {
         ) {
 
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "no zero retries message",
                     ElectionSchedulerFactory.class.getName(),
                     Level.INFO,
@@ -69,7 +69,7 @@ public class ElectionSchedulerFactoryTests extends ESTestCase {
             for (int i : new int[] { 10, 20, 990 }) {
                 // the test may stop after 1000 attempts, so might not report the 1000th failure; it definitely reports the 990th tho.
                 appender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         i + " retries message",
                         ElectionSchedulerFactory.class.getName(),
                         Level.INFO,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.CapturingTransport.CapturedRequest;
@@ -346,9 +346,9 @@ public class JoinHelperTests extends ESTestCase {
         joinAccumulator.handleJoinRequest(localNode, CompatibilityVersionsUtils.staticCurrent(), Set.of(), joinListener);
         assert joinListener.isDone() == false;
 
-        try (var mockAppender = MockLogAppender.capture(JoinHelper.class)) {
+        try (var mockAppender = MockLog.capture(JoinHelper.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "warning log",
                     JoinHelper.class.getCanonicalName(),
                     Level.WARN,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -346,8 +346,8 @@ public class JoinHelperTests extends ESTestCase {
         joinAccumulator.handleJoinRequest(localNode, CompatibilityVersionsUtils.staticCurrent(), Set.of(), joinListener);
         assert joinListener.isDone() == false;
 
-        try (var mockAppender = MockLog.capture(JoinHelper.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(JoinHelper.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "warning log",
                     JoinHelper.class.getCanonicalName(),
@@ -356,7 +356,7 @@ public class JoinHelperTests extends ESTestCase {
                 )
             );
             joinAccumulator.close(Coordinator.Mode.LEADER);
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
 
         assertEquals("simulated", expectThrows(ElasticsearchException.class, () -> FutureUtils.get(joinListener)).getMessage());

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -40,7 +40,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -801,12 +801,12 @@ public class NodeJoinExecutorTests extends ESTestCase {
 
         final ThreadPool threadPool = new TestThreadPool("test");
         try (
-            var appender = MockLogAppender.capture(NodeJoinExecutor.class);
+            var appender = MockLog.capture(NodeJoinExecutor.class);
             var clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
         ) {
             final var node1 = DiscoveryNodeUtils.create(UUIDs.base64UUID());
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "info message",
                     LOGGER_NAME,
                     Level.INFO,
@@ -831,7 +831,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
             final var node2 = DiscoveryNodeUtils.create(UUIDs.base64UUID());
             final var testReasonWithLink = new JoinReason("test", ReferenceDocs.UNSTABLE_CLUSTER_TROUBLESHOOTING);
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "warn message with troubleshooting link",
                     LOGGER_NAME,
                     Level.WARN,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -801,11 +801,11 @@ public class NodeJoinExecutorTests extends ESTestCase {
 
         final ThreadPool threadPool = new TestThreadPool("test");
         try (
-            var appender = MockLog.capture(NodeJoinExecutor.class);
+            var mockLog = MockLog.capture(NodeJoinExecutor.class);
             var clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
         ) {
             final var node1 = DiscoveryNodeUtils.create(UUIDs.base64UUID());
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "info message",
                     LOGGER_NAME,
@@ -826,11 +826,11 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     TimeUnit.SECONDS
                 )
             );
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             final var node2 = DiscoveryNodeUtils.create(UUIDs.base64UUID());
             final var testReasonWithLink = new JoinReason("test", ReferenceDocs.UNSTABLE_CLUSTER_TROUBLESHOOTING);
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "warn message with troubleshooting link",
                     LOGGER_NAME,
@@ -862,7 +862,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     TimeUnit.SECONDS
                 )
             );
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             TestThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeLeftExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeLeftExecutorTests.java
@@ -116,11 +116,11 @@ public class NodeLeftExecutorTests extends ESTestCase {
 
         final ThreadPool threadPool = new TestThreadPool("test");
         try (
-            var appender = MockLog.capture(NodeLeftExecutor.class);
+            var mockLog = MockLog.capture(NodeLeftExecutor.class);
             var clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
         ) {
             final var nodeToRemove = clusterState.nodes().get("other");
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "info message",
                     LOGGER_NAME,
@@ -135,7 +135,7 @@ public class NodeLeftExecutorTests extends ESTestCase {
                         .submitTask("test", new NodeLeftExecutor.Task(nodeToRemove, "test reason", () -> future.onResponse(null)), null)
                 )
             );
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             TestThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeLeftExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeLeftExecutorTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -116,12 +116,12 @@ public class NodeLeftExecutorTests extends ESTestCase {
 
         final ThreadPool threadPool = new TestThreadPool("test");
         try (
-            var appender = MockLogAppender.capture(NodeLeftExecutor.class);
+            var appender = MockLog.capture(NodeLeftExecutor.class);
             var clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
         ) {
             final var nodeToRemove = clusterState.nodes().get("other");
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "info message",
                     LOGGER_NAME,
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
@@ -83,9 +83,9 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
         final var heartbeatFrequency = TimeValue.timeValueSeconds(randomIntBetween(15, 30));
         final var maxTimeSinceLastHeartbeat = TimeValue.timeValueSeconds(2 * heartbeatFrequency.seconds());
         DiscoveryNodeUtils.create("master");
-        try (var appender = MockLogAppender.capture(AtomicRegisterPreVoteCollector.class)) {
+        try (var appender = MockLog.capture(AtomicRegisterPreVoteCollector.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "log emitted when skipping election",
                     AtomicRegisterPreVoteCollector.class.getCanonicalName(),
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
@@ -83,8 +83,8 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
         final var heartbeatFrequency = TimeValue.timeValueSeconds(randomIntBetween(15, 30));
         final var maxTimeSinceLastHeartbeat = TimeValue.timeValueSeconds(2 * heartbeatFrequency.seconds());
         DiscoveryNodeUtils.create("master");
-        try (var appender = MockLog.capture(AtomicRegisterPreVoteCollector.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(AtomicRegisterPreVoteCollector.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "log emitted when skipping election",
                     AtomicRegisterPreVoteCollector.class.getCanonicalName(),
@@ -116,7 +116,7 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
             preVoteCollector.start(ClusterState.EMPTY_STATE, Collections.emptyList());
 
             assertThat(startElection.get(), is(false));
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/StoreHeartbeatServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/StoreHeartbeatServiceTests.java
@@ -262,8 +262,8 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
             fakeClock.set(maxTimeSinceLastHeartbeat.millis() + 1);
             failReadingHeartbeat.set(true);
 
-            try (var mockAppender = MockLog.capture(StoreHeartbeatService.class)) {
-                mockAppender.addExpectation(
+            try (var mockLog = MockLog.capture(StoreHeartbeatService.class)) {
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "warning log",
                         StoreHeartbeatService.class.getCanonicalName(),
@@ -272,7 +272,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
                     )
                 );
                 heartbeatService.checkLeaderHeartbeatAndRun(() -> fail("should not be called"), hb -> {});
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/StoreHeartbeatServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/StoreHeartbeatServiceTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
@@ -262,9 +262,9 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
             fakeClock.set(maxTimeSinceLastHeartbeat.millis() + 1);
             failReadingHeartbeat.set(true);
 
-            try (var mockAppender = MockLogAppender.capture(StoreHeartbeatService.class)) {
+            try (var mockAppender = MockLog.capture(StoreHeartbeatService.class)) {
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "warning log",
                         StoreHeartbeatService.class.getCanonicalName(),
                         Level.WARN,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -241,7 +241,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
     @TestLogging(reason = "testing log output", value = "org.elasticsearch.cluster.routing.BatchedRerouteService:DEBUG")
     public void testExceptionFidelity() {
 
-        try (var mockLogAppender = MockLog.capture(BatchedRerouteService.class)) {
+        try (var mockLog = MockLog.capture(BatchedRerouteService.class)) {
 
             clusterService.getMasterService()
                 .setClusterStatePublisher(
@@ -250,7 +250,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
 
             // Case 1: an exception thrown from within the reroute itself
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "failure within reroute",
                     BatchedRerouteService.class.getCanonicalName(),
@@ -269,17 +269,17 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                     .getMessage(),
                 equalTo("simulated")
             );
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // None of the other cases should yield any log messages by default
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation("no errors", BatchedRerouteService.class.getCanonicalName(), Level.ERROR, "*")
             );
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation("no warnings", BatchedRerouteService.class.getCanonicalName(), Level.WARN, "*")
             );
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation("no info", BatchedRerouteService.class.getCanonicalName(), Level.INFO, "*")
             );
 
@@ -290,7 +290,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                 return ClusterState.builder(s).build();
             });
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "publish failure",
                     BatchedRerouteService.class.getCanonicalName(),
@@ -306,7 +306,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                 FailedToCommitClusterStateException.class,
                 () -> publishFailureFuture.get(10, TimeUnit.SECONDS)
             );
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // Case 3: a NotMasterException
 
@@ -317,7 +317,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
                 }, future);
             }, 10, TimeUnit.SECONDS);
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "not-master failure",
                     BatchedRerouteService.class.getCanonicalName(),
@@ -329,7 +329,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             batchedRerouteService.reroute("not-master failure", randomFrom(EnumSet.allOf(Priority.class)), notMasterFuture);
             expectThrows(ExecutionException.class, NotMasterException.class, () -> notMasterFuture.get(10, TimeUnit.SECONDS));
 
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -21,7 +21,7 @@ import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -241,7 +241,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
     @TestLogging(reason = "testing log output", value = "org.elasticsearch.cluster.routing.BatchedRerouteService:DEBUG")
     public void testExceptionFidelity() {
 
-        try (var mockLogAppender = MockLogAppender.capture(BatchedRerouteService.class)) {
+        try (var mockLogAppender = MockLog.capture(BatchedRerouteService.class)) {
 
             clusterService.getMasterService()
                 .setClusterStatePublisher(
@@ -251,7 +251,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             // Case 1: an exception thrown from within the reroute itself
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "failure within reroute",
                     BatchedRerouteService.class.getCanonicalName(),
                     Level.ERROR,
@@ -274,13 +274,13 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             // None of the other cases should yield any log messages by default
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation("no errors", BatchedRerouteService.class.getCanonicalName(), Level.ERROR, "*")
+                new MockLog.UnseenEventExpectation("no errors", BatchedRerouteService.class.getCanonicalName(), Level.ERROR, "*")
             );
             mockLogAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation("no warnings", BatchedRerouteService.class.getCanonicalName(), Level.WARN, "*")
+                new MockLog.UnseenEventExpectation("no warnings", BatchedRerouteService.class.getCanonicalName(), Level.WARN, "*")
             );
             mockLogAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation("no info", BatchedRerouteService.class.getCanonicalName(), Level.INFO, "*")
+                new MockLog.UnseenEventExpectation("no info", BatchedRerouteService.class.getCanonicalName(), Level.INFO, "*")
             );
 
             // Case 2: a FailedToCommitClusterStateException (see the call to setClusterStatePublisher above)
@@ -291,7 +291,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             });
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "publish failure",
                     BatchedRerouteService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -318,7 +318,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             }, 10, TimeUnit.SECONDS);
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "not-master failure",
                     BatchedRerouteService.class.getCanonicalName(),
                     Level.DEBUG,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationComman
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexVersion;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.RELOCATING;
@@ -97,11 +97,11 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
 
         assertTrue(initialState.toString(), initialState.getRoutingNodes().unassigned().isEmpty());
 
-        try (var appender = MockLogAppender.capture(AllocationService.class)) {
+        try (var appender = MockLog.capture(AllocationService.class)) {
             final String dissociationReason = "node left " + randomAlphaOfLength(10);
 
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "health change log message",
                     AllocationService.class.getName(),
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DeadNodesAllocationTests.java
@@ -97,10 +97,10 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
 
         assertTrue(initialState.toString(), initialState.getRoutingNodes().unassigned().isEmpty());
 
-        try (var appender = MockLog.capture(AllocationService.class)) {
+        try (var mockLog = MockLog.capture(AllocationService.class)) {
             final String dissociationReason = "node left " + randomAlphaOfLength(10);
 
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "health change log message",
                     AllocationService.class.getName(),
@@ -117,7 +117,7 @@ public class DeadNodesAllocationTests extends ESAllocationTestCase {
                 dissociationReason
             );
 
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.Arrays;
@@ -1363,9 +1363,9 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
     }
 
     private void assertNoLogging(DiskThresholdMonitor monitor, Map<String, DiskUsage> diskUsages) throws IllegalAccessException {
-        try (var mockAppender = MockLogAppender.capture(DiskThresholdMonitor.class)) {
+        try (var mockAppender = MockLog.capture(DiskThresholdMonitor.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "any INFO message",
                     DiskThresholdMonitor.class.getCanonicalName(),
                     Level.INFO,
@@ -1373,7 +1373,7 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "any WARN message",
                     DiskThresholdMonitor.class.getCanonicalName(),
                     Level.WARN,
@@ -1409,12 +1409,12 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
     }
 
     private void assertLogging(DiskThresholdMonitor monitor, Map<String, DiskUsage> diskUsages, Level level, String message) {
-        try (var mockAppender = MockLogAppender.capture(DiskThresholdMonitor.class)) {
+        try (var mockAppender = MockLog.capture(DiskThresholdMonitor.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation("expected message", DiskThresholdMonitor.class.getCanonicalName(), level, message)
+                new MockLog.SeenEventExpectation("expected message", DiskThresholdMonitor.class.getCanonicalName(), level, message)
             );
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "any message of another level",
                     DiskThresholdMonitor.class.getCanonicalName(),
                     level == Level.INFO ? Level.WARN : Level.INFO,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -1365,20 +1365,10 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
     private void assertNoLogging(DiskThresholdMonitor monitor, Map<String, DiskUsage> diskUsages) throws IllegalAccessException {
         try (var mockLog = MockLog.capture(DiskThresholdMonitor.class)) {
             mockLog.addExpectation(
-                new MockLog.UnseenEventExpectation(
-                    "any INFO message",
-                    DiskThresholdMonitor.class.getCanonicalName(),
-                    Level.INFO,
-                    "*"
-                )
+                new MockLog.UnseenEventExpectation("any INFO message", DiskThresholdMonitor.class.getCanonicalName(), Level.INFO, "*")
             );
             mockLog.addExpectation(
-                new MockLog.UnseenEventExpectation(
-                    "any WARN message",
-                    DiskThresholdMonitor.class.getCanonicalName(),
-                    Level.WARN,
-                    "*"
-                )
+                new MockLog.UnseenEventExpectation("any WARN message", DiskThresholdMonitor.class.getCanonicalName(), Level.WARN, "*")
             );
 
             for (int i = between(1, 3); i >= 0; i--) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -1363,8 +1363,8 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
     }
 
     private void assertNoLogging(DiskThresholdMonitor monitor, Map<String, DiskUsage> diskUsages) throws IllegalAccessException {
-        try (var mockAppender = MockLog.capture(DiskThresholdMonitor.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(DiskThresholdMonitor.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "any INFO message",
                     DiskThresholdMonitor.class.getCanonicalName(),
@@ -1372,7 +1372,7 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
                     "*"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "any WARN message",
                     DiskThresholdMonitor.class.getCanonicalName(),
@@ -1385,7 +1385,7 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
                 monitor.onNewInfo(clusterInfo(diskUsages));
             }
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -1409,11 +1409,11 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
     }
 
     private void assertLogging(DiskThresholdMonitor monitor, Map<String, DiskUsage> diskUsages, Level level, String message) {
-        try (var mockAppender = MockLog.capture(DiskThresholdMonitor.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(DiskThresholdMonitor.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation("expected message", DiskThresholdMonitor.class.getCanonicalName(), level, message)
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "any message of another level",
                     DiskThresholdMonitor.class.getCanonicalName(),
@@ -1423,7 +1423,7 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
             );
 
             monitor.onNewInfo(clusterInfo(diskUsages));
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ContinuousComputationTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.cluster.routing.allocation.allocator;
 
 import org.apache.logging.log4j.Level;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.AfterClass;
@@ -167,10 +167,10 @@ public class ContinuousComputationTests extends ESTestCase {
             }
         };
 
-        MockLogAppender.assertThatLogger(
+        MockLog.assertThatLogger(
             () -> computation.onNewInput(input1),
             ContinuousComputation.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "error log",
                 ContinuousComputation.class.getCanonicalName(),
                 Level.ERROR,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -51,7 +51,7 @@ import org.elasticsearch.snapshots.InternalSnapshotsInfoService.SnapshotShard;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
@@ -75,7 +75,7 @@ import static org.elasticsearch.cluster.routing.ShardRoutingState.UNASSIGNED;
 import static org.elasticsearch.cluster.routing.TestShardRouting.newShardRouting;
 import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBuilder;
 import static org.elasticsearch.common.settings.ClusterSettings.createBuiltInClusterSettings;
-import static org.elasticsearch.test.MockLogAppender.assertThatLogger;
+import static org.elasticsearch.test.MockLog.assertThatLogger;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
@@ -1201,7 +1201,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
         checkIterationLogging(
             999,
             10L,
-            new MockLogAppender.UnseenEventExpectation(
+            new MockLog.UnseenEventExpectation(
                 "Should not report long computation too early",
                 DesiredBalanceComputer.class.getCanonicalName(),
                 Level.INFO,
@@ -1212,7 +1212,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
         checkIterationLogging(
             1001,
             10L,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "Should report long computation based on iteration count",
                 DesiredBalanceComputer.class.getCanonicalName(),
                 Level.INFO,
@@ -1223,7 +1223,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
         checkIterationLogging(
             61,
             1000L,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "Should report long computation based on time",
                 DesiredBalanceComputer.class.getCanonicalName(),
                 Level.INFO,
@@ -1232,7 +1232,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
         );
     }
 
-    private void checkIterationLogging(int iterations, long eachIterationDuration, MockLogAppender.AbstractEventExpectation expectation) {
+    private void checkIterationLogging(int iterations, long eachIterationDuration, MockLog.AbstractEventExpectation expectation) {
 
         var mockThreadPool = mock(ThreadPool.class);
         var currentTime = new AtomicLong(0L);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -65,7 +65,7 @@ import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.snapshots.SnapshotsInfoService;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.BeforeClass;
 
@@ -95,7 +95,7 @@ import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAll
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_CONCURRENT_OUTGOING_RECOVERIES_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
 import static org.elasticsearch.common.settings.ClusterSettings.createBuiltInClusterSettings;
-import static org.elasticsearch.test.MockLogAppender.assertThatLogger;
+import static org.elasticsearch.test.MockLog.assertThatLogger;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -1287,7 +1287,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
         assertThatLogger(
             () -> reconciler.reconcile(new DesiredBalance(1, dataNode1Assignments), createRoutingAllocationFrom(clusterState)),
             DesiredBalanceReconciler.class,
-            new MockLogAppender.UnseenEventExpectation(
+            new MockLog.UnseenEventExpectation(
                 "Should not log if all shards on desired location",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,
@@ -1297,7 +1297,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
         assertThatLogger(
             () -> reconciler.reconcile(new DesiredBalance(1, dataNode2Assignments), createRoutingAllocationFrom(clusterState)),
             DesiredBalanceReconciler.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "Should log first too many shards on undesired locations",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,
@@ -1307,7 +1307,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
         assertThatLogger(
             () -> reconciler.reconcile(new DesiredBalance(1, dataNode2Assignments), createRoutingAllocationFrom(clusterState)),
             DesiredBalanceReconciler.class,
-            new MockLogAppender.UnseenEventExpectation(
+            new MockLog.UnseenEventExpectation(
                 "Should not log immediate second too many shards on undesired locations",
                 DesiredBalanceReconciler.class.getCanonicalName(),
                 Level.WARN,

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierRecordingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierRecordingServiceTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
@@ -146,10 +146,10 @@ public class ClusterApplierRecordingServiceTests extends ESTestCase {
             deterministicTaskQueue.getCurrentTimeMillis() + debugLoggingTimeout.millis() + between(1, 1000),
             slowAction::close
         );
-        MockLogAppender.assertThatLogger(
+        MockLog.assertThatLogger(
             deterministicTaskQueue::runAllTasksInTimeOrder,
             ClusterApplierRecordingService.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "hot threads",
                 ClusterApplierRecordingService.class.getCanonicalName(),
                 Level.DEBUG,
@@ -163,10 +163,10 @@ public class ClusterApplierRecordingServiceTests extends ESTestCase {
             randomLongBetween(0, deterministicTaskQueue.getCurrentTimeMillis() + debugLoggingTimeout.millis() - 1),
             fastAction::close
         );
-        MockLogAppender.assertThatLogger(
+        MockLog.assertThatLogger(
             deterministicTaskQueue::runAllTasksInTimeOrder,
             ClusterApplierRecordingService.class,
-            new MockLogAppender.UnseenEventExpectation(
+            new MockLog.UnseenEventExpectation(
                 "hot threads",
                 ClusterApplierRecordingService.class.getCanonicalName(),
                 Level.DEBUG,

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierRecordingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierRecordingServiceTests.java
@@ -166,12 +166,7 @@ public class ClusterApplierRecordingServiceTests extends ESTestCase {
         MockLog.assertThatLogger(
             deterministicTaskQueue::runAllTasksInTimeOrder,
             ClusterApplierRecordingService.class,
-            new MockLog.UnseenEventExpectation(
-                "hot threads",
-                ClusterApplierRecordingService.class.getCanonicalName(),
-                Level.DEBUG,
-                "*"
-            )
+            new MockLog.UnseenEventExpectation("hot threads", ClusterApplierRecordingService.class.getCanonicalName(), Level.DEBUG, "*")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -117,8 +117,8 @@ public class ClusterApplierServiceTests extends ESTestCase {
 
     @TestLogging(value = "org.elasticsearch.cluster.service:TRACE", reason = "to ensure that we log cluster state events on TRACE level")
     public void testClusterStateUpdateLogging() throws Exception {
-        try (var mockAppender = MockLog.capture(ClusterApplierService.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(ClusterApplierService.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test1",
                     ClusterApplierService.class.getCanonicalName(),
@@ -126,7 +126,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                     "*processing [test1]: took [1s] no change in cluster state"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test2",
                     ClusterApplierService.class.getCanonicalName(),
@@ -134,7 +134,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                     "*failed to execute cluster state applier in [2s]*"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test3",
                     ClusterApplierService.class.getCanonicalName(),
@@ -180,14 +180,14 @@ public class ClusterApplierServiceTests extends ESTestCase {
                     fail();
                 }
             });
-            assertBusy(mockAppender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
         }
     }
 
     @TestLogging(value = "org.elasticsearch.cluster.service:WARN", reason = "to ensure that we log cluster state events on WARN level")
     public void testLongClusterStateUpdateLogging() throws Exception {
-        try (var mockAppender = MockLog.capture(ClusterApplierService.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(ClusterApplierService.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "test1 shouldn't see because setting is too low",
                     ClusterApplierService.class.getCanonicalName(),
@@ -195,7 +195,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                     "*cluster state applier task [test1] took [*] which is above the warn threshold of *"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test2",
                     ClusterApplierService.class.getCanonicalName(),
@@ -204,7 +204,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                         + "[running task [test2]] took [*"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test4",
                     ClusterApplierService.class.getCanonicalName(),
@@ -280,7 +280,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
             });
             latch.await();
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -117,9 +117,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
 
     @TestLogging(value = "org.elasticsearch.cluster.service:TRACE", reason = "to ensure that we log cluster state events on TRACE level")
     public void testClusterStateUpdateLogging() throws Exception {
-        try (var mockAppender = MockLogAppender.capture(ClusterApplierService.class)) {
+        try (var mockAppender = MockLog.capture(ClusterApplierService.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test1",
                     ClusterApplierService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -127,7 +127,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test2",
                     ClusterApplierService.class.getCanonicalName(),
                     Level.TRACE,
@@ -135,7 +135,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test3",
                     ClusterApplierService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -186,9 +186,9 @@ public class ClusterApplierServiceTests extends ESTestCase {
 
     @TestLogging(value = "org.elasticsearch.cluster.service:WARN", reason = "to ensure that we log cluster state events on WARN level")
     public void testLongClusterStateUpdateLogging() throws Exception {
-        try (var mockAppender = MockLogAppender.capture(ClusterApplierService.class)) {
+        try (var mockAppender = MockLog.capture(ClusterApplierService.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "test1 shouldn't see because setting is too low",
                     ClusterApplierService.class.getCanonicalName(),
                     Level.WARN,
@@ -196,7 +196,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test2",
                     ClusterApplierService.class.getCanonicalName(),
                     Level.WARN,
@@ -205,7 +205,7 @@ public class ClusterApplierServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test4",
                     ClusterApplierService.class.getCanonicalName(),
                     Level.WARN,

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -52,7 +52,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.ReachabilityChecker;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.tasks.MockTaskManager;
@@ -374,9 +374,9 @@ public class MasterServiceTests extends ESTestCase {
     @TestLogging(value = "org.elasticsearch.cluster.service:TRACE", reason = "to ensure that we log cluster state events on TRACE level")
     public void testClusterStateUpdateLogging() throws Exception {
 
-        try (var mockAppender = MockLogAppender.capture(MasterService.class); var masterService = createMasterService(true)) {
+        try (var mockAppender = MockLog.capture(MasterService.class); var masterService = createMasterService(true)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test1 start",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -384,7 +384,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test1 computation",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -392,7 +392,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test1 notification",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -401,7 +401,7 @@ public class MasterServiceTests extends ESTestCase {
             );
 
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test2 start",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -409,7 +409,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test2 failure",
                     MasterService.class.getCanonicalName(),
                     Level.TRACE,
@@ -417,7 +417,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test2 computation",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -425,7 +425,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test2 notification",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -434,7 +434,7 @@ public class MasterServiceTests extends ESTestCase {
             );
 
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test3 start",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -442,7 +442,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test3 computation",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -450,7 +450,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test3 notification",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -459,7 +459,7 @@ public class MasterServiceTests extends ESTestCase {
             );
 
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test4",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -1109,7 +1109,7 @@ public class MasterServiceTests extends ESTestCase {
             .put(Node.NODE_NAME_SETTING.getKey(), "test_node")
             .build();
         try (
-            var mockAppender = MockLogAppender.capture(MasterService.class);
+            var mockAppender = MockLog.capture(MasterService.class);
             MasterService masterService = new MasterService(
                 settings,
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
@@ -1124,7 +1124,7 @@ public class MasterServiceTests extends ESTestCase {
             }
         ) {
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "test1 shouldn't log because it was fast enough",
                     MasterService.class.getCanonicalName(),
                     Level.WARN,
@@ -1132,7 +1132,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test2",
                     MasterService.class.getCanonicalName(),
                     Level.WARN,
@@ -1140,7 +1140,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test3",
                     MasterService.class.getCanonicalName(),
                     Level.WARN,
@@ -1148,7 +1148,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test4",
                     MasterService.class.getCanonicalName(),
                     Level.WARN,
@@ -1156,7 +1156,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "test5 should not log despite publishing slowly",
                     MasterService.class.getCanonicalName(),
                     Level.WARN,
@@ -1164,7 +1164,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "test6 should log due to slow and failing publication",
                     MasterService.class.getCanonicalName(),
                     Level.WARN,
@@ -1717,7 +1717,7 @@ public class MasterServiceTests extends ESTestCase {
         final long startTimeMillis = relativeTimeInMillis;
         final long taskDurationMillis = TimeValue.timeValueSeconds(1).millis();
 
-        try (MasterService masterService = createMasterService(true); var mockAppender = MockLogAppender.capture(MasterService.class)) {
+        try (MasterService masterService = createMasterService(true); var mockAppender = MockLog.capture(MasterService.class)) {
             final AtomicBoolean keepRunning = new AtomicBoolean(true);
             final CyclicBarrier cyclicBarrier = new CyclicBarrier(2);
             final Runnable awaitNextTask = () -> {
@@ -1760,7 +1760,7 @@ public class MasterServiceTests extends ESTestCase {
             });
 
             // check that a warning is logged after 5m
-            final MockLogAppender.EventuallySeenEventExpectation expectation1 = new MockLogAppender.EventuallySeenEventExpectation(
+            final MockLog.EventuallySeenEventExpectation expectation1 = new MockLog.EventuallySeenEventExpectation(
                 "starvation warning",
                 MasterService.class.getCanonicalName(),
                 Level.WARN,
@@ -1782,7 +1782,7 @@ public class MasterServiceTests extends ESTestCase {
             mockAppender.assertAllExpectationsMatched();
 
             // check that another warning is logged after 10m
-            final MockLogAppender.EventuallySeenEventExpectation expectation2 = new MockLogAppender.EventuallySeenEventExpectation(
+            final MockLog.EventuallySeenEventExpectation expectation2 = new MockLog.EventuallySeenEventExpectation(
                 "starvation warning",
                 MasterService.class.getCanonicalName(),
                 Level.WARN,
@@ -1815,7 +1815,7 @@ public class MasterServiceTests extends ESTestCase {
         reason = "to ensure that we log the right batch description, which only happens at DEBUG level"
     )
     public void testBatchedUpdateSummaryLogging() throws Exception {
-        try (var mockAppender = MockLogAppender.capture(MasterService.class); var masterService = createMasterService(true)) {
+        try (var mockAppender = MockLog.capture(MasterService.class); var masterService = createMasterService(true)) {
 
             final var barrier = new CyclicBarrier(2);
             final var blockingTask = new ClusterStateUpdateTask() {
@@ -1873,7 +1873,7 @@ public class MasterServiceTests extends ESTestCase {
                     smallBatchQueue.submitTask("source-" + source, new Task("task-" + source + "-" + task), null);
                 }
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "mention of tasks source-" + source,
                         MasterService.class.getCanonicalName(),
                         Level.DEBUG,
@@ -1890,7 +1890,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
             }
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "truncated description of batch with many sources",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -1913,7 +1913,7 @@ public class MasterServiceTests extends ESTestCase {
                 manyTasksPerSourceQueue.submitTask("unique-source", new Task("task-" + task), null);
             }
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "truncated description of batch with many tasks from a single source",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,
@@ -2249,14 +2249,14 @@ public class MasterServiceTests extends ESTestCase {
         };
 
         try (
-            var appender = MockLogAppender.capture(MasterService.class);
+            var appender = MockLog.capture(MasterService.class);
             var masterService = createMasterService(true, null, threadPool, threadPoolExecutor)
         ) {
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation("warning", MasterService.class.getCanonicalName(), Level.WARN, "*")
+                new MockLog.UnseenEventExpectation("warning", MasterService.class.getCanonicalName(), Level.WARN, "*")
             );
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "debug",
                     MasterService.class.getCanonicalName(),
                     Level.DEBUG,

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -374,8 +374,8 @@ public class MasterServiceTests extends ESTestCase {
     @TestLogging(value = "org.elasticsearch.cluster.service:TRACE", reason = "to ensure that we log cluster state events on TRACE level")
     public void testClusterStateUpdateLogging() throws Exception {
 
-        try (var mockAppender = MockLog.capture(MasterService.class); var masterService = createMasterService(true)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(MasterService.class); var masterService = createMasterService(true)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test1 start",
                     MasterService.class.getCanonicalName(),
@@ -383,7 +383,7 @@ public class MasterServiceTests extends ESTestCase {
                     "executing cluster state update for [test1]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test1 computation",
                     MasterService.class.getCanonicalName(),
@@ -391,7 +391,7 @@ public class MasterServiceTests extends ESTestCase {
                     "took [1s] to compute cluster state update for [test1]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test1 notification",
                     MasterService.class.getCanonicalName(),
@@ -400,7 +400,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test2 start",
                     MasterService.class.getCanonicalName(),
@@ -408,7 +408,7 @@ public class MasterServiceTests extends ESTestCase {
                     "executing cluster state update for [test2]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test2 failure",
                     MasterService.class.getCanonicalName(),
@@ -416,7 +416,7 @@ public class MasterServiceTests extends ESTestCase {
                     "failed to execute cluster state update (on version: [*], uuid: [*]) for [test2]*"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test2 computation",
                     MasterService.class.getCanonicalName(),
@@ -424,7 +424,7 @@ public class MasterServiceTests extends ESTestCase {
                     "took [2s] to compute cluster state update for [test2]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test2 notification",
                     MasterService.class.getCanonicalName(),
@@ -433,7 +433,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test3 start",
                     MasterService.class.getCanonicalName(),
@@ -441,7 +441,7 @@ public class MasterServiceTests extends ESTestCase {
                     "executing cluster state update for [test3]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test3 computation",
                     MasterService.class.getCanonicalName(),
@@ -449,7 +449,7 @@ public class MasterServiceTests extends ESTestCase {
                     "took [3s] to compute cluster state update for [test3]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test3 notification",
                     MasterService.class.getCanonicalName(),
@@ -458,7 +458,7 @@ public class MasterServiceTests extends ESTestCase {
                 )
             );
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test4",
                     MasterService.class.getCanonicalName(),
@@ -522,7 +522,7 @@ public class MasterServiceTests extends ESTestCase {
                     fail();
                 }
             });
-            assertBusy(mockAppender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
         }
     }
 
@@ -1109,7 +1109,7 @@ public class MasterServiceTests extends ESTestCase {
             .put(Node.NODE_NAME_SETTING.getKey(), "test_node")
             .build();
         try (
-            var mockAppender = MockLog.capture(MasterService.class);
+            var mockLog = MockLog.capture(MasterService.class);
             MasterService masterService = new MasterService(
                 settings,
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
@@ -1123,7 +1123,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
             }
         ) {
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "test1 shouldn't log because it was fast enough",
                     MasterService.class.getCanonicalName(),
@@ -1131,7 +1131,7 @@ public class MasterServiceTests extends ESTestCase {
                     "*took*test1*"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test2",
                     MasterService.class.getCanonicalName(),
@@ -1139,7 +1139,7 @@ public class MasterServiceTests extends ESTestCase {
                     "*took [*] to compute cluster state update for [test2], which exceeds the warn threshold of [10s]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test3",
                     MasterService.class.getCanonicalName(),
@@ -1147,7 +1147,7 @@ public class MasterServiceTests extends ESTestCase {
                     "*took [*] to compute cluster state update for [test3], which exceeds the warn threshold of [10s]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test4",
                     MasterService.class.getCanonicalName(),
@@ -1155,7 +1155,7 @@ public class MasterServiceTests extends ESTestCase {
                     "*took [*] to compute cluster state update for [test4], which exceeds the warn threshold of [10s]"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "test5 should not log despite publishing slowly",
                     MasterService.class.getCanonicalName(),
@@ -1163,7 +1163,7 @@ public class MasterServiceTests extends ESTestCase {
                     "*took*test5*"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "test6 should log due to slow and failing publication",
                     MasterService.class.getCanonicalName(),
@@ -1325,7 +1325,7 @@ public class MasterServiceTests extends ESTestCase {
                 }
             });
             latch.await();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -1717,7 +1717,7 @@ public class MasterServiceTests extends ESTestCase {
         final long startTimeMillis = relativeTimeInMillis;
         final long taskDurationMillis = TimeValue.timeValueSeconds(1).millis();
 
-        try (MasterService masterService = createMasterService(true); var mockAppender = MockLog.capture(MasterService.class)) {
+        try (MasterService masterService = createMasterService(true); var mockLog = MockLog.capture(MasterService.class)) {
             final AtomicBoolean keepRunning = new AtomicBoolean(true);
             final CyclicBarrier cyclicBarrier = new CyclicBarrier(2);
             final Runnable awaitNextTask = () -> {
@@ -1767,11 +1767,11 @@ public class MasterServiceTests extends ESTestCase {
                 "pending task queue has been nonempty for [5m/300000ms] which is longer than the warn threshold of [300000ms];"
                     + " there are currently [2] pending tasks, the oldest of which has age [*"
             );
-            mockAppender.addExpectation(expectation1);
+            mockLog.addExpectation(expectation1);
 
             while (relativeTimeInMillis - startTimeMillis < warnThresholdMillis) {
                 awaitNextTask.run();
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
 
             expectation1.setExpectSeen();
@@ -1779,7 +1779,7 @@ public class MasterServiceTests extends ESTestCase {
             // the master service thread is somewhere between completing the previous task and starting the next one, which is when the
             // logging happens, so we must wait for another task to run too to ensure that the message was logged
             awaitNextTask.run();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // check that another warning is logged after 10m
             final MockLog.EventuallySeenEventExpectation expectation2 = new MockLog.EventuallySeenEventExpectation(
@@ -1789,11 +1789,11 @@ public class MasterServiceTests extends ESTestCase {
                 "pending task queue has been nonempty for [10m/600000ms] which is longer than the warn threshold of [300000ms];"
                     + " there are currently [2] pending tasks, the oldest of which has age [*"
             );
-            mockAppender.addExpectation(expectation2);
+            mockLog.addExpectation(expectation2);
 
             while (relativeTimeInMillis - startTimeMillis < warnThresholdMillis * 2) {
                 awaitNextTask.run();
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
 
             expectation2.setExpectSeen();
@@ -1801,7 +1801,7 @@ public class MasterServiceTests extends ESTestCase {
             // the master service thread is somewhere between completing the previous task and starting the next one, which is when the
             // logging happens, so we must wait for another task to run too to ensure that the message was logged
             awaitNextTask.run();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // now stop the starvation and clean up
             keepRunning.set(false);
@@ -1815,7 +1815,7 @@ public class MasterServiceTests extends ESTestCase {
         reason = "to ensure that we log the right batch description, which only happens at DEBUG level"
     )
     public void testBatchedUpdateSummaryLogging() throws Exception {
-        try (var mockAppender = MockLog.capture(MasterService.class); var masterService = createMasterService(true)) {
+        try (var mockLog = MockLog.capture(MasterService.class); var masterService = createMasterService(true)) {
 
             final var barrier = new CyclicBarrier(2);
             final var blockingTask = new ClusterStateUpdateTask() {
@@ -1872,7 +1872,7 @@ public class MasterServiceTests extends ESTestCase {
                 for (int task = 0; task < 2; task++) {
                     smallBatchQueue.submitTask("source-" + source, new Task("task-" + source + "-" + task), null);
                 }
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "mention of tasks source-" + source,
                         MasterService.class.getCanonicalName(),
@@ -1889,7 +1889,7 @@ public class MasterServiceTests extends ESTestCase {
                     manySourceQueue.submitTask("source-" + source, new Task("task-" + task), null);
                 }
             }
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "truncated description of batch with many sources",
                     MasterService.class.getCanonicalName(),
@@ -1912,7 +1912,7 @@ public class MasterServiceTests extends ESTestCase {
             for (int task = 0; task < 2048; task++) {
                 manyTasksPerSourceQueue.submitTask("unique-source", new Task("task-" + task), null);
             }
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "truncated description of batch with many tasks from a single source",
                     MasterService.class.getCanonicalName(),
@@ -1930,7 +1930,7 @@ public class MasterServiceTests extends ESTestCase {
             assertTrue(smallBatchExecutor.semaphore.tryAcquire(4, 10, TimeUnit.SECONDS));
             assertTrue(manySourceExecutor.semaphore.tryAcquire(2048, 10, TimeUnit.SECONDS));
             assertTrue(manyTasksPerSourceExecutor.semaphore.tryAcquire(2048, 10, TimeUnit.SECONDS));
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -2249,13 +2249,13 @@ public class MasterServiceTests extends ESTestCase {
         };
 
         try (
-            var appender = MockLog.capture(MasterService.class);
+            var mockLog = MockLog.capture(MasterService.class);
             var masterService = createMasterService(true, null, threadPool, threadPoolExecutor)
         ) {
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation("warning", MasterService.class.getCanonicalName(), Level.WARN, "*")
             );
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "debug",
                     MasterService.class.getCanonicalName(),
@@ -2293,7 +2293,7 @@ public class MasterServiceTests extends ESTestCase {
             assertFalse(deterministicTaskQueue.hasRunnableTasks());
             assertFalse(deterministicTaskQueue.hasDeferredTasks());
 
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -2252,9 +2252,7 @@ public class MasterServiceTests extends ESTestCase {
             var mockLog = MockLog.capture(MasterService.class);
             var masterService = createMasterService(true, null, threadPool, threadPoolExecutor)
         ) {
-            mockLog.addExpectation(
-                new MockLog.UnseenEventExpectation("warning", MasterService.class.getCanonicalName(), Level.WARN, "*")
-            );
+            mockLog.addExpectation(new MockLog.UnseenEventExpectation("warning", MasterService.class.getCanonicalName(), Level.WARN, "*"));
             mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "debug",

--- a/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
@@ -13,9 +13,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
-import org.elasticsearch.test.MockLogAppender.LoggingExpectation;
-import org.elasticsearch.test.MockLogAppender.SeenEventExpectation;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.MockLog.LoggingExpectation;
+import org.elasticsearch.test.MockLog.SeenEventExpectation;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -62,7 +62,7 @@ public class JULBridgeTests extends ESTestCase {
         Logger testLogger = LogManager.getLogger("");
         Level savedLevel = testLogger.getLevel();
 
-        try (var mockAppender = MockLogAppender.capture("")) {
+        try (var mockAppender = MockLog.capture("")) {
             Loggers.setLevel(testLogger, Level.ALL);
             for (var expectation : expectations) {
                 mockAppender.addExpectation(expectation);

--- a/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/JULBridgeTests.java
@@ -62,13 +62,13 @@ public class JULBridgeTests extends ESTestCase {
         Logger testLogger = LogManager.getLogger("");
         Level savedLevel = testLogger.getLevel();
 
-        try (var mockAppender = MockLog.capture("")) {
+        try (var mockLog = MockLog.capture("")) {
             Loggers.setLevel(testLogger, Level.ALL);
             for (var expectation : expectations) {
-                mockAppender.addExpectation(expectation);
+                mockLog.addExpectation(expectation);
             }
             loggingCode.run();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             Loggers.setLevel(testLogger, savedLevel);
         }

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.Arrays;
@@ -1433,9 +1433,9 @@ public class SettingTests extends ESTestCase {
         );
         final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
 
-        try (var mockLogAppender = MockLogAppender.capture(IndexScopedSettings.class)) {
+        try (var mockLogAppender = MockLog.capture(IndexScopedSettings.class)) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "message",
                     "org.elasticsearch.common.settings.IndexScopedSettings",
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingTests.java
@@ -1433,8 +1433,8 @@ public class SettingTests extends ESTestCase {
         );
         final IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
 
-        try (var mockLogAppender = MockLog.capture(IndexScopedSettings.class)) {
-            mockLogAppender.addExpectation(
+        try (var mockLog = MockLog.capture(IndexScopedSettings.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "message",
                     "org.elasticsearch.common.settings.IndexScopedSettings",
@@ -1451,7 +1451,7 @@ public class SettingTests extends ESTestCase {
                 newIndexMeta("index1", Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "10s").build())
             );
 
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
@@ -117,10 +117,10 @@ public class SettingsFilterTests extends ESTestCase {
 
     private void assertExpectedLogMessages(Consumer<Logger> consumer, MockLog.LoggingExpectation... expectations) {
         Logger testLogger = LogManager.getLogger("org.elasticsearch.test");
-        try (var appender = MockLog.capture("org.elasticsearch.test")) {
-            Arrays.stream(expectations).forEach(appender::addExpectation);
+        try (var mockLog = MockLog.capture("org.elasticsearch.test")) {
+            Arrays.stream(expectations).forEach(mockLog::addExpectation);
             consumer.accept(testLogger);
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
@@ -106,12 +106,7 @@ public class SettingsFilterTests extends ESTestCase {
         Setting<String> regularSetting = Setting.simpleString("key");
         assertExpectedLogMessages(
             (testLogger) -> Setting.logSettingUpdate(regularSetting, newSettings, oldSettings, testLogger),
-            new MockLog.SeenEventExpectation(
-                "regular logging",
-                "org.elasticsearch.test",
-                Level.INFO,
-                "updating [key] from [old] to [new]"
-            )
+            new MockLog.SeenEventExpectation("regular logging", "org.elasticsearch.test", Level.INFO, "updating [key] from [old] to [new]")
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/SettingsFilterTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -93,9 +93,9 @@ public class SettingsFilterTests extends ESTestCase {
         Setting<String> filteredSetting = Setting.simpleString("key", Property.Filtered);
         assertExpectedLogMessages(
             (testLogger) -> Setting.logSettingUpdate(filteredSetting, newSettings, oldSettings, testLogger),
-            new MockLogAppender.SeenEventExpectation("secure logging", "org.elasticsearch.test", Level.INFO, "updating [key]"),
-            new MockLogAppender.UnseenEventExpectation("unwanted old setting name", "org.elasticsearch.test", Level.INFO, "*old*"),
-            new MockLogAppender.UnseenEventExpectation("unwanted new setting name", "org.elasticsearch.test", Level.INFO, "*new*")
+            new MockLog.SeenEventExpectation("secure logging", "org.elasticsearch.test", Level.INFO, "updating [key]"),
+            new MockLog.UnseenEventExpectation("unwanted old setting name", "org.elasticsearch.test", Level.INFO, "*old*"),
+            new MockLog.UnseenEventExpectation("unwanted new setting name", "org.elasticsearch.test", Level.INFO, "*new*")
         );
     }
 
@@ -106,7 +106,7 @@ public class SettingsFilterTests extends ESTestCase {
         Setting<String> regularSetting = Setting.simpleString("key");
         assertExpectedLogMessages(
             (testLogger) -> Setting.logSettingUpdate(regularSetting, newSettings, oldSettings, testLogger),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "regular logging",
                 "org.elasticsearch.test",
                 Level.INFO,
@@ -115,9 +115,9 @@ public class SettingsFilterTests extends ESTestCase {
         );
     }
 
-    private void assertExpectedLogMessages(Consumer<Logger> consumer, MockLogAppender.LoggingExpectation... expectations) {
+    private void assertExpectedLogMessages(Consumer<Logger> consumer, MockLog.LoggingExpectation... expectations) {
         Logger testLogger = LogManager.getLogger("org.elasticsearch.test");
-        try (var appender = MockLogAppender.capture("org.elasticsearch.test")) {
+        try (var appender = MockLog.capture("org.elasticsearch.test")) {
             Arrays.stream(expectations).forEach(appender::addExpectation);
             consumer.accept(testLogger);
             appender.assertAllExpectationsMatched();

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -153,8 +153,8 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
 
         FailureListener failureListener = new FailureListener();
 
-        try (var mockAppender = MockLog.capture(HandshakingTransportAddressConnector.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(HandshakingTransportAddressConnector.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "message",
                     HandshakingTransportAddressConnector.class.getCanonicalName(),
@@ -171,7 +171,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
 
             handshakingTransportAddressConnector.connectToRemoteMasterNode(discoveryAddress, failureListener);
             assertThat(failureListener.getFailureMessage(), containsString("simulated"));
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransport;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -153,9 +153,9 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
 
         FailureListener failureListener = new FailureListener();
 
-        try (var mockAppender = MockLogAppender.capture(HandshakingTransportAddressConnector.class)) {
+        try (var mockAppender = MockLog.capture(HandshakingTransportAddressConnector.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "message",
                     HandshakingTransportAddressConnector.class.getCanonicalName(),
                     Level.WARN,

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -808,8 +808,8 @@ public class PeerFinderTests extends ESTestCase {
         final long endTime = deterministicTaskQueue.getCurrentTimeMillis() + VERBOSITY_INCREASE_TIMEOUT_SETTING.get(Settings.EMPTY)
             .millis();
 
-        try (var appender = MockLog.capture(PeerFinder.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(PeerFinder.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "discovery result",
                     "org.elasticsearch.discovery.PeerFinder",
@@ -826,7 +826,7 @@ public class PeerFinderTests extends ESTestCase {
                 deterministicTaskQueue.advanceTime();
                 runAllRunnableTasks();
             }
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -841,8 +841,8 @@ public class PeerFinderTests extends ESTestCase {
         final long endTime = deterministicTaskQueue.getCurrentTimeMillis() + VERBOSITY_INCREASE_TIMEOUT_SETTING.get(Settings.EMPTY)
             .millis();
 
-        try (var appender = MockLog.capture(PeerFinder.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(PeerFinder.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "discovery result",
                     "org.elasticsearch.discovery.PeerFinder",
@@ -858,9 +858,9 @@ public class PeerFinderTests extends ESTestCase {
 
             deterministicTaskQueue.advanceTime();
             runAllRunnableTasks();
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "discovery result",
                     "org.elasticsearch.discovery.PeerFinder",
@@ -877,7 +877,7 @@ public class PeerFinderTests extends ESTestCase {
                 deterministicTaskQueue.advanceTime();
                 runAllRunnableTasks();
             }
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.CapturingTransport;
 import org.elasticsearch.test.transport.CapturingTransport.CapturedRequest;
@@ -808,9 +808,9 @@ public class PeerFinderTests extends ESTestCase {
         final long endTime = deterministicTaskQueue.getCurrentTimeMillis() + VERBOSITY_INCREASE_TIMEOUT_SETTING.get(Settings.EMPTY)
             .millis();
 
-        try (var appender = MockLogAppender.capture(PeerFinder.class)) {
+        try (var appender = MockLog.capture(PeerFinder.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "discovery result",
                     "org.elasticsearch.discovery.PeerFinder",
                     Level.WARN,
@@ -841,9 +841,9 @@ public class PeerFinderTests extends ESTestCase {
         final long endTime = deterministicTaskQueue.getCurrentTimeMillis() + VERBOSITY_INCREASE_TIMEOUT_SETTING.get(Settings.EMPTY)
             .millis();
 
-        try (var appender = MockLogAppender.capture(PeerFinder.class)) {
+        try (var appender = MockLog.capture(PeerFinder.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "discovery result",
                     "org.elasticsearch.discovery.PeerFinder",
                     Level.DEBUG,
@@ -861,7 +861,7 @@ public class PeerFinderTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "discovery result",
                     "org.elasticsearch.discovery.PeerFinder",
                     Level.WARN,
@@ -897,7 +897,7 @@ public class PeerFinderTests extends ESTestCase {
         final DiscoveryNode unreachableMaster = newDiscoveryNode("unreachable-master");
         transportAddressConnector.unreachableAddresses.add(unreachableMaster.getAddress());
 
-        MockLogAppender.assertThatLogger(() -> {
+        MockLog.assertThatLogger(() -> {
             while (deterministicTaskQueue.getCurrentTimeMillis() <= endTime) {
                 deterministicTaskQueue.advanceTime();
                 runAllRunnableTasks();
@@ -908,7 +908,7 @@ public class PeerFinderTests extends ESTestCase {
             }
         },
             PeerFinder.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "discovery result",
                 "org.elasticsearch.discovery.PeerFinder",
                 Level.WARN,

--- a/server/src/test/java/org/elasticsearch/discovery/SeedHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/SeedHostsResolverTests.java
@@ -22,7 +22,7 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
@@ -215,9 +215,9 @@ public class SeedHostsResolverTests extends ESTestCase {
         closeables.push(transportService);
         recreateSeedHostsResolver(transportService);
 
-        try (var appender = MockLogAppender.capture(SeedHostsResolver.class)) {
+        try (var appender = MockLog.capture(SeedHostsResolver.class)) {
             appender.addExpectation(
-                new MockLogAppender.ExceptionSeenEventExpectation(
+                new MockLog.ExceptionSeenEventExpectation(
                     getTestName(),
                     SeedHostsResolver.class.getCanonicalName(),
                     Level.WARN,
@@ -285,9 +285,9 @@ public class SeedHostsResolverTests extends ESTestCase {
         closeables.push(transportService);
         recreateSeedHostsResolver(transportService);
 
-        try (var appender = MockLogAppender.capture(SeedHostsResolver.class)) {
+        try (var appender = MockLog.capture(SeedHostsResolver.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     getTestName(),
                     SeedHostsResolver.class.getCanonicalName(),
                     Level.WARN,
@@ -402,9 +402,9 @@ public class SeedHostsResolverTests extends ESTestCase {
         closeables.push(transportService);
         recreateSeedHostsResolver(transportService);
 
-        try (var appender = MockLogAppender.capture(SeedHostsResolver.class)) {
+        try (var appender = MockLog.capture(SeedHostsResolver.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     getTestName(),
                     SeedHostsResolver.class.getCanonicalName(),
                     Level.WARN,

--- a/server/src/test/java/org/elasticsearch/discovery/SeedHostsResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/SeedHostsResolverTests.java
@@ -215,8 +215,8 @@ public class SeedHostsResolverTests extends ESTestCase {
         closeables.push(transportService);
         recreateSeedHostsResolver(transportService);
 
-        try (var appender = MockLog.capture(SeedHostsResolver.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(SeedHostsResolver.class)) {
+            mockLog.addExpectation(
                 new MockLog.ExceptionSeenEventExpectation(
                     getTestName(),
                     SeedHostsResolver.class.getCanonicalName(),
@@ -228,7 +228,7 @@ public class SeedHostsResolverTests extends ESTestCase {
             );
 
             assertThat(seedHostsResolver.resolveHosts(Collections.singletonList(hostname)), empty());
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -285,8 +285,8 @@ public class SeedHostsResolverTests extends ESTestCase {
         closeables.push(transportService);
         recreateSeedHostsResolver(transportService);
 
-        try (var appender = MockLog.capture(SeedHostsResolver.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(SeedHostsResolver.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     getTestName(),
                     SeedHostsResolver.class.getCanonicalName(),
@@ -297,7 +297,7 @@ public class SeedHostsResolverTests extends ESTestCase {
                 )
             );
             assertThat(seedHostsResolver.resolveHosts(Arrays.asList("hostname1", "hostname2")), hasSize(1));
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             latch.countDown();
         }
@@ -402,8 +402,8 @@ public class SeedHostsResolverTests extends ESTestCase {
         closeables.push(transportService);
         recreateSeedHostsResolver(transportService);
 
-        try (var appender = MockLog.capture(SeedHostsResolver.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(SeedHostsResolver.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     getTestName(),
                     SeedHostsResolver.class.getCanonicalName(),
@@ -417,7 +417,7 @@ public class SeedHostsResolverTests extends ESTestCase {
             assertThat(transportAddresses, hasSize(1)); // only one of the two is valid and will be used
             assertThat(transportAddresses.get(0).getAddress(), equalTo("127.0.0.1"));
             assertThat(transportAddresses.get(0).getPort(), equalTo(9301));
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -132,8 +132,8 @@ public class NodeEnvironmentTests extends ESTestCase {
 
             Index index = new Index("foo", "fooUUID");
 
-            try (var appender = MockLog.capture(NodeEnvironment.class); var lock = env.shardLock(new ShardId(index, 0), "1")) {
-                appender.addExpectation(
+            try (var mockLog = MockLog.capture(NodeEnvironment.class); var lock = env.shardLock(new ShardId(index, 0), "1")) {
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "hot threads logging",
                         NODE_ENVIRONMENT_LOGGER_NAME,
@@ -141,7 +141,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                         "hot threads while failing to obtain shard lock for [foo][0]: obtaining shard lock for [2] timed out after *"
                     )
                 );
-                appender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.UnseenEventExpectation(
                         "second attempt should be suppressed due to throttling",
                         NODE_ENVIRONMENT_LOGGER_NAME,
@@ -163,7 +163,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                     () -> env.lockAllForIndex(index, idxSettings, "3", randomIntBetween(0, 10))
                 );
 
-                appender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
 
             // can lock again?

--- a/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
+++ b/server/src/test/java/org/elasticsearch/env/NodeEnvironmentTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.NodeRoles;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
@@ -132,9 +132,9 @@ public class NodeEnvironmentTests extends ESTestCase {
 
             Index index = new Index("foo", "fooUUID");
 
-            try (var appender = MockLogAppender.capture(NodeEnvironment.class); var lock = env.shardLock(new ShardId(index, 0), "1")) {
+            try (var appender = MockLog.capture(NodeEnvironment.class); var lock = env.shardLock(new ShardId(index, 0), "1")) {
                 appender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "hot threads logging",
                         NODE_ENVIRONMENT_LOGGER_NAME,
                         Level.DEBUG,
@@ -142,7 +142,7 @@ public class NodeEnvironmentTests extends ESTestCase {
                     )
                 );
                 appender.addExpectation(
-                    new MockLogAppender.UnseenEventExpectation(
+                    new MockLog.UnseenEventExpectation(
                         "second attempt should be suppressed due to throttling",
                         NODE_ENVIRONMENT_LOGGER_NAME,
                         Level.DEBUG,

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -1540,8 +1540,8 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 writer.writeFullStateAndCommit(randomNonNegativeLong(), ClusterState.EMPTY_STATE);
             }
 
-            try (var mockAppender = MockLog.capture(PersistedClusterStateService.class)) {
-                mockAppender.addExpectation(
+            try (var mockLog = MockLog.capture(PersistedClusterStateService.class)) {
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "should see checkindex message",
                         PersistedClusterStateService.class.getCanonicalName(),
@@ -1549,7 +1549,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                         "checking cluster state integrity"
                     )
                 );
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "should see commit message including timestamps",
                         PersistedClusterStateService.class.getCanonicalName(),
@@ -1557,7 +1557,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                         "loading cluster state from commit [*] in [*creationTime*"
                     )
                 );
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "should see user data",
                         PersistedClusterStateService.class.getCanonicalName(),
@@ -1565,7 +1565,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                         "cluster state commit user data: *" + PersistedClusterStateService.NODE_VERSION_KEY + "*"
                     )
                 );
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "should see segment message including timestamp",
                         PersistedClusterStateService.class.getCanonicalName(),
@@ -1575,7 +1575,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 );
 
                 persistedClusterStateService.loadBestOnDiskState();
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
         }
     }
@@ -1881,15 +1881,15 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         PersistedClusterStateService.Writer writer,
         MockLog.LoggingExpectation expectation
     ) throws IOException {
-        try (var mockAppender = MockLog.capture(PersistedClusterStateService.class)) {
-            mockAppender.addExpectation(expectation);
+        try (var mockLog = MockLog.capture(PersistedClusterStateService.class)) {
+            mockLog.addExpectation(expectation);
 
             if (previousState == null) {
                 writer.writeFullStateAndCommit(currentTerm, clusterState);
             } else {
                 writer.writeIncrementalStateAndCommit(currentTerm, previousState, clusterState);
             }
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -63,7 +63,7 @@ import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.test.CorruptionUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.io.IOError;
@@ -1186,7 +1186,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     null,
                     clusterState,
                     writer,
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "should see warning at threshold",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.WARN,
@@ -1202,7 +1202,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     null,
                     clusterState,
                     writer,
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "should see warning above threshold",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.WARN,
@@ -1218,7 +1218,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     null,
                     clusterState,
                     writer,
-                    new MockLogAppender.UnseenEventExpectation(
+                    new MockLog.UnseenEventExpectation(
                         "should not see warning below threshold",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.WARN,
@@ -1236,7 +1236,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     null,
                     clusterState,
                     writer,
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "should see warning at reduced threshold",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.WARN,
@@ -1270,7 +1270,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     clusterState,
                     newClusterState,
                     writer,
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "should see warning at threshold",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.WARN,
@@ -1289,7 +1289,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     null,
                     clusterState,
                     writer,
-                    new MockLogAppender.UnseenEventExpectation(
+                    new MockLog.UnseenEventExpectation(
                         "should not see warning below threshold",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.WARN,
@@ -1302,7 +1302,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     clusterState,
                     newClusterState,
                     writer,
-                    new MockLogAppender.UnseenEventExpectation(
+                    new MockLog.UnseenEventExpectation(
                         "should not see warning below threshold",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.WARN,
@@ -1540,9 +1540,9 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 writer.writeFullStateAndCommit(randomNonNegativeLong(), ClusterState.EMPTY_STATE);
             }
 
-            try (var mockAppender = MockLogAppender.capture(PersistedClusterStateService.class)) {
+            try (var mockAppender = MockLog.capture(PersistedClusterStateService.class)) {
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "should see checkindex message",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.DEBUG,
@@ -1550,7 +1550,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     )
                 );
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "should see commit message including timestamps",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.DEBUG,
@@ -1558,7 +1558,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     )
                 );
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "should see user data",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.DEBUG,
@@ -1566,7 +1566,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                     )
                 );
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "should see segment message including timestamp",
                         PersistedClusterStateService.class.getCanonicalName(),
                         Level.DEBUG,
@@ -1879,9 +1879,9 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
         ClusterState previousState,
         ClusterState clusterState,
         PersistedClusterStateService.Writer writer,
-        MockLogAppender.LoggingExpectation expectation
+        MockLog.LoggingExpectation expectation
     ) throws IOException {
-        try (var mockAppender = MockLogAppender.capture(PersistedClusterStateService.class)) {
+        try (var mockAppender = MockLog.capture(PersistedClusterStateService.class)) {
             mockAppender.addExpectation(expectation);
 
             if (previousState == null) {

--- a/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.metric.LongGaugeMetric;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -613,9 +613,9 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
     }
 
     public void testLoggingHappens() {
-        try (var mockAppender = MockLogAppender.capture(HealthPeriodicLogger.class)) {
+        try (var mockAppender = MockLog.capture(HealthPeriodicLogger.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "overall",
                     HealthPeriodicLogger.class.getCanonicalName(),
                     Level.INFO,
@@ -623,7 +623,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "master_is_stable",
                     HealthPeriodicLogger.class.getCanonicalName(),
                     Level.INFO,
@@ -631,7 +631,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "disk",
                     HealthPeriodicLogger.class.getCanonicalName(),
                     Level.INFO,
@@ -639,7 +639,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "ilm",
                     HealthPeriodicLogger.class.getCanonicalName(),
                     Level.INFO,
@@ -673,9 +673,9 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
     }
 
     public void testOutputModeNoLogging() {
-        try (var mockAppender = MockLogAppender.capture(HealthPeriodicLogger.class)) {
+        try (var mockAppender = MockLog.capture(HealthPeriodicLogger.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "overall",
                     HealthPeriodicLogger.class.getCanonicalName(),
                     Level.INFO,
@@ -683,7 +683,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "master_is_stable",
                     HealthPeriodicLogger.class.getCanonicalName(),
                     Level.INFO,
@@ -691,7 +691,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "disk",
                     HealthPeriodicLogger.class.getCanonicalName(),
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/health/HealthPeriodicLoggerTests.java
@@ -613,8 +613,8 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
     }
 
     public void testLoggingHappens() {
-        try (var mockAppender = MockLog.capture(HealthPeriodicLogger.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(HealthPeriodicLogger.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "overall",
                     HealthPeriodicLogger.class.getCanonicalName(),
@@ -622,7 +622,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                     String.format(Locale.ROOT, "%s=\"yellow\"", makeHealthStatusString("overall"))
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "master_is_stable",
                     HealthPeriodicLogger.class.getCanonicalName(),
@@ -630,7 +630,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                     String.format(Locale.ROOT, "%s=\"green\"", makeHealthStatusString("master_is_stable"))
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "disk",
                     HealthPeriodicLogger.class.getCanonicalName(),
@@ -638,7 +638,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                     String.format(Locale.ROOT, "%s=\"yellow\"", makeHealthStatusString("disk"))
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "ilm",
                     HealthPeriodicLogger.class.getCanonicalName(),
@@ -668,13 +668,13 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
 
             SchedulerEngine.Event event = new SchedulerEngine.Event(HealthPeriodicLogger.HEALTH_PERIODIC_LOGGER_JOB_NAME, 0, 0);
             testHealthPeriodicLogger.triggered(event);
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
     public void testOutputModeNoLogging() {
-        try (var mockAppender = MockLog.capture(HealthPeriodicLogger.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(HealthPeriodicLogger.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "overall",
                     HealthPeriodicLogger.class.getCanonicalName(),
@@ -682,7 +682,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                     String.format(Locale.ROOT, "%s=\"yellow\"", makeHealthStatusString("overall"))
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "master_is_stable",
                     HealthPeriodicLogger.class.getCanonicalName(),
@@ -690,7 +690,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
                     String.format(Locale.ROOT, "%s=\"green\"", makeHealthStatusString("master_is_stable"))
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "disk",
                     HealthPeriodicLogger.class.getCanonicalName(),
@@ -721,7 +721,7 @@ public class HealthPeriodicLoggerTests extends ESTestCase {
             SchedulerEngine.Event event = new SchedulerEngine.Event(HealthPeriodicLogger.HEALTH_PERIODIC_LOGGER_JOB_NAME, 0, 0);
             testHealthPeriodicLogger.triggered(event);
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -41,7 +41,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -581,11 +581,11 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                     .put(HttpTransportSettings.SETTING_HTTP_TRACE_LOG_EXCLUDE.getKey(), excludeSettings)
                     .build()
             );
-            try (var appender = MockLogAppender.capture(HttpTracer.class)) {
+            try (var appender = MockLog.capture(HttpTracer.class)) {
 
                 final String opaqueId = UUIDs.randomBase64UUID(random());
                 appender.addExpectation(
-                    new MockLogAppender.PatternSeenEventExpectation(
+                    new MockLog.PatternSeenEventExpectation(
                         "received request",
                         HttpTracerTests.HTTP_TRACER_LOGGER,
                         Level.TRACE,
@@ -596,7 +596,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                 final boolean badRequest = randomBoolean();
 
                 appender.addExpectation(
-                    new MockLogAppender.PatternSeenEventExpectation(
+                    new MockLog.PatternSeenEventExpectation(
                         "sent response",
                         HttpTracerTests.HTTP_TRACER_LOGGER,
                         Level.TRACE,
@@ -611,7 +611,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
                 );
 
                 appender.addExpectation(
-                    new MockLogAppender.UnseenEventExpectation(
+                    new MockLog.UnseenEventExpectation(
                         "received other request",
                         HttpTracerTests.HTTP_TRACER_LOGGER,
                         Level.TRACE,
@@ -671,7 +671,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             .put(TransportSettings.SLOW_OPERATION_THRESHOLD_SETTING.getKey(), TimeValue.timeValueMillis(5))
             .build();
         try (
-            var mockAppender = MockLogAppender.capture(AbstractHttpServerTransport.class);
+            var mockAppender = MockLog.capture(AbstractHttpServerTransport.class);
             AbstractHttpServerTransport transport = new AbstractHttpServerTransport(
                 settings,
                 networkService,
@@ -719,7 +719,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             }
         ) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected message",
                     AbstractHttpServerTransport.class.getCanonicalName(),
                     Level.WARN,
@@ -1350,13 +1350,13 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
 
     private static class LogExpectation implements AutoCloseable {
         private final Logger mockLogger;
-        private final MockLogAppender appender;
+        private final MockLog appender;
         private final int grace;
 
         private LogExpectation(int grace) {
             mockLogger = LogManager.getLogger(AbstractHttpServerTransport.class);
             Loggers.setLevel(mockLogger, Level.DEBUG);
-            appender = MockLogAppender.capture(AbstractHttpServerTransport.class);
+            appender = MockLog.capture(AbstractHttpServerTransport.class);
             this.grace = grace;
         }
 
@@ -1382,9 +1382,9 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             var logger = AbstractHttpServerTransport.class.getName();
             var level = Level.WARN;
             if (expected) {
-                appender.addExpectation(new MockLogAppender.SeenEventExpectation(name, logger, level, message));
+                appender.addExpectation(new MockLog.SeenEventExpectation(name, logger, level, message));
             } else {
-                appender.addExpectation(new MockLogAppender.UnseenEventExpectation(name, logger, level, message));
+                appender.addExpectation(new MockLog.UnseenEventExpectation(name, logger, level, message));
             }
             return this;
         }
@@ -1395,9 +1395,9 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             var logger = AbstractHttpServerTransport.class.getName();
             var level = Level.DEBUG;
             if (expected) {
-                appender.addExpectation(new MockLogAppender.SeenEventExpectation(name, logger, level, message));
+                appender.addExpectation(new MockLog.SeenEventExpectation(name, logger, level, message));
             } else {
-                appender.addExpectation(new MockLogAppender.UnseenEventExpectation(name, logger, level, message));
+                appender.addExpectation(new MockLog.UnseenEventExpectation(name, logger, level, message));
             }
             return this;
         }
@@ -1407,7 +1407,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             var name = "update message";
             var logger = AbstractHttpServerTransport.class.getName();
             var level = Level.INFO;
-            appender.addExpectation(new MockLogAppender.SeenEventExpectation(name, logger, level, message));
+            appender.addExpectation(new MockLog.SeenEventExpectation(name, logger, level, message));
             return this;
         }
 

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -38,7 +38,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -587,9 +587,9 @@ public class DefaultRestChannelTests extends ESTestCase {
             tracer
         );
 
-        try (var sendingResponseMockLog = MockLogAppender.capture(HttpTracer.class)) {
+        try (var sendingResponseMockLog = MockLog.capture(HttpTracer.class)) {
             sendingResponseMockLog.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "no response should be logged",
                     HttpTracer.class.getName(),
                     Level.TRACE,
@@ -603,9 +603,9 @@ public class DefaultRestChannelTests extends ESTestCase {
             sendingResponseMockLog.assertAllExpectationsMatched();
         }
 
-        try (var sendingResponseCompleteMockLog = MockLogAppender.capture(HttpTracer.class)) {
+        try (var sendingResponseCompleteMockLog = MockLog.capture(HttpTracer.class)) {
             sendingResponseCompleteMockLog.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "response should be logged",
                     HttpTracer.class.getName(),
                     Level.TRACE,
@@ -647,9 +647,9 @@ public class DefaultRestChannelTests extends ESTestCase {
             tracer
         );
 
-        try (var mockLogAppender = MockLogAppender.capture(HttpTracer.class)) {
+        try (var mockLogAppender = MockLog.capture(HttpTracer.class)) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "response should be logged with success = false",
                     HttpTracer.class.getName(),
                     Level.TRACE,

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -647,8 +647,8 @@ public class DefaultRestChannelTests extends ESTestCase {
             tracer
         );
 
-        try (var mockLogAppender = MockLog.capture(HttpTracer.class)) {
-            mockLogAppender.addExpectation(
+        try (var mockLog = MockLog.capture(HttpTracer.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "response should be logged with success = false",
                     HttpTracer.class.getName(),
@@ -658,7 +658,7 @@ public class DefaultRestChannelTests extends ESTestCase {
             );
 
             expectThrows(RuntimeException.class, () -> channel.sendResponse(new RestResponse(RestStatus.OK, "ignored")));
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/http/HttpTracerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpTracerTests.java
@@ -36,9 +36,9 @@ public class HttpTracerTests extends ESTestCase {
 
     @TestLogging(reason = "testing trace logging", value = HTTP_TRACER_LOGGER + ":TRACE," + HTTP_BODY_TRACER_LOGGER + ":INFO")
     public void testLogging() {
-        try (var appender = MockLog.capture(HttpTracer.class)) {
+        try (var mockLog = MockLog.capture(HttpTracer.class)) {
 
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "request log",
                     HTTP_TRACER_LOGGER,
@@ -46,7 +46,7 @@ public class HttpTracerTests extends ESTestCase {
                     "\\[\\d+]\\[idHeader]\\[GET]\\[uri] received request from \\[.*] trace.id: 4bf92f3577b34da6a3ce929d0e0e4736"
                 )
             );
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "response log",
                     HTTP_TRACER_LOGGER,
@@ -80,7 +80,7 @@ public class HttpTracerTests extends ESTestCase {
                 true
             );
 
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/http/HttpTracerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpTracerTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -36,10 +36,10 @@ public class HttpTracerTests extends ESTestCase {
 
     @TestLogging(reason = "testing trace logging", value = HTTP_TRACER_LOGGER + ":TRACE," + HTTP_BODY_TRACER_LOGGER + ":INFO")
     public void testLogging() {
-        try (var appender = MockLogAppender.capture(HttpTracer.class)) {
+        try (var appender = MockLog.capture(HttpTracer.class)) {
 
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "request log",
                     HTTP_TRACER_LOGGER,
                     Level.TRACE,
@@ -47,7 +47,7 @@ public class HttpTracerTests extends ESTestCase {
                 )
             );
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "response log",
                     HTTP_TRACER_LOGGER,
                     Level.TRACE,

--- a/server/src/test/java/org/elasticsearch/index/CompositeIndexEventListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/CompositeIndexEventListenerTests.java
@@ -39,7 +39,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
 
     public void testBeforeIndexShardRecoveryInOrder() throws Exception {
         var shard = newShard(randomBoolean());
-        try (var appender = MockLog.capture(CompositeIndexEventListener.class)) {
+        try (var mockLog = MockLog.capture(CompositeIndexEventListener.class)) {
             final var stepNumber = new AtomicInteger();
             final var stepCount = between(0, 20);
             final var failAtStep = new AtomicInteger(-1);
@@ -85,7 +85,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
             assertEquals(stepCount, stepNumber.getAndSet(0));
 
             if (stepCount > 0) {
-                appender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "warning",
                         CompositeIndexEventListener.class.getCanonicalName(),
@@ -98,7 +98,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
                 final var rootCause = getRootCause(expectThrows(ElasticsearchException.class, beforeIndexShardRecoveryRunner::run));
                 assertEquals("simulated failure at step " + failAtStep.get(), rootCause.getMessage());
                 assertEquals(failAtStep.get() + 1, stepNumber.getAndSet(0));
-                appender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
 
         } finally {
@@ -108,7 +108,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
 
     public void testAfterIndexShardRecoveryInOrder() throws Exception {
         var shard = newShard(randomBoolean());
-        try (var appender = MockLog.capture(CompositeIndexEventListener.class)) {
+        try (var mockLog = MockLog.capture(CompositeIndexEventListener.class)) {
             final var stepNumber = new AtomicInteger();
             final var stepCount = between(0, 20);
             final var failAtStep = new AtomicInteger(-1);
@@ -147,7 +147,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
             assertEquals(stepCount, stepNumber.getAndSet(0));
 
             if (stepCount > 0) {
-                appender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "warning",
                         CompositeIndexEventListener.class.getCanonicalName(),
@@ -160,7 +160,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
                 final var rootCause = getRootCause(expectThrows(ElasticsearchException.class, afterIndexShardRecoveryRunner::run));
                 assertEquals("simulated failure at step " + failAtStep.get(), rootCause.getMessage());
                 assertEquals(failAtStep.get() + 1, stepNumber.getAndSet(0));
-                appender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
             }
 
         } finally {

--- a/server/src/test/java/org/elasticsearch/index/CompositeIndexEventListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/CompositeIndexEventListenerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.hamcrest.Matchers;
 
 import java.util.concurrent.TimeUnit;
@@ -39,7 +39,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
 
     public void testBeforeIndexShardRecoveryInOrder() throws Exception {
         var shard = newShard(randomBoolean());
-        try (var appender = MockLogAppender.capture(CompositeIndexEventListener.class)) {
+        try (var appender = MockLog.capture(CompositeIndexEventListener.class)) {
             final var stepNumber = new AtomicInteger();
             final var stepCount = between(0, 20);
             final var failAtStep = new AtomicInteger(-1);
@@ -86,7 +86,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
 
             if (stepCount > 0) {
                 appender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "warning",
                         CompositeIndexEventListener.class.getCanonicalName(),
                         Level.WARN,
@@ -108,7 +108,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
 
     public void testAfterIndexShardRecoveryInOrder() throws Exception {
         var shard = newShard(randomBoolean());
-        try (var appender = MockLogAppender.capture(CompositeIndexEventListener.class)) {
+        try (var appender = MockLog.capture(CompositeIndexEventListener.class)) {
             final var stepNumber = new AtomicInteger();
             final var stepCount = between(0, 20);
             final var failAtStep = new AtomicInteger(-1);
@@ -148,7 +148,7 @@ public class CompositeIndexEventListenerTests extends IndexShardTestCase {
 
             if (stepCount > 0) {
                 appender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "warning",
                         CompositeIndexEventListener.class.getCanonicalName(),
                         Level.WARN,

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -124,7 +124,7 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.CorruptionUtils;
 import org.elasticsearch.test.DummyShardLock;
 import org.elasticsearch.test.FieldMaskingReader;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.store.MockFSDirectoryFactory;
@@ -3527,9 +3527,9 @@ public class IndexShardTests extends IndexShardTestCase {
             EMPTY_EVENT_LISTENER
         );
 
-        try (var appender = MockLogAppender.capture(IndexShard.class)) {
+        try (var appender = MockLog.capture(IndexShard.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expensive checks warning",
                     "org.elasticsearch.index.shard.IndexShard",
                     Level.WARN,
@@ -3539,7 +3539,7 @@ public class IndexShardTests extends IndexShardTestCase {
             );
 
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "failure message",
                     "org.elasticsearch.index.shard.IndexShard",
                     Level.WARN,
@@ -4061,7 +4061,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
     @TestLogging(reason = "testing traces of concurrent flushes", value = "org.elasticsearch.index.engine.Engine:TRACE")
     public void testFlushOnIdleConcurrentFlushDoesNotWait() throws Exception {
-        try (var mockLogAppender = MockLogAppender.capture(Engine.class)) {
+        try (var mockLogAppender = MockLog.capture(Engine.class)) {
             CountDownLatch readyToCompleteFlushLatch = new CountDownLatch(1);
             IndexShard shard = newStartedShard(false, Settings.EMPTY, config -> new InternalEngine(config) {
                 @Override
@@ -4078,7 +4078,7 @@ public class IndexShardTests extends IndexShardTestCase {
             // Issue the first flushOnIdle request. The flush happens in the background using the flush threadpool.
             // Then wait for log message that flush acquired lock immediately
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "should see first flush getting lock immediately",
                     Engine.class.getCanonicalName(),
                     Level.TRACE,
@@ -4094,7 +4094,7 @@ public class IndexShardTests extends IndexShardTestCase {
             indexDoc(shard, "_doc", Integer.toString(3));
             assertTrue(shard.isActive());
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "should see second flush returning since it will not wait for the ongoing flush",
                     Engine.class.getCanonicalName(),
                     Level.TRACE,
@@ -4112,7 +4112,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
             // Wait for first flushOnIdle to log a message that it released the flush lock
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "should see first flush releasing lock",
                     Engine.class.getCanonicalName(),
                     Level.TRACE,

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -43,9 +43,9 @@ import static org.elasticsearch.indices.recovery.RecoverySettings.NODE_BANDWIDTH
 import static org.elasticsearch.indices.recovery.RecoverySettings.NODE_BANDWIDTH_RECOVERY_SETTINGS;
 import static org.elasticsearch.indices.recovery.RecoverySettings.TOTAL_PHYSICAL_MEMORY_OVERRIDING_TEST_SETTING;
 import static org.elasticsearch.node.NodeRoleSettings.NODE_ROLES_SETTING;
-import static org.elasticsearch.test.MockLogAppender.LoggingExpectation;
-import static org.elasticsearch.test.MockLogAppender.SeenEventExpectation;
-import static org.elasticsearch.test.MockLogAppender.assertThatLogger;
+import static org.elasticsearch.test.MockLog.LoggingExpectation;
+import static org.elasticsearch.test.MockLog.SeenEventExpectation;
+import static org.elasticsearch.test.MockLog.assertThatLogger;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -490,9 +490,9 @@ public class RecoverySettingsTests extends ESTestCase {
         final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
 
-        try (var mockAppender = MockLogAppender.capture(RecoverySettings.class)) {
+        try (var mockAppender = MockLog.capture(RecoverySettings.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation("no warnings", RecoverySettings.class.getCanonicalName(), Level.WARN, "*")
+                new MockLog.UnseenEventExpectation("no warnings", RecoverySettings.class.getCanonicalName(), Level.WARN, "*")
             );
 
             assertThat(recoverySettings.getUseSnapshotsDuringRecovery(), is(false));

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySettingsTests.java
@@ -490,8 +490,8 @@ public class RecoverySettingsTests extends ESTestCase {
         final ClusterSettings clusterSettings = new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         final RecoverySettings recoverySettings = new RecoverySettings(settings, clusterSettings);
 
-        try (var mockAppender = MockLog.capture(RecoverySettings.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(RecoverySettings.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation("no warnings", RecoverySettings.class.getCanonicalName(), Level.WARN, "*")
             );
 
@@ -507,7 +507,7 @@ public class RecoverySettingsTests extends ESTestCase {
             assertThat(releasable, is(notNullValue()));
             releasable.close();
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -60,7 +60,7 @@ import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.TemplateScript;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -758,10 +758,10 @@ public class IngestServiceTests extends ESTestCase {
             XContentType.JSON
         );
         ClusterState clusterState = executePut(putRequest, previousClusterState);
-        MockLogAppender.assertThatLogger(
+        MockLog.assertThatLogger(
             () -> ingestService.applyClusterState(new ClusterChangedEvent("", clusterState, previousClusterState)),
             IngestService.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test1",
                 IngestService.class.getCanonicalName(),
                 Level.WARN,

--- a/server/src/test/java/org/elasticsearch/monitor/fs/FsHealthServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/FsHealthServiceTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.core.PathUtils;
 import org.elasticsearch.core.PathUtilsForTesting;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -127,12 +127,12 @@ public class FsHealthServiceTests extends ESTestCase {
         PathUtilsForTesting.installMock(fileSystem);
         final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
-        try (NodeEnvironment env = newNodeEnvironment(); var mockAppender = MockLogAppender.capture(FsHealthService.class)) {
+        try (NodeEnvironment env = newNodeEnvironment(); var mockAppender = MockLog.capture(FsHealthService.class)) {
             FsHealthService fsHealthService = new FsHealthService(settings, clusterSettings, testThreadPool, env);
             int counter = 0;
             for (Path path : env.nodeDataPaths()) {
                 mockAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "test" + ++counter,
                         FsHealthService.class.getCanonicalName(),
                         Level.WARN,

--- a/server/src/test/java/org/elasticsearch/monitor/fs/FsHealthServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/fs/FsHealthServiceTests.java
@@ -127,11 +127,11 @@ public class FsHealthServiceTests extends ESTestCase {
         PathUtilsForTesting.installMock(fileSystem);
         final ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
 
-        try (NodeEnvironment env = newNodeEnvironment(); var mockAppender = MockLog.capture(FsHealthService.class)) {
+        try (NodeEnvironment env = newNodeEnvironment(); var mockLog = MockLog.capture(FsHealthService.class)) {
             FsHealthService fsHealthService = new FsHealthService(settings, clusterSettings, testThreadPool, env);
             int counter = 0;
             for (Path path : env.nodeDataPaths()) {
-                mockAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "test" + ++counter,
                         FsHealthService.class.getCanonicalName(),
@@ -145,7 +145,7 @@ public class FsHealthServiceTests extends ESTestCase {
             disruptFileSystemProvider.injectIOException.set(true);
             fsHealthService.new FsHealthMonitor().run();
             assertEquals(env.nodeDataPaths().length, disruptFileSystemProvider.getInjectedPathCount());
-            assertBusy(mockAppender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
         } finally {
             PathUtilsForTesting.teardown();
             ThreadPool.terminate(testThreadPool, 500, TimeUnit.MILLISECONDS);

--- a/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
@@ -33,7 +33,7 @@ import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.http.HttpStats;
 import org.elasticsearch.reservedstate.service.FileSettingsService;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.readiness.ReadinessClientProbe;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -266,9 +266,9 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
             )
             .build();
         event = new ClusterChangedEvent("test", nodeShuttingDownState, completeState);
-        try (var mockAppender = MockLogAppender.capture(ReadinessService.class)) {
+        try (var mockAppender = MockLog.capture(ReadinessService.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "node shutting down logged",
                     ReadinessService.class.getCanonicalName(),
                     Level.INFO,
@@ -279,7 +279,7 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
             mockAppender.assertAllExpectationsMatched();
 
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "node shutting down not logged twice",
                     ReadinessService.class.getCanonicalName(),
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
@@ -266,8 +266,8 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
             )
             .build();
         event = new ClusterChangedEvent("test", nodeShuttingDownState, completeState);
-        try (var mockAppender = MockLog.capture(ReadinessService.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(ReadinessService.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "node shutting down logged",
                     ReadinessService.class.getCanonicalName(),
@@ -276,9 +276,9 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
                 )
             );
             readinessService.clusterChanged(event);
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "node shutting down not logged twice",
                     ReadinessService.class.getCanonicalName(),
@@ -287,7 +287,7 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
                 )
             );
             readinessService.clusterChanged(event);
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
         assertFalse(readinessService.ready());
         tcpReadinessProbeFalse(readinessService);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -182,7 +182,7 @@ import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BytesRefRecycler;
@@ -1451,13 +1451,13 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     })
             );
 
-        MockLogAppender.assertThatLogger(() -> {
+        MockLog.assertThatLogger(() -> {
             deterministicTaskQueue.runAllRunnableTasks();
             assertTrue("executed all runnable tasks but test steps are still incomplete", testListener.isDone());
             safeAwait(testListener); // shouldn't throw
         },
             SnapshotsService.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "INFO log",
                 SnapshotsService.class.getCanonicalName(),
                 Level.INFO,
@@ -1502,13 +1502,13 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     })
             );
 
-        MockLogAppender.assertThatLogger(() -> {
+        MockLog.assertThatLogger(() -> {
             deterministicTaskQueue.runAllRunnableTasks();
             assertTrue("executed all runnable tasks but test steps are still incomplete", testListener.isDone());
             safeAwait(testListener); // shouldn't throw
         },
             SnapshotsService.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "INFO log",
                 SnapshotsService.class.getCanonicalName(),
                 Level.INFO,
@@ -1555,13 +1555,13 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     })
             );
 
-        MockLogAppender.assertThatLogger(() -> {
+        MockLog.assertThatLogger(() -> {
             deterministicTaskQueue.runAllRunnableTasks();
             assertTrue("executed all runnable tasks but test steps are still incomplete", testListener.isDone());
             safeAwait(testListener); // shouldn't throw
         },
             SnapshotsService.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "INFO log",
                 SnapshotsService.class.getCanonicalName(),
                 Level.INFO,
@@ -1607,13 +1607,13 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     })
             );
 
-        MockLogAppender.assertThatLogger(() -> {
+        MockLog.assertThatLogger(() -> {
             deterministicTaskQueue.runAllRunnableTasks();
             assertTrue("executed all runnable tasks but test steps are still incomplete", testListener.isDone());
             safeAwait(testListener); // shouldn't throw
         },
             SnapshotsService.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "INFO log",
                 SnapshotsService.class.getCanonicalName(),
                 Level.INFO,

--- a/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
@@ -169,9 +169,9 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
                 new ChildResponseHandler(() -> parentTransportService.getTaskManager().unregister(parentTask))
             );
 
-            try (MockLog appender = MockLog.capture(TaskCancellationService.class)) {
+            try (MockLog mockLog = MockLog.capture(TaskCancellationService.class)) {
                 for (MockLog.LoggingExpectation expectation : expectations.apply(childTransportService.getLocalDiscoNode())) {
-                    appender.addExpectation(expectation);
+                    mockLog.addExpectation(expectation);
                 }
 
                 final PlainActionFuture<Void> cancellationFuture = new PlainActionFuture<>();
@@ -183,7 +183,7 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
                 }
 
                 // assert busy since failure to remove a ban may be logged after cancellation completed
-                assertBusy(appender::assertAllExpectationsMatched);
+                assertBusy(mockLog::assertAllExpectationsMatched);
             }
 
             assertTrue("child tasks did not finish in time", childTaskLock.tryLock(15, TimeUnit.SECONDS));

--- a/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.test.transport.StubbableTransport;
@@ -55,13 +55,13 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
             connection.sendRequest(requestId, action, request, options);
         },
             childNode -> List.of(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "cannot send ban",
                     TaskCancellationService.class.getName(),
                     Level.DEBUG,
                     "*cannot send ban for tasks*" + childNode.getId() + "*"
                 ),
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "cannot remove ban",
                     TaskCancellationService.class.getName(),
                     Level.DEBUG,
@@ -81,13 +81,13 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
             connection.sendRequest(requestId, action, request, options);
         },
             childNode -> List.of(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "cannot send ban",
                     TaskCancellationService.class.getName(),
                     Level.DEBUG,
                     "*cannot send ban for tasks*" + childNode.getId() + "*"
                 ),
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "cannot remove ban",
                     TaskCancellationService.class.getName(),
                     Level.DEBUG,
@@ -99,7 +99,7 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
 
     private void runTest(
         StubbableTransport.SendRequestBehavior sendRequestBehavior,
-        Function<DiscoveryNode, List<MockLogAppender.LoggingExpectation>> expectations
+        Function<DiscoveryNode, List<MockLog.LoggingExpectation>> expectations
     ) throws Exception {
 
         final ArrayList<Closeable> resources = new ArrayList<>(3);
@@ -169,8 +169,8 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
                 new ChildResponseHandler(() -> parentTransportService.getTaskManager().unregister(parentTask))
             );
 
-            try (MockLogAppender appender = MockLogAppender.capture(TaskCancellationService.class)) {
-                for (MockLogAppender.LoggingExpectation expectation : expectations.apply(childTransportService.getLocalDiscoNode())) {
+            try (MockLog appender = MockLog.capture(TaskCancellationService.class)) {
+                for (MockLog.LoggingExpectation expectation : expectations.apply(childTransportService.getLocalDiscoNode())) {
                     appender.addExpectation(expectation);
                 }
 

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.common.util.concurrent.TaskExecutionTimeTrackingEsThreadPoolExecutor;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -106,9 +106,9 @@ public class ThreadPoolTests extends ESTestCase {
     }
 
     public void testTimerThreadWarningLogging() throws Exception {
-        try (var appender = MockLogAppender.capture(ThreadPool.class)) {
+        try (var appender = MockLog.capture(ThreadPool.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected warning for absolute clock",
                     ThreadPool.class.getName(),
                     Level.WARN,
@@ -116,7 +116,7 @@ public class ThreadPoolTests extends ESTestCase {
                 )
             );
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected warning for relative clock",
                     ThreadPool.class.getName(),
                     Level.WARN,
@@ -135,14 +135,14 @@ public class ThreadPoolTests extends ESTestCase {
     }
 
     public void testTimeChangeChecker() throws Exception {
-        try (var appender = MockLogAppender.capture(ThreadPool.class)) {
+        try (var appender = MockLog.capture(ThreadPool.class)) {
             long absoluteMillis = randomLong(); // overflow should still be handled correctly
             long relativeNanos = randomLong(); // overflow should still be handled correctly
 
             final ThreadPool.TimeChangeChecker timeChangeChecker = new ThreadPool.TimeChangeChecker(100, absoluteMillis, relativeNanos);
 
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected warning for absolute clock",
                     ThreadPool.class.getName(),
                     Level.WARN,
@@ -155,7 +155,7 @@ public class ThreadPoolTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected warning for relative clock",
                     ThreadPool.class.getName(),
                     Level.WARN,
@@ -168,7 +168,7 @@ public class ThreadPoolTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected warning for absolute clock",
                     ThreadPool.class.getName(),
                     Level.WARN,
@@ -181,7 +181,7 @@ public class ThreadPoolTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected warning for relative clock",
                     ThreadPool.class.getName(),
                     Level.ERROR,
@@ -270,9 +270,9 @@ public class ThreadPoolTests extends ESTestCase {
             "test",
             Settings.builder().put(ThreadPool.SLOW_SCHEDULER_TASK_WARN_THRESHOLD_SETTING.getKey(), "10ms").build()
         );
-        try (var appender = MockLogAppender.capture(ThreadPool.class)) {
+        try (var appender = MockLog.capture(ThreadPool.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected warning for slow task",
                     ThreadPool.class.getName(),
                     Level.WARN,

--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -173,8 +173,8 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         final Releasable localConnectionRef = toClose.getAndSet(null);
         assertThat(localConnectionRef, notNullValue());
 
-        try (var appender = MockLog.capture(ClusterConnectionManager.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(ClusterConnectionManager.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "locally-triggered close message",
                     ClusterConnectionManager.class.getCanonicalName(),
@@ -182,7 +182,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                     "closing unused transport connection to [" + localClose + "]"
                 )
             );
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "remotely-triggered close message",
                     ClusterConnectionManager.class.getCanonicalName(),
@@ -190,7 +190,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                     "transport connection to [" + remoteClose.descriptionWithoutAttributes() + "] closed by remote"
                 )
             );
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "shutdown-triggered close message",
                     ClusterConnectionManager.class.getCanonicalName(),
@@ -203,7 +203,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
             connectionManager.disconnectFromNode(remoteClose);
             connectionManager.close();
 
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -173,9 +173,9 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         final Releasable localConnectionRef = toClose.getAndSet(null);
         assertThat(localConnectionRef, notNullValue());
 
-        try (var appender = MockLogAppender.capture(ClusterConnectionManager.class)) {
+        try (var appender = MockLog.capture(ClusterConnectionManager.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "locally-triggered close message",
                     ClusterConnectionManager.class.getCanonicalName(),
                     Level.DEBUG,
@@ -183,7 +183,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                 )
             );
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "remotely-triggered close message",
                     ClusterConnectionManager.class.getCanonicalName(),
                     Level.INFO,
@@ -191,7 +191,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                 )
             );
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "shutdown-triggered close message",
                     ClusterConnectionManager.class.getCanonicalName(),
                     Level.TRACE,

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -231,12 +231,7 @@ public class InboundHandlerTests extends ESTestCase {
 
         try (var mockLog = MockLog.capture(InboundHandler.class)) {
             mockLog.addExpectation(
-                new MockLog.SeenEventExpectation(
-                    "expected message",
-                    EXPECTED_LOGGER_NAME,
-                    Level.WARN,
-                    "error processing handshake version"
-                )
+                new MockLog.SeenEventExpectation("expected message", EXPECTED_LOGGER_NAME, Level.WARN, "error processing handshake version")
             );
 
             final AtomicBoolean isClosed = new AtomicBoolean();

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -229,8 +229,8 @@ public class InboundHandlerTests extends ESTestCase {
         // response so we must just close the connection on an error. To avoid the failure disappearing into a black hole we at least log
         // it.
 
-        try (var mockAppender = MockLog.capture(InboundHandler.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(InboundHandler.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "expected message",
                     EXPECTED_LOGGER_NAME,
@@ -260,7 +260,7 @@ public class InboundHandlerTests extends ESTestCase {
             handler.inboundMessage(channel, requestMessage);
             assertTrue(isClosed.get());
             assertNull(channel.getMessageCaptor().get());
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -273,10 +273,10 @@ public class InboundHandlerTests extends ESTestCase {
     public void testLogsSlowInboundProcessing() throws Exception {
 
         handler.setSlowLogThreshold(TimeValue.timeValueMillis(5L));
-        try (var mockAppender = MockLog.capture(InboundHandler.class)) {
+        try (var mockLog = MockLog.capture(InboundHandler.class)) {
             final TransportVersion remoteVersion = TransportVersion.current();
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation("expected slow request", EXPECTED_LOGGER_NAME, Level.WARN, "handling request ")
             );
 
@@ -301,9 +301,9 @@ public class InboundHandlerTests extends ESTestCase {
             requestHeader.headers = Tuple.tuple(Map.of(), Map.of());
             handler.inboundMessage(channel, requestMessage);
             // expect no response - channel just closed on exception
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation("expected slow response", EXPECTED_LOGGER_NAME, Level.WARN, "handling response ")
             );
 
@@ -324,7 +324,7 @@ public class InboundHandlerTests extends ESTestCase {
             });
             handler.inboundMessage(channel, new InboundMessage(responseHeader, ReleasableBytesReference.empty(), () -> {}));
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -31,7 +31,7 @@ import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -229,9 +229,9 @@ public class InboundHandlerTests extends ESTestCase {
         // response so we must just close the connection on an error. To avoid the failure disappearing into a black hole we at least log
         // it.
 
-        try (var mockAppender = MockLogAppender.capture(InboundHandler.class)) {
+        try (var mockAppender = MockLog.capture(InboundHandler.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected message",
                     EXPECTED_LOGGER_NAME,
                     Level.WARN,
@@ -273,11 +273,11 @@ public class InboundHandlerTests extends ESTestCase {
     public void testLogsSlowInboundProcessing() throws Exception {
 
         handler.setSlowLogThreshold(TimeValue.timeValueMillis(5L));
-        try (var mockAppender = MockLogAppender.capture(InboundHandler.class)) {
+        try (var mockAppender = MockLog.capture(InboundHandler.class)) {
             final TransportVersion remoteVersion = TransportVersion.current();
 
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation("expected slow request", EXPECTED_LOGGER_NAME, Level.WARN, "handling request ")
+                new MockLog.SeenEventExpectation("expected slow request", EXPECTED_LOGGER_NAME, Level.WARN, "handling request ")
             );
 
             final long requestId = randomNonNegativeLong();
@@ -304,7 +304,7 @@ public class InboundHandlerTests extends ESTestCase {
             mockAppender.assertAllExpectationsMatched();
 
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation("expected slow response", EXPECTED_LOGGER_NAME, Level.WARN, "handling response ")
+                new MockLog.SeenEventExpectation("expected slow response", EXPECTED_LOGGER_NAME, Level.WARN, "handling response ")
             );
 
             final long responseId = randomNonNegativeLong();

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -536,8 +536,8 @@ public class OutboundHandlerTests extends ESTestCase {
     public void testSlowLogOutboundMessage() throws Exception {
         handler.setSlowLogThreshold(TimeValue.timeValueMillis(5L));
 
-        try (var mockAppender = MockLog.capture(OutboundHandler.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(OutboundHandler.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation("expected message", EXPECTED_LOGGER_NAME, Level.WARN, "sending transport message ")
             );
 
@@ -555,7 +555,7 @@ public class OutboundHandlerTests extends ESTestCase {
                 }
             }, new BytesArray(randomByteArrayOfLength(length)), f);
             f.get();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -34,7 +34,7 @@ import org.elasticsearch.core.Streams;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -536,9 +536,9 @@ public class OutboundHandlerTests extends ESTestCase {
     public void testSlowLogOutboundMessage() throws Exception {
         handler.setSlowLogThreshold(TimeValue.timeValueMillis(5L));
 
-        try (var mockAppender = MockLogAppender.capture(OutboundHandler.class)) {
+        try (var mockAppender = MockLog.capture(OutboundHandler.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation("expected message", EXPECTED_LOGGER_NAME, Level.WARN, "sending transport message ")
+                new MockLog.SeenEventExpectation("expected message", EXPECTED_LOGGER_NAME, Level.WARN, "sending transport message ")
             );
 
             final int length = randomIntBetween(1, 100);

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -27,7 +27,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 
-import static org.elasticsearch.test.MockLogAppender.assertThatLogger;
+import static org.elasticsearch.test.MockLog.assertThatLogger;
 import static org.elasticsearch.test.NodeRoles.masterOnlyNode;
 import static org.elasticsearch.test.NodeRoles.nonMasterNode;
 import static org.elasticsearch.test.NodeRoles.onlyRoles;
@@ -1638,7 +1638,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
                     Settings.builder().putList("cluster.remote.remote_1.seeds", remote.getLocalDiscoNode().getAddress().toString()).build()
                 ),
                 RemoteClusterService.class,
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "Should log when connecting to remote",
                     RemoteClusterService.class.getCanonicalName(),
                     Level.INFO,
@@ -1649,7 +1649,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             assertThatLogger(
                 () -> clusterSettings.applySettings(Settings.EMPTY),
                 RemoteClusterService.class,
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "Should log when disconnecting from remote",
                     RemoteClusterService.class.getCanonicalName(),
                     Level.INFO,
@@ -1660,7 +1660,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
             assertThatLogger(
                 () -> clusterSettings.applySettings(Settings.builder().put(randomIdentifier(), randomIdentifier()).build()),
                 RemoteClusterService.class,
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "Should not log when changing unrelated setting",
                     RemoteClusterService.class.getCanonicalName(),
                     Level.INFO,

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -23,7 +23,7 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -420,15 +420,15 @@ public class TcpTransportTests extends ESTestCase {
             false,
             new ElasticsearchException("simulated"),
             true,
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.ERROR, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.WARN, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.INFO, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.DEBUG, "*")
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.ERROR, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.WARN, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.INFO, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.DEBUG, "*")
         );
 
         testExceptionHandling(
             new ElasticsearchException("simulated"),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "message",
                 "org.elasticsearch.transport.TcpTransport",
                 Level.WARN,
@@ -444,7 +444,7 @@ public class TcpTransportTests extends ESTestCase {
             "An existing connection was forcibly closed by remote host" }) {
             testExceptionHandling(
                 new ElasticsearchException(message),
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     message,
                     "org.elasticsearch.transport.TcpTransport",
                     Level.INFO,
@@ -460,14 +460,14 @@ public class TcpTransportTests extends ESTestCase {
             false,
             new ElasticsearchException("simulated"),
             true,
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.ERROR, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.WARN, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.INFO, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.DEBUG, "*")
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.ERROR, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.WARN, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.INFO, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.DEBUG, "*")
         );
         testExceptionHandling(
             new ElasticsearchException("simulated"),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "message",
                 "org.elasticsearch.transport.TcpTransport",
                 Level.WARN,
@@ -476,7 +476,7 @@ public class TcpTransportTests extends ESTestCase {
         );
         testExceptionHandling(
             new ClosedChannelException(),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "message",
                 "org.elasticsearch.transport.TcpTransport",
                 Level.DEBUG,
@@ -493,7 +493,7 @@ public class TcpTransportTests extends ESTestCase {
             "An existing connection was forcibly closed by remote host" }) {
             testExceptionHandling(
                 new ElasticsearchException(message),
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     message,
                     "org.elasticsearch.transport.TcpTransport",
                     Level.INFO,
@@ -506,7 +506,7 @@ public class TcpTransportTests extends ESTestCase {
         for (final String message : new String[] { "Socket is closed", "Socket closed", "SSLEngine closed already" }) {
             testExceptionHandling(
                 new ElasticsearchException(message),
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     message,
                     "org.elasticsearch.transport.TcpTransport",
                     Level.DEBUG,
@@ -517,7 +517,7 @@ public class TcpTransportTests extends ESTestCase {
 
         testExceptionHandling(
             new BindException(),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "message",
                 "org.elasticsearch.transport.TcpTransport",
                 Level.DEBUG,
@@ -526,7 +526,7 @@ public class TcpTransportTests extends ESTestCase {
         );
         testExceptionHandling(
             new CancelledKeyException(),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "message",
                 "org.elasticsearch.transport.TcpTransport",
                 Level.DEBUG,
@@ -537,14 +537,14 @@ public class TcpTransportTests extends ESTestCase {
             true,
             new TcpTransport.HttpRequestOnTransportException("test"),
             false,
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.ERROR, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.WARN, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.INFO, "*"),
-            new MockLogAppender.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.DEBUG, "*")
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.ERROR, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.WARN, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.INFO, "*"),
+            new MockLog.UnseenEventExpectation("message", "org.elasticsearch.transport.TcpTransport", Level.DEBUG, "*")
         );
         testExceptionHandling(
             new StreamCorruptedException("simulated"),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "message",
                 "org.elasticsearch.transport.TcpTransport",
                 Level.WARN,
@@ -553,7 +553,7 @@ public class TcpTransportTests extends ESTestCase {
         );
         testExceptionHandling(
             new TransportNotReadyException(),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "message",
                 "org.elasticsearch.transport.TcpTransport",
                 Level.DEBUG,
@@ -562,7 +562,7 @@ public class TcpTransportTests extends ESTestCase {
         );
     }
 
-    private void testExceptionHandling(Exception exception, MockLogAppender.LoggingExpectation... expectations)
+    private void testExceptionHandling(Exception exception, MockLog.LoggingExpectation... expectations)
         throws IllegalAccessException {
         testExceptionHandling(true, exception, true, expectations);
     }
@@ -571,11 +571,11 @@ public class TcpTransportTests extends ESTestCase {
         boolean startTransport,
         Exception exception,
         boolean expectClosed,
-        MockLogAppender.LoggingExpectation... expectations
+        MockLog.LoggingExpectation... expectations
     ) {
         final TestThreadPool testThreadPool = new TestThreadPool("test");
-        try (var appender = MockLogAppender.capture(TcpTransport.class)) {
-            for (MockLogAppender.LoggingExpectation expectation : expectations) {
+        try (var appender = MockLog.capture(TcpTransport.class)) {
+            for (MockLog.LoggingExpectation expectation : expectations) {
                 appender.addExpectation(expectation);
             }
 

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -562,8 +562,7 @@ public class TcpTransportTests extends ESTestCase {
         );
     }
 
-    private void testExceptionHandling(Exception exception, MockLog.LoggingExpectation... expectations)
-        throws IllegalAccessException {
+    private void testExceptionHandling(Exception exception, MockLog.LoggingExpectation... expectations) throws IllegalAccessException {
         testExceptionHandling(true, exception, true, expectations);
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TcpTransportTests.java
@@ -574,9 +574,9 @@ public class TcpTransportTests extends ESTestCase {
         MockLog.LoggingExpectation... expectations
     ) {
         final TestThreadPool testThreadPool = new TestThreadPool("test");
-        try (var appender = MockLog.capture(TcpTransport.class)) {
+        try (var mockLog = MockLog.capture(TcpTransport.class)) {
             for (MockLog.LoggingExpectation expectation : expectations) {
-                appender.addExpectation(expectation);
+                mockLog.addExpectation(expectation);
             }
 
             final Lifecycle lifecycle = new Lifecycle();
@@ -611,7 +611,7 @@ public class TcpTransportTests extends ESTestCase {
                 assertFalse(listener.isDone());
             }
 
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
         } finally {
             ThreadPool.terminate(testThreadPool, 30, TimeUnit.SECONDS);

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.io.IOException;
@@ -35,7 +35,7 @@ public class TransportLoggerTests extends ESTestCase {
             + ", header size: \\d+B"
             + ", action: cluster:monitor/stats]"
             + " WRITE: \\d+B";
-        final MockLogAppender.LoggingExpectation writeExpectation = new MockLogAppender.PatternSeenEventExpectation(
+        final MockLog.LoggingExpectation writeExpectation = new MockLog.PatternSeenEventExpectation(
             "hot threads request",
             TransportLogger.class.getCanonicalName(),
             Level.TRACE,
@@ -50,14 +50,14 @@ public class TransportLoggerTests extends ESTestCase {
             + ", action: cluster:monitor/stats]"
             + " READ: \\d+B";
 
-        final MockLogAppender.LoggingExpectation readExpectation = new MockLogAppender.PatternSeenEventExpectation(
+        final MockLog.LoggingExpectation readExpectation = new MockLog.PatternSeenEventExpectation(
             "cluster monitor request",
             TransportLogger.class.getCanonicalName(),
             Level.TRACE,
             readPattern
         );
 
-        try (var appender = MockLogAppender.capture(TransportLogger.class)) {
+        try (var appender = MockLog.capture(TransportLogger.class)) {
             appender.addExpectation(writeExpectation);
             appender.addExpectation(readExpectation);
             BytesReference bytesReference = buildRequest();

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -57,13 +57,13 @@ public class TransportLoggerTests extends ESTestCase {
             readPattern
         );
 
-        try (var appender = MockLog.capture(TransportLogger.class)) {
-            appender.addExpectation(writeExpectation);
-            appender.addExpectation(readExpectation);
+        try (var mockLog = MockLog.capture(TransportLogger.class)) {
+            mockLog.addExpectation(writeExpectation);
+            mockLog.addExpectation(readExpectation);
             BytesReference bytesReference = buildRequest();
             TransportLogger.logInboundMessage(mock(TcpChannel.class), bytesReference.slice(6, bytesReference.length() - 6));
             TransportLogger.logOutboundMessage(mock(TcpChannel.class), bytesReference);
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -260,7 +260,7 @@ public abstract class ESTestCase extends LuceneTestCase {
         // TODO: consolidate logging initialization for tests so it all occurs in logconfigurator
         LogConfigurator.loadLog4jPlugins();
         LogConfigurator.configureESLogging();
-        MockLogAppender.init();
+        MockLog.init();
 
         final List<Appender> testAppenders = new ArrayList<>(3);
         for (String leakLoggerName : Arrays.asList("io.netty.util.ResourceLeakDetector", LeakTracker.class.getName())) {

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLog.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLog.java
@@ -327,12 +327,12 @@ public class MockLog implements Releasable {
      * Executes an action and verifies expectations against the provided logger
      */
     public static void assertThatLogger(Runnable action, Class<?> loggerOwner, MockLog.LoggingExpectation... expectations) {
-        try (var mockAppender = MockLog.capture(loggerOwner)) {
+        try (var mockLog = MockLog.capture(loggerOwner)) {
             for (var expectation : expectations) {
-                mockAppender.addExpectation(expectation);
+                mockLog.addExpectation(expectation);
             }
             action.run();
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLog.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLog.java
@@ -31,10 +31,10 @@ import static org.hamcrest.Matchers.is;
 /**
  * Test appender that can be used to verify that certain events were logged correctly
  */
-public class MockLogAppender implements Releasable {
+public class MockLog implements Releasable {
 
-    private static final Map<String, List<MockLogAppender>> mockAppenders = new ConcurrentHashMap<>();
-    private static final RealMockAppender parent = new RealMockAppender();
+    private static final Map<String, List<MockLog>> mockLogs = new ConcurrentHashMap<>();
+    private static final MockAppender appender = new MockAppender();
     private final List<String> loggers;
     private final List<WrappedLoggingExpectation> expectations;
     private volatile boolean isAlive = true;
@@ -43,7 +43,7 @@ public class MockLogAppender implements Releasable {
     public void close() {
         isAlive = false;
         for (String logger : loggers) {
-            mockAppenders.compute(logger, (k, v) -> {
+            mockLogs.compute(logger, (k, v) -> {
                 assert v != null;
                 v.remove(this);
                 return v.isEmpty() ? null : v;
@@ -59,20 +59,20 @@ public class MockLogAppender implements Releasable {
         }
     }
 
-    private static class RealMockAppender extends AbstractAppender {
+    private static class MockAppender extends AbstractAppender {
 
-        RealMockAppender() {
+        MockAppender() {
             super("mock", null, null, false, Property.EMPTY_ARRAY);
         }
 
         @Override
         public void append(LogEvent event) {
-            List<MockLogAppender> appenders = mockAppenders.get(event.getLoggerName());
+            List<MockLog> appenders = mockLogs.get(event.getLoggerName());
             if (appenders == null) {
                 // check if there is a root appender
-                appenders = mockAppenders.getOrDefault("", List.of());
+                appenders = mockLogs.getOrDefault("", List.of());
             }
-            for (MockLogAppender appender : appenders) {
+            for (MockLog appender : appenders) {
                 if (appender.isAlive == false) {
                     continue;
                 }
@@ -83,7 +83,7 @@ public class MockLogAppender implements Releasable {
         }
     }
 
-    private MockLogAppender(List<String> loggers) {
+    private MockLog(List<String> loggers) {
         /*
          * We use a copy-on-write array list since log messages could be appended while we are setting up expectations. When that occurs,
          * we would run into a concurrent modification exception from the iteration over the expectations in #append, concurrent with a
@@ -97,8 +97,8 @@ public class MockLogAppender implements Releasable {
      * Initialize the mock log appender with the log4j system.
      */
     public static void init() {
-        parent.start();
-        Loggers.addAppender(LogManager.getLogger(""), parent);
+        appender.start();
+        Loggers.addAppender(LogManager.getLogger(""), appender);
     }
 
     public void addExpectation(LoggingExpectation expectation) {
@@ -290,34 +290,34 @@ public class MockLogAppender implements Releasable {
     }
 
     /**
-     * Adds the list of class loggers to this {@link MockLogAppender}.
+     * Adds the list of class loggers to this {@link MockLog}.
      *
-     * Stops and runs some checks on the {@link MockLogAppender} once the returned object is released.
+     * Stops and runs some checks on the {@link MockLog} once the returned object is released.
      */
-    public static MockLogAppender capture(Class<?>... classes) {
+    public static MockLog capture(Class<?>... classes) {
         return create(Arrays.stream(classes).map(Class::getCanonicalName).toList());
     }
 
     /**
      * Same as above except takes string class names of each logger.
      */
-    public static MockLogAppender capture(String... names) {
+    public static MockLog capture(String... names) {
         return create(Arrays.asList(names));
     }
 
-    private static MockLogAppender create(List<String> loggers) {
-        MockLogAppender appender = new MockLogAppender(loggers);
-        addToMockAppenders(appender, loggers);
+    private static MockLog create(List<String> loggers) {
+        MockLog appender = new MockLog(loggers);
+        addToMockLogs(appender, loggers);
         return appender;
     }
 
-    private static void addToMockAppenders(MockLogAppender appender, List<String> loggers) {
+    private static void addToMockLogs(MockLog mockLog, List<String> loggers) {
         for (String logger : loggers) {
-            mockAppenders.compute(logger, (k, v) -> {
+            mockLogs.compute(logger, (k, v) -> {
                 if (v == null) {
                     v = new CopyOnWriteArrayList<>();
                 }
-                v.add(appender);
+                v.add(mockLog);
                 return v;
             });
         }
@@ -326,8 +326,8 @@ public class MockLogAppender implements Releasable {
     /**
      * Executes an action and verifies expectations against the provided logger
      */
-    public static void assertThatLogger(Runnable action, Class<?> loggerOwner, MockLogAppender.LoggingExpectation... expectations) {
-        try (var mockAppender = MockLogAppender.capture(loggerOwner)) {
+    public static void assertThatLogger(Runnable action, Class<?> loggerOwner, MockLog.LoggingExpectation... expectations) {
+        try (var mockAppender = MockLog.capture(loggerOwner)) {
             for (var expectation : expectations) {
                 mockAppender.addExpectation(expectation);
             }

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -52,7 +52,7 @@ import org.elasticsearch.mocksocket.MockServerSocket;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -1319,7 +1319,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 .build()
         );
 
-        try (var appender = MockLogAppender.capture("org.elasticsearch.transport.TransportService.tracer")) {
+        try (var appender = MockLog.capture("org.elasticsearch.transport.TransportService.tracer")) {
 
             ////////////////////////////////////////////////////////////////////////
             // tests for included action type "internal:test"
@@ -1327,7 +1327,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             // serviceA logs the request was sent
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "sent request",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1336,7 +1336,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceB logs the request was received
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "received request",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1345,7 +1345,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceB logs the response was sent
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "sent response",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1354,7 +1354,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceA logs the response was received
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "received response",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1374,7 +1374,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             // serviceA logs the request was sent
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "sent request",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1383,7 +1383,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceB logs the request was received
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "received request",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1392,7 +1392,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceB logs the error response was sent
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "sent error response",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1401,7 +1401,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceA logs the error response was sent
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "received error response",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1421,7 +1421,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             // serviceA does not log that it sent the message
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "not seen request sent",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1430,7 +1430,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceB does log that it received the request
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "not seen request received",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1439,7 +1439,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceB does log that it sent the response
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "not seen request received",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,
@@ -1448,7 +1448,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             );
             // serviceA does not log that it received the response
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "not seen request sent",
                     "org.elasticsearch.transport.TransportService.tracer",
                     Level.TRACE,

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -1319,14 +1319,14 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 .build()
         );
 
-        try (var appender = MockLog.capture("org.elasticsearch.transport.TransportService.tracer")) {
+        try (var mockLog = MockLog.capture("org.elasticsearch.transport.TransportService.tracer")) {
 
             ////////////////////////////////////////////////////////////////////////
             // tests for included action type "internal:test"
             //
 
             // serviceA logs the request was sent
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "sent request",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1335,7 +1335,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceB logs the request was received
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "received request",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1344,7 +1344,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceB logs the response was sent
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "sent response",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1353,7 +1353,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceA logs the response was received
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "received response",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1364,7 +1364,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             serviceA.sendRequest(nodeB, "internal:test", new StringMessageRequest("", 10), noopResponseHandler);
 
-            assertBusy(appender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
 
             ////////////////////////////////////////////////////////////////////////
             // tests for included action type "internal:testError" which returns an error
@@ -1373,7 +1373,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             // appender down. The logging happens after messages are sent so might happen out of order.
 
             // serviceA logs the request was sent
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "sent request",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1382,7 +1382,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceB logs the request was received
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "received request",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1391,7 +1391,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceB logs the error response was sent
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "sent error response",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1400,7 +1400,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceA logs the error response was sent
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "received error response",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1411,7 +1411,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             serviceA.sendRequest(nodeB, "internal:testError", new StringMessageRequest(""), noopResponseHandler);
 
-            assertBusy(appender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
 
             ////////////////////////////////////////////////////////////////////////
             // tests for excluded action type "internal:testNotSeen"
@@ -1420,7 +1420,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             // The logging happens after messages are sent so might happen after the response future is completed.
 
             // serviceA does not log that it sent the message
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "not seen request sent",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1429,7 +1429,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceB does log that it received the request
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "not seen request received",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1438,7 +1438,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceB does log that it sent the response
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "not seen request received",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1447,7 +1447,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 )
             );
             // serviceA does not log that it received the response
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "not seen request sent",
                     "org.elasticsearch.transport.TransportService.tracer",
@@ -1458,7 +1458,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
             submitRequest(serviceA, nodeB, "internal:testNotSeen", new StringMessageRequest(""), noopResponseHandler).get();
 
-            assertBusy(appender::assertAllExpectationsMatched);
+            assertBusy(mockLog::assertAllExpectationsMatched);
         }
     }
 

--- a/test/framework/src/test/java/org/elasticsearch/test/MockLogTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/MockLogTests.java
@@ -26,7 +26,7 @@ public class MockLogTests extends ESTestCase {
         logThread.start();
 
         for (int i = 0; i < 1000; i++) {
-            try (var appender = MockLog.capture(MockLogTests.class)) {
+            try (var mockLog = MockLog.capture(MockLogTests.class)) {
                 Thread.yield();
             }
         }

--- a/test/framework/src/test/java/org/elasticsearch/test/MockLogTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/MockLogTests.java
@@ -13,10 +13,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class MockLogAppenderTests extends ESTestCase {
+public class MockLogTests extends ESTestCase {
 
     public void testConcurrentLogAndLifecycle() throws Exception {
-        Logger logger = LogManager.getLogger(MockLogAppenderTests.class);
+        Logger logger = LogManager.getLogger(MockLogTests.class);
         final var keepGoing = new AtomicBoolean(true);
         final var logThread = new Thread(() -> {
             while (keepGoing.get()) {
@@ -26,7 +26,7 @@ public class MockLogAppenderTests extends ESTestCase {
         logThread.start();
 
         for (int i = 0; i < 1000; i++) {
-            try (var appender = MockLogAppender.capture(MockLogAppenderTests.class)) {
+            try (var appender = MockLog.capture(MockLogTests.class)) {
                 Thread.yield();
             }
         }

--- a/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
+++ b/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
@@ -33,8 +33,8 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
     )
     @Override
     public void test() throws IOException {
-        try (var mockLogAppender = MockLog.capture(ESClientYamlSuiteTestCaseFailLogIT.class)) {
-            mockLogAppender.addExpectation(
+        try (var mockLog = MockLog.capture(ESClientYamlSuiteTestCaseFailLogIT.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "message with dump of the test yaml",
                     ESClientYamlSuiteTestCaseFailLogIT.class.getCanonicalName(),
@@ -43,7 +43,7 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
                 )
             );
 
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "message with stash dump of response",
                     ESClientYamlSuiteTestCaseFailLogIT.class.getCanonicalName(),
@@ -61,7 +61,7 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
                 }
             }
 
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 }

--- a/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
+++ b/test/yaml-rest-runner/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/ESClientYamlSuiteTestCaseFailLogIT.java
@@ -11,7 +11,7 @@ package org.elasticsearch.test.rest.yaml;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.logging.log4j.Level;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.io.IOException;
@@ -33,9 +33,9 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
     )
     @Override
     public void test() throws IOException {
-        try (var mockLogAppender = MockLogAppender.capture(ESClientYamlSuiteTestCaseFailLogIT.class)) {
+        try (var mockLogAppender = MockLog.capture(ESClientYamlSuiteTestCaseFailLogIT.class)) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "message with dump of the test yaml",
                     ESClientYamlSuiteTestCaseFailLogIT.class.getCanonicalName(),
                     Level.INFO,
@@ -44,7 +44,7 @@ public class ESClientYamlSuiteTestCaseFailLogIT extends ESClientYamlSuiteTestCas
             );
 
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "message with stash dump of response",
                     ESClientYamlSuiteTestCaseFailLogIT.class.getCanonicalName(),
                     Level.INFO,

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
@@ -47,8 +47,8 @@ public class TransportGetAutoscalingCapacityActionIT extends AutoscalingIntegTes
     }
 
     public void assertCurrentCapacity(long memory, long storage, int nodes) {
-        try (var appender = MockLog.capture(TransportGetAutoscalingCapacityAction.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(TransportGetAutoscalingCapacityAction.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "autoscaling capacity response message with " + storage,
                     TransportGetAutoscalingCapacityAction.class.getName(),
@@ -67,7 +67,7 @@ public class TransportGetAutoscalingCapacityActionIT extends AutoscalingIntegTes
             assertThat(currentCapacity.total().memory().getBytes(), Matchers.equalTo(memory * nodes));
             assertThat(currentCapacity.node().storage().getBytes(), Matchers.equalTo(storage));
             assertThat(currentCapacity.total().storage().getBytes(), Matchers.equalTo(storage * nodes));
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Level;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.monitor.os.OsProbe;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.autoscaling.AutoscalingIntegTestCase;
 import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingCapacity;
@@ -47,9 +47,9 @@ public class TransportGetAutoscalingCapacityActionIT extends AutoscalingIntegTes
     }
 
     public void assertCurrentCapacity(long memory, long storage, int nodes) {
-        try (var appender = MockLogAppender.capture(TransportGetAutoscalingCapacityAction.class)) {
+        try (var appender = MockLog.capture(TransportGetAutoscalingCapacityAction.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "autoscaling capacity response message with " + storage,
                     TransportGetAutoscalingCapacityAction.class.getName(),
                     Level.DEBUG,

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
@@ -19,7 +19,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.xpack.CcrSingleNodeTestCase;
 import org.elasticsearch.xpack.ccr.action.AutoFollowCoordinator;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
@@ -133,9 +133,9 @@ public class CcrLicenseIT extends CcrSingleNodeTestCase {
 
     public void testAutoFollowCoordinatorLogsSkippingAutoFollowCoordinationWithNonCompliantLicense() throws Exception {
         final Logger logger = LogManager.getLogger(AutoFollowCoordinator.class);
-        try (var appender = MockLogAppender.capture(AutoFollowCoordinator.class)) {
+        try (var appender = MockLog.capture(AutoFollowCoordinator.class)) {
             appender.addExpectation(
-                new MockLogAppender.ExceptionSeenEventExpectation(
+                new MockLog.ExceptionSeenEventExpectation(
                     getTestName(),
                     logger.getName(),
                     Level.WARN,

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrLicenseIT.java
@@ -133,8 +133,8 @@ public class CcrLicenseIT extends CcrSingleNodeTestCase {
 
     public void testAutoFollowCoordinatorLogsSkippingAutoFollowCoordinationWithNonCompliantLicense() throws Exception {
         final Logger logger = LogManager.getLogger(AutoFollowCoordinator.class);
-        try (var appender = MockLog.capture(AutoFollowCoordinator.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(AutoFollowCoordinator.class)) {
+            mockLog.addExpectation(
                 new MockLog.ExceptionSeenEventExpectation(
                     getTestName(),
                     logger.getName(),
@@ -195,7 +195,7 @@ public class CcrLicenseIT extends CcrSingleNodeTestCase {
                 }
             });
             latch.await();
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModelTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/mapper/expressiondsl/ExpressionModelTests.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.Message;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.FieldExpression.FieldValue;
 import org.junit.Before;
 
@@ -34,10 +34,10 @@ public class ExpressionModelTests extends ESTestCase {
         ExpressionModel model = new ExpressionModel();
         model.defineField("some_int", randomIntBetween(1, 99));
 
-        MockLogAppender.assertThatLogger(
+        MockLog.assertThatLogger(
             () -> assertThat(model.test("another_field", List.of(new FieldValue("bork"), new FieldValue("bork!"))), is(false)),
             ExpressionModel.class,
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "undefined field",
                 model.getClass().getName(),
                 Level.DEBUG,
@@ -51,7 +51,7 @@ public class ExpressionModelTests extends ESTestCase {
         ExpressionModel model = new ExpressionModel();
         model.defineField("some_int", randomIntBetween(1, 99));
 
-        MockLogAppender.assertThatLogger(
+        MockLog.assertThatLogger(
             () -> assertThat(model.test("another_field", List.of(new FieldValue(null))), is(true)),
             ExpressionModel.class,
             new NoMessagesExpectation()
@@ -62,14 +62,14 @@ public class ExpressionModelTests extends ESTestCase {
         ExpressionModel model = new ExpressionModel();
         model.defineField("some_int", randomIntBetween(1, 99));
 
-        MockLogAppender.assertThatLogger(
+        MockLog.assertThatLogger(
             () -> assertThat(model.test("some_int", List.of(new FieldValue(randomIntBetween(100, 200)))), is(false)),
             ExpressionModel.class,
             new NoMessagesExpectation()
         );
     }
 
-    private class NoMessagesExpectation implements MockLogAppender.LoggingExpectation {
+    private class NoMessagesExpectation implements MockLog.LoggingExpectation {
 
         private final List<Message> messages = new ArrayList<>();
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -42,7 +42,7 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -192,9 +192,9 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        try (var mockAppender = MockLogAppender.capture(cache.getClass())) {
+        try (var mockAppender = MockLog.capture(cache.getClass())) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "[bitset too big]",
                     cache.getClass().getName(),
                     Level.WARN,
@@ -229,9 +229,9 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        try (var mockAppender = MockLogAppender.capture(cache.getClass())) {
+        try (var mockAppender = MockLog.capture(cache.getClass())) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "[cache full]",
                     cache.getClass().getName(),
                     Level.INFO,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCacheTests.java
@@ -192,8 +192,8 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        try (var mockAppender = MockLog.capture(cache.getClass())) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(cache.getClass())) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "[bitset too big]",
                     cache.getClass().getName(),
@@ -215,7 +215,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
                 assertThat(bitSet.ramBytesUsed(), equalTo(EXPECTED_BYTES_PER_BIT_SET));
             });
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -229,8 +229,8 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
         assertThat(cache.entryCount(), equalTo(0));
         assertThat(cache.ramBytesUsed(), equalTo(0L));
 
-        try (var mockAppender = MockLog.capture(cache.getClass())) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(cache.getClass())) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "[cache full]",
                     cache.getClass().getName(),
@@ -250,7 +250,7 @@ public class DocumentSubsetBitsetCacheTests extends ESTestCase {
                 }
             });
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -18,7 +18,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -116,9 +116,9 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
 
         SetStepInfoUpdateTask task = new SetStepInfoUpdateTask(index, policy, currentStepKey, stepInfo);
 
-        try (var mockAppender = MockLogAppender.capture(SetStepInfoUpdateTask.class)) {
+        try (var mockAppender = MockLog.capture(SetStepInfoUpdateTask.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "warning",
                     SetStepInfoUpdateTask.class.getCanonicalName(),
                     Level.WARN,

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/SetStepInfoUpdateTaskTests.java
@@ -116,8 +116,8 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
 
         SetStepInfoUpdateTask task = new SetStepInfoUpdateTask(index, policy, currentStepKey, stepInfo);
 
-        try (var mockAppender = MockLog.capture(SetStepInfoUpdateTask.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(SetStepInfoUpdateTask.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "warning",
                     SetStepInfoUpdateTask.class.getCanonicalName(),
@@ -127,7 +127,7 @@ public class SetStepInfoUpdateTaskTests extends ESTestCase {
             );
 
             task.onFailure(new RuntimeException("test exception"));
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -28,7 +28,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -63,9 +63,9 @@ public class TransportGetPipelineActionTests extends ESTestCase {
             new MultiGetItemResponse[] { new MultiGetItemResponse(mockResponse, null), new MultiGetItemResponse(null, failure) }
         );
 
-        try (var threadPool = createThreadPool(); var mockLogAppender = MockLogAppender.capture(TransportGetPipelineAction.class)) {
+        try (var threadPool = createThreadPool(); var mockLogAppender = MockLog.capture(TransportGetPipelineAction.class)) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "message",
                     "org.elasticsearch.xpack.logstash.action.TransportGetPipelineAction",
                     Level.INFO,

--- a/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
+++ b/x-pack/plugin/logstash/src/test/java/org/elasticsearch/xpack/logstash/action/TransportGetPipelineActionTests.java
@@ -63,8 +63,8 @@ public class TransportGetPipelineActionTests extends ESTestCase {
             new MultiGetItemResponse[] { new MultiGetItemResponse(mockResponse, null), new MultiGetItemResponse(null, failure) }
         );
 
-        try (var threadPool = createThreadPool(); var mockLogAppender = MockLog.capture(TransportGetPipelineAction.class)) {
-            mockLogAppender.addExpectation(
+        try (var threadPool = createThreadPool(); var mockLog = MockLog.capture(TransportGetPipelineAction.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "message",
                     "org.elasticsearch.xpack.logstash.action.TransportGetPipelineAction",
@@ -86,7 +86,7 @@ public class TransportGetPipelineActionTests extends ESTestCase {
                     assertThat(getPipelineResponse.pipelines().size(), equalTo(1));
 
                     // check that failed pipeline get is logged
-                    mockLogAppender.assertAllExpectationsMatched();
+                    mockLog.assertAllExpectationsMatched();
                 }
 
                 @Override

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
@@ -110,30 +110,15 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.INFO,
             "test_throttling",
-            new MockLog.SeenEventExpectation(
-                "test1",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 1"
-            ),
+            new MockLog.SeenEventExpectation("test1", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 1"),
             new MockLog.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [5]"
             ),
-            new MockLog.SeenEventExpectation(
-                "test3",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 4"
-            ),
-            new MockLog.SeenEventExpectation(
-                "test4",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 5"
-            )
+            new MockLog.SeenEventExpectation("test3", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 4"),
+            new MockLog.SeenEventExpectation("test4", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 5")
         );
     }
 
@@ -154,30 +139,15 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.INFO,
             "test_throttling",
-            new MockLog.SeenEventExpectation(
-                "test1",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 1"
-            ),
+            new MockLog.SeenEventExpectation("test1", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 1"),
             new MockLog.UnseenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [1]"
             ),
-            new MockLog.SeenEventExpectation(
-                "test1",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 4"
-            ),
-            new MockLog.SeenEventExpectation(
-                "test2",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 5"
-            )
+            new MockLog.SeenEventExpectation("test1", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 4"),
+            new MockLog.SeenEventExpectation("test2", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 5")
         );
     }
 
@@ -204,42 +174,22 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.INFO,
             "test_throttling",
-            new MockLog.SeenEventExpectation(
-                "test1",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 1"
-            ),
+            new MockLog.SeenEventExpectation("test1", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 1"),
             new MockLog.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [2]"
             ),
-            new MockLog.SeenEventExpectation(
-                "test3",
-                CppLogMessageHandler.class.getName(),
-                Level.ERROR,
-                "[test_throttling] * message 3"
-            ),
+            new MockLog.SeenEventExpectation("test3", CppLogMessageHandler.class.getName(), Level.ERROR, "[test_throttling] * message 3"),
             new MockLog.SeenEventExpectation(
                 "test4",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [3]"
             ),
-            new MockLog.SeenEventExpectation(
-                "test5",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 4"
-            ),
-            new MockLog.SeenEventExpectation(
-                "test6",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 5"
-            )
+            new MockLog.SeenEventExpectation("test5", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 4"),
+            new MockLog.SeenEventExpectation("test6", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 5")
         );
     }
 
@@ -261,12 +211,7 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.INFO,
             "test_throttling",
-            new MockLog.SeenEventExpectation(
-                "test1",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 1"
-            ),
+            new MockLog.SeenEventExpectation("test1", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 1"),
             new MockLog.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
@@ -295,18 +240,8 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.DEBUG,
             "test_throttling",
-            new MockLog.SeenEventExpectation(
-                "test1",
-                CppLogMessageHandler.class.getName(),
-                Level.INFO,
-                "[test_throttling] * message 1"
-            ),
-            new MockLog.SeenEventExpectation(
-                "test2",
-                CppLogMessageHandler.class.getName(),
-                Level.DEBUG,
-                "[test_throttling] * message 6"
-            ),
+            new MockLog.SeenEventExpectation("test1", CppLogMessageHandler.class.getName(), Level.INFO, "[test_throttling] * message 1"),
+            new MockLog.SeenEventExpectation("test2", CppLogMessageHandler.class.getName(), Level.DEBUG, "[test_throttling] * message 6"),
             new MockLog.UnseenEventExpectation(
                 "test3",
                 CppLogMessageHandler.class.getName(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/logging/CppLogMessageHandlerTests.java
@@ -11,8 +11,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
-import org.elasticsearch.test.MockLogAppender.LoggingExpectation;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.MockLog.LoggingExpectation;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -110,25 +110,25 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.INFO,
             "test_throttling",
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [5]"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test3",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 4"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test4",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
@@ -154,25 +154,25 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.INFO,
             "test_throttling",
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
             ),
-            new MockLogAppender.UnseenEventExpectation(
+            new MockLog.UnseenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [1]"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 4"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
@@ -204,37 +204,37 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.INFO,
             "test_throttling",
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [2]"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test3",
                 CppLogMessageHandler.class.getName(),
                 Level.ERROR,
                 "[test_throttling] * message 3"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test4",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1 | repeated [3]"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test5",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 4"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test6",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
@@ -261,13 +261,13 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.INFO,
             "test_throttling",
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
@@ -295,19 +295,19 @@ public class CppLogMessageHandlerTests extends ESTestCase {
             is,
             Level.DEBUG,
             "test_throttling",
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test1",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
                 "[test_throttling] * message 1"
             ),
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "test2",
                 CppLogMessageHandler.class.getName(),
                 Level.DEBUG,
                 "[test_throttling] * message 6"
             ),
-            new MockLogAppender.UnseenEventExpectation(
+            new MockLog.UnseenEventExpectation(
                 "test3",
                 CppLogMessageHandler.class.getName(),
                 Level.INFO,
@@ -353,7 +353,7 @@ public class CppLogMessageHandlerTests extends ESTestCase {
         Logger cppMessageLogger = LogManager.getLogger(CppLogMessageHandler.class);
         Level oldLevel = cppMessageLogger.getLevel();
 
-        MockLogAppender.assertThatLogger(() -> {
+        MockLog.assertThatLogger(() -> {
             Loggers.setLevel(cppMessageLogger, level);
             try (CppLogMessageHandler handler = new CppLogMessageHandler(jobId, is)) {
                 handler.tailStream();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
@@ -64,8 +64,8 @@ public class SearchableSnapshotsRecoverFromSnapshotIntegTests extends BaseSearch
 
         final var newNode = internalCluster().startDataOnlyNode();
 
-        try (var mockAppender = MockLog.capture(ShardSnapshotsService.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(ShardSnapshotsService.class)) {
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "Error fetching segments file",
                     ShardSnapshotsService.class.getCanonicalName(),
@@ -81,7 +81,7 @@ public class SearchableSnapshotsRecoverFromSnapshotIntegTests extends BaseSearch
 
             assertHitCount(prepareSearch(restoredIndexName).setTrackTotalHits(true), totalHits.value);
 
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.indices.recovery.plan.ShardSnapshotsService;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.fs.FsRepository;
 import org.elasticsearch.search.SearchResponseUtils;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.xpack.core.searchablesnapshots.MountSearchableSnapshotRequest;
 
 import java.util.List;
@@ -64,9 +64,9 @@ public class SearchableSnapshotsRecoverFromSnapshotIntegTests extends BaseSearch
 
         final var newNode = internalCluster().startDataOnlyNode();
 
-        try (var mockAppender = MockLogAppender.capture(ShardSnapshotsService.class)) {
+        try (var mockAppender = MockLog.capture(ShardSnapshotsService.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "Error fetching segments file",
                     ShardSnapshotsService.class.getCanonicalName(),
                     Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -63,7 +63,7 @@ import org.elasticsearch.telemetry.TelemetryProvider;
 import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.test.rest.FakeRestRequest;
@@ -127,7 +127,7 @@ import java.util.stream.Collectors;
 import static java.util.Collections.emptyMap;
 import static org.elasticsearch.test.LambdaMatchers.falseWith;
 import static org.elasticsearch.test.LambdaMatchers.trueWith;
-import static org.elasticsearch.test.MockLogAppender.assertThatLogger;
+import static org.elasticsearch.test.MockLog.assertThatLogger;
 import static org.elasticsearch.xpack.core.security.authc.RealmSettings.getFullSettingKey;
 import static org.elasticsearch.xpack.security.operator.OperatorPrivileges.NOOP_OPERATOR_PRIVILEGES_SERVICE;
 import static org.elasticsearch.xpack.security.operator.OperatorPrivileges.OPERATOR_PRIVILEGES_ENABLED;
@@ -791,14 +791,14 @@ public class SecurityTests extends ESTestCase {
         SettingsModule settingsModule = new SettingsModule(Settings.EMPTY);
         ThreadPool threadPool = new TestThreadPool(getTestName());
 
-        try (var appender = MockLogAppender.capture(ActionModule.class)) {
+        try (var appender = MockLog.capture(ActionModule.class)) {
             UsageService usageService = new UsageService();
             Security security = new Security(settings);
 
             // Verify Security rest interceptor is about to be installed
             // We will throw later if another interceptor is already installed
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "Security rest interceptor",
                     ActionModule.class.getName(),
                     Level.DEBUG,
@@ -845,9 +845,9 @@ public class SecurityTests extends ESTestCase {
             settings.put("xpack.security.enabled", securityEnabled);
         }
 
-        try (var appender = MockLogAppender.capture(Security.class)) {
+        try (var appender = MockLog.capture(Security.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "message",
                     Security.class.getName(),
                     Level.INFO,
@@ -1130,8 +1130,8 @@ public class SecurityTests extends ESTestCase {
         );
     }
 
-    private MockLogAppender.SeenEventExpectation logEventForNonCompliantCacheHash(String settingKey) {
-        return new MockLogAppender.SeenEventExpectation(
+    private MockLog.SeenEventExpectation logEventForNonCompliantCacheHash(String settingKey) {
+        return new MockLog.SeenEventExpectation(
             "cache hash not fips compliant",
             Security.class.getName(),
             Level.WARN,
@@ -1142,8 +1142,8 @@ public class SecurityTests extends ESTestCase {
         );
     }
 
-    private MockLogAppender.SeenEventExpectation logEventForNonCompliantStoredHash(String settingKey) {
-        return new MockLogAppender.SeenEventExpectation(
+    private MockLog.SeenEventExpectation logEventForNonCompliantStoredHash(String settingKey) {
+        return new MockLog.SeenEventExpectation(
             "stored hash not fips compliant",
             Security.class.getName(),
             Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -791,13 +791,13 @@ public class SecurityTests extends ESTestCase {
         SettingsModule settingsModule = new SettingsModule(Settings.EMPTY);
         ThreadPool threadPool = new TestThreadPool(getTestName());
 
-        try (var appender = MockLog.capture(ActionModule.class)) {
+        try (var mockLog = MockLog.capture(ActionModule.class)) {
             UsageService usageService = new UsageService();
             Security security = new Security(settings);
 
             // Verify Security rest interceptor is about to be installed
             // We will throw later if another interceptor is already installed
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "Security rest interceptor",
                     ActionModule.class.getName(),
@@ -827,7 +827,7 @@ public class SecurityTests extends ESTestCase {
             );
             actionModule.initRestHandlers(null, null);
 
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             threadPool.shutdown();
         }
@@ -845,8 +845,8 @@ public class SecurityTests extends ESTestCase {
             settings.put("xpack.security.enabled", securityEnabled);
         }
 
-        try (var appender = MockLog.capture(Security.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(Security.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "message",
                     Security.class.getName(),
@@ -855,7 +855,7 @@ public class SecurityTests extends ESTestCase {
                 )
             );
             createComponents(settings.build());
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -11,7 +11,7 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
@@ -59,11 +59,11 @@ public class AuditTrailServiceTests extends ESTestCase {
     }
 
     public void testLogWhenLicenseProhibitsAuditing() throws Exception {
-        try (var mockLogAppender = MockLogAppender.capture(AuditTrailService.class)) {
+        try (var mockLogAppender = MockLog.capture(AuditTrailService.class)) {
             when(licenseState.getOperationMode()).thenReturn(randomFrom(License.OperationMode.values()));
             if (isAuditingAllowed) {
                 mockLogAppender.addExpectation(
-                    new MockLogAppender.UnseenEventExpectation(
+                    new MockLog.UnseenEventExpectation(
                         "audit disabled because of license",
                         AuditTrailService.class.getName(),
                         Level.WARN,
@@ -74,7 +74,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                 );
             } else {
                 mockLogAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "audit disabled because of license",
                         AuditTrailService.class.getName(),
                         Level.WARN,
@@ -93,10 +93,10 @@ public class AuditTrailServiceTests extends ESTestCase {
     }
 
     public void testNoLogRecentlyWhenLicenseProhibitsAuditing() throws Exception {
-        try (var mockLogAppender = MockLogAppender.capture(AuditTrailService.class)) {
+        try (var mockLogAppender = MockLog.capture(AuditTrailService.class)) {
             service.nextLogInstantAtomic.set(randomFrom(Instant.now().minus(Duration.ofMinutes(5)), Instant.now()));
             mockLogAppender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "audit disabled because of license",
                     AuditTrailService.class.getName(),
                     Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/AuditTrailServiceTests.java
@@ -59,10 +59,10 @@ public class AuditTrailServiceTests extends ESTestCase {
     }
 
     public void testLogWhenLicenseProhibitsAuditing() throws Exception {
-        try (var mockLogAppender = MockLog.capture(AuditTrailService.class)) {
+        try (var mockLog = MockLog.capture(AuditTrailService.class)) {
             when(licenseState.getOperationMode()).thenReturn(randomFrom(License.OperationMode.values()));
             if (isAuditingAllowed) {
-                mockLogAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.UnseenEventExpectation(
                         "audit disabled because of license",
                         AuditTrailService.class.getName(),
@@ -73,7 +73,7 @@ public class AuditTrailServiceTests extends ESTestCase {
                     )
                 );
             } else {
-                mockLogAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "audit disabled because of license",
                         AuditTrailService.class.getName(),
@@ -88,14 +88,14 @@ public class AuditTrailServiceTests extends ESTestCase {
                 service.get();
             }
 
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
     public void testNoLogRecentlyWhenLicenseProhibitsAuditing() throws Exception {
-        try (var mockLogAppender = MockLog.capture(AuditTrailService.class)) {
+        try (var mockLog = MockLog.capture(AuditTrailService.class)) {
             service.nextLogInstantAtomic.set(randomFrom(Instant.now().minus(Duration.ofMinutes(5)), Instant.now()));
-            mockLogAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.UnseenEventExpectation(
                     "audit disabled because of license",
                     AuditTrailService.class.getName(),
@@ -106,7 +106,7 @@ public class AuditTrailServiceTests extends ESTestCase {
             for (int i = 1; i <= randomIntBetween(2, 6); i++) {
                 service.get();
             }
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -65,7 +65,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.XContentTestUtils;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
@@ -1499,9 +1499,9 @@ public class ApiKeyServiceTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
 
-        try (var appender = MockLogAppender.capture(ApiKeyService.class)) {
+        try (var appender = MockLog.capture(ApiKeyService.class)) {
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "evict",
                     ApiKeyService.class.getName(),
                     Level.TRACE,
@@ -1509,7 +1509,7 @@ public class ApiKeyServiceTests extends ESTestCase {
                 )
             );
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "no-thrashing",
                     ApiKeyService.class.getName(),
                     Level.WARN,
@@ -1520,7 +1520,7 @@ public class ApiKeyServiceTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "replace",
                     ApiKeyService.class.getName(),
                     Level.TRACE,
@@ -1531,7 +1531,7 @@ public class ApiKeyServiceTests extends ESTestCase {
             appender.assertAllExpectationsMatched();
 
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "invalidate",
                     ApiKeyService.class.getName(),
                     Level.TRACE,
@@ -1559,9 +1559,9 @@ public class ApiKeyServiceTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
 
-        try (var appender = MockLogAppender.capture(ApiKeyService.class)) {
+        try (var appender = MockLog.capture(ApiKeyService.class)) {
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "evict",
                     ApiKeyService.class.getName(),
                     Level.TRACE,
@@ -1591,7 +1591,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(ApiKeyService.class);
         Loggers.setLevel(logger, Level.TRACE);
 
-        try (var appender = MockLogAppender.capture(ApiKeyService.class)) {
+        try (var appender = MockLog.capture(ApiKeyService.class)) {
             // Prepare the warning logging to trigger
             service.getEvictionCounter().add(4500);
             final long thrashingCheckIntervalInSeconds = 300L;
@@ -1604,7 +1604,7 @@ public class ApiKeyServiceTests extends ESTestCase {
             // Ensure the counter is updated
             assertBusy(() -> assertThat(service.getEvictionCounter().longValue() >= 4500, is(true)));
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "evict",
                     ApiKeyService.class.getName(),
                     Level.TRACE,
@@ -1612,7 +1612,7 @@ public class ApiKeyServiceTests extends ESTestCase {
                 )
             );
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "thrashing",
                     ApiKeyService.class.getName(),
                     Level.WARN,
@@ -1628,7 +1628,7 @@ public class ApiKeyServiceTests extends ESTestCase {
 
             // Will not log warning again for the next eviction because of throttling
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "evict-again",
                     ApiKeyService.class.getName(),
                     Level.TRACE,
@@ -1636,7 +1636,7 @@ public class ApiKeyServiceTests extends ESTestCase {
                 )
             );
             appender.addExpectation(
-                new MockLogAppender.UnseenEventExpectation(
+                new MockLog.UnseenEventExpectation(
                     "throttling",
                     ApiKeyService.class.getName(),
                     Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -417,8 +417,8 @@ public class AuthenticationServiceTests extends ESTestCase {
     }
 
     public void testTokenMissing() throws Exception {
-        try (var mockAppender = MockLog.capture(RealmsAuthenticator.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(RealmsAuthenticator.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "unlicensed realms",
                     RealmsAuthenticator.class.getName(),
@@ -454,7 +454,7 @@ public class AuthenticationServiceTests extends ESTestCase {
                     verify(auditTrail).anonymousAccessDenied(reqId.get(), "_action", transportRequest);
                 }
                 verifyNoMoreInteractions(auditTrail);
-                mockAppender.assertAllExpectationsMatched();
+                mockLog.assertAllExpectationsMatched();
                 setCompletedToTrue(completed);
             });
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticationServiceTests.java
@@ -53,7 +53,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.threadpool.FixedExecutorBuilder;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -417,9 +417,9 @@ public class AuthenticationServiceTests extends ESTestCase {
     }
 
     public void testTokenMissing() throws Exception {
-        try (var mockAppender = MockLogAppender.capture(RealmsAuthenticator.class)) {
+        try (var mockAppender = MockLog.capture(RealmsAuthenticator.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "unlicensed realms",
                     RealmsAuthenticator.class.getName(),
                     Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.xpack.core.security.action.apikey.ApiKey;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
@@ -481,9 +481,9 @@ public class AuthenticatorChainTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(AuthenticatorChain.class);
         Loggers.setLevel(logger, Level.INFO);
 
-        try (var appender = MockLogAppender.capture(AuthenticatorChain.class)) {
+        try (var appender = MockLog.capture(AuthenticatorChain.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "run-as",
                     AuthenticatorChain.class.getName(),
                     Level.INFO,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/AuthenticatorChainTests.java
@@ -481,8 +481,8 @@ public class AuthenticatorChainTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(AuthenticatorChain.class);
         Loggers.setLevel(logger, Level.INFO);
 
-        try (var appender = MockLog.capture(AuthenticatorChain.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(AuthenticatorChain.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "run-as",
                     AuthenticatorChain.class.getName(),
@@ -493,7 +493,7 @@ public class AuthenticatorChainTests extends ESTestCase {
             final PlainActionFuture<Authentication> future = new PlainActionFuture<>();
             authenticatorChain.maybeLookupRunAsUser(context, authentication, future);
             assertThat(future.actionGet(), equalTo(authentication));
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             Loggers.setLevel(logger, Level.INFO);
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -205,8 +205,8 @@ public class RealmsAuthenticatorTests extends AbstractAuthenticatorTests {
         final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
         when(request.authenticationFailed(authenticationToken)).thenReturn(e);
 
-        try (var mockAppender = MockLog.capture(RealmsAuthenticator.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(RealmsAuthenticator.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "unlicensed realms",
                     RealmsAuthenticator.class.getName(),
@@ -218,7 +218,7 @@ public class RealmsAuthenticatorTests extends AbstractAuthenticatorTests {
             final PlainActionFuture<AuthenticationResult<Authentication>> future = new PlainActionFuture<>();
             realmsAuthenticator.authenticate(context, future);
             assertThat(expectThrows(ElasticsearchSecurityException.class, future::actionGet), is(e));
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsAuthenticatorTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.telemetry.TestTelemetryPlugin;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationServiceField;
@@ -205,9 +205,9 @@ public class RealmsAuthenticatorTests extends AbstractAuthenticatorTests {
         final ElasticsearchSecurityException e = new ElasticsearchSecurityException("fail");
         when(request.authenticationFailed(authenticationToken)).thenReturn(e);
 
-        try (var mockAppender = MockLogAppender.capture(RealmsAuthenticator.class)) {
+        try (var mockAppender = MockLog.capture(RealmsAuthenticator.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "unlicensed realms",
                     RealmsAuthenticator.class.getName(),
                     Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -937,9 +937,9 @@ public class RealmsTests extends ESTestCase {
         final Logger realmsLogger = LogManager.getLogger(Realms.class);
 
         when(licenseState.statusDescription()).thenReturn("mock license");
-        try (var appender = MockLog.capture(Realms.class)) {
+        try (var mockLog = MockLog.capture(Realms.class)) {
             for (String realmId : List.of("kerberos.kerberos_realm", "type_0.custom_realm_1", "type_1.custom_realm_2")) {
-                appender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "Realm [" + realmId + "] disabled",
                         realmsLogger.getName(),
@@ -949,7 +949,7 @@ public class RealmsTests extends ESTestCase {
                 );
             }
             allowOnlyStandardRealms();
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
 
         final List<String> unlicensedRealmNames = realms.getUnlicensedRealms().stream().map(r -> r.name()).collect(Collectors.toList());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RealmsTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -937,10 +937,10 @@ public class RealmsTests extends ESTestCase {
         final Logger realmsLogger = LogManager.getLogger(Realms.class);
 
         when(licenseState.statusDescription()).thenReturn("mock license");
-        try (var appender = MockLogAppender.capture(Realms.class)) {
+        try (var appender = MockLog.capture(Realms.class)) {
             for (String realmId : List.of("kerberos.kerberos_realm", "type_0.custom_realm_1", "type_1.custom_realm_2")) {
                 appender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "Realm [" + realmId + "] disabled",
                         realmsLogger.getName(),
                         Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
@@ -77,7 +77,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.mocksocket.MockHttpServer;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TestMatchers;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.oidc.OpenIdConnectRealmSettings;
@@ -996,12 +996,12 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
         final Nonce expectedNonce = new Nonce(randomAlphaOfLength(10));
 
-        try (var appender = MockLogAppender.capture(OpenIdConnectAuthenticator.class)) {
+        try (var appender = MockLog.capture(OpenIdConnectAuthenticator.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation("JWT header", logger.getName(), Level.DEBUG, "ID Token Header: " + headerString)
+                new MockLog.SeenEventExpectation("JWT header", logger.getName(), Level.DEBUG, "ID Token Header: " + headerString)
             );
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "JWT exception",
                     logger.getName(),
                     Level.DEBUG,
@@ -1059,9 +1059,9 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
         final Logger logger = LogManager.getLogger(PoolingNHttpClientConnectionManager.class);
         // Note: Setting an org.apache.http logger to DEBUG requires es.insecure_network_trace_enabled=true
         Loggers.setLevel(logger, Level.DEBUG);
-        try (var appender = MockLogAppender.capture(PoolingNHttpClientConnectionManager.class)) {
+        try (var appender = MockLog.capture(PoolingNHttpClientConnectionManager.class)) {
             appender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "log",
                     logger.getName(),
                     Level.DEBUG,
@@ -1201,9 +1201,9 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
         final Logger logger = LogManager.getLogger(OpenIdConnectAuthenticator.class);
         Loggers.setLevel(logger, Level.DEBUG);
-        try (var appender = MockLogAppender.capture(OpenIdConnectAuthenticator.class)) {
+        try (var appender = MockLog.capture(OpenIdConnectAuthenticator.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "log",
                     logger.getName(),
                     Level.DEBUG,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/oidc/OpenIdConnectAuthenticatorTests.java
@@ -996,11 +996,11 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
         final Nonce expectedNonce = new Nonce(randomAlphaOfLength(10));
 
-        try (var appender = MockLog.capture(OpenIdConnectAuthenticator.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(OpenIdConnectAuthenticator.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation("JWT header", logger.getName(), Level.DEBUG, "ID Token Header: " + headerString)
             );
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "JWT exception",
                     logger.getName(),
@@ -1013,7 +1013,7 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
             final ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
             assertThat(e.getCause(), is(joseException));
             // The logging message assertion is the only thing we actually care in this test
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             Loggers.setLevel(logger, (Level) null);
             openIdConnectAuthenticator.close();
@@ -1059,8 +1059,8 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
         final Logger logger = LogManager.getLogger(PoolingNHttpClientConnectionManager.class);
         // Note: Setting an org.apache.http logger to DEBUG requires es.insecure_network_trace_enabled=true
         Loggers.setLevel(logger, Level.DEBUG);
-        try (var appender = MockLog.capture(PoolingNHttpClientConnectionManager.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(PoolingNHttpClientConnectionManager.class)) {
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "log",
                     logger.getName(),
@@ -1090,7 +1090,7 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
                 latch.await();
                 Thread.sleep(1500);
             }
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
             assertThat(portTested.get(), is(true));
         } finally {
             Loggers.setLevel(logger, (Level) null);
@@ -1201,8 +1201,8 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
 
         final Logger logger = LogManager.getLogger(OpenIdConnectAuthenticator.class);
         Loggers.setLevel(logger, Level.DEBUG);
-        try (var appender = MockLog.capture(OpenIdConnectAuthenticator.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(OpenIdConnectAuthenticator.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "log",
                     logger.getName(),
@@ -1212,7 +1212,7 @@ public class OpenIdConnectAuthenticatorTests extends OpenIdConnectTestCase {
             );
             final ConnectionKeepAliveStrategy keepAliveStrategy = authenticator.getKeepAliveStrategy();
             assertThat(keepAliveStrategy.getKeepAliveDuration(httpResponse, null), equalTo(effectiveTtlInMs));
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             Loggers.setLevel(logger, (Level) null);
             authenticator.close();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
@@ -13,7 +13,7 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.common.util.NamedFormatter;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.xpack.core.watcher.watch.ClockMock;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -215,9 +215,9 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             .add(getAttribute(attributeName, attributeFriendlyName, null, List.of("daredevil")));
         SamlToken token = token(signResponse(response));
 
-        try (var mockAppender = MockLogAppender.capture(authenticator.getClass())) {
+        try (var mockAppender = MockLog.capture(authenticator.getClass())) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "attribute name warning",
                     authenticator.getClass().getName(),
                     Level.WARN,
@@ -239,7 +239,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         assertion.getAttributeStatements().get(0).getAttributes().add(getAttribute(UID_OID, "friendly", null, List.of("daredevil")));
         SamlToken token = token(signResponse(response));
 
-        try (var mockAppender = MockLogAppender.capture(authenticator.getClass())) {
+        try (var mockAppender = MockLog.capture(authenticator.getClass())) {
             final SamlAttributes attributes = authenticator.authenticate(token);
             assertThat(attributes, notNullValue());
             mockAppender.assertAllExpectationsMatched();
@@ -259,9 +259,9 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         SamlToken token = token(signResponse(response));
 
         final Logger samlLogger = LogManager.getLogger(authenticator.getClass());
-        try (var mockAppender = MockLogAppender.capture(authenticator.getClass())) {
+        try (var mockAppender = MockLog.capture(authenticator.getClass())) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "attribute name warning",
                     authenticator.getClass().getName(),
                     Level.WARN,
@@ -269,7 +269,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "attribute friendly name warning",
                     authenticator.getClass().getName(),
                     Level.WARN,
@@ -863,9 +863,9 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         String xml = SamlUtils.getXmlContent(response, false);
         final SamlToken token = token(signResponse(xml));
 
-        try (var mockAppender = MockLogAppender.capture(authenticator.getClass())) {
+        try (var mockAppender = MockLog.capture(authenticator.getClass())) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "similar audience",
                     authenticator.getClass().getName(),
                     Level.INFO,
@@ -879,7 +879,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
                 )
             );
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "not similar audience",
                     authenticator.getClass().getName(),
                     Level.INFO,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlAuthenticatorTests.java
@@ -215,8 +215,8 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             .add(getAttribute(attributeName, attributeFriendlyName, null, List.of("daredevil")));
         SamlToken token = token(signResponse(response));
 
-        try (var mockAppender = MockLog.capture(authenticator.getClass())) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(authenticator.getClass())) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "attribute name warning",
                     authenticator.getClass().getName(),
@@ -226,7 +226,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             );
             final SamlAttributes attributes = authenticator.authenticate(token);
             assertThat(attributes, notNullValue());
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -239,10 +239,10 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         assertion.getAttributeStatements().get(0).getAttributes().add(getAttribute(UID_OID, "friendly", null, List.of("daredevil")));
         SamlToken token = token(signResponse(response));
 
-        try (var mockAppender = MockLog.capture(authenticator.getClass())) {
+        try (var mockLog = MockLog.capture(authenticator.getClass())) {
             final SamlAttributes attributes = authenticator.authenticate(token);
             assertThat(attributes, notNullValue());
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -259,8 +259,8 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         SamlToken token = token(signResponse(response));
 
         final Logger samlLogger = LogManager.getLogger(authenticator.getClass());
-        try (var mockAppender = MockLog.capture(authenticator.getClass())) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(authenticator.getClass())) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "attribute name warning",
                     authenticator.getClass().getName(),
@@ -268,7 +268,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
                     SPECIAL_ATTRIBUTE_LOG_MESSAGE
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "attribute friendly name warning",
                     authenticator.getClass().getName(),
@@ -278,7 +278,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             );
             final SamlAttributes attributes = authenticator.authenticate(token);
             assertThat(attributes, notNullValue());
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 
@@ -863,8 +863,8 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
         String xml = SamlUtils.getXmlContent(response, false);
         final SamlToken token = token(signResponse(xml));
 
-        try (var mockAppender = MockLog.capture(authenticator.getClass())) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(authenticator.getClass())) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "similar audience",
                     authenticator.getClass().getName(),
@@ -878,7 +878,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
                         + "] [:80/] vs [/])"
                 )
             );
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "not similar audience",
                     authenticator.getClass().getName(),
@@ -888,7 +888,7 @@ public class SamlAuthenticatorTests extends SamlResponseHandlerTests {
             );
             final ElasticsearchSecurityException exception = expectSamlException(() -> authenticator.authenticate(token));
             assertThat(exception.getMessage(), containsString("required audience"));
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -111,10 +111,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
         final Logger sasLogger = LogManager.getLogger(ServiceAccountService.class);
         Loggers.setLevel(sasLogger, Level.TRACE);
 
-        try (
-                var satMockLog = MockLog.capture(ServiceAccountToken.class);
-                var sasMockLog = MockLog.capture(ServiceAccountService.class)
-        ) {
+        try (var satMockLog = MockLog.capture(ServiceAccountToken.class); var sasMockLog = MockLog.capture(ServiceAccountService.class)) {
             // Less than 4 bytes
             satMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -112,11 +112,11 @@ public class ServiceAccountServiceTests extends ESTestCase {
         Loggers.setLevel(sasLogger, Level.TRACE);
 
         try (
-                var satAppender = MockLog.capture(ServiceAccountToken.class);
-                var sasAppender = MockLog.capture(ServiceAccountService.class)
+                var satMockLog = MockLog.capture(ServiceAccountToken.class);
+                var sasMockLog = MockLog.capture(ServiceAccountService.class)
         ) {
             // Less than 4 bytes
-            satAppender.addExpectation(
+            satMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "less than 4 bytes",
                     ServiceAccountToken.class.getName(),
@@ -126,10 +126,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
             );
             final SecureString bearerString0 = createBearerString(List.of(Arrays.copyOfRange(magicBytes, 0, randomIntBetween(0, 3))));
             assertNull(ServiceAccountService.tryParseToken(bearerString0));
-            satAppender.assertAllExpectationsMatched();
+            satMockLog.assertAllExpectationsMatched();
 
             // Prefix mismatch
-            satAppender.addExpectation(
+            satMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "prefix mismatch",
                     ServiceAccountToken.class.getName(),
@@ -144,10 +144,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 )
             );
             assertNull(ServiceAccountService.tryParseToken(bearerString1));
-            satAppender.assertAllExpectationsMatched();
+            satMockLog.assertAllExpectationsMatched();
 
             // No colon
-            satAppender.addExpectation(
+            satMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "no colon",
                     ServiceAccountToken.class.getName(),
@@ -159,10 +159,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 List.of(magicBytes, randomAlphaOfLengthBetween(30, 50).getBytes(StandardCharsets.UTF_8))
             );
             assertNull(ServiceAccountService.tryParseToken(bearerString2));
-            satAppender.assertAllExpectationsMatched();
+            satMockLog.assertAllExpectationsMatched();
 
             // Invalid delimiter for qualified name
-            satAppender.addExpectation(
+            satMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "invalid delimiter for qualified name",
                     ServiceAccountToken.class.getName(),
@@ -191,10 +191,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 );
                 assertNull(ServiceAccountService.tryParseToken(bearerString3));
             }
-            satAppender.assertAllExpectationsMatched();
+            satMockLog.assertAllExpectationsMatched();
 
             // Invalid token name
-            sasAppender.addExpectation(
+            sasMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "invalid token name",
                     ServiceAccountService.class.getName(),
@@ -215,7 +215,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 )
             );
             assertNull(ServiceAccountService.tryParseToken(bearerString4));
-            sasAppender.assertAllExpectationsMatched();
+            sasMockLog.assertAllExpectationsMatched();
 
             // Everything is good
             final String namespace = randomAlphaOfLengthBetween(3, 8);
@@ -239,7 +239,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertThat(parsedToken, equalTo(serviceAccountToken2));
 
             // Invalid magic byte
-            satAppender.addExpectation(
+            satMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "invalid magic byte again",
                     ServiceAccountToken.class.getName(),
@@ -250,10 +250,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertNull(
                 ServiceAccountService.tryParseToken(new SecureString("AQEAAWVsYXN0aWMvZmxlZXQvdG9rZW4xOnN1cGVyc2VjcmV0".toCharArray()))
             );
-            satAppender.assertAllExpectationsMatched();
+            satMockLog.assertAllExpectationsMatched();
 
             // No colon
-            satAppender.addExpectation(
+            satMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "no colon again",
                     ServiceAccountToken.class.getName(),
@@ -264,10 +264,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertNull(
                 ServiceAccountService.tryParseToken(new SecureString("AAEAAWVsYXN0aWMvZmxlZXQvdG9rZW4xX3N1cGVyc2VjcmV0".toCharArray()))
             );
-            satAppender.assertAllExpectationsMatched();
+            satMockLog.assertAllExpectationsMatched();
 
             // Invalid qualified name
-            satAppender.addExpectation(
+            satMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "invalid delimiter for qualified name again",
                     ServiceAccountToken.class.getName(),
@@ -278,10 +278,10 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertNull(
                 ServiceAccountService.tryParseToken(new SecureString("AAEAAWVsYXN0aWMvZmxlZXRfdG9rZW4xOnN1cGVyc2VjcmV0".toCharArray()))
             );
-            satAppender.assertAllExpectationsMatched();
+            satMockLog.assertAllExpectationsMatched();
 
             // Invalid token name
-            sasAppender.addExpectation(
+            sasMockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "invalid token name again",
                     ServiceAccountService.class.getName(),
@@ -292,7 +292,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             assertNull(
                 ServiceAccountService.tryParseToken(new SecureString("AAEAAWVsYXN0aWMvZmxlZXQvdG9rZW4hOnN1cGVyc2VjcmV0".toCharArray()))
             );
-            sasAppender.assertAllExpectationsMatched();
+            sasMockLog.assertAllExpectationsMatched();
 
             // everything is fine
             assertThat(
@@ -363,13 +363,13 @@ public class ServiceAccountServiceTests extends ESTestCase {
         final Logger sasLogger = LogManager.getLogger(ServiceAccountService.class);
         Loggers.setLevel(sasLogger, Level.TRACE);
 
-        try (var appender = MockLog.capture(ServiceAccountService.class)) {
+        try (var mockLog = MockLog.capture(ServiceAccountService.class)) {
             // non-elastic service account
             final ServiceAccountId accountId1 = new ServiceAccountId(
                 randomValueOtherThan(ElasticServiceAccounts.NAMESPACE, () -> randomAlphaOfLengthBetween(3, 8)),
                 randomAlphaOfLengthBetween(3, 8)
             );
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "non-elastic service account",
                     ServiceAccountService.class.getName(),
@@ -393,14 +393,14 @@ public class ServiceAccountServiceTests extends ESTestCase {
                         + "]"
                 )
             );
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // Unknown elastic service name
             final ServiceAccountId accountId2 = new ServiceAccountId(
                 ElasticServiceAccounts.NAMESPACE,
                 randomValueOtherThan("fleet-server", () -> randomAlphaOfLengthBetween(3, 8))
             );
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "unknown elastic service name",
                     ServiceAccountService.class.getName(),
@@ -423,13 +423,13 @@ public class ServiceAccountServiceTests extends ESTestCase {
                         + "]"
                 )
             );
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // Length of secret value is too short
             final ServiceAccountId accountId3 = new ServiceAccountId(ElasticServiceAccounts.NAMESPACE, "fleet-server");
             final SecureString secret3 = new SecureString(randomAlphaOfLengthBetween(1, 9).toCharArray());
             final ServiceAccountToken token3 = new ServiceAccountToken(accountId3, randomAlphaOfLengthBetween(3, 8), secret3);
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "secret value too short",
                     ServiceAccountService.class.getName(),
@@ -453,7 +453,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                         + "]"
                 )
             );
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             final TokenInfo.TokenSource tokenSource = randomFrom(TokenInfo.TokenSource.values());
             final CachingServiceAccountTokenStore store;
@@ -520,7 +520,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 )
             );
 
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "invalid credential",
                     ServiceAccountService.class.getName(),
@@ -546,7 +546,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                         + "]"
                 )
             );
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             Loggers.setLevel(sasLogger, Level.INFO);
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountServiceTests.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.security.action.service.CreateServiceAccountTokenRequest;
@@ -112,12 +112,12 @@ public class ServiceAccountServiceTests extends ESTestCase {
         Loggers.setLevel(sasLogger, Level.TRACE);
 
         try (
-            var satAppender = MockLogAppender.capture(ServiceAccountToken.class);
-            var sasAppender = MockLogAppender.capture(ServiceAccountService.class)
+                var satAppender = MockLog.capture(ServiceAccountToken.class);
+                var sasAppender = MockLog.capture(ServiceAccountService.class)
         ) {
             // Less than 4 bytes
             satAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "less than 4 bytes",
                     ServiceAccountToken.class.getName(),
                     Level.TRACE,
@@ -130,7 +130,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
             // Prefix mismatch
             satAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "prefix mismatch",
                     ServiceAccountToken.class.getName(),
                     Level.TRACE,
@@ -148,7 +148,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
             // No colon
             satAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "no colon",
                     ServiceAccountToken.class.getName(),
                     Level.TRACE,
@@ -163,7 +163,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
             // Invalid delimiter for qualified name
             satAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "invalid delimiter for qualified name",
                     ServiceAccountToken.class.getName(),
                     Level.TRACE,
@@ -195,7 +195,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
             // Invalid token name
             sasAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "invalid token name",
                     ServiceAccountService.class.getName(),
                     Level.TRACE,
@@ -240,7 +240,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
             // Invalid magic byte
             satAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "invalid magic byte again",
                     ServiceAccountToken.class.getName(),
                     Level.TRACE,
@@ -254,7 +254,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
             // No colon
             satAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "no colon again",
                     ServiceAccountToken.class.getName(),
                     Level.TRACE,
@@ -268,7 +268,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
             // Invalid qualified name
             satAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "invalid delimiter for qualified name again",
                     ServiceAccountToken.class.getName(),
                     Level.TRACE,
@@ -282,7 +282,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
 
             // Invalid token name
             sasAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "invalid token name again",
                     ServiceAccountService.class.getName(),
                     Level.TRACE,
@@ -363,14 +363,14 @@ public class ServiceAccountServiceTests extends ESTestCase {
         final Logger sasLogger = LogManager.getLogger(ServiceAccountService.class);
         Loggers.setLevel(sasLogger, Level.TRACE);
 
-        try (var appender = MockLogAppender.capture(ServiceAccountService.class)) {
+        try (var appender = MockLog.capture(ServiceAccountService.class)) {
             // non-elastic service account
             final ServiceAccountId accountId1 = new ServiceAccountId(
                 randomValueOtherThan(ElasticServiceAccounts.NAMESPACE, () -> randomAlphaOfLengthBetween(3, 8)),
                 randomAlphaOfLengthBetween(3, 8)
             );
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "non-elastic service account",
                     ServiceAccountService.class.getName(),
                     Level.DEBUG,
@@ -401,7 +401,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
                 randomValueOtherThan("fleet-server", () -> randomAlphaOfLengthBetween(3, 8))
             );
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "unknown elastic service name",
                     ServiceAccountService.class.getName(),
                     Level.DEBUG,
@@ -430,7 +430,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             final SecureString secret3 = new SecureString(randomAlphaOfLengthBetween(1, 9).toCharArray());
             final ServiceAccountToken token3 = new ServiceAccountToken(accountId3, randomAlphaOfLengthBetween(3, 8), secret3);
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "secret value too short",
                     ServiceAccountService.class.getName(),
                     Level.DEBUG,
@@ -521,7 +521,7 @@ public class ServiceAccountServiceTests extends ESTestCase {
             );
 
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "invalid credential",
                     ServiceAccountService.class.getName(),
                     Level.DEBUG,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/LoadAuthorizedIndicesTimeCheckerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/LoadAuthorizedIndicesTimeCheckerTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
 import org.elasticsearch.xpack.core.security.authz.AuthorizationEngine;
@@ -130,7 +130,7 @@ public class LoadAuthorizedIndicesTimeCheckerTests extends ESTestCase {
         );
         final int elapsedMs = warnMs + randomIntBetween(1, 100);
 
-        final MockLogAppender.PatternSeenEventExpectation expectation = new MockLogAppender.PatternSeenEventExpectation(
+        final MockLog.PatternSeenEventExpectation expectation = new MockLog.PatternSeenEventExpectation(
             "WARN-Slow Index Resolution",
             timerLogger.getName(),
             Level.WARN,
@@ -156,7 +156,7 @@ public class LoadAuthorizedIndicesTimeCheckerTests extends ESTestCase {
         );
         final int elapsedMs = infoMs + randomIntBetween(1, 100);
 
-        final MockLogAppender.PatternSeenEventExpectation expectation = new MockLogAppender.PatternSeenEventExpectation(
+        final MockLog.PatternSeenEventExpectation expectation = new MockLog.PatternSeenEventExpectation(
             "INFO-Slow Index Resolution",
             timerLogger.getName(),
             Level.INFO,
@@ -171,7 +171,7 @@ public class LoadAuthorizedIndicesTimeCheckerTests extends ESTestCase {
     private void testLogging(
         LoadAuthorizedIndicesTimeChecker.Thresholds thresholds,
         int elapsedMs,
-        MockLogAppender.PatternSeenEventExpectation expectation
+        MockLog.PatternSeenEventExpectation expectation
     ) throws IllegalAccessException {
         final User user = new User("slow-user", "slow-role");
         final Authentication authentication = AuthenticationTestHelper.builder()
@@ -192,7 +192,7 @@ public class LoadAuthorizedIndicesTimeCheckerTests extends ESTestCase {
             requestInfo,
             thresholds
         );
-        try (var mockAppender = MockLogAppender.capture(timerLogger.getName())) {
+        try (var mockAppender = MockLog.capture(timerLogger.getName())) {
             mockAppender.addExpectation(expectation);
             checker.accept(List.of());
             mockAppender.assertAllExpectationsMatched();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/LoadAuthorizedIndicesTimeCheckerTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/LoadAuthorizedIndicesTimeCheckerTests.java
@@ -192,10 +192,10 @@ public class LoadAuthorizedIndicesTimeCheckerTests extends ESTestCase {
             requestInfo,
             thresholds
         );
-        try (var mockAppender = MockLog.capture(timerLogger.getName())) {
-            mockAppender.addExpectation(expectation);
+        try (var mockLog = MockLog.capture(timerLogger.getName())) {
+            mockLog.addExpectation(expectation);
             checker.accept(List.of());
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -45,7 +45,7 @@ import org.elasticsearch.license.LicenseStateListener;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
@@ -296,9 +296,9 @@ public class CompositeRolesStoreTests extends ESTestCase {
             effectiveRoleDescriptors::set
         );
 
-        try (var mockAppender = MockLogAppender.capture(RoleDescriptorStore.class)) {
+        try (var mockAppender = MockLog.capture(RoleDescriptorStore.class)) {
             mockAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "disabled role warning",
                     RoleDescriptorStore.class.getName(),
                     Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -296,8 +296,8 @@ public class CompositeRolesStoreTests extends ESTestCase {
             effectiveRoleDescriptors::set
         );
 
-        try (var mockAppender = MockLog.capture(RoleDescriptorStore.class)) {
-            mockAppender.addExpectation(
+        try (var mockLog = MockLog.capture(RoleDescriptorStore.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "disabled role warning",
                     RoleDescriptorStore.class.getName(),
@@ -310,7 +310,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
             getRoleForRoleNames(compositeRolesStore, Collections.singleton("dls"), roleFuture);
             assertEquals(Role.EMPTY, roleFuture.actionGet());
             assertThat(effectiveRoleDescriptors.get(), empty());
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/DefaultOperatorPrivilegesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/DefaultOperatorPrivilegesTests.java
@@ -21,7 +21,7 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationField;
@@ -103,9 +103,9 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
         Loggers.setLevel(logger, Level.DEBUG);
 
-        try (var appender = MockLogAppender.capture(OperatorPrivileges.class)) {
+        try (var appender = MockLog.capture(OperatorPrivileges.class)) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "marking",
                     logger.getName(),
                     Level.DEBUG,
@@ -211,10 +211,10 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
         Loggers.setLevel(logger, Level.DEBUG);
 
-        try (var appender = MockLogAppender.capture(OperatorPrivileges.class)) {
+        try (var appender = MockLog.capture(OperatorPrivileges.class)) {
             final RestoreSnapshotRequest restoreSnapshotRequest = mock(RestoreSnapshotRequest.class);
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "intercepting",
                     logger.getName(),
                     Level.DEBUG,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/DefaultOperatorPrivilegesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/DefaultOperatorPrivilegesTests.java
@@ -103,8 +103,8 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
         Loggers.setLevel(logger, Level.DEBUG);
 
-        try (var appender = MockLog.capture(OperatorPrivileges.class)) {
-            appender.addExpectation(
+        try (var mockLog = MockLog.capture(OperatorPrivileges.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "marking",
                     logger.getName(),
@@ -117,7 +117,7 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
                 AuthenticationField.PRIVILEGE_CATEGORY_VALUE_OPERATOR,
                 threadContext.getHeader(AuthenticationField.PRIVILEGE_CATEGORY_KEY)
             );
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             Loggers.setLevel(logger, (Level) null);
         }
@@ -211,9 +211,9 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
         final Logger logger = LogManager.getLogger(OperatorPrivileges.class);
         Loggers.setLevel(logger, Level.DEBUG);
 
-        try (var appender = MockLog.capture(OperatorPrivileges.class)) {
+        try (var mockLog = MockLog.capture(OperatorPrivileges.class)) {
             final RestoreSnapshotRequest restoreSnapshotRequest = mock(RestoreSnapshotRequest.class);
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "intercepting",
                     logger.getName(),
@@ -223,7 +223,7 @@ public class DefaultOperatorPrivilegesTests extends ESTestCase {
             );
             operatorPrivilegesService.maybeInterceptRequest(new ThreadContext(Settings.EMPTY), restoreSnapshotRequest);
             verify(restoreSnapshotRequest).skipOperatorOnlyState(licensed);
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         } finally {
             Loggers.setLevel(logger, (Level) null);
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -178,10 +178,10 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         Loggers.setLevel(logger, Level.TRACE);
 
         try (
-                var appender = MockLog.capture(FileOperatorUsersStore.class);
+                var mockLog = MockLog.capture(FileOperatorUsersStore.class);
                 ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)
         ) {
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "1st file parsing",
                     logger.getName(),
@@ -208,7 +208,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
                 groups.get(2)
             );
             assertEquals(new FileOperatorUsersStore.Group(Set.of("me@elastic.co"), "jwt1", "jwt", "realm", null, null), groups.get(3));
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // Content does not change, the groups should not be updated
             try (BufferedWriter writer = Files.newBufferedWriter(inUseFile, StandardCharsets.UTF_8, StandardOpenOption.APPEND)) {
@@ -216,10 +216,10 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             }
             watcherService.notifyNow(ResourceWatcherService.Frequency.HIGH);
             assertSame(groups, fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups());
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // Add one more entry
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "updating",
                     logger.getName(),
@@ -235,10 +235,10 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
                 assertEquals(5, newGroups.size());
                 assertEquals(new FileOperatorUsersStore.Group(Set.of("operator_4")), newGroups.get(4));
             });
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // Add mal-formatted entry
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.ExceptionSeenEventExpectation(
                     "mal-formatted",
                     logger.getName(),
@@ -253,10 +253,10 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             }
             watcherService.notifyNow(ResourceWatcherService.Frequency.HIGH);
             assertEquals(5, fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups().size());
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // Delete the file will remove all the operator users
-            appender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "file not exist warning",
                     logger.getName(),
@@ -267,7 +267,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
             );
             Files.delete(inUseFile);
             assertBusy(() -> assertEquals(0, fileOperatorUsersStore.getOperatorUsersDescriptor().getGroups().size()));
-            appender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
 
             // Back to original content
             Files.copy(sampleFile, inUseFile, StandardCopyOption.REPLACE_EXISTING);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -178,8 +178,8 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         Loggers.setLevel(logger, Level.TRACE);
 
         try (
-                var mockLog = MockLog.capture(FileOperatorUsersStore.class);
-                ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)
+            var mockLog = MockLog.capture(FileOperatorUsersStore.class);
+            ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)
         ) {
             mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/operator/FileOperatorUsersStoreTests.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -178,11 +178,11 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
         Loggers.setLevel(logger, Level.TRACE);
 
         try (
-            var appender = MockLogAppender.capture(FileOperatorUsersStore.class);
-            ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)
+                var appender = MockLog.capture(FileOperatorUsersStore.class);
+                ResourceWatcherService watcherService = new ResourceWatcherService(settings, threadPool)
         ) {
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "1st file parsing",
                     logger.getName(),
                     Level.INFO,
@@ -220,7 +220,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
 
             // Add one more entry
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "updating",
                     logger.getName(),
                     Level.INFO,
@@ -239,7 +239,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
 
             // Add mal-formatted entry
             appender.addExpectation(
-                new MockLogAppender.ExceptionSeenEventExpectation(
+                new MockLog.ExceptionSeenEventExpectation(
                     "mal-formatted",
                     logger.getName(),
                     Level.ERROR,
@@ -257,7 +257,7 @@ public class FileOperatorUsersStoreTests extends ESTestCase {
 
             // Delete the file will remove all the operator users
             appender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "file not exist warning",
                     logger.getName(),
                     Level.WARN,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
@@ -120,9 +120,9 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
         // Apache clients implement their own hostname checking, but we don't want that.
         // We use a raw socket so we get the builtin JDK checking (which is what we use for transport protocol SSL checks)
         try (
-                var mockLog = MockLog.capture(DiagnosticTrustManager.class);
-                MockWebServer webServer = initWebServer(sslService);
-                SSLSocket clientSocket = (SSLSocket) clientSocketFactory.createSocket()
+            var mockLog = MockLog.capture(DiagnosticTrustManager.class);
+            MockWebServer webServer = initWebServer(sslService);
+            SSLSocket clientSocket = (SSLSocket) clientSocketFactory.createSocket()
         ) {
 
             String fileName = "/x-pack/plugin/security/build/resources/test/org/elasticsearch/xpack/ssl/SSLErrorMessageTests/ca1.crt"

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
@@ -120,14 +120,14 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
         // Apache clients implement their own hostname checking, but we don't want that.
         // We use a raw socket so we get the builtin JDK checking (which is what we use for transport protocol SSL checks)
         try (
-                var mockAppender = MockLog.capture(DiagnosticTrustManager.class);
+                var mockLog = MockLog.capture(DiagnosticTrustManager.class);
                 MockWebServer webServer = initWebServer(sslService);
                 SSLSocket clientSocket = (SSLSocket) clientSocketFactory.createSocket()
         ) {
 
             String fileName = "/x-pack/plugin/security/build/resources/test/org/elasticsearch/xpack/ssl/SSLErrorMessageTests/ca1.crt"
                 .replace('/', platformFileSeparator());
-            mockAppender.addExpectation(
+            mockLog.addExpectation(
                 new MockLog.PatternSeenEventExpectation(
                     "ssl diagnostic",
                     DiagnosticTrustManager.class.getName(),
@@ -163,7 +163,7 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
 
             // Logging message failures are tricky to debug because you just get a "didn't find match" assertion failure.
             // You should be able to check the log output for the text that was logged and compare to the regex above.
-            mockAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/ssl/SSLErrorMessageCertificateVerificationTests.java
@@ -24,7 +24,7 @@ import org.elasticsearch.common.ssl.SslVerificationMode;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.http.MockResponse;
 import org.elasticsearch.test.http.MockWebServer;
 import org.elasticsearch.xpack.core.common.socket.SocketAccess;
@@ -120,15 +120,15 @@ public class SSLErrorMessageCertificateVerificationTests extends ESTestCase {
         // Apache clients implement their own hostname checking, but we don't want that.
         // We use a raw socket so we get the builtin JDK checking (which is what we use for transport protocol SSL checks)
         try (
-            var mockAppender = MockLogAppender.capture(DiagnosticTrustManager.class);
-            MockWebServer webServer = initWebServer(sslService);
-            SSLSocket clientSocket = (SSLSocket) clientSocketFactory.createSocket()
+                var mockAppender = MockLog.capture(DiagnosticTrustManager.class);
+                MockWebServer webServer = initWebServer(sslService);
+                SSLSocket clientSocket = (SSLSocket) clientSocketFactory.createSocket()
         ) {
 
             String fileName = "/x-pack/plugin/security/build/resources/test/org/elasticsearch/xpack/ssl/SSLErrorMessageTests/ca1.crt"
                 .replace('/', platformFileSeparator());
             mockAppender.addExpectation(
-                new MockLogAppender.PatternSeenEventExpectation(
+                new MockLog.PatternSeenEventExpectation(
                     "ssl diagnostic",
                     DiagnosticTrustManager.class.getName(),
                     Level.WARN,

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -376,8 +376,8 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         createSnapshot(repoName, "snap", Collections.singletonList(indexName));
 
         String targetNode;
-        try (var mockLogAppender = MockLog.capture(RecoverySourceHandler.class)) {
-            mockLogAppender.addExpectation(
+        try (var mockLog = MockLog.capture(RecoverySourceHandler.class)) {
+            mockLog.addExpectation(
                 new MockLog.SeenEventExpectation(
                     "expected warn log about restore failure",
                     RecoverySourceHandler.class.getName(),
@@ -391,7 +391,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
             ensureGreen();
 
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
         }
 
         RecoveryState recoveryState = getLatestPeerRecoveryStateForShard(indexName, 0);
@@ -610,8 +610,8 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
             recoverSnapshotFileRequestReceived.await();
 
-            try (var mockLogAppender = MockLog.capture(RecoverySourceHandler.class)) {
-                mockLogAppender.addExpectation(
+            try (var mockLog = MockLog.capture(RecoverySourceHandler.class)) {
+                mockLog.addExpectation(
                     new MockLog.SeenEventExpectation(
                         "expected debug log about restore cancellation",
                         RecoverySourceHandler.class.getName(),
@@ -619,7 +619,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                         "cancelled while recovering file [*] from snapshot"
                     )
                 );
-                mockLogAppender.addExpectation(
+                mockLog.addExpectation(
                     new MockLog.UnseenEventExpectation(
                         "expected no WARN logs",
                         RecoverySourceHandler.class.getName(),
@@ -630,7 +630,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
                 assertAcked(indicesAdmin().prepareDelete(indexName).get());
 
-                assertBusy(mockLogAppender::assertAllExpectationsMatched);
+                assertBusy(mockLog::assertAllExpectationsMatched);
             }
 
             respondToRecoverSnapshotFile.countDown();

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -67,7 +67,7 @@ import org.elasticsearch.snapshots.RestoreInfo;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalSettingsPlugin;
-import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -376,9 +376,9 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         createSnapshot(repoName, "snap", Collections.singletonList(indexName));
 
         String targetNode;
-        try (var mockLogAppender = MockLogAppender.capture(RecoverySourceHandler.class)) {
+        try (var mockLogAppender = MockLog.capture(RecoverySourceHandler.class)) {
             mockLogAppender.addExpectation(
-                new MockLogAppender.SeenEventExpectation(
+                new MockLog.SeenEventExpectation(
                     "expected warn log about restore failure",
                     RecoverySourceHandler.class.getName(),
                     Level.WARN,
@@ -610,9 +610,9 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
             recoverSnapshotFileRequestReceived.await();
 
-            try (var mockLogAppender = MockLogAppender.capture(RecoverySourceHandler.class)) {
+            try (var mockLogAppender = MockLog.capture(RecoverySourceHandler.class)) {
                 mockLogAppender.addExpectation(
-                    new MockLogAppender.SeenEventExpectation(
+                    new MockLog.SeenEventExpectation(
                         "expected debug log about restore cancellation",
                         RecoverySourceHandler.class.getName(),
                         Level.DEBUG,
@@ -620,7 +620,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                     )
                 );
                 mockLogAppender.addExpectation(
-                    new MockLogAppender.UnseenEventExpectation(
+                    new MockLog.UnseenEventExpectation(
                         "expected no WARN logs",
                         RecoverySourceHandler.class.getName(),
                         Level.WARN,

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -620,12 +620,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                     )
                 );
                 mockLog.addExpectation(
-                    new MockLog.UnseenEventExpectation(
-                        "expected no WARN logs",
-                        RecoverySourceHandler.class.getName(),
-                        Level.WARN,
-                        "*"
-                    )
+                    new MockLog.UnseenEventExpectation("expected no WARN logs", RecoverySourceHandler.class.getName(), Level.WARN, "*")
                 );
 
                 assertAcked(indicesAdmin().prepareDelete(indexName).get());

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -468,10 +468,10 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         transformAuditor.reset();
         transformAuditor.addExpectation(auditExpectation);
 
-        try (var mockLogAppender = MockLog.capture(checkpointProviderLogger.getName())) {
-            mockLogAppender.addExpectation(loggingExpectation);
+        try (var mockLog = MockLog.capture(checkpointProviderLogger.getName())) {
+            mockLog.addExpectation(loggingExpectation);
             codeBlock.run();
-            mockLogAppender.assertAllExpectationsMatched();
+            mockLog.assertAllExpectationsMatched();
             transformAuditor.assertAllExpectationsMatched();
         }
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProviderTests.java
@@ -28,8 +28,8 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLogAppender;
-import org.elasticsearch.test.MockLogAppender.LoggingExpectation;
+import org.elasticsearch.test.MockLog;
+import org.elasticsearch.test.MockLog.LoggingExpectation;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.xpack.core.transform.action.GetCheckpointAction;
@@ -103,7 +103,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         DefaultCheckpointProvider provider = newCheckpointProvider(transformConfig);
 
         assertExpectation(
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "warn when source is empty",
                 checkpointProviderLogger.getName(),
                 Level.WARN,
@@ -121,7 +121,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         );
 
         assertExpectation(
-            new MockLogAppender.UnseenEventExpectation(
+            new MockLog.UnseenEventExpectation(
                 "do not warn if empty again",
                 checkpointProviderLogger.getName(),
                 Level.WARN,
@@ -145,7 +145,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         DefaultCheckpointProvider provider = newCheckpointProvider(transformConfig);
 
         assertExpectation(
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "info about adds/removal",
                 checkpointProviderLogger.getName(),
                 Level.DEBUG,
@@ -163,7 +163,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         );
 
         assertExpectation(
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "info about adds/removal",
                 checkpointProviderLogger.getName(),
                 Level.DEBUG,
@@ -180,7 +180,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
             }
         );
         assertExpectation(
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "info about adds/removal",
                 checkpointProviderLogger.getName(),
                 Level.DEBUG,
@@ -213,7 +213,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         }
 
         assertExpectation(
-            new MockLogAppender.SeenEventExpectation(
+            new MockLog.SeenEventExpectation(
                 "info about adds/removal",
                 checkpointProviderLogger.getName(),
                 Level.DEBUG,
@@ -468,7 +468,7 @@ public class DefaultCheckpointProviderTests extends ESTestCase {
         transformAuditor.reset();
         transformAuditor.addExpectation(auditExpectation);
 
-        try (var mockLogAppender = MockLogAppender.capture(checkpointProviderLogger.getName())) {
+        try (var mockLogAppender = MockLog.capture(checkpointProviderLogger.getName())) {
             mockLogAppender.addExpectation(loggingExpectation);
             codeBlock.run();
             mockLogAppender.assertAllExpectationsMatched();


### PR DESCRIPTION
Now that mock logging has a single internal appender, the "appender"
suffix for MockLogAppender doesn't make sense. This commit renames the
class to MockLog. It was completely mechanical, done with IntelliJ
renames.