### PR TITLE
[Inference API] Make method names for building expectations more explicit

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/huggingface/HuggingFaceActionCreatorTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/action/huggingface/HuggingFaceActionCreatorTests.java
@@ -99,7 +99,7 @@ public class HuggingFaceActionCreatorTests extends ESTestCase {
             assertThat(
                 result.asMap(),
                 is(
-                    SparseEmbeddingResultsTests.buildExpectation(
+                    SparseEmbeddingResultsTests.buildExpectationSparseEmbeddings(
                         List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f), false))
                     )
                 )

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntityTests.java
@@ -239,7 +239,11 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
 
         assertThat(
             parsedResults.asMap(),
-            is(buildExpectationSparseEmbeddings(List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("field", 1.0f), false))))
+            is(
+                buildExpectationSparseEmbeddings(
+                    List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("field", 1.0f), false))
+                )
+            )
         );
     }
 
@@ -259,7 +263,11 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
 
         assertThat(
             parsedResults.asMap(),
-            is(buildExpectationSparseEmbeddings(List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("field", 4.0294965E10F), false))))
+            is(
+                buildExpectationSparseEmbeddings(
+                    List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("field", 4.0294965E10F), false))
+                )
+            )
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntityTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/external/response/huggingface/HuggingFaceElserResponseEntityTests.java
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.xpack.inference.results.SparseEmbeddingResultsTests.buildExpectation;
+import static org.elasticsearch.xpack.inference.results.SparseEmbeddingResultsTests.buildExpectationSparseEmbeddings;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -46,7 +46,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         assertThat(
             parsedResults.asMap(),
             is(
-                buildExpectation(
+                buildExpectationSparseEmbeddings(
                     List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f, "the", 0.67472112f), false))
                 )
             )
@@ -73,7 +73,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         assertThat(
             parsedResults.asMap(),
             is(
-                buildExpectation(
+                buildExpectationSparseEmbeddings(
                     List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f, "the", 0.67472112f), true))
                 )
             )
@@ -101,7 +101,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         assertThat(
             parsedResults.asMap(),
             is(
-                buildExpectation(
+                buildExpectationSparseEmbeddings(
                     List.of(
                         new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f, "the", 0.67472112f), false),
                         new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("hi", 0.13315596f, "super", 0.67472112f), false)
@@ -135,7 +135,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         assertThat(
             parsedResults.asMap(),
             is(
-                buildExpectation(
+                buildExpectationSparseEmbeddings(
                     List.of(
                         new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f, "the", 0.67472112f), true),
                         new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("hi", 0.13315596f, "super", 0.67472112f), false)
@@ -169,7 +169,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
         assertThat(
             parsedResults.asMap(),
             is(
-                buildExpectation(
+                buildExpectationSparseEmbeddings(
                     List.of(
                         new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f, "the", 0.67472112f), false),
                         new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("hi", 0.13315596f, "super", 0.67472112f), false)
@@ -239,7 +239,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
 
         assertThat(
             parsedResults.asMap(),
-            is(buildExpectation(List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("field", 1.0f), false))))
+            is(buildExpectationSparseEmbeddings(List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("field", 1.0f), false))))
         );
     }
 
@@ -259,7 +259,7 @@ public class HuggingFaceElserResponseEntityTests extends ESTestCase {
 
         assertThat(
             parsedResults.asMap(),
-            is(buildExpectation(List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("field", 4.0294965E10F), false))))
+            is(buildExpectationSparseEmbeddings(List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of("field", 4.0294965E10F), false))))
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/results/SparseEmbeddingResultsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/results/SparseEmbeddingResultsTests.java
@@ -87,7 +87,7 @@ public class SparseEmbeddingResultsTests extends AbstractWireSerializingTestCase
 
     public void testToXContent_CreatesTheRightFormatForASingleEmbedding() throws IOException {
         var entity = createSparseResult(List.of(createEmbedding(List.of(new SparseEmbedding.WeightedToken("token", 0.1F)), false)));
-        assertThat(entity.asMap(), is(buildExpectation(List.of(new EmbeddingExpectation(Map.of("token", 0.1F), false)))));
+        assertThat(entity.asMap(), is(buildExpectationSparseEmbeddings(List.of(new EmbeddingExpectation(Map.of("token", 0.1F), false)))));
         String xContentResult = Strings.toString(entity, true, true);
         assertThat(xContentResult, is("""
             {
@@ -118,7 +118,7 @@ public class SparseEmbeddingResultsTests extends AbstractWireSerializingTestCase
         assertThat(
             entity.asMap(),
             is(
-                buildExpectation(
+                buildExpectationSparseEmbeddings(
                     List.of(
                         new EmbeddingExpectation(Map.of("token", 0.1F, "token2", 0.2F), false),
                         new EmbeddingExpectation(Map.of("token3", 0.3F, "token4", 0.4F), false)
@@ -170,7 +170,7 @@ public class SparseEmbeddingResultsTests extends AbstractWireSerializingTestCase
 
     public record EmbeddingExpectation(Map<String, Float> tokens, boolean isTruncated) {}
 
-    public static Map<String, Object> buildExpectation(List<EmbeddingExpectation> embeddings) {
+    public static Map<String, Object> buildExpectationSparseEmbeddings(List<EmbeddingExpectation> embeddings) {
         return Map.of(
             SparseEmbeddingResults.SPARSE_EMBEDDING,
             embeddings.stream()

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/results/TextEmbeddingByteResultsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/results/TextEmbeddingByteResultsTests.java
@@ -131,7 +131,7 @@ public class TextEmbeddingByteResultsTests extends AbstractWireSerializingTestCa
         }
     }
 
-    public static Map<String, Object> buildExpectation(List<List<Byte>> embeddings) {
+    public static Map<String, Object> buildExpectationByte(List<List<Byte>> embeddings) {
         return Map.of(
             TextEmbeddingByteResults.TEXT_EMBEDDING_BYTES,
             embeddings.stream().map(embedding -> Map.of(ByteEmbedding.EMBEDDING, embedding)).toList()

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
@@ -494,7 +494,7 @@ public class HuggingFaceServiceTests extends ESTestCase {
             assertThat(
                 result.asMap(),
                 Matchers.is(
-                    SparseEmbeddingResultsTests.buildExpectation(
+                    SparseEmbeddingResultsTests.buildExpectationSparseEmbeddings(
                         List.of(new SparseEmbeddingResultsTests.EmbeddingExpectation(Map.of(".", 0.13315596f), false))
                     )
                 )


### PR DESCRIPTION
We have a lot of methods like `buildExpectationFloat`, `buildExpectationByte`, `buildExpectationCompletion` etc., which are explicit in their method name what they expect, which makes it easier to reason about tests and to find/distinguish these methods. Therefore adjusted the names of some `buildExpectation` methods to be more explicit.