### PR TITLE
[test] Log AutoscalingDeciderResults after we manually updated total space on nodes

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -30,6 +30,7 @@ import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.autoscaling.action.GetAutoscalingCapacityAction;
 import org.elasticsearch.xpack.autoscaling.action.PutAutoscalingPolicyAction;
+import org.elasticsearch.xpack.autoscaling.capacity.AutoscalingDeciderResults;
 import org.hamcrest.Matchers;
 
 import java.util.Arrays;
@@ -296,8 +297,10 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
 
         GetAutoscalingCapacityAction.Response response = capacity();
         assertThat(response.results().keySet(), equalTo(Set.of(policyName)));
-        assertThat(response.results().get(policyName).currentCapacity().total().storage().getBytes(), equalTo(enoughSpace));
-        assertThat(response.results().get(policyName).requiredCapacity().total().storage().getBytes(), equalTo(enoughSpace));
+        AutoscalingDeciderResults autoscalingDeciderResults = response.results().get(policyName);
+        logger.info("Verifying autoscaling decider results: {} for with node shard stats: {}", autoscalingDeciderResults, byNode);
+        assertThat(autoscalingDeciderResults.currentCapacity().total().storage().getBytes(), equalTo(enoughSpace));
+        assertThat(autoscalingDeciderResults.requiredCapacity().total().storage().getBytes(), equalTo(enoughSpace));
         assertThat(
             response.results().get(policyName).requiredCapacity().node().storage().getBytes(),
             equalTo(maxShardSize + LOW_WATERMARK_BYTES + ReactiveStorageDeciderService.NODE_DISK_OVERHEAD)


### PR DESCRIPTION
`ReactiveStorageIT#testScaleWhileShrinking` failures do not reproduce locally, the test failed twice over the last three months. I don't see any warnings in the logs for both failures.

Add additional logging fir the autoscaling decider results response after manually set total space on nodes, so we have more debug information in the future if the test fails.

See #108192
