### PR TITLE
[Connecor API] Add references to tutorial in docs

### DIFF
--- a/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/cancel-connector-sync-job-api.asciidoc
@@ -8,6 +8,8 @@ beta::[]
 
 Cancels a connector sync job.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[cancel-connector-sync-job-api-request]]
 ==== {api-request-title}
 `PUT _connector/_sync_job/<connector_sync_job_id>/_cancel`

--- a/docs/reference/connector/apis/check-in-connector-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-api.asciidoc
@@ -8,6 +8,8 @@ preview::[]
 
 Updates the `last_seen` field of a connector with current timestamp.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[check-in-connector-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/check-in-connector-sync-job-api.asciidoc
@@ -8,6 +8,8 @@ preview::[]
 
 Checks in a connector sync job (updates `last_seen` to the current time).
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[check-in-connector-sync-job-api-request]]
 ==== {api-request-title}
 `PUT _connector/_sync_job/<connector_sync_job_id>/_check_in/`

--- a/docs/reference/connector/apis/connector-apis.asciidoc
+++ b/docs/reference/connector/apis/connector-apis.asciidoc
@@ -3,7 +3,7 @@
 
 beta::[]
 
-The connector and sync jobs APIs provide a convenient way to create and manage Elastic {enterprise-search-ref}/connectors.html[connectors^] and sync jobs in an internal index.
+The connector and sync jobs APIs provide a convenient way to create and manage Elastic {enterprise-search-ref}/connectors.html[connectors^] and sync jobs in an internal index. To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
 
 Connectors are {es} integrations that bring content from third-party data sources, which can be deployed on {ecloud} or hosted on your own infrastructure:
 

--- a/docs/reference/connector/apis/create-connector-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-api.asciidoc
@@ -14,6 +14,8 @@ Connectors are {es} integrations that bring content from third-party data source
 
 Find a list of all supported service types in the {enterprise-search-ref}/connectors.html[connectors documentation^].
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [source,console]
 --------------------------------------------------
 PUT _connector/my-connector

--- a/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/create-connector-sync-job-api.asciidoc
@@ -9,6 +9,8 @@ beta::[]
 
 Creates a connector sync job.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [source, console]
 --------------------------------------------------
 POST _connector/_sync_job

--- a/docs/reference/connector/apis/delete-connector-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-api.asciidoc
@@ -11,6 +11,8 @@ This is a destructive action that is not recoverable.
 
 Note: this action doesn't delete any API key, ingest pipeline or data index associated with the connector. These need to be removed manually.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[delete-connector-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/delete-connector-sync-job-api.asciidoc
@@ -9,6 +9,8 @@ beta::[]
 Removes a connector sync job and its associated data.
 This is a destructive action that is not recoverable.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[delete-connector-sync-job-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/get-connector-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-api.asciidoc
@@ -8,6 +8,8 @@ beta::[]
 
 Retrieves the details about a connector.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[get-connector-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
+++ b/docs/reference/connector/apis/get-connector-sync-job-api.asciidoc
@@ -8,6 +8,8 @@ beta::[]
 
 Retrieves the details about a connector sync job.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[get-connector-sync-job-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
+++ b/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
@@ -9,6 +9,7 @@ beta::[]
 
 Returns information about all stored connector sync jobs ordered by their creation date in ascending order.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
 
 [[list-connector-sync-jobs-api-request]]
 ==== {api-request-title}

--- a/docs/reference/connector/apis/list-connectors-api.asciidoc
+++ b/docs/reference/connector/apis/list-connectors-api.asciidoc
@@ -9,6 +9,8 @@ beta::[]
 
 Returns information about all created connectors.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 
 [[list-connector-api-request]]
 ==== {api-request-title}

--- a/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-error-api.asciidoc
@@ -8,6 +8,8 @@ preview::[]
 
 Sets a connector sync job error.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[set-connector-sync-job-error-api-request]]
 ==== {api-request-title}
 `PUT _connector/_sync_job/<connector_sync_job_id>/_error`

--- a/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
+++ b/docs/reference/connector/apis/set-connector-sync-job-stats-api.asciidoc
@@ -8,6 +8,8 @@ preview::[]
 
 Sets connector sync job stats.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[set-connector-sync-job-stats-api-request]]
 ==== {api-request-title}
 `PUT _connector/_sync_job/<connector_sync_job_id>/_stats`

--- a/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-api-key-id-api.asciidoc
@@ -15,6 +15,8 @@ The Connector Secret ID is only required for native connectors.
 Connector clients do not use this field.
 See the documentation for {enterprise-search-ref}/native-connectors.html#native-connectors-manage-API-keys-programmatically[managing native connector API keys programmatically^] for more details.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-api-key-id-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-configuration-api.asciidoc
@@ -8,6 +8,7 @@ beta::[]
 
 Updates a connector's `configuration`, allowing for config value updates within a registered configuration schema.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
 
 [[update-connector-configuration-api-request]]
 ==== {api-request-title}

--- a/docs/reference/connector/apis/update-connector-error-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-error-api.asciidoc
@@ -8,6 +8,8 @@ preview::[]
 
 Updates the `error` field of a connector.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-error-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-filtering-api.asciidoc
@@ -10,6 +10,8 @@ Updates the draft `filtering` configuration of a connector and marks the draft v
 
 The filtering property is used to configure sync rules (both basic and advanced) for a connector. Learn more in the {enterprise-search-ref}/sync-rules.html[sync rules documentation].
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-filtering-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-index-name-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-index-name-api.asciidoc
@@ -8,6 +8,8 @@ beta::[]
 
 Updates the `index_name` field of a connector, specifying the index where the data ingested by the connector is stored.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-index-name-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-last-sync-api.asciidoc
@@ -10,6 +10,8 @@ Updates the fields related to the last sync of a connector.
 
 This action is used for analytics and monitoring.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-last-sync-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-name-description-api.asciidoc
@@ -9,6 +9,8 @@ beta::[]
 
 Updates the `name` and `description` fields of a connector.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-name-description-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-pipeline-api.asciidoc
@@ -10,6 +10,8 @@ Updates the `pipeline` configuration of a connector.
 
 When you create a new connector, the configuration of an <<ingest-pipeline-search-details-generic-reference, ingest pipeline>> is populated with default settings.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-pipeline-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-scheduling-api.asciidoc
@@ -8,6 +8,8 @@ beta::[]
 
 Updates the `scheduling` configuration of a connector.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-scheduling-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-service-type-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-service-type-api.asciidoc
@@ -8,6 +8,8 @@ beta::[]
 
 Updates the `service_type` of a connector.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-service-type-api-request]]
 ==== {api-request-title}
 

--- a/docs/reference/connector/apis/update-connector-status-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-status-api.asciidoc
@@ -8,6 +8,8 @@ preview::[]
 
 Updates the `status` of a connector.
 
+To get started with Connector APIs, check out the {enterprise-search-ref}/connectors-tutorial-api.html[tutorial^].
+
 [[update-connector-status-api-request]]
 ==== {api-request-title}
 


### PR DESCRIPTION
### Changes

Add references to [Connector API tutorial](https://www.elastic.co/guide/en/enterprise-search/master/connectors-tutorial-api.html) from API docs