### PR TITLE
[docs] Prevent DLS/FLS if replication is assigned

### DIFF
--- a/docs/reference/rest-api/security/create-cross-cluster-api-key.asciidoc
+++ b/docs/reference/rest-api/security/create-cross-cluster-api-key.asciidoc
@@ -65,12 +65,12 @@ At least one of them must be specified.
 `names`:::: (required, list) A list of indices or name patterns to which the
 permissions in this entry apply.
 `field_security`:::: (optional, object) The document fields that the owners of the role have
-read access to. This may not be set when the `replication` is also defined. For more information,
-see <<ccx-apikeys-dls-fls, Field and document level security with Cross-cluster API keys>>.
+read access to. This may not be set when the `replication` field is also defined. For more information,
+see <<ccx-apikeys-dls-fls, Field and document level security with cross-cluster API keys>>.
 `query`:::: (optional) A search query that defines the documents the owners of the role have
 read access to. A document within the specified indices must match this query to be accessible by the
-owners of the role. This may not be set when the `replication` is also defined. For more information,
-see <<ccx-apikeys-dls-fls, Field and document level security with Cross-cluster API keys>>.
+owners of the role. This may not be set when the `replication` field is also defined. For more information,
+see <<ccx-apikeys-dls-fls, Field and document level security with cross-cluster API keys>>.
 `allow_restricted_indices`:::: (optional, boolean) This needs to be set to `true` (default
 is `false`) if the patterns in the `names` field should cover <<system-indices,system indices>>.
 `replication`::: (optional, list) A list of indices permission entries for cross-cluster replication.

--- a/docs/reference/rest-api/security/create-cross-cluster-api-key.asciidoc
+++ b/docs/reference/rest-api/security/create-cross-cluster-api-key.asciidoc
@@ -65,10 +65,12 @@ At least one of them must be specified.
 `names`:::: (required, list) A list of indices or name patterns to which the
 permissions in this entry apply.
 `field_security`:::: (optional, object) The document fields that the owners of the role have
-read access to. For more information, check <<field-and-document-access-control>>.
+read access to. This may not be set when the `replication` is also defined. For more information,
+see <<ccx-apikeys-dls-fls, Field and document level security with Cross-cluster API keys>>.
 `query`:::: (optional) A search query that defines the documents the owners of the role have
-read access to. A document within the specified indices must match this query to be accessible by the owners of the role. For more information, check
-<<field-and-document-access-control>>.
+read access to. A document within the specified indices must match this query to be accessible by the
+owners of the role. This may not be set when the `replication` is also defined. For more information,
+see <<ccx-apikeys-dls-fls, Field and document level security with Cross-cluster API keys>>.
 `allow_restricted_indices`:::: (optional, boolean) This needs to be set to `true` (default
 is `false`) if the patterns in the `names` field should cover <<system-indices,system indices>>.
 `replication`::: (optional, list) A list of indices permission entries for cross-cluster replication.

--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -65,18 +65,18 @@ include::set-security-user.asciidoc[]
 ==== Field and document level security with Cross-cluster API keys
 
 <<security-api-create-cross-cluster-api-key, Cross-Cluster API keys>> can be used to authenticate
-requests to a remote cluster.`access` provides access for Cross Cluster Search.
-`replication` provides access for Cross Cluster Replication.
+requests to a remote cluster. The `access` parameter defines permissions for cross-cluster search.
+The `replication` parameter defines permissions for cross-cluster replication.
 
-`replication` does not support any field or document level security. `access` supports field and/or document level security.
-However, for reasons similar those described in  <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
-it is not allowed to create a single Cross-Cluster API key with both `access` and `replication` where
-`access` has document or field level security defined.
+`replication` does not support any field or document level security. `access` supports field and document level security.
 
-If you need both `access` and `replication` with the need to
-define document or field level security for `access`, create two separate Cross-Cluster API keys. One with `access` that defines
-document or field level security, and another with `replication`. You will need to also setup two different
-remote connections (to the same cluster), with each named connection using the appropriate Cross-Cluster API key.
+For reasons similar those described in  <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
+you can't create a single Cross-Cluster API key with both the `access` and `replication` parameter, where the
+`access` parameter has document or field level security defined.
+
+If you to use both of these parameters, and need to
+define document or field level security for the `access` parameter, create two separate Cross-Cluster API keys, one using the `access` parameter, and one using the `replication` parameter. You'll also need to set up two different
+remote connections to the same cluster, with each named connection using the appropriate Cross-Cluster API key.
 
 
 

