### PR TITLE
Move rlimit calls into NativeAccess

### DIFF
--- a/libs/native/jna/src/main/java/module-info.java
+++ b/libs/native/jna/src/main/java/module-info.java
@@ -15,5 +15,7 @@ module org.elasticsearch.nativeaccess.jna {
     requires org.elasticsearch.logging;
     requires com.sun.jna;
 
+    exports org.elasticsearch.nativeaccess.jna to com.sun.jna;
+
     provides NativeLibraryProvider with JnaNativeLibraryProvider;
 }

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaPosixCLibrary.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaPosixCLibrary.java
@@ -46,8 +46,6 @@ class JnaPosixCLibrary implements PosixCLibrary {
 
         int getrlimit(int resource, JnaRLimit rlimit);
 
-        int setrlimit(int resource, JnaRLimit rlimit);
-
         String strerror(int errno);
     }
 

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaPosixCLibrary.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaPosixCLibrary.java
@@ -10,13 +10,45 @@ package org.elasticsearch.nativeaccess.jna;
 
 import com.sun.jna.Library;
 import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Structure;
 
 import org.elasticsearch.nativeaccess.lib.PosixCLibrary;
 
+import java.util.Arrays;
+import java.util.List;
+
 class JnaPosixCLibrary implements PosixCLibrary {
+
+    /** corresponds to struct rlimit */
+    public static final class JnaRLimit extends Structure implements Structure.ByReference, RLimit {
+        public NativeLong rlim_cur = new NativeLong(0);
+        public NativeLong rlim_max = new NativeLong(0);
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("rlim_cur", "rlim_max");
+        }
+
+        @Override
+        public long rlim_cur() {
+            return rlim_cur.longValue();
+        }
+
+        @Override
+        public long rlim_max() {
+            return rlim_max.longValue();
+        }
+    }
 
     private interface NativeFunctions extends Library {
         int geteuid();
+
+        int getrlimit(int resource, JnaRLimit rlimit);
+
+        int setrlimit(int resource, JnaRLimit rlimit);
+
+        String strerror(int errno);
     }
 
     private final NativeFunctions functions;
