### PR TITLE
[ESQL] Make AggregateMapper#mapper static

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -47,13 +47,13 @@ import java.util.stream.Stream;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.CARTESIAN_POINT;
 import static org.elasticsearch.xpack.esql.type.EsqlDataTypes.GEO_POINT;
 
-public class AggregateMapper {
+final class AggregateMapper {
 
-    static final List<String> NUMERIC = List.of("Int", "Long", "Double");
-    static final List<String> SPATIAL = List.of("GeoPoint", "CartesianPoint");
+    private static final List<String> NUMERIC = List.of("Int", "Long", "Double");
+    private static final List<String> SPATIAL = List.of("GeoPoint", "CartesianPoint");
 
     /** List of all mappable ESQL agg functions (excludes surrogates like AVG = SUM/COUNT). */
-    static final List<? extends Class<? extends Function>> AGG_FUNCTIONS = List.of(
+    private static final List<? extends Class<? extends Function>> AGG_FUNCTIONS = List.of(
         Count.class,
         CountDistinct.class,
         Max.class,
@@ -66,23 +66,19 @@ public class AggregateMapper {
     );
 
     /** Record of agg Class, type, and grouping (or non-grouping). */
-    record AggDef(Class<?> aggClazz, String type, String extra, boolean grouping) {}
+    private record AggDef(Class<?> aggClazz, String type, String extra, boolean grouping) {}
 
     /** Map of AggDef types to intermediate named expressions. */
-    private final Map<AggDef, List<IntermediateStateDesc>> mapper;
+    private static final Map<AggDef, List<IntermediateStateDesc>> mapper = AGG_FUNCTIONS.stream()
+        .flatMap(AggregateMapper::typeAndNames)
+        .flatMap(AggregateMapper::groupingAndNonGrouping)
+        .collect(Collectors.toUnmodifiableMap(aggDef -> aggDef, AggregateMapper::lookupIntermediateState));
 
     /** Cache of aggregates to intermediate expressions. */
-    private final HashMap<Expression, List<? extends NamedExpression>> cache = new HashMap<>();
+    private final HashMap<Expression, List<? extends NamedExpression>> cache;
 
     AggregateMapper() {
-        this(AGG_FUNCTIONS);
-    }
-
-    AggregateMapper(List<? extends Class<? extends Function>> aggregateFunctionClasses) {
-        mapper = aggregateFunctionClasses.stream()
-            .flatMap(AggregateMapper::typeAndNames)
-            .flatMap(AggregateMapper::groupingAndNonGrouping)
-            .collect(Collectors.toUnmodifiableMap(aggDef -> aggDef, AggregateMapper::lookupIntermediateState));
+        cache = new HashMap<>();
     }
 
     public List<? extends NamedExpression> mapNonGrouping(List<? extends Expression> aggregates) {
@@ -108,11 +104,10 @@ public class AggregateMapper {
     }
 
     private Stream<? extends NamedExpression> map(Expression aggregate, boolean grouping) {
-        aggregate = Alias.unwrap(aggregate);
-        return cache.computeIfAbsent(aggregate, aggKey -> computeEntryForAgg(aggKey, grouping)).stream();
+        return cache.computeIfAbsent(Alias.unwrap(aggregate), aggKey -> computeEntryForAgg(aggKey, grouping)).stream();
     }
 
-    private List<? extends NamedExpression> computeEntryForAgg(Expression aggregate, boolean grouping) {
+    private static List<? extends NamedExpression> computeEntryForAgg(Expression aggregate, boolean grouping) {
         var aggDef = aggDefOrNull(aggregate, grouping);
         if (aggDef != null) {
             var is = getNonNull(aggDef);
@@ -128,7 +123,7 @@ public class AggregateMapper {
     }
 
     /** Gets the agg from the mapper - wrapper around map::get for more informative failure.*/
-    private List<IntermediateStateDesc> getNonNull(AggDef aggDef) {
+    private static List<IntermediateStateDesc> getNonNull(AggDef aggDef) {
         var l = mapper.get(aggDef);
         if (l == null) {
             throw new EsqlIllegalArgumentException("Cannot find intermediate state for: " + aggDef);
@@ -267,10 +262,5 @@ public class AggregateMapper {
             } else {
                 throw new EsqlIllegalArgumentException("illegal agg type: " + type.typeName());
             }
-    }
-
-    private static Expression unwrapAlias(Expression expression) {
-        if (expression instanceof Alias alias) return alias.child();
-        return expression;
     }
 }


### PR DESCRIPTION
We are currently building this hashmap whenever we create an AggregateMapper although it is always the same. Therefore let's make it static. In addition I am adjusting the visibility of the variables according to how they are accessed.