### PR TITLE
ESQL: Remove `nested` shims

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/FieldAttribute.java
@@ -10,7 +10,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
-import org.elasticsearch.xpack.esql.core.type.DataTypes;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.util.StringUtils;
 
@@ -27,7 +26,6 @@ import java.util.Objects;
 public class FieldAttribute extends TypedAttribute {
 
     private final FieldAttribute parent;
-    private final FieldAttribute nestedParent;
     private final String path;
     private final EsField field;
 
@@ -67,16 +65,6 @@ public class FieldAttribute extends TypedAttribute {
         this.path = parent != null ? parent.name() : StringUtils.EMPTY;
         this.parent = parent;
         this.field = field;
-
-        // figure out the last nested parent
-        FieldAttribute nestedPar = null;
-        if (parent != null) {
-            nestedPar = parent.nestedParent;
-            if (parent.dataType() == DataTypes.NESTED) {
-                nestedPar = parent;
-            }
-        }
-        this.nestedParent = nestedPar;
     }
 
     @Override
@@ -95,14 +83,6 @@ public class FieldAttribute extends TypedAttribute {
     public String qualifiedPath() {
         // return only the qualifier is there's no path
         return qualifier() != null ? qualifier() + (Strings.hasText(path) ? "." + path : StringUtils.EMPTY) : path;
-    }
-
-    public boolean isNested() {
-        return nestedParent != null;
-    }
-
-    public FieldAttribute nestedParent() {
-        return nestedParent;
     }
 
     public EsField.Exact getExactInfo() {

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/ExpressionTranslator.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/ExpressionTranslator.java
@@ -11,7 +11,6 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.TypedAttribute;
-import org.elasticsearch.xpack.esql.core.querydsl.query.NestedQuery;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.util.Check;
 import org.elasticsearch.xpack.esql.core.util.ReflectionUtils;
@@ -26,15 +25,6 @@ public abstract class ExpressionTranslator<E extends Expression> {
     }
 
     protected abstract Query asQuery(E e, TranslatorHandler handler);
-
-    public static Query wrapIfNested(Query query, Expression exp) {
-        if (query != null && exp instanceof FieldAttribute fa) {
-            if (fa.isNested()) {
-                return new NestedQuery(fa.source(), fa.nestedParent().name(), query);
-            }
-        }
-        return query;
-    }
 
     public static FieldAttribute checkIsFieldAttribute(Expression e) {
         Check.isTrue(e instanceof FieldAttribute, "Expected a FieldAttribute but received [{}]", e);

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/ExpressionTranslators.java
@@ -105,7 +105,7 @@ public final class ExpressionTranslators {
                 throw new QlIllegalArgumentException("Cannot translate query for " + e);
             }
 
-            return wrapIfNested(q, field);
+            return q;
         }
 
         private static Query translateField(RegexMatch e, String targetFieldName) {
@@ -182,10 +182,9 @@ public final class ExpressionTranslators {
         }
 
         public static Query doTranslate(Not not, TranslatorHandler handler) {
-            Expression e = not.field();
             Query wrappedQuery = handler.asQuery(not.field());
             Query q = wrappedQuery.negate(not.source());
-            return wrapIfNested(q, e);
+            return q;
         }
     }
 

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/TranslatorHandler.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/planner/TranslatorHandler.java
@@ -27,7 +27,7 @@ public interface TranslatorHandler {
 
     default Query wrapFunctionQuery(ScalarFunction sf, Expression field, Supplier<Query> querySupplier) {
         if (field instanceof FieldAttribute) {
-            return ExpressionTranslator.wrapIfNested(querySupplier.get(), field);
+            return querySupplier.get();
         }
         throw new QlIllegalArgumentException("Cannot translate expression:[" + sf.sourceText() + "]");
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlExpressionTranslators.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlExpressionTranslators.java
@@ -385,17 +385,17 @@ public final class EsqlExpressionTranslators {
          * improvement overall.
          * TODO: Remove this method and call the parent method once the SingleValueQuery improvements have been made
          */
-        public static Query wrapFunctionQuery(Expression field, Supplier<Query> querySupplier) {
-            return ExpressionTranslator.wrapIfNested(querySupplier.get(), field);
+        public static Query wrapFunctionQuery(Supplier<Query> querySupplier) {
+            return querySupplier.get();
         }
 
         public static Query doTranslate(SpatialRelatesFunction bc, TranslatorHandler handler) {
             if (bc.left().foldable()) {
                 checkSpatialRelatesFunction(bc.left(), bc.queryRelation());
-                return wrapFunctionQuery(bc.right(), () -> translate(bc, handler, bc.right(), bc.left()));
+                return wrapFunctionQuery(() -> translate(bc, handler, bc.right(), bc.left()));
             } else {
                 checkSpatialRelatesFunction(bc.right(), bc.queryRelation());
-                return wrapFunctionQuery(bc.left(), () -> translate(bc, handler, bc.left(), bc.right()));
+                return wrapFunctionQuery(() -> translate(bc, handler, bc.left(), bc.right()));
             }
         }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlTranslatorHandler.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsqlTranslatorHandler.java
@@ -15,7 +15,6 @@ import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNull;
-import org.elasticsearch.xpack.esql.core.planner.ExpressionTranslator;
 import org.elasticsearch.xpack.esql.core.planner.TranslatorHandler;
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.type.DataType;
@@ -50,7 +49,7 @@ public final class EsqlTranslatorHandler implements TranslatorHandler {
             if ((sf instanceof IsNull || sf instanceof IsNotNull) == false) {
                 query = new SingleValueQuery(query, fa.name());
             }
-            return ExpressionTranslator.wrapIfNested(query, field);
+            return query;
         }
         if (field instanceof MetadataAttribute) {
             return querySupplier.get(); // MetadataAttributes are always single valued


### PR DESCRIPTION
This removes the shim layers for `nested` that we inherited from QL. ESQL doesn't support nested yet and when it does support nested its not going to use the same tricks that QL uses.
