### PR TITLE
Add docs note for limits on synonyms

### DIFF
--- a/docs/reference/synonyms/apis/put-synonyms-set.asciidoc
+++ b/docs/reference/synonyms/apis/put-synonyms-set.asciidoc
@@ -9,7 +9,7 @@ Creates or updates a synonyms set.
 
 NOTE: Synonyms sets are limited to a maximum of 10,000 synonym rules per set.
 Synonym sets with more than 10,000 synonym rules will provide inconsistent search results.
-If you need to manage more than 10,000 synonym rules, you can create multiple synonyms sets.
+If you need to manage more synonym rules, you can create multiple synonyms sets.
 
 [[put-synonyms-set-request]]
 ==== {api-request-title}

--- a/docs/reference/synonyms/apis/put-synonyms-set.asciidoc
+++ b/docs/reference/synonyms/apis/put-synonyms-set.asciidoc
@@ -7,6 +7,10 @@
 
 Creates or updates a synonyms set.
 
+NOTE: Synonyms sets are limited to a maximum of 10,000 synonym rules per set.
+Synonym sets with more than 10,000 synonym rules will provide inconsistent search results.
+If you need to manage more than 10,000 synonym rules, you can create multiple synonyms sets.
+
 [[put-synonyms-set-request]]
 ==== {api-request-title}
 

--- a/docs/reference/synonyms/apis/synonyms-apis.asciidoc
+++ b/docs/reference/synonyms/apis/synonyms-apis.asciidoc
@@ -20,7 +20,7 @@ These filters are applied as part of the <<analysis,analysis>> process by the <<
 
 NOTE: Synonyms sets are limited to a maximum of 10,000 synonym rules per set.
 Synonym sets with more than 10,000 synonym rules will provide inconsistent search results.
-If you need to manage more than 10,000 synonym rules, you can create multiple synonyms sets.
+If you need to manage more synonym rules, you can create multiple synonyms sets.
 
 [discrete]
 [[synonyms-sets-apis]]

--- a/docs/reference/synonyms/apis/synonyms-apis.asciidoc
+++ b/docs/reference/synonyms/apis/synonyms-apis.asciidoc
@@ -18,6 +18,10 @@ This provides an alternative to:
 Synonyms sets can be used to configure <<analysis-synonym-graph-tokenfilter,synonym graph token filters>> and <<analysis-synonym-tokenfilter,synonym token filters>>.
 These filters are applied as part of the <<analysis,analysis>> process by the <<search-analyzer,search analyzer>>.
 
+NOTE: Synonyms sets are limited to a maximum of 10,000 synonym rules per set.
+Synonym sets with more than 10,000 synonym rules will provide inconsistent search results.
+If you need to manage more than 10,000 synonym rules, you can create multiple synonyms sets.
+
 [discrete]
 [[synonyms-sets-apis]]
 === Synonyms sets APIs


### PR DESCRIPTION
Add a note about limitations on synonyms sets.

This note is added to both the overall Synonyms API page:
![Screenshot 2024-05-23 at 17 42 29](https://github.com/elastic/elasticsearch/assets/6339205/f9bfde6b-ac19-4ada-ab26-84bef206b56a)

And the specific create or update synonyms set:
![Screenshot 2024-05-23 at 17 43 03](https://github.com/elastic/elasticsearch/assets/6339205/8c2fa58e-3c92-467a-8314-3531ec871c90)

As this is something we added retroactively, I thought interesting to add the note to the main entry points for the Synonyms Sets APIs.