### PR TITLE
ESQL: Move serialization of DataType

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -7,12 +7,16 @@
 
 package org.elasticsearch.xpack.esql.core.type;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.search.sort.ScriptSortBuilder;
 
+import java.io.IOException;
 import java.util.Locale;
 import java.util.Objects;
 
-public class DataType {
+public class DataType implements Writeable {
 
     private final String typeName;
 
@@ -117,5 +121,22 @@ public class DataType {
     @Override
     public String toString() {
         return name;
+    }
+
+    public static DataType readFrom(StreamInput in) throws IOException {
+        String name = in.readString();
+        if (name.equalsIgnoreCase(DataTypes.DOC_DATA_TYPE.name())) {
+            return DataTypes.DOC_DATA_TYPE;
+        }
+        DataType dataType = DataTypes.fromTypeName(name);
+        if (dataType == null) {
+            throw new IOException("Unknown DataType for type name: " + name);
+        }
+        return dataType;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(typeName);
     }
 }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataTypes.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataTypes.java
@@ -78,6 +78,9 @@ public final class DataTypes {
     public static final DataType COUNTER_INTEGER = new DataType("counter_integer", Integer.BYTES, false, false, true);
     public static final DataType COUNTER_DOUBLE = new DataType("counter_double", Double.BYTES, false, false, true);
 
+    public static final DataType DOC_DATA_TYPE = new DataType("_doc", Integer.BYTES * 3, false, false, false);
+    public static final DataType TSID_DATA_TYPE = new DataType("_tsid", Integer.MAX_VALUE, false, false, true);
+
     private static final Collection<DataType> TYPES = Stream.of(
         UNSUPPORTED,
         NULL,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -1070,7 +1070,7 @@ public final class PlanNamedTypes {
             Source.readFrom(in),
             in.readOptionalWithReader(PlanNamedTypes::readFieldAttribute),
             in.readString(),
-            in.dataTypeFromTypeName(in.readString()),
+            DataType.readFrom(in),
             in.readEsFieldNamed(),
             in.readOptionalString(),
             in.readEnum(Nullability.class),
@@ -1095,7 +1095,7 @@ public final class PlanNamedTypes {
         return new ReferenceAttribute(
             Source.readFrom(in),
             in.readString(),
-            in.dataTypeFromTypeName(in.readString()),
+            DataType.readFrom(in),
             in.readOptionalString(),
             in.readEnum(Nullability.class),
             in.nameIdFromLongValue(in.readLong()),
@@ -1117,7 +1117,7 @@ public final class PlanNamedTypes {
         return new MetadataAttribute(
             Source.readFrom(in),
             in.readString(),
-            in.dataTypeFromTypeName(in.readString()),
+            DataType.readFrom(in),
             in.readOptionalString(),
             in.readEnum(Nullability.class),
             in.nameIdFromLongValue(in.readLong()),
@@ -1160,7 +1160,7 @@ public final class PlanNamedTypes {
     static EsField readEsField(PlanStreamInput in) throws IOException {
         return new EsField(
             in.readString(),
-            in.dataTypeFromTypeName(in.readString()),
+            DataType.readFrom(in),
             in.readImmutableMap(StreamInput::readString, readerFromPlanReader(PlanStreamInput::readEsFieldNamed)),
             in.readBoolean(),
             in.readBoolean()
@@ -1875,7 +1875,7 @@ public final class PlanNamedTypes {
     static Literal readLiteral(PlanStreamInput in) throws IOException {
         Source source = Source.readFrom(in);
         Object value = in.readGenericValue();
-        DataType dataType = in.dataTypeFromTypeName(in.readString());
+        DataType dataType = DataType.readFrom(in);
         return new Literal(source, mapToLiteralValue(in, dataType, value), dataType);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanStreamInput.java
@@ -30,14 +30,11 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanNamedReader;
 import org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanReader;
-import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.PhysicalPlan;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -95,19 +92,6 @@ public final class PlanStreamInput extends NamedWriteableAwareStreamInput
 
     NameId nameIdFromLongValue(long value) {
         return nameIdFunction.apply(value);
-    }
-
-    DataType dataTypeFromTypeName(String typeName) throws IOException {
-        DataType dataType;
-        if (typeName.equalsIgnoreCase(EsQueryExec.DOC_DATA_TYPE.name())) {
-            dataType = EsQueryExec.DOC_DATA_TYPE;
-        } else {
-            dataType = EsqlDataTypes.fromTypeName(typeName);
-        }
-        if (dataType == null) {
-            throw new IOException("Unknown DataType for type name: " + typeName);
-        }
-        return dataType;
     }
 
     public LogicalPlan readLogicalPlanNode() throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xpack.esql.core.querydsl.container.Sort;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.NodeUtils;
 import org.elasticsearch.xpack.esql.core.tree.Source;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
 import org.elasticsearch.xpack.esql.core.type.EsField;
 
@@ -29,11 +28,8 @@ import java.util.Map;
 import java.util.Objects;
 
 public class EsQueryExec extends LeafExec implements EstimatesRowSize {
-    public static final DataType DOC_DATA_TYPE = new DataType("_doc", Integer.BYTES * 3, false, false, false);
-    public static final DataType TSID_DATA_TYPE = new DataType("_tsid", Integer.MAX_VALUE, false, false, true);
-
-    static final EsField DOC_ID_FIELD = new EsField("_doc", DOC_DATA_TYPE, Map.of(), false);
-    static final EsField TSID_FIELD = new EsField("_tsid", TSID_DATA_TYPE, Map.of(), true);
+    static final EsField DOC_ID_FIELD = new EsField("_doc", DataTypes.DOC_DATA_TYPE, Map.of(), false);
+    static final EsField TSID_FIELD = new EsField("_tsid", DataTypes.TSID_DATA_TYPE, Map.of(), true);
     static final EsField TIMESTAMP_FIELD = new EsField("@timestamp", DataTypes.DATETIME, Map.of(), true);
     static final EsField INTERVAL_FIELD = new EsField("@timestamp_interval", DataTypes.DATETIME, Map.of(), true);
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -39,7 +39,6 @@ import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.physical.AggregateExec;
-import org.elasticsearch.xpack.esql.plan.physical.EsQueryExec;
 import org.elasticsearch.xpack.esql.plan.physical.EsSourceExec;
 import org.elasticsearch.xpack.esql.plan.physical.EstimatesRowSize;
 import org.elasticsearch.xpack.esql.plan.physical.ExchangeExec;
@@ -268,10 +267,10 @@ public class PlannerUtils {
         if (dataType == DataTypes.BOOLEAN) {
             return ElementType.BOOLEAN;
         }
-        if (dataType == EsQueryExec.DOC_DATA_TYPE) {
+        if (dataType == DataTypes.DOC_DATA_TYPE) {
             return ElementType.DOC;
         }
-        if (dataType == EsQueryExec.TSID_DATA_TYPE) {
+        if (dataType == DataTypes.TSID_DATA_TYPE) {
             return ElementType.BYTES_REF;
         }
         if (EsqlDataTypes.isSpatialPoint(dataType)) {


### PR DESCRIPTION
This moves the serialization of `DataType` from `PlanNamedTypes` and into `DataType` itself to better align with the rest of Elasticsearch.
