### PR TITLE
Remove Block#nullValuesCount

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractArrayBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractArrayBlock.java
@@ -113,8 +113,7 @@ abstract class AbstractArrayBlock extends AbstractNonThreadSafeRefCounted implem
         return nullsMask != null;
     }
 
-    @Override
-    public final int nullValuesCount() {
+    final int nullValuesCount() {
         return mayHaveNulls() ? nullsMask.cardinality() : 0;
     }
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVectorBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/AbstractVectorBlock.java
@@ -32,11 +32,6 @@ abstract class AbstractVectorBlock extends AbstractNonThreadSafeRefCounted imple
     }
 
     @Override
-    public final int nullValuesCount() {
-        return 0;
-    }
-
-    @Override
     public final boolean mayHaveNulls() {
         return false;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/Block.java
@@ -105,11 +105,6 @@ public interface Block extends Accountable, BlockLoader.Block, NamedWriteable, R
     boolean isNull(int position);
 
     /**
-     * @return the number of null values in this block.
-     */
-    int nullValuesCount();
-
-    /**
      * @return true if some values might be null. False, if all values are guaranteed to be not null.
      */
     boolean mayHaveNulls();

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/ConstantNullBlock.java
@@ -53,11 +53,6 @@ final class ConstantNullBlock extends AbstractNonThreadSafeRefCounted
     }
 
     @Override
-    public int nullValuesCount() {
-        return getPositionCount();
-    }
-
-    @Override
     public boolean areAllValuesNull() {
         return true;
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/OrdinalBytesRefBlock.java
@@ -177,11 +177,6 @@ public final class OrdinalBytesRefBlock extends AbstractNonThreadSafeRefCounted 
     }
 
     @Override
-    public int nullValuesCount() {
-        return ordinals.nullValuesCount();
-    }
-
-    @Override
     public boolean mayHaveNulls() {
         return ordinals.mayHaveNulls();
     }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/blockhash/BlockHashTests.java
@@ -1305,7 +1305,9 @@ public class BlockHashTests extends ESTestCase {
             try (ReleasableIterator<IntBlock> lookup = blockHash.lookup(new Page(keys), ByteSizeValue.ofKb(between(1, 100)))) {
                 while (lookup.hasNext()) {
                     try (IntBlock ords = lookup.next()) {
-                        assertThat(ords.nullValuesCount(), equalTo(0));
+                        for (int p = 0; p < ords.getPositionCount(); p++) {
+                            assertFalse(ords.isNull(p));
+                        }
                     }
                 }
             } finally {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BasicBlockTests.java
@@ -166,7 +166,6 @@ public class BasicBlockTests extends ESTestCase {
             assertThat(block.asVector().getPositionCount(), is(positionCount));
             assertThat(block.asVector().asBlock().getTotalValueCount(), is(positionCount));
             assertThat(block.asVector().asBlock().getPositionCount(), is(positionCount));
-            assertThat(block.nullValuesCount(), is(0));
             assertThat(block.mayHaveNulls(), is(false));
             assertThat(block.areAllValuesNull(), is(false));
             assertThat(block.mayHaveMultivaluedFields(), is(false));
@@ -823,7 +822,6 @@ public class BasicBlockTests extends ESTestCase {
                     assertThat(block.getInt(i), is(values[i]));
                 }
             }
-            assertThat(block.nullValuesCount(), is(nullCount));
             assertThat(block.asVector(), nullCount > 0 ? is(nullValue()) : is(notNullValue()));
             block.close();
         }
@@ -857,7 +855,6 @@ public class BasicBlockTests extends ESTestCase {
                     assertThat(block.getLong(i), is(values[i]));
                 }
             }
-            assertThat(block.nullValuesCount(), is(nullCount));
             assertThat(block.asVector(), nullCount > 0 ? is(nullValue()) : is(notNullValue()));
             block.close();
         }
@@ -891,7 +888,6 @@ public class BasicBlockTests extends ESTestCase {
                     assertThat(block.getDouble(i), is(values[i]));
                 }
             }
-            assertThat(block.nullValuesCount(), is(nullCount));
             assertThat(block.asVector(), nullCount > 0 ? is(nullValue()) : is(notNullValue()));
             block.close();
         }
@@ -925,7 +921,6 @@ public class BasicBlockTests extends ESTestCase {
                     assertThat(block.getBoolean(i), is(values[i]));
                 }
             }
-            assertThat(block.nullValuesCount(), is(nullCount));
             assertThat(block.asVector(), nullCount > 0 ? is(nullValue()) : is(notNullValue()));
             block.close();
         }

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockMultiValuedTests.java
@@ -169,7 +169,6 @@ public class BlockMultiValuedTests extends ESTestCase {
 
     private void assertExpanded(Block orig) {
         try (orig; Block expanded = orig.expand()) {
-            assertThat(expanded.getPositionCount(), equalTo(orig.getTotalValueCount() + orig.nullValuesCount()));
             assertThat(expanded.getTotalValueCount(), equalTo(orig.getTotalValueCount()));
 
             int np = 0;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/FilteredBlockTests.java
@@ -133,7 +133,6 @@ public class FilteredBlockTests extends ESTestCase {
         assertTrue(filtered.isNull(0));
         assertTrue(filtered.mayHaveNulls());
         assertFalse(filtered.areAllValuesNull());
-        assertEquals(1, filtered.nullValuesCount());
         assertEquals(2, filtered.getTotalValueCount());
         assertFalse(filtered.isNull(1));
         assertEquals(30, filtered.getInt(filtered.getFirstValueIndex(1)));
@@ -161,7 +160,6 @@ public class FilteredBlockTests extends ESTestCase {
         assertTrue(filtered.isNull(0));
         assertTrue(filtered.mayHaveNulls());
         assertTrue(filtered.areAllValuesNull());
-        assertEquals(3, filtered.nullValuesCount());
         assertEquals(0, filtered.getTotalValueCount());
         block.close();
         releaseAndAssertBreaker(filtered);
@@ -184,7 +182,6 @@ public class FilteredBlockTests extends ESTestCase {
         assertFalse(filtered.isNull(0));
         assertFalse(filtered.mayHaveNulls());
         assertFalse(filtered.areAllValuesNull());
-        assertEquals(0, filtered.nullValuesCount());
         assertEquals(3, filtered.getTotalValueCount());
 
         assertEquals(20, filtered.asVector().getInt(0));


### PR DESCRIPTION
This change removes Block#nullValuesCount. While there is no practical usage for this method, exposing it would add burden to the implementation of new blocks.