### PR TITLE
Capture GC logs alongside heap dumps

### DIFF
--- a/docs/reference/troubleshooting/common-issues/high-jvm-memory-pressure.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/high-jvm-memory-pressure.asciidoc
@@ -30,7 +30,8 @@ collection.
 **Capture a JVM heap dump**
 
 To determine the exact reason for the high JVM memory pressure, capture a heap
-dump of the JVM while its memory usage is high.
+dump of the JVM while its memory usage is high, and also capture the
+<<gc-logging,garbage collector logs>> covering the same time period.
 
 [discrete]
 [[reduce-jvm-memory-pressure]]

--- a/docs/reference/troubleshooting/network-timeouts.asciidoc
+++ b/docs/reference/troubleshooting/network-timeouts.asciidoc
@@ -4,8 +4,8 @@ usually by the `JvmMonitorService` in the main node logs. Use these logs to
 confirm whether or not the node is experiencing high heap usage with long GC
 pauses. If so, <<high-jvm-memory-pressure,the troubleshooting guide for high
 heap usage>> has some suggestions for further investigation but typically you
-will need to capture a heap dump during a time of high heap usage to fully
-understand the problem.
+will need to capture a heap dump and the <<gc-logging,garbage collector logs>>
+during a time of high heap usage to fully understand the problem.
 
 * VM pauses also affect other processes on the same host. A VM pause also
 typically causes a discontinuity in the system clock, which {es} will report in


### PR DESCRIPTION
GC logs can be important to understand a heap dump, especially if
there's lots of unreachable objects and the GC is struggling to keep up.