### PR TITLE
Clarify that red/yellow health must be addressed

### DIFF
--- a/docs/reference/troubleshooting/common-issues/red-yellow-cluster-status.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/red-yellow-cluster-status.asciidoc
@@ -1,22 +1,23 @@
 [[red-yellow-cluster-status]]
-=== Red or yellow cluster health
+=== Red or yellow cluster health status
 
-A red or yellow cluster health indicates one or more shards are not assigned to
-a node. A cluster with red health has some unassigned primary shards which
-means that some operations such as searches and indexing may fail. A cluster
-with yellow health has no unassigned primary shards but some unassigned replica
-shards which increases your risk of data loss and can degrade cluster
-performance.
+A red or yellow cluster health status indicates one or more shards are not assigned to
+a node. 
 
-While your cluster is in red or yellow health it will continue to process
-searches and indexing as best as it can, but may delay certain management and
-cleanup activities until the cluster returns to green health. For instance,
-some <<index-lifecycle-management,ILM>> actions require the index on which they
-operate to be fully healthy.
+* **Red health status**: The cluster has some unassigned primary shards, which
+means that some operations such as searches and indexing may fail. 
+* **Yellow health status**: The cluster has no unassigned primary shards but some 
+unassigned replica shards. This increases your risk of data loss and can degrade 
+cluster performance.
 
-In many cases your cluster will recover to green health automatically, but if
-it does not then you must manually address the remaining problems as soon as
-possible.
+When your cluster has a red or yellow health status, it will continue to process
+searches and indexing where possible, but may delay certain management and
+cleanup activities until the cluster returns to green health status. For instance,
+some <<index-lifecycle-management,{ilm-init}>> actions require the index on which they
+operate to have a green health status.
+
+In many cases, your cluster will recover to green health status automatically. 
+If the cluster doesn't automatically recover, then you must <<fix-red-yellow-cluster-status,manually address>> the remaining problems as soon as possible.
 
 [discrete]
 [[diagnose-cluster-status]]

--- a/docs/reference/troubleshooting/common-issues/red-yellow-cluster-status.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/red-yellow-cluster-status.asciidoc
@@ -17,7 +17,8 @@ some <<index-lifecycle-management,{ilm-init}>> actions require the index on whic
 operate to have a green health status.
 
 In many cases, your cluster will recover to green health status automatically. 
-If the cluster doesn't automatically recover, then you must <<fix-red-yellow-cluster-status,manually address>> the remaining problems as soon as possible.
+If the cluster doesn't automatically recover, then you must <<fix-red-yellow-cluster-status,manually address>> 
+the remaining problems so management and cleanup activities can proceed.
 
 [discrete]
 [[diagnose-cluster-status]]

--- a/docs/reference/troubleshooting/common-issues/red-yellow-cluster-status.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/red-yellow-cluster-status.asciidoc
@@ -1,9 +1,22 @@
 [[red-yellow-cluster-status]]
-=== Red or yellow cluster status
+=== Red or yellow cluster health
 
-A red or yellow cluster status indicates one or more shards are missing or
-unallocated. These unassigned shards increase your risk of data loss and can
-degrade cluster performance.
+A red or yellow cluster health indicates one or more shards are not assigned to
+a node. A cluster with red health has some unassigned primary shards which
+means that some operations such as searches and indexing may fail. A cluster
+with yellow health has no unassigned primary shards but some unassigned replica
+shards which increases your risk of data loss and can degrade cluster
+performance.
+
+While your cluster is in red or yellow health it will continue to process
+searches and indexing as best as it can, but may delay certain management and
+cleanup activities until the cluster returns to green health. For instance,
+some <<index-lifecycle-management,ILM>> actions require the index on which they
+operate to be fully healthy.
+
+In many cases your cluster will recover to green health automatically, but if
+it does not then you must manually address the remaining problems as soon as
+possible.
 
 [discrete]
 [[diagnose-cluster-status]]


### PR DESCRIPTION
We don't expect a cluster to run with `yellow` health for an extended
period of time, but it's not clear from these docs that it's important
to bring the cluster back to `green` health ASAP. This commit clarifies
these docs.