### PR TITLE
[DOCS] Fixes sparse vector query docs

### DIFF
--- a/docs/reference/query-dsl/sparse-vector-query.asciidoc
+++ b/docs/reference/query-dsl/sparse-vector-query.asciidoc
@@ -36,6 +36,7 @@ GET _search
 ----
 // TEST[skip: Requires inference]
 
+[discrete]
 === Example request using precomputed vectors
 
 [source,console]


### PR DESCRIPTION
## Overview

This PR adds a `[discrete]` flag to a level 3 section (`Example request using precomputed vectors`) in the sparse vector query docs, so the section won't be published on a separate subpage.

**BEFORE**
![Screenshot 2024-05-29 at 11 57 11](https://github.com/elastic/elasticsearch/assets/22324794/cc1fc942-1b6d-4c62-bf3b-88193d3f82ba)

**AFTER**
![Screenshot 2024-05-29 at 12 35 23](https://github.com/elastic/elasticsearch/assets/22324794/37cb34c6-8cc4-4a31-b068-48ef41d31b25)

### Preview

[Sparse vector query](https://elasticsearch_bk_109153.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-sparse-vector-query.html)