### PR TITLE
Adding score from RankDoc to SearchHit

### DIFF
--- a/docs/changelog/108870.yaml
+++ b/docs/changelog/108870.yaml
@@ -1,5 +1,5 @@
 pr: 108870
 summary: Adding score from `RankDoc` to `SearchHit`
-area: "Search, Ranking"
+area: Search
 type: bug
 issues: []

--- a/docs/changelog/108870.yaml
+++ b/docs/changelog/108870.yaml
@@ -1,0 +1,5 @@
+pr: 108870
+summary: Adding score from `RankDoc` to `SearchHit`
+area: "Search, Ranking"
+type: bug
+issues: []

--- a/docs/reference/search/rrf.asciidoc
+++ b/docs/reference/search/rrf.asciidoc
@@ -214,7 +214,10 @@ PUT example-index
                 "type": "dense_vector",
                 "dims": 1,
                 "index": true,
-                "similarity": "l2_norm"
+                "similarity": "l2_norm",
+                 "index_options": {
+                     "type": "hnsw"
+                 }
             },
             "integer" : {
                 "type" : "integer"
@@ -306,8 +309,8 @@ GET example-index/_search
 // TEST[continued]
 
 And we receive the response with ranked `hits` and the terms
-aggregation result. Note that `_score` is `null`, and we instead
-use `_rank` to show our top-ranked documents.
+aggregation result. We have both the ranker's `score`
+and the `_rank` option to show our top-ranked documents.
 
 [source,console-response]
 ----
@@ -330,7 +333,7 @@ use `_rank` to show our top-ranked documents.
             {
                 "_index" : "example-index",
                 "_id" : "3",
-                "_score" : null,
+                "_score" : 0.8333334,
                 "_rank" : 1,
                 "_source" : {
                     "integer" : 1,
@@ -343,7 +346,7 @@ use `_rank` to show our top-ranked documents.
             {
                 "_index" : "example-index",
                 "_id" : "2",
-                "_score" : null,
+                "_score" : 0.5833334,
                 "_rank" : 2,
                 "_source" : {
                     "integer" : 2,
@@ -356,7 +359,7 @@ use `_rank` to show our top-ranked documents.
             {
                 "_index" : "example-index",
                 "_id" : "4",
-                "_score" : null,
+                "_score" : 0.5,
                 "_rank" : 3,
                 "_source" : {
                     "integer" : 2,

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseController.java
@@ -459,6 +459,7 @@ public final class SearchPhaseController {
                 if (reducedQueryPhase.rankCoordinatorContext != null) {
                     assert shardDoc instanceof RankDoc;
                     searchHit.setRank(((RankDoc) shardDoc).rank);
+                    searchHit.score(shardDoc.score);
                 } else if (sortedTopDocs.isSortedByField) {
                     FieldDoc fieldDoc = (FieldDoc) shardDoc;
                     searchHit.sortValues(fieldDoc.fields, reducedQueryPhase.sortValueFormats);


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/108538

As part of the work on adding the RankFeature phase, we also update the `SearchHit` returned to the user, to include information about the score, as computed from the ranker. 