### PR TITLE
[test] Print out recovery translog state

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -439,7 +439,9 @@ public class ReplicaShardAllocatorIT extends ESIntegTestCase {
         for (RecoveryState recovery : indicesAdmin().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName)) {
             if (recovery.getPrimary() == false) {
                 assertThat(recovery.getIndex().fileDetails(), empty());
-                assertThat(recovery.getTranslog().totalLocal(), equalTo(recovery.getTranslog().totalOperations()));
+                var translog = recovery.getTranslog();
+                logger.info("Verifying recovery translog state: {} for index: {}", translog, indexName);
+                assertThat(translog.totalLocal(), equalTo(translog.totalOperations()));
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -612,7 +612,7 @@ public class RecoveryState implements ToXContentFragment, Writeable {
         }
 
         @Override
-        public String toString() {
+        public synchronized String toString() {
             return Strings.format(
                 "Translog{recovered=%d, total=%d, totalOnStart=%d, totalLocal=%d}",
                 recovered,

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryState.java
@@ -610,6 +610,17 @@ public class RecoveryState implements ToXContentFragment, Writeable {
             builder.humanReadableField(Fields.TOTAL_TIME_IN_MILLIS, Fields.TOTAL_TIME, new TimeValue(time()));
             return builder;
         }
+
+        @Override
+        public String toString() {
+            return Strings.format(
+                "Translog{recovered=%d, total=%d, totalOnStart=%d, totalLocal=%d}",
+                recovered,
+                total,
+                totalOnStart,
+                totalLocal
+            );
+        }
     }
 
     public static class FileDetail implements ToXContentObject, Writeable {


### PR DESCRIPTION
The test in #108037 failed only once in 3 months, it never reproduces on my machine. Let's print the state of translog before verifying, so we have more debug information about it if the failure ever happens again.

See #108037
