### PR TITLE
Move memory locking into NativeAccess

### DIFF
--- a/build-tools-internal/src/main/resources/checkstyle_suppressions.xml
+++ b/build-tools-internal/src/main/resources/checkstyle_suppressions.xml
@@ -16,6 +16,8 @@
 
   <!-- JNA requires the no-argument constructor on JNAKernel32Library.SizeT to be public-->
   <suppress files="server[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]bootstrap[/\\]JNAKernel32Library.java" checks="RedundantModifier" />
+  <!-- JNA requires the no-argument constructor on JnaKernel32Library.SizeT to be public -->
+  <suppress files="libs[/\\]native[/\\]jna[/\\]src[/\\]main[/\\]java[/\\]org[/\\]elasticsearch[/\\]nativeaccess[/\\]jna[/\\]JnaKernel32Library.java" checks="RedundantModifier" />
 
   <!-- the constructors on some local classes in these tests must be public-->
   <suppress files="server[/\\]src[/\\]test[/\\]java[/\\]org[/\\]elasticsearch[/\\]plugins[/\\]PluginsServiceTests.java" checks="RedundantModifier" />

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaKernel32Library.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaKernel32Library.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess.jna;
+
+import com.sun.jna.IntegerType;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLong;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.win32.StdCallLibrary;
+
+import org.elasticsearch.nativeaccess.lib.Kernel32Library;
+
+import java.util.List;
+
+class JnaKernel32Library implements Kernel32Library {
+    private static class JnaHandle implements Handle {
+        final Pointer pointer;
+
+        JnaHandle(Pointer pointer) {
+            this.pointer = pointer;
+        }
+    }
+
+    static class JnaAddress implements Address {
+        final Pointer pointer;
+
+        JnaAddress(Pointer pointer) {
+            this.pointer = pointer;
+        }
+
+        @Override
+        public Address add(long offset) {
+            return new JnaAddress(new Pointer(Pointer.nativeValue(pointer) + offset));
+        }
+    }
+
+    public static class SizeT extends IntegerType {
+        // JNA requires this no-arg constructor to be public,
+        // otherwise it fails to register kernel32 library
+        public SizeT() {
+            this(0);
+        }
+
+        public SizeT(long value) {
+            super(Native.SIZE_T_SIZE, value);
+        }
+    }
+
+    /**
+     * @see MemoryBasicInformation
+     */
+    public static class JnaMemoryBasicInformation extends Structure implements MemoryBasicInformation {
+        // note: these members must be public for jna to set them
+        public Pointer BaseAddress = new Pointer(0);
+        public byte[] _ignore = new byte[16];
+        public SizeT RegionSize = new SizeT();
+        public NativeLong State;
+        public NativeLong Protect;
+        public NativeLong Type;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return List.of("BaseAddress", "_ignore", "RegionSize", "State", "Protect", "Type");
+        }
+
+        @Override
+        public Address BaseAddress() {
+            return new JnaAddress(BaseAddress);
+        }
+
+        @Override
+        public long RegionSize() {
+            return RegionSize.longValue();
+        }
+
+        @Override
+        public long State() {
+            return State.longValue();
+        }
+
+        @Override
+        public long Protect() {
+            return Protect.longValue();
+        }
+
+        @Override
+        public long Type() {
+            return Type.longValue();
+        }
+    }
+
+    private interface NativeFunctions extends StdCallLibrary {
+        Pointer GetCurrentProcess();
+
+        boolean CloseHandle(Pointer handle);
+
+        boolean VirtualLock(Pointer address, SizeT size);
+
+        int VirtualQueryEx(Pointer handle, Pointer address, JnaMemoryBasicInformation memoryInfo, int length);
+
+        boolean SetProcessWorkingSetSize(Pointer handle, SizeT minSize, SizeT maxSize);
+    }
+
+    private final NativeFunctions functions;
+
+    JnaKernel32Library() {
+        this.functions = Native.load("kernel32", NativeFunctions.class);
+    }
+
+    @Override
+    public Handle GetCurrentProcess() {
+        return new JnaHandle(functions.GetCurrentProcess());
+    }
+
+    @Override
+    public boolean CloseHandle(Handle handle) {
+        assert handle instanceof JnaHandle;
+        var jnaHandle = (JnaHandle) handle;
+        return functions.CloseHandle(jnaHandle.pointer);
+    }
+
+    @Override
+    public int GetLastError() {
+        // JNA does not like linking direclty to GetLastError, so we must use the Native helper function
+        return Native.getLastError();
+    }
+
+    @Override
+    public MemoryBasicInformation newMemoryBasicInformation() {
+        return new JnaMemoryBasicInformation();
+    }
+
+    @Override
+    public boolean VirtualLock(Address address, long size) {
+        assert address instanceof JnaAddress;
+        var jnaAddress = (JnaAddress) address;
+        return functions.VirtualLock(jnaAddress.pointer, new SizeT(size));
+    }
+
+    @Override
+    public int VirtualQueryEx(Handle handle, Address address, MemoryBasicInformation memoryInfo) {
+        assert handle instanceof JnaHandle;
+        assert address instanceof JnaAddress;
+        assert memoryInfo instanceof JnaMemoryBasicInformation;
+        var jnaHandle = (JnaHandle) handle;
+        var jnaAddress = (JnaAddress) address;
+        var jnaMemoryInfo = (JnaMemoryBasicInformation) memoryInfo;
+        return functions.VirtualQueryEx(jnaHandle.pointer, jnaAddress.pointer, jnaMemoryInfo, jnaMemoryInfo.size());
+    }
+
+    @Override
+    public boolean SetProcessWorkingSetSize(Handle handle, long minSize, long maxSize) {
+        assert handle instanceof JnaHandle;
+        var jnaHandle = (JnaHandle) handle;
+        return functions.SetProcessWorkingSetSize(jnaHandle.pointer, new SizeT(minSize), new SizeT(maxSize));
+    }
+}

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaNativeLibraryProvider.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaNativeLibraryProvider.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.nativeaccess.jna;
 
 import org.elasticsearch.nativeaccess.lib.JavaLibrary;
