### PR TITLE
Simplify FetchSearchPhase and its tests a little

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
+++ b/server/src/main/java/org/elasticsearch/action/search/FetchSearchPhase.java
@@ -109,14 +109,14 @@ final class FetchSearchPhase extends SearchPhase {
         if (queryAndFetchOptimization) {
             assert assertConsistentWithQueryAndFetchOptimization();
             // query AND fetch optimization
-            moveToNextPhase(reducedQueryPhase, queryResults);
+            moveToNextPhase(queryResults);
         } else {
             ScoreDoc[] scoreDocs = reducedQueryPhase.sortedTopDocs().scoreDocs();
             // no docs to fetch -- sidestep everything and return
             if (scoreDocs.length == 0) {
                 // we have to release contexts here to free up resources
                 queryResults.asList().stream().map(SearchPhaseResult::queryResult).forEach(this::releaseIrrelevantSearchContext);
-                moveToNextPhase(reducedQueryPhase, fetchResults.getAtomicArray());
+                moveToNextPhase(fetchResults.getAtomicArray());
             } else {
                 final ScoreDoc[] lastEmittedDocPerShard = context.getRequest().scroll() != null
                     ? SearchPhaseController.getLastEmittedDocPerShard(reducedQueryPhase, numShards)
@@ -125,7 +125,7 @@ final class FetchSearchPhase extends SearchPhase {
                 final CountedCollector<FetchSearchResult> counter = new CountedCollector<>(
                     fetchResults,
                     docIdsToLoad.length, // we count down every shard in the result no matter if we got any results or not
-                    () -> moveToNextPhase(reducedQueryPhase, fetchResults.getAtomicArray()),
+                    () -> moveToNextPhase(fetchResults.getAtomicArray()),
                     context
                 );
                 for (int i = 0; i < docIdsToLoad.length; i++) {
@@ -224,15 +224,12 @@ final class FetchSearchPhase extends SearchPhase {
                     context.getOriginalIndices(queryResult.getShardIndex())
                 );
             } catch (Exception e) {
-                context.getLogger().trace("failed to release context", e);
+                logger.trace("failed to release context", e);
             }
         }
     }
 
-    private void moveToNextPhase(
-        SearchPhaseController.ReducedQueryPhase reducedQueryPhase,
-        AtomicArray<? extends SearchPhaseResult> fetchResultsArr
-    ) {
+    private void moveToNextPhase(AtomicArray<? extends SearchPhaseResult> fetchResultsArr) {
         var resp = SearchPhaseController.merge(context.getRequest().scroll() != null, reducedQueryPhase, fetchResultsArr);
         context.addReleasable(resp::decRef);
         fetchResults.close();


### PR DESCRIPTION
We can dry up the tests a little, remove a branch that is never taken (equality of response object and `Integer` is always false there) and remove redundant arguments in the production code to simplify this code a little.