### PR TITLE
[ML] GA the update trained model action

### DIFF
--- a/docs/changelog/108868.yaml
+++ b/docs/changelog/108868.yaml
@@ -1,0 +1,5 @@
+pr: 108868
+summary: GA the update trained model action
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/reference/ml/trained-models/apis/update-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/update-trained-model-deployment.asciidoc
@@ -9,8 +9,6 @@
 
 Updates certain properties of a trained model deployment.
 
-beta::[]
-
 [[update-trained-model-deployment-request]]
 == {api-request-title}
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_trained_model_deployment.json
@@ -4,7 +4,7 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/update-trained-model-deployment.html",
       "description":"Updates certain properties of trained model deployment."
     },
-    "stability":"beta",
+    "stability":"stable",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"],
@@ -26,9 +26,16 @@
         }
       ]
     },
+    "params":{
+      "number_of_allocations":{
+        "type":"int",
+        "required":false,
+        "description":"Update the model deployment to this number of allocations."
+      }
+    },
     "body":{
       "description":"The updated trained model deployment settings",
-      "required":true
+      "required":false
     }
   }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestUpdateTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestUpdateTrainedModelDeploymentAction.java
@@ -50,8 +50,19 @@ public class RestUpdateTrainedModelDeploymentAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String modelId = restRequest.param(StartTrainedModelDeploymentAction.Request.MODEL_ID.getPreferredName());
-        XContentParser parser = restRequest.contentParser();
-        UpdateTrainedModelDeploymentAction.Request request = UpdateTrainedModelDeploymentAction.Request.parseRequest(modelId, parser);
+
+        UpdateTrainedModelDeploymentAction.Request request;
+        if (restRequest.hasParam(StartTrainedModelDeploymentAction.Request.NUMBER_OF_ALLOCATIONS.getPreferredName())) {
+            int numberOfAllocations = restRequest.paramAsInt(
+                StartTrainedModelDeploymentAction.Request.NUMBER_OF_ALLOCATIONS.getPreferredName(),
+                0
+            );
+            request = new UpdateTrainedModelDeploymentAction.Request(modelId);
+            request.setNumberOfAllocations(numberOfAllocations);
+        } else {
+            XContentParser parser = restRequest.contentParser();
+            request = UpdateTrainedModelDeploymentAction.Request.parseRequest(modelId, parser);
+        }
         request.ackTimeout(getAckTimeout(restRequest));
         request.masterNodeTimeout(getMasterNodeTimeout(restRequest));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/rest/inference/RestUpdateTrainedModelDeploymentActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/rest/inference/RestUpdateTrainedModelDeploymentActionTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.rest.inference;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.elasticsearch.test.rest.RestActionTestCase;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.action.CreateTrainedModelAssignmentAction;
+import org.elasticsearch.xpack.core.ml.action.UpdateTrainedModelDeploymentAction;
+
+import java.util.HashMap;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+
+public class RestUpdateTrainedModelDeploymentActionTests extends RestActionTestCase {
+    public void testNumberOfAllocationInParam() {
+        controller().registerHandler(new RestUpdateTrainedModelDeploymentAction());
+        SetOnce<Boolean> executeCalled = new SetOnce<>();
+        verifyingClient.setExecuteVerifier(((actionType, actionRequest) -> {
+            assertThat(actionRequest, instanceOf(UpdateTrainedModelDeploymentAction.Request.class));
+
+            var request = (UpdateTrainedModelDeploymentAction.Request) actionRequest;
+            assertEquals(request.getNumberOfAllocations(), 5);
+
+            executeCalled.set(true);
+            return mock(CreateTrainedModelAssignmentAction.Response.class);
+        }));
+        var params = new HashMap<String, String>();
+        params.put("number_of_allocations", "5");
+
+        RestRequest inferenceRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath("_ml/trained_models/test_id/deployment/_update")
+            .withParams(params)
+            .build();
+        dispatchRequest(inferenceRequest);
+        assertThat(executeCalled.get(), equalTo(true));
+    }
+
+    public void testNumberOfAllocationInBody() {
+        controller().registerHandler(new RestUpdateTrainedModelDeploymentAction());
+        SetOnce<Boolean> executeCalled = new SetOnce<>();
+        verifyingClient.setExecuteVerifier(((actionType, actionRequest) -> {
+            assertThat(actionRequest, instanceOf(UpdateTrainedModelDeploymentAction.Request.class));
+
+            var request = (UpdateTrainedModelDeploymentAction.Request) actionRequest;
+            assertEquals(request.getNumberOfAllocations(), 6);
+
+            executeCalled.set(true);
+            return mock(CreateTrainedModelAssignmentAction.Response.class);
+        }));
+
+        final String content = """
+            {"number_of_allocations": 6}
+            """;
+        RestRequest inferenceRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
+            .withPath("_ml/trained_models/test_id/deployment/_update")
+            .withContent(new BytesArray(content), XContentType.JSON)
+            .build();
+        dispatchRequest(inferenceRequest);
+        assertThat(executeCalled.get(), equalTo(true));
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -395,6 +395,21 @@ setup:
           }
   - match: { assignment.task_parameters.model_id: test_model }
   - match: { assignment.task_parameters.number_of_allocations: 1 }
+
+  # Update with a query parameter
+  - do:
+      # We update to the same value of 1 as if the test runs on a node with just 1 processor it would fail otherwise
+      ml.update_trained_model_deployment:
+        model_id: test_model_deployment
+        number_of_allocations: 1
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.number_of_allocations: 1 }
+
+  - do:
+      catch: /\[number_of_allocations\] must be a positive integer/
+      ml.update_trained_model_deployment:
+        model_id: test_model_deployment
+        number_of_allocations: -1
 ---
 "Test clear deployment cache":
   - skip:


### PR DESCRIPTION
When the ML trained models APIs were made GA the Update API was somehow missed. The PR corrects that mistake and makes the `number_of_allocations` option configurable as a query parameter similar to the start model API.