### PR TITLE
Deserialize publish requests on generic thread-pool

### DIFF
--- a/docs/changelog/108814.yaml
+++ b/docs/changelog/108814.yaml
@@ -1,0 +1,6 @@
+pr: 108814
+summary: Deserialize publish requests on generic thread-pool
+area: Cluster Coordination
+type: bug
+issues:
+ - 106352

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -432,6 +432,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
     }
 
     PublishWithJoinResponse handlePublishRequest(PublishRequest publishRequest) {
+        assert ThreadPool.assertCurrentThreadPool(Names.CLUSTER_COORDINATION);
         assert publishRequest.getAcceptedState().nodes().getLocalNode().equals(getLocalNode())
             : publishRequest.getAcceptedState().nodes().getLocalNode() + " != " + getLocalNode();
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -151,10 +151,10 @@ public class PublicationTransportHandler {
                 }
                 fullClusterStateReceivedCount.incrementAndGet();
                 logger.debug("received full cluster state version [{}] with size [{}]", incomingState.version(), request.bytes().length());
-                acceptState(
-                    incomingState,
-                    ActionListener.runBefore(publishResponseListener, () -> lastSeenClusterState.set(incomingState))
-                );
+                acceptState(incomingState, publishResponseListener.delegateFailure((delegate, response) -> {
+                    lastSeenClusterState.set(incomingState);
+                    delegate.onResponse(response);
+                }));
             } else {
                 final ClusterState lastSeen = lastSeenClusterState.get();
                 if (lastSeen == null) {
@@ -170,10 +170,10 @@ public class PublicationTransportHandler {
                         incomingState.stateUUID(),
                         request.bytes().length()
                     );
-                    acceptState(
-                        incomingState,
-                        ActionListener.runBefore(publishResponseListener, () -> lastSeenClusterState.set(incomingState))
-                    );
+                    acceptState(incomingState, publishResponseListener.delegateFailure((delegate, response) -> {
+                        lastSeenClusterState.set(incomingState);
+                        delegate.onResponse(response);
+                    }));
                 }
             }
         } finally {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -170,9 +170,9 @@ public class PublicationTransportHandler {
                         incomingState.stateUUID(),
                         request.bytes().length()
                     );
-                    acceptState(incomingState, publishResponseListener.delegateFailure((delegate, response) -> {
+                    acceptState(incomingState, publishResponseListener.map(response -> {
                         lastSeenClusterState.compareAndSet(lastSeen, incomingState);
-                        delegate.onResponse(response);
+                        return response;
                     }));
                 }
             }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -151,9 +151,9 @@ public class PublicationTransportHandler {
                 }
                 fullClusterStateReceivedCount.incrementAndGet();
                 logger.debug("received full cluster state version [{}] with size [{}]", incomingState.version(), request.bytes().length());
-                acceptState(incomingState, publishResponseListener.delegateFailure((delegate, response) -> {
+                acceptState(incomingState, publishResponseListener.map(response -> {
                     lastSeenClusterState.set(incomingState);
-                    delegate.onResponse(response);
+                    return response;
                 }));
             } else {
                 final ClusterState lastSeen = lastSeenClusterState.get();

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PublicationTransportHandler.java
@@ -171,7 +171,7 @@ public class PublicationTransportHandler {
                         request.bytes().length()
                     );
                     acceptState(incomingState, publishResponseListener.delegateFailure((delegate, response) -> {
-                        lastSeenClusterState.set(incomingState);
+                        lastSeenClusterState.compareAndSet(lastSeen, incomingState);
                         delegate.onResponse(response);
                     }));
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -458,6 +458,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
                 new PublishRequest(clusterState0),
                 ActionListener.running(() -> assertTrue(completed.compareAndSet(false, true)))
             );
+            deterministicTaskQueue.runAllRunnableTasks();
             assertTrue(completed.getAndSet(false));
             receivedState0 = receivedStateRef.getAndSet(null);
             assertEquals(clusterState0.stateUUID(), receivedState0.stateUUID());
@@ -499,6 +500,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
                 new PublishRequest(clusterState1),
                 ActionListener.running(() -> assertTrue(completed.compareAndSet(false, true)))
             );
+            deterministicTaskQueue.runAllRunnableTasks();
             assertTrue(completed.getAndSet(false));
             var receivedState1 = receivedStateRef.getAndSet(null);
             assertEquals(clusterState1.stateUUID(), receivedState1.stateUUID());

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -217,9 +217,9 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
     // 1. submit the task to the master service
     // 2. state publisher task on master
     // 3. master sends out PublishRequests to nodes
-    // 4. master receives PublishResponses from nodes
-    // 5. master sends ApplyCommitRequests to nodes
-    // 6. nodes deserialize committed cluster state
+    // 4. nodes deserialize received cluster state
+    // 5. master receives PublishResponses from nodes
+    // 6. master sends ApplyCommitRequests to nodes
     // 7. nodes apply committed cluster state
     // 8. master receives ApplyCommitResponses
     // 9. apply committed state on master (last one to apply cluster state)

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -219,11 +219,12 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
     // 3. master sends out PublishRequests to nodes
     // 4. master receives PublishResponses from nodes
     // 5. master sends ApplyCommitRequests to nodes
-    // 6. nodes apply committed cluster state
-    // 7. master receives ApplyCommitResponses
-    // 8. apply committed state on master (last one to apply cluster state)
-    // 9. complete the publication listener back on the master service thread
-    public static final int CLUSTER_STATE_UPDATE_NUMBER_OF_DELAYS = 9;
+    // 6. nodes deserialize committed cluster state
+    // 7. nodes apply committed cluster state
+    // 8. master receives ApplyCommitResponses
+    // 9. apply committed state on master (last one to apply cluster state)
+    // 10. complete the publication listener back on the master service thread
+    public static final int CLUSTER_STATE_UPDATE_NUMBER_OF_DELAYS = 10;
     public static final long DEFAULT_CLUSTER_STATE_UPDATE_DELAY = CLUSTER_STATE_UPDATE_NUMBER_OF_DELAYS * DEFAULT_DELAY_VARIABILITY;
 
     private static final int ELECTION_RETRIES = 10;


### PR DESCRIPTION
This PR moves the `publish_state` handler from the `CLUSTER_COORDINATION` thread pool to the `GENERIC` one. This means the initial handling of the publish request, including the deserialisation of the cluster state, happens on one of the `GENERIC` threads instead of the `CLUSTER_COORDINATION` thread. Once we have deserialised the cluster state and done some validation, we delegate to the `CLUSTER_COORDINATION` pool to apply the new state.

The consequences of this include
- The generic pool contains multiple threads, but the cluster coordination pool contains a single thread. So (in theory) multiple instances of the handler could now be executing concurrently, where previously these messages would be handled serially.
- The delegation to the cluster coordination thread for the apply means we add some more asynchrony.

Closes #106352
