### PR TITLE
[Transform] Fix NPE during destination index creation

### DIFF
--- a/docs/changelog/108891.yaml
+++ b/docs/changelog/108891.yaml
@@ -1,0 +1,6 @@
+pr: 108891
+summary: Fix NPE during destination index creation
+area: Transform
+type: bug
+issues:
+ - 108890

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformIndex.java
@@ -155,11 +155,16 @@ public final class TransformIndex {
                 ClientHelper.TRANSFORM_ORIGIN,
                 client.admin().indices().prepareStats(dest).clear().setDocs(true).request(),
                 ActionListener.<IndicesStatsResponse>wrap(r -> {
-                    long docTotal = r.getTotal().docs.getCount();
-                    if (docTotal > 0L) {
+                    var docsStats = r.getTotal().docs;
+                    if (docsStats != null && docsStats.getCount() > 0L) {
                         auditor.warning(
                             config.getId(),
-                            "Non-empty destination index [" + destinationIndex + "]. " + "Contains [" + docTotal + "] total documents."
+                            "Non-empty destination index ["
+                                + destinationIndex
+                                + "]. "
+                                + "Contains ["
+                                + docsStats.getCount()
+                                + "] total documents."
                         );
                     }
                     createDestinationIndexListener.onResponse(false);


### PR DESCRIPTION
During destination index creation, we fetch dest index stats to find out if the destination index is empty or not.
Unfortunately, `r.getTotal().docs` is nullable.
This PR takes this fact into account, fixing NPE.

Fixes https://github.com/elastic/elasticsearch/issues/108890