### PR TITLE
Guard bootstrap plugins loading from detecting plugins cache

### DIFF
--- a/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/BootstrapJvmOptions.java
+++ b/distribution/tools/launchers/src/main/java/org/elasticsearch/tools/launchers/BootstrapJvmOptions.java
@@ -45,6 +45,10 @@ public class BootstrapJvmOptions {
         for (Path pluginDir : pluginDirs) {
             final List<String> jarFiles = new ArrayList<>();
             final Properties props = new Properties();
+            if (pluginDir.getFileName().toString().equals(".elasticsearch-plugins.yml.cache") == false) {
+                // skip plugins cache, see SyncPluginsAction
+                continue;
+            }
 
             final List<Path> pluginFiles = Files.list(pluginDir).collect(Collectors.toList());
             for (Path pluginFile : pluginFiles) {

--- a/docs/changelog/109116.yaml
+++ b/docs/changelog/109116.yaml
@@ -1,0 +1,6 @@
+pr: 109116
+summary: Guard bootstrap plugins loading from detecting plugins cache
+area: Infra/Plugins
+type: bug
+issues:
+ - 97702


### PR DESCRIPTION
This commit guards iteration over plugin infos from mistakenly trying to inspect the plugins cache file as a plugin.

closes #97702