### PR TITLE
Add missing THREAD_POOL_TYPES

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -152,12 +152,14 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
     public static final Map<String, ThreadPoolType> THREAD_POOL_TYPES = Map.ofEntries(
         entry(Names.GENERIC, ThreadPoolType.SCALING),
+        entry(Names.CLUSTER_COORDINATION, ThreadPoolType.FIXED),
         entry(Names.GET, ThreadPoolType.FIXED),
         entry(Names.ANALYZE, ThreadPoolType.FIXED),
         entry(Names.WRITE, ThreadPoolType.FIXED),
         entry(Names.SEARCH, ThreadPoolType.FIXED),
         entry(Names.SEARCH_WORKER, ThreadPoolType.FIXED),
         entry(Names.SEARCH_COORDINATION, ThreadPoolType.FIXED),
+        entry(Names.AUTO_COMPLETE, ThreadPoolType.FIXED),
         entry(Names.MANAGEMENT, ThreadPoolType.SCALING),
         entry(Names.FLUSH, ThreadPoolType.SCALING),
         entry(Names.REFRESH, ThreadPoolType.SCALING),


### PR DESCRIPTION
Add a couple of missing entries to `ThreadPool.THREAD_POOL_TYPES`.

There's probably more refactoring to do here. In production, this map is used only by `ExecutorNames` to ensure all names correspond to built-in thread pools; all other uses are in tests.

Furthermore, this map has a lot of overlap with the `builders` field, because the builder classes map 1:1 with the `ThreadPoolType` values. However, `THREAD_POOL_TYPES` is static while `builders` is not, so we can't derive the former from the latter.