### PR TITLE
Prevent reading or writing to a closed cache file channel

### DIFF
--- a/docs/changelog/109108.yaml
+++ b/docs/changelog/109108.yaml
@@ -1,0 +1,5 @@
+pr: 109108
+summary: Prevent reading or writing to a closed cache file channel
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
@@ -37,7 +37,7 @@ public class SharedBytesTests extends ESTestCase {
             );
             final var sharedBytesPath = nodeEnv.nodeDataPaths()[0].resolve("shared_snapshot_cache");
             assertTrue(Files.exists(sharedBytesPath));
-            sharedBytes.decRef();
+            sharedBytes.close();
             assertFalse(Files.exists(sharedBytesPath));
         }
     }


### PR DESCRIPTION
This pull request reintroduces the refcounting around the cache file channel (ie, `SharedBytes`) so that it cannot be closed while read or write operations are queued or being executed.

Thanks to `SharedBytes` already implementing `RefCounted`, we can increment the refcount of the cache file channel before populating the cache, and decrement the refcount back when all required gaps are filled and read. 

It also completes the gaps before releasing the `CacheFileRegion` and `SharedBytes`, therefore it supersedes #107359.

Relates ES-8531