### PR TITLE
ES|QL: Remove asScript() logic

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/Function.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/Function.java
@@ -11,7 +11,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.ConstantInput;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.List;
@@ -85,6 +84,4 @@ public abstract class Function extends Expression {
         }
         return sj.toString();
     }
-
-    public abstract ScriptTemplate asScript();
 }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/UnresolvedFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/UnresolvedFunction.java
@@ -10,7 +10,6 @@ import org.elasticsearch.xpack.esql.core.capabilities.Unresolvable;
 import org.elasticsearch.xpack.esql.core.capabilities.UnresolvedException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.session.Configuration;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -128,11 +127,6 @@ public class UnresolvedFunction extends Function implements Unresolvable {
     @Override
     public Nullability nullable() {
         throw new UnresolvedException("nullable", this);
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        throw new UnresolvedException("script", this);
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/aggregate/AggregateFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/aggregate/AggregateFunction.java
@@ -6,13 +6,11 @@
  */
 package org.elasticsearch.xpack.esql.core.expression.function.aggregate;
 
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.AggNameInput;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 
@@ -58,11 +56,6 @@ public abstract class AggregateFunction extends Function {
     protected Pipe makePipe() {
         // unresolved AggNameInput (should always get replaced by the folder)
         return new AggNameInput(source(), this, sourceText());
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        throw new QlIllegalArgumentException("Aggregate functions cannot be scripted");
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/grouping/GroupingFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/grouping/GroupingFunction.java
@@ -6,12 +6,10 @@
  */
 package org.elasticsearch.xpack.esql.core.expression.function.grouping;
 
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.AggNameInput;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 
@@ -51,11 +49,6 @@ public abstract class GroupingFunction extends Function {
     protected Pipe makePipe() {
         // unresolved AggNameInput (should always get replaced by the folder)
         return new AggNameInput(source(), this, sourceText());
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        throw new QlIllegalArgumentException("Grouping functions cannot be scripted");
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/BaseSurrogateFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/BaseSurrogateFunction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.core.expression.function.scalar;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.List;
@@ -49,10 +48,5 @@ public abstract class BaseSurrogateFunction extends ScalarFunction implements Su
     @Override
     protected Pipe makePipe() {
         return substitute().asPipe();
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        return substitute().asScript();
     }
 }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/BinaryScalarFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/BinaryScalarFunction.java
@@ -7,13 +7,10 @@
 package org.elasticsearch.xpack.esql.core.expression.function.scalar;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 public abstract class BinaryScalarFunction extends ScalarFunction {
 
@@ -46,21 +43,5 @@ public abstract class BinaryScalarFunction extends ScalarFunction {
     @Override
     public boolean foldable() {
         return left.foldable() && right.foldable();
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        ScriptTemplate leftScript = asScript(left());
-        ScriptTemplate rightScript = asScript(right());
-
-        return asScriptFrom(leftScript, rightScript);
-    }
-
-    protected ScriptTemplate asScriptFrom(ScriptTemplate leftScript, ScriptTemplate rightScript) {
-        return Scripts.binaryMethod(Scripts.classPackageAsPrefix(getClass()), scriptMethodName(), leftScript, rightScript, dataType());
-    }
-
-    protected String scriptMethodName() {
-        return getClass().getSimpleName().toLowerCase(Locale.ROOT);
     }
 }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/ScalarFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/ScalarFunction.java
@@ -6,31 +6,18 @@
  */
 package org.elasticsearch.xpack.esql.core.expression.function.scalar;
 
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
-import org.elasticsearch.xpack.esql.core.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.core.expression.function.grouping.GroupingFunction;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.Params;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder;
 import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.core.util.DateUtils;
 
-import java.time.OffsetTime;
-import java.time.ZonedDateTime;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
-import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder.paramsBuilder;
 import static org.elasticsearch.xpack.esql.core.expression.gen.script.Scripts.PARAM;
-import static org.elasticsearch.xpack.esql.core.type.DataTypes.DATETIME;
-import static org.elasticsearch.xpack.esql.core.type.DataTypes.LONG;
-import static org.elasticsearch.xpack.esql.core.type.DataTypes.UNSIGNED_LONG;
 
 /**
  * A {@code ScalarFunction} is a {@code Function} that takes values from some
@@ -48,120 +35,11 @@ public abstract class ScalarFunction extends Function {
         super(source, fields);
     }
 
-    //
-    // Script generation
-    //
-    public ScriptTemplate asScript(Expression exp) {
-        if (exp.foldable()) {
-            return scriptWithFoldable(exp);
-        }
-
-        if (exp instanceof FieldAttribute) {
-            return scriptWithField((FieldAttribute) exp);
-        }
-
-        if (exp instanceof ScalarFunction) {
-            return scriptWithScalar((ScalarFunction) exp);
-        }
-
-        if (exp instanceof AggregateFunction) {
-            return scriptWithAggregate((AggregateFunction) exp);
-        }
-
-        if (exp instanceof GroupingFunction) {
-            return scriptWithGrouping((GroupingFunction) exp);
-        }
-        throw new QlIllegalArgumentException("Cannot evaluate script for expression {}", exp);
-    }
-
-    protected ScriptTemplate scriptWithFoldable(Expression foldable) {
-        Object fold = foldable.fold();
-
-        // FIXME: this needs to be refactored
-        //
-        // Custom type handling
-        //
-
-        // wrap intervals with dedicated methods for serialization
-        if (fold instanceof ZonedDateTime zdt) {
-            return new ScriptTemplate(
-                processScript("{sql}.asDateTime({})"),
-                paramsBuilder().variable(DateUtils.toString(zdt)).build(),
-                dataType()
-            );
-        }
-
-        if (fold instanceof IntervalScripting is) {
-            return new ScriptTemplate(
-                processScript(is.script()),
-                paramsBuilder().variable(is.value()).variable(is.typeName()).build(),
-                dataType()
-            );
-        }
-
-        if (fold instanceof OffsetTime ot) {
-            return new ScriptTemplate(processScript("{sql}.asTime({})"), paramsBuilder().variable(ot.toString()).build(), dataType());
-        }
-
-        if (fold != null && fold.getClass().getSimpleName().equals("GeoShape")) {
-            return new ScriptTemplate(processScript("{sql}.stWktToSql({})"), paramsBuilder().variable(fold.toString()).build(), dataType());
-        }
-
-        return new ScriptTemplate(processScript("{}"), paramsBuilder().variable(fold).build(), dataType());
-    }
-
-    protected ScriptTemplate scriptWithScalar(ScalarFunction scalar) {
-        ScriptTemplate nested = scalar.asScript();
-        return new ScriptTemplate(processScript(nested.template()), paramsBuilder().script(nested.params()).build(), dataType());
-    }
-
-    protected ScriptTemplate scriptWithAggregate(AggregateFunction aggregate) {
-        String template = PARAM;
-        ParamsBuilder paramsBuilder = paramsBuilder().agg(aggregate);
-
-        DataType nullSafeCastDataType = null;
-        DataType dataType = aggregate.dataType();
-        if (dataType.name().equals("DATE") || dataType == DATETIME ||
-        // Aggregations on date_nanos are returned as string
-            aggregate.field().dataType() == DATETIME) {
-
-            template = "{sql}.asDateTime({})";
-        } else if (dataType.isInteger()) {
-            // MAX, MIN need to retain field's data type, so that possible operations on integral types (like division) work
-            // correctly -> perform a cast in the aggs filtering script, the bucket selector for HAVING.
-            // SQL function classes not available in QL: filter by name
-            String fn = aggregate.functionName();
-            if ("MAX".equals(fn) || "MIN".equals(fn)) {
-                nullSafeCastDataType = dataType;
-            } else if ("SUM".equals(fn)) {
-                // SUM(integral_type) requires returning a LONG value
-                nullSafeCastDataType = LONG;
-            }
-        }
-        if (nullSafeCastDataType != null) {
-            template = "{ql}.nullSafeCastNumeric({},{})";
-            paramsBuilder.variable(nullSafeCastDataType.name());
-        }
-        return new ScriptTemplate(processScript(template), paramsBuilder.build(), dataType());
-    }
-
     // This method isn't actually used at the moment, since there is no grouping function (ie HISTOGRAM)
     // that currently results in a script being generated
     protected ScriptTemplate scriptWithGrouping(GroupingFunction grouping) {
         String template = PARAM;
         return new ScriptTemplate(processScript(template), paramsBuilder().grouping(grouping).build(), dataType());
-    }
-
-    protected ScriptTemplate scriptWithField(FieldAttribute field) {
-        Params params = paramsBuilder().variable(field.exactAttribute().name()).build();
-        // unsigned_long fields get returned in scripts as plain longs, so a conversion is required
-        return field.dataType() != UNSIGNED_LONG
-            ? new ScriptTemplate(processScript(Scripts.DOC_VALUE), params, dataType())
-            : new ScriptTemplate(
-                processScript(format("{ql}.", "nullSafeCastToUnsignedLong({})", Scripts.DOC_VALUE)),
-                params,
-                UNSIGNED_LONG
-            );
     }
 
     protected String processScript(String script) {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/UnaryScalarFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/UnaryScalarFunction.java
@@ -11,7 +11,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.UnaryPipe;
 import org.elasticsearch.xpack.esql.core.expression.gen.processor.Processor;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.List;
@@ -58,10 +57,5 @@ public abstract class UnaryScalarFunction extends ScalarFunction {
     @Override
     public Object fold() {
         return makeProcessor().process(field().fold());
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        return asScript(field);
     }
 }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/string/BinaryComparisonCaseInsensitiveFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/string/BinaryComparisonCaseInsensitiveFunction.java
@@ -8,21 +8,16 @@
 package org.elasticsearch.xpack.esql.core.expression.function.scalar.string;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
 
-import java.util.Locale;
 import java.util.Objects;
 
-import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isStringAndExact;
-import static org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder.paramsBuilder;
 
 public abstract class BinaryComparisonCaseInsensitiveFunction extends CaseInsensitiveScalarFunction {
 
@@ -64,35 +59,6 @@ public abstract class BinaryComparisonCaseInsensitiveFunction extends CaseInsens
     @Override
     public boolean foldable() {
         return left.foldable() && right.foldable();
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        ScriptTemplate leftScript = asScript(left);
-        ScriptTemplate rightScript = asScript(right);
-
-        return asScriptFrom(leftScript, rightScript);
-    }
-
-    protected ScriptTemplate asScriptFrom(ScriptTemplate leftScript, ScriptTemplate rightScript) {
-        return new ScriptTemplate(
-            format(
-                Locale.ROOT,
-                formatTemplate("%s.%s(%s,%s,%s)"),
-                Scripts.classPackageAsPrefix(getClass()),
-                scriptMethodName(),
-                leftScript.template(),
-                rightScript.template(),
-                "{}"
-            ),
-            paramsBuilder().script(leftScript.params()).script(rightScript.params()).variable(isCaseInsensitive()).build(),
-            dataType()
-        );
-    }
-
-    protected String scriptMethodName() {
-        String simpleName = getClass().getSimpleName();
-        return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/string/CaseInsensitiveScalarFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/string/CaseInsensitiveScalarFunction.java
@@ -8,16 +8,11 @@
 package org.elasticsearch.xpack.esql.core.expression.function.scalar.string;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
 import java.util.List;
 import java.util.Objects;
-
-import static org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder.paramsBuilder;
 
 public abstract class CaseInsensitiveScalarFunction extends ScalarFunction {
 
@@ -30,15 +25,6 @@ public abstract class CaseInsensitiveScalarFunction extends ScalarFunction {
 
     public boolean isCaseInsensitive() {
         return caseInsensitive;
-    }
-
-    @Override
-    public ScriptTemplate scriptWithField(FieldAttribute field) {
-        return new ScriptTemplate(
-            processScript(Scripts.DOC_VALUE),
-            paramsBuilder().variable(field.exactAttribute().name()).build(),
-            dataType()
-        );
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/string/StartsWith.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/string/StartsWith.java
@@ -9,11 +9,7 @@ package org.elasticsearch.xpack.esql.core.expression.function.scalar.string;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
-import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.Scripts;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
@@ -24,7 +20,6 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isStringAndExact;
 import static org.elasticsearch.xpack.esql.core.expression.function.scalar.string.StartsWithFunctionProcessor.doProcess;
-import static org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder.paramsBuilder;
 
 /**
  * Function that checks if first parameter starts with the second parameter. Both parameters should be strings
@@ -76,32 +71,6 @@ public abstract class StartsWith extends CaseInsensitiveScalarFunction {
     @Override
     public Object fold() {
         return doProcess(input.fold(), pattern.fold(), isCaseInsensitive());
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        ScriptTemplate fieldScript = asScript(input);
-        ScriptTemplate patternScript = asScript(pattern);
-
-        return asScriptFrom(fieldScript, patternScript);
-    }
-
-    protected ScriptTemplate asScriptFrom(ScriptTemplate fieldScript, ScriptTemplate patternScript) {
-        ParamsBuilder params = paramsBuilder();
-
-        String template = formatTemplate("{ql}.startsWith(" + fieldScript.template() + ", " + patternScript.template() + ", {})");
-        params.script(fieldScript.params()).script(patternScript.params()).variable(isCaseInsensitive());
-
-        return new ScriptTemplate(template, params.build(), dataType());
-    }
-
-    @Override
-    public ScriptTemplate scriptWithField(FieldAttribute field) {
-        return new ScriptTemplate(
-            processScript(Scripts.DOC_VALUE),
-            paramsBuilder().variable(field.exactAttribute().name()).build(),
-            dataType()
-        );
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/BinaryPredicate.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/BinaryPredicate.java
@@ -34,11 +34,6 @@ public abstract class BinaryPredicate<T, U, R, F extends PredicateBiFunction<T, 
     }
 
     @Override
-    protected String scriptMethodName() {
-        return function.scriptMethodName();
-    }
-
-    @Override
     public int hashCode() {
         return Objects.hash(left(), right(), function.symbol());
     }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/Range.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/Range.java
@@ -10,8 +10,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.Params;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogicPipe;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogicProcessor.BinaryLogicOperation;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
@@ -26,12 +24,9 @@ import org.elasticsearch.xpack.esql.core.type.DateUtils;
 import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 
-import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder.paramsBuilder;
 
 // BETWEEN or range - is a mix of gt(e) AND lt(e)
 public class Range extends ScalarFunction {
@@ -139,34 +134,6 @@ public class Range extends ScalarFunction {
     @Override
     public DataType dataType() {
         return DataTypes.BOOLEAN;
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        ScriptTemplate valueScript = asScript(value);
-        ScriptTemplate lowerScript = asScript(lower);
-        ScriptTemplate upperScript = asScript(upper);
-
-        String template = formatTemplate(
-            format(
-                Locale.ROOT,
-                "{ql}.and({ql}.%s(%s, %s), {ql}.%s(%s, %s))",
-                includeLower() ? "gte" : "gt",
-                valueScript.template(),
-                lowerScript.template(),
-                includeUpper() ? "lte" : "lt",
-                valueScript.template(),
-                upperScript.template()
-            )
-        );
-
-        Params params = paramsBuilder().script(valueScript.params())
-            .script(lowerScript.params())
-            .script(valueScript.params())
-            .script(upperScript.params())
-            .build();
-
-        return new ScriptTemplate(template, params, DataTypes.BOOLEAN);
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/operator/comparison/In.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/operator/comparison/In.java
@@ -13,7 +13,6 @@ import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -31,7 +30,6 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
-import static org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder.paramsBuilder;
 import static org.elasticsearch.xpack.esql.core.util.StringUtils.ordinal;
 
 public class In extends ScalarFunction {
@@ -103,20 +101,6 @@ public class In extends ScalarFunction {
         List<Expression> canonicalValues = Expressions.canonicalize(list);
         Collections.sort(canonicalValues, (l, r) -> Integer.compare(l.hashCode(), r.hashCode()));
         return new In(source(), value, canonicalValues, zoneId);
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        ScriptTemplate leftScript = asScript(value);
-
-        // fold & remove duplicates
-        List<Object> values = new ArrayList<>(new LinkedHashSet<>(foldAndConvertListOfValues(list, value.dataType())));
-
-        return new ScriptTemplate(
-            formatTemplate(format("{ql}.", "in({}, {})", leftScript.template())),
-            paramsBuilder().script(leftScript.params()).variable(values).build(),
-            dataType()
-        );
     }
 
     protected List<Object> foldAndConvertListOfValues(List<Expression> expressions, DataType dataType) {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/RegexMatch.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/regex/RegexMatch.java
@@ -12,17 +12,14 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.UnaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.expression.gen.processor.Processor;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
 
 import java.util.Objects;
 
-import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isStringAndExact;
-import static org.elasticsearch.xpack.esql.core.expression.gen.script.ParamsBuilder.paramsBuilder;
 
 public abstract class RegexMatch<T extends StringPattern> extends UnaryScalarFunction {
 
@@ -79,24 +76,6 @@ public abstract class RegexMatch<T extends StringPattern> extends UnaryScalarFun
     @Override
     protected Processor makeProcessor() {
         return new RegexProcessor(pattern().asJavaRegex());
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        ScriptTemplate fieldAsScript = asScript(field());
-        // keep backwards compatibility with previous 7.x versions
-        if (caseInsensitive == false) {
-            return new ScriptTemplate(
-                formatTemplate(format("{ql}.", "regex({},{})", fieldAsScript.template())),
-                paramsBuilder().script(fieldAsScript.params()).variable(pattern.asJavaRegex()).build(),
-                dataType()
-            );
-        }
-        return new ScriptTemplate(
-            formatTemplate(format("{ql}.", "regex({},{},{})", fieldAsScript.template())),
-            paramsBuilder().script(fieldAsScript.params()).variable(pattern.asJavaRegex()).variable(caseInsensitive).build(),
-            dataType()
-        );
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/TranslatorHandler.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/TranslatorHandler.java
@@ -7,11 +7,11 @@
 
 package org.elasticsearch.xpack.esql.core.planner;
 
+import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
-import org.elasticsearch.xpack.esql.core.querydsl.query.ScriptQuery;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
 import java.util.function.Supplier;
@@ -29,7 +29,7 @@ public interface TranslatorHandler {
         if (field instanceof FieldAttribute) {
             return ExpressionTranslator.wrapIfNested(querySupplier.get(), field);
         }
-        return new ScriptQuery(sf.source(), sf.asScript());
+        throw new QlIllegalArgumentException("Cannot translate expression:[" + sf.sourceText() + "]");
     }
 
     String nameOf(Expression e);

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/function/FunctionRegistryTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/expression/function/FunctionRegistryTests.java
@@ -13,7 +13,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ConfigurationFunction;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.session.Configuration;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -205,11 +204,6 @@ public class FunctionRegistryTests extends ESTestCase {
         }
 
         @Override
-        public ScriptTemplate asScript() {
-            return null;
-        }
-
-        @Override
         protected Pipe makePipe() {
             return null;
         }
@@ -229,11 +223,6 @@ public class FunctionRegistryTests extends ESTestCase {
 
         @Override
         public DataType dataType() {
-            return null;
-        }
-
-        @Override
-        public ScriptTemplate asScript() {
             return null;
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
@@ -6,13 +6,11 @@
  */
 package org.elasticsearch.xpack.esql.expression.function.aggregate;
 
-import org.elasticsearch.xpack.esql.core.QlIllegalArgumentException;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.AggNameInput;
 import org.elasticsearch.xpack.esql.core.expression.gen.pipeline.Pipe;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 
@@ -58,11 +56,6 @@ public abstract class AggregateFunction extends Function {
     protected Pipe makePipe() {
         // unresolved AggNameInput (should always get replaced by the folder)
         return new AggNameInput(source(), this, sourceText());
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        throw new QlIllegalArgumentException("Aggregate functions cannot be scripted");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/GroupingFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/GroupingFunction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.expression.function.grouping;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.Function;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 
@@ -26,8 +25,4 @@ public abstract class GroupingFunction extends Function implements EvaluatorMapp
         return EvaluatorMapper.super.fold();
     }
 
-    @Override
-    public final ScriptTemplate asScript() {
-        throw new UnsupportedOperationException("functions do not support scripting");
-    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/EsqlScalarFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/EsqlScalarFunction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.expression.function.scalar;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 
@@ -30,8 +29,4 @@ public abstract class EsqlScalarFunction extends ScalarFunction implements Evalu
         return EvaluatorMapper.super.fold();
     }
 
-    @Override
-    public final ScriptTemplate asScript() {
-        throw new UnsupportedOperationException("functions do not support scripting");
-    }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/BinaryDateTimeFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/date/BinaryDateTimeFunction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.date;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
@@ -40,11 +39,6 @@ public abstract class BinaryDateTimeFunction extends BinaryScalarFunction {
 
     public ZoneId zoneId() {
         return zoneId;
-    }
-
-    @Override
-    public ScriptTemplate asScript() {
-        throw new UnsupportedOperationException("functions do not support scripting");
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/DoubleConstantFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/DoubleConstantFunction.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
-import org.elasticsearch.xpack.esql.core.expression.gen.script.ScriptTemplate;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -31,11 +30,6 @@ public abstract class DoubleConstantFunction extends ScalarFunction {
     @Override
     public final DataType dataType() {
         return DataTypes.DOUBLE;
-    }
-
-    @Override
-    public final ScriptTemplate asScript() {
-        throw new UnsupportedOperationException("functions do not support scripting");
     }
 
     @Override


### PR DESCRIPTION
Starting a refactoring to remove dead code after [branching from QL](https://github.com/elastic/elasticsearch/pull/108773).

This PR removes the logic that translates functions into scripts (not used by ESQL)