### PR TITLE
Fix ESRestTestCase.clusterHasCapability to work in bwc / mixed cluster tests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -122,6 +122,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import javax.net.ssl.SSLContext;
 
 import static java.util.Collections.sort;


### PR DESCRIPTION
Fix ESRestTestCase.clusterHasCapability to work in bwc / mixed cluster tests when capabilities API is unsupported.