### PR TITLE
Small cleanups and performance improvements in o.e.c.u.concurrent.AtomicArray

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkOperation.java
@@ -323,9 +323,7 @@ final class BulkOperation extends ActionRunnable<BulkResponse> {
     }
 
     private void completeBulkOperation() {
-        listener.onResponse(
-            new BulkResponse(responses.toArray(new BulkItemResponse[responses.length()]), buildTookInMillis(startTimeNanos))
-        );
+        listener.onResponse(new BulkResponse(responses.toArray(BulkItemResponse.class), buildTookInMillis(startTimeNanos)));
         // Allow memory for bulk shard request items to be reclaimed before all items have been completed
         bulkRequest = null;
     }

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportSimulateBulkAction.java
@@ -99,7 +99,7 @@ public class TransportSimulateBulkAction extends TransportBulkAction {
                 )
             );
         }
-        listener.onResponse(new BulkResponse(responses.toArray(new BulkItemResponse[responses.length()]), buildTookInMillis(startTime)));
+        listener.onResponse(new BulkResponse(responses.toArray(BulkItemResponse.class), buildTookInMillis(startTime)));
     }
 
     /*

--- a/server/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportMultiGetAction.java
@@ -99,7 +99,7 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
 
         if (shardRequests.isEmpty()) {
             // only failures..
-            listener.onResponse(new MultiGetResponse(responses.toArray(new MultiGetItemResponse[responses.length()])));
+            listener.onResponse(new MultiGetResponse(responses.toArray(MultiGetItemResponse.class)));
         }
 
         executeShardAction(listener, responses, shardRequests);
@@ -138,7 +138,7 @@ public class TransportMultiGetAction extends HandledTransportAction<MultiGetRequ
                 }
 
                 private void finishHim() {
-                    delegate.onResponse(new MultiGetResponse(responses.toArray(new MultiGetItemResponse[responses.length()])));
+                    delegate.onResponse(new MultiGetResponse(responses.toArray(MultiGetItemResponse.class)));
                 }
             });
         }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportMultiSearchAction.java
@@ -189,7 +189,7 @@ public class TransportMultiSearchAction extends HandledTransportAction<MultiSear
             private void finish() {
                 ActionListener.respondAndRelease(
                     listener,
-                    new MultiSearchResponse(responses.toArray(new MultiSearchResponse.Item[responses.length()]), buildTookInMillis())
+                    new MultiSearchResponse(responses.toArray(MultiSearchResponse.Item.class), buildTookInMillis())
                 );
             }
 

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TransportMultiTermVectorsAction.java
@@ -101,7 +101,7 @@ public class TransportMultiTermVectorsAction extends HandledTransportAction<Mult
 
         if (shardRequests.size() == 0) {
             // only failures..
-            listener.onResponse(new MultiTermVectorsResponse(responses.toArray(new MultiTermVectorsItemResponse[responses.length()])));
+            listener.onResponse(new MultiTermVectorsResponse(responses.toArray(MultiTermVectorsItemResponse.class)));
         }
 
         executeShardAction(listener, responses, shardRequests);
@@ -148,9 +148,7 @@ public class TransportMultiTermVectorsAction extends HandledTransportAction<Mult
                 }
 
                 private void finishHim() {
-                    listener.onResponse(
-                        new MultiTermVectorsResponse(responses.toArray(new MultiTermVectorsItemResponse[responses.length()]))
-                    );
+                    listener.onResponse(new MultiTermVectorsResponse(responses.toArray(MultiTermVectorsItemResponse.class)));
                 }
             });
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -638,7 +638,7 @@ public class MetadataIndexStateService {
 
                     private void processIfFinished() {
                         if (countDown.countDown()) {
-                            onResponse.accept(new IndexResult(index, results.toArray(new ShardResult[results.length()])));
+                            onResponse.accept(new IndexResult(index, results.toArray(ShardResult.class)));
                         }
                     }
                 }));
@@ -768,7 +768,7 @@ public class MetadataIndexStateService {
 
                     private void processIfFinished() {
                         if (countDown.countDown()) {
-                            AddBlockResult result = new AddBlockResult(index, results.toArray(new AddBlockShardResult[results.length()]));
+                            AddBlockResult result = new AddBlockResult(index, results.toArray(AddBlockShardResult.class));
                             logger.debug("result of applying block to index {}: {}", index, result);
                             onResponse.accept(result);
                         }


### PR DESCRIPTION
Some small obvious cleanups in AtomicArray, drying up a volatile hack, removing some redundant and potentially buggy volatile access and simplifying (and for large arrays also potentially speeding up by saving `calloc`) the API for copying the contents to an array.

