### PR TITLE
Allow LuceneSourceOperator to early terminate

### DIFF
--- a/docs/changelog/108820.yaml
+++ b/docs/changelog/108820.yaml
@@ -1,5 +1,5 @@
 pr: 108820
 summary: Allow `LuceneSourceOperator` to early terminate
-area: Compute Engine
+area: ES|QL
 type: enhancement
 issues: []

--- a/docs/changelog/108820.yaml
+++ b/docs/changelog/108820.yaml
@@ -1,0 +1,5 @@
+pr: 108820
+summary: Allow `LuceneSourceOperator` to early terminate
+area: Compute Engine
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -9,6 +9,7 @@ package org.elasticsearch.compute.lucene;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BulkScorer;
+import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
@@ -181,7 +182,11 @@ public abstract class LuceneOperator extends SourceOperator {
             // avoid overflow and limit the range
             numDocs = Math.min(maxPosition - position, numDocs);
             assert numDocs > 0 : "scorer was exhausted";
-            position = bulkScorer.score(collector, acceptDocs, position, Math.min(maxPosition, position + numDocs));
+            try {
+                position = bulkScorer.score(collector, acceptDocs, position, Math.min(maxPosition, position + numDocs));
+            } catch (CollectionTerminatedException ex) {
+                position = DocIdSetIterator.NO_MORE_DOCS;
+            }
         }
 
         LeafReaderContext leafReaderContext() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.compute.lucene;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.BulkScorer;
-import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.DocIdSetIterator;
 import org.apache.lucene.search.LeafCollector;
@@ -182,11 +181,7 @@ public abstract class LuceneOperator extends SourceOperator {
             // avoid overflow and limit the range
             numDocs = Math.min(maxPosition - position, numDocs);
             assert numDocs > 0 : "scorer was exhausted";
-            try {
-                position = bulkScorer.score(collector, acceptDocs, position, Math.min(maxPosition, position + numDocs));
-            } catch (CollectionTerminatedException ex) {
-                position = DocIdSetIterator.NO_MORE_DOCS;
-            }
+            position = bulkScorer.score(collector, acceptDocs, position, Math.min(maxPosition, position + numDocs));
         }
 
         LeafReaderContext leafReaderContext() {

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSourceOperator.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.compute.lucene;
 
+import org.apache.lucene.search.CollectionTerminatedException;
 import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.Scorable;
@@ -89,6 +90,8 @@ public class LuceneSourceOperator extends LuceneOperator {
                     --remainingDocs;
                     docsBuilder.appendInt(doc);
                     currentPagePos++;
+                } else {
+                    throw new CollectionTerminatedException();
                 }
             }
         };


### PR DESCRIPTION
In the geo benchmarks, this is clearly showing as an issue as we are iterating all the matched documents to get the first 10:

![image](https://github.com/elastic/elasticsearch/assets/29038686/c7e1ab29-8a98-42de-ba72-4190c6affeb0)


We can make the LuceneSourceOperator collector to throw a CollectionTerminatedException whenever it has collected enough documents.