### PR TITLE
apm-data: set concrete values for metricset.interval

### DIFF
--- a/docs/changelog/109043.yaml
+++ b/docs/changelog/109043.yaml
@@ -1,0 +1,5 @@
+pr: 109043
+summary: "Apm-data: set concrete values for `metricset.interval`"
+area: Data streams
+type: bug
+issues: []

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_destination@mappings.yaml
@@ -9,8 +9,6 @@ template:
       metricset.name:
         type: constant_keyword
         value: service_destination
-      metricset.interval:
-        type: constant_keyword
       transaction.duration.histogram:
         type: histogram
       transaction.duration.summary:

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_summary@mappings.yaml
@@ -9,8 +9,6 @@ template:
       metricset.name:
         type: constant_keyword
         value: service_summary
-      metricset.interval:
-        type: constant_keyword
       transaction.duration.histogram:
         type: histogram
       transaction.duration.summary:

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.service_transaction@mappings.yaml
@@ -8,8 +8,6 @@ template:
       metricset.name:
         type: constant_keyword
         value: service_transaction
-      metricset.interval:
-        type: constant_keyword
       transaction.duration.histogram:
         type: histogram
       transaction.duration.summary:

--- a/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction@mappings.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/component-templates/metrics-apm.transaction@mappings.yaml
@@ -8,8 +8,6 @@ template:
       metricset.name:
         type: constant_keyword
         value: transaction
-      metricset.interval:
-        type: constant_keyword
       transaction.duration.histogram:
         type: histogram
       transaction.duration.summary:

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.10m@template.yaml
@@ -27,3 +27,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 10m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.1m@template.yaml
@@ -26,3 +26,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 1m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_destination.60m@template.yaml
@@ -27,3 +27,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_destination@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 60m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.10m@template.yaml
@@ -27,3 +27,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 10m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.1m@template.yaml
@@ -26,3 +26,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 1m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_summary.60m@template.yaml
@@ -27,3 +27,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_summary@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 60m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.10m@template.yaml
@@ -27,3 +27,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 10m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.1m@template.yaml
@@ -26,3 +26,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 1m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.service_transaction.60m@template.yaml
@@ -27,3 +27,8 @@ template:
     index:
       default_pipeline: metrics-apm.service_transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 60m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.10m@template.yaml
@@ -27,3 +27,8 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 10m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.1m@template.yaml
@@ -26,3 +26,8 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 1m

--- a/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
+++ b/x-pack/plugin/apm-data/src/main/resources/index-templates/metrics-apm.transaction.60m@template.yaml
@@ -27,3 +27,8 @@ template:
     index:
       default_pipeline: metrics-apm.transaction@default-pipeline
       final_pipeline: metrics-apm@pipeline
+  mappings:
+    properties:
+      metricset.interval:
+        type: constant_keyword
+        value: 60m


### PR DESCRIPTION
While testing the upgrade path from 8.14 to 8.15 I noticed an [unexpected mapping error](https://github.com/elastic/apm-server/issues/11529#issuecomment-2129836271).

This PR aims at solving it by adding a concrete value to `metricset.interval` mappings as suggested [here](https://github.com/elastic/apm-server/issues/11529#issuecomment-2129897869).


Upon testing the upgrade path again the mentioned error did not present themselves anymore.
