### PR TITLE
[ML] Use default translog durability on AD results index

### DIFF
--- a/docs/changelog/108999.yaml
+++ b/docs/changelog/108999.yaml
@@ -1,0 +1,5 @@
+pr: 108999
+summary: Use default translog durability on AD results index
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_template.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/ml/anomalydetection/results_index_template.json
@@ -7,9 +7,6 @@
   "template" : {
     "settings" : {
       "index" : {
-        "translog" : {
-          "durability" : "async"
-        },
         "auto_expand_replicas" : "0-1",
         "query" : {
           "default_field" : "all_field_values"


### PR DESCRIPTION
Anomaly detection results indices have been configured with `translog.durability : async` setting for at least the last 8 years.  A comment in the private and now redundant x-pack-elasticsearch repo suggested the setting was chosen for performance reasons. 
```
// Sacrifice durability for performance: in the event of power
// failure we can lose the last 5 seconds of changes, but it's
// much faster
```
The comment relates to how frequently the translog is flushed to disk and does not appear in the current code base due to the settings being moved out of code to a resource file.

The original reasoning no longer applies to Elasticsearch and we would prefer to not loose the last 5 seconds of anomaly detection results if the machine suddenly goes down, the change here is to use the [default translog setting](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-translog.html) (`request`). The PR is labeled as a bug due to the potential to loose anomalies. 
