### PR TITLE
[Inference API] Use randomSecureStringOfLength instead of manual construction in test

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiSecretSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureopenai/AzureOpenAiSecretSettingsTests.java
@@ -29,10 +29,7 @@ import static org.hamcrest.Matchers.is;
 public class AzureOpenAiSecretSettingsTests extends AbstractWireSerializingTestCase<AzureOpenAiSecretSettings> {
 
     public static AzureOpenAiSecretSettings createRandom() {
-        return new AzureOpenAiSecretSettings(
-            new SecureString(randomAlphaOfLength(15).toCharArray()),
-            new SecureString(randomAlphaOfLength(15).toCharArray())
-        );
+        return new AzureOpenAiSecretSettings(randomSecureStringOfLength(15), randomSecureStringOfLength(15));
     }
 
     public void testFromMap_ApiKey_Only() {


### PR DESCRIPTION
Saw a small room for improvement while working on Google AI Studio by using `randomSecureStringOfLength` directly