### PR TITLE
ESQL: Allow evaluators to return null

### DIFF
--- a/docs/changelog/109209.yaml
+++ b/docs/changelog/109209.yaml
@@ -1,0 +1,5 @@
+pr: 109209
+summary: "ESQL: Allow evaluators to return null"
+area: ES|QL
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/ConvertEvaluator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/ConvertEvaluator.java
@@ -26,6 +26,12 @@ public @interface ConvertEvaluator {
     String extraName() default "";
 
     /**
+     * True if the process method may return null, false otherwise.
+     * Defaults to false.
+     */
+    boolean nullableReturn() default false;
+
+    /**
      * Exceptions thrown by the process method to catch and convert
      * into a warning and turn into a null value.
      */

--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Evaluator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/Evaluator.java
@@ -38,6 +38,12 @@ public @interface Evaluator {
     String extraName() default "";
 
     /**
+     * True if the process method may return null, false otherwise.
+     * Defaults to false.
+     */
+    boolean nullableReturn() default false;
+
+    /**
      * Exceptions thrown by the process method to catch and convert
      * into a warning and turn into a null value.
      */

--- a/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/MvEvaluator.java
+++ b/x-pack/plugin/esql/compute/ann/src/main/java/org/elasticsearch/compute/ann/MvEvaluator.java
@@ -75,6 +75,12 @@ public @interface MvEvaluator {
     String ascending() default "";
 
     /**
+     * True if the process method may return null, false otherwise.
+     * Defaults to false.
+     */
+    boolean nullableReturn() default false;
+
+    /**
      * Exceptions thrown by the process method to catch and convert
      * into a warning and turn into a null value.
      */

--- a/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorImplementer.java
+++ b/x-pack/plugin/esql/compute/gen/src/main/java/org/elasticsearch/compute/gen/EvaluatorImplementer.java
@@ -1050,7 +1050,7 @@ public class EvaluatorImplementer {
             if (builderArg != null) {
                 return builderArg.type.enclosingClassName();
             }
-            boolean useBlockStyle = blockStyle || nullableReturn ||  warnExceptions.isEmpty() == false;
+            boolean useBlockStyle = blockStyle || nullableReturn || warnExceptions.isEmpty() == false;
             return useBlockStyle ? blockType(TypeName.get(function.getReturnType())) : vectorType(TypeName.get(function.getReturnType()));
         }
     }


### PR DESCRIPTION
# Changes
Added a "nullableReturn" attribute to the *Evaluator annotations, that mark the evaluator as "possibly returning null".
Implementers without the nullableReturn flag won't be changed.

# Reasons
Before, it would throw a NPE (Identified in https://github.com/elastic/elasticsearch/pull/109174).

Currently, the only way to return null from a function is using a Builder parameter, or using `warnExceptions` (Which is for, warnings, not for nulls, anyway).

# Do not merge
I didn't identify an existing case for this, as the substring one was fixed instead to not return null, and for that reason none was implemented yet, and this PR won't be merged yet


