### PR TITLE
(+Doc) Link split-brain wiki from Voting config

### DIFF
--- a/docs/reference/modules/discovery/voting.asciidoc
+++ b/docs/reference/modules/discovery/voting.asciidoc
@@ -63,7 +63,8 @@ departed nodes from the voting configuration manually. Use the
 of resilience.
 
 No matter how it is configured, Elasticsearch will not suffer from a 
-"split-brain" inconsistency. The `cluster.auto_shrink_voting_configuration`
+"{wikipedia}/Split-brain_(computing)[split-brain]" inconsistency. 
+The `cluster.auto_shrink_voting_configuration`
 setting affects only its availability in the event of the failure of some of its
 nodes and the administrative tasks that must be performed as nodes join and
 leave the cluster.


### PR DESCRIPTION
Mini change to link the [wiki page about "split-brain"](https://en.wikipedia.org/wiki/Split-brain_(computing)) as an industry-not-Elastic term under [Voting configurations](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-voting.html).
