### PR TITLE
[Transform] Prevent concurrent jobs during cleanup

### DIFF
--- a/docs/changelog/109047.yaml
+++ b/docs/changelog/109047.yaml
@@ -1,0 +1,5 @@
+pr: 109047
+summary: Prevent concurrent jobs during cleanup
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -657,22 +657,6 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 return false;
             }
 
-            /*
-             * ignore if indexer thread is shutting down (after finishing a checkpoint)
-             * shutting down means:
-             *  - indexer has finished a checkpoint and called onFinish
-             *  - indexer state has changed from indexing to started
-             *  - state persistence has been called but has _not_ returned yet
-             *
-             *  If we trigger the indexer in this situation the 2nd indexer thread might
-             *  try to save state at the same time, causing a version conflict
-             *  see gh#67121
-             */
-            if (indexerThreadShuttingDown) {
-                logger.debug("[{}] indexer thread is shutting down. Ignoring trigger.", getJobId());
-                return false;
-            }
-
             return super.maybeTriggerAsyncJob(now);
         }
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -122,6 +122,7 @@ public class TransformIndexerStateTests extends ESTestCase {
         private CountDownLatch searchLatch;
         private CountDownLatch doProcessLatch;
         private CountDownLatch finishLatch = new CountDownLatch(1);
+        private CountDownLatch afterFinishLatch;
 
         MockedTransformIndexer(
             ThreadPool threadPool,
@@ -306,6 +307,16 @@ public class TransformIndexerStateTests extends ESTestCase {
 
         void finishCheckpoint() {
             searchResponse = null;
+        }
+
+        @Override
+        protected void afterFinishOrFailure() {
+            maybeWaitOnLatch(afterFinishLatch);
+            super.afterFinishOrFailure();
+        }
+
+        public CountDownLatch createAfterFinishLatch(int count) {
+            return afterFinishLatch = new CountDownLatch(count);
         }
     }
 
@@ -957,6 +968,57 @@ public class TransformIndexerStateTests extends ESTestCase {
 
         indexer.stop();
         assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STOPPED)), 5, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Given
+     * When
+     * Then
+     */
+    public void testRunOneJobAtATime() throws Exception {
+        var indexer = createMockIndexer(
+            createTransformConfig(),
+            new AtomicReference<>(IndexerState.STARTED),
+            null,
+            threadPool,
+            auditor,
+            null,
+            new TransformIndexerStats(),
+            new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class))
+        );
+
+        // stop the indexer thread once it kicks off
+        var startLatch = indexer.createAwaitForStartLatch(1);
+        // stop the indexer thread before afterFinishOrFailure
+        var afterFinishLatch = indexer.createAfterFinishLatch(1);
+
+        // flip IndexerState to INDEXING
+        assertEquals(IndexerState.STARTED, indexer.start());
+        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertEquals(IndexerState.INDEXING, indexer.getState());
+
+        // now let the indexer thread run
+        indexer.finishCheckpoint();
+        startLatch.countDown();
+
+        // wait until the IndexerState flips back to STARTED
+        assertBusy(() -> assertThat(indexer.getState(), equalTo(IndexerState.STARTED)), 5, TimeUnit.SECONDS);
+
+        assertFalse(
+            "Indexer state is STARTED, but the Indexer is not finished cleaning up from the previous run.",
+            indexer.maybeTriggerAsyncJob(System.currentTimeMillis())
+        );
+
+        // let the first job finish
+        afterFinishLatch.countDown();
+        indexer.waitUntilFinished();
+
+        // we should now (eventually) be able to schedule the next job
+        assertBusy(() -> assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis())), 5, TimeUnit.SECONDS);
+
+        // stop the indexer, equivalent to _stop?force=true
+        assertFalse("Transform Indexer thread should still be running", indexer.abort());
+        assertEquals(IndexerState.ABORTING, indexer.getState());
     }
 
     private void setStopAtCheckpoint(

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -971,9 +971,10 @@ public class TransformIndexerStateTests extends ESTestCase {
     }
 
     /**
-     * Given
-     * When
-     * Then
+     * Given one indexer thread is finishing its run
+     * And that thread is after finishAndSetState() but before afterFinishOrFailure()
+     * When another thread calls maybeTriggerAsyncJob
+     * Then that other thread should not start another indexer run
      */
     public void testRunOneJobAtATime() throws Exception {
         var indexer = createMockIndexer(


### PR DESCRIPTION
It is possible for two threads to be running an AsyncTwoPhaseIndexer job at the same time.

- Thread 1 calls `finishAndSetState()`, state changes from `INDEXING` to `STARTED`.
- Thread 2 calls `maybeTriggerAsyncJob()`, state changes from `STARTED` to `INDEXING`.
- Thread 1 calls `doSaveState()` and `afterFinishOrFailure()` while Thread 2 calls `onStart()`.  Both share memory, so it is possible for them to conflict with one another.

AsyncTwoPhaseIndexer now manages a boolean as an additional control gating `maybeTriggerAsyncJob()` called `isJobFinishing`.

- Thread 1 sets `isJobFinishing` to true, then calls `finishAndSetState()`.
- Thread 2 calls `maybeTriggerAsyncJob()` and exits early because `isJobFinishing` is true.
- Thread 1 finishes `afterFinishOrFailure()` and sets `isJobFinishing` to false.
- Thread 2 will retry `maybeTriggerAsyncJob()` and successfully start.

Relate #67121
