### PR TITLE
[8.14] Revert "Revert back to using DRA repository for ML artifacts on main branch (#100752)" (#109028)

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.dra.DraResolvePlugin
 import org.elasticsearch.gradle.internal.info.BuildParams
@@ -15,42 +16,27 @@ esplugin {
   extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
 }
 
-def localRepo = providers.systemProperty('build.ml_cpp.repo').orNull
 if (useDra == false) {
   repositories {
     exclusiveContent {
-      filter {
-        includeGroup 'org.elasticsearch.ml'
-      }
       forRepository {
         ivy {
           name "ml-cpp"
+          url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
           metadataSources {
             // no repository metadata, look directly for the artifact
             artifact()
           }
-          if (localRepo) {
-            url localRepo
-            patternLayout {
-              artifact "maven/[orgPath]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"
-            }
-          } else {
-            url "https://artifacts-snapshot.elastic.co/"
-            patternLayout {
-              if (VersionProperties.isElasticsearchSnapshot()) {
-                artifact '/ml-cpp/[revision]/downloads/ml-cpp/[module]-[revision]-[classifier].[ext]'
-              } else {
-                // When building locally we always use snapshot artifacts even if passing `-Dbuild.snapshot=false`.
-                // Release builds are always done with a local repo.
-                artifact '/ml-cpp/[revision]-SNAPSHOT/downloads/ml-cpp/[module]-[revision]-SNAPSHOT-[classifier].[ext]'
-              }
-            }
+          patternLayout {
+            artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/[module]-[revision](-[classifier]).[ext]"
           }
         }
       }
+      filter {
+        includeGroup 'org.elasticsearch.ml'
+      }
     }
   }
-
 }
 
 configurations {
@@ -100,14 +86,19 @@ dependencies {
   api "org.apache.lucene:lucene-analysis-icu:${versions.lucene}"
   api "org.apache.lucene:lucene-analysis-kuromoji:${versions.lucene}"
   implementation 'org.ojalgo:ojalgo:51.2.0'
-  nativeBundle("org.elasticsearch.ml:ml-cpp:${project.version}:deps@zip") {
+  nativeBundle("org.elasticsearch.ml:ml-cpp:${mlCppVersion()}:deps@zip") {
     changing = true
   }
-  nativeBundle("org.elasticsearch.ml:ml-cpp:${project.version}:nodeps@zip") {
+  nativeBundle("org.elasticsearch.ml:ml-cpp:${mlCppVersion()}:nodeps@zip") {
     changing = true
   }
   testImplementation 'org.ini4j:ini4j:0.5.2'
   testImplementation "com.google.jimfs:jimfs:${versions.jimfs}"
+}
+
+def mlCppVersion(){
+  return (project.gradle.parent != null && BuildParams.isSnapshotBuild() == false) ?
+      (project.version + "-SNAPSHOT") : project.version;
 }
 
 artifacts {


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Revert "Revert back to using DRA repository for ML artifacts on main branch (#100752)" (#109028)