+import org.elasticsearch.nativeaccess.lib.Kernel32Library;
 import org.elasticsearch.nativeaccess.lib.NativeLibrary;
 import org.elasticsearch.nativeaccess.lib.NativeLibraryProvider;
 import org.elasticsearch.nativeaccess.lib.PosixCLibrary;
@@ -29,6 +30,8 @@ public class JnaNativeLibraryProvider extends NativeLibraryProvider {
                 JnaJavaLibrary::new,
                 PosixCLibrary.class,
                 JnaPosixCLibrary::new,
+                Kernel32Library.class,
+                JnaKernel32Library::new,
                 SystemdLibrary.class,
                 JnaSystemdLibrary::new,
                 ZstdLibrary.class,

--- a/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaPosixCLibrary.java
+++ b/libs/native/jna/src/main/java/org/elasticsearch/nativeaccess/jna/JnaPosixCLibrary.java
@@ -46,6 +46,8 @@ class JnaPosixCLibrary implements PosixCLibrary {
 
         int getrlimit(int resource, JnaRLimit rlimit);
 
+        int mlockall(int flags);
+
         String strerror(int errno);
     }
 
@@ -70,6 +72,11 @@ class JnaPosixCLibrary implements PosixCLibrary {
         assert rlimit instanceof JnaRLimit;
         var jnaRlimit = (JnaRLimit) rlimit;
         return functions.getrlimit(resource, jnaRlimit);
+    }
+
+    @Override
+    public int mlockall(int flags) {
+        return functions.mlockall(flags);
     }
 
     @Override

--- a/libs/native/src/main/java/module-info.java
+++ b/libs/native/src/main/java/module-info.java
@@ -13,6 +13,7 @@ import org.elasticsearch.nativeaccess.lib.NativeLibraryProvider;
 module org.elasticsearch.nativeaccess {
     requires org.elasticsearch.base;
     requires org.elasticsearch.logging;
+    requires java.management; // for access to heap size
 
     exports org.elasticsearch.nativeaccess
         to

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/AbstractNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/AbstractNativeAccess.java
@@ -21,6 +21,7 @@ abstract class AbstractNativeAccess implements NativeAccess {
     private final String name;
     private final JavaLibrary javaLib;
     private final Zstd zstd;
+    protected boolean isMemoryLocked = false;
 
     protected AbstractNativeAccess(String name, NativeLibraryProvider libraryProvider) {
         this.name = name;
@@ -46,5 +47,10 @@ abstract class AbstractNativeAccess implements NativeAccess {
     public CloseableByteBuffer newBuffer(int len) {
         assert len > 0;
         return javaLib.newBuffer(len);
+    }
+
+    @Override
+    public boolean isMemoryLocked() {
+        return isMemoryLocked;
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/LinuxNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/LinuxNativeAccess.java
@@ -16,7 +16,7 @@ class LinuxNativeAccess extends PosixNativeAccess {
     Systemd systemd;
 
     LinuxNativeAccess(NativeLibraryProvider libraryProvider) {
-        super("Linux", libraryProvider, new PosixConstants(-1L, 9, 1));
+        super("Linux", libraryProvider, new PosixConstants(-1L, 9, 1, 8));
         this.systemd = new Systemd(libraryProvider.getLibrary(SystemdLibrary.class));
     }
 
@@ -33,5 +33,17 @@ class LinuxNativeAccess extends PosixNativeAccess {
     @Override
     public Systemd systemd() {
         return systemd;
+    }
+
+    @Override
+    protected void logMemoryLimitInstructions() {
+        // give specific instructions for the linux case to make it easy
+        String user = System.getProperty("user.name");
+        logger.warn("""
+            These can be adjusted by modifying /etc/security/limits.conf, for example:
+            \t# allow user '{}' mlockall
+            \t{} soft memlock unlimited
+            \t{} hard memlock unlimited""", user, user, user);
+        logger.warn("If you are logged in interactively, you will have to re-login for the new limits to take effect.");
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/MacNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/MacNativeAccess.java
@@ -13,11 +13,16 @@ import org.elasticsearch.nativeaccess.lib.NativeLibraryProvider;
 class MacNativeAccess extends PosixNativeAccess {
 
     MacNativeAccess(NativeLibraryProvider libraryProvider) {
-        super("MacOS", libraryProvider, new PosixConstants(9223372036854775807L, 5, 1));
+        super("MacOS", libraryProvider, new PosixConstants(9223372036854775807L, 5, 1, 6));
     }
 
     @Override
     protected long getMaxThreads() {
         return ProcessLimits.UNKNOWN;
+    }
+
+    @Override
+    protected void logMemoryLimitInstructions() {
+        // we don't have instructions for macos
     }
 }

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
@@ -34,6 +34,14 @@ public interface NativeAccess {
      */
     ProcessLimits getProcessLimits();
 
+    /**
+     *
+     * @return
+     */
+    void tryLockMemory();
+
+    boolean isMemoryLocked();
+
     Systemd systemd();
 
     /**

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NativeAccess.java
@@ -35,11 +35,13 @@ public interface NativeAccess {
     ProcessLimits getProcessLimits();
 
     /**
-     *
-     * @return
+     * Attempt to lock this process's virtual memory address space into physical RAM.
      */
     void tryLockMemory();
 
+    /**
+     * Return whether locking memory was successful, or false otherwise.
+     */
     boolean isMemoryLocked();
 
     Systemd systemd();

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/NoopNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/NoopNativeAccess.java
@@ -32,6 +32,16 @@ class NoopNativeAccess implements NativeAccess {
     }
 
     @Override
+    public void tryLockMemory() {
+        logger.warn("Cannot lock memory because native access is not available");
+    }
+
+    @Override
+    public boolean isMemoryLocked() {
+        return false;
+    }
+
+    @Override
     public Systemd systemd() {
         logger.warn("Cannot get systemd access because native access is not available");
         return null;

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/PosixConstants.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/PosixConstants.java
@@ -11,4 +11,4 @@ package org.elasticsearch.nativeaccess;
 /**
  * Code constants on POSIX systems.
  */
-record PosixConstants(long RLIMIT_INFINITY, int RLIMIT_AS, int RLIMIT_FSIZE) {}
+record PosixConstants(long RLIMIT_INFINITY, int RLIMIT_AS, int RLIMIT_FSIZE, int RLIMIT_MEMLOCK) {}

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/WindowsNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/WindowsNativeAccess.java
@@ -14,7 +14,7 @@ import org.elasticsearch.nativeaccess.lib.NativeLibraryProvider;
 
 import java.util.Optional;
 
-import static java.lang.management.ManagementFactory.*;
+import static java.lang.management.ManagementFactory.getMemoryMXBean;
 
 class WindowsNativeAccess extends AbstractNativeAccess {
 

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/WindowsNativeAccess.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/WindowsNativeAccess.java
@@ -8,19 +8,62 @@
 
 package org.elasticsearch.nativeaccess;
 
+import org.elasticsearch.nativeaccess.lib.Kernel32Library;
+import org.elasticsearch.nativeaccess.lib.Kernel32Library.Handle;
 import org.elasticsearch.nativeaccess.lib.NativeLibraryProvider;
 
 import java.util.Optional;
 
+import static java.lang.management.ManagementFactory.*;
+
 class WindowsNativeAccess extends AbstractNativeAccess {
+
+    /**
+     * Memory protection constraints
+     *
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa366786%28v=vs.85%29.aspx">docs</a>
+     */
+    public static final int PAGE_NOACCESS = 0x0001;
+    public static final int PAGE_GUARD = 0x0100;
+    public static final int MEM_COMMIT = 0x1000;
+
+    private final Kernel32Library kernel;
 
     WindowsNativeAccess(NativeLibraryProvider libraryProvider) {
         super("Windows", libraryProvider);
+        this.kernel = libraryProvider.getLibrary(Kernel32Library.class);
     }
 
     @Override
     public boolean definitelyRunningAsRoot() {
         return false; // don't know
+    }
+
+    @Override
+    public void tryLockMemory() {
+        Handle process = kernel.GetCurrentProcess();
+        // By default, Windows limits the number of pages that can be locked.
+        // Thus, we need to first increase the working set size of the JVM by
+        // the amount of memory we wish to lock, plus a small overhead (1MB).
+        long size = getMemoryMXBean().getHeapMemoryUsage().getInit() + (1024 * 1024);
+        if (kernel.SetProcessWorkingSetSize(process, size, size) == false) {
+            logger.warn("Unable to lock JVM memory. Failed to set working set size. Error code {}", kernel.GetLastError());
+        } else {
+            var memInfo = kernel.newMemoryBasicInformation();
+            var address = memInfo.BaseAddress();
+            while (kernel.VirtualQueryEx(process, address, memInfo) != 0) {
+                boolean lockable = memInfo.State() == MEM_COMMIT
+                    && (memInfo.Protect() & PAGE_NOACCESS) != PAGE_NOACCESS
+                    && (memInfo.Protect() & PAGE_GUARD) != PAGE_GUARD;
+                if (lockable) {
+                    kernel.VirtualLock(memInfo.BaseAddress(), memInfo.RegionSize());
+                }
+                // Move to the next region
+                address = address.add(memInfo.RegionSize());
+            }
+            isMemoryLocked = true;
+        }
+        // note: no need to close the process handle because GetCurrentProcess returns a pseudo handle
     }
 
     @Override

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/Kernel32Library.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/Kernel32Library.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess.lib;
+
+public non-sealed interface Kernel32Library extends NativeLibrary {
+    interface Handle {}
+
+    interface Address {
+        Address add(long offset);
+    }
+
+    Handle GetCurrentProcess();
+
+    boolean CloseHandle(Handle handle);
+
+    int GetLastError();
+
+    /**
+     * Contains information about a range of pages in the virtual address space of a process.
+     * The VirtualQuery and VirtualQueryEx functions use this structure.
+     *
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa366775%28v=vs.85%29.aspx">MemoryBasicInformation docs</a>
+     */
+    interface MemoryBasicInformation {
+        Address BaseAddress();
+
+        long RegionSize();
+
+        long State();
+
+        long Protect();
+
+        long Type();
+    }
+
+    /**
+     * Create a new MemoryBasicInformation for use by VirtualQuery and VirtualQueryEx
+     */
+    MemoryBasicInformation newMemoryBasicInformation();
+
+    /**
+     * Locks the specified region of the process's virtual address space into physical
+     * memory, ensuring that subsequent access to the region will not incur a page fault.
+     *
+     * @param address A pointer to the base address of the region of pages to be locked.
+     * @param size The size of the region to be locked, in bytes.
+     * @return true if the function succeeds
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa366895%28v=vs.85%29.aspx>VirtualLock docs</a>
+     */
+    boolean VirtualLock(Address address, long size);
+
+    /**
+     * Retrieves information about a range of pages within the virtual address space of a specified process.
+     *
+     * Note: the dwLength parameter is handled by the underlying implementation
+     *
+     * @param handle A handle to the process whose memory information is queried.
+     * @param address A pointer to the base address of the region of pages to be queried.
+     * @param memoryInfo A pointer to a structure in which information about the specified page range is returned.
+     * @return the actual number of bytes returned in the information buffer.
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa366907%28v=vs.85%29.aspx">VirtualQueryEx docs</a>
+     */
+    int VirtualQueryEx(Handle handle, Address address, MemoryBasicInformation memoryInfo);
+
+    /**
+     * Sets the minimum and maximum working set sizes for the specified process.
+     *
+     * @param handle A handle to the process whose working set sizes is to be set.
+     * @param minSize The minimum working set size for the process, in bytes.
+     * @param maxSize The maximum working set size for the process, in bytes.
+     * @return true if the function succeeds.
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms686234%28v=vs.85%29.aspx">SetProcessWorkingSetSize docs</a>
+     */
+    boolean SetProcessWorkingSetSize(Handle handle, long minSize, long maxSize);
+}

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/Kernel32Library.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/Kernel32Library.java
@@ -51,7 +51,7 @@ public non-sealed interface Kernel32Library extends NativeLibrary {
      * @param address A pointer to the base address of the region of pages to be locked.
      * @param size The size of the region to be locked, in bytes.
      * @return true if the function succeeds
-     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa366895%28v=vs.85%29.aspx>VirtualLock docs</a>
+     * @see <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/aa366895%28v=vs.85%29.aspx">VirtualLock docs</a>
      */
     boolean VirtualLock(Address address, long size);
 

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/NativeLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/NativeLibrary.java
@@ -9,4 +9,4 @@
 package org.elasticsearch.nativeaccess.lib;
 
 /** A marker interface for libraries that can be loaded by {@link org.elasticsearch.nativeaccess.lib.NativeLibraryProvider} */
-public sealed interface NativeLibrary permits JavaLibrary, PosixCLibrary, SystemdLibrary, VectorLibrary, ZstdLibrary {}
+public sealed interface NativeLibrary permits JavaLibrary, PosixCLibrary, Kernel32Library, SystemdLibrary, VectorLibrary, ZstdLibrary {}

--- a/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/PosixCLibrary.java
+++ b/libs/native/src/main/java/org/elasticsearch/nativeaccess/lib/PosixCLibrary.java
@@ -17,7 +17,7 @@ public non-sealed interface PosixCLibrary extends NativeLibrary {
      * Gets the effective userid of the current process.
      *
      * @return the effective user id
-     * @see <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/geteuid.html">geteuid</a>
+     * @see <a href="https://man7.org/linux/man-pages/man3/geteuid.3p.html">geteuid manpage</a>
      */
     int geteuid();
 
@@ -28,11 +28,40 @@ public non-sealed interface PosixCLibrary extends NativeLibrary {
         long rlim_max();
     }
 
+    /**
+     * Create a new RLimit struct for use by getrlimit.
+     */
     RLimit newRLimit();
 
+    /**
+     * Retrieve the current rlimit values for the given resource.
+     *
+     * @return 0 on success, -1 on failure with errno set
+     * @see <a href="https://man7.org/linux/man-pages/man2/getrlimit.2.html">getrlimit manpage</a>
+     */
     int getrlimit(int resource, RLimit rlimit);
 
+    /**
+     * Lock all the current process's virtual address space into RAM.
+     * @param flags flags determining how memory will be locked
+     * @return 0 on success, -1 on failure with errno set
+     * @see <a href="https://man7.org/linux/man-pages/man2/mlock.2.html">mlockall manpage</a>
+     */
+    int mlockall(int flags);
+
+    /**
+     * Return a string description for an error.
+     *
+     * @param errno The error number
+     * @return a String description for the error
+     * @see <a href="https://man7.org/linux/man-pages/man3/strerror.3.html">strerror manpage</a>
+     */
     String strerror(int errno);
 
+    /**
+     * Return the error number from the last failed C library call.
+     *
+     * @see <a href="https://man7.org/linux/man-pages/man3/errno.3.html">errno manpage</a>
+     */
     int errno();
 }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkKernel32Library.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkKernel32Library.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.nativeaccess.jdk;
+
+import org.elasticsearch.nativeaccess.lib.Kernel32Library;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.StructLayout;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import static java.lang.foreign.MemoryLayout.PathElement.groupElement;
+import static java.lang.foreign.MemoryLayout.paddingLayout;
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_BOOLEAN;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static java.lang.foreign.ValueLayout.JAVA_LONG;
+import static org.elasticsearch.nativeaccess.jdk.LinkerHelper.downcallHandle;
+import static org.elasticsearch.nativeaccess.jdk.MemorySegmentUtil.varHandleWithoutOffset;
+
+class JdkKernel32Library implements Kernel32Library {
+    static {
+        System.loadLibrary("kernel32");
+    }
+
+    // GetLastError can change from other Java threads so capture it
+    private static final StructLayout CAPTURE_GETLASTERROR_LAYOUT = Linker.Option.captureStateLayout();
+    private static final Linker.Option CAPTURE_GETLASTERROR_OPTION = Linker.Option.captureCallState("GetLastError");
+    private static final VarHandle GetLastError$vh = varHandleWithoutOffset(CAPTURE_GETLASTERROR_LAYOUT, groupElement("GetLastError"));
+
+    private static final MethodHandle GetCurrentProcess$mh = downcallHandle("GetCurrentProcess", FunctionDescriptor.of(ADDRESS));
+    private static final MethodHandle CloseHandle$mh = downcallHandleWithError("CloseHandle", FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS));
+    private static final MethodHandle VirtualLock$mh = downcallHandleWithError(
+        "VirtualLock",
+        FunctionDescriptor.of(JAVA_BOOLEAN, ADDRESS, JAVA_LONG)
+    );
+    private static final MethodHandle VirtualQueryEx$mh = downcallHandleWithError(
+        "VirtualQueryEx",
+        FunctionDescriptor.of(JAVA_INT, ADDRESS, ADDRESS, ADDRESS, JAVA_LONG)
+    );
+    private static final MethodHandle SetProcessWorkingSetSize$mh = downcallHandleWithError(
+        "SetProcessWorkingSetSize",
+        FunctionDescriptor.of(ADDRESS, JAVA_LONG, JAVA_LONG)
+    );
+
+    private static MethodHandle downcallHandleWithError(String function, FunctionDescriptor functionDescriptor) {
+        return downcallHandle(function, functionDescriptor, CAPTURE_GETLASTERROR_OPTION);
+    }
+
+    static class JdkHandle implements Handle {
+        MemorySegment address;
+
+        JdkHandle(MemorySegment address) {
+            this.address = address;
+        }
+    }
+
+    static class JdkAddress implements Address {
+        MemorySegment address;
+
+        JdkAddress(MemorySegment address) {
+            this.address = address;
+        }
+
+        @Override
+        public Address add(long offset) {
+            return new JdkAddress(MemorySegment.ofAddress(address.address()));
+        }
+    }
+
+    static class JdkMemoryBasicInformation implements MemoryBasicInformation {
+        private static final MemoryLayout layout = MemoryLayout.structLayout(
+            ADDRESS,
+            paddingLayout(16),
+            JAVA_LONG,
+            JAVA_LONG,
+            JAVA_LONG,
+            JAVA_LONG
+        );
+        private static final VarHandle BaseAddress$vh = varHandleWithoutOffset(layout, groupElement(0));
+        private static final VarHandle RegionSize$vh = varHandleWithoutOffset(layout, groupElement(2));
+        private static final VarHandle State$vh = varHandleWithoutOffset(layout, groupElement(3));
+        private static final VarHandle Protect$vh = varHandleWithoutOffset(layout, groupElement(4));
+        private static final VarHandle Type$vh = varHandleWithoutOffset(layout, groupElement(5));
+
+        private final MemorySegment segment;
+
+        JdkMemoryBasicInformation() {
+            this.segment = Arena.ofAuto().allocate(layout);
+            this.segment.fill((byte) 0);
+        }
+
+        @Override
+        public Address BaseAddress() {
+            return new JdkAddress((MemorySegment) BaseAddress$vh.get(segment));
+        }
+
+        @Override
+        public long RegionSize() {
+            return (long) RegionSize$vh.get(segment);
+        }
+
+        @Override
+        public long State() {
+            return (long) State$vh.get(segment);
+        }
+
+        @Override
+        public long Protect() {
+            return (long) Protect$vh.get(segment);
+        }
+
+        @Override
+        public long Type() {
+            return (long) Type$vh.get(segment);
+        }
+    }
+
+    private final MemorySegment lastErrorState;
+
+    JdkKernel32Library() {
+        Arena arena = Arena.ofAuto();
+        lastErrorState = arena.allocate(CAPTURE_GETLASTERROR_LAYOUT);
+    }
+
+    @Override
+    public Handle GetCurrentProcess() {
+        try {
+            return new JdkHandle((MemorySegment) GetCurrentProcess$mh.invokeExact());
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    @Override
+    public boolean CloseHandle(Handle handle) {
+        assert handle instanceof JdkHandle;
+        var jdkHandle = (JdkHandle) handle;
+
+        try {
+            return (boolean) CloseHandle$mh.invokeExact(lastErrorState, jdkHandle.address);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    @Override
+    public int GetLastError() {
+        return (int) GetLastError$vh.get(lastErrorState);
+    }
+
+    @Override
+    public MemoryBasicInformation newMemoryBasicInformation() {
+        return new JdkMemoryBasicInformation();
+    }
+
+    @Override
+    public boolean VirtualLock(Address address, long size) {
+        assert address instanceof JdkAddress;
+        var jdkAddress = (JdkAddress) address;
+
+        try {
+            return (boolean) VirtualLock$mh.invokeExact(lastErrorState, jdkAddress.address, size);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    @Override
+    public int VirtualQueryEx(Handle process, Address address, MemoryBasicInformation memoryInfo) {
+        assert process instanceof JdkHandle;
+        assert address instanceof JdkAddress;
+        assert memoryInfo instanceof JdkMemoryBasicInformation;
+        var jdkProcess = (JdkHandle) process;
+        var jdkAddress = (JdkAddress) address;
+        var jdkMemoryInfo = (JdkMemoryBasicInformation) memoryInfo;
+
+        try {
+            return (int) VirtualQueryEx$mh.invokeExact(
+                lastErrorState,
+                jdkProcess.address,
+                jdkAddress.address,
+                jdkMemoryInfo.segment,
+                jdkMemoryInfo.segment.byteSize()
+            );
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
+    @Override
+    public boolean SetProcessWorkingSetSize(Handle process, long minSize, long maxSize) {
+        assert process instanceof JdkHandle;
+        var jdkProcess = (JdkHandle) process;
+        try {
+            return (boolean) SetProcessWorkingSetSize$mh.invokeExact(lastErrorState, jdkProcess.address, minSize, maxSize);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+}

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkNativeLibraryProvider.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkNativeLibraryProvider.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.nativeaccess.jdk;
 
 import org.elasticsearch.nativeaccess.lib.JavaLibrary;
+import org.elasticsearch.nativeaccess.lib.Kernel32Library;
 import org.elasticsearch.nativeaccess.lib.NativeLibraryProvider;
 import org.elasticsearch.nativeaccess.lib.PosixCLibrary;
 import org.elasticsearch.nativeaccess.lib.SystemdLibrary;
@@ -27,6 +28,8 @@ public class JdkNativeLibraryProvider extends NativeLibraryProvider {
                 JdkJavaLibrary::new,
                 PosixCLibrary.class,
                 JdkPosixCLibrary::new,
+                Kernel32Library.class,
+                JdkKernel32Library::new,
                 SystemdLibrary.class,
                 JdkSystemdLibrary::new,
                 ZstdLibrary.class,

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
@@ -26,7 +26,7 @@ import static java.lang.foreign.ValueLayout.ADDRESS;
 import static java.lang.foreign.ValueLayout.JAVA_INT;
 import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.elasticsearch.nativeaccess.jdk.LinkerHelper.downcallHandle;
-import static org.elasticsearch.nativeaccess.jdk.MemorySegmentUtil.varHandleDropOffset;
+import static org.elasticsearch.nativeaccess.jdk.MemorySegmentUtil.varHandleWithoutOffset;
 
 class JdkPosixCLibrary implements PosixCLibrary {
 
@@ -35,7 +35,7 @@ class JdkPosixCLibrary implements PosixCLibrary {
     // errno can change between system calls, so we capture it
     private static final StructLayout CAPTURE_ERRNO_LAYOUT = Linker.Option.captureStateLayout();
     static final Linker.Option CAPTURE_ERRNO_OPTION = Linker.Option.captureCallState("errno");
-    private static final VarHandle errno$vh = CAPTURE_ERRNO_LAYOUT.varHandle(groupElement("errno"));
+    private static final VarHandle errno$vh = varHandleWithoutOffset(CAPTURE_ERRNO_LAYOUT, groupElement("errno"));
 
     private static final MethodHandle geteuid$mh = downcallHandle("geteuid", FunctionDescriptor.of(JAVA_INT));
     private static final MethodHandle strerror$mh = downcallHandle("strerror", FunctionDescriptor.of(ADDRESS, JAVA_INT));
@@ -43,6 +43,7 @@ class JdkPosixCLibrary implements PosixCLibrary {
         "getrlimit",
         FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS)
     );
+    private static final MethodHandle mlockall$mh = downcallHandleWithErrno("mlockall", FunctionDescriptor.of(JAVA_INT, JAVA_INT));
 
     static final MemorySegment errnoState = Arena.ofAuto().allocate(CAPTURE_ERRNO_LAYOUT);
 
@@ -90,10 +91,19 @@ class JdkPosixCLibrary implements PosixCLibrary {
         }
     }
 
+    @Override
+    public int mlockall(int flags) {
+        try {
+            return (int) mlockall$mh.invokeExact(errnoState, flags);
+        } catch (Throwable t) {
+            throw new AssertionError(t);
+        }
+    }
+
     static class JdkRLimit implements RLimit {
         private static final MemoryLayout layout = MemoryLayout.structLayout(JAVA_LONG, JAVA_LONG);
-        private static final VarHandle rlim_cur$vh = varHandleDropOffset(layout.varHandle(groupElement(0)));
-        private static final VarHandle rlim_max$vh = varHandleDropOffset(layout.varHandle(groupElement(1)));
+        private static final VarHandle rlim_cur$vh = varHandleWithoutOffset(layout, groupElement(0));
+        private static final VarHandle rlim_max$vh = varHandleWithoutOffset(layout, groupElement(1));
 
         private final MemorySegment segment;
 

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/JdkPosixCLibrary.java
@@ -60,7 +60,7 @@ class JdkPosixCLibrary implements PosixCLibrary {
     public String strerror(int errno) {
         try {
             MemorySegment str = (MemorySegment) strerror$mh.invokeExact(errno);
-            return str.reinterpret(Long.MAX_VALUE).getUtf8String(0);
+            return MemorySegmentUtil.getString(str.reinterpret(Long.MAX_VALUE), 0);
         } catch (Throwable t) {
             throw new AssertionError(t);
         }

--- a/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main21/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.nativeaccess.jdk;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.VarHandle;
 
@@ -25,10 +26,17 @@ class MemorySegmentUtil {
         return arena.allocateUtf8String(s);
     }
 
-    // MemorySegment.varHandle changed between 21 and 22. The resulting varHandle now requires an additional
-    // long offset parameter. We omit the offset at runtime, instead binding to the VarHandle in JDK 22.
-    static VarHandle varHandleDropOffset(VarHandle varHandle) {
-        return varHandle;
+    /**
+     * Return a {@link VarHandle} to access an element within the given memory segment.
+     *
+     * Note: This is no-op in Java 21, see the Java 22 implementation.
+     *
+     * @param layout The layout of a struct to access
+     * @param element The element within the struct to access
+     * @return A {@link VarHandle} that accesses the element with a fixed offset of 0
+     */
+    static VarHandle varHandleWithoutOffset(MemoryLayout layout, MemoryLayout.PathElement element) {
+        return layout.varHandle(element);
     }
 
     private MemorySegmentUtil() {}

--- a/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
+++ b/libs/native/src/main22/java/org/elasticsearch/nativeaccess/jdk/MemorySegmentUtil.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.nativeaccess.jdk;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
@@ -23,10 +24,10 @@ class MemorySegmentUtil {
         return arena.allocateFrom(s);
     }
 
-    // MemorySegment.varHandle changed between 21 and 22. The resulting varHandle now requires an additional
-    // long offset parameter. We omit the offset at runtime, instead binding to the VarHandle in JDK 22.
-    static VarHandle varHandleDropOffset(VarHandle varHandle) {
-        return MethodHandles.insertCoordinates(varHandle, 1, 0L);
+    // MemoryLayout.varHandle changed between Java 21 and 22 to require a new offset
+    // parameter for the returned VarHandle. This function exists to remove the need for that offset.
+    static VarHandle varHandleWithoutOffset(MemoryLayout layout, MemoryLayout.PathElement element) {
+        return MethodHandles.insertCoordinates(layout.varHandle(element), 1, 0L);
     }
 
     private MemorySegmentUtil() {}

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapChecks.java
@@ -262,7 +262,7 @@ final class BootstrapChecks {
         }
 
         boolean isMemoryLocked() {
-            return Natives.isMemoryLocked();
+            return NativeAccess.instance().isMemoryLocked();
         }
 
     }
@@ -334,7 +334,7 @@ final class BootstrapChecks {
 
         // visible for testing
         boolean isMemoryLocked() {
-            return Natives.isMemoryLocked();
+            return NativeAccess.instance().isMemoryLocked();
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
@@ -11,6 +11,7 @@ package org.elasticsearch.bootstrap;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.nativeaccess.NativeAccess;
 
 import java.util.Dictionary;
 import java.util.Enumeration;
@@ -40,7 +41,7 @@ public final class BootstrapInfo {
      * Returns true if we were able to lock the process's address space.
      */
     public static boolean isMemoryLocked() {
-        return Natives.isMemoryLocked();
+        return NativeAccess.instance().isMemoryLocked();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.StringHelper;
 import org.apache.lucene.util.VectorUtil;
 import org.elasticsearch.Build;
@@ -280,9 +279,10 @@ class Elasticsearch {
      */
     static void initializeNatives(final Path tmpFile, final boolean mlockAll, final boolean systemCallFilter, final boolean ctrlHandler) {
         final Logger logger = LogManager.getLogger(Elasticsearch.class);
+        var nativeAccess = NativeAccess.instance();
 
         // check if the user is running as root, and bail
-        if (NativeAccess.instance().definitelyRunningAsRoot()) {
+        if (nativeAccess.definitelyRunningAsRoot()) {
             throw new RuntimeException("can not run elasticsearch as root");
         }
 
@@ -297,11 +297,7 @@ class Elasticsearch {
 
         // mlockall if requested
         if (mlockAll) {
-            if (Constants.WINDOWS) {
-                Natives.tryVirtualLock();
-            } else {
-                Natives.tryMlockall();
-            }
+            nativeAccess.tryLockMemory();
         }
 
         // listener for windows close event

--- a/server/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/JNANatives.java
@@ -9,17 +9,13 @@
 package org.elasticsearch.bootstrap;
 
 import com.sun.jna.Native;
-import com.sun.jna.Pointer;
 import com.sun.jna.WString;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.Constants;
-import org.elasticsearch.monitor.jvm.JvmInfo;
 
 import java.nio.file.Path;
-
-import static org.elasticsearch.bootstrap.JNAKernel32Library.SizeT;
 
 /**
  * This class performs the actual work with JNA and library bindings to call native methods. It should only be used after
@@ -32,115 +28,11 @@ class JNANatives {
 
     private static final Logger logger = LogManager.getLogger(JNANatives.class);
 
-    // Set to true, in case native mlockall call was successful
-    static boolean LOCAL_MLOCKALL = false;
     // Set to true, in case native system call filter install was successful
     static boolean LOCAL_SYSTEM_CALL_FILTER = false;
     // Set to true, in case policy can be applied to all threads of the process (even existing ones)
     // otherwise they are only inherited for new threads (ES app threads)
     static boolean LOCAL_SYSTEM_CALL_FILTER_ALL = false;
-
-    static void tryMlockall() {
-        int errno = Integer.MIN_VALUE;
-        String errMsg = null;
-        boolean rlimitSuccess = false;
-        long softLimit = 0;
-        long hardLimit = 0;
-
-        try {
-            int result = JNACLibrary.mlockall(JNACLibrary.MCL_CURRENT);
-            if (result == 0) {
-                LOCAL_MLOCKALL = true;
-                return;
-            }
-
-            errno = Native.getLastError();
-            errMsg = JNACLibrary.strerror(errno);
-            if (Constants.LINUX || Constants.MAC_OS_X) {
-                // we only know RLIMIT_MEMLOCK for these two at the moment.
-                JNACLibrary.Rlimit rlimit = new JNACLibrary.Rlimit();
-                if (JNACLibrary.getrlimit(JNACLibrary.RLIMIT_MEMLOCK, rlimit) == 0) {
-                    rlimitSuccess = true;
-                    softLimit = rlimit.rlim_cur.longValue();
-                    hardLimit = rlimit.rlim_max.longValue();
-                } else {
-                    logger.warn("Unable to retrieve resource limits: {}", JNACLibrary.strerror(Native.getLastError()));
-                }
-            }
-        } catch (UnsatisfiedLinkError e) {
-            // this will have already been logged by CLibrary, no need to repeat it
-            return;
-        }
-
-        // mlockall failed for some reason
-        logger.warn("Unable to lock JVM Memory: error={}, reason={}", errno, errMsg);
-        logger.warn("This can result in part of the JVM being swapped out.");
-        if (errno == JNACLibrary.ENOMEM) {
-            if (rlimitSuccess) {
-                logger.warn(
-                    "Increase RLIMIT_MEMLOCK, soft limit: {}, hard limit: {}",
-                    rlimitToString(softLimit),
-                    rlimitToString(hardLimit)
-                );
-                if (Constants.LINUX) {
-                    // give specific instructions for the linux case to make it easy
-                    String user = System.getProperty("user.name");
-                    logger.warn("""
-                        These can be adjusted by modifying /etc/security/limits.conf, for example:
-                        \t# allow user '{}' mlockall
-                        \t{} soft memlock unlimited
-                        \t{} hard memlock unlimited""", user, user, user);
-                    logger.warn("If you are logged in interactively, you will have to re-login for the new limits to take effect.");
-                }
-            } else {
-                logger.warn("Increase RLIMIT_MEMLOCK (ulimit).");
-            }
-        }
-    }
-
-    static String rlimitToString(long value) {
-        assert Constants.LINUX || Constants.MAC_OS_X;
-        if (value == JNACLibrary.RLIM_INFINITY) {
-            return "unlimited";
-        } else {
-            return Long.toUnsignedString(value);
-        }
-    }
-
-    static void tryVirtualLock() {
-        JNAKernel32Library kernel = JNAKernel32Library.getInstance();
-        Pointer process = null;
-        try {
-            process = kernel.GetCurrentProcess();
-            // By default, Windows limits the number of pages that can be locked.
-            // Thus, we need to first increase the working set size of the JVM by
-            // the amount of memory we wish to lock, plus a small overhead (1MB).
-            SizeT size = new SizeT(JvmInfo.jvmInfo().getMem().getHeapInit().getBytes() + (1024 * 1024));
-            if (kernel.SetProcessWorkingSetSize(process, size, size) == false) {
-                logger.warn("Unable to lock JVM memory. Failed to set working set size. Error code {}", Native.getLastError());
-            } else {
-                JNAKernel32Library.MemoryBasicInformation memInfo = new JNAKernel32Library.MemoryBasicInformation();
-                long address = 0;
-                while (kernel.VirtualQueryEx(process, new Pointer(address), memInfo, memInfo.size()) != 0) {
-                    boolean lockable = memInfo.State.longValue() == JNAKernel32Library.MEM_COMMIT
-                        && (memInfo.Protect.longValue() & JNAKernel32Library.PAGE_NOACCESS) != JNAKernel32Library.PAGE_NOACCESS
-                        && (memInfo.Protect.longValue() & JNAKernel32Library.PAGE_GUARD) != JNAKernel32Library.PAGE_GUARD;
-                    if (lockable) {
-                        kernel.VirtualLock(memInfo.BaseAddress, new SizeT(memInfo.RegionSize.longValue()));
-                    }
-                    // Move to the next region
-                    address += memInfo.RegionSize.longValue();
-                }
-                LOCAL_MLOCKALL = true;
-            }
-        } catch (UnsatisfiedLinkError e) {
-            // this will have already been logged by Kernel32Library, no need to repeat it
-        } finally {
-            if (process != null) {
-                kernel.CloseHandle(process);
-            }
-        }
-    }
 
     /**
      * Retrieves the short path form of the specified path.

--- a/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Natives.java
@@ -51,22 +51,6 @@ final class Natives {
         JNA_AVAILABLE = v;
     }
 
-    static void tryMlockall() {
-        if (JNA_AVAILABLE == false) {
-            logger.warn("cannot mlockall because JNA is not available");
-            return;
-        }
-        JNANatives.tryMlockall();
-    }
-
-    static void tryVirtualLock() {
-        if (JNA_AVAILABLE == false) {
-            logger.warn("cannot virtual lock because JNA is not available");
-            return;
-        }
-        JNANatives.tryVirtualLock();
-    }
-
     /**
      * Retrieves the short path form of the specified path.
      *
@@ -87,13 +71,6 @@ final class Natives {
             return;
         }
         JNANatives.addConsoleCtrlHandler(handler);
-    }
-
-    static boolean isMemoryLocked() {
-        if (JNA_AVAILABLE == false) {
-            return false;
-        }
-        return JNANatives.LOCAL_MLOCKALL;
     }
 
     static void tryInstallSystemCallFilter(Path tmpFile) {

--- a/server/src/test/java/org/elasticsearch/bootstrap/JNANativesTests.java
+++ b/server/src/test/java/org/elasticsearch/bootstrap/JNANativesTests.java
@@ -14,11 +14,6 @@ import org.elasticsearch.test.ESTestCase;
 import static org.hamcrest.Matchers.equalTo;
 
 public class JNANativesTests extends ESTestCase {
-    public void testMlockall() {
-        if (Constants.MAC_OS_X) {
-            assertFalse("Memory locking is not available on OS X platforms", JNANatives.LOCAL_MLOCKALL);
-        }
-    }
 
     public void testConsoleCtrlHandler() {
         if (Constants.WINDOWS) {


### PR DESCRIPTION
This commit moves the implementations of locking virtual memory into RAM into NativeAccess.

relates https://github.com/elastic/elasticsearch/pull/104876