### PR TITLE
[8.14] Guard against a null scorer in painless execute (#109048)

### DIFF
--- a/docs/changelog/109048.yaml
+++ b/docs/changelog/109048.yaml
@@ -1,0 +1,6 @@
+pr: 109048
+summary: Guard against a null scorer in painless execute
+area: Infra/Scripting
+type: bug
+issues:
+ - 43541

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -648,6 +648,9 @@ public class PainlessExecuteAction {
                         luceneQuery = indexSearcher.rewrite(luceneQuery);
                         Weight weight = indexSearcher.createWeight(luceneQuery, ScoreMode.COMPLETE, 1f);
                         Scorer scorer = weight.scorer(indexSearcher.getIndexReader().leaves().get(0));
+                        if (scorer == null) {
+                            throw new IllegalArgumentException("The provided query did not match the sample document");
+                        }
                         // Consume the first (and only) match.
                         int docID = scorer.iterator().nextDoc();
                         assert docID == scorer.docID();


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Guard against a null scorer in painless execute (#109048)