### PR TITLE
[8.14] [ESQL] Mark date_diff as requiring all three arguments (#108834)

### DIFF
--- a/docs/changelog/108834.yaml
+++ b/docs/changelog/108834.yaml
@@ -1,0 +1,6 @@
+pr: 108834
+summary: "[ESQL] Mark `date_diff` as requiring all three arguments"
+area: ES|QL
+type: bug
+issues:
+ - 108383

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiff.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/DateDiff.java
@@ -16,7 +16,6 @@ import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
 import org.elasticsearch.xpack.ql.InvalidArgumentException;
 import org.elasticsearch.xpack.ql.expression.Expression;
-import org.elasticsearch.xpack.ql.expression.function.OptionalArgument;
 import org.elasticsearch.xpack.ql.tree.NodeInfo;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataType;
@@ -47,7 +46,7 @@ import static org.elasticsearch.xpack.ql.type.DataTypeConverter.safeToInt;
  * in multiples of the unit specified in the first argument.
  * If the second argument (start) is greater than the third argument (end), then negative values are returned.
  */
-public class DateDiff extends EsqlScalarFunction implements OptionalArgument {
+public class DateDiff extends EsqlScalarFunction {
 
     public static final ZoneId UTC = ZoneId.of("Z");
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [ESQL] Mark date_diff as requiring all three arguments (#108834)