### PR TITLE
Save one reschedule in Driver

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/Driver.java
@@ -361,11 +361,11 @@ public class Driver implements Releasable, Describable {
 
             @Override
             protected void doRun() {
+                SubscribableListener<Void> fut = driver.run(maxTime, maxIterations, System::nanoTime);
                 if (driver.isFinished()) {
                     onComplete(listener);
                     return;
                 }
-                SubscribableListener<Void> fut = driver.run(maxTime, maxIterations, System::nanoTime);
                 if (fut.isDone()) {
                     schedule(maxTime, maxIterations, threadContext, executor, driver, listener);
                 } else {


### PR DESCRIPTION
We can avoid an additional rescheduling by completing the driver in the final loop instead.