### PR TITLE
Return noop instance DocSizeObserver for updates with scripts

### DIFF
--- a/docs/changelog/108856.yaml
+++ b/docs/changelog/108856.yaml
@@ -1,0 +1,5 @@
+pr: 108856
+summary: Return noop instance `DocSizeObserver` for updates with scripts
+area: Infra/Metrics
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -449,11 +449,11 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
      * or return a new DocumentSizeObserver that will be used when parsing.
      */
     private static DocumentSizeObserver getDocumentSizeObserver(DocumentParsingProvider documentParsingProvider, IndexRequest request) {
-        if (request.getNormalisedBytesParsed() != -1) {
+        if (request.getNormalisedBytesParsed() > 0) {
             return documentParsingProvider.newFixedSizeDocumentObserver(request.getNormalisedBytesParsed());
         } else if (request.getNormalisedBytesParsed() == 0) {
             return DocumentSizeObserver.EMPTY_INSTANCE;
-        }
+        } // request.getNormalisedBytesParsed() == -1
         return documentParsingProvider.newDocumentSizeObserver();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -453,7 +453,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             return documentParsingProvider.newFixedSizeDocumentObserver(request.getNormalisedBytesParsed());
         } else if (request.getNormalisedBytesParsed() == 0) {
             return DocumentSizeObserver.EMPTY_INSTANCE;
-        } // request.getNormalisedBytesParsed() == -1, meaning an IndexRequest has a default value (not being used in updates or ingest)
+        } // request.getNormalisedBytesParsed() -1, meaning normalisedBytesParsed isn't set as parsing wasn't done yet
         return documentParsingProvider.newDocumentSizeObserver();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -453,7 +453,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             return documentParsingProvider.newFixedSizeDocumentObserver(request.getNormalisedBytesParsed());
         } else if (request.getNormalisedBytesParsed() == 0) {
             return DocumentSizeObserver.EMPTY_INSTANCE;
-        } // request.getNormalisedBytesParsed() == -1
+        } // request.getNormalisedBytesParsed() == -1, meaning an IndexRequest has a default value (not being used in updates or ingest)
         return documentParsingProvider.newDocumentSizeObserver();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -595,7 +595,10 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
             .retryOnConflict(retries);
         BulkItemRequest primaryRequest = new BulkItemRequest(0, writeRequest);
 
-        IndexRequest updateResponse = new IndexRequest("index").id("id").source(Requests.INDEX_CONTENT_TYPE, "field", "value");
+        IndexRequest updateResponse = new IndexRequest("index").id("id")
+            .source(Requests.INDEX_CONTENT_TYPE, "field", "value")
+            .noParsedBytesToReport();// let's pretend this was modified by a script
+        DocumentParsingProvider documentParsingProvider = mock(DocumentParsingProvider.class);
 
         Exception err = new VersionConflictEngineException(shardId, "id", "I'm conflicted <(;_;)>");
         Engine.IndexResult indexResult = new Engine.IndexResult(err, 0, 0, 0, "id");
@@ -630,7 +633,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
                 new NoopMappingUpdatePerformer(),
                 listener -> listener.onResponse(null),
                 ASSERTING_DONE_LISTENER,
-                DocumentParsingProvider.EMPTY_INSTANCE
+                documentParsingProvider
             );
         }
         assertFalse(context.hasMoreOperationsToExecute());
@@ -647,6 +650,10 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         assertThat(failure.getId(), equalTo("id"));
         assertThat(failure.getCause(), equalTo(err));
         assertThat(failure.getStatus(), equalTo(RestStatus.CONFLICT));
+
+        // we have set noParsedBytesToReport on the IndexRequest, like it happens with updates by script.
+        verify(documentParsingProvider, times(0)).newDocumentSizeObserver();
+        verify(documentParsingProvider, times(0)).newFixedSizeDocumentObserver(any(Integer.class));
     }
 
     public void testUpdateRequestWithSuccess() throws Exception {
@@ -654,7 +661,10 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         DocWriteRequest<UpdateRequest> writeRequest = new UpdateRequest("index", "id").doc(Requests.INDEX_CONTENT_TYPE, "field", "value");
         BulkItemRequest primaryRequest = new BulkItemRequest(0, writeRequest);
 
-        IndexRequest updateResponse = new IndexRequest("index").id("id").source(Requests.INDEX_CONTENT_TYPE, "field", "value");
+        IndexRequest updateResponse = new IndexRequest("index").id("id")
+            .source(Requests.INDEX_CONTENT_TYPE, "field", "value")
+            .setNormalisedBytesParsed(100L);
+        DocumentParsingProvider documentParsingProvider = mock(DocumentParsingProvider.class);
 
         boolean created = randomBoolean();
         Translog.Location resultLocation = new Translog.Location(42, 42, 42);
@@ -689,7 +699,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
             new NoopMappingUpdatePerformer(),
             listener -> {},
             ASSERTING_DONE_LISTENER,
-            DocumentParsingProvider.EMPTY_INSTANCE
+            documentParsingProvider
         );
         assertFalse(context.hasMoreOperationsToExecute());
 
@@ -705,6 +715,8 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         DocWriteResponse response = primaryResponse.getResponse();
         assertThat(response.status(), equalTo(created ? RestStatus.CREATED : RestStatus.OK));
         assertThat(response.getSeqNo(), equalTo(13L));
+        verify(documentParsingProvider, times(0)).newDocumentSizeObserver();
+        verify(documentParsingProvider, times(1)).newFixedSizeDocumentObserver(eq(100L));
     }
 
     public void testUpdateWithDelete() throws Exception {


### PR DESCRIPTION
current logic was returning a fixedSizeDocumentObserver (preset to 0) when an update request with a script was used (we do not meter those). 
The intention was to return a noop instance, even though the effect is the same - noop returns 0 for normalisedBytesParsed - the logic in the if/else was confusing and never exercised a noop branch
