### PR TITLE
[Profiling] Add support for nanosecond timestamps in profiling-events

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-events.json
@@ -39,7 +39,7 @@
         },
         "@timestamp": {
           "type": "date",
-          "format": "epoch_second"
+          "format": "strict_date_optional_time_nanos||epoch_second"
         },
         "host.id": {
           "type": "keyword"


### PR DESCRIPTION
The profiling host agent and the profiling collector are moving to nanosecond time resolution. This PR is backwards compatible in that it also supports the old Unix seconds since the epoch format.

