### PR TITLE
Disable index.mapper.dynamic index setting validation.

### DIFF
--- a/docs/changelog/109160.yaml
+++ b/docs/changelog/109160.yaml
@@ -1,0 +1,5 @@
+pr: 109160
+summary: Disable `index.mapper.dynamic` index setting validation
+area: Mapping
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperService.java
@@ -59,6 +59,8 @@ import java.util.stream.Collectors;
 
 public class MapperService extends AbstractIndexComponent implements Closeable {
 
+    private static final DeprecationLogger DEPRECATION_LOGGER = DeprecationLogger.getLogger(MapperService.class);
+
     /**
      * The reason why a mapping is being merged.
      */
@@ -205,7 +207,12 @@ public class MapperService extends AbstractIndexComponent implements Closeable {
 
         if (INDEX_MAPPER_DYNAMIC_SETTING.exists(indexSettings.getSettings())
             && indexSettings.getIndexVersionCreated().onOrAfter(Version.V_7_0_0)) {
-            throw new IllegalArgumentException("Setting " + INDEX_MAPPER_DYNAMIC_SETTING.getKey() + " was removed after version 6.0.0");
+            DEPRECATION_LOGGER.warn(
+                DeprecationCategory.MAPPINGS,
+                "index.mapper.dynamic",
+                "Setting {} was removed after version 6.0.0",
+                INDEX_MAPPER_DYNAMIC_SETTING.getKey()
+            );
         }
         defaultMappingSource = "{\"_default_\":{}}";
         if (logger.isTraceEnabled()) {


### PR DESCRIPTION
This setting was removed via #25734, because the setting no longer used since 6.0.0

However, the validation only kicked when trying to set this setting on a closed index. Applying the setting on an open index would just work. With severe consequences later on. For example when upgrading the cluster, nodes would refuse to boot, because the validation would kick in.

Relates to #96075