### PR TITLE
Replace THIRTY_SECONDS with TEST_REQUEST_TIMEOUT in tests

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/CrudDataStreamLifecycleIT.java
@@ -230,7 +230,7 @@ public class CrudDataStreamLifecycleIT extends ESIntegTestCase {
         // Remove lifecycle from concrete data stream
         {
             DeleteDataStreamLifecycleAction.Request deleteDataLifecycleRequest = new DeleteDataStreamLifecycleAction.Request(
-                TimeValue.THIRTY_SECONDS,
+                TEST_REQUEST_TIMEOUT,
                 AcknowledgedRequest.DEFAULT_ACK_TIMEOUT,
                 new String[] { "with-lifecycle-1" }
             );
@@ -257,7 +257,7 @@ public class CrudDataStreamLifecycleIT extends ESIntegTestCase {
         // Remove lifecycle from all data streams
         {
             DeleteDataStreamLifecycleAction.Request deleteDataLifecycleRequest = new DeleteDataStreamLifecycleAction.Request(
-                TimeValue.THIRTY_SECONDS,
+                TEST_REQUEST_TIMEOUT,
                 AcknowledgedRequest.DEFAULT_ACK_TIMEOUT,
                 new String[] { "*" }
             );

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceIT.java
@@ -203,7 +203,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
             client().execute(
                 PutDataStreamGlobalRetentionAction.INSTANCE,
                 new PutDataStreamGlobalRetentionAction.Request(
-                    TimeValue.THIRTY_SECONDS,
+                    TEST_REQUEST_TIMEOUT,
                     TimeValue.timeValueSeconds(globalRetentionSeconds),
                     TimeValue.timeValueSeconds(globalRetentionSeconds)
                 )
@@ -293,7 +293,7 @@ public class DataStreamLifecycleServiceIT extends ESIntegTestCase {
             } finally {
                 client().execute(
                     DeleteDataStreamGlobalRetentionAction.INSTANCE,
-                    new DeleteDataStreamGlobalRetentionAction.Request(TimeValue.THIRTY_SECONDS)
+                    new DeleteDataStreamGlobalRetentionAction.Request(TEST_REQUEST_TIMEOUT)
                 );
             }
         } finally {

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/lifecycle/ExplainDataStreamLifecycleIT.java
@@ -213,7 +213,7 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         client().execute(
             PutDataStreamGlobalRetentionAction.INSTANCE,
             new PutDataStreamGlobalRetentionAction.Request(
-                TimeValue.THIRTY_SECONDS,
+                TEST_REQUEST_TIMEOUT,
                 TimeValue.timeValueSeconds(globalRetentionSeconds),
                 TimeValue.timeValueSeconds(globalRetentionSeconds)
             )
@@ -263,7 +263,7 @@ public class ExplainDataStreamLifecycleIT extends ESIntegTestCase {
         } finally {
             client().execute(
                 DeleteDataStreamGlobalRetentionAction.INSTANCE,
-                new DeleteDataStreamGlobalRetentionAction.Request(TimeValue.THIRTY_SECONDS)
+                new DeleteDataStreamGlobalRetentionAction.Request(TEST_REQUEST_TIMEOUT)
             );
         }
     }

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -154,7 +154,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
         private final RefCounted refCounted = AbstractRefCounted.of(() -> {});
 
         Request() {
-            super(TimeValue.THIRTY_SECONDS);
+            super(TEST_REQUEST_TIMEOUT);
         }
 
         Request(StreamInput in) throws IOException {

--- a/server/src/test/java/org/elasticsearch/indices/settings/InternalOrPrivateSettingsPlugin.java
+++ b/server/src/test/java/org/elasticsearch/indices/settings/InternalOrPrivateSettingsPlugin.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.tasks.Task;
@@ -40,6 +39,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static org.elasticsearch.test.ESTestCase.TEST_REQUEST_TIMEOUT;
 
 public class InternalOrPrivateSettingsPlugin extends Plugin implements ActionPlugin {
 
@@ -78,7 +79,7 @@ public class InternalOrPrivateSettingsPlugin extends Plugin implements ActionPlu
             }
 
             public Request(final String index, final String key, final String value) {
-                super(TimeValue.THIRTY_SECONDS);
+                super(TEST_REQUEST_TIMEOUT);
                 this.index = index;
                 this.key = key;
                 this.value = value;

--- a/server/src/test/java/org/elasticsearch/reservedstate/ReservedClusterStateHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/ReservedClusterStateHandlerTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.reservedstate;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.settings.InternalOrPrivateSettingsPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentParser;
@@ -45,7 +44,7 @@ public class ReservedClusterStateHandlerTests extends ESTestCase {
 
     static class ValidRequest extends MasterNodeRequest<InternalOrPrivateSettingsPlugin.UpdateInternalOrPrivateAction.Request> {
         ValidRequest() {
-            super(TimeValue.THIRTY_SECONDS);
+            super(TEST_REQUEST_TIMEOUT);
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2103,6 +2103,13 @@ public abstract class ESTestCase extends LuceneTestCase {
     }
 
     /**
+     * Various timeouts in various REST APIs default to 30s, and many tests do not care about such timeouts, but must specify some value
+     * anyway when constructing the corresponding transport/action request instance since we would prefer to avoid having implicit defaults
+     * in these requests. This constant can be used as a slightly more meaningful way to refer to the 30s default value in tests.
+     */
+    public static final TimeValue TEST_REQUEST_TIMEOUT = TimeValue.THIRTY_SECONDS;
+
+    /**
      * The timeout used for the various "safe" wait methods such as {@link #safeAwait} and {@link #safeAcquire}. In tests we generally want
      * these things to complete almost immediately, but sometimes the CI runner executes things rather slowly so we use {@code 10s} as a
      * fairly relaxed definition of "immediately".

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AbstractFrozenAutoscalingIntegTestCase.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AbstractFrozenAutoscalingIntegTestCase.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.snapshots.AbstractSnapshotIntegTestCase;
 import org.elasticsearch.snapshots.SnapshotInfo;
@@ -112,7 +111,7 @@ public abstract class AbstractFrozenAutoscalingIntegTestCase extends AbstractSna
     }
 
     protected GetAutoscalingCapacityAction.Response capacity() {
-        GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS);
+        GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT);
         return client().execute(GetAutoscalingCapacityAction.INSTANCE, request).actionGet();
     }
 
@@ -120,8 +119,8 @@ public abstract class AbstractFrozenAutoscalingIntegTestCase extends AbstractSna
         // randomly set the setting to verify it can be set.
         final Settings settings = randomBoolean() ? Settings.EMPTY : addDeciderSettings(Settings.builder()).build();
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             policyName,
             new TreeSet<>(Set.of(DataTier.DATA_FROZEN)),
             new TreeMap<>(Map.of(deciderName(), settings))

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingFileSettingsIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingFileSettingsIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.metadata.ReservedStateHandlerMetadata;
 import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.core.Strings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.reservedstate.service.FileSettingsService;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
@@ -226,8 +225,8 @@ public class AutoscalingFileSettingsIT extends AutoscalingIntegTestCase {
             return PutAutoscalingPolicyAction.Request.parse(
                 parser,
                 (roles, deciders) -> new PutAutoscalingPolicyAction.Request(
-                    TimeValue.THIRTY_SECONDS,
-                    TimeValue.THIRTY_SECONDS,
+                    TEST_REQUEST_TIMEOUT,
+                    TEST_REQUEST_TIMEOUT,
                     name,
                     roles,
                     deciders

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingLicenseCheckerIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingLicenseCheckerIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.xpack.autoscaling.action.DeleteAutoscalingPolicyAction;
@@ -46,8 +45,8 @@ public class AutoscalingLicenseCheckerIT extends ESSingleNodeTestCase {
 
     public void testCanNotPutPolicyWithNonCompliantLicense() throws InterruptedException {
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             "",
             Collections.emptySortedSet(),
             Collections.emptySortedMap()
@@ -78,7 +77,7 @@ public class AutoscalingLicenseCheckerIT extends ESSingleNodeTestCase {
     }
 
     public void testCanNotGetPolicyWithNonCompliantLicense() throws InterruptedException {
-        final GetAutoscalingPolicyAction.Request request = new GetAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, "");
+        final GetAutoscalingPolicyAction.Request request = new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, "");
         final CountDownLatch latch = new CountDownLatch(1);
         client().execute(GetAutoscalingPolicyAction.INSTANCE, request, new ActionListener<>() {
 
@@ -105,7 +104,7 @@ public class AutoscalingLicenseCheckerIT extends ESSingleNodeTestCase {
     }
 
     public void testCanNonGetAutoscalingCapacityDecisionWithNonCompliantLicense() throws InterruptedException {
-        final GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS);
+        final GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT);
         final CountDownLatch latch = new CountDownLatch(1);
         client().execute(GetAutoscalingCapacityAction.INSTANCE, request, new ActionListener<>() {
 
@@ -133,8 +132,8 @@ public class AutoscalingLicenseCheckerIT extends ESSingleNodeTestCase {
 
     public void testCanDeleteAutoscalingPolicyEvenWithNonCompliantLicense() throws InterruptedException {
         final DeleteAutoscalingPolicyAction.Request request = new DeleteAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             "*"
         );
         final CountDownLatch latch = new CountDownLatch(1);

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingSnapshotsIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingSnapshotsIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.autoscaling.action.DeleteAutoscalingPolicyAction;
 import org.elasticsearch.xpack.autoscaling.action.GetAutoscalingPolicyAction;
@@ -57,8 +56,8 @@ public class AutoscalingSnapshotsIT extends AutoscalingIntegTestCase {
         final boolean deletePolicy = randomBoolean();
         if (deletePolicy) {
             final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(
-                TimeValue.THIRTY_SECONDS,
-                TimeValue.THIRTY_SECONDS,
+                TEST_REQUEST_TIMEOUT,
+                TEST_REQUEST_TIMEOUT,
                 policy.name()
             );
             assertAcked(client.execute(DeleteAutoscalingPolicyAction.INSTANCE, deleteRequest).actionGet());
@@ -88,8 +87,8 @@ public class AutoscalingSnapshotsIT extends AutoscalingIntegTestCase {
 
     private void putPolicy(AutoscalingPolicy policy) {
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             policy.name(),
             policy.roles(),
             policy.deciders()
@@ -98,19 +97,13 @@ public class AutoscalingSnapshotsIT extends AutoscalingIntegTestCase {
     }
 
     private void assertPolicy(AutoscalingPolicy policy) {
-        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            policy.name()
-        );
+        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, policy.name());
         final AutoscalingPolicy actualPolicy = client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest).actionGet().policy();
         assertThat(actualPolicy, equalTo(policy));
     }
 
     private void assertPolicyNotFound(AutoscalingPolicy policy) {
-        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            policy.name()
-        );
+        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, policy.name());
         final ResourceNotFoundException e = expectThrows(
             ResourceNotFoundException.class,
             () -> client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest).actionGet().policy()

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityRestCancellationIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityRestCancellationIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
 import org.elasticsearch.tasks.CancellableTask;
@@ -144,8 +143,8 @@ public class GetAutoscalingCapacityRestCancellationIT extends AutoscalingIntegTe
 
     private void putAutoscalingPolicy(Map<String, Settings> settingsMap) {
         final PutAutoscalingPolicyAction.Request request1 = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             "test",
             new TreeSet<>(Set.of(DiscoveryNodeRole.DATA_ROLE.roleName())),
             // test depends on using treemap's internally, i.e., count is evaluated before wait_for_cancel.

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.autoscaling.action;
 
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.autoscaling.AutoscalingIntegTestCase;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
@@ -26,8 +25,8 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
     public void testDeletePolicy() {
         final AutoscalingPolicy policy = randomAutoscalingPolicy();
         final PutAutoscalingPolicyAction.Request putRequest = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             policy.name(),
             policy.roles(),
             policy.deciders()
@@ -36,8 +35,8 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
         // we trust that the policy is in the cluster state since we have tests for putting policies
         String deleteName = randomFrom("*", policy.name(), policy.name().substring(0, between(0, policy.name().length())) + "*");
         final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             deleteName
         );
         assertAcked(client().execute(DeleteAutoscalingPolicyAction.INSTANCE, deleteRequest).actionGet());
@@ -47,10 +46,7 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
         assertNotNull(metadata);
         assertThat(metadata.policies(), not(hasKey(policy.name())));
         // and verify that we can not obtain the policy via get
-        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            policy.name()
-        );
+        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, policy.name());
         final ResourceNotFoundException e = expectThrows(
             ResourceNotFoundException.class,
             client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest)
@@ -61,8 +57,8 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
     public void testDeleteNonExistentPolicy() {
         final String name = randomAlphaOfLength(8);
         final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             name
         );
         final ResourceNotFoundException e = expectThrows(
@@ -75,8 +71,8 @@ public class TransportDeleteAutoscalingPolicyActionIT extends AutoscalingIntegTe
     public void testDeleteNonExistentPolicyByWildcard() {
         final String name = randomFrom("*", randomAlphaOfLength(8) + "*");
         final DeleteAutoscalingPolicyAction.Request deleteRequest = new DeleteAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             name
         );
         assertAcked(client().execute(DeleteAutoscalingPolicyAction.INSTANCE, deleteRequest).actionGet());

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingCapacityActionIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.autoscaling.action;
 
 import org.apache.logging.log4j.Level;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.monitor.os.OsProbe;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -73,15 +72,15 @@ public class TransportGetAutoscalingCapacityActionIT extends AutoscalingIntegTes
     }
 
     public GetAutoscalingCapacityAction.Response capacity() {
-        GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS);
+        GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT);
         GetAutoscalingCapacityAction.Response response = client().execute(GetAutoscalingCapacityAction.INSTANCE, request).actionGet();
         return response;
     }
 
     private void putAutoscalingPolicy(String policyName) {
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             policyName,
             new TreeSet<>(Set.of("data")),
             new TreeMap<>()

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.autoscaling.action;
 
 import org.elasticsearch.ResourceNotFoundException;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.autoscaling.AutoscalingIntegTestCase;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
 
@@ -23,22 +22,22 @@ public class TransportGetAutoscalingPolicyActionIT extends AutoscalingIntegTestC
         final String name = randomAlphaOfLength(8);
         final AutoscalingPolicy expectedPolicy = randomAutoscalingPolicyOfName(name);
         final PutAutoscalingPolicyAction.Request putRequest = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             expectedPolicy.name(),
             expectedPolicy.roles(),
             expectedPolicy.deciders()
         );
         assertAcked(client().execute(PutAutoscalingPolicyAction.INSTANCE, putRequest).actionGet());
         // we trust that the policy is in the cluster state since we have tests for putting policies
-        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, name);
+        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, name);
         final AutoscalingPolicy actualPolicy = client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest).actionGet().policy();
         assertThat(expectedPolicy, equalTo(actualPolicy));
     }
 
     public void testGetNonExistentPolicy() {
         final String name = randomAlphaOfLength(8);
-        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, name);
+        final GetAutoscalingPolicyAction.Request getRequest = new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, name);
         final ResourceNotFoundException e = expectThrows(
             ResourceNotFoundException.class,
             client().execute(GetAutoscalingPolicyAction.INSTANCE, getRequest)

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionIT.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.autoscaling.action;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.autoscaling.AutoscalingIntegTestCase;
 import org.elasticsearch.xpack.autoscaling.AutoscalingMetadata;
 import org.elasticsearch.xpack.autoscaling.policy.AutoscalingPolicy;
@@ -99,8 +98,8 @@ public class TransportPutAutoscalingPolicyActionIT extends AutoscalingIntegTestC
 
     private void putAutoscalingPolicy(final AutoscalingPolicy policy) {
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             policy.name(),
             policy.roles(),
             policy.deciders()

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/AutoscalingStorageIntegTestCase.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/AutoscalingStorageIntegTestCase.java
@@ -14,7 +14,6 @@ import org.elasticsearch.cluster.InternalClusterInfoService;
 import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.datastreams.DataStreamsPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.autoscaling.LocalStateAutoscaling;
@@ -53,7 +52,7 @@ public abstract class AutoscalingStorageIntegTestCase extends DiskUsageIntegTest
     }
 
     public GetAutoscalingCapacityAction.Response capacity() {
-        GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS);
+        GetAutoscalingCapacityAction.Request request = new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT);
         GetAutoscalingCapacityAction.Response response = client().execute(GetAutoscalingCapacityAction.INSTANCE, request).actionGet();
         return response;
     }

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageIT.java
@@ -111,8 +111,8 @@ public class ProactiveStorageIT extends AutoscalingStorageIntegTestCase {
 
     private void putAutoscalingPolicy(String policyName, Settings settings) {
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             policyName,
             new TreeSet<>(Set.of("data")),
             new TreeMap<>(Map.of("proactive_storage", settings))

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -21,7 +21,6 @@ import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -541,8 +540,8 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
 
     private void putAutoscalingPolicy(String policyName, String role) {
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             policyName,
             new TreeSet<>(Set.of(role)),
             new TreeMap<>(Map.of("reactive_storage", Settings.EMPTY))

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/DeleteAutoscalingPolicyActionRequestWireSerializingTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/DeleteAutoscalingPolicyActionRequestWireSerializingTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.autoscaling.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 public class DeleteAutoscalingPolicyActionRequestWireSerializingTests extends AbstractWireSerializingTestCase<
@@ -21,7 +20,7 @@ public class DeleteAutoscalingPolicyActionRequestWireSerializingTests extends Ab
 
     @Override
     protected DeleteAutoscalingPolicyAction.Request createTestInstance() {
-        return new DeleteAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS, randomAlphaOfLength(8));
+        return new DeleteAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, randomAlphaOfLength(8));
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityActionRequestWireSerializingTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityActionRequestWireSerializingTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.autoscaling.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 public class GetAutoscalingCapacityActionRequestWireSerializingTests extends AbstractWireSerializingTestCase<
@@ -21,7 +20,7 @@ public class GetAutoscalingCapacityActionRequestWireSerializingTests extends Abs
 
     @Override
     protected GetAutoscalingCapacityAction.Request createTestInstance() {
-        return new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS);
+        return new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT);
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingPolicyActionRequestWireSerializingTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingPolicyActionRequestWireSerializingTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.autoscaling.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 public class GetAutoscalingPolicyActionRequestWireSerializingTests extends AbstractWireSerializingTestCase<
@@ -21,7 +20,7 @@ public class GetAutoscalingPolicyActionRequestWireSerializingTests extends Abstr
 
     @Override
     protected GetAutoscalingPolicyAction.Request createTestInstance() {
-        return new GetAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, randomAlphaOfLength(8));
+        return new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, randomAlphaOfLength(8));
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportDeleteAutoscalingPolicyActionTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.regex.Regex;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -61,7 +60,7 @@ public class TransportDeleteAutoscalingPolicyActionTests extends AutoscalingTest
             .build();
         final ClusterState state = ClusterState.builder(new ClusterName(randomAlphaOfLength(8))).blocks(blocks).build();
         final ClusterBlockException e = action.checkBlock(
-            new DeleteAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS, randomAlphaOfLength(8)),
+            new DeleteAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, randomAlphaOfLength(8)),
             state
         );
         assertThat(e, not(nullValue()));
@@ -80,7 +79,7 @@ public class TransportDeleteAutoscalingPolicyActionTests extends AutoscalingTest
         final ClusterBlocks blocks = ClusterBlocks.builder().build();
         final ClusterState state = ClusterState.builder(new ClusterName(randomAlphaOfLength(8))).blocks(blocks).build();
         final ClusterBlockException e = action.checkBlock(
-            new DeleteAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, TimeValue.THIRTY_SECONDS, randomAlphaOfLength(8)),
+            new DeleteAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, TEST_REQUEST_TIMEOUT, randomAlphaOfLength(8)),
             state
         );
         assertThat(e, nullValue());

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportGetAutoscalingPolicyActionTests.java
@@ -18,7 +18,6 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -64,7 +63,7 @@ public class TransportGetAutoscalingPolicyActionTests extends AutoscalingTestCas
             .build();
         final ClusterState state = ClusterState.builder(new ClusterName(randomAlphaOfLength(8))).blocks(blocks).build();
         final ClusterBlockException e = action.checkBlock(
-            new GetAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, randomAlphaOfLength(8)),
+            new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, randomAlphaOfLength(8)),
             state
         );
         assertThat(e, not(nullValue()));
@@ -84,7 +83,7 @@ public class TransportGetAutoscalingPolicyActionTests extends AutoscalingTestCas
         final ClusterBlocks blocks = ClusterBlocks.builder().build();
         final ClusterState state = ClusterState.builder(new ClusterName(randomAlphaOfLength(8))).blocks(blocks).build();
         final ClusterBlockException e = action.checkBlock(
-            new GetAutoscalingPolicyAction.Request(TimeValue.THIRTY_SECONDS, randomAlphaOfLength(8)),
+            new GetAutoscalingPolicyAction.Request(TEST_REQUEST_TIMEOUT, randomAlphaOfLength(8)),
             state
         );
         assertThat(e, nullValue());

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/action/TransportPutAutoscalingPolicyActionTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.cluster.coordination.NoMasterBlockService;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -130,8 +129,8 @@ public class TransportPutAutoscalingPolicyActionTests extends AutoscalingTestCas
 
     public void testAddPolicyWithNoRoles() {
         PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(8),
             null,
             randomAutoscalingDeciders()
@@ -161,8 +160,8 @@ public class TransportPutAutoscalingPolicyActionTests extends AutoscalingTestCas
         final String name = randomFrom(currentMetadata.policies().keySet());
         // add to the existing deciders, to ensure the policy has changed
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             name,
             randomBoolean() ? randomRoles() : null,
             mutateAutoscalingDeciders(currentMetadata.policies().get(name).policy().deciders())
@@ -211,8 +210,8 @@ public class TransportPutAutoscalingPolicyActionTests extends AutoscalingTestCas
         final AutoscalingMetadata currentMetadata = currentState.metadata().custom(AutoscalingMetadata.NAME);
         final AutoscalingPolicy policy = randomFrom(currentMetadata.policies().values()).policy();
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             policy.name(),
             randomBoolean() ? policy.roles() : null,
             randomBoolean() ? policy.deciders() : null
@@ -232,8 +231,8 @@ public class TransportPutAutoscalingPolicyActionTests extends AutoscalingTestCas
 
     public void testPolicyValidator() {
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(8),
             randomRoles(),
             Collections.emptySortedMap()
@@ -251,8 +250,8 @@ public class TransportPutAutoscalingPolicyActionTests extends AutoscalingTestCas
 
     static PutAutoscalingPolicyAction.Request randomPutAutoscalingPolicyRequest() {
         return new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             randomAlphaOfLength(8),
             randomRoles(),
             randomBoolean() ? randomAutoscalingDeciders() : null

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetMlAutoscalingStatsRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetMlAutoscalingStatsRequestTests.java
@@ -23,14 +23,11 @@ public class GetMlAutoscalingStatsRequestTests extends AbstractWireSerializingTe
 
     @Override
     protected Request createTestInstance() {
-        return new Request(TimeValue.THIRTY_SECONDS, randomTimeValue(0, 10_000));
+        return new Request(TEST_REQUEST_TIMEOUT, randomTimeValue(0, 10_000));
     }
 
     @Override
     protected Request mutateInstance(Request instance) throws IOException {
-        return new Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.timeValueMillis(instance.requestTimeout().millis() + randomIntBetween(1, 1000))
-        );
+        return new Request(TEST_REQUEST_TIMEOUT, TimeValue.timeValueMillis(instance.requestTimeout().millis() + randomIntBetween(1, 1000)));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.indices.SystemIndexDescriptor;
@@ -297,7 +296,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
                 {"_doc":{"properties":{"some-field":{"type":"long"}}}}""",
             client,
             clusterState,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             ActionTestUtils.assertNoFailureListener(Assert::assertTrue),
             1
         );

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -370,7 +370,7 @@ public class MlIndexAndAliasTests extends ESTestCase {
             TestIndexNameExpressionResolver.newInstance(),
             TEST_INDEX_PREFIX,
             TEST_INDEX_ALIAS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             listener
         );
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionServiceTests.java
@@ -23,7 +23,6 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.TriFunction;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -401,7 +400,7 @@ public class AnalyticsCollectionServiceTests extends ESTestCase {
         ClusterState clusterState,
         String... collectionName
     ) throws Exception {
-        GetAnalyticsCollectionAction.Request request = new GetAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, collectionName);
+        GetAnalyticsCollectionAction.Request request = new GetAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, collectionName);
         return new Executor<>(clusterState, analyticsCollectionService::getAnalyticsCollection).execute(request).getAnalyticsCollections();
     }
 
@@ -410,7 +409,7 @@ public class AnalyticsCollectionServiceTests extends ESTestCase {
         ClusterState clusterState,
         String collectionName
     ) throws Exception {
-        PutAnalyticsCollectionAction.Request request = new PutAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, collectionName);
+        PutAnalyticsCollectionAction.Request request = new PutAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, collectionName);
         return new Executor<>(clusterState, analyticsCollectionService::putAnalyticsCollection).execute(request);
     }
 
@@ -419,10 +418,7 @@ public class AnalyticsCollectionServiceTests extends ESTestCase {
         ClusterState clusterState,
         String collectionName
     ) throws Exception {
-        DeleteAnalyticsCollectionAction.Request request = new DeleteAnalyticsCollectionAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            collectionName
-        );
+        DeleteAnalyticsCollectionAction.Request request = new DeleteAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, collectionName);
         return new Executor<>(clusterState, analyticsCollectionService::deleteAnalyticsCollection).execute(request);
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/DeleteAnalyticsCollectionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/DeleteAnalyticsCollectionRequestBWCSerializingTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.application.analytics.action;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
@@ -29,7 +28,7 @@ public class DeleteAnalyticsCollectionRequestBWCSerializingTests extends Abstrac
 
     @Override
     protected DeleteAnalyticsCollectionAction.Request createTestInstance() {
-        return new DeleteAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, randomIdentifier());
+        return new DeleteAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, randomIdentifier());
     }
 
     @Override
@@ -47,12 +46,12 @@ public class DeleteAnalyticsCollectionRequestBWCSerializingTests extends Abstrac
         DeleteAnalyticsCollectionAction.Request instance,
         TransportVersion version
     ) {
-        return new DeleteAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, instance.getCollectionName());
+        return new DeleteAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, instance.getCollectionName());
     }
 
     private static final ConstructingObjectParser<DeleteAnalyticsCollectionAction.Request, Void> PARSER = new ConstructingObjectParser<>(
         "delete_analytics_collection_request",
-        p -> new DeleteAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, (String) p[0])
+        p -> new DeleteAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, (String) p[0])
     );
 
     static {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/GetAnalyticsCollectionRequestBWCSerializingTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.application.analytics.action;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
@@ -30,7 +29,7 @@ public class GetAnalyticsCollectionRequestBWCSerializingTests extends AbstractBW
 
     @Override
     protected GetAnalyticsCollectionAction.Request createTestInstance() {
-        return new GetAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, new String[] { randomIdentifier() });
+        return new GetAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, new String[] { randomIdentifier() });
     }
 
     @Override
@@ -48,13 +47,13 @@ public class GetAnalyticsCollectionRequestBWCSerializingTests extends AbstractBW
         GetAnalyticsCollectionAction.Request instance,
         TransportVersion version
     ) {
-        return new GetAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, instance.getNames());
+        return new GetAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, instance.getNames());
     }
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<GetAnalyticsCollectionAction.Request, Void> PARSER = new ConstructingObjectParser<>(
         "get_analytics_collection_request",
-        p -> new GetAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, ((List<String>) p[0]).toArray(String[]::new))
+        p -> new GetAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, ((List<String>) p[0]).toArray(String[]::new))
     );
     static {
         PARSER.declareStringArray(constructorArg(), NAMES_FIELD);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PutAnalyticsCollectionRequestBWCSerializingTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.application.analytics.action;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
@@ -29,7 +28,7 @@ public class PutAnalyticsCollectionRequestBWCSerializingTests extends AbstractBW
 
     @Override
     protected PutAnalyticsCollectionAction.Request createTestInstance() {
-        return new PutAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, randomIdentifier());
+        return new PutAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, randomIdentifier());
     }
 
     @Override
@@ -47,13 +46,13 @@ public class PutAnalyticsCollectionRequestBWCSerializingTests extends AbstractBW
         PutAnalyticsCollectionAction.Request instance,
         TransportVersion version
     ) {
-        return new PutAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, instance.getName());
+        return new PutAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, instance.getName());
     }
 
     private static final ConstructingObjectParser<PutAnalyticsCollectionAction.Request, String> PARSER = new ConstructingObjectParser<>(
         "put_analytics_collection_request",
         false,
-        (p) -> new PutAnalyticsCollectionAction.Request(TimeValue.THIRTY_SECONDS, (String) p[0])
+        (p) -> new PutAnalyticsCollectionAction.Request(TEST_REQUEST_TIMEOUT, (String) p[0])
     );
     static {
         PARSER.declareString(constructorArg(), NAME_FIELD);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
@@ -86,8 +86,8 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
             Settings.builder().put(MlAutoscalingDeciderService.DOWN_SCALE_DELAY.getKey(), TimeValue.ZERO).build()
         );
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             "ml_test",
             new TreeSet<>(List.of("master", "data", "ingest", "ml")),
             deciders
@@ -96,7 +96,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
 
         assertBusy(
             () -> assertMlCapacity(
-                client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS))
+                client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT))
                     .actionGet(),
                 "Requesting scale down as tier and/or node size could be smaller",
                 0L,
@@ -116,7 +116,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         );
 
         assertMlCapacity(
-            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS))
+            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT))
                 .actionGet(),
             "Requesting scale down as tier and/or node size could be smaller",
             expectedTierBytes,
@@ -155,7 +155,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         );
 
         assertMlCapacity(
-            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS))
+            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT))
                 .actionGet(),
             "requesting scale up as number of jobs in queues exceeded configured limit",
             expectedTierBytes,
@@ -170,7 +170,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         expectedNodeBytes = (long) Math.ceil(ByteSizeValue.ofMb(200 + PER_JOB_OVERHEAD_MB + PER_NODE_OVERHEAD_MB).getBytes() * 100 / 30.0);
 
         assertMlCapacity(
-            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS))
+            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT))
                 .actionGet(),
             "Requesting scale down as tier and/or node size could be smaller",
             expectedTierBytes,
@@ -181,7 +181,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         closeJob("job2");
 
         assertMlCapacity(
-            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS))
+            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT))
                 .actionGet(),
             "Requesting scale down as tier and/or node size could be smaller",
             0L,
@@ -204,8 +204,8 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
             Settings.builder().put(MlAutoscalingDeciderService.DOWN_SCALE_DELAY.getKey(), TimeValue.ZERO).build()
         );
         final PutAutoscalingPolicyAction.Request request = new PutAutoscalingPolicyAction.Request(
-            TimeValue.THIRTY_SECONDS,
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
+            TEST_REQUEST_TIMEOUT,
             "ml_test",
             new TreeSet<>(List.of("master", "data", "ingest", "ml")),
             deciders
@@ -221,7 +221,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         );
 
         assertMlCapacity(
-            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS))
+            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT))
                 .actionGet(),
             "Requesting scale down as tier and/or node size could be smaller",
             expectedTierBytes,
@@ -257,7 +257,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         );
 
         assertMlCapacity(
-            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TimeValue.THIRTY_SECONDS))
+            client().execute(GetAutoscalingCapacityAction.INSTANCE, new GetAutoscalingCapacityAction.Request(TEST_REQUEST_TIMEOUT))
                 .actionGet(),
             "requesting scale up as number of jobs in queues exceeded configured limit "
                 + "or there is at least one trained model waiting for assignment "

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelSnapshotRetentionIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelSnapshotRetentionIT.java
@@ -70,7 +70,7 @@ public class ModelSnapshotRetentionIT extends MlNativeAutodetectIntegTestCase {
             client(),
             ClusterState.EMPTY_STATE,
             TestIndexNameExpressionResolver.newInstance(),
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             future
         );
         future.actionGet();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelSnapshotSearchIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelSnapshotSearchIT.java
@@ -16,7 +16,6 @@ import org.elasticsearch.action.index.TransportIndexAction;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -60,7 +59,7 @@ public class ModelSnapshotSearchIT extends MlNativeAutodetectIntegTestCase {
             client(),
             ClusterState.EMPTY_STATE,
             TestIndexNameExpressionResolver.newInstance(),
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             future
         );
         future.actionGet();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -199,7 +199,7 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
             client(),
             ClusterState.EMPTY_STATE,
             TestIndexNameExpressionResolver.newInstance(),
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             future
         );
         future.get();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -1100,7 +1100,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
             client(),
             ClusterState.EMPTY_STATE,
             TestIndexNameExpressionResolver.newInstance(),
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             future
         );
         future.actionGet();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/UnusedStatsRemoverIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/UnusedStatsRemoverIT.java
@@ -11,7 +11,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ToXContent;
@@ -57,7 +56,7 @@ public class UnusedStatsRemoverIT extends BaseMlIntegTestCase {
             client(),
             clusterService().state(),
             TestIndexNameExpressionResolver.newInstance(client().threadPool().getThreadContext()),
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             future
         );
         future.actionGet();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -267,7 +267,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
         when(jobTask.getAllocationId()).thenReturn(1L);
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         assertEquals(1, manager.numberOfOpenJobs());
         assertTrue(manager.jobHasActiveAutodetectProcess(jobTask));
         ArgumentCaptor<JobTaskState> captor = ArgumentCaptor.forClass(JobTaskState.class);
@@ -295,7 +295,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn(job.getId());
         AtomicReference<Exception> errorHolder = new AtomicReference<>();
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> errorHolder.set(e));
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> errorHolder.set(e));
         Exception error = errorHolder.get();
         assertThat(error, is(notNullValue()));
         assertThat(error.getMessage(), equalTo("Cannot open job [no_version] because jobs created prior to version 5.5 are not supported"));
@@ -338,22 +338,22 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("bar");
         when(jobTask.getAllocationId()).thenReturn(1L);
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("baz");
         when(jobTask.getAllocationId()).thenReturn(2L);
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         assertEquals(3, manager.numberOfOpenJobs());
 
         Exception[] holder = new Exception[1];
         jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foobar");
         when(jobTask.getAllocationId()).thenReturn(3L);
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> holder[0] = e);
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> holder[0] = e);
         Exception e = holder[0];
         assertEquals("max running job capacity [3] reached", e.getMessage());
 
@@ -362,7 +362,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         when(jobTask.getJobId()).thenReturn("baz");
         manager.closeJob(jobTask, null);
         assertEquals(2, manager.numberOfOpenJobs());
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e1, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e1, b) -> {});
         assertEquals(3, manager.numberOfOpenJobs());
     }
 
@@ -373,7 +373,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
         DataLoadParams params = new DataLoadParams(TimeRange.builder().build(), Optional.empty());
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -400,7 +400,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         Exception[] holder = new Exception[1];
         manager.processData(jobTask, analysisRegistry, inputStream, xContentType, params, (dataCounts1, e) -> holder[0] = e);
         assertNotNull(holder[0]);
@@ -412,7 +412,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -442,7 +442,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
         when(jobTask.triggerVacate()).thenReturn(true);
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -474,7 +474,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -527,7 +527,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -561,7 +561,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         InputStream inputStream = createInputStream("");
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(jobTask, analysisRegistry, inputStream, xContentType, params, (dataCounts1, e) -> {});
         verify(autodetectCommunicator).writeToJob(same(inputStream), same(analysisRegistry), same(xContentType), same(params), any());
     }
@@ -572,7 +572,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
         InputStream inputStream = createInputStream("");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -616,7 +616,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         // create a jobtask
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -659,7 +659,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         when(jobTask.getJobId()).thenReturn("foo");
         assertFalse(manager.jobHasActiveAutodetectProcess(jobTask));
 
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -682,7 +682,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         when(jobTask.getJobId()).thenReturn("foo");
         assertFalse(manager.jobHasActiveAutodetectProcess(jobTask));
 
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,
@@ -727,7 +727,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
 
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         InputStream inputStream = createInputStream("");
         DataCounts[] dataCounts = new DataCounts[1];
         manager.processData(
@@ -835,7 +835,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         AutodetectProcessManager manager = createSpyManager();
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn("foo");
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
 
         long expectedSizeBytes = Job.PROCESS_MEMORY_OVERHEAD.getBytes() + switch (assignmentMemoryBasis) {
             case MODEL_MEMORY_LIMIT -> modelMemoryLimitBytes;
@@ -904,7 +904,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         AutodetectProcessManager manager = createSpyManager();
         JobTask jobTask = mock(JobTask.class);
         when(jobTask.getJobId()).thenReturn(jobId);
-        manager.openJob(jobTask, clusterState, TimeValue.THIRTY_SECONDS, (e, b) -> {});
+        manager.openJob(jobTask, clusterState, TEST_REQUEST_TIMEOUT, (e, b) -> {});
         manager.processData(
             jobTask,
             analysisRegistry,

--- a/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetStatusActionIT.java
+++ b/x-pack/plugin/profiling/src/internalClusterTest/java/org/elasticsearch/xpack/profiling/action/GetStatusActionIT.java
@@ -31,7 +31,7 @@ public class GetStatusActionIT extends ProfilingTestCase {
     public void testTimeoutIfResourcesNotCreated() throws Exception {
         updateProfilingTemplatesEnabled(false);
         GetStatusAction.Request request = new GetStatusAction.Request(
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             true,
             // shorter than the default timeout to avoid excessively long execution:
             TimeValue.timeValueSeconds(15)
@@ -45,7 +45,7 @@ public class GetStatusActionIT extends ProfilingTestCase {
 
     public void testNoTimeoutIfNotWaiting() throws Exception {
         updateProfilingTemplatesEnabled(false);
-        GetStatusAction.Request request = new GetStatusAction.Request(TimeValue.THIRTY_SECONDS, false, randomTimeValue());
+        GetStatusAction.Request request = new GetStatusAction.Request(TEST_REQUEST_TIMEOUT, false, randomTimeValue());
 
         GetStatusAction.Response response = client().execute(GetStatusAction.INSTANCE, request).get();
         assertEquals(RestStatus.OK, response.status());
@@ -56,7 +56,7 @@ public class GetStatusActionIT extends ProfilingTestCase {
     public void testWaitsUntilResourcesAreCreated() throws Exception {
         updateProfilingTemplatesEnabled(true);
         GetStatusAction.Request request = new GetStatusAction.Request(
-            TimeValue.THIRTY_SECONDS,
+            TEST_REQUEST_TIMEOUT,
             true,
             // higher timeout since we have more shards than usual:
             TimeValue.timeValueSeconds(120)
@@ -70,7 +70,7 @@ public class GetStatusActionIT extends ProfilingTestCase {
 
     public void testHasData() throws Exception {
         doSetupData();
-        GetStatusAction.Request request = new GetStatusAction.Request(TimeValue.THIRTY_SECONDS, true, TimeValue.THIRTY_SECONDS);
+        GetStatusAction.Request request = new GetStatusAction.Request(TEST_REQUEST_TIMEOUT, true, TEST_REQUEST_TIMEOUT);
         GetStatusAction.Response response = client().execute(GetStatusAction.INSTANCE, request).get();
         assertEquals(RestStatus.OK, response.status());
         assertTrue(response.isResourcesCreated());


### PR DESCRIPTION
Introduces the `TEST_REQUEST_TIMEOUT` constant for use in tests which
need to specify a timeout when constructing a request but which do not
really care about its value and would traditionally have used the common
default of 30s. More readable than using the `THIRTY_SECONDS` constant
directly since it allows for the conceptual difference between not
caring about the timeout value and requiring the exact value of 30s.

Relates #107984