--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -3,10 +3,10 @@
 === Setting up field and document level security
 
 You can control access to data within a data stream or index by adding field and document level
-security permissions to a role. 
-<<field-level-security,Field level security permissions>> restrict access to 
-particular fields within a document. 
-<<document-level-security,Document level security permissions>> restrict access 
+security permissions to a role.
+<<field-level-security,Field level security permissions>> restrict access to
+particular fields within a document.
+<<document-level-security,Document level security permissions>> restrict access
 to particular documents.
 
 NOTE: Document and field level security is currently meant to operate with
@@ -59,3 +59,24 @@ documents by index instead.
 
 include::role-templates.asciidoc[]
 include::set-security-user.asciidoc[]
+
+
+[[ccx-apikeys-dls-fls]]
+==== Field and document level security with Cross-cluster API keys
+
+Cross-cluster API keys can be used to authenticate requests to a remote cluster.
+`access` controls Cross Cluster Search, and `replication` controls Cross Cluster Replication.
+
+For reasons similar those described in  <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
+it is not allowed to create a single Cross-cluster API key with both `access` and `replication` where
+`access` has document or field level security defined.
+
+If you need both `access` and `replication` with the need to
+define document or field level security, create two separate Cross-cluster API keys. One with `access` that defines
+document or field level security, and another with `replication`. You will need to also setup two different
+remote connections (to the same cluster), with each named connection using the appropriate Cross-cluster API key.
+
+
+
+
+

--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -64,17 +64,19 @@ include::set-security-user.asciidoc[]
 [[ccx-apikeys-dls-fls]]
 ==== Field and document level security with Cross-cluster API keys
 
-Cross-cluster API keys can be used to authenticate requests to a remote cluster.
-`access` controls Cross Cluster Search, and `replication` controls Cross Cluster Replication.
+<<security-api-create-cross-cluster-api-key, Cross-Cluster API keys>> can be used to authenticate
+requests to a remote cluster.`access` provides access for Cross Cluster Search.
+`replication` provides access for Cross Cluster Replication.
 
-For reasons similar those described in  <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
-it is not allowed to create a single Cross-cluster API key with both `access` and `replication` where
+`replication` does not support any field or document level security. `access` supports field and/or document level security.
+However, for reasons similar those described in  <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
+it is not allowed to create a single Cross-Cluster API key with both `access` and `replication` where
 `access` has document or field level security defined.
 
 If you need both `access` and `replication` with the need to
-define document or field level security, create two separate Cross-cluster API keys. One with `access` that defines
+define document or field level security for `access`, create two separate Cross-Cluster API keys. One with `access` that defines
 document or field level security, and another with `replication`. You will need to also setup two different
-remote connections (to the same cluster), with each named connection using the appropriate Cross-cluster API key.
+remote connections (to the same cluster), with each named connection using the appropriate Cross-Cluster API key.
 
 
 

--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -70,7 +70,7 @@ The `replication` parameter defines permissions for cross-cluster replication.
 
 `replication` does not support any field or document level security. `search` supports field and document level security.
 
-For reasons similar those described in <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
+For reasons similar to those described in <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
 you can't create a single cross-cluster API key with both the `search` and `replication` parameters if the
 `search` parameter has document or field level security defined.
 

--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -74,7 +74,7 @@ For reasons similar those described in <<multiple-roles-dls-fls,Multiple roles w
 you can't create a single cross-cluster API key with both the `search` and `replication` parameters if the
 `search` parameter has document or field level security defined.
 
-If you to use both of these parameters, and you need to define document or field level security for the `search` parameter,
+If you need to use both of these parameters, and you need to define document or field level security for the `search` parameter,
 create two separate cross-cluster API keys, one using the `search` parameter,
 and one using the `replication` parameter. You will also need to set up two different
 remote connections to the same cluster, with each named connection using the appropriate cross-cluster API key.

--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -71,7 +71,7 @@ The `replication` parameter defines permissions for cross-cluster replication.
 `replication` does not support any field or document level security. `search` supports field and document level security.
 
 For reasons similar those described in <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
