### PR TITLE
[ESQL] Mark date_diff as requiring all three arguments

### DIFF
--- a/docs/changelog/108834.yaml
+++ b/docs/changelog/108834.yaml
@@ -1,0 +1,6 @@
+pr: 108834
+summary: "[ESQL] Mark `date_diff` as requiring all three arguments"
+area: ES|QL
+type: bug
+issues:
+ - 108383

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiff.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiff.java
@@ -48,7 +48,7 @@ import static org.elasticsearch.xpack.ql.type.DataTypeConverter.safeToInt;
  * in multiples of the unit specified in the first argument.
  * If the second argument (start) is greater than the third argument (end), then negative values are returned.
  */
-public class DateDiff extends EsqlScalarFunction implements OptionalArgument {
+public class DateDiff extends EsqlScalarFunction {
 
     public static final ZoneId UTC = ZoneId.of("Z");
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiff.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiff.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
 import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
-import org.elasticsearch.xpack.ql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/108383

I didn't see a good place to add a test for this; if there is one, let me know and I'm happy to add it.

This fixes a bug where we had incorrectly marked `date_diff` as having an optional argument, which resulted in an NPE when that argument was not provided.  In fact, all three of `date_diff`'s arguments are required.  After this change, failing to provide one will cause a parse exception, as one would expect.