### PR TITLE
[Inference API] Return rateLimitSettings field for getter instead of default constant

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/completion/AzureOpenAiCompletionServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/azureopenai/completion/AzureOpenAiCompletionServiceSettings.java
@@ -120,7 +120,7 @@ public class AzureOpenAiCompletionServiceSettings extends FilteredXContentObject
 
     @Override
     public RateLimitSettings rateLimitSettings() {
-        return DEFAULT_RATE_LIMIT_SETTINGS;
+        return rateLimitSettings;
     }
 
     public String apiVersion() {


### PR DESCRIPTION
We should return the field `rateLimitSettings` and not `DEFAULT_RATE_LIMIT_SETTINGS` for the accessor method. 