### PR TITLE
set default value of cluster.routing.allocation.cluster_concurrent_rebalance to -1

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/ConcurrentRebalanceAllocationDecider.java
@@ -34,9 +34,11 @@ public class ConcurrentRebalanceAllocationDecider extends AllocationDecider {
 
     public static final String NAME = "concurrent_rebalance";
 
+    public static final int DEFAULT_CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE = -1;
+
     public static final Setting<Integer> CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE_SETTING = Setting.intSetting(
         "cluster.routing.allocation.cluster_concurrent_rebalance",
-        2,
+        DEFAULT_CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE,
         -1,
         Property.Dynamic,
         Property.NodeScope

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AddIncrementallyTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AddIncrementallyTests.java
@@ -154,7 +154,8 @@ public class AddIncrementallyTests extends ESAllocationTestCase {
             ClusterRebalanceAllocationDecider.ClusterRebalanceType.ALWAYS.toString()
         )
             .put("cluster.routing.allocation.node_concurrent_recoveries", 100)
-            .put("cluster.routing.allocation.node_initial_primaries_recoveries", 100);
+            .put("cluster.routing.allocation.node_initial_primaries_recoveries", 100)
+            .put("cluster.routing.allocation.cluster_concurrent_rebalance", 2);
         AllocationService service = createAllocationService(settings.build());
 
         ClusterState clusterState = initCluster(service, 1, 3, 3, 1);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -1238,7 +1238,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
             assertThat(
                 "Reconciling nodes should all have same amount (max 1 delta) of moves: " + totalOutgoingMoves,
                 summary.getMax() - summary.getMin(),
-                lessThanOrEqualTo(1)
+                lessThanOrEqualTo(numberOfNodes)
             );
 
             totalOutgoingMoves.keySet().removeIf(nodeId -> isReconciled(allocation.routingNodes().node(nodeId), balance));


### PR DESCRIPTION
 Default value  for cluster.routing.allocation.cluster_concurrent_rebalance is set to -1, in effect disabling "cluster_concurrent_rebalance" bound .  As a default behaviour throttling is controlled by 
` cluster.routing.allocation.node_concurrent_incoming_recoveries / cluster.routing.allocation.node_concurrent_outgoing_recoveries`. 

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
   ✅ 
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
   ✅ 
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
  ✅ 
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
✅ 
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.


Issue : https://github.com/elastic/elasticsearch/issues/97750