-you can't create a single cross-cluster API key with both the `search` and `replication` parameter, where the
+you can't create a single cross-cluster API key with both the `search` and `replication` parameters if the
 `search` parameter has document or field level security defined.
 
 If you to use both of these parameters, and you need to define document or field level security for the `search` parameter,

--- a/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+++ b/docs/reference/security/authorization/field-and-document-access-control.asciidoc
@@ -65,18 +65,19 @@ include::set-security-user.asciidoc[]
 ==== Field and document level security with Cross-cluster API keys
 
 <<security-api-create-cross-cluster-api-key, Cross-Cluster API keys>> can be used to authenticate
-requests to a remote cluster. The `access` parameter defines permissions for cross-cluster search.
+requests to a remote cluster. The `search` parameter defines permissions for cross-cluster search.
 The `replication` parameter defines permissions for cross-cluster replication.
 
-`replication` does not support any field or document level security. `access` supports field and document level security.
+`replication` does not support any field or document level security. `search` supports field and document level security.
 
-For reasons similar those described in  <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
-you can't create a single Cross-Cluster API key with both the `access` and `replication` parameter, where the
-`access` parameter has document or field level security defined.
+For reasons similar those described in <<multiple-roles-dls-fls,Multiple roles with document and field level security>>,
+you can't create a single cross-cluster API key with both the `search` and `replication` parameter, where the
+`search` parameter has document or field level security defined.
 
-If you to use both of these parameters, and need to
-define document or field level security for the `access` parameter, create two separate Cross-Cluster API keys, one using the `access` parameter, and one using the `replication` parameter. You'll also need to set up two different
-remote connections to the same cluster, with each named connection using the appropriate Cross-Cluster API key.
+If you to use both of these parameters, and you need to define document or field level security for the `search` parameter,
+create two separate cross-cluster API keys, one using the `search` parameter,
+and one using the `replication` parameter. You will also need to set up two different
+remote connections to the same cluster, with each named connection using the appropriate cross-cluster API key.
 
 
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CrossClusterApiKeyRoleDescriptorBuilder.java
@@ -162,8 +162,8 @@ public class CrossClusterApiKeyRoleDescriptorBuilder {
         final String[] clusterPrivileges = roleDescriptor.getClusterPrivileges();
         // only need to check if both "search" and "replication" are defined
         // no need to check for DLS if set of cluster privileges are not the set used pre 8.14
-        final String[] pre8_14ClusterPrivileges = { "cross_cluster_search", "cross_cluster_replication" };
-        final boolean hasBoth = Arrays.equals(clusterPrivileges, pre8_14ClusterPrivileges);
+        final String[] legacyClusterPrivileges = { "cross_cluster_search", "cross_cluster_replication" };
+        final boolean hasBoth = Arrays.equals(clusterPrivileges, legacyClusterPrivileges);
         if (false == hasBoth) {
             return;
         }
@@ -171,9 +171,9 @@ public class CrossClusterApiKeyRoleDescriptorBuilder {
         final RoleDescriptor.IndicesPrivileges[] indicesPrivileges = roleDescriptor.getIndicesPrivileges();
         for (RoleDescriptor.IndicesPrivileges indexPrivilege : indicesPrivileges) {
             final String[] privileges = indexPrivilege.getPrivileges();
-            final String[] pre8_14IndicesPrivileges = { "read", "read_cross_cluster", "view_index_metadata" };
+            final String[] legacyIndicesPrivileges = { "read", "read_cross_cluster", "view_index_metadata" };
             // find the "search" privilege, no need to check for DLS if set of index privileges are not the set used pre 8.14
-            if (Arrays.equals(privileges, pre8_14IndicesPrivileges)) {
+            if (Arrays.equals(privileges, legacyIndicesPrivileges)) {
                 if (indexPrivilege.isUsingDocumentOrFieldLevelSecurity()) {
                     throw new IllegalArgumentException(
                         "Cross cluster API key ["


### PR DESCRIPTION
this commit adds documentation for the DLS/FLS restriction for RCS 2.0 API keys where both access and replication are defined and access has DSL/FLS. 

this commit also fixes a few misleading variable names.  

related: https://github.com/elastic/elasticsearch/pull/108600