### PR TITLE
[8.13] Removing server from the version compatibility table (#109168)

### DIFF
--- a/docs/reference/sql/endpoints/version-compat.asciidoc
+++ b/docs/reference/sql/endpoints/version-compat.asciidoc
@@ -1,11 +1,11 @@
-Your driver must be compatible with your {es} server version.
+Your driver must be compatible with your {es} version.
 
-IMPORTANT: The driver version cannot be newer than the {es} server version.
-For example, A 7.10.0 server is not compatible with {version} drivers.
+IMPORTANT: The driver version cannot be newer than the {es} version.
+For example, {es} version 7.10.0 is not compatible with {version} drivers.
 
 [options="header",cols="1,3a,1"]
 |====
-| {es} server version
+| {es} version
 | Compatible driver versions
 | Example
 
@@ -16,22 +16,21 @@ ifeval::[ "{minor-version}" != "8.0" ]
 | * The same version
   * Any earlier 8.x version
   * Any 7.x version after 7.7.0.
-| An {version} server is compatible with {version} and earlier 8.x drivers. An
-{version} server is also compatible with 7.7.0 and later 7.x drivers.
+| {es} {version} is compatible with {version} and earlier 8.x drivers. {es} {version} is also compatible with 7.7.0 and later 7.x drivers.
 endif::[]
 
 ifeval::[ "{minor-version}" == "8.0" ]
 | 8.0.0
 | * The same version
   * Any 7.x version after 7.7.0.
-| An 8.0.0 server is compatible with 8.0.0 drivers. An 8.0.0 server is also
+| {es} 8.0.0 is compatible with 8.0.0 drivers. {es} 8.0.0 is also
 compatible with 7.7.0 and later 7.x drivers.
 endif::[]
 
 | 7.7.1-{prev-major-last}
 | * The same version
   * An earlier 7.x version, back to 7.7.0.
-| A 7.10.0 server is compatible with 7.7.0-7.10.0 drivers.
+| {es} 7.10.0 is compatible with 7.7.0-7.10.0 drivers.
 
 endif::[]
 
@@ -39,10 +38,10 @@ ifeval::[ "{major-version}" == "7.x" ]
 | 7.7.1-{version}
 | * The same version
   * An earlier 7.x version, back to 7.7.0.
-| A 7.10.0 server is compatible with 7.7.0-7.10.0 drivers.
+| {es} 7.10.0 is compatible with 7.7.0-7.10.0 drivers.
 endif::[]
 
 | 7.7.0 and earlier versions
 | * The same version.
-| A 7.6.1 server is only compatible with 7.6.1 drivers.
+| {es} 7.6.1 is only compatible with 7.6.1 drivers.
 |====


### PR DESCRIPTION
Backports the following commits to 8.13:
 - Removing server from the version compatibility table (#109168)