### PR TITLE
Add SearchOrgs to changelog schema

### DIFF
--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -39,6 +39,8 @@
             "EQL",
             "ES|QL",
             "Engine",
+            "Experiences",
+            "Extract&Transform",
             "FIPS",
             "Features",
             "Geo",
@@ -48,6 +50,7 @@
             "ILM+SLM",
             "IdentityProvider",
             "Indices APIs",
+            "Inference",
             "Infra/CLI",
             "Infra/Circuit Breakers",
             "Infra/Core",
@@ -76,6 +79,7 @@
             "Ranking",
             "Recovery",
             "Reindex",
+            "Relevance",
             "Rollup",
             "SQL",
             "Search",
@@ -174,7 +178,9 @@
             }
           },
           "then": {
-            "required": ["breaking"]
+            "required": [
+              "breaking"
+            ]
           }
         },
         {
@@ -186,7 +192,9 @@
             }
           },
           "then": {
-            "required": ["breaking"]
+            "required": [
+              "breaking"
+            ]
           }
         }
       ],
@@ -198,7 +206,9 @@
         }
       },
       "then": {
-        "required": ["deprecation"]
+        "required": [
+          "deprecation"
+        ]
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
Today, if you label an Elasticsearch PR with `:SearchOrg/Relevance` you will get a yaml error because `Relevance` is not a known team. The workaround is to manually edit the Changelog Yaml to `Application` to reference the previous `EnterpriseSearch/Application` team. 

This PR adds the `SearchOrg` teams to the Changelog yaml: 

- `:SearchOrg/Inference` -> `Inference`
- `:SearchOrg/Experiences` -> `Experiences`
- `:SearchOrg/Extract&Transform` -> `Extract&Transform`
- `:SearchOrg/Relevance` -> `Relevance`

I did not remove the `Application` label in case we want to keep it for legacy reasons.
