### PR TITLE
Revert "[Connector API] Assert required service_type of connector before starting a sync (#108769)

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/sync_job/10_connector_sync_job_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/sync_job/10_connector_sync_job_post.yml
@@ -20,15 +20,6 @@ setup:
           is_native: false
           service_type: super-connector
 
-  - do:
-      connector.put:
-        connector_id: test-connector-no-service-type
-        body:
-          index_name: search-test-2
-          name: my-connector
-          language: de
-          is_native: false
-
 ---
 'Create connector sync job':
   - do:
@@ -312,16 +303,6 @@ setup:
       connector.sync_job_post:
         body:
           id: test-connector-detached-index
-          job_type: full
-          trigger_method: full
-      catch: bad_request
-
----
-'Create connector sync job with no service type':
-  - do:
-      connector.sync_job_post:
-        body:
-          id: test-connector-no-service-type
           job_type: full
           trigger_method: full
       catch: bad_request

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java
@@ -98,6 +98,7 @@ public class ConnectorSyncJobIndexService {
         String connectorId = request.getId();
         try {
             getSyncJobConnectorInfo(connectorId, listener.delegateFailure((l, connector) -> {
+
                 if (Strings.isNullOrEmpty(connector.getIndexName())) {
                     l.onFailure(
                         new ElasticsearchStatusException(
@@ -105,19 +106,6 @@ public class ConnectorSyncJobIndexService {
                                 + connectorId
                                 + "] with no index attached. Set the [index_name] property for the connector "
                                 + "to enable syncing data.",
-                            RestStatus.BAD_REQUEST
-                        )
-                    );
-                    return;
-                }
-
-                if (Strings.isNullOrEmpty(connector.getServiceType())) {
-                    l.onFailure(
-                        new ElasticsearchStatusException(
-                            "Cannot start a sync for connector ["
-                                + connectorId
-                                + "] with [service_type] not defined. Set the service type of your connector "
-                                + "before starting the sync.",
                             RestStatus.BAD_REQUEST
                         )
                     );

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTestUtils.java
@@ -330,7 +330,6 @@ public final class ConnectorTestUtils {
             .setSyncInfo(getRandomConnectorSyncInfo())
             .setName(randomFrom(new String[] { null, randomAlphaOfLength(10) }))
             .setPipeline(randomBoolean() ? getRandomConnectorIngestPipeline() : null)
-            .setServiceType(randomAlphaOfLengthBetween(5, 10))
             .setScheduling(getRandomConnectorScheduling())
             .setStatus(getRandomConnectorInitialStatus())
             .setSyncCursor(randomBoolean() ? Map.of(randomAlphaOfLengthBetween(5, 10), randomAlphaOfLengthBetween(5, 10)) : null)
@@ -343,10 +342,6 @@ public final class ConnectorTestUtils {
 
     public static Connector getRandomConnectorWithDetachedIndex() {
         return getRandomConnectorBuilder().setIndexName(null).build();
-    }
-
-    public static Connector getRandomConnectorWithServiceTypeNotDefined() {
-        return getRandomConnectorBuilder().setServiceType(null).build();
     }
 
     private static BytesReference convertConnectorToBytesReference(Connector connector) {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexServiceTests.java
@@ -77,7 +77,6 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
     private String connectorOneId;
     private String connectorTwoId;
     private String connectorThreeId;
-    private String connectorFourId;
 
     @Override
     protected Collection<Class<? extends Plugin>> getPlugins() {
@@ -95,7 +94,6 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
         connectorOneId = createConnector(ConnectorTestUtils.getRandomConnector());
         connectorTwoId = createConnector(ConnectorTestUtils.getRandomConnector());
         connectorThreeId = createConnector(ConnectorTestUtils.getRandomConnectorWithDetachedIndex());
-        connectorFourId = createConnector(ConnectorTestUtils.getRandomConnectorWithServiceTypeNotDefined());
 
         this.connectorSyncJobIndexService = new ConnectorSyncJobIndexService(client());
     }
@@ -172,15 +170,6 @@ public class ConnectorSyncJobIndexServiceTests extends ESSingleNodeTestCase {
     public void testDeleteConnectorSyncJob_WithDetachedConnectorIndex_ExpectException() {
         PostConnectorSyncJobAction.Request syncJobRequest = new PostConnectorSyncJobAction.Request(
             connectorThreeId,
-            ConnectorSyncJobType.FULL,
-            ConnectorSyncJobTriggerMethod.ON_DEMAND
-        );
-        expectThrows(ElasticsearchStatusException.class, () -> awaitPutConnectorSyncJob(syncJobRequest));
-    }
-
-    public void testDeleteConnectorSyncJob_WithServiceTypeNotDefined_ExpectException() {
-        PostConnectorSyncJobAction.Request syncJobRequest = new PostConnectorSyncJobAction.Request(
-            connectorFourId,
             ConnectorSyncJobType.FULL,
             ConnectorSyncJobTriggerMethod.ON_DEMAND
         );


### PR DESCRIPTION
This reverts commit 458e14787cc922e7960c300a136ec0a86caa96ae.

## Why we should revert this?

~~I realised we need to revert the new check for non-null `service_type` as this can break the flow with customized connectors, e.g. connectors that are not officially supported by elastic and can be developed by users. In that case the Kibana populates the `service_type` as `null`.~~

Not true, even if customized connector is initialized with null service type, upon the connector service start its service will be updated to be non null

Not marking this as a bug since it was not released yet. 
