### PR TITLE
Use unique index patterns in template tests

### DIFF
--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -12,7 +12,7 @@ that can be applied automatically to new indices.
 --------------------------------------------------
 PUT /_index_template/template_1
 {
-  "index_patterns" : ["te*"],
+  "index_patterns" : ["template*"],
   "priority" : 1,
   "template": {
     "settings" : {
@@ -186,7 +186,7 @@ You can include <<aliases,index aliases>> in an index template.
 --------------------------------------------------
 PUT _index_template/template_1
 {
-  "index_patterns" : ["te*"],
+  "index_patterns" : ["template*"],
   "template": {
     "settings" : {
         "number_of_shards" : 1
@@ -218,7 +218,7 @@ the template with the highest priority is used. For example:
 --------------------------------------------------
 PUT /_index_template/template_1
 {
-  "index_patterns" : ["t*"],
+  "index_patterns" : ["temp*"],
   "priority" : 0,
   "template": {
     "settings" : {
@@ -233,7 +233,7 @@ PUT /_index_template/template_1
 
 PUT /_index_template/template_2
 {
-  "index_patterns" : ["te*"],
+  "index_patterns" : ["template*"],
   "priority" : 1,
   "template": {
     "settings" : {
@@ -246,7 +246,7 @@ PUT /_index_template/template_2
 }
 --------------------------------------------------
 
-For indices that start with `te*`, `_source` will enabled, and the index will have two primary
+For indices that start with `template*`, `_source` will enabled, and the index will have two primary
 shards and one replica, because only `template_2` will be applied.
 
 NOTE: Multiple templates with overlapping index patterns at the same priority are not allowed, and

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.templates/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cat.templates/10_basic.yml
@@ -92,7 +92,7 @@
           body:
             order: 0
             version: 1
-            index_patterns: t*
+            index_patterns: test*
             settings:
               number_of_shards: 1
               number_of_replicas: 0
@@ -103,7 +103,7 @@
           body:
             order: 2
             version: 1
-            index_patterns: tea*
+            index_patterns: nomatch*
             settings:
               number_of_shards: 1
               number_of_replicas: 0
@@ -116,7 +116,7 @@
         $body: |
                 /^
                     test    \s+
-                    \[t\*\] \s+
+                    \[test\*\] \s+
                     0       \s+
                     1       \s*
                     \n
@@ -134,7 +134,7 @@
           body:
             order: 0
             version: 1
-            index_patterns: t*
+            index_patterns: test*
             settings:
               number_of_shards: 1
               number_of_replicas: 0
@@ -154,7 +154,7 @@
                     composed_of
                     \n
                     test            \s+
-                    \[t\*\]         \s+
+                    \[test\*\]         \s+
                     0               \s+
                     1               \s*
                     \n
@@ -172,7 +172,7 @@
           body:
             order: 0
             version: 1
-            index_patterns: t*
+            index_patterns: test*
             settings:
               number_of_shards: 1
               number_of_replicas: 0
@@ -190,7 +190,7 @@
                     index_patterns
                     \n
                     test        \s+
-                    \[t\*\]
+                    \[test*\*\]
                     \n
                 $/
 
@@ -206,7 +206,7 @@
           name: test
           body:
             order: 0
-            index_patterns: t*
+            index_patterns: test*
             settings:
               number_of_shards: 1
               number_of_replicas: 0
@@ -217,7 +217,7 @@
           body:
             order: 0
             version: 1
-            index_patterns: te*
+            index_patterns: test-*
             settings:
               number_of_shards: 1
               number_of_replicas: 0
@@ -230,8 +230,8 @@
     - match:
         $body: |
               /^
-                  test   \s+ \[t\*\]  \s+   \n \n
-                  test_1 \s+ \[te\*\] \s+ 1 \n \n
+                  test   \s+ \[test\*\]  \s+   \n \n
+                  test_1 \s+ \[test-\*\] \s+ 1 \n \n
               $/
 
     - do:
@@ -242,8 +242,8 @@
     - match:
         $body: |
               /^
-                  test_1 \s+ \[te\*\]   \s+ 1\n \n
-                  test   \s+ \[t\*\]    \s+  \n \n
+                  test_1 \s+ \[test-\*\]   \s+ 1\n \n
+                  test   \s+ \[test\*\]    \s+  \n \n
 
               $/
 
@@ -260,7 +260,7 @@
           body:
             order: 0
             version: 1
-            index_patterns: [t*, te*]
+            index_patterns: [test*, test-*]
             settings:
               number_of_shards: 1
               number_of_replicas: 0
@@ -278,7 +278,7 @@
                  index_patterns
                  \n
                  test_1       \s+
-                 \[t\*,\ te\*\]
+                 \[test\*,\ test-\*\]
                  \n
                  \n
               $/

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
@@ -9,7 +9,7 @@
       indices.put_index_template:
         name: test
         body:
-          index_patterns: te*
+          index_patterns: test*
           template:
             settings:
               number_of_shards:   1
@@ -39,7 +39,7 @@
       indices.put_index_template:
         name: existing_test
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 10
           template:
             settings:
@@ -66,7 +66,7 @@
       indices.simulate_index_template:
         name: test
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 15
           template:
             settings:
@@ -79,7 +79,7 @@
   - match: {template.settings.index.number_of_replicas: "2"}
   - match: {template.mappings.properties.ct_field.type: "keyword"}
   - match: {overlapping.0.name: existing_test}
-  - match: {overlapping.0.index_patterns: ["te*"]}
+  - match: {overlapping.0.index_patterns: ["test*"]}
   - length: {template.aliases: 1}
   - is_true: template.aliases.test_alias
 
@@ -92,11 +92,11 @@
 
   - do:
       allowed_warnings:
-        - "index template [test] has index patterns [te*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
+        - "index template [test] has index patterns [test*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test] will take precedence during new index creation"
       indices.put_index_template:
         name: test
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 10
           template:
             settings:
@@ -124,18 +124,18 @@
       indices.put_template:
         name: v1_template
         body:
-          index_patterns: [t*, t1*]
+          index_patterns: [test*, t1*]
           settings:
             number_of_shards:   5
 
   - do:
       allowed_warnings:
-        - "index template [v2_template] has index patterns [te*] matching patterns from existing older templates [v1_template] with patterns
-        (v1_template => [t*, t1*]); this template [v2_template] will take precedence during new index creation"
+        - "index template [v2_template] has index patterns [test*] matching patterns from existing older templates [v1_template] with patterns
+        (v1_template => [test*, t1*]); this template [v2_template] will take precedence during new index creation"
       indices.put_index_template:
         name: v2_template
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 10
           template:
             settings:
@@ -148,12 +148,12 @@
 
   - do:
       allowed_warnings:
-        - "index template [winning_v2_template] has index patterns [te*] matching patterns from existing older templates [v1_template] with patterns
-        (v1_template => [t*, t1*]); this template [winning_v2_template] will take precedence during new index creation"
+        - "index template [winning_v2_template] has index patterns [test*] matching patterns from existing older templates [v1_template] with patterns
+        (v1_template => [test*, t1*]); this template [winning_v2_template] will take precedence during new index creation"
       indices.put_index_template:
         name: winning_v2_template
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 20
           template:
             settings:
@@ -172,9 +172,9 @@
   - match: {template.settings.index.number_of_replicas: "0"}
   - match: {template.mappings.properties.field.type: "keyword"}
   - match: {overlapping.0.name: v1_template}
-  - match: {overlapping.0.index_patterns: ["t*", "t1*"]}
+  - match: {overlapping.0.index_patterns: ["test*", "t1*"]}
   - match: {overlapping.1.name: v2_template}
-  - match: {overlapping.1.index_patterns: ["te*"]}
+  - match: {overlapping.1.index_patterns: ["test*"]}
 
 ---
 "Simulate an index for and index or alias that already exists":
@@ -187,7 +187,7 @@
       indices.put_index_template:
         name: test
         body:
-          index_patterns: [te*]
+          index_patterns: [test*]
           template:
             settings:
               number_of_shards:   1
@@ -235,7 +235,7 @@
       indices.put_index_template:
         name: test
         body:
-          index_patterns: te*
+          index_patterns: test*
           template:
             lifecycle:
               data_retention: "7d"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
@@ -39,7 +39,7 @@
       indices.put_index_template:
         name: existing_test
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 10
           template:
             settings:
@@ -65,7 +65,7 @@
   - do:
       indices.simulate_template:
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 15
           template:
             settings:
@@ -78,7 +78,7 @@
   - match: {template.settings.index.number_of_replicas: "2"}
   - match: {template.mappings.properties.ct_field.type: "keyword"}
   - match: {overlapping.0.name: existing_test}
-  - match: {overlapping.0.index_patterns: ["te*"]}
+  - match: {overlapping.0.index_patterns: ["test*"]}
   - length: {template.aliases: 1}
   - is_true: template.aliases.test_alias
 
@@ -93,18 +93,18 @@
       indices.put_template:
         name: v1_template
         body:
-          index_patterns: [t*, t1*]
+          index_patterns: [test*, t1*]
           settings:
             number_of_shards:   5
 
   - do:
       allowed_warnings:
-        - "index template [v2_template] has index patterns [te*] matching patterns from existing older templates [v1_template] with patterns
-        (v1_template => [t*, t1*]); this template [v2_template] will take precedence during new index creation"
+        - "index template [v2_template] has index patterns [test*] matching patterns from existing older templates [v1_template] with patterns
+        (v1_template => [test*, t1*]); this template [v2_template] will take precedence during new index creation"
       indices.put_index_template:
         name: v2_template
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 10
           template:
             settings:
@@ -117,12 +117,12 @@
 
   - do:
       allowed_warnings:
-        - "index template [winning_v2_template] has index patterns [te*] matching patterns from existing older templates [v1_template] with patterns
-        (v1_template => [t*, t1*]); this template [winning_v2_template] will take precedence during new index creation"
+        - "index template [winning_v2_template] has index patterns [test*] matching patterns from existing older templates [v1_template] with patterns
+        (v1_template => [test*, t1*]); this template [winning_v2_template] will take precedence during new index creation"
       indices.put_index_template:
         name: winning_v2_template
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 20
           template:
             settings:
@@ -141,9 +141,9 @@
   - match: {template.settings.index.number_of_replicas: "0"}
   - match: {template.mappings.properties.field.type: "keyword"}
   - match: {overlapping.0.name: v1_template}
-  - match: {overlapping.0.index_patterns: ["t*", "t1*"]}
+  - match: {overlapping.0.index_patterns: ["test*", "t1*"]}
   - match: {overlapping.1.name: v2_template}
-  - match: {overlapping.1.index_patterns: ["te*"]}
+  - match: {overlapping.1.index_patterns: ["test*"]}
 
 ---
 "Simulate replacing a template with a newer version":
@@ -156,7 +156,7 @@
       indices.put_index_template:
         name: v2_template
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 10
           template:
             settings:
@@ -183,7 +183,7 @@
       indices.simulate_template:
         name: v2_template
         body:
-          index_patterns: te*
+          index_patterns: test*
           priority: 10
           template:
             settings:


### PR DESCRIPTION
These patterns were overlapping with certain templates from the APM plugin.

Fixes #108902