### PR TITLE
ES|QL: more tests for coalesce() function

### DIFF
--- a/docs/reference/esql/functions/kibana/definition/coalesce.json
+++ b/docs/reference/esql/functions/kibana/definition/coalesce.json
@@ -38,6 +38,96 @@
       "params" : [
         {
           "name" : "first",
+          "type" : "cartesian_point",
+          "optional" : false,
+          "description" : "Expression to evaluate."
+        },
+        {
+          "name" : "rest",
+          "type" : "cartesian_point",
+          "optional" : true,
+          "description" : "Other expression to evaluate."
+        }
+      ],
+      "variadic" : true,
+      "returnType" : "cartesian_point"
+    },
+    {
+      "params" : [
+        {
+          "name" : "first",
+          "type" : "cartesian_shape",
+          "optional" : false,
+          "description" : "Expression to evaluate."
+        },
+        {
+          "name" : "rest",
+          "type" : "cartesian_shape",
+          "optional" : true,
+          "description" : "Other expression to evaluate."
+        }
+      ],
+      "variadic" : true,
+      "returnType" : "cartesian_shape"
+    },
+    {
+      "params" : [
+        {
+          "name" : "first",
+          "type" : "datetime",
+          "optional" : false,
+          "description" : "Expression to evaluate."
+        },
+        {
+          "name" : "rest",
+          "type" : "datetime",
+          "optional" : true,
+          "description" : "Other expression to evaluate."
+        }
+      ],
+      "variadic" : true,
+      "returnType" : "datetime"
+    },
+    {
+      "params" : [
+        {
+          "name" : "first",
+          "type" : "geo_point",
+          "optional" : false,
+          "description" : "Expression to evaluate."
+        },
+        {
+          "name" : "rest",
+          "type" : "geo_point",
+          "optional" : true,
+          "description" : "Other expression to evaluate."
+        }
+      ],
+      "variadic" : true,
+      "returnType" : "geo_point"
+    },
+    {
+      "params" : [
+        {
+          "name" : "first",
+          "type" : "geo_shape",
+          "optional" : false,
+          "description" : "Expression to evaluate."
+        },
+        {
+          "name" : "rest",
+          "type" : "geo_shape",
+          "optional" : true,
+          "description" : "Other expression to evaluate."
+        }
+      ],
+      "variadic" : true,
+      "returnType" : "geo_shape"
+    },
+    {
+      "params" : [
+        {
+          "name" : "first",
           "type" : "integer",
           "optional" : false,
           "description" : "Expression to evaluate."
@@ -63,6 +153,24 @@
       ],
       "variadic" : true,
       "returnType" : "integer"
+    },
+    {
+      "params" : [
+        {
+          "name" : "first",
+          "type" : "ip",
+          "optional" : false,
+          "description" : "Expression to evaluate."
+        },
+        {
+          "name" : "rest",
+          "type" : "ip",
+          "optional" : true,
+          "description" : "Other expression to evaluate."
+        }
+      ],
+      "variadic" : true,
+      "returnType" : "ip"
     },
     {
       "params" : [

--- a/docs/reference/esql/functions/types/coalesce.asciidoc
+++ b/docs/reference/esql/functions/types/coalesce.asciidoc
@@ -7,8 +7,14 @@
 first | rest | result
 boolean | boolean | boolean
 boolean | | boolean
+cartesian_point | cartesian_point | cartesian_point
+cartesian_shape | cartesian_shape | cartesian_shape
+datetime | datetime | datetime
+geo_point | geo_point | geo_point
+geo_shape | geo_shape | geo_shape
 integer | integer | integer
 integer | | integer
+ip | ip | ip
 keyword | keyword | keyword
 keyword | | keyword
 long | long | long

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/meta.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/meta.csv-spec
@@ -14,7 +14,7 @@ synopsis:keyword
 "double cbrt(number:double|integer|long|unsigned_long)"
 "double|integer|long|unsigned_long ceil(number:double|integer|long|unsigned_long)"
 "boolean cidr_match(ip:ip, blockX...:keyword|text)"
-"boolean|text|integer|keyword|long coalesce(first:boolean|text|integer|keyword|long, ?rest...:boolean|text|integer|keyword|long)"
+"boolean|cartesian_point|cartesian_shape|date|geo_point|geo_shape|integer|ip|keyword|long|text coalesce(first:boolean|cartesian_point|cartesian_shape|date|geo_point|geo_shape|integer|ip|keyword|long|text, ?rest...:boolean|cartesian_point|cartesian_shape|date|geo_point|geo_shape|integer|ip|keyword|long|text)"
 "keyword concat(string1:keyword|text, string2...:keyword|text)"
 "double cos(angle:double|integer|long|unsigned_long)"
 "double cosh(angle:double|integer|long|unsigned_long)"
@@ -128,7 +128,7 @@ case          |[condition, trueValue]              |[boolean, "boolean|cartesian
 cbrt          |number                              |"double|integer|long|unsigned_long"                                                                                               |"Numeric expression. If `null`, the function returns `null`."
 ceil          |number                              |"double|integer|long|unsigned_long"                                                                                               |Numeric expression. If `null`, the function returns `null`.
 cidr_match    |[ip, blockX]                        |[ip, "keyword|text"]                                                                                                              |[IP address of type `ip` (both IPv4 and IPv6 are supported)., CIDR block to test the IP against.]
-coalesce      |first                               |"boolean|text|integer|keyword|long"                                                                                               |Expression to evaluate.
+coalesce      |first                               |"boolean|cartesian_point|cartesian_shape|date|geo_point|geo_shape|integer|ip|keyword|long|text"                                   |Expression to evaluate.
 concat        |[string1, string2]                  |["keyword|text", "keyword|text"]                                                                                                  |[Strings to concatenate., Strings to concatenate.]
 cos           |angle                               |"double|integer|long|unsigned_long"                                                                                               |An angle, in radians. If `null`, the function returns `null`.
 cosh          |angle                               |"double|integer|long|unsigned_long"                                                                                               |An angle, in radians. If `null`, the function returns `null`.
@@ -359,7 +359,7 @@ case          |"boolean|cartesian_point|date|double|geo_point|integer|ip|keyword
 cbrt          |double                                                                                                                      |false                       |false           |false
 ceil          |"double|integer|long|unsigned_long"                                                                                         |false                       |false           |false
 cidr_match    |boolean                                                                                                                     |[false, false]              |true            |false
-coalesce      |"boolean|text|integer|keyword|long"                                                                                         |false                       |true            |false
+coalesce      |"boolean|cartesian_point|cartesian_shape|date|geo_point|geo_shape|integer|ip|keyword|long|text"                             |false                       |true            |false
 concat        |keyword                                                                                                                     |[false, false]              |true            |false
 cos           |double                                                                                                                      |false                       |false           |false
 cosh          |double                                                                                                                      |false                       |false           |false

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/Coalesce.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/nulls/Coalesce.java
@@ -43,7 +43,18 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
     private DataType dataType;
 
     @FunctionInfo(
-        returnType = { "boolean", "text", "integer", "keyword", "long" },
+        returnType = {
+            "boolean",
+            "cartesian_point",
+            "cartesian_shape",
+            "date",
+            "geo_point",
+            "geo_shape",
+            "integer",
+            "ip",
+            "keyword",
+            "long",
+            "text" },
         description = "Returns the first of its arguments that is not null. If all arguments are null, it returns `null`.",
         examples = { @Example(file = "null", tag = "coalesce") }
     )
@@ -51,12 +62,34 @@ public class Coalesce extends EsqlScalarFunction implements OptionalArgument {
         Source source,
         @Param(
             name = "first",
-            type = { "boolean", "text", "integer", "keyword", "long" },
+            type = {
+                "boolean",
+                "cartesian_point",
+                "cartesian_shape",
+                "date",
+                "geo_point",
+                "geo_shape",
+                "integer",
+                "ip",
+                "keyword",
+                "long",
+                "text" },
             description = "Expression to evaluate."
         ) Expression first,
         @Param(
             name = "rest",
-            type = { "boolean", "text", "integer", "keyword", "long" },
+            type = {
+                "boolean",
+                "cartesian_point",
+                "cartesian_shape",
+                "date",
+                "geo_point",
+                "geo_shape",
+                "integer",
+                "ip",
+                "keyword",
+                "long",
+                "text" },
             description = "Other expression to evaluate.",
             optional = true
         ) List<Expression> rest

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunctionTestCase.java
@@ -112,7 +112,7 @@ public abstract class SpatialRelatesFunctionTestCase extends AbstractFunctionTes
         return Strings.join(compatibleTypeNames(spatialDataType), " or ");
     }
 
-    private static TestCaseSupplier.TypedDataSupplier testCaseSupplier(DataType dataType) {
+    public static TestCaseSupplier.TypedDataSupplier testCaseSupplier(DataType dataType) {
         return switch (dataType.esType()) {
             case "geo_point" -> TestCaseSupplier.geoPointCases(() -> false).get(0);
             case "geo_shape" -> TestCaseSupplier.geoShapeCases(() -> false).get(0);
@@ -190,7 +190,7 @@ public abstract class SpatialRelatesFunctionTestCase extends AbstractFunctionTes
         }
     }
 
-    private static Matcher<String> spatialEvaluatorString(DataType leftType, DataType rightType) {
+    public static Matcher<String> spatialEvaluatorString(DataType leftType, DataType rightType) {
         String crsType = isSpatialGeo(pickSpatialType(leftType, rightType)) ? "Geo" : "Cartesian";
         return equalTo(
             getFunctionClassName() + crsType + "SourceAndSourceEvaluator[leftValue=Attribute[channel=0], rightValue=Attribute[channel=1]]"


### PR DESCRIPTION
Adding more unit tests for `coalesce()` function, in particular adding tests for `ip`, `date` and spatial data types.

This also generates the right signatures for Kibana.

Related to https://github.com/elastic/elasticsearch/issues/108982