### PR TITLE
Await at least one security migration in AutoconfigIntegTests

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -35,12 +35,6 @@ tests:
 - class: "org.elasticsearch.upgrades.MlTrainedModelsUpgradeIT"
   issue: "https://github.com/elastic/elasticsearch/issues/108993"
   method: "testTrainedModelInference"
-- class: "org.elasticsearch.xpack.security.authc.esnative.ReservedRealmElasticAutoconfigIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/109058"
-  method: "testAutoconfigSucceedsAfterPromotionFailure"
-- class: "org.elasticsearch.xpack.security.authc.esnative.ReservedRealmElasticAutoconfigIntegTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/109059"
-  method: "testAutoconfigFailedPasswordPromotion"
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/test/SecuritySingleNodeTestCase.java
@@ -93,7 +93,7 @@ public abstract class SecuritySingleNodeTestCase extends ESSingleNodeTestCase {
         return getTaskWithId(state, TASK_NAME) == null;
     }
 
-    protected void awaitSecurityMigration() {
+    private void awaitSecurityMigration() {
         final var latch = new CountDownLatch(1);
         ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         clusterService.addListener((event) -> {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmElasticAutoconfigIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmElasticAutoconfigIntegTests.java
@@ -15,7 +15,10 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureString;
@@ -29,7 +32,10 @@ import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken
 import org.elasticsearch.xpack.core.security.test.TestRestrictedIndices;
 import org.junit.BeforeClass;
 
+import java.util.concurrent.CountDownLatch;
+
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.elasticsearch.xpack.core.security.action.UpdateIndexMigrationVersionAction.MIGRATION_VERSION_CUSTOM_KEY;
 import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SECURITY_MAIN_ALIAS;
 import static org.hamcrest.Matchers.is;
 
@@ -64,6 +70,25 @@ public class ReservedRealmElasticAutoconfigIntegTests extends SecuritySingleNode
         return null; // no bootstrap password for this test
     }
 
+    private boolean isMigrationComplete(ClusterState state) {
+        IndexMetadata indexMetadata = state.metadata().getIndices().get(TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7);
+        return indexMetadata.getCustomData(MIGRATION_VERSION_CUSTOM_KEY) != null;
+    }
+
+    private void awaitSecurityMigrationRanOnce() {
+        final var latch = new CountDownLatch(1);
+        ClusterService clusterService = getInstanceFromNode(ClusterService.class);
+        clusterService.addListener((event) -> {
+            if (isMigrationComplete(event.state())) {
+                latch.countDown();
+            }
+        });
+        if (isMigrationComplete(clusterService.state())) {
+            latch.countDown();
+        }
+        safeAwait(latch);
+    }
+
     public void testAutoconfigFailedPasswordPromotion() {
         try {
             // prevents the .security index from being created automatically (after elastic user authentication)
@@ -80,7 +105,7 @@ public class ReservedRealmElasticAutoconfigIntegTests extends SecuritySingleNode
                 assertThat(getIndexResponse.getIndices().length, is(1));
                 assertThat(getIndexResponse.getIndices()[0], is(TestRestrictedIndices.INTERNAL_SECURITY_MAIN_INDEX_7));
                 // Security migration needs to finish before deleting the index
-                awaitSecurityMigration();
+                awaitSecurityMigrationRanOnce();
                 DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(getIndexResponse.getIndices());
                 assertAcked(client().admin().indices().delete(deleteIndexRequest).actionGet());
             }
@@ -140,7 +165,7 @@ public class ReservedRealmElasticAutoconfigIntegTests extends SecuritySingleNode
             putUserRequest.roles(Strings.EMPTY_ARRAY);
             client().execute(PutUserAction.INSTANCE, putUserRequest).get();
             // Security migration needs to finish before making the cluster read only
-            awaitSecurityMigration();
+            awaitSecurityMigrationRanOnce();
 
             // but then make the cluster read-only
             ClusterUpdateSettingsRequest updateSettingsRequest = new ClusterUpdateSettingsRequest();


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/109058 https://github.com/elastic/elasticsearch/issues/109059 

`ReservedRealmElasticAutoconfigIntegTests` deletes the `.security-7` and makes the index metadata read only, this causes the persistent task that run the migration job to not be able to update its status to completed even though it is successful. When the  `teardown` happens at the end of the test it then fails because it looks like the migration task is not finished (still not marked as completed or failed). 

This adds a check to these specific tests that makes sure the migration finishes before the index is removed/its metadata is made read only. 