### PR TITLE
Mute DataStreamLifecycleServiceTests

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/lifecycle/DataStreamLifecycleServiceTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.datastreams.lifecycle;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -128,6 +129,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108952")
 public class DataStreamLifecycleServiceTests extends ESTestCase {
 
     private long now;


### PR DESCRIPTION
Muting due to https://github.com/elastic/elasticsearch/issues/108952