### PR TITLE
Close listener refs in finally block

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -697,7 +697,7 @@ public class ComputeService {
         final RefCountingListener listenerRefs = new RefCountingListener(
             ActionListener.runBefore(listener.map(unused -> new ComputeResponse(collectedProfiles)), responseHeadersCollector::finish)
         );
-        try (listenerRefs) {
+        try {
             final AtomicBoolean cancelled = new AtomicBoolean();
             // run compute with target shards
             var internalSink = exchangeService.createSinkHandler(request.sessionId(), request.pragmas().exchangeBufferSize());
@@ -746,6 +746,8 @@ public class ComputeService {
             exchangeService.finishSinkHandler(externalId, e);
             exchangeService.finishSinkHandler(request.sessionId(), e);
             listenerRefs.acquire().onFailure(e);
+        } finally {
+            listenerRefs.close();
         }
     }
 


### PR DESCRIPTION
We will need to acquire a new listener in the catch block; therefore, we should not release the listenerRefs in the try-with-resources block, which is executed before the catch block.

Relates #108580