### PR TITLE
Fix API key assertion in QA 

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKey.java
@@ -103,7 +103,7 @@ public final class ApiKey implements ToXContentObject {
         }
     }
 
-    public static final ApiKey.Version CURRENT_API_KEY_VERSION = new ApiKey.Version(8_13_00_99);
+    public static final ApiKey.Version CURRENT_API_KEY_VERSION = new ApiKey.Version(8_15_00_99);
 
     private final String name;
     private final String id;


### PR DESCRIPTION
In [this](https://github.com/elastic/elasticsearch/pull/104156) PR the API key version was decoupled from the node version. The version was set to [8_13_00_99](https://github.com/elastic/elasticsearch/pull/104156/files#diff-e7022f056f405c6c7fa8ecdbe8680faf085c69453c765bb86e236e00571fac8bR106) but while the PR was in review the node version was [increased passed](https://github.com/elastic/elasticsearch/blob/32deb7fa465913aac8fdbb6b6eecc848706f17fd/server/src/main/java/org/elasticsearch/Version.java#L177) that, so API keys were created with a version > `8_13_00_99`. The API keys created with the higher version number before the change then triggers [this](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java#L1617) assertion in QA when updated. 

The fix is to set the API key version to something >= current node version. 