### PR TITLE
Fix Data Stream Lifecycle health indicator to return UNKNOWN

### DIFF
--- a/docs/changelog/108812.yaml
+++ b/docs/changelog/108812.yaml
@@ -1,0 +1,5 @@
+pr: 108812
+summary: Fix Data Stream Lifecycle health indicator to return UNKNOWN
+area: Health
+type: bug
+issues: []

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthIndicatorService.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthIndicatorService.java
@@ -65,7 +65,7 @@ public class DataStreamLifecycleHealthIndicatorService implements HealthIndicato
             // DSL reports health information on every run, so data will eventually arrive to the health node. In the meantime, let's
             // report UNKNOWN health
             return createIndicator(
-                HealthStatus.GREEN,
+                HealthStatus.UNKNOWN,
                 "No data stream lifecycle health data available yet. Health information will be reported after the first run.",
                 HealthIndicatorDetails.EMPTY,
                 List.of(),

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthIndicatorServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/health/DataStreamLifecycleHealthIndicatorServiceTests.java
@@ -40,9 +40,9 @@ public class DataStreamLifecycleHealthIndicatorServiceTests extends ESTestCase {
         service = new DataStreamLifecycleHealthIndicatorService();
     }
 
-    public void testGreenWhenNoDSLHealthData() {
+    public void testUnknownWhenNoDSLHealthData() {
         HealthIndicatorResult result = service.calculate(true, constructHealthInfo(null));
-        assertThat(result.status(), is(HealthStatus.GREEN));
+        assertThat(result.status(), is(HealthStatus.UNKNOWN));
         assertThat(
             result.symptom(),
             is("No data stream lifecycle health data available yet. Health information will be reported after the first run.")

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/HealthNodeUpgradeIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/HealthNodeUpgradeIT.java
@@ -13,8 +13,11 @@ import com.carrotsearch.randomizedtesting.annotations.Name;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Settings;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -24,6 +27,12 @@ public class HealthNodeUpgradeIT extends AbstractRollingUpgradeTestCase {
 
     public HealthNodeUpgradeIT(@Name("upgradedNodes") int upgradedNodes) {
         super(upgradedNodes);
+    }
+
+    @Before
+    public void updatePollInterval() throws IOException {
+        // We need Data Stream Lifecycle to run at least once to have a "green" status.
+        updateClusterSettings(client(), Settings.builder().put("data_streams.lifecycle.poll_interval", "5s").build());
     }
 
     public void testHealthNode() throws Exception {


### PR DESCRIPTION
When there is no health info available from the health node, the status should be UNKNOWN instead of GREEN.