### PR TITLE
Revert "Make AggregateMapper a singleton (#108828)"

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -16,9 +16,6 @@ tests:
 - class: "org.elasticsearch.xpack.esql.ccq.MultiClusterSpecIT"
   issue: "https://github.com/elastic/elasticsearch/issues/108809"
   method: "test {k8s-metrics.MetricsWithoutAggs}"
-- class: "org.elasticsearch.xpack.esql.action.ManyShardsIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/108847"
-  method: "testConcurrentQueries"
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -50,8 +50,8 @@
   - is_true: status
   - match: { indicators.shards_capacity.status: "green" }
   - match: { indicators.shards_capacity.symptom: "The cluster has enough room to add new shards." }
-  - is_true: indicators.shards_capacity.details.data.max_shards_in_cluster
-  - is_true: indicators.shards_capacity.details.frozen.max_shards_in_cluster
+  - exists: indicators.shards_capacity.details.data.max_shards_in_cluster
+  - exists: indicators.shards_capacity.details.frozen.max_shards_in_cluster
 
 ---
 "basic data stream lifecycle health indicator test":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -50,8 +50,8 @@
   - is_true: status
   - match: { indicators.shards_capacity.status: "green" }
   - match: { indicators.shards_capacity.symptom: "The cluster has enough room to add new shards." }
-  - exists: indicators.shards_capacity.details.data.max_shards_in_cluster
-  - exists: indicators.shards_capacity.details.frozen.max_shards_in_cluster
+  - is_true: indicators.shards_capacity.details.data.max_shards_in_cluster
+  - is_true: indicators.shards_capacity.details.frozen.max_shards_in_cluster
 
 ---
 "basic data stream lifecycle health indicator test":

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -65,8 +65,6 @@ public class AggregateMapper {
         Values.class
     );
 
-    static AggregateMapper INSTANCE = new AggregateMapper();
-
     /** Record of agg Class, type, and grouping (or non-grouping). */
     record AggDef(Class<?> aggClazz, String type, String extra, boolean grouping) {}
 
@@ -76,8 +74,12 @@ public class AggregateMapper {
     /** Cache of aggregates to intermediate expressions. */
     private final HashMap<Expression, List<? extends NamedExpression>> cache = new HashMap<>();
 
-    private AggregateMapper() {
-        mapper = AGG_FUNCTIONS.stream()
+    AggregateMapper() {
+        this(AGG_FUNCTIONS);
+    }
+
+    AggregateMapper(List<? extends Class<? extends Function>> aggregateFunctionClasses) {
+        mapper = aggregateFunctionClasses.stream()
             .flatMap(AggregateMapper::typeAndNames)
             .flatMap(AggregateMapper::groupingAndNonGrouping)
             .collect(Collectors.toUnmodifiableMap(aggDef -> aggDef, AggregateMapper::lookupIntermediateState));


### PR DESCRIPTION
I did not realize that we are using a cache object on AggregatorMapper.
 
This reverts commit 090cee5a6f5727a0b4cada9af98a59f0a1723bff.

revert https://github.com/elastic/elasticsearch/pull/108828
fixes https://github.com/elastic/elasticsearch/issues/108847
