### PR TITLE
Ban sync client calls

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/master/TransportMasterNodeAction.java
@@ -332,7 +332,9 @@ public abstract class TransportMasterNodeAction<Request extends MasterNodeReques
                         currentStateVersion
                     );
                 }
-            }, clusterState -> isTaskCancelled() || statePredicate.test(clusterState));
+                // todo: figure out if executor need to be of certain type like scaling to avoid spurious rejections
+                // (and what about shutdown).
+            }, clusterState -> isTaskCancelled() || statePredicate.test(clusterState), null, executor);
         }
 
         private boolean isTaskCancelled() {

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -121,8 +121,11 @@ public abstract class AbstractClient implements Client {
         ActionType<Response> action,
         Request request
     ) {
-        assert EsExecutors.executorName(Thread.currentThread()) == null
-            : "can only call synchronous execute on a test thread " + Thread.currentThread();
+        if (EsExecutors.executorName(Thread.currentThread()) != null) {
+            throw new IllegalStateException("can only call synchronous execute on a test thread " + Thread.currentThread());
+        }
+        // assert EsExecutors.executorName(Thread.currentThread()) == null
+        // : "can only call synchronous execute on a test thread " + Thread.currentThread();
         PlainActionFuture<Response> actionFuture = new RefCountedFuture<>();
         execute(action, request, actionFuture);
         return actionFuture;

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -121,9 +121,9 @@ public abstract class AbstractClient implements Client {
         ActionType<Response> action,
         Request request
     ) {
-        if (EsExecutors.executorName(Thread.currentThread()) != null) {
-            throw new IllegalStateException("can only call synchronous execute on a test thread " + Thread.currentThread());
-        }
+//        if (EsExecutors.executorName(Thread.currentThread()) != null) {
+//            throw new IllegalStateException("can only call synchronous execute on a test thread " + Thread.currentThread());
+//        }
         // assert EsExecutors.executorName(Thread.currentThread()) == null
         // : "can only call synchronous execute on a test thread " + Thread.currentThread();
         PlainActionFuture<Response> actionFuture = new RefCountedFuture<>();
@@ -419,10 +419,9 @@ public abstract class AbstractClient implements Client {
      */
     // todo: the use of UnsafePlainActionFuture here is quite broad, we should find a better way to be more specific
     // (unless making all usages safe is easy).
-    private static class RefCountedFuture<R extends RefCounted> extends UnsafePlainActionFuture<R> {
+    private static class RefCountedFuture<R extends RefCounted> extends PlainActionFuture<R> {
 
         private RefCountedFuture() {
-            super(ThreadPool.Names.GENERIC);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -59,7 +59,6 @@ import org.elasticsearch.action.search.TransportMultiSearchAction;
 import org.elasticsearch.action.search.TransportSearchAction;
 import org.elasticsearch.action.search.TransportSearchScrollAction;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.action.support.UnsafePlainActionFuture;
 import org.elasticsearch.action.termvectors.MultiTermVectorsAction;
 import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
 import org.elasticsearch.action.termvectors.MultiTermVectorsRequestBuilder;
@@ -76,7 +75,6 @@ import org.elasticsearch.client.internal.AdminClient;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.FilterClient;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
@@ -121,9 +119,9 @@ public abstract class AbstractClient implements Client {
         ActionType<Response> action,
         Request request
     ) {
-//        if (EsExecutors.executorName(Thread.currentThread()) != null) {
-//            throw new IllegalStateException("can only call synchronous execute on a test thread " + Thread.currentThread());
-//        }
+        // if (EsExecutors.executorName(Thread.currentThread()) != null) {
+        // throw new IllegalStateException("can only call synchronous execute on a test thread " + Thread.currentThread());
+        // }
         // assert EsExecutors.executorName(Thread.currentThread()) == null
         // : "can only call synchronous execute on a test thread " + Thread.currentThread();
         PlainActionFuture<Response> actionFuture = new RefCountedFuture<>();
@@ -421,8 +419,7 @@ public abstract class AbstractClient implements Client {
     // (unless making all usages safe is easy).
     private static class RefCountedFuture<R extends RefCounted> extends PlainActionFuture<R> {
 
-        private RefCountedFuture() {
-        }
+        private RefCountedFuture() {}
 
         @Override
         public final void onResponse(R result) {

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -76,6 +76,7 @@ import org.elasticsearch.client.internal.AdminClient;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.FilterClient;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.RefCounted;
@@ -120,6 +121,8 @@ public abstract class AbstractClient implements Client {
         ActionType<Response> action,
         Request request
     ) {
+        assert EsExecutors.executorName(Thread.currentThread()) == null
+            : "can only call synchronous execute on a test thread " + Thread.currentThread();
         PlainActionFuture<Response> actionFuture = new RefCountedFuture<>();
         execute(action, request, actionFuture);
         return actionFuture;

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -45,6 +45,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -251,7 +252,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
      *
      * NOTE: the listener is not removed on timeout. This is the responsibility of the caller.
      */
-    public void addTimeoutListener(@Nullable final TimeValue timeout, final TimeoutClusterStateListener listener) {
+    public void addTimeoutListener(@Nullable final TimeValue timeout, final TimeoutClusterStateListener listener, Executor executor) {
         if (lifecycle.stoppedOrClosed()) {
             listener.onClose();
             return;
@@ -269,7 +270,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
                         return;
                     }
                     if (timeout != null) {
-                        notifyTimeout.cancellable = threadPool.schedule(notifyTimeout, timeout, threadPool.generic());
+                        notifyTimeout.cancellable = threadPool.schedule(notifyTimeout, timeout, executor);
                     }
                     listener.postAdded();
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateObserverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateObserverTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.Predicates;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
@@ -37,7 +38,7 @@ public class ClusterStateObserverTests extends ESTestCase {
             assertThat(Arrays.toString(invocation.getArguments()), containsString("test-listener"));
             listenerAdded.set(true);
             return null;
-        }).when(clusterApplierService).addTimeoutListener(any(), any());
+        }).when(clusterApplierService).addTimeoutListener(any(), any(), any());
 
         final ClusterState clusterState = ClusterState.builder(new ClusterName("test")).nodes(DiscoveryNodes.builder()).build();
         when(clusterApplierService.state()).thenReturn(clusterState);
@@ -63,7 +64,7 @@ public class ClusterStateObserverTests extends ESTestCase {
             public String toString() {
                 return "test-listener";
             }
-        });
+        }, Predicates.always(), null, null);
 
         assertTrue(listenerAdded.get());
     }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
@@ -130,7 +130,14 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
             EnrichCache enrichCache,
             EnrichCoordinatorProxyAction.Coordinator coordinator
         ) {
-            super(NAME, clusterService, transportService, actionFilters, NodeRequest::new, threadPool.executor(ThreadPool.Names.MANAGEMENT));
+            super(
+                NAME,
+                clusterService,
+                transportService,
+                actionFilters,
+                NodeRequest::new,
+                threadPool.executor(ThreadPool.Names.MANAGEMENT)
+            );
             this.enrichCache = enrichCache;
             this.coordinator = coordinator;
         }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
@@ -130,7 +130,7 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
             EnrichCache enrichCache,
             EnrichCoordinatorProxyAction.Coordinator coordinator
         ) {
-            super(NAME, clusterService, transportService, actionFilters, NodeRequest::new, threadPool.executor(ThreadPool.Names.GENERIC));
+            super(NAME, clusterService, transportService, actionFilters, NodeRequest::new, threadPool.executor(ThreadPool.Names.MANAGEMENT));
             this.enrichCache = enrichCache;
             this.coordinator = coordinator;
         }


### PR DESCRIPTION
Sync client calls should be avoided in all production code. This commit bans them on all non-test threads as a first step.

Relates ES-8642
