### PR TITLE
ESQL: Stop sending version in tests (#108961)

### DIFF
--- a/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
+++ b/test/external-modules/esql-heap-attack/src/javaRestTest/java/org/elasticsearch/xpack/esql/heap_attack/HeapAttackIT.java
@@ -61,8 +61,6 @@ public class HeapAttackIT extends ESRestTestCase {
 
     static volatile boolean SUITE_ABORTED = false;
 
-    private static String ESQL_VERSION = "2024.04.01";
-
     @Override
     protected String getTestRestCluster() {
         return cluster.getHttpAddresses();
@@ -156,7 +154,7 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     private StringBuilder makeManyLongs(int count) {
-        StringBuilder query = startQueryWithVersion(ESQL_VERSION);
+        StringBuilder query = startQuery();
         query.append("FROM manylongs\\n| EVAL i0 = a + b, i1 = b + i0");
         for (int i = 2; i < count; i++) {
             query.append(", i").append(i).append(" = i").append(i - 2).append(" + ").append(i - 1);
@@ -187,7 +185,7 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     private Response concat(int evals) throws IOException {
-        StringBuilder query = startQueryWithVersion(ESQL_VERSION);
+        StringBuilder query = startQuery();
         query.append("FROM single | EVAL str = TO_STRING(a)");
         for (int e = 0; e < evals; e++) {
             query.append("\n| EVAL str=CONCAT(")
@@ -224,7 +222,7 @@ public class HeapAttackIT extends ESRestTestCase {
      * Tests that generate many moderately long strings.
      */
     private Response manyConcat(int strings) throws IOException {
-        StringBuilder query = startQueryWithVersion(ESQL_VERSION);
+        StringBuilder query = startQuery();
         query.append("FROM manylongs | EVAL str = CONCAT(");
         query.append(
             Arrays.stream(new String[] { "a", "b", "c", "d", "e" })
@@ -275,7 +273,7 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     private Response manyEval(int evalLines) throws IOException {
-        StringBuilder query = startQueryWithVersion(ESQL_VERSION);
+        StringBuilder query = startQuery();
         query.append("FROM manylongs");
         for (int e = 0; e < evalLines; e++) {
             query.append("\n| EVAL ");
@@ -357,7 +355,7 @@ public class HeapAttackIT extends ESRestTestCase {
      * Fetches documents containing 1000 fields which are {@code 1kb} each.
      */
     private void fetchManyBigFields(int docs) throws IOException {
-        StringBuilder query = startQueryWithVersion(ESQL_VERSION);
+        StringBuilder query = startQuery();
         query.append("FROM manybigfields | SORT f000 | LIMIT " + docs + "\"}");
         Response response = query(query.toString(), "columns");
         Map<?, ?> map = responseAsMap(response);
@@ -386,7 +384,7 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     private Response aggMvLongs(int fields) throws IOException {
-        StringBuilder query = startQueryWithVersion(ESQL_VERSION);
+        StringBuilder query = startQuery();
         query.append("FROM mv_longs | STATS MAX(f00) BY f00");
         for (int f = 1; f < fields; f++) {
             query.append(", f").append(String.format(Locale.ROOT, "%02d", f));
@@ -412,7 +410,7 @@ public class HeapAttackIT extends ESRestTestCase {
     }
 
     private Response fetchMvLongs() throws IOException {
-        StringBuilder query = startQueryWithVersion(ESQL_VERSION);
+        StringBuilder query = startQuery();
         query.append("FROM mv_longs\"}");
         return query(query.toString(), "columns");
     }
@@ -583,11 +581,9 @@ public class HeapAttackIT extends ESRestTestCase {
         });
     }
 
-    private static StringBuilder startQueryWithVersion(String version) {
+    private static StringBuilder startQuery() {
         StringBuilder query = new StringBuilder();
-        query.append("{\"version\":\"" + version + "\",");
-        query.append("\"query\":\"");
-
+        query.append("{\"query\":\"");
         return query;
     }
 }

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlAsyncSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlAsyncSecurityIT.java
@@ -90,7 +90,6 @@ public class EsqlAsyncSecurityIT extends EsqlSecurityIT {
         }
         XContentBuilder json = JsonXContent.contentBuilder();
         json.startObject();
-        json.field("version", ESQL_VERSION);
         json.field("query", command);
         addRandomPragmas(json);
         json.field("wait_for_completion_timeout", timeValueNanos(randomIntBetween(1, 1000)));

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -38,8 +38,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class EsqlSecurityIT extends ESRestTestCase {
-    static String ESQL_VERSION = "2024.04.01.🚀";
-
     @ClassRule
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .distribution(DistributionType.DEFAULT)
@@ -355,7 +353,6 @@ public class EsqlSecurityIT extends ESRestTestCase {
         }
         XContentBuilder json = JsonXContent.contentBuilder();
         json.startObject();
-        json.field("version", ESQL_VERSION);
         json.field("query", command);
         addRandomPragmas(json);
         json.endObject();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryRequestTests.java
@@ -193,7 +193,6 @@ public class EsqlQueryRequestTests extends ESTestCase {
     public void testPragmasOnlyValidOnSnapshot() throws IOException {
         String json = """
             {
-                "version": "2024.04.01",
                 "query": "ROW x = 1",
                 "pragma": {"foo": "bar"}
             }

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityEsqlIT.java
@@ -44,7 +44,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTestCase {
-
     private static final AtomicReference<Map<String, Object>> API_KEY_MAP_REF = new AtomicReference<>();
     private static final AtomicReference<Map<String, Object>> REST_API_KEY_MAP_REF = new AtomicReference<>();
     private static final AtomicBoolean SSL_ENABLED_REF = new AtomicBoolean();
@@ -690,9 +689,6 @@ public class RemoteClusterSecurityEsqlIT extends AbstractRemoteClusterSecurityTe
                 body.endObject();
             }
         }
-        // TODO: we should use the latest or a random version, even when new versions are released.
-        String version = Build.current().isSnapshot() ? "snapshot" : "2024.04.01";
-        body.field("version", version);
         body.endObject();
         Request request = new Request("POST", "_query");
         request.setJsonEntity(org.elasticsearch.common.Strings.toString(body));

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/100_bug_fix.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/100_bug_fix.yml
@@ -22,7 +22,6 @@
       esql.query:
         body:
           query: 'FROM test | sort emp_no | eval ip = to_ip(coalesce(ip1.keyword, "255.255.255.255")) | keep emp_no, ip'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -42,8 +41,6 @@
       esql.query:
         body:
           query: 'FROM test | sort emp_no | eval x1 = concat(ip1, ip2), x2 = coalesce(x1, "255.255.255.255"), x3 = to_ip(x2) | keep emp_no, x*'
-          version: 2024.04.01
-
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
   - match: { columns.1.name: "x1" }
@@ -111,7 +108,6 @@
       esql.query:
         body:
           query: 'from index* metadata _index | limit 5 | sort _index desc'
-          version: 2024.04.01
   - match: { columns.0.name: http.headers }
   - match: { columns.0.type: unsupported }
   - match: { columns.1.name: http.headers.location }
@@ -174,7 +170,6 @@
       esql.query:
         body:
           query: 'from npe_single_value* | stats x = avg(field1) | limit 10'
-          version: 2024.04.01
   - match: { columns.0.name: x }
   - match: { columns.0.type: double }
   - length: { values: 1 }
@@ -184,7 +179,6 @@
       esql.query:
         body:
           query: 'from npe_single_value* | stats x = avg(field2) | limit 10'
-          version: 2024.04.01
   - match: { columns.0.name: x }
   - match: { columns.0.type: double }
   - length: { values: 1 }
@@ -194,7 +188,6 @@
       esql.query:
         body:
           query: 'from npe_single_value* | stats x = avg(field3) | limit 10'
-          version: 2024.04.01
   - match: { columns.0.name: x }
   - match: { columns.0.type: double }
   - length: { values: 1 }
@@ -238,7 +231,6 @@
       esql.query:
         body:
           query: 'from idx_with_date_ip_txt | where id == 1 | eval x = date_format(text, date), y = date_extract(text2, date), p = date_parse(text, "2024-03-14") | keep x, y, p | limit 1'
-          version: 2024.04.01
   - match: { columns.0.name: x }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: y }
@@ -252,7 +244,6 @@
       esql.query:
         body:
           query: 'from idx_with_date_ip_txt | where id > 1 | eval x = cidr_match(ip, text) | sort id | keep id, x | limit 2'
-          version: 2024.04.01
   - match: { columns.0.name: id }
   - match: { columns.0.type: long }
   - match: { columns.1.name: x }
@@ -296,7 +287,6 @@
       esql.query:
         body:
           query: 'from idx_with_multivalues | eval b = mv_dedupe(boolean), k = mv_dedupe(keyword), i = mv_dedupe(integer), l = mv_dedupe(long), d = mv_dedupe(double) | keep b, k, i, l, d | limit 1'
-          version: 2024.04.01
   - match: { columns.0.name: b }
   - match: { columns.0.type: boolean }
   - match: { columns.1.name: k }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/10_basic.yml
@@ -118,7 +118,6 @@ setup:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
 
   - match: {columns.0.name: "color"}
   - match: {columns.0.type: "keyword"}
@@ -140,7 +139,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort count | limit 1'
-          version: 2024.04.01
 
   - match: {columns.1.name: "count"}
   - match: {columns.1.type: "long"}
@@ -153,7 +151,6 @@ setup:
         body:
           query: 'from test | keep data | sort data | limit 2'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "data"}
   - match: {columns.0.type: "long"}
@@ -165,7 +162,6 @@ setup:
       esql.query:
         body:
           query: 'from test | eval x = count + 7 | sort x | limit 1'
-          version: 2024.04.01
 
   - match: {columns.0.name: "color"}
   - match: {columns.1.name: "count"}
@@ -183,7 +179,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort time | eval x = data + 1, y = data_d + count, z = x + y | keep data, x, y, z, time | limit 2'
-          version: 2024.04.01
 
   - match: {columns.0.name: "data"}
   - match: {columns.0.type: "long"}
@@ -214,7 +209,6 @@ setup:
         body:
           query: 'from test | sort time | limit 2 | keep count'
           columnar: true
-          version: 2024.04.01
 
   - length: {columns: 1}
   - match: {columns.0.name: "count"}
@@ -228,7 +222,6 @@ setup:
         body:
           query: 'from test | sort time desc | limit 2 | keep count'
           columnar: true
-          version: 2024.04.01
 
   - length: {columns: 1}
   - match: {columns.0.name: "count"}
@@ -242,7 +235,6 @@ setup:
         body:
           query: 'from test | sort time | limit 2 | keep count | eval x = count + 1'
           columnar: true
-          version: 2024.04.01
 
   - length: {columns: 2}
   - match: {columns.0.name: "count"}
@@ -260,7 +252,6 @@ setup:
         body:
           query: 'from test | sort time | limit 2 | keep count | eval x = count + 1 | keep x'
           columnar: true
-          version: 2024.04.01
 
   - length: {columns: 1}
   - match: {columns.0.name: "x"}
@@ -274,7 +265,6 @@ setup:
       esql.query:
         body:
           query: 'from test | limit 10 | sort time | limit 1'
-          version: 2024.04.01
 
   - length: {columns: 6}
   - length: {values: 1}
@@ -288,7 +278,6 @@ setup:
         body:
           query: 'row a = ? | eval b = ?, c = 1 + ?'
           params: ["foo", 15, 10]
-          version: 2024.04.01
 
   - length: {columns: 3}
   - match: {columns.0.name: "a"}
@@ -308,7 +297,6 @@ setup:
         body:
           query: 'from test | where color == ? and count == ? and time == ? | keep data, count, color'
           params: ["green", 44, 1674835275193]
-          version: 2024.04.01
 
   - length: {columns: 3}
   - match: {columns.0.name: "data"}
@@ -327,7 +315,6 @@ setup:
         body:
           query: 'from test | eval x = ?, y = ?, z = ?, t = ?, u = ?, v = ? | keep x, y, z, t, u, v | limit 3'
           params: [{"value": 1, "type": "keyword"}, {"value": 2, "type": "double"}, null, true, 123, {"value": 123, "type": "long"}]
-          version: 2024.04.01
 
   - length: {columns: 6}
   - match: {columns.0.name: "x"}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/110_all_null.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/110_all_null.yml
@@ -122,7 +122,6 @@ row wise and keep null:
         body:
           query: 'FROM test | WHERE time <= 1674835275188 | SORT time ASC | LIMIT 2'
           columnar: false
-          version: 2024.04.01
 
   - length: {columns: 8}
   - match: {columns.0.name: "always_null"}
@@ -154,7 +153,6 @@ row wise and drop null:
         body:
           query: 'FROM test | WHERE time <= 1674835275188 | SORT time ASC | LIMIT 2'
           columnar: false
-          version: 2024.04.01
 
   - length: {all_columns: 8}
   - match: {all_columns.0.name: "always_null"}
@@ -198,7 +196,6 @@ columnar and keep null:
         body:
           query: 'FROM test | WHERE time <= 1674835275188 | SORT time ASC | LIMIT 2'
           columnar: true
-          version: 2024.04.01
 
   - length: {columns: 8}
   - match: {columns.0.name: "always_null"}
@@ -230,7 +227,6 @@ columnar and drop null:
         body:
           query: 'FROM test | WHERE time <= 1674835275188 | SORT time ASC | LIMIT 2'
           columnar: true
-          version: 2024.04.01
 
   - length: {all_columns: 8}
   - match: {all_columns.0.name: "always_null"}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/110_insensitive_equals.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/110_insensitive_equals.yml
@@ -47,7 +47,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where keyword =~ keywordUpper | keep id, keyword, keywordUpper'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -67,7 +66,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where text =~ textCamel | keep id, text, textCamel'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -88,7 +86,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where keyword =~ text | keep id, keyword, text'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -109,7 +106,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where keywordUpper =~ textCamel | keep id, keywordUpper, textCamel | sort id'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -131,7 +127,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where keywordUpper =~ "fo*" | keep id, keywordUpper'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -146,7 +141,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where wildcard =~ "foo*" | keep id, wildcard'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -162,7 +156,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where wildcard =~ "fOo*" | keep id, wildcard'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -179,7 +172,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where keywordUpper =~ "fo?" | keep id, keywordUpper'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -194,7 +186,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where wildcard =~ "bar?" | keep id, wildcard'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -210,7 +201,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where wildcard =~ "bAr?" | keep id, wildcard'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -229,7 +219,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where text =~ "Fo*" | keep id, text | sort id'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -244,7 +233,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where wildcardText =~ "fOo*" | keep id, wildcardText'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -260,7 +248,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where wildcardText =~ "bAr?" | keep id, wildcardText'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -279,7 +266,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where text =~ "fo\\*" | keep id, text'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -297,7 +283,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where wildcard =~ wildcardText | keep id, wildcard, wildcardText | sort id'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }
@@ -317,7 +302,6 @@ setup:
       esql.query:
         body:
           query: 'FROM test | where NOT wildcard =~ wildcardText | keep id, wildcard, wildcardText | sort id'
-          version: 2024.04.01
 
   - match: { columns.0.name: "id" }
   - match: { columns.0.type: "long" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/120_profile.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/120_profile.yml
@@ -130,7 +130,6 @@ avg 8.14 or after:
           query: 'FROM test | STATS AVG(data) | LIMIT 1'
           columnar: true
           profile: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "AVG(data)"}
   - match: {columns.0.type: "double"}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/130_spatial.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/130_spatial.yml
@@ -97,7 +97,6 @@ geo_point:
       esql.query:
         body:
           query: 'from geo_points | sort id'
-          version: 2024.04.01
   - match: { columns.0.name: id }
   - match: { columns.0.type: integer }
   - match: { columns.1.name: location }
@@ -115,7 +114,6 @@ geo_point unsortable:
       esql.query:
         body:
           query: 'from geo_points | sort location'
-          version: 2024.04.01
 
 ---
 geo_point unsortable with limit:
@@ -124,7 +122,6 @@ geo_point unsortable with limit:
       esql.query:
         body:
           query: 'from geo_points | LIMIT 10 | sort location'
-          version: 2024.04.01
 
 ---
 geo_point unsortable with limit from row:
@@ -133,7 +130,6 @@ geo_point unsortable with limit from row:
       esql.query:
         body:
           query: 'ROW wkt = ["POINT(42.9711 -14.7553)", "POINT(75.8093 22.7277)"] | MV_EXPAND wkt | EVAL pt = TO_GEOPOINT(wkt) | limit 5 | sort pt'
-          version: 2024.04.01
 
 ---
 values unsupported for geo_point:
@@ -142,7 +138,6 @@ values unsupported for geo_point:
       esql.query:
         body:
           query: 'FROM geo_points | STATS VALUES(location)'
-          version: 2024.04.01
 
 ---
 cartesian_point:
@@ -152,7 +147,6 @@ cartesian_point:
       esql.query:
         body:
           query: 'from cartesian_points | sort id'
-          version: 2024.04.01
   - match: { columns.0.name: id }
   - match: { columns.0.type: integer }
   - match: { columns.1.name: location }
@@ -170,7 +164,6 @@ cartesian_point unsortable:
       esql.query:
         body:
           query: 'from cartesian_points | sort location'
-          version: 2024.04.01
 
 ---
 cartesian_point unsortable with limit:
@@ -179,7 +172,6 @@ cartesian_point unsortable with limit:
       esql.query:
         body:
           query: 'from cartesian_points | LIMIT 10 | sort location'
-          version: 2024.04.01
 
 ---
 cartesian_point unsortable with limit from row:
@@ -188,7 +180,6 @@ cartesian_point unsortable with limit from row:
       esql.query:
         body:
           query: 'ROW wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"] | MV_EXPAND wkt | EVAL pt = TO_CARTESIANPOINT(wkt) | limit 5 | sort pt'
-          version: 2024.04.01
 
 ---
 geo_shape:
@@ -198,7 +189,6 @@ geo_shape:
       esql.query:
         body:
           query: 'from geo_shapes | sort id'
-          version: 2024.04.01
   - match: { columns.0.name: id }
   - match: { columns.0.type: integer }
   - match: { columns.1.name: shape }
@@ -216,7 +206,6 @@ geo_shape unsortable:
       esql.query:
         body:
           query: 'from geo_shapes | sort shape'
-          version: 2024.04.01
 
 ---
 geo_shape unsortable with limit:
@@ -225,7 +214,6 @@ geo_shape unsortable with limit:
       esql.query:
         body:
           query: 'from geo_shapes | LIMIT 10 | sort shape'
-          version: 2024.04.01
 
 ---
 geo_shape unsortable with limit from row:
@@ -234,7 +222,6 @@ geo_shape unsortable with limit from row:
       esql.query:
         body:
           query: 'ROW wkt = ["POINT(42.9711 -14.7553)", "POINT(75.8093 22.7277)"] | MV_EXPAND wkt | EVAL shape = TO_GEOSHAPE(wkt) | limit 5 | sort shape'
-          version: 2024.04.01
 
 ---
 cartesian_shape:
@@ -244,7 +231,6 @@ cartesian_shape:
       esql.query:
         body:
           query: 'from cartesian_shapes | sort id'
-          version: 2024.04.01
   - match: { columns.0.name: id }
   - match: { columns.0.type: integer }
   - match: { columns.1.name: shape }
@@ -262,7 +248,6 @@ cartesian_shape unsortable:
       esql.query:
         body:
           query: 'from cartesian_shapes | sort shape'
-          version: 2024.04.01
 
 ---
 cartesian_shape unsortable with limit:
@@ -271,7 +256,6 @@ cartesian_shape unsortable with limit:
       esql.query:
         body:
           query: 'from cartesian_shapes | LIMIT 10 | sort shape'
-          version: 2024.04.01
 
 ---
 cartesian_shape unsortable with limit from row:
@@ -280,4 +264,3 @@ cartesian_shape unsortable with limit from row:
       esql.query:
         body:
           query: 'ROW wkt = ["POINT(4297.11 -1475.53)", "POINT(7580.93 2272.77)"] | MV_EXPAND wkt | EVAL shape = TO_CARTESIANSHAPE(wkt) | limit 5 | sort shape'
-          version: 2024.04.01

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/20_aggs.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/20_aggs.yml
@@ -120,7 +120,6 @@ setup:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
 
   - match: {columns.0.name: "color"}
   - match: {columns.0.type: "keyword"}
@@ -147,7 +146,6 @@ setup:
         body:
           query: 'from test | where color == "red" | stats avg(data) by color'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "avg(data)"}
   - match: {columns.0.type: "double"}
@@ -164,7 +162,6 @@ setup:
         body:
           query: 'from test | stats avg(count)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "avg(count)"}
   - match: {columns.0.type: "double"}
@@ -179,7 +176,6 @@ setup:
         body:
           query: 'from test | stats f1 = avg(count)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "f1"}
   - match: {columns.0.type: "double"}
@@ -194,7 +190,6 @@ setup:
         body:
           query: 'from test | stats count(data)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "count(data)"}
   - match: {columns.0.type: "long"}
@@ -209,7 +204,6 @@ setup:
         body:
           query: 'from test | stats dataCount = count(data)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "dataCount"}
   - match: {columns.0.type: "long"}
@@ -224,7 +218,6 @@ setup:
         body:
           query: 'from test | stats min(count)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "min(count)"}
   - match: {columns.0.type: "long"}
@@ -239,7 +232,6 @@ setup:
         body:
           query: 'from test | stats minCount=min(count)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "minCount"}
   - match: {columns.0.type: "long"}
@@ -254,7 +246,6 @@ setup:
         body:
           query: 'from test | stats max(count)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "max(count)"}
   - match: {columns.0.type: "long"}
@@ -269,7 +260,6 @@ setup:
         body:
           query: 'from test | stats maxCount=max(count)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "maxCount"}
   - match: {columns.0.type: "long"}
@@ -282,7 +272,6 @@ setup:
         body:
           query: 'from test | stats avg(count) by color | sort color | limit 2'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "avg(count)"}
   - match: {columns.0.type: "double"}
@@ -300,7 +289,6 @@ setup:
         body:
           query: 'from test | stats med=median(count)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
@@ -315,7 +303,6 @@ setup:
         body:
           query: 'from test | stats med=median(count_d)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
@@ -330,7 +317,6 @@ setup:
         body:
           query: 'from test | stats med=median(count) by color | sort med'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
@@ -348,7 +334,6 @@ setup:
         body:
           query: 'from test | stats med=median(count_d) by color | sort med'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
@@ -366,7 +351,6 @@ setup:
         body:
           query: 'from test | stats med=median_absolute_deviation(count)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
@@ -381,7 +365,6 @@ setup:
         body:
           query: 'from test | stats med=median_absolute_deviation(count_d)'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
@@ -396,7 +379,6 @@ setup:
         body:
           query: 'from test | stats med=median_absolute_deviation(count) by color | sort color'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
@@ -414,7 +396,6 @@ setup:
         body:
           query: 'from test | stats med=median_absolute_deviation(count_d) by color | sort color'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
@@ -431,7 +412,6 @@ setup:
       esql.query:
         body:
           query: 'from test | stats avg_count = avg(count) | eval x = avg_count + 7'
-          version: 2024.04.01
 
   - length: {values: 1}
   - length: {values.0: 2}
@@ -445,7 +425,6 @@ setup:
       esql.query:
         body:
           query: 'from test | stats x = avg(count) | where x > 100'
-          version: 2024.04.01
 
   - length: {values: 0}
 
@@ -455,7 +434,6 @@ setup:
       esql.query:
         body:
           query: 'from test | eval nullsum = count_d + null | sort nullsum | limit 1'
-          version: 2024.04.01
 
   - length: {columns: 8}
   - length: {values: 1}
@@ -471,7 +449,6 @@ setup:
       esql.query:
         body:
           query: 'row a = 1, b = 2, c = null | eval z = c + b + a'
-          version: 2024.04.01
 
   - length: {columns: 4}
   - length: {values: 1}
@@ -497,7 +474,6 @@ setup:
       esql.query:
         body:
           query: 'from test | eval nullsum = count_d + null | stats count(nullsum)'
-          version: 2024.04.01
 
   - length: {columns: 1}
   - length: {values: 1}
@@ -514,7 +490,6 @@ setup:
       esql.query:
         body:
           query: 'row l=1, d=1.0, ln=1 + null, dn=1.0 + null | stats sum(l), sum(d), sum(ln), sum(dn)'
-          version: 2024.04.01
 
   - length: {columns: 4}
   - length: {values: 1}
@@ -541,7 +516,6 @@ grouping on text:
         body:
           query: 'FROM test | STATS med=median(count) BY text | SORT med'
           columnar: true
-          version: 2024.04.01
 
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/25_aggs_on_null.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/25_aggs_on_null.yml
@@ -39,7 +39,6 @@ group on null:
         body:
           query: 'FROM test | STATS med=median(never_null) BY always_null | LIMIT 1'
           columnar: true
-          version: 2024.04.01
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
   - match: {columns.1.name: "always_null"}
@@ -55,7 +54,6 @@ group on null, long:
         body:
           query: 'FROM test | STATS med=median(sometimes_null) BY always_null, never_null | SORT always_null, never_null | LIMIT 10'
           columnar: true
-          version: 2024.04.01
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
   - match: {columns.1.name: "always_null"}
@@ -74,7 +72,6 @@ agg on null:
         body:
           query: 'FROM test | STATS med=median(always_null) | LIMIT 1'
           columnar: true
-          version: 2024.04.01
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
   - length: {values: 1}
@@ -88,7 +85,6 @@ agg on missing:
         body:
           query: 'FROM test | STATS med=median(missing) | LIMIT 1'
           columnar: true
-          version: 2024.04.01
 
 ---
 group on missing:
@@ -98,7 +94,6 @@ group on missing:
         body:
           query: 'FROM test | STATS med=median(never_null) BY missing | LIMIT 1'
           columnar: true
-          version: 2024.04.01
 
 ---
 agg on half missing:
@@ -124,7 +119,6 @@ agg on half missing:
         body:
           query: 'FROM test* | STATS med=median(missing) | LIMIT 1'
           columnar: true
-          version: 2024.04.01
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
   - length: {values: 1}
@@ -154,7 +148,6 @@ group on half missing:
         body:
           query: 'FROM test,test2 | STATS med=median(never_null) BY missing | LIMIT 1'
           columnar: true
-          version: 2024.04.01
   - match: {columns.0.name: "med"}
   - match: {columns.0.type: "double"}
   - match: {columns.1.name: "missing"}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/30_types.yml
@@ -35,7 +35,6 @@ constant_keyword:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: { columns.0.name: color }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: kind }
@@ -50,7 +49,6 @@ constant_keyword:
       esql.query:
         body:
           query: 'from test | eval l=length(kind) | keep l'
-          version: 2024.04.01
   - match: {columns.0.name: l}
   - match: {columns.0.type: integer}
   - length: {values: 1}
@@ -81,7 +79,6 @@ constant_keyword with null value:
       esql.query:
         body:
           query: 'from test | limit 1'
-          version: 2024.04.01
   - match: { columns.0.name: color }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: kind }
@@ -115,7 +112,6 @@ multivalued keyword:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: {columns.0.name: card}
   - match: {columns.0.type: keyword}
   - length: {values: 1}
@@ -147,7 +143,6 @@ keyword no doc_values:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: {columns.0.name: card}
   - match: {columns.0.type: keyword}
   - length: {values: 1}
@@ -178,7 +173,6 @@ wildcard:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: {columns.0.name: card}
   - match: {columns.0.type: keyword}
   - length: {values: 1}
@@ -190,7 +184,6 @@ wildcard:
       esql.query:
         body:
           query: 'from test | eval l=length(card) | keep l'
-          version: 2024.04.01
   - match: {columns.0.name: l}
   - match: {columns.0.type: integer}
   - length: {values: 1}
@@ -231,7 +224,6 @@ numbers:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: {columns.0.name: d}
   - match: {columns.0.type: double}
   - match: {columns.1.name: i}
@@ -283,7 +275,6 @@ small_numbers:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: {columns.0.name: b}
   - match: {columns.0.type: integer}
   - match: {columns.1.name: f}
@@ -304,7 +295,6 @@ small_numbers:
       esql.query:
         body:
           query: 'from test | eval sum_d = b + f + hf + s, sum_i = b + s | keep sum_d, sum_i'
-          version: 2024.04.01
   - match: {columns.0.name: sum_d}
   - match: {columns.0.type: double}
   - match: {columns.1.name: sum_i}
@@ -319,7 +309,6 @@ small_numbers:
       esql.query:
         body:
           query: 'from test | eval r_f = round(f), r_hf = round(hf) | keep r_f, r_hf'
-          version: 2024.04.01
   - match: {columns.0.name: r_f}
   - match: {columns.0.type: double}
   - match: {columns.1.name: r_hf}
@@ -356,7 +345,6 @@ scaled_float:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: {columns.0.name: d}
   - match: {columns.0.type: double}
   - match: {columns.1.name: f}
@@ -371,7 +359,6 @@ scaled_float:
       esql.query:
         body:
           query: 'from test | eval sum = d + f | keep sum'
-          version: 2024.04.01
   - match: {columns.0.name: sum}
   - match: {columns.0.type: double}
   - length: {values: 1}
@@ -402,7 +389,6 @@ multivalued boolean:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: { columns.0.name: booleans }
   - match: { columns.0.type: boolean }
   - length: { values: 1 }
@@ -435,7 +421,6 @@ ip:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: { columns.0.name: ip }
   - match: { columns.0.type: ip }
   - match: { columns.1.name: keyword }
@@ -450,7 +435,6 @@ ip:
       esql.query:
         body:
           query: 'from test | where keyword == "127.0.0.2" | rename ip as IP | drop keyword'
-          version: 2024.04.01
   - match: {columns.0.name: IP }
   - match: {columns.0.type: ip }
   - length: {values: 1 }
@@ -506,7 +490,6 @@ alias:
       esql.query:
         body:
           query: 'from test | keep foo, bar, level1.level2, level2_alias, some_long, some_long_alias, some_long_alias2, some_date, some_date_alias | sort level2_alias'
-          version: 2024.04.01
   - match: { columns.0.name: foo }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: bar }
@@ -551,7 +534,6 @@ alias:
       esql.query:
         body:
           query: 'from test | where bar == "abc" | keep foo, bar, level1.level2, level2_alias'
-          version: 2024.04.01
   - match: { columns.0.name: foo }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: bar }
@@ -572,7 +554,6 @@ alias:
       esql.query:
         body:
           query: 'from test | where level2_alias == 10 | keep foo, bar, level1.level2, level2_alias'
-          version: 2024.04.01
   - match: { columns.0.name: foo }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: bar }
@@ -593,7 +574,6 @@ alias:
       esql.query:
         body:
           query: 'from test | where level2_alias == 20'
-          version: 2024.04.01
   - length: { values: 0 }
 
   - do:
@@ -602,7 +582,6 @@ alias:
       esql.query:
         body:
           query: 'from test | stats x = max(level2_alias)'
-          version: 2024.04.01
   - match: { columns.0.name: x }
   - match: { columns.0.type: long }
   - length: { values: 1 }
@@ -633,7 +612,6 @@ version:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: { columns.0.name: version }
   - match: { columns.0.type: version }
   - length: { values: 1 }
@@ -667,7 +645,6 @@ id:
       esql.query:
         body:
           query: 'from test metadata _id | keep _id, kw'
-          version: 2024.04.01
   - match: { columns.0.name: _id }
   - match: { columns.0.type: keyword }
   - length: { values: 1 }
@@ -699,7 +676,6 @@ unsigned_long:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: { columns.0.name: number }
   - match: { columns.0.type: unsigned_long }
   - length: { values: 1 }
@@ -723,7 +699,6 @@ _source:
       esql.query:
         body:
           query: 'FROM test METADATA _source | KEEP _source | LIMIT 1'
-          version: 2024.04.01
   - match: { columns.0.name: _source }
   - match: { columns.0.type: _source }
   - length: { values: 1 }
@@ -759,7 +734,6 @@ _source keep all:
       esql.query:
         body:
           query: 'FROM test METADATA _source | LIMIT 1'
-          version: 2024.04.01
   - match: { columns.0.name: _source }
   - match: { columns.0.type: _source }
   - length: { values: 1 }
@@ -796,7 +770,6 @@ _source disabled:
       esql.query:
         body:
           query: 'FROM test METADATA _source | KEEP _source | LIMIT 1'
-          version: 2024.04.01
   - match: { columns.0.name: _source }
   - match: { columns.0.type: _source }
   - length: { values: 1 }
@@ -825,7 +798,6 @@ text:
       esql.query:
         body:
           query: 'FROM test | LIMIT 1'
-          version: 2024.04.01
   - match: {columns.0.name: card}
   - match: {columns.0.type: text}
   - length: {values: 1}
@@ -857,7 +829,6 @@ synthetic _source text stored:
       esql.query:
         body:
           query: 'FROM test | LIMIT 1'
-          version: 2024.04.01
   - match: {columns.0.name: card}
   - match: {columns.0.type: text}
   - length: {values: 1}
@@ -891,7 +862,6 @@ synthetic _source text with parent keyword:
       esql.query:
         body:
           query: 'FROM test | KEEP card.text | LIMIT 1'
-          version: 2024.04.01
   - match: {columns.0.name: card.text}
   - match: {columns.0.type: text}
   - length: {values: 1}
@@ -925,7 +895,6 @@ geo_point:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: { columns.0.name: location }
   - match: { columns.0.type: geo_point }
   - length: { values: 1 }
@@ -959,7 +928,6 @@ cartesian_point:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
   - match: { columns.0.name: location }
   - match: { columns.0.type: cartesian_point }
   - length: { values: 1 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_tsdb.yml
@@ -117,7 +117,6 @@ load everything:
       esql.query:
         body:
           query: 'from test metadata _id'
-          version: 2024.04.01
 
   - match: {columns.0.name: "@timestamp"}
   - match: {columns.0.type: "date"}
@@ -144,7 +143,6 @@ load a document:
       esql.query:
         body:
           query: 'from test | where @timestamp == "2021-04-28T18:50:23.142Z"'
-          version: 2024.04.01
 
   - length: {values: 1}
   - length: {values.0: 7}
@@ -163,7 +161,6 @@ filter on counter:
       esql.query:
         body:
           query: 'from test | where k8s.pod.network.tx == 1434577921'
-          version: 2024.04.01
 
 ---
 from doc with aggregate_metric_double:
@@ -174,7 +171,6 @@ from doc with aggregate_metric_double:
       esql.query:
         body:
           query: 'from test2'
-          version: 2024.04.01
 
   - match: {columns.0.name: "@timestamp"}
   - match: {columns.0.type: "date"}
@@ -195,7 +191,6 @@ stats on aggregate_metric_double:
       esql.query:
         body:
           query: 'FROM test2 | STATS max(agg_metric) BY dim'
-          version: 2024.04.01
 
 ---
 from index pattern unsupported counter:
@@ -206,7 +201,6 @@ from index pattern unsupported counter:
       esql.query:
         body:
           query: 'FROM test*'
-          version: 2024.04.01
 
   - match: {columns.0.name: "@timestamp"}
   - match: {columns.0.type: "date"}
@@ -235,7 +229,6 @@ from index pattern explicit counter use:
       esql.query:
         body:
           query: 'FROM test* | keep *.tx'
-          version: 2024.04.01
 
 
 ---
@@ -256,7 +249,6 @@ _source:
       esql.query:
         body:
           query: 'FROM test METADATA _source | WHERE @timestamp == "2021-04-28T18:50:23.142Z" | KEEP _source | LIMIT 1'
-          version: 2024.04.01
   - match: { columns.0.name: _source }
   - match: { columns.0.type: _source }
   - length: { values: 1 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/40_unsupported_types.yml
@@ -120,7 +120,6 @@ unsupported:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
 
   - match: { columns.0.name: aggregate_metric_double }
   - match: { columns.0.type: unsupported }
@@ -218,7 +217,6 @@ unsupported:
       esql.query:
         body:
           query: 'from test | limit 0'
-          version: 2024.04.01
   - match: { columns.0.name: aggregate_metric_double }
   - match: { columns.0.type: unsupported }
   - match: { columns.1.name: binary }
@@ -285,7 +283,6 @@ unsupported:
       esql.query:
         body:
           query: 'from test | keep histogram | limit 0'
-          version: 2024.04.01
   - match: { columns.0.name: histogram }
   - match: { columns.0.type: unsupported }
   - length: { values: 0 }
@@ -303,7 +300,6 @@ unsupported with sort:
       esql.query:
         body:
           query: 'from test | sort some_doc.bar'
-          version: 2024.04.01
 
   - match: { columns.0.name: aggregate_metric_double }
   - match: { columns.0.type: unsupported }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/45_non_tsdb_counter.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/45_non_tsdb_counter.yml
@@ -66,7 +66,6 @@ load everything:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
 
   - match: {columns.0.name: "@timestamp"}
   - match: {columns.0.type: "date"}
@@ -92,7 +91,6 @@ load a document:
       esql.query:
         body:
           query: 'from test | where @timestamp == "2021-04-28T18:50:23.142Z"'
-          version: 2024.04.01
 
   - length: {values: 1}
   - length: {values.0: 7}
@@ -112,7 +110,6 @@ filter on counter:
       esql.query:
         body:
           query: 'from test | where k8s.pod.network.tx == 1434577921'
-          version: 2024.04.01
 
   - length: {values: 1}
   - length: {values.0: 7}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/50_index_patterns.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/50_index_patterns.yml
@@ -51,7 +51,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -68,7 +67,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1 | limit 2'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -83,7 +81,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1 desc nulls last | limit 1'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -98,7 +95,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1, message2'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -117,7 +113,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1, message2 | limit 3'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -135,7 +130,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1 desc nulls first, message2 | limit 3'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -152,7 +146,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1, message2 | limit 2'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -169,7 +162,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1 nulls first, message2'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -190,7 +182,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1 nulls first, message2 nulls first'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -211,7 +202,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | keep message1, message2 | sort message1 desc nulls first, message2 desc nulls first'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -232,7 +222,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | where message1 == "foo1" | keep message1, message2 | sort message1, message2'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -247,7 +236,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | where message1 == "foo1" or message2 == 2 | keep message1, message2 | sort message1, message2'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -264,7 +252,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | stats x = max(message2)'
-          version: 2024.04.01
   - match: { columns.0.name: x }
   - match: { columns.0.type: long }
   - length: { values: 1 }
@@ -276,7 +263,6 @@ disjoint_mappings:
       esql.query:
         body:
           query: 'from test1,test2 | sort message1, message2 | eval x = message1, y = message2 + 1 | keep message1, message2, x, y'
-          version: 2024.04.01
   - match: { columns.0.name: message1 }
   - match: { columns.0.type: keyword }
   - match: { columns.1.name: message2 }
@@ -352,7 +338,6 @@ same_name_different_type:
       esql.query:
         body:
           query: 'from test1,test2'
-          version: 2024.04.01
   - match: { columns.0.name: message }
   - match: { columns.0.type: unsupported }
   - length: { values: 4 }
@@ -404,7 +389,6 @@ same_name_different_type_same_family:
       esql.query:
         body:
           query: 'from test1,test2 | sort message | keep message'
-          version: 2024.04.01
   - match: { columns.0.name: message }
   - match: { columns.0.type: keyword }
   - length: { values: 4 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_enrich.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_enrich.yml
@@ -103,7 +103,6 @@ teardown:
       esql.query:
         body:
           query: 'from test | enrich city_codes_policy on city_id | keep name, city, country | sort name'
-          version: 2024.04.01
 
   - match: { columns.0.name: "name" }
   - match: { columns.0.type: "keyword" }
@@ -127,7 +126,6 @@ teardown:
       esql.query:
         body:
           query: 'from test | keep name, city_id | enrich city_codes_policy on city_id with country | sort name'
-          version: 2024.04.01
 
   - match: { columns.0.name: "name" }
   - match: { columns.0.type: "keyword" }
@@ -151,7 +149,6 @@ teardown:
       esql.query:
         body:
           query: 'from test | keep name, city_id | enrich city_codes_policy on city_id with country_name = country | sort name'
-          version: 2024.04.01
 
   - match: { columns.0.name: "name" }
   - match: { columns.0.type: "keyword" }
@@ -179,7 +176,6 @@ teardown:
       esql.query:
         body:
           query: 'from test | keep name, city_name | enrich city_names_policy on city_name | sort name'
-          version: 2024.04.01
 
   - match: { columns.0.name: "name" }
   - match: { columns.0.type: "keyword" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/60_usage.yml
@@ -52,7 +52,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where data > 2 | sort count desc | limit 5 | stats m = max(data)'
-          version: 2024.04.01
 
   - do: {xpack.usage: {}}
   - match: { esql.available: true }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/61_enrich_ip.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/61_enrich_ip.yml
@@ -115,7 +115,6 @@ teardown:
       esql.query:
         body:
           query: 'FROM events | eval ip_str = to_string(ip) | ENRICH networks-policy ON ip_str | sort @timestamp | KEEP ip, name, department, message'
-          version: 2024.04.01
 
   - match: { columns.0.name: "ip" }
   - match: { columns.0.type: "ip" }
@@ -144,7 +143,6 @@ teardown:
       esql.query:
         body:
           query: 'FROM events_text | ENRICH networks-policy ON ip_text | sort @timestamp | KEEP ip_text, name, department, message'
-          version: 2024.04.01
 
   - match: { columns.0.name: "ip_text" }
   - match: { columns.0.type: "text" }
@@ -172,7 +170,6 @@ teardown:
       esql.query:
         body:
           query: 'FROM events | eval ip_str = concat("invalid_", to_string(ip)) | ENRICH networks-policy ON ip_str | sort @timestamp | KEEP ip, name, department, message'
-          version: 2024.04.01
 
 ---
 "IP":
@@ -186,7 +183,6 @@ teardown:
       esql.query:
         body:
           query: 'FROM events | ENRICH networks-policy ON ip | sort @timestamp | KEEP ip, name, department, message'
-          version: 2024.04.01
 
   - match: { columns.0.name: "ip" }
   - match: { columns.0.type: "ip" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/62_extra_enrich.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/62_extra_enrich.yml
@@ -44,7 +44,6 @@
       esql.query:
         body:
           query: 'ROW name="engineering" | ENRICH departments-policy | LIMIT 10 | KEEP name, employees'
-          version: 2024.04.01
 
   - match: { columns.0.name: "name" }
   - match: { columns.0.type: "keyword" }
@@ -59,7 +58,6 @@
       esql.query:
         body:
           query: 'ROW name="sales" | ENRICH departments-policy ON name WITH department=name | WHERE name==department | KEEP name, department | LIMIT 10'
-          version: 2024.04.01
 
   - match: { columns.0.name: "name" }
   - match: { columns.0.type: "keyword" }
@@ -259,7 +257,6 @@ movies:
             SORT total DESC, title ASC |
             KEEP total, title |
             LIMIT 10
-          version: 2024.04.01
 
   - match: { columns.0.name: "total" }
   - match: { columns.0.type: "long" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/70_locale.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/70_locale.yml
@@ -32,7 +32,6 @@ setup:
       esql.query:
         body:
           query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
-          version: 2024.04.01
 
   - match: { columns.0.name: "@timestamp" }
   - match: { columns.0.type: "date" }
@@ -55,7 +54,6 @@ setup:
         body:
           query: 'FROM events | eval fixed_format = date_format("MMMM", @timestamp), variable_format = date_format(format, @timestamp) | sort @timestamp | keep @timestamp, fixed_format, variable_format'
           locale: "it-IT"
-          version: 2024.04.01
 
   - match: { columns.0.name: "@timestamp" }
   - match: { columns.0.type: "date" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/80_text.yml
@@ -41,7 +41,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort emp_no'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -67,7 +66,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where tag == "baz" | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -89,7 +87,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where tag LIKE "*az" | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -111,7 +108,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where tag RLIKE ".*az" | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -137,7 +133,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where tag IN ("abc", "baz") | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -163,7 +158,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where tag IN ("abc", tag) | keep emp_no, name, job, tag | sort emp_no'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -190,7 +184,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where tag NOT IN ("abc", "baz") | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -212,7 +205,6 @@ setup:
       esql.query:
         body:
           query: 'from test | eval x = tag | where x == "baz" | keep emp_no, name, job, x'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -234,7 +226,6 @@ setup:
       esql.query:
         body:
           query: 'from test |  where job == "IT Director" | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -256,7 +247,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where job LIKE "*Specialist" | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -278,7 +268,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where job RLIKE ".*Specialist" | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -301,7 +290,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort tag | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -325,7 +313,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort job | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -348,7 +335,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort job desc | keep emp_no, name, job, tag'
-          version: 2024.04.01
 
   - match: { columns.0.name: "emp_no" }
   - match: { columns.0.type: "long" }
@@ -372,7 +358,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort name | eval description = concat(name, " - ", job) | keep description'
-          version: 2024.04.01
 
   - match: { columns.0.name: "description" }
   - match: { columns.0.type: "keyword" }
@@ -393,7 +378,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort emp_no | eval split = split(tag, " ") | keep split'
-          version: 2024.04.01
 
   - match: { columns.0.name: "split" }
   - match: { columns.0.type: "keyword" }
@@ -411,7 +395,6 @@ setup:
       esql.query:
         body:
           query: 'from test | stats jobs = count(job) | keep jobs'
-          version: 2024.04.01
 
   - match: { columns.0.name: "jobs" }
   - match: { columns.0.type: "long" }
@@ -428,7 +411,6 @@ setup:
       esql.query:
         body:
           query: 'from test | stats tags = count(tag) | keep tags'
-          version: 2024.04.01
 
   - match: { columns.0.name: "tags" }
   - match: { columns.0.type: "long" }
@@ -445,7 +427,6 @@ setup:
       esql.query:
         body:
           query: 'from test | stats names = count(name) by job | keep names'
-          version: 2024.04.01
 
   - match: { columns.0.name: "names" }
   - match: { columns.0.type: "long" }
@@ -463,7 +444,6 @@ setup:
       esql.query:
         body:
           query: 'from test | stats names = count(name) by tag | keep names'
-          version: 2024.04.01
 
   - match: { columns.0.name: "names" }
   - match: { columns.0.type: "long" }
@@ -508,7 +488,6 @@ setup:
       esql.query:
         body:
           query: 'from test2 | sort emp_no | keep job'
-          version: 2024.04.01
 
   - match: { columns.0.name: "job" }
   - match: { columns.0.type: "text" }
@@ -552,7 +531,6 @@ setup:
       esql.query:
         body:
           query: 'from test2 | sort emp_no | keep job'
-          version: 2024.04.01
 
   - match: { columns.0.name: "job" }
   - match: { columns.0.type: "text" }
@@ -571,7 +549,6 @@ values:
       esql.query:
         body:
           query: 'FROM test | STATS job = VALUES(job) | EVAL job = MV_SORT(job) | LIMIT 1'
-          version: 2024.04.01
   - match: { columns.0.name: "job" }
   - match: { columns.0.type: "text" }
   - length: { values: 1 }
@@ -589,7 +566,6 @@ values:
       esql.query:
         body:
           query: 'FROM test | STATS job = VALUES(job) BY tag | EVAL job = MV_SORT(job) | SORT tag | LIMIT 10'
-          version: 2024.04.01
   - match: { columns.0.name: "tag" }
   - match: { columns.0.type: "text" }
   - match: { columns.1.name: "job" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/81_text_exact_subfields.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/81_text_exact_subfields.yml
@@ -57,7 +57,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort emp_no | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -84,7 +83,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where text_ignore_above == "this" | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -108,7 +106,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where text_ignore_above == "this is a long text" | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -133,7 +130,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where text_ignore_above is null | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -157,7 +153,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where text_ignore_above is not null | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -181,7 +176,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where text_ignore_above LIKE "*long*" | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -207,7 +201,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where text_normalizer == "CamelCase" | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -232,7 +225,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where text_normalizer == text_normalizer.raw | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -258,7 +250,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort text_ignore_above asc | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -283,7 +274,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort text_ignore_above desc | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -308,7 +298,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort text_ignore_above asc nulls first | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -333,7 +322,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort text_ignore_above asc nulls last | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -360,7 +348,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort text_normalizer asc | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -385,7 +372,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort text_normalizer desc | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -410,7 +396,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort text_normalizer.raw asc | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -438,7 +423,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort non_indexed asc | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -463,7 +447,6 @@ setup:
       esql.query:
         body:
           query: 'from test | sort non_indexed desc | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }
@@ -488,7 +471,6 @@ setup:
       esql.query:
         body:
           query: 'from test | where non_indexed == "foo" | keep text_ignore_above, text_ignore_above.raw, text_normalizer, text_normalizer.raw, non_indexed, non_indexed.raw'
-          version: 2024.04.01
 
   - match: { columns.0.name: "text_ignore_above" }
   - match: { columns.0.type: "text" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/90_non_indexed.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/90_non_indexed.yml
@@ -102,7 +102,6 @@ fetch:
       esql.query:
         body:
           query: 'from test'
-          version: 2024.04.01
 
   - length: { columns: 18 }
   - match: { columns.0.name: boolean }

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/FullClusterRestartIT.java
@@ -1041,7 +1041,6 @@ public class FullClusterRestartIT extends AbstractXpackFullClusterRestartTestCas
             Request esql = new Request("POST", "_query");
             esql.setJsonEntity("""
                 {
-                  "version": "2024.04.01",
                   "query": "FROM nofnf | LIMIT 1"
                 }""");
             // {"columns":[{"name":"dv","type":"keyword"},{"name":"no_dv","type":"keyword"}],"values":[["test",null]]}

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/src/test/resources/rest-api-spec/test/querying_cluster/80_esql.yml
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/src/test/resources/rest-api-spec/test/querying_cluster/80_esql.yml
@@ -97,7 +97,6 @@ teardown:
       esql.query:
         body:
           query: 'FROM *:esql*,esql_* | STATS total = sum(cost) by tag | SORT tag | LIMIT 10'
-          version: '2024.04.01'
 
   - match: {columns.0.name: "total"}
   - match: {columns.0.type: "long"}
@@ -128,7 +127,6 @@ teardown:
                 gte: "2023-01-02"
                 lte: "2023-01-03"
                 format: "yyyy-MM-dd"
-          version: '2024.04.01'
 
   - match: {columns.0.name: "_index"}
   - match: {columns.0.type: "keyword"}
@@ -200,7 +198,6 @@ teardown:
       esql.query:
         body:
           query: 'FROM *:esql*,esql_* | STATS total = sum(cost) by tag | SORT total DESC | LIMIT 3 | ENRICH suggestions | KEEP tag, total, phrase'
-          version: '2024.04.01'
 
   - match: {columns.0.name: "tag"}
   - match: {columns.0.type: "keyword"}


### PR DESCRIPTION
Now that `version` is no longer required anywhere we can stop sending it in all of our tests.

Closes #108957
