### PR TITLE
[ML] Offload request to generic threadpool

### DIFF
--- a/docs/changelog/109104.yaml
+++ b/docs/changelog/109104.yaml
@@ -1,0 +1,6 @@
+pr: 109104
+summary: Offload request to generic threadpool
+area: Machine Learning
+type: bug
+issues:
+ - 109100

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TextStructExecutor.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TextStructExecutor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.textstructure.transport;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.common.CheckedSupplier;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+
+import static org.elasticsearch.common.util.concurrent.EsExecutors.DIRECT_EXECUTOR_SERVICE;
+import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
+
+/**
+ * workaround for https://github.com/elastic/elasticsearch/issues/97916
+ * TODO delete this entire class when we can
+ */
+public class TextStructExecutor {
+    private final ThreadPool threadPool;
+
+    @Inject
+    public TextStructExecutor(ThreadPool threadPool) {
+        this.threadPool = threadPool;
+    }
+
+    /**
+     * when the workaround is removed, change the value in each consuming class's constructor passes to the super constructor from
+     * DIRECT_EXECUTOR_SERVICE back to threadpool.generic() so that we continue to fork off of the transport thread.
+     */
+    ExecutorService handledTransportActionExecutorService() {
+        return DIRECT_EXECUTOR_SERVICE;
+    }
+
+    /**
+     * when the workaround is removed, change the callers of this function to
+     * {@link ActionListener#completeWith(ActionListener, CheckedSupplier)}.
+     */
+    <T> void execute(ActionListener<T> listener, CheckedSupplier<T, Exception> supplier) {
+        var runnable = ActionRunnable.supply(listener, () -> {
+            assert ThreadPool.assertCurrentThreadPool(GENERIC);
+            return supplier.get();
+        });
+        try {
+            threadPool.generic().execute(runnable);
+        } catch (RejectedExecutionException e) {
+            runnable.onRejection(e);
+        }
+    }
+}

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TextStructExecutor.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TextStructExecutor.java
@@ -16,7 +16,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.util.concurrent.ExecutorService;
 
 import static org.elasticsearch.common.util.concurrent.EsExecutors.DIRECT_EXECUTOR_SERVICE;
-import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
 
 /**
  * workaround for https://github.com/elastic/elasticsearch/issues/97916
@@ -43,9 +42,6 @@ public class TextStructExecutor {
      * {@link ActionListener#completeWith(ActionListener, CheckedSupplier)}.
      */
     <T> void execute(ActionListener<T> listener, CheckedSupplier<T, Exception> supplier) {
-        threadPool.generic().execute(ActionRunnable.supply(listener, () -> {
-            assert ThreadPool.assertCurrentThreadPool(GENERIC);
-            return supplier.get();
-        }));
+        threadPool.generic().execute(ActionRunnable.supply(listener, supplier));
     }
 }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindMessageStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindMessageStructureAction.java
@@ -19,6 +19,8 @@ import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinder
 import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinderManager;
 import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureOverrides;
 
