### PR TITLE
Wrap "Pattern too complex" exception into an IllegalArgumentException

### DIFF
--- a/docs/changelog/109173.yaml
+++ b/docs/changelog/109173.yaml
@@ -1,0 +1,5 @@
+pr: 109173
+summary: Wrap "Pattern too complex" exception into an `IllegalArgumentException`
+area: Mapping
+type: bug
+issues: []

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_char_filters.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/50_char_filters.yml
@@ -28,6 +28,33 @@
     - match:  { tokens.0.token: "replacedSample 6 sample1" }
 
 ---
+"pattern_replace error handling (too complex pattern)":
+  - do:
+      catch: bad_request
+      indices.create:
+        index: test_too_complex_regex_pattern
+        body:
+          settings:
+            index:
+              analysis:
+                analyzer:
+                  my_analyzer:
+                    tokenizer: standard
+                    char_filter:
+                      - my_char_filter
+                char_filter:
+                  my_char_filter:
+                    type: "pattern_replace"
+                    # This pattern intentionally uses special characters designed to throw an error.
+                    # It's expected that the pattern may not render correctly.
+                    pattern: "(\\d+)-(?=\\d\nͭͭͭͭͭͭͭͭͭͭͭͭͭͭͭ"
+                    flags: CASE_INSENSITIVE|MULTILINE|DOTALL|UNICODE_CASE|CANON_EQ
+                    replacement: "_$1"
+  - match: { status: 400 }
+  - match: { error.type: illegal_argument_exception }
+  - match: { error.reason: "Too complex regex pattern" }
+
+---
 "mapping":
     - do:
         indices.analyze:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
@@ -45,32 +45,6 @@
     - match:  { tokens.1.token: hay }
 
 ---
-"Too complex regex pattern":
-    - do:
-        catch: bad_request
-        indices.create:
-          index: test_too_complex_regex_pattern
-          body:
-            settings:
-              index:
-                analysis:
-                  analyzer:
-                    my_analyzer:
-                      tokenizer: standard
-                      char_filter:
-                        - my_char_filter
-                  char_filter:
-                    my_char_filter:
-                      type: "pattern_replace"
-                      pattern: "(\\d+)-(?=\\d\nͭͭͭͭͭͭͭͭͭͭͭͭͭͭͭ"
-                      flags: CASE_INSENSITIVE|MULTILINE|DOTALL|UNICODE_CASE|CANON_EQ
-                      replacement: "_$1"
-    - match: { status: 400 }
-    - match: { error.type: illegal_argument_exception }
-    - match: { error.reason: "Too complex regex pattern" }
-
-
----
 "Custom normalizer in request":
     - do:
         indices.analyze:

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/indices.analyze/10_analyze.yml
@@ -45,6 +45,32 @@
     - match:  { tokens.1.token: hay }
 
 ---
+"Too complex regex pattern":
+    - do:
+        catch: bad_request
+        indices.create:
+          index: test_too_complex_regex_pattern
+          body:
+            settings:
+              index:
+                analysis:
+                  analyzer:
+                    my_analyzer:
+                      tokenizer: standard
+                      char_filter:
+                        - my_char_filter
+                  char_filter:
+                    my_char_filter:
+                      type: "pattern_replace"
+                      pattern: "(\\d+)-(?=\\d\nͭͭͭͭͭͭͭͭͭͭͭͭͭͭͭ"
+                      flags: CASE_INSENSITIVE|MULTILINE|DOTALL|UNICODE_CASE|CANON_EQ
+                      replacement: "_$1"
+    - match: { status: 400 }
+    - match: { error.type: illegal_argument_exception }
+    - match: { error.reason: "Too complex regex pattern" }
+
+
+---
 "Custom normalizer in request":
     - do:
         indices.analyze:


### PR DESCRIPTION
The behavior of `java.util.regex.Pattern.:compile` has been updated in a way that make it possible too handle OutOfMemoryError errors cause by too complex pattern more gracefully and make them recoverable.
