### PR TITLE
Update files.asciidoc

### DIFF
--- a/docs/reference/security/reference/files.asciidoc
+++ b/docs/reference/security/reference/files.asciidoc
@@ -7,10 +7,10 @@ The {es} {security-features} use the following files:
 * `ES_PATH_CONF/roles.yml` defines the roles in use on the cluster. See
 <<defining-roles>>.
 
-* `ES_PATH_CONF/elasticsearch-users` defines the users and their hashed passwords for
+* `ES_PATH_CONF/users` defines the users and their hashed passwords for
   the `file` realm. See <<file-realm>>.
 
-* `ES_PATH_CONF/elasticsearch-users_roles` defines the user roles assignment for the
+* `ES_PATH_CONF/users_roles` defines the user roles assignment for the
   `file` realm. See <<file-realm>>.
 
 * `ES_PATH_CONF/role_mapping.yml` defines the role assignments for a


### PR DESCRIPTION
Rename security files ES_PATH_CONF/elasticsearch-users and ES_PATH_CONF/elasticsearch-users_roles to  ES_PATH_CONF/users and ES_PATH_CONF/users_roles, respectively

In this [PR](https://github.com/elastic/elasticsearch/commit/c7c0e330b82adbda09db6df745af187db6b3eb43 ) the files got erroneously renamed to ES_PATH_CONF/elasticsearch-users and ES_PATH_CONF/elasticsearch-users_roles. This commit tries to fix that.


- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
