### PR TITLE
[8.14] Fix IOOBE in TTest aggregation when using filters 

### DIFF
--- a/docs/changelog/109034.yaml
+++ b/docs/changelog/109034.yaml
@@ -1,0 +1,5 @@
+pr: 109034
+summary: Fix IOOBE in TTest aggregation when using filters
+area: Aggregations
+type: bug
+issues: []

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/PairedTTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/PairedTTestAggregator.java
@@ -48,7 +48,7 @@ public class PairedTTestAggregator extends TTestAggregator<PairedTTestState> {
 
     @Override
     protected PairedTTestState getEmptyState() {
-        return new PairedTTestState(new TTestStats(0, 0, 0), tails);
+        return new PairedTTestState(TTestStats.EMPTY, tails);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestStats.java
@@ -20,6 +20,8 @@ import java.util.function.Consumer;
  * Collects basic stats that are needed to perform t-test
  */
 public class TTestStats implements Writeable {
+    static TTestStats EMPTY = new TTestStats(0, 0, 0);
+
     public final long count;
     public final double sum;
     public final double sumOfSqrs;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestStats.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
  * Collects basic stats that are needed to perform t-test
  */
 public class TTestStats implements Writeable {
-    static TTestStats EMPTY = new TTestStats(0, 0, 0);
+    static final TTestStats EMPTY = new TTestStats(0, 0, 0);
 
     public final long count;
     public final double sum;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
@@ -56,12 +56,14 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
 
     @Override
     protected UnpairedTTestState getState(long bucket) {
-        return new UnpairedTTestState(a.get(bucket), b.get(bucket), homoscedastic, tails);
+        final TTestStats aTTestStats = a.getSize() > bucket ? a.get(bucket) : TTestStats.EMPTY;
+        final TTestStats bTTestStats = b.getSize() > bucket ? b.get(bucket) : TTestStats.EMPTY;
+        return new UnpairedTTestState(aTTestStats, bTTestStats, homoscedastic, tails);
     }
 
     @Override
     protected UnpairedTTestState getEmptyState() {
-        return new UnpairedTTestState(new TTestStats(0, 0, 0), new TTestStats(0, 0, 0), homoscedastic, tails);
+        return new UnpairedTTestState(TTestStats.EMPTY, TTestStats.EMPTY, homoscedastic, tails);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/UnpairedTTestAggregator.java
@@ -111,8 +111,8 @@ public class UnpairedTTestAggregator extends TTestAggregator<UnpairedTTestState>
                     processValues(doc, bucket, docAValues, compSumA, compSumOfSqrA, a);
                 }
                 if (bitsB == null || bitsB.get(doc)) {
-                    processValues(doc, bucket, docBValues, compSumB, compSumOfSqrB, b);
                     b.grow(bigArrays(), bucket + 1);
+                    processValues(doc, bucket, docBValues, compSumB, compSumOfSqrB, b);
                 }
             }
         };


### PR DESCRIPTION
There is a corner case in the TTEst aggregation where we are throwing an IOOBE becuase we are not checking properly the bounds of the arrays. It happens when using filters on the aggregation and the aggregation is a sub-aggregation. Then one of the TTestStats can be empty which my mean that the array might have not been grown. When reading it, we don't check the current range.

This commit makes sure we only read the state if it exist in the array.

Backport https://github.com/elastic/elasticsearch/pull/109034