### PR TITLE
Rename to `ChunkedRestResponseBodyPart`

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4ChunkedEncodingIT.java
@@ -37,7 +37,7 @@ import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
@@ -245,19 +245,19 @@ public class Netty4ChunkedEncodingIT extends ESNetty4IntegTestCase {
         private static void sendChunksResponse(RestChannel channel, Iterator<BytesReference> chunkIterator) {
             final var localRefs = refs; // single volatile read
             if (localRefs != null && localRefs.tryIncRef()) {
-                channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBody() {
+                channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBodyPart() {
                     @Override
-                    public boolean isDone() {
+                    public boolean isPartComplete() {
                         return chunkIterator.hasNext() == false;
                     }
 
                     @Override
-                    public boolean isEndOfResponse() {
+                    public boolean isLastPart() {
                         return true;
                     }
 
                     @Override
-                    public void getContinuation(ActionListener<ChunkedRestResponseBody> listener) {
+                    public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
                         assert false : "no continuations";
                     }
 

--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4PipeliningIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/http/netty4/Netty4PipeliningIT.java
@@ -34,7 +34,7 @@ import org.elasticsearch.http.HttpServerTransport;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -243,21 +243,21 @@ public class Netty4PipeliningIT extends ESNetty4IntegTestCase {
                         throw new IllegalArgumentException("[" + FAIL_AFTER_BYTES_PARAM + "] must be present and non-negative");
                     }
                     return channel -> randomExecutor(client.threadPool()).execute(
-                        () -> channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBody() {
+                        () -> channel.sendResponse(RestResponse.chunked(RestStatus.OK, new ChunkedRestResponseBodyPart() {
                             int bytesRemaining = failAfterBytes;
 
                             @Override
-                            public boolean isDone() {
+                            public boolean isPartComplete() {
                                 return false;
                             }
 
                             @Override
-                            public boolean isEndOfResponse() {
+                            public boolean isLastPart() {
                                 return true;
                             }
 
                             @Override
-                            public void getContinuation(ActionListener<ChunkedRestResponseBody> listener) {
+                            public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
                                 fail("no continuations here");
                             }
 

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4ChunkedHttpContinuation.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4ChunkedHttpContinuation.java
@@ -10,16 +10,16 @@ package org.elasticsearch.http.netty4;
 
 import io.netty.util.concurrent.PromiseCombiner;
 
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 
 final class Netty4ChunkedHttpContinuation implements Netty4HttpResponse {
     private final int sequence;
-    private final ChunkedRestResponseBody body;
+    private final ChunkedRestResponseBodyPart bodyPart;
     private final PromiseCombiner combiner;
 
-    Netty4ChunkedHttpContinuation(int sequence, ChunkedRestResponseBody body, PromiseCombiner combiner) {
+    Netty4ChunkedHttpContinuation(int sequence, ChunkedRestResponseBodyPart bodyPart, PromiseCombiner combiner) {
         this.sequence = sequence;
-        this.body = body;
+        this.bodyPart = bodyPart;
         this.combiner = combiner;
     }
 
@@ -28,8 +28,8 @@ final class Netty4ChunkedHttpContinuation implements Netty4HttpResponse {
         return sequence;
     }
 
-    public ChunkedRestResponseBody body() {
-        return body;
+    public ChunkedRestResponseBodyPart bodyPart() {
+        return bodyPart;
     }
 
     public PromiseCombiner combiner() {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4ChunkedHttpResponse.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4ChunkedHttpResponse.java
@@ -13,7 +13,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
 import org.elasticsearch.http.HttpResponse;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestStatus;
 
 /**
@@ -23,16 +23,16 @@ final class Netty4ChunkedHttpResponse extends DefaultHttpResponse implements Net
 
     private final int sequence;
 
-    private final ChunkedRestResponseBody body;
+    private final ChunkedRestResponseBodyPart firstBodyPart;
 
-    Netty4ChunkedHttpResponse(int sequence, HttpVersion version, RestStatus status, ChunkedRestResponseBody body) {
+    Netty4ChunkedHttpResponse(int sequence, HttpVersion version, RestStatus status, ChunkedRestResponseBodyPart firstBodyPart) {
         super(version, HttpResponseStatus.valueOf(status.getStatus()));
         this.sequence = sequence;
-        this.body = body;
+        this.firstBodyPart = firstBodyPart;
     }
 
-    public ChunkedRestResponseBody body() {
-        return body;
+    public ChunkedRestResponseBodyPart firstBodyPart() {
+        return firstBodyPart;
     }
 
     @Override

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandler.java
@@ -34,7 +34,7 @@ import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.transport.Transports;
 import org.elasticsearch.transport.netty4.Netty4Utils;
 import org.elasticsearch.transport.netty4.Netty4WriteThrottlingHandler;
@@ -58,7 +58,7 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
     private final int maxEventsHeld;
     private final PriorityQueue<Tuple<? extends Netty4HttpResponse, ChannelPromise>> outboundHoldingQueue;
 
-    private record ChunkedWrite(PromiseCombiner combiner, ChannelPromise onDone, ChunkedRestResponseBody responseBody) {}
+    private record ChunkedWrite(PromiseCombiner combiner, ChannelPromise onDone, ChunkedRestResponseBodyPart responseBodyPart) {}
 
     /**
      * The current {@link ChunkedWrite} if a chunked write is executed at the moment.
@@ -214,9 +214,9 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
         final PromiseCombiner combiner = new PromiseCombiner(ctx.executor());
         final ChannelPromise first = ctx.newPromise();
         combiner.add((Future<Void>) first);
-        final var responseBody = readyResponse.body();
+        final var firstBodyPart = readyResponse.firstBodyPart();
         assert currentChunkedWrite == null;
-        currentChunkedWrite = new ChunkedWrite(combiner, promise, responseBody);
+        currentChunkedWrite = new ChunkedWrite(combiner, promise, firstBodyPart);
         if (enqueueWrite(ctx, readyResponse, first)) {
             // We were able to write out the first chunk directly, try writing out subsequent chunks until the channel becomes unwritable.
             // NB "writable" means there's space in the downstream ChannelOutboundBuffer, we aren't trying to saturate the physical channel.
@@ -232,9 +232,10 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
     private void doWriteChunkedContinuation(ChannelHandlerContext ctx, Netty4ChunkedHttpContinuation continuation, ChannelPromise promise) {
         final PromiseCombiner combiner = continuation.combiner();
         assert currentChunkedWrite == null;
-        final var responseBody = continuation.body();
-        assert responseBody.isDone() == false : "response with continuations must have at least one (possibly-empty) chunk in each part";
-        currentChunkedWrite = new ChunkedWrite(combiner, promise, responseBody);
+        final var bodyPart = continuation.bodyPart();
+        assert bodyPart.isPartComplete() == false
+            : "response with continuations must have at least one (possibly-empty) chunk in each part";
+        currentChunkedWrite = new ChunkedWrite(combiner, promise, bodyPart);
         // NB "writable" means there's space in the downstream ChannelOutboundBuffer, we aren't trying to saturate the physical channel.
         while (ctx.channel().isWritable()) {
             if (writeChunk(ctx, currentChunkedWrite)) {
@@ -251,9 +252,9 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
         }
         final var finishingWrite = currentChunkedWrite;
         currentChunkedWrite = null;
-        final var finishingWriteBody = finishingWrite.responseBody();
-        assert finishingWriteBody.isDone();
-        final var endOfResponse = finishingWriteBody.isEndOfResponse();
+        final var finishingWriteBodyPart = finishingWrite.responseBodyPart();
+        assert finishingWriteBodyPart.isPartComplete();
+        final var endOfResponse = finishingWriteBodyPart.isLastPart();
         if (endOfResponse) {
             writeSequence++;
             finishingWrite.combiner().finish(finishingWrite.onDone());
@@ -261,7 +262,7 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
             final var channel = finishingWrite.onDone().channel();
             ActionListener.run(ActionListener.assertOnce(new ActionListener<>() {
                 @Override
-                public void onResponse(ChunkedRestResponseBody continuation) {
+                public void onResponse(ChunkedRestResponseBodyPart continuation) {
                     channel.writeAndFlush(
                         new Netty4ChunkedHttpContinuation(writeSequence, continuation, finishingWrite.combiner()),
                         finishingWrite.onDone() // pass the terminal listener/promise along the line
@@ -296,7 +297,7 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
                     }
                 }
 
-            }), finishingWriteBody::getContinuation);
+            }), finishingWriteBodyPart::getNextPart);
         }
     }
 
@@ -374,22 +375,22 @@ public class Netty4HttpPipeliningHandler extends ChannelDuplexHandler {
     }
 
     private boolean writeChunk(ChannelHandlerContext ctx, ChunkedWrite chunkedWrite) {
-        final var body = chunkedWrite.responseBody();
+        final var bodyPart = chunkedWrite.responseBodyPart();
         final var combiner = chunkedWrite.combiner();
-        assert body.isDone() == false : "should not continue to try and serialize once done";
+        assert bodyPart.isPartComplete() == false : "should not continue to try and serialize once done";
         final ReleasableBytesReference bytes;
         try {
-            bytes = body.encodeChunk(Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE, serverTransport.recycler());
+            bytes = bodyPart.encodeChunk(Netty4WriteThrottlingHandler.MAX_BYTES_PER_WRITE, serverTransport.recycler());
         } catch (Exception e) {
             return handleChunkingFailure(ctx, chunkedWrite, e);
         }
         final ByteBuf content = Netty4Utils.toByteBuf(bytes);
-        final boolean done = body.isDone();
-        final boolean lastChunk = done && body.isEndOfResponse();
-        final ChannelFuture f = ctx.write(lastChunk ? new DefaultLastHttpContent(content) : new DefaultHttpContent(content));
+        final boolean isPartComplete = bodyPart.isPartComplete();
+        final boolean isBodyComplete = isPartComplete && bodyPart.isLastPart();
+        final ChannelFuture f = ctx.write(isBodyComplete ? new DefaultLastHttpContent(content) : new DefaultHttpContent(content));
         f.addListener(ignored -> bytes.close());
         combiner.add(f);
-        return done;
+        return isPartComplete;
     }
 
     private boolean handleChunkingFailure(ChannelHandlerContext ctx, ChunkedWrite chunkedWrite, Exception e) {

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/Netty4HttpRequest.java
@@ -22,7 +22,7 @@ import io.netty.handler.codec.http.cookie.ServerCookieEncoder;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.http.HttpRequest;
 import org.elasticsearch.http.HttpResponse;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.netty4.Netty4Utils;
@@ -176,8 +176,8 @@ public class Netty4HttpRequest implements HttpRequest {
     }
 
     @Override
-    public HttpResponse createResponse(RestStatus status, ChunkedRestResponseBody content) {
-        return new Netty4ChunkedHttpResponse(sequence, request.protocolVersion(), status, content);
+    public HttpResponse createResponse(RestStatus status, ChunkedRestResponseBodyPart firstBodyPart) {
+        return new Netty4ChunkedHttpResponse(sequence, request.protocolVersion(), status, firstBodyPart);
     }
 
     @Override

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpPipeliningHandlerTests.java
@@ -36,7 +36,7 @@ import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.bytes.ZeroBytesReference;
 import org.elasticsearch.common.recycler.Recycler;
 import org.elasticsearch.http.HttpResponse;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.netty4.Netty4Utils;
@@ -502,23 +502,23 @@ public class Netty4HttpPipeliningHandlerTests extends ESTestCase {
         };
     }
 
-    private static ChunkedRestResponseBody getRepeatedChunkResponseBody(int chunkCount, BytesReference chunk) {
-        return new ChunkedRestResponseBody() {
+    private static ChunkedRestResponseBodyPart getRepeatedChunkResponseBody(int chunkCount, BytesReference chunk) {
+        return new ChunkedRestResponseBodyPart() {
 
             private int remaining = chunkCount;
 
             @Override
-            public boolean isDone() {
+            public boolean isPartComplete() {
                 return remaining == 0;
             }
 
             @Override
-            public boolean isEndOfResponse() {
+            public boolean isLastPart() {
                 return true;
             }
 
             @Override
-            public void getContinuation(ActionListener<ChunkedRestResponseBody> listener) {
+            public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
                 fail("no continuations here");
             }
 

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -71,7 +71,7 @@ import org.elasticsearch.http.HttpTransportSettings;
 import org.elasticsearch.http.NullDispatcher;
 import org.elasticsearch.http.netty4.internal.HttpHeadersAuthenticatorUtils;
 import org.elasticsearch.http.netty4.internal.HttpValidator;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -692,7 +692,7 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
             public void dispatchRequest(final RestRequest request, final RestChannel channel, final ThreadContext threadContext) {
                 try {
                     channel.sendResponse(
-                        RestResponse.chunked(OK, ChunkedRestResponseBody.fromXContent(ignored -> Iterators.single((builder, params) -> {
+                        RestResponse.chunked(OK, ChunkedRestResponseBodyPart.fromXContent(ignored -> Iterators.single((builder, params) -> {
                             throw new AssertionError("should not be called for HEAD REQUEST");
                         }), ToXContent.EMPTY_PARAMS, channel), null)
                     );
@@ -1048,7 +1048,7 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
                 assertEquals(request.uri(), url);
                 final var response = RestResponse.chunked(
                     OK,
-                    ChunkedRestResponseBody.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator()),
+                    ChunkedRestResponseBodyPart.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator()),
                     responseReleasedLatch::countDown
                 );
                 transportClosedFuture.addListener(ActionListener.running(() -> channel.sendResponse(response)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/rest/RestControllerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/rest/RestControllerIT.java
@@ -82,7 +82,7 @@ public class RestControllerIT extends ESIntegTestCase {
                     return channel -> {
                         final var response = RestResponse.chunked(
                             RestStatus.OK,
-                            ChunkedRestResponseBody.fromXContent(
+                            ChunkedRestResponseBodyPart.fromXContent(
                                 params -> Iterators.single((b, p) -> b.startObject().endObject()),
                                 request,
                                 channel

--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -21,8 +21,8 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.rest.AbstractRestChannel;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
-import org.elasticsearch.rest.LoggingChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
+import org.elasticsearch.rest.LoggingChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
@@ -113,7 +113,7 @@ public class DefaultRestChannel extends AbstractRestChannel {
         try {
             final HttpResponse httpResponse;
             if (isHeadRequest == false && restResponse.isChunked()) {
-                ChunkedRestResponseBody chunkedContent = restResponse.chunkedContent();
+                ChunkedRestResponseBodyPart chunkedContent = restResponse.chunkedContent();
                 if (httpLogger != null && httpLogger.isBodyTracerEnabled()) {
                     final var loggerStream = httpLogger.openResponseBodyLoggingStream(request.getRequestId());
                     toClose.add(() -> {
@@ -123,7 +123,7 @@ public class DefaultRestChannel extends AbstractRestChannel {
                             assert false : e; // nothing much to go wrong here
                         }
                     });
-                    chunkedContent = new LoggingChunkedRestResponseBody(chunkedContent, loggerStream);
+                    chunkedContent = new LoggingChunkedRestResponseBodyPart(chunkedContent, loggerStream);
                 }
 
                 httpResponse = httpRequest.createResponse(restResponse.status(), chunkedContent);

--- a/server/src/main/java/org/elasticsearch/http/HttpRequest.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpRequest.java
@@ -10,7 +10,7 @@ package org.elasticsearch.http;
 
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestStatus;
 
 import java.util.List;
@@ -40,7 +40,7 @@ public interface HttpRequest extends HttpPreRequest {
      */
     HttpResponse createResponse(RestStatus status, BytesReference content);
 
-    HttpResponse createResponse(RestStatus status, ChunkedRestResponseBody content);
+    HttpResponse createResponse(RestStatus status, ChunkedRestResponseBodyPart firstBodyPart);
 
     @Nullable
     Exception getInboundException();

--- a/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBodyPart.java
+++ b/server/src/main/java/org/elasticsearch/rest/ChunkedRestResponseBodyPart.java
@@ -39,32 +39,32 @@ import java.util.Iterator;
  * materializing the full response into on-heap buffers up front, instead serializing only as much of the response as can be flushed to the
  * network right away.</p>
  *
- * <p>Each {@link ChunkedRestResponseBody} represents a sequence of chunks that are ready for immediate transmission: if {@link #isDone}
- * returns {@code false} then {@link #encodeChunk} can be called at any time and must synchronously return the next chunk to be sent.
- * Many HTTP responses will be a single such sequence. However, if an implementation's {@link #isEndOfResponse} returns {@code false} at the
- * end of the sequence then the transmission is paused and {@link #getContinuation} is called to compute the next sequence of chunks
+ * <p>Each {@link ChunkedRestResponseBodyPart} represents a sequence of chunks that are ready for <i>immediate</i> transmission: if
+ * {@link #isPartComplete} returns {@code false} then {@link #encodeChunk} can be called at any time and must synchronously return the next
+ * chunk to be sent. Many HTTP responses will be a single part, but if an implementation's {@link #isLastPart} returns {@code false} at the
+ * end of the part then the transmission is paused and {@link #getNextPart} is called to compute the next sequence of chunks
  * asynchronously.</p>
  */
-public interface ChunkedRestResponseBody {
+public interface ChunkedRestResponseBodyPart {
 
-    Logger logger = LogManager.getLogger(ChunkedRestResponseBody.class);
+    Logger logger = LogManager.getLogger(ChunkedRestResponseBodyPart.class);
 
     /**
-     * @return {@code true} if this body contains no more chunks and the REST layer should check for a possible continuation by calling
-     * {@link #isEndOfResponse}, or {@code false} if the REST layer should request another chunk from this body using {@link #encodeChunk}.
+     * @return {@code true} if this body part contains no more chunks and the REST layer should check for a possible continuation by calling
+     * {@link #isLastPart}, or {@code false} if the REST layer should request another chunk from this body using {@link #encodeChunk}.
      */
-    boolean isDone();
+    boolean isPartComplete();
 
     /**
-     * @return {@code true} if this is the last chunked body in the response, or {@code false} if the REST layer should request further
-     * chunked bodies by calling {@link #getContinuation}.
+     * @return {@code true} if this is the last chunked body part in the response, or {@code false} if the REST layer should request further
+     * chunked bodies by calling {@link #getNextPart}.
      */
-    boolean isEndOfResponse();
+    boolean isLastPart();
 
     /**
-     * <p>Asynchronously retrieves the next part of the body. Called if {@link #isEndOfResponse} returns {@code false}.</p>
+     * <p>Asynchronously retrieves the next part of the response body. Called if {@link #isLastPart} returns {@code false}.</p>
      *
-     * <p>Note that this is called on a transport thread, so implementations must take care to dispatch any nontrivial work elsewhere.</p>
+     * <p>Note that this is called on a transport thread: implementations must take care to dispatch any nontrivial work elsewhere.</p>
 
      * <p>Note that the {@link Task} corresponding to any invocation of {@link Client#execute} completes as soon as the client action
      * returns its response, so it no longer exists when this method is called and cannot be used to receive cancellation notifications.
@@ -78,7 +78,7 @@ public interface ChunkedRestResponseBody {
      *                 the body of the response, so there's no good ways to handle an exception here. Completing the listener exceptionally
      *                 will log an error, abort sending the response, and close the HTTP connection.
      */
-    void getContinuation(ActionListener<ChunkedRestResponseBody> listener);
+    void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener);
 
     /**
      * Serializes approximately as many bytes of the response as request by {@code sizeHint} to a {@link ReleasableBytesReference} that
@@ -97,17 +97,17 @@ public interface ChunkedRestResponseBody {
     String getResponseContentTypeString();
 
     /**
-     * Create a chunked response body to be written to a specific {@link RestChannel} from a {@link ChunkedToXContent}.
+     * Create a one-part chunked response body to be written to a specific {@link RestChannel} from a {@link ChunkedToXContent}.
      *
      * @param chunkedToXContent chunked x-content instance to serialize
      * @param params parameters to use for serialization
      * @param channel channel the response will be written to
      * @return chunked rest response body
      */
-    static ChunkedRestResponseBody fromXContent(ChunkedToXContent chunkedToXContent, ToXContent.Params params, RestChannel channel)
+    static ChunkedRestResponseBodyPart fromXContent(ChunkedToXContent chunkedToXContent, ToXContent.Params params, RestChannel channel)
         throws IOException {
 
-        return new ChunkedRestResponseBody() {
+        return new ChunkedRestResponseBodyPart() {
 
             private final OutputStream out = new OutputStream() {
                 @Override
@@ -135,17 +135,17 @@ public interface ChunkedRestResponseBody {
             private BytesStream target;
 
             @Override
-            public boolean isDone() {
+            public boolean isPartComplete() {
                 return serialization.hasNext() == false;
             }
 
             @Override
-            public boolean isEndOfResponse() {
+            public boolean isLastPart() {
                 return true;
             }
 
             @Override
-            public void getContinuation(ActionListener<ChunkedRestResponseBody> listener) {
+            public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
                 assert false : "no continuations";
                 listener.onFailure(new IllegalStateException("no continuations available"));
             }
@@ -191,11 +191,11 @@ public interface ChunkedRestResponseBody {
     }
 
     /**
-     * Create a chunked response body to be written to a specific {@link RestChannel} from a stream of text chunks, each represented as a
-     * consumer of a {@link Writer}.
+     * Create a one-part chunked response body to be written to a specific {@link RestChannel} from a stream of UTF-8-encoded text chunks,
+     * each represented as a consumer of a {@link Writer}.
      */
-    static ChunkedRestResponseBody fromTextChunks(String contentType, Iterator<CheckedConsumer<Writer, IOException>> chunkIterator) {
-        return new ChunkedRestResponseBody() {
+    static ChunkedRestResponseBodyPart fromTextChunks(String contentType, Iterator<CheckedConsumer<Writer, IOException>> chunkIterator) {
+        return new ChunkedRestResponseBodyPart() {
             private RecyclerBytesStreamOutput currentOutput;
             private final Writer writer = new OutputStreamWriter(new OutputStream() {
                 @Override
@@ -224,17 +224,17 @@ public interface ChunkedRestResponseBody {
             }, StandardCharsets.UTF_8);
 
             @Override
-            public boolean isDone() {
+            public boolean isPartComplete() {
                 return chunkIterator.hasNext() == false;
             }
 
             @Override
-            public boolean isEndOfResponse() {
+            public boolean isLastPart() {
                 return true;
             }
 
             @Override
-            public void getContinuation(ActionListener<ChunkedRestResponseBody> listener) {
+            public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
                 assert false : "no continuations";
                 listener.onFailure(new IllegalStateException("no continuations available"));
             }

--- a/server/src/main/java/org/elasticsearch/rest/LoggingChunkedRestResponseBodyPart.java
+++ b/server/src/main/java/org/elasticsearch/rest/LoggingChunkedRestResponseBodyPart.java
@@ -16,29 +16,29 @@ import org.elasticsearch.common.recycler.Recycler;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class LoggingChunkedRestResponseBody implements ChunkedRestResponseBody {
+public class LoggingChunkedRestResponseBodyPart implements ChunkedRestResponseBodyPart {
 
-    private final ChunkedRestResponseBody inner;
+    private final ChunkedRestResponseBodyPart inner;
     private final OutputStream loggerStream;
 
-    public LoggingChunkedRestResponseBody(ChunkedRestResponseBody inner, OutputStream loggerStream) {
+    public LoggingChunkedRestResponseBodyPart(ChunkedRestResponseBodyPart inner, OutputStream loggerStream) {
         this.inner = inner;
         this.loggerStream = loggerStream;
     }
 
     @Override
-    public boolean isDone() {
-        return inner.isDone();
+    public boolean isPartComplete() {
+        return inner.isPartComplete();
     }
 
     @Override
-    public boolean isEndOfResponse() {
-        return inner.isEndOfResponse();
+    public boolean isLastPart() {
+        return inner.isLastPart();
     }
 
     @Override
-    public void getContinuation(ActionListener<ChunkedRestResponseBody> listener) {
-        inner.getContinuation(listener.map(continuation -> new LoggingChunkedRestResponseBody(continuation, loggerStream)));
+    public void getNextPart(ActionListener<ChunkedRestResponseBodyPart> listener) {
+        inner.getNextPart(listener.map(continuation -> new LoggingChunkedRestResponseBodyPart(continuation, loggerStream)));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -48,7 +48,7 @@ public final class RestResponse implements Releasable {
     private final BytesReference content;
 
     @Nullable
-    private final ChunkedRestResponseBody chunkedResponseBody;
+    private final ChunkedRestResponseBodyPart chunkedResponseBody;
     private final String responseMediaType;
     private Map<String, List<String>> customHeaders;
 
@@ -84,9 +84,9 @@ public final class RestResponse implements Releasable {
         this(status, responseMediaType, content, null, releasable);
     }
 
-    public static RestResponse chunked(RestStatus restStatus, ChunkedRestResponseBody content, @Nullable Releasable releasable) {
-        if (content.isDone()) {
-            assert content.isEndOfResponse() : "response with continuations must have at least one (possibly-empty) chunk in each part";
+    public static RestResponse chunked(RestStatus restStatus, ChunkedRestResponseBodyPart content, @Nullable Releasable releasable) {
+        if (content.isPartComplete()) {
+            assert content.isLastPart() : "response with continuations must have at least one (possibly-empty) chunk in each part";
             return new RestResponse(restStatus, content.getResponseContentTypeString(), BytesArray.EMPTY, releasable);
         } else {
             return new RestResponse(restStatus, content.getResponseContentTypeString(), null, content, releasable);
@@ -100,7 +100,7 @@ public final class RestResponse implements Releasable {
         RestStatus status,
         String responseMediaType,
         @Nullable BytesReference content,
-        @Nullable ChunkedRestResponseBody chunkedResponseBody,
+        @Nullable ChunkedRestResponseBodyPart chunkedResponseBody,
         @Nullable Releasable releasable
     ) {
         this.status = status;
@@ -162,7 +162,7 @@ public final class RestResponse implements Releasable {
     }
 
     @Nullable
-    public ChunkedRestResponseBody chunkedContent() {
+    public ChunkedRestResponseBodyPart chunkedContent() {
         return chunkedResponseBody;
     }
 

--- a/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestChunkedToXContentListener.java
@@ -10,7 +10,7 @@ package org.elasticsearch.rest.action;
 
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.Releasable;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
@@ -40,7 +40,7 @@ public class RestChunkedToXContentListener<Response extends ChunkedToXContent> e
         channel.sendResponse(
             RestResponse.chunked(
                 getRestStatus(response),
-                ChunkedRestResponseBody.fromXContent(response, params, channel),
+                ChunkedRestResponseBodyPart.fromXContent(response, params, channel),
                 releasableFromResponse(response)
             )
         );

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
-import static org.elasticsearch.rest.ChunkedRestResponseBody.fromTextChunks;
+import static org.elasticsearch.rest.ChunkedRestResponseBodyPart.fromTextChunks;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestResponse.TEXT_CONTENT_TYPE;
 import static org.elasticsearch.rest.RestUtils.getTimeout;

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestTable.java
@@ -17,7 +17,7 @@ import org.elasticsearch.common.unit.SizeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -63,7 +63,7 @@ public class RestTable {
 
         return RestResponse.chunked(
             RestStatus.OK,
-            ChunkedRestResponseBody.fromXContent(
+            ChunkedRestResponseBodyPart.fromXContent(
                 ignored -> Iterators.concat(
                     Iterators.single((builder, params) -> builder.startArray()),
                     Iterators.map(rowOrder.iterator(), row -> (builder, params) -> {
@@ -94,7 +94,7 @@ public class RestTable {
 
         return RestResponse.chunked(
             RestStatus.OK,
-            ChunkedRestResponseBody.fromTextChunks(
+            ChunkedRestResponseBodyPart.fromTextChunks(
                 RestResponse.TEXT_CONTENT_TYPE,
                 Iterators.concat(
                     // optional header

--- a/server/src/main/java/org/elasticsearch/rest/action/info/RestClusterInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/info/RestClusterInfoAction.java
@@ -19,7 +19,7 @@ import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.http.HttpStats;
 import org.elasticsearch.ingest.IngestStats;
 import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
@@ -122,7 +122,7 @@ public class RestClusterInfoAction extends BaseRestHandler {
 
                     return RestResponse.chunked(
                         RestStatus.OK,
-                        ChunkedRestResponseBody.fromXContent(
+                        ChunkedRestResponseBodyPart.fromXContent(
                             outerParams -> Iterators.concat(
                                 ChunkedToXContentHelper.startObject(),
                                 Iterators.single((builder, params) -> builder.field("cluster_name", response.getClusterName().value())),

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -797,8 +797,8 @@ public class DefaultRestChannelTests extends ESTestCase {
                 () -> channel.sendResponse(RestResponse.chunked(RestStatus.OK, firstPart, () -> {
                     assertTrue(isClosed.compareAndSet(false, true));
                     for (int i = 0; i < parts.size(); i++) {
-                        assertTrue("isDone " + i, parts.get(i).isPartComplete());
-                        assertEquals("isEndOfResponse " + i, i == parts.size() - 1, parts.get(i).isLastPart());
+                        assertTrue("isPartComplete " + i, parts.get(i).isPartComplete());
+                        assertEquals("isLastPart " + i, i == parts.size() - 1, parts.get(i).isLastPart());
                     }
                 }))
             )

--- a/server/src/test/java/org/elasticsearch/http/TestHttpRequest.java
+++ b/server/src/test/java/org/elasticsearch/http/TestHttpRequest.java
@@ -10,7 +10,7 @@ package org.elasticsearch.http;
 
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 
@@ -78,7 +78,7 @@ class TestHttpRequest implements HttpRequest {
     }
 
     @Override
-    public HttpResponse createResponse(RestStatus status, ChunkedRestResponseBody content) {
+    public HttpResponse createResponse(RestStatus status, ChunkedRestResponseBodyPart firstBodyPart) {
         throw new UnsupportedOperationException("chunked responses not supported");
     }
 

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -733,7 +733,7 @@ public class RestControllerTests extends ESTestCase {
             }
 
             @Override
-            public HttpResponse createResponse(RestStatus status, ChunkedRestResponseBody content) {
+            public HttpResponse createResponse(RestStatus status, ChunkedRestResponseBodyPart firstBodyPart) {
                 throw new AssertionError("should not be called");
             }
 

--- a/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
@@ -97,7 +97,7 @@ public class RestResponseTests extends ESTestCase {
     public void testEmptyChunkedBody() {
         RestResponse response = RestResponse.chunked(
             RestStatus.OK,
-            ChunkedRestResponseBody.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator()),
+            ChunkedRestResponseBodyPart.fromTextChunks(RestResponse.TEXT_CONTENT_TYPE, Collections.emptyIterator()),
             null
         );
         assertFalse(response.isChunked());

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestTableTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestTableTests.java
@@ -432,14 +432,15 @@ public class RestTableTests extends ESTestCase {
         };
 
         final var bodyChunks = new ArrayList<String>();
-        final var chunkedRestResponseBody = response.chunkedContent();
+        final var firstBodyPart = response.chunkedContent();
 
-        while (chunkedRestResponseBody.isDone() == false) {
-            try (var chunk = chunkedRestResponseBody.encodeChunk(pageSize, recycler)) {
+        while (firstBodyPart.isPartComplete() == false) {
+            try (var chunk = firstBodyPart.encodeChunk(pageSize, recycler)) {
                 assertThat(chunk.length(), greaterThan(0));
                 bodyChunks.add(chunk.utf8ToString());
             }
         }
+        assertTrue(firstBodyPart.isLastPart());
         assertEquals(0, openPages.get());
         return bodyChunks;
     }

--- a/test/framework/src/main/java/org/elasticsearch/rest/RestResponseUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/rest/RestResponseUtils.java
@@ -28,8 +28,8 @@ public class RestResponseUtils {
             return restResponse.content();
         }
 
-        final var chunkedRestResponseBody = restResponse.chunkedContent();
-        assert chunkedRestResponseBody.isDone() == false;
+        final var firstResponseBodyPart = restResponse.chunkedContent();
+        assert firstResponseBodyPart.isPartComplete() == false;
 
         final int pageSize;
         try (var page = NON_RECYCLING_INSTANCE.obtain()) {
@@ -37,12 +37,12 @@ public class RestResponseUtils {
         }
 
         try (var out = new BytesStreamOutput()) {
-            while (chunkedRestResponseBody.isDone() == false) {
-                try (var chunk = chunkedRestResponseBody.encodeChunk(pageSize, NON_RECYCLING_INSTANCE)) {
+            while (firstResponseBodyPart.isPartComplete() == false) {
+                try (var chunk = firstResponseBodyPart.encodeChunk(pageSize, NON_RECYCLING_INSTANCE)) {
                     chunk.writeTo(out);
                 }
             }
-            assert chunkedRestResponseBody.isEndOfResponse() : "RestResponseUtils#getBodyContent does not support continuations (yet)";
+            assert firstResponseBodyPart.isLastPart() : "RestResponseUtils#getBodyContent does not support continuations (yet)";
 
             out.flush();
             return out.bytes();

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.http.HttpChannel;
 import org.elasticsearch.http.HttpRequest;
 import org.elasticsearch.http.HttpResponse;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
@@ -129,7 +129,7 @@ public class FakeRestRequest extends RestRequest {
         }
 
         @Override
-        public HttpResponse createResponse(RestStatus status, ChunkedRestResponseBody content) {
+        public HttpResponse createResponse(RestStatus status, ChunkedRestResponseBodyPart firstBodyPart) {
             return createResponse(status, BytesArray.EMPTY);
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlResponseListener.java
@@ -12,7 +12,7 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.rest.ChunkedRestResponseBody;
+import org.elasticsearch.rest.ChunkedRestResponseBodyPart;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
@@ -132,13 +132,13 @@ public final class EsqlResponseListener extends RestRefCountedChunkedToXContentL
             if (mediaType instanceof TextFormat format) {
                 restResponse = RestResponse.chunked(
                     RestStatus.OK,
-                    ChunkedRestResponseBody.fromTextChunks(format.contentType(restRequest), format.format(restRequest, esqlResponse)),
+                    ChunkedRestResponseBodyPart.fromTextChunks(format.contentType(restRequest), format.format(restRequest, esqlResponse)),
                     releasable
                 );
             } else {
                 restResponse = RestResponse.chunked(
                     RestStatus.OK,
-                    ChunkedRestResponseBody.fromXContent(esqlResponse, channel.request(), channel),
+                    ChunkedRestResponseBodyPart.fromXContent(esqlResponse, channel.request(), channel),
                     releasable
                 );
             }


### PR DESCRIPTION
Follow-up to #104851 to rename some symbols to reflect that the class
formerly known as a `ChunkedRestResponseBody` may now only be _part_ of
the whole response body.