### PR TITLE
Make TTestStats#EMPTY final

### DIFF
--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/ttest/TTestStats.java
@@ -20,7 +20,7 @@ import java.util.function.Consumer;
  * Collects basic stats that are needed to perform t-test
  */
 public class TTestStats implements Writeable {
-    static TTestStats EMPTY = new TTestStats(0, 0, 0);
+    static final TTestStats EMPTY = new TTestStats(0, 0, 0);
 
     public final long count;
     public final double sum;


### PR DESCRIPTION
This is an oversight, let's make the static variable final so it does not get override by mistake.