### PR TITLE
NodeJoinTests fix for future complete assertion

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -270,7 +270,7 @@ public class EsExecutors {
         // subtract 2 to avoid the `]` of the thread number part.
         int executorNameEnd = threadName.lastIndexOf(']', threadName.length() - 2);
         int executorNameStart = threadName.lastIndexOf('[', executorNameEnd);
-        if (executorNameStart == -1 || executorNameEnd - executorNameStart <= 1 || threadName.startsWith("TEST-")) {
+        if (executorNameStart == -1 || executorNameEnd - executorNameStart <= 1 || threadName.startsWith("TEST-") || threadName.startsWith("LuceneTestCase")) {
             return null;
         }
         return threadName.substring(executorNameStart + 1, executorNameEnd);

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -270,7 +270,7 @@ public class EsExecutors {
         // subtract 2 to avoid the `]` of the thread number part.
         int executorNameEnd = threadName.lastIndexOf(']', threadName.length() - 2);
         int executorNameStart = threadName.lastIndexOf('[', executorNameEnd);
-        if (executorNameStart == -1 || executorNameEnd - executorNameStart <= 1) {
+        if (executorNameStart == -1 || executorNameEnd - executorNameStart <= 1 || threadName.startsWith("TEST-")) {
             return null;
         }
         return threadName.substring(executorNameStart + 1, executorNameEnd);

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/EsExecutors.java
@@ -270,7 +270,10 @@ public class EsExecutors {
         // subtract 2 to avoid the `]` of the thread number part.
         int executorNameEnd = threadName.lastIndexOf(']', threadName.length() - 2);
         int executorNameStart = threadName.lastIndexOf('[', executorNameEnd);
-        if (executorNameStart == -1 || executorNameEnd - executorNameStart <= 1 || threadName.startsWith("TEST-") || threadName.startsWith("LuceneTestCase")) {
+        if (executorNameStart == -1
+            || executorNameEnd - executorNameStart <= 1
+            || threadName.startsWith("TEST-")
+            || threadName.startsWith("LuceneTestCase")) {
             return null;
         }
         return threadName.substring(executorNameStart + 1, executorNameEnd);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -678,7 +678,6 @@ public class NodeJoinTests extends ESTestCase {
         assertFalse(isLocalNodeElectedMaster());
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/109103")
     public void testConcurrentJoining() {
         List<DiscoveryNode> masterNodes = IntStream.rangeClosed(1, randomIntBetween(2, 5))
             .mapToObj(nodeId -> newNode(nodeId, true))
@@ -775,14 +774,14 @@ public class NodeJoinTests extends ESTestCase {
         final List<Thread> joinThreads = Stream.concat(correctJoinRequests.stream().map(joinRequest -> new Thread(() -> {
             safeAwait(barrier);
             joinNode(joinRequest);
-        }, "process " + joinRequest)), possiblyFailingJoinRequests.stream().map(joinRequest -> new Thread(() -> {
+        }, "TEST-process " + joinRequest)), possiblyFailingJoinRequests.stream().map(joinRequest -> new Thread(() -> {
             safeAwait(barrier);
             try {
                 joinNode(joinRequest);
             } catch (CoordinationStateRejectedException e) {
                 // ignore - these requests are expected to fail
             }
-        }, "process " + joinRequest))).toList();
+        }, "TEST-process " + joinRequest))).toList();
 
         assertionThread.start();
         joinThreads.forEach(Thread::start);

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -37,6 +37,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.nullValue;
 
 /**
  * Tests for EsExecutors and its components like EsAbortPolicy.
@@ -646,6 +647,8 @@ public class EsExecutorsTests extends ESTestCase {
         final var thread = threadFactory.newThread(() -> {});
         try {
             assertThat(EsExecutors.executorName(thread.getName()), equalTo(executorName));
+            assertThat(EsExecutors.executorName(thread), equalTo(executorName));
+            assertThat(EsExecutors.executorName("TEST-" + thread.getName()), is(nullValue()));
         } finally {
             thread.join();
         }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/EsExecutorsTests.java
@@ -649,6 +649,7 @@ public class EsExecutorsTests extends ESTestCase {
             assertThat(EsExecutors.executorName(thread.getName()), equalTo(executorName));
             assertThat(EsExecutors.executorName(thread), equalTo(executorName));
             assertThat(EsExecutors.executorName("TEST-" + thread.getName()), is(nullValue()));
+            assertThat(EsExecutors.executorName("LuceneTestCase" + thread.getName()), is(nullValue()));
         } finally {
             thread.join();
         }


### PR DESCRIPTION
NodeJoinTests.testConcurrentJoining use their own threads, but the thread name parsing done for validating that wait and complete of future is on different executors would pick up more or less random fields. Now disregard these test threads for that assertion.

Closes #109103
