### PR TITLE
ES|QL: Fix double precision error on sumOfDouble CSV spec test

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -214,7 +214,7 @@ l:long
 ;
 
 sumOfDouble
-from employees | stats h = sum(height);
+from employees | stats h = round(sum(height), 10);
 
 h:double
 176.82


### PR DESCRIPTION
The test failed repeatedly due to small differences in the final result, especially in multi-node.
These differences are only due to the order of double operations

https://gradle-enterprise.elastic.co/s/yke3pbfiqsvfo/console-log?page=5
https://gradle-enterprise.elastic.co/s/yjustunaoqnss/console-log?anchor=4650&page=5

Related to https://github.com/elastic/elasticsearch/issues/108560