### PR TITLE
Guard systemd library lookup from unreadable directories

### DIFF
--- a/docs/changelog/108931.yaml
+++ b/docs/changelog/108931.yaml
@@ -1,0 +1,5 @@
+pr: 108931
+summary: Guard systemd library lookup from unreadable directories
+area: Infra/Core
+type: bug
+issues: []


### PR DESCRIPTION
When scanning the library path we may come across directories that are unreadable. If that happens, the recursive walk of the library path directories will throw a fatal IOException. This commit guards the walk of the library paths to first check for readability of each directory we are about to traverse.