### PR TITLE
ES|QL: Skip test stats.SumOfDouble before 8.13 (backport of #108888)

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/stats.csv-spec
@@ -213,7 +213,7 @@ l:long
 281
 ;
 
-sumOfDouble
+sumOfDouble#[skip:-8.12.99,reason:expressions in aggs added in 8.13]
 from employees | stats h = round(sum(height), 10);
 
 h:double


### PR DESCRIPTION
Manually backporting #108888