### PR TITLE
Reduce slow `OutboundHandler` warnings to `DEBUG`

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -260,12 +260,15 @@ final class OutboundHandler {
                 }
 
                 private void maybeLogSlowMessage(boolean success) {
+                    if (logger.isDebugEnabled() == false) {
+                        return;
+                    }
                     final long logThreshold = slowLogThresholdMs;
                     if (logThreshold > 0) {
                         final long took = threadPool.rawRelativeTimeInMillis() - startTime;
                         handlingTimeTracker.addHandlingTime(took);
                         if (took > logThreshold) {
-                            logger.warn(
+                            logger.debug(
                                 "sending transport message [{}] of size [{}] on [{}] took [{}ms] which is above the warn "
                                     + "threshold of [{}ms] with success [{}]",
                                 message,

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TransportVersionUtils;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
@@ -533,12 +534,13 @@ public class OutboundHandlerTests extends ESTestCase {
      */
     private static final String EXPECTED_LOGGER_NAME = "org.elasticsearch.transport.OutboundHandler";
 
+    @TestLogging(reason = "asserting DEBUG logging", value = EXPECTED_LOGGER_NAME + ":DEBUG")
     public void testSlowLogOutboundMessage() throws Exception {
         handler.setSlowLogThreshold(TimeValue.timeValueMillis(5L));
 
         try (var mockLog = MockLog.capture(OutboundHandler.class)) {
             mockLog.addExpectation(
-                new MockLog.SeenEventExpectation("expected message", EXPECTED_LOGGER_NAME, Level.WARN, "sending transport message ")
+                new MockLog.SeenEventExpectation("expected message", EXPECTED_LOGGER_NAME, Level.DEBUG, "sending transport message ")
             );
 
             final int length = randomIntBetween(1, 100);


### PR DESCRIPTION
These warnings can be very noisy, but in practice they don't seem to
help pin down any specific problem with the use of network threads and
indeed the problems the report can be indistinguishable from network
congestion.

This commit changes the log level to `DEBUG` to reduce the noise in this
area.