@@ -28,5 +60,27 @@ class JnaPosixCLibrary implements PosixCLibrary {
     @Override
     public int geteuid() {
         return functions.geteuid();
+    }
+
+    @Override
+    public RLimit newRLimit() {
+        return new JnaRLimit();
+    }
+
+    @Override
+    public int getrlimit(int resource, RLimit rlimit) {
+        assert rlimit instanceof JnaRLimit;
+        var jnaRlimit = (JnaRLimit) rlimit;
+        return functions.getrlimit(resource, jnaRlimit);
+    }
+
+    @Override
+    public String strerror(int errno) {
+        return functions.strerror(errno);
+    }
+
+    @Override
+    public int errno() {
+        return Native.getLastError();
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/LinuxNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/LinuxNativeAccess.java
@@ -16,8 +16,18 @@ class LinuxNativeAccess extends PosixNativeAccess {
     Systemd systemd;
 
     LinuxNativeAccess(NativeLibraryProvider libraryProvider) {
-        super("Linux", libraryProvider);
+        super("Linux", libraryProvider, new PosixConstants(-1L, 9, 1));
         this.systemd = new Systemd(libraryProvider.getLibrary(SystemdLibrary.class));
+    }
+
+    @Override
+    protected long getMaxThreads() {
+        // this is only valid on Linux and the value *is* different on OS X
+        // see /usr/include/sys/resource.h on OS X
+        // on Linux the resource RLIMIT_NPROC means *the number of threads*
+        // this is in opposition to BSD-derived OSes
+        final int rlimit_nproc = 6;
+        return getRLimit(rlimit_nproc, "max number of threads");
     }
 
     @Override

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
@@ -29,6 +29,11 @@ public interface NativeAccess {
      */
     boolean definitelyRunningAsRoot();
 
+    /**
+     * Return limits for the current process.
+     */
+    ProcessLimits getProcessLimits();
+
     Systemd systemd();
 
     /**

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NoopNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NoopNativeAccess.java
@@ -26,6 +26,12 @@ class NoopNativeAccess implements NativeAccess {
     }
 
     @Override
+    public ProcessLimits getProcessLimits() {
+        logger.warn("Cannot get process limits because native access is not available");
+        return new ProcessLimits(ProcessLimits.UNKNOWN, ProcessLimits.UNKNOWN, ProcessLimits.UNKNOWN);
+    }
+
+    @Override
     public Systemd systemd() {
         logger.warn("Cannot get systemd access because native access is not available");
         return null;

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/PosixConstants.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/PosixConstants.java
@@ -8,16 +8,7 @@
 
 package org.elasticsearch.nativeaccess;
 
-import org.elasticsearch.nativeaccess.lib.NativeLibraryProvider;
-
-class MacNativeAccess extends PosixNativeAccess {
-
-    MacNativeAccess(NativeLibraryProvider libraryProvider) {
-        super("MacOS", libraryProvider, new PosixConstants(9223372036854775807L, 5, 1));
-    }
-
-    @Override
-    protected long getMaxThreads() {
-        return ProcessLimits.UNKNOWN;
-    }
-}
+/**
+ * Code constants on POSIX systems.
+ */
+record PosixConstants(long RLIMIT_INFINITY, int RLIMIT_AS, int RLIMIT_FSIZE) {}

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/PosixNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/PosixNativeAccess.java
@@ -18,11 +18,40 @@ abstract class PosixNativeAccess extends AbstractNativeAccess {
 
     protected final PosixCLibrary libc;
     protected final VectorSimilarityFunctions vectorDistance;
+    protected final PosixConstants constants;
+    protected final ProcessLimits processLimits;
 
-    PosixNativeAccess(String name, NativeLibraryProvider libraryProvider) {
+    PosixNativeAccess(String name, NativeLibraryProvider libraryProvider, PosixConstants constants) {
         super(name, libraryProvider);
         this.libc = libraryProvider.getLibrary(PosixCLibrary.class);
         this.vectorDistance = vectorSimilarityFunctionsOrNull(libraryProvider);
+        this.constants = constants;
+        this.processLimits = new ProcessLimits(
+            getMaxThreads(),
+            getRLimit(constants.RLIMIT_AS(), "max size virtual memory"),
+            getRLimit(constants.RLIMIT_FSIZE(), "max file size")
+        );
+    }
+
+    /**
+     * Return the maximum number of threads this process may start, or {@link ProcessLimits#UNKNOWN}.
+     */
+    protected abstract long getMaxThreads();
+
+    /**
+     * Return the current rlimit for the given resource.
+     * If getrlimit fails, returns {@link ProcessLimits#UNKNOWN}.
+     * If the rlimit is unlimited, returns {@link ProcessLimits#UNLIMITED}.
+     * */
+    protected long getRLimit(int resource, String description) {
+        var rlimit = libc.newRLimit();
+        if (libc.getrlimit(resource, rlimit) == 0) {
+            long value = rlimit.rlim_cur();
+            return value == constants.RLIMIT_INFINITY() ? ProcessLimits.UNLIMITED : value;
+        } else {
+            logger.warn("unable to retrieve " + description + " [" + libc.strerror(libc.errno()) + "]");
+            return ProcessLimits.UNKNOWN;
+        }
     }
 
     static VectorSimilarityFunctions vectorSimilarityFunctionsOrNull(NativeLibraryProvider libraryProvider) {
@@ -37,6 +66,11 @@ abstract class PosixNativeAccess extends AbstractNativeAccess {
     @Override
     public boolean definitelyRunningAsRoot() {
         return libc.geteuid() == 0;
+    }
+
+    @Override
+    public ProcessLimits getProcessLimits() {
+        return processLimits;
     }
 
     @Override

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/ProcessLimits.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/ProcessLimits.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess;
+
+/**
+ * Limits for the current process.
+ *
+ * @param maxThreads The maximum number of threads that may be created.
+ * @param maxVirtualMemorySize The maximum size of virtual memory.
+ * @param maxFileSize The maximum size of a single file.
+ */
+public record ProcessLimits(long maxThreads, long maxVirtualMemorySize, long maxFileSize) {
+    public static final long UNKNOWN = -1;
+    public static final long UNLIMITED = Long.MAX_VALUE;
+}

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/WindowsNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/WindowsNativeAccess.java
@@ -24,6 +24,11 @@ class WindowsNativeAccess extends AbstractNativeAccess {
     }
 
     @Override
+    public ProcessLimits getProcessLimits() {
+        return new ProcessLimits(ProcessLimits.UNKNOWN, ProcessLimits.UNKNOWN, ProcessLimits.UNKNOWN);
+    }
+
+    @Override
     public Optional<VectorSimilarityFunctions> getVectorSimilarityFunctions() {
         return Optional.empty(); // not supported yet
     }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/PosixCLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/PosixCLibrary.java
@@ -20,4 +20,19 @@ public non-sealed interface PosixCLibrary extends NativeLibrary {
      * @see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/geteuid.html">geteuid</a>
      */
     int geteuid();
+
+    /** corresponds to struct rlimit */
+    interface RLimit {
+        long rlim_cur();
+
+        long rlim_max();
+    }
+
+    RLimit newRLimit();
+
+    int getrlimit(int resource, RLimit rlimit);
+
+    String strerror(int errno);
+
+    int errno();
 }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
@@ -103,12 +103,12 @@ class JdkPosixCLibrary implements PosixCLibrary {
 
         @Override
         public long rlim_cur() {
-            return (long) rlim_cur$vh.get(segment);
+            return (long) rlim_cur$vh.get(segment, 0);
         }
 
         @Override
         public long rlim_max() {
-            return (long) rlim_max$vh.get(segment);
+            return (long) rlim_max$vh.get(segment, 0);
         }
 
         @Override

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
@@ -26,6 +26,7 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.elasticsearch.nativeaccess.jdk.LinkerHelper.downcallHandle;
+import static org.elasticsearch.nativeaccess.jdk.MemorySegmentUtil.varHandleDropOffset;
 
 class JdkPosixCLibrary implements PosixCLibrary {
 
@@ -91,8 +92,8 @@ class JdkPosixCLibrary implements PosixCLibrary {
 
     static class JdkRLimit implements RLimit {
         private static final MemoryLayout layout = MemoryLayout.structLayout(JAVA_LONG, JAVA_LONG);
-        private static final VarHandle rlim_cur$vh = layout.varHandle(groupElement(0));
-        private static final VarHandle rlim_max$vh = layout.varHandle(groupElement(1));
+        private static final VarHandle rlim_cur$vh = varHandleDropOffset(layout.varHandle(groupElement(0)));
+        private static final VarHandle rlim_max$vh = varHandleDropOffset(layout.varHandle(groupElement(1)));
 
         private final MemorySegment segment;
 
@@ -103,12 +104,12 @@ class JdkPosixCLibrary implements PosixCLibrary {
 
         @Override
         public long rlim_cur() {
-            return (long) rlim_cur$vh.get(segment, 0);
+            return (long) rlim_cur$vh.get(segment, 0L);
         }
 
         @Override
         public long rlim_max() {
-            return (long) rlim_max$vh.get(segment, 0);
+            return (long) rlim_max$vh.get(segment, 0L);
         }
 
         @Override

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
@@ -12,17 +12,57 @@ import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.nativeaccess.lib.PosixCLibrary;
 
+import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
 
+import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
+import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.elasticsearch.nativeaccess.jdk.LinkerHelper.downcallHandle;
 
 class JdkPosixCLibrary implements PosixCLibrary {
 
     private static final Logger logger = LogManager.getLogger(JdkPosixCLibrary.class);
 
+    // errno can change between system calls, so we capture it
+    private static final StructLayout CAPTURE_ERRNO_LAYOUT = Linker.Option.captureStateLayout();
+    static final Linker.Option CAPTURE_ERRNO_OPTION = Linker.Option.captureCallState("errno");
+    private static final VarHandle errno$vh = CAPTURE_ERRNO_LAYOUT.varHandle(groupElement("errno"));
+
     private static final MethodHandle geteuid$mh = downcallHandle("geteuid", FunctionDescriptor.of(JAVA_INT));
+    private static final MethodHandle strerror$mh = downcallHandle("strerror", FunctionDescriptor.of(ADDRESS, JAVA_INT));
+    private static final MethodHandle getrlimit$mh = downcallHandleWithErrno(
+        "getrlimit",
+        FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS)
+    );
+
+    static final MemorySegment errnoState = Arena.ofAuto().allocate(CAPTURE_ERRNO_LAYOUT);
+
+    static MethodHandle downcallHandleWithErrno(String function, FunctionDescriptor functionDescriptor) {
+        return downcallHandle(function, functionDescriptor, CAPTURE_ERRNO_OPTION);
+    }
+
+    @Override
+    public int errno() {
+        return (int) errno$vh.get(errnoState);
+    }
+
+    @Override
+    public String strerror(int errno) {
+        try {
+            MemorySegment str = (MemorySegment) strerror$mh.invokeExact(errno);
+            return str.reinterpret(Long.MAX_VALUE).getUtf8String(0);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
 
     @Override
     public int geteuid() {
@@ -30,6 +70,50 @@ class JdkPosixCLibrary implements PosixCLibrary {
             return (int) geteuid$mh.invokeExact();
         } catch (Throwable t) {
             throw new AssertionError(t);
+        }
+    }
+
+    @Override
+    public RLimit newRLimit() {
+        return new JdkRLimit();
+    }
+
+    @Override
+    public int getrlimit(int resource, RLimit rlimit) {
+        assert rlimit instanceof JdkRLimit;
+        var jdkRlimit = (JdkRLimit) rlimit;
+        try {
+            return (int) getrlimit$mh.invokeExact(errnoState, resource, jdkRlimit.segment);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    static class JdkRLimit implements RLimit {
+        private static final MemoryLayout layout = MemoryLayout.structLayout(JAVA_LONG, JAVA_LONG);
+        private static final VarHandle rlim_cur$vh = layout.varHandle(groupElement(0));
+        private static final VarHandle rlim_max$vh = layout.varHandle(groupElement(1));
+
+        private final MemorySegment segment;
+
+        JdkRLimit() {
+            var arena = Arena.ofAuto();
+            this.segment = arena.allocate(layout);
+        }
+
+        @Override
+        public long rlim_cur() {
+            return (long) rlim_cur$vh.get(segment);
+        }
+
+        @Override
+        public long rlim_max() {
+            return (long) rlim_max$vh.get(segment);
+        }
+
+        @Override
+        public String toString() {
+            return "JdkRLimit[rlim_cur=" + rlim_cur() + ", rlim_max=" + rlim_max();
         }
     }
 }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
@@ -104,12 +104,12 @@ class JdkPosixCLibrary implements PosixCLibrary {
 
         @Override
         public long rlim_cur() {
-            return (long) rlim_cur$vh.get(segment, 0L);
+            return (long) rlim_cur$vh.get(segment);
         }
 
         @Override
         public long rlim_max() {
-            return (long) rlim_max$vh.get(segment, 0L);
+            return (long) rlim_max$vh.get(segment);
         }
 
         @Override

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -10,7 +10,6 @@ package org.elasticsearch.nativeaccess.jdk;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
-import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
 /**
@@ -27,9 +26,9 @@ class MemorySegmentUtil {
     }
 
     // MemorySegment.varHandle changed between 21 and 22. The resulting varHandle now requires an additional
-    // long offset parameter. We pass the offset in at runtime, and drop this offset for 21.
+    // long offset parameter. We omit the offset at runtime, instead binding to the VarHandle in JDK 22.
     static VarHandle varHandleDropOffset(VarHandle varHandle) {
-        return MethodHandles.dropCoordinates(varHandle, 1, Long.class);
+        return varHandle;
     }
 
     private MemorySegmentUtil() {}

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -10,6 +10,8 @@ package org.elasticsearch.nativeaccess.jdk;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 
 /**
  * Utility methods to act on MemorySegment apis which have changed in subsequent JDK releases.
@@ -22,6 +24,12 @@ class MemorySegmentUtil {
 
     static MemorySegment allocateString(Arena arena, String s) {
         return arena.allocateUtf8String(s);
+    }
+
+    // MemorySegment.varHandle changed between 21 and 22. The resulting varHandle now requires an additional
+    // long offset parameter. We pass the offset in at runtime, and drop this offset for 21.
+    static VarHandle varHandleDropOffset(VarHandle varHandle) {
+        return MethodHandles.dropCoordinates(varHandle, 1, Long.class);
     }
 
     private MemorySegmentUtil() {}

--- a/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -10,6 +10,7 @@ package org.elasticsearch.nativeaccess.jdk;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.invoke.VarHandle;
 
 public class MemorySegmentUtil {
 
@@ -19,6 +20,13 @@ public class MemorySegmentUtil {
 
     static MemorySegment allocateString(Arena arena, String s) {
         return arena.allocateFrom(s);
+    }
+
+    // MemorySegment.varHandle changed between 21 and 22. The resulting varHandle now requires an additional
+    // long offset parameter. We pass the offset in at runtime, but drop it for Java 21. Here we just pass
+    // through the varHandle
+    static VarHandle varHandleDropOffset(VarHandle varHandle) {
+        return varHandle;
     }
 
     private MemorySegmentUtil() {}

--- a/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -10,9 +10,10 @@ package org.elasticsearch.nativeaccess.jdk;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
-public class MemorySegmentUtil {
+class MemorySegmentUtil {
 
     static String getString(MemorySegment segment, long offset) {
         return segment.getString(offset);
@@ -23,10 +24,9 @@ public class MemorySegmentUtil {
     }
 
     // MemorySegment.varHandle changed between 21 and 22. The resulting varHandle now requires an additional
-    // long offset parameter. We pass the offset in at runtime, but drop it for Java 21. Here we just pass
-    // through the varHandle
+    // long offset parameter. We omit the offset at runtime, instead binding to the VarHandle in JDK 22.
     static VarHandle varHandleDropOffset(VarHandle varHandle) {
-        return varHandle;
+        return MethodHandles.insertCoordinates(varHandle, 1, 0L);
     }
 
     private MemorySegmentUtil() {}

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/ProcessLimitsTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/ProcessLimitsTests.java
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-package org.elasticsearch.bootstrap;
+package org.elasticsearch.nativeaccess;
 
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.core.PathUtils;
@@ -16,11 +16,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
-import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
-public class EvilJNANativesTests extends ESTestCase {
+public class ProcessLimitsTests extends ESTestCase {
+
+    private static final NativeAccess nativeAccess = NativeAccess.instance();
 
     public void testSetMaximumNumberOfThreads() throws IOException {
         if (Constants.LINUX) {
@@ -28,14 +29,14 @@ public class EvilJNANativesTests extends ESTestCase {
             for (final String line : lines) {
                 if (line != null && line.startsWith("Max processes")) {
                     final String[] fields = line.split("\\s+");
-                    final long limit = "unlimited".equals(fields[2]) ? JNACLibrary.RLIM_INFINITY : Long.parseLong(fields[2]);
-                    assertThat(JNANatives.MAX_NUMBER_OF_THREADS, equalTo(limit));
+                    final long limit = "unlimited".equals(fields[2]) ? ProcessLimits.UNLIMITED : Long.parseLong(fields[2]);
+                    assertThat(nativeAccess.getProcessLimits().maxThreads(), equalTo(limit));
                     return;
                 }
             }
             fail("should have read max processes from /proc/self/limits");
         } else {
-            assertThat(JNANatives.MAX_NUMBER_OF_THREADS, equalTo(-1L));
+            assertThat(nativeAccess.getProcessLimits().maxThreads(), equalTo(-1L));
         }
     }
 
@@ -45,16 +46,16 @@ public class EvilJNANativesTests extends ESTestCase {
             for (final String line : lines) {
                 if (line != null && line.startsWith("Max address space")) {
                     final String[] fields = line.split("\\s+");
-                    final String limit = fields[3];
-                    assertThat(JNANatives.rlimitToString(JNANatives.MAX_SIZE_VIRTUAL_MEMORY), equalTo(limit));
+                    final long limit = "unlimited".equals(fields[3]) ? ProcessLimits.UNLIMITED : Long.parseLong(fields[3]);
+                    assertThat(nativeAccess.getProcessLimits().maxVirtualMemorySize(), equalTo(limit));
                     return;
                 }
             }
             fail("should have read max size virtual memory from /proc/self/limits");
         } else if (Constants.MAC_OS_X) {
-            assertThat(JNANatives.MAX_SIZE_VIRTUAL_MEMORY, anyOf(equalTo(Long.MIN_VALUE), greaterThanOrEqualTo(0L)));
+            assertThat(nativeAccess.getProcessLimits().maxVirtualMemorySize(), greaterThanOrEqualTo(0L));
         } else {
-            assertThat(JNANatives.MAX_SIZE_VIRTUAL_MEMORY, equalTo(Long.MIN_VALUE));
+            assertThat(nativeAccess.getProcessLimits().maxVirtualMemorySize(), equalTo(ProcessLimits.UNKNOWN));
         }
     }
 
@@ -64,16 +65,16 @@ public class EvilJNANativesTests extends ESTestCase {
             for (final String line : lines) {
                 if (line != null && line.startsWith("Max file size")) {
                     final String[] fields = line.split("\\s+");
-                    final String limit = fields[3];
-                    assertThat(JNANatives.rlimitToString(JNANatives.MAX_FILE_SIZE), equalTo(limit));
+                    final long limit = "unlimited".equals(fields[3]) ? ProcessLimits.UNLIMITED : Long.parseLong(fields[3]);
+                    assertThat(nativeAccess.getProcessLimits().maxFileSize(), equalTo(limit));
                     return;
                 }
             }
             fail("should have read max file size from /proc/self/limits");
         } else if (Constants.MAC_OS_X) {
-            assertThat(JNANatives.MAX_FILE_SIZE, anyOf(equalTo(Long.MIN_VALUE), greaterThanOrEqualTo(0L)));
+            assertThat(nativeAccess.getProcessLimits().maxFileSize(), greaterThanOrEqualTo(0L));
         } else {
-            assertThat(JNANatives.MAX_FILE_SIZE, equalTo(Long.MIN_VALUE));
+            assertThat(nativeAccess.getProcessLimits().maxFileSize(), equalTo(ProcessLimits.UNKNOWN));
         }
     }
 

--- a/libs/native/src/test/java/org/elasticsearch/nativeaccess/ProcessLimitsTests.java
+++ b/libs/native/src/test/java/org/elasticsearch/nativeaccess/ProcessLimitsTests.java
@@ -19,6 +19,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
+@ESTestCase.WithoutSecurityManager
 public class ProcessLimitsTests extends ESTestCase {
 
     private static final NativeAccess nativeAccess = NativeAccess.instance();

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -22,6 +22,8 @@ import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.index.IndexModule;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.monitor.process.ProcessProbe;
+import org.elasticsearch.nativeaccess.NativeAccess;
+import org.elasticsearch.nativeaccess.ProcessLimits;
 import org.elasticsearch.node.NodeValidationException;
 
 import java.io.BufferedReader;
@@ -349,7 +351,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (getMaxNumberOfThreads() != -1 && getMaxNumberOfThreads() < MAX_NUMBER_OF_THREADS_THRESHOLD) {
+            if (getMaxNumberOfThreads() != ProcessLimits.UNKNOWN && getMaxNumberOfThreads() < MAX_NUMBER_OF_THREADS_THRESHOLD) {
                 final String message = String.format(
                     Locale.ROOT,
                     "max number of threads [%d] for user [%s] is too low, increase to at least [%d]",
@@ -365,7 +367,7 @@ final class BootstrapChecks {
 
         // visible for testing
         long getMaxNumberOfThreads() {
-            return JNANatives.MAX_NUMBER_OF_THREADS;
+            return NativeAccess.instance().getProcessLimits().maxThreads();
         }
 
         @Override
@@ -378,7 +380,7 @@ final class BootstrapChecks {
 
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
-            if (getMaxSizeVirtualMemory() != Long.MIN_VALUE && getMaxSizeVirtualMemory() != getRlimInfinity()) {
+            if (getMaxSizeVirtualMemory() != Long.MIN_VALUE && getMaxSizeVirtualMemory() != ProcessLimits.UNLIMITED) {
                 final String message = String.format(
                     Locale.ROOT,
                     "max size virtual memory [%d] for user [%s] is too low, increase to [unlimited]",
@@ -392,13 +394,8 @@ final class BootstrapChecks {
         }
 
         // visible for testing
-        long getRlimInfinity() {
-            return JNACLibrary.RLIM_INFINITY;
-        }
-
-        // visible for testing
         long getMaxSizeVirtualMemory() {
-            return JNANatives.MAX_SIZE_VIRTUAL_MEMORY;
+            return NativeAccess.instance().getProcessLimits().maxVirtualMemorySize();
         }
 
         @Override
@@ -415,7 +412,7 @@ final class BootstrapChecks {
         @Override
         public BootstrapCheckResult check(BootstrapContext context) {
             final long maxFileSize = getMaxFileSize();
-            if (maxFileSize != Long.MIN_VALUE && maxFileSize != getRlimInfinity()) {
+            if (maxFileSize != Long.MIN_VALUE && maxFileSize != ProcessLimits.UNLIMITED) {
                 final String message = String.format(
                     Locale.ROOT,
                     "max file size [%d] for user [%s] is too low, increase to [unlimited]",
@@ -428,12 +425,8 @@ final class BootstrapChecks {
             }
         }
 
-        long getRlimInfinity() {
-            return JNACLibrary.RLIM_INFINITY;
-        }
-
         long getMaxFileSize() {
-            return JNANatives.MAX_FILE_SIZE;
+            return NativeAccess.instance().getProcessLimits().maxVirtualMemorySize();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -326,10 +326,6 @@ class Elasticsearch {
             // we've already logged this.
         }
 
-        Natives.trySetMaxNumberOfThreads();
-        Natives.trySetMaxSizeVirtualMemory();
-        Natives.trySetMaxFileSize();
-
         // init lucene random seed. it will use /dev/urandom where available:
         StringHelper.randomId();
 

--- a/server/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
@@ -39,13 +39,6 @@ class JNANatives {
     // Set to true, in case policy can be applied to all threads of the process (even existing ones)
     // otherwise they are only inherited for new threads (ES app threads)
     static boolean LOCAL_SYSTEM_CALL_FILTER_ALL = false;
-    // set to the maximum number of threads that can be created for
-    // the user ID that owns the running Elasticsearch process
-    static long MAX_NUMBER_OF_THREADS = -1;
-
-    static long MAX_SIZE_VIRTUAL_MEMORY = Long.MIN_VALUE;
-
-    static long MAX_FILE_SIZE = Long.MIN_VALUE;
 
     static void tryMlockall() {
         int errno = Integer.MIN_VALUE;
@@ -101,45 +94,6 @@ class JNANatives {
                 }
             } else {
                 logger.warn("Increase RLIMIT_MEMLOCK (ulimit).");
-            }
-        }
-    }
-
-    static void trySetMaxNumberOfThreads() {
-        if (Constants.LINUX) {
-            // this is only valid on Linux and the value *is* different on OS X
-            // see /usr/include/sys/resource.h on OS X
-            // on Linux the resource RLIMIT_NPROC means *the number of threads*
-            // this is in opposition to BSD-derived OSes
-            final int rlimit_nproc = 6;
-
-            final JNACLibrary.Rlimit rlimit = new JNACLibrary.Rlimit();
-            if (JNACLibrary.getrlimit(rlimit_nproc, rlimit) == 0) {
-                MAX_NUMBER_OF_THREADS = rlimit.rlim_cur.longValue();
-            } else {
-                logger.warn("unable to retrieve max number of threads [" + JNACLibrary.strerror(Native.getLastError()) + "]");
-            }
-        }
-    }
-
-    static void trySetMaxSizeVirtualMemory() {
-        if (Constants.LINUX || Constants.MAC_OS_X) {
-            final JNACLibrary.Rlimit rlimit = new JNACLibrary.Rlimit();
-            if (JNACLibrary.getrlimit(JNACLibrary.RLIMIT_AS, rlimit) == 0) {
-                MAX_SIZE_VIRTUAL_MEMORY = rlimit.rlim_cur.longValue();
-            } else {
-                logger.warn("unable to retrieve max size virtual memory [" + JNACLibrary.strerror(Native.getLastError()) + "]");
-            }
-        }
-    }
-
-    static void trySetMaxFileSize() {
-        if (Constants.LINUX || Constants.MAC_OS_X) {
-            final JNACLibrary.Rlimit rlimit = new JNACLibrary.Rlimit();
-            if (JNACLibrary.getrlimit(JNACLibrary.RLIMIT_FSIZE, rlimit) == 0) {
-                MAX_FILE_SIZE = rlimit.rlim_cur.longValue();
-            } else {
-                logger.warn("unable to retrieve max file size [" + JNACLibrary.strerror(Native.getLastError()) + "]");
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -104,30 +104,6 @@ final class Natives {
         JNANatives.tryInstallSystemCallFilter(tmpFile);
     }
 
-    static void trySetMaxNumberOfThreads() {
-        if (JNA_AVAILABLE == false) {
-            logger.warn("cannot getrlimit RLIMIT_NPROC because JNA is not available");
-            return;
-        }
-        JNANatives.trySetMaxNumberOfThreads();
-    }
-
-    static void trySetMaxSizeVirtualMemory() {
-        if (JNA_AVAILABLE == false) {
-            logger.warn("cannot getrlimit RLIMIT_AS because JNA is not available");
-            return;
-        }
-        JNANatives.trySetMaxSizeVirtualMemory();
-    }
-
-    static void trySetMaxFileSize() {
-        if (JNA_AVAILABLE == false) {
-            logger.warn("cannot getrlimit RLIMIT_FSIZE because JNA is not available");
-            return;
-        }
-        JNANatives.trySetMaxFileSize();
-    }
-
     static boolean isSystemCallFilterInstalled() {
         if (JNA_AVAILABLE == false) {
             return false;

--- a/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/BootstrapChecksTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.bootstrap;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.cluster.coordination.ClusterBootstrapService;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.ReferenceDocs;
@@ -20,6 +19,7 @@ import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.discovery.SettingsBasedSeedHostsProvider;
 import org.elasticsearch.monitor.jvm.JvmInfo;
+import org.elasticsearch.nativeaccess.ProcessLimits;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.test.AbstractBootstrapCheckTestCase;
 import org.hamcrest.Matcher;
@@ -355,22 +355,16 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
 
         // nothing should happen if current max number of threads is
         // not available
-        maxNumberOfThreads.set(-1);
+        maxNumberOfThreads.set(ProcessLimits.UNKNOWN);
         BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
     }
 
     public void testMaxSizeVirtualMemory() throws NodeValidationException {
-        final long rlimInfinity = Constants.MAC_OS_X ? 9223372036854775807L : -1L;
         final AtomicLong maxSizeVirtualMemory = new AtomicLong(randomIntBetween(0, Integer.MAX_VALUE));
         final BootstrapChecks.MaxSizeVirtualMemoryCheck check = new BootstrapChecks.MaxSizeVirtualMemoryCheck() {
             @Override
             long getMaxSizeVirtualMemory() {
                 return maxSizeVirtualMemory.get();
-            }
-
-            @Override
-            long getRlimInfinity() {
-                return rlimInfinity;
             }
         };
 
@@ -381,7 +375,7 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
         assertThat(e.getMessage(), containsString("max size virtual memory"));
         assertThat(e.getMessage(), containsString("; for more information see [https://www.elastic.co/guide/en/elasticsearch/reference/"));
 
-        maxSizeVirtualMemory.set(rlimInfinity);
+        maxSizeVirtualMemory.set(ProcessLimits.UNLIMITED);
 
         BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 
@@ -391,17 +385,11 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
     }
 
     public void testMaxFileSizeCheck() throws NodeValidationException {
-        final long rlimInfinity = Constants.MAC_OS_X ? 9223372036854775807L : -1L;
         final AtomicLong maxFileSize = new AtomicLong(randomIntBetween(0, Integer.MAX_VALUE));
         final BootstrapChecks.MaxFileSizeCheck check = new BootstrapChecks.MaxFileSizeCheck() {
             @Override
             long getMaxFileSize() {
                 return maxFileSize.get();
-            }
-
-            @Override
-            long getRlimInfinity() {
-                return rlimInfinity;
             }
         };
 
@@ -412,7 +400,7 @@ public class BootstrapChecksTests extends AbstractBootstrapCheckTestCase {
         assertThat(e.getMessage(), containsString("max file size"));
         assertThat(e.getMessage(), containsString("; for more information see [https://www.elastic.co/guide/en/elasticsearch/reference/"));
 
-        maxFileSize.set(rlimInfinity);
+        maxFileSize.set(ProcessLimits.UNLIMITED);
 
         BootstrapChecks.check(emptyContext, true, Collections.singletonList(check));
 


### PR DESCRIPTION
This commit moves getting max threads, max virtual memory size, and max file size into NativeAccess.

relates https://github.com/elastic/elasticsearch/pull/104876