### PR TITLE
ESQL: Skip test stats.SumOfDouble before 8.13

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -23,9 +23,6 @@ tests:
   issue: "https://github.com/elastic/elasticsearch/issues/108857"
   method: "test {yaml=search/180_locale_dependent_mapping/Test Index and Search locale\
     \ dependent mappings / dates}"
-- class: "org.elasticsearch.xpack.esql.qa.mixed.MixedClusterEsqlSpecIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/108859"
-  method: "test {stats.SumOfDouble SYNC}"
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -213,7 +213,7 @@ l:long
 281
 ;
 
-sumOfDouble
+sumOfDouble#[skip:-8.12.99,reason:expressions in aggs added in 8.13]
 from employees | stats h = round(sum(height), 10);
 
 h:double


### PR DESCRIPTION
Fix https://github.com/elastic/elasticsearch/issues/108859

Before 8.13, aggs could only contain agg functions, so exclude this from bwc tests for earlier versions.