### PR TITLE
apm-data: increase priority above Fleet templates

### DIFF
--- a/docs/changelog/108885.yaml
+++ b/docs/changelog/108885.yaml
@@ -1,0 +1,5 @@
+pr: 108885
+summary: "Apm-data: increase priority above Fleet templates"
+area: Data streams
+type: enhancement
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.app@template.yaml
@@ -1,6 +1,6 @@
 version: ${xpack.apmdata.template.version}
 index_patterns: ["logs-apm.app.*-*"]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/logs-apm.error@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: ["logs-apm.error-*"]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.app@template.yaml
@@ -1,6 +1,6 @@
 version: ${xpack.apmdata.template.version}
 index_patterns: ["metrics-apm.app.*-*"]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.internal@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: ["metrics-apm.internal-*"]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_destination.10m-*]
-priority: 140
+priority: 210
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_destination.1m-*]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_destination.60m-*]
-priority: 140
+priority: 210
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_summary.10m-*]
-priority: 140
+priority: 210
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_summary.1m-*]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_summary.60m-*]
-priority: 140
+priority: 210
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_transaction.10m-*]
-priority: 140
+priority: 210
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_transaction.1m-*]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.service_transaction.60m-*]
-priority: 140
+priority: 210
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.transaction.10m-*]
-priority: 140
+priority: 210
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.transaction.1m-*]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: [metrics-apm.transaction.60m-*]
-priority: 140
+priority: 210
 data_stream:
   hidden: true
 allow_auto_create: true

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.rum@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: ["traces-apm.rum-*"]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm.sampled@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: ["traces-apm.sampled-*"]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/traces-apm@template.yaml
@@ -1,7 +1,7 @@
 ---
 version: ${xpack.apmdata.template.version}
 index_patterns: ["traces-apm-*"]
-priority: 140
+priority: 210
 data_stream: {}
 allow_auto_create: true
 _meta:

--- a/x-pack/plugin/apm-data/src/main/resources/resources.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/resources.yaml
@@ -1,7 +1,7 @@
 # "version" holds the version of the templates and ingest pipelines installed
 # by xpack-plugin apm-data. This must be increased whenever an existing template or
 # pipeline is changed, in order for it to be updated on Elasticsearch upgrade.
-version: 4
+version: 5
 
 component-templates:
   # Data lifecycle.


### PR DESCRIPTION
Fleet installs templates with a priority of either 150 or 200, documented to be anything between 100 and 200, per https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html.

We now want the apm-data templates to take precedence over the ones installed by the integration package, so we increase their priority to 210.

Relates to https://github.com/elastic/apm-server/issues/11528