### PR TITLE
[8.13] Add docs note for limits on synonyms (#108967)

### DIFF
--- a/docs/reference/synonyms/apis/put-synonyms-set.asciidoc
+++ b/docs/reference/synonyms/apis/put-synonyms-set.asciidoc
@@ -7,6 +7,10 @@
 
 Creates or updates a synonyms set.
 
+NOTE: Synonyms sets are limited to a maximum of 10,000 synonym rules per set.
+Synonym sets with more than 10,000 synonym rules will provide inconsistent search results.
+If you need to manage more synonym rules, you can create multiple synonyms sets.
+
 [[put-synonyms-set-request]]
 ==== {api-request-title}
 

--- a/docs/reference/synonyms/apis/synonyms-apis.asciidoc
+++ b/docs/reference/synonyms/apis/synonyms-apis.asciidoc
@@ -18,6 +18,10 @@ This provides an alternative to:
 Synonyms sets can be used to configure <<analysis-synonym-graph-tokenfilter,synonym graph token filters>> and <<analysis-synonym-tokenfilter,synonym token filters>>.
 These filters are applied as part of the <<analysis,analysis>> process by the <<search-analyzer,search analyzer>>.
 
+NOTE: Synonyms sets are limited to a maximum of 10,000 synonym rules per set.
+Synonym sets with more than 10,000 synonym rules will provide inconsistent search results.
+If you need to manage more synonym rules, you can create multiple synonyms sets.
+
 [discrete]
 [[synonyms-sets-apis]]
 === Synonyms sets APIs


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Add docs note for limits on synonyms (#108967)