+import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
+
 public class TransportFindMessageStructureAction extends HandledTransportAction<FindMessageStructureAction.Request, FindStructureResponse> {
 
     private final ThreadPool threadPool;
@@ -48,6 +50,7 @@ public class TransportFindMessageStructureAction extends HandledTransportAction<
     }
 
     private FindStructureResponse buildTextStructureResponse(FindMessageStructureAction.Request request) throws Exception {
+        assert ThreadPool.assertCurrentThreadPool(GENERIC);
         TextStructureFinderManager structureFinderManager = new TextStructureFinderManager(threadPool.scheduler());
         TextStructureFinder textStructureFinder = structureFinderManager.findTextStructure(
             request.getMessages(),

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindMessageStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindMessageStructureAction.java
@@ -22,26 +22,29 @@ import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureOverri
 public class TransportFindMessageStructureAction extends HandledTransportAction<FindMessageStructureAction.Request, FindStructureResponse> {
 
     private final ThreadPool threadPool;
+    private final TextStructExecutor executor;
 
     @Inject
-    public TransportFindMessageStructureAction(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool) {
+    public TransportFindMessageStructureAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool,
+        TextStructExecutor executor
+    ) {
         super(
             FindMessageStructureAction.NAME,
             transportService,
             actionFilters,
             FindMessageStructureAction.Request::new,
-            threadPool.generic()
+            executor.handledTransportActionExecutorService()
         );
         this.threadPool = threadPool;
+        this.executor = executor;
     }
 
     @Override
     protected void doExecute(Task task, FindMessageStructureAction.Request request, ActionListener<FindStructureResponse> listener) {
-        try {
-            listener.onResponse(buildTextStructureResponse(request));
-        } catch (Exception e) {
-            listener.onFailure(e);
-        }
+        executor.execute(listener, () -> buildTextStructureResponse(request));
     }
 
     private FindStructureResponse buildTextStructureResponse(FindMessageStructureAction.Request request) throws Exception {

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
@@ -52,7 +52,7 @@ public class TransportFindStructureAction extends HandledTransportAction<FindStr
     }
 
     private FindStructureResponse buildTextStructureResponse(FindStructureAction.Request request) throws Exception {
-        assert Transports.assertNotTransportThread("TransportFindStructureAction work must always fork to an appropriate executor");
+        assert ThreadPool.assertCurrentThreadPool(Names.GENERIC);
         TextStructureFinderManager structureFinderManager = new TextStructureFinderManager(threadPool.scheduler());
         try (InputStream sampleStream = request.getSample().streamInput()) {
             TextStructureFinder textStructureFinder = structureFinderManager.findTextStructure(

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
@@ -34,7 +34,10 @@ public class TransportFindStructureAction extends HandledTransportAction<FindStr
     @Override
     protected void doExecute(Task task, FindStructureAction.Request request, ActionListener<FindStructureResponse> listener) {
         try {
-            listener.onResponse(buildTextStructureResponse(request));
+            // for GH#109100, offload request to generic threadpool (and preserve thread context)
+            threadPool.generic().execute(threadPool.getThreadContext().preserveContext(() -> {
+                ActionListener.completeWith(listener, () -> buildTextStructureResponse(request));
+            }));
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
@@ -21,6 +21,8 @@ import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureOverri
 
 import java.io.InputStream;
 
+import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
+
 public class TransportFindStructureAction extends HandledTransportAction<FindStructureAction.Request, FindStructureResponse> {
 
     private final ThreadPool threadPool;
@@ -50,6 +52,7 @@ public class TransportFindStructureAction extends HandledTransportAction<FindStr
     }
 
     private FindStructureResponse buildTextStructureResponse(FindStructureAction.Request request) throws Exception {
+        assert ThreadPool.assertCurrentThreadPool(GENERIC);
         TextStructureFinderManager structureFinderManager = new TextStructureFinderManager(threadPool.scheduler());
         try (InputStream sampleStream = request.getSample().streamInput()) {
             TextStructureFinder textStructureFinder = structureFinderManager.findTextStructure(

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.textstructure.transport;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
@@ -21,39 +20,36 @@ import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinder
 import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureOverrides;
 
 import java.io.InputStream;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.RejectedExecutionException;
-
-import static org.elasticsearch.common.util.concurrent.EsExecutors.DIRECT_EXECUTOR_SERVICE;
-import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
 
 public class TransportFindStructureAction extends HandledTransportAction<FindStructureAction.Request, FindStructureResponse> {
 
     private final ThreadPool threadPool;
-    private final ExecutorService executorService;
+    private final TextStructExecutor executor;
 
     @Inject
-    public TransportFindStructureAction(TransportService transportService, ActionFilters actionFilters, ThreadPool threadPool) {
-        super(FindStructureAction.NAME, transportService, actionFilters, FindStructureAction.Request::new, DIRECT_EXECUTOR_SERVICE);
+    public TransportFindStructureAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ThreadPool threadPool,
+        TextStructExecutor executor
+    ) {
+        super(
+            FindStructureAction.NAME,
+            transportService,
+            actionFilters,
+            FindStructureAction.Request::new,
+            executor.handledTransportActionExecutorService()
+        );
         this.threadPool = threadPool;
-        this.executorService = threadPool.generic();
+        this.executor = executor;
     }
 
     @Override
     protected void doExecute(Task task, FindStructureAction.Request request, ActionListener<FindStructureResponse> listener) {
-        // workaround for https://github.com/elastic/elasticsearch/issues/97916 - TODO remove this when we can
-        // when the workaround is removed, change the value that this class's constructor passes to the super constructor from
-        // DIRECT_EXECUTOR_SERVICE back to threadpool.generic() so that we continue to fork off of the transport thread.
-        var buildTextStructureResponse = ActionRunnable.supply(listener, () -> buildTextStructureResponse(request));
-        try {
-            executorService.execute(buildTextStructureResponse);
-        } catch (RejectedExecutionException e) {
-            buildTextStructureResponse.onRejection(e);
-        }
+        executor.execute(listener, () -> buildTextStructureResponse(request));
     }
 
     private FindStructureResponse buildTextStructureResponse(FindStructureAction.Request request) throws Exception {
-        assert ThreadPool.assertCurrentThreadPool(GENERIC);
         TextStructureFinderManager structureFinderManager = new TextStructureFinderManager(threadPool.scheduler());
         try (InputStream sampleStream = request.getSample().streamInput()) {
             TextStructureFinder textStructureFinder = structureFinderManager.findTextStructure(

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/transport/TransportFindStructureAction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.transport.Transports;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureResponse;
 import org.elasticsearch.xpack.textstructure.structurefinder.TextStructureFinder;
@@ -26,6 +25,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
 import static org.elasticsearch.common.util.concurrent.EsExecutors.DIRECT_EXECUTOR_SERVICE;
+import static org.elasticsearch.threadpool.ThreadPool.Names.GENERIC;
 
 public class TransportFindStructureAction extends HandledTransportAction<FindStructureAction.Request, FindStructureResponse> {
 
@@ -53,7 +53,7 @@ public class TransportFindStructureAction extends HandledTransportAction<FindStr
     }
 
     private FindStructureResponse buildTextStructureResponse(FindStructureAction.Request request) throws Exception {
-        assert ThreadPool.assertCurrentThreadPool(Names.GENERIC);
+        assert ThreadPool.assertCurrentThreadPool(GENERIC);
         TextStructureFinderManager structureFinderManager = new TextStructureFinderManager(threadPool.scheduler());
         try (InputStream sampleStream = request.getSample().streamInput()) {
             TextStructureFinder textStructureFinder = structureFinderManager.findTextStructure(


### PR DESCRIPTION
buildTextStructureResponse can take a long time, presumably up to 25s, and is currently blocking the transport thread for that amount of time. Offloading the request to the generic threadpool will at least let the transport thread handle other requests concurrently.

Fix #109100

