### PR TITLE
[8.14] Fix double precision error on CSV spec tests (#108845)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -214,7 +214,7 @@ l:long
 ;
 
 sumOfDouble
-from employees | stats h = sum(height);
+from employees | stats h = round(sum(height), 10);
 
 h:double
 176.82


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Fix double precision error on CSV spec tests (#108845)