### PR TITLE
Fix lucene_snapshot build

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ForbiddenApisPrecommitPlugin.java
@@ -43,7 +43,6 @@ public class ForbiddenApisPrecommitPlugin extends PrecommitPlugin {
             t.copy("forbidden/jdk-deprecated.txt");
             t.copy("forbidden/es-all-signatures.txt");
             t.copy("forbidden/es-test-signatures.txt");
-            t.copy("forbidden/hppc-signatures.txt");
             t.copy("forbidden/http-signatures.txt");
             t.copy("forbidden/es-server-signatures.txt");
         });

--- a/build-tools-internal/src/main/resources/forbidden/hppc-signatures.txt
+++ b/build-tools-internal/src/main/resources/forbidden/hppc-signatures.txt
@@ -1,1 +1,0 @@
-com.carrotsearch.hppc.BitMixer @ use @org.apache.lucene.util.hppc.BitMixer instead

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -99,13 +99,6 @@ tasks.named("forbiddenPatterns").configure {
     exclude '**/*.st'
 }
 
-tasks.named('forbiddenApisMain').configure {
-  addSignatureFiles 'hppc-signatures'
-}
-tasks.named('forbiddenApisTest').configure {
-  addSignatureFiles 'hppc-signatures'
-}
-
 tasks.named('internalClusterTestTestingConventions').configure {
     baseClass "org.elasticsearch.test.AbstractMultiClustersTestCase"
     baseClass "org.elasticsearch.test.ESIntegTestCase"

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/function/RandomScoreFunction.java
@@ -7,10 +7,11 @@
  */
 package org.elasticsearch.common.lucene.search.function;
 
+import com.carrotsearch.hppc.BitMixer;
+
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.util.StringHelper;
-import org.apache.lucene.util.hppc.BitMixer;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;

--- a/server/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
+++ b/server/src/main/java/org/elasticsearch/common/recycler/Recyclers.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.common.recycler;
 
-import org.apache.lucene.util.hppc.BitMixer;
+import com.carrotsearch.hppc.BitMixer;
 
 import java.util.ArrayDeque;
 

--- a/server/src/main/java/org/elasticsearch/common/util/AbstractPagedHashMap.java
+++ b/server/src/main/java/org/elasticsearch/common/util/AbstractPagedHashMap.java
@@ -8,7 +8,8 @@
 
 package org.elasticsearch.common.util;
 
-import org.apache.lucene.util.hppc.BitMixer;
+import com.carrotsearch.hppc.BitMixer;
+
 import org.elasticsearch.core.Releasable;
 
 /**

--- a/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/BytesRefHash.java
@@ -8,10 +8,11 @@
 
 package org.elasticsearch.common.util;
 
+import com.carrotsearch.hppc.BitMixer;
+
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.hppc.BitMixer;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 

--- a/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/Int3Hash.java
@@ -8,7 +8,8 @@
 
 package org.elasticsearch.common.util;
 
-import org.apache.lucene.util.hppc.BitMixer;
+import com.carrotsearch.hppc.BitMixer;
+
 import org.elasticsearch.core.Releasables;
 
 /**

--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
@@ -8,7 +8,8 @@
 
 package org.elasticsearch.common.util;
 
-import org.apache.lucene.util.hppc.BitMixer;
+import com.carrotsearch.hppc.BitMixer;
+
 import org.elasticsearch.core.Releasables;
 
 /**

--- a/server/src/main/java/org/elasticsearch/script/ScoreScriptUtils.java
+++ b/server/src/main/java/org/elasticsearch/script/ScoreScriptUtils.java
@@ -23,7 +23,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import static org.apache.lucene.util.hppc.BitMixer.mix32;
+import static com.carrotsearch.hppc.BitMixer.mix32;
 
 public final class ScoreScriptUtils {
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplingQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/sampler/random/RandomSamplingQuery.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.search.aggregations.bucket.sampler.random;
 
+import com.carrotsearch.hppc.BitMixer;
+
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.ConstantScoreScorer;
 import org.apache.lucene.search.DocIdSetIterator;
@@ -18,7 +20,6 @@ import org.apache.lucene.search.QueryVisitor;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.hppc.BitMixer;
 
 import java.io.IOException;
 import java.util.Objects;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/IncludeExclude.java
@@ -7,6 +7,8 @@
  */
 package org.elasticsearch.search.aggregations.bucket.terms;
 
+import com.carrotsearch.hppc.BitMixer;
+
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
@@ -20,7 +22,6 @@ import org.apache.lucene.util.automaton.ByteRunAutomaton;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.RegExp;
-import org.apache.lucene.util.hppc.BitMixer;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregator.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import com.carrotsearch.hppc.BitMixer;
+
 import org.apache.lucene.index.BinaryDocValues;
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
@@ -18,7 +20,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.apache.lucene.util.RamUsageEstimator;
-import org.apache.lucene.util.hppc.BitMixer;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.BitArray;

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java
@@ -301,7 +301,7 @@ public final class HighlightBuilder extends AbstractHighlighterBuilder<Highlight
             targetOptionsBuilder.boundaryMaxScan(highlighterBuilder.boundaryMaxScan);
         }
         if (highlighterBuilder.boundaryChars != null) {
-            targetOptionsBuilder.boundaryChars(convertCharArray(highlighterBuilder.boundaryChars));
+            targetOptionsBuilder.boundaryChars(highlighterBuilder.boundaryChars);
         }
         if (highlighterBuilder.boundaryScannerLocale != null) {
             targetOptionsBuilder.boundaryScannerLocale(highlighterBuilder.boundaryScannerLocale);

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SearchHighlightContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/SearchHighlightContext.java
@@ -86,7 +86,7 @@ public class SearchHighlightContext {
 
         private int boundaryMaxScan = -1;
 
-        private Character[] boundaryChars = null;
+        private char[] boundaryChars = null;
 
         private Locale boundaryScannerLocale;
 
@@ -156,7 +156,7 @@ public class SearchHighlightContext {
             return boundaryMaxScan;
         }
 
-        public Character[] boundaryChars() {
+        public char[] boundaryChars() {
             return boundaryChars;
         }
 
@@ -258,7 +258,7 @@ public class SearchHighlightContext {
                 return this;
             }
 
-            Builder boundaryChars(Character[] boundaryChars) {
+            Builder boundaryChars(char[] boundaryChars) {
                 fieldOptions.boundaryChars = boundaryChars;
                 return this;
             }

--- a/server/src/main/java/org/elasticsearch/search/slice/DocValuesSliceQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/slice/DocValuesSliceQuery.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.search.slice;
 
+import com.carrotsearch.hppc.BitMixer;
+
 import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -19,7 +21,6 @@ import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TwoPhaseIterator;
 import org.apache.lucene.search.Weight;
-import org.apache.lucene.util.hppc.BitMixer;
 
 import java.io.IOException;
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusSparseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusSparseTests.java
@@ -8,7 +8,8 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.util.hppc.BitMixer;
+import com.carrotsearch.hppc.BitMixer;
+
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/HyperLogLogPlusPlusTests.java
@@ -8,7 +8,8 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.util.hppc.BitMixer;
+import com.carrotsearch.hppc.BitMixer;
+
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalCardinalityTests.java
@@ -8,7 +8,8 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
-import org.apache.lucene.util.hppc.BitMixer;
+import com.carrotsearch.hppc.BitMixer;
+
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;

--- a/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilderTests.java
@@ -412,12 +412,8 @@ public class HighlightBuilderTests extends ESTestCase {
             Object actualValue = fieldOptionsParameterAccessor.apply(options);
             if (actualValue instanceof String[]) {
                 assertArrayEquals((String[]) expectedValue, (String[]) actualValue);
-            } else if (actualValue instanceof Character[]) {
-                if (expectedValue instanceof char[]) {
-                    assertArrayEquals(HighlightBuilder.convertCharArray((char[]) expectedValue), (Character[]) actualValue);
-                } else {
-                    assertArrayEquals((Character[]) expectedValue, (Character[]) actualValue);
-                }
+            } else if (actualValue instanceof char[]) {
+                assertArrayEquals((char[]) expectedValue, (char[]) actualValue);
             } else {
                 assertEquals(expectedValue, actualValue);
             }

--- a/server/src/test/java/org/elasticsearch/search/slice/DocValuesSliceQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/slice/DocValuesSliceQueryTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.search.slice;
 
+import com.carrotsearch.hppc.BitMixer;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -24,7 +26,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.tests.search.QueryUtils;
 import org.apache.lucene.util.NumericUtils;
-import org.apache.lucene.util.hppc.BitMixer;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.test.ESTestCase;
 

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   compileOnly project(':server')
   compileOnly project('ann')
   annotationProcessor project('gen')
+  implementation 'com.carrotsearch:hppc:0.8.1'
 
   testImplementation project(':test:framework')
   testImplementation(project(xpackModule('esql-core')))

--- a/x-pack/plugin/esql/compute/src/main/java/module-info.java
+++ b/x-pack/plugin/esql/compute/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module org.elasticsearch.compute {
     requires org.elasticsearch.logging;
     requires org.elasticsearch.tdigest;
     requires org.elasticsearch.geo;
+    requires hppc;
 
     exports org.elasticsearch.compute;
     exports org.elasticsearch.compute.aggregation;

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/HllStates.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/HllStates.java
@@ -7,9 +7,10 @@
 
 package org.elasticsearch.compute.aggregation;
 
+import com.carrotsearch.hppc.BitMixer;
+
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.BytesRefIterator;
-import org.apache.lucene.util.hppc.BitMixer;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.hash.MurmurHash3;
 import org.elasticsearch.common.io.stream.ByteArrayStreamInput;


### PR DESCRIPTION
Fix lucene_snapshot build.

Replaces Lucene's BitMixer with that of hppc, since Lucene no longer exports hppc types, see, https://github.com/apache/lucene/pull/13422. It was more by accident than by design that they were available at all.

Fixes Character[] / char[], see https://github.com/apache/lucene/pull/13420