### PR TITLE
More detailed apm spans for cluster state updates

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/APMJvmOptions.java
@@ -77,10 +77,10 @@ class APMJvmOptions {
         "log_level", "warn",
         "log_format_file", "JSON",
         "application_packages", "org.elasticsearch,org.apache.lucene",
-        "metrics_interval", "120s",
+        "metrics_interval", "5s",
         "breakdown_metrics", "false",
         "central_config", "false",
-        "transaction_sample_rate", "0.2"
+        "transaction_sample_rate", "1.0"
         );
     // end::noformat
 

--- a/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
+++ b/modules/apm/src/main/java/org/elasticsearch/telemetry/apm/internal/tracing/APMTracer.java
@@ -103,6 +103,10 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
         }
     }
 
+    public boolean isEnabled() {
+        return enabled;
+    }
+
     public void setIncludeNames(List<String> includeNames) {
         this.includeNames = includeNames;
         this.filterAutomaton = buildAutomaton(includeNames, excludeNames);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -99,310 +99,306 @@ public class DesiredBalanceComputer {
             logger.debug("Recomputing desired balance for [{}]", desiredBalanceInput.index());
         }
 
-        return TracerSpan.span(
-            threadPool,
-            tracer,
-            "compute-desired-balance",
-            Map.of("desired-balance-index", desiredBalanceInput.index()),
-            () -> {
-                final var routingAllocation = desiredBalanceInput.routingAllocation().mutableCloneForSimulation();
-                final var routingNodes = routingAllocation.routingNodes();
-                final var knownNodeIds = routingNodes.getAllNodeIds();
-                final var changes = routingAllocation.changes();
-                final var ignoredShards = getIgnoredShardsWithDiscardedAllocationStatus(desiredBalanceInput.ignoredShards());
-                final var clusterInfoSimulator = new ClusterInfoSimulator(routingAllocation);
+        try (
+            var span = TracerSpan.span(
+                threadPool,
+                tracer,
+                "compute-desired-balance",
+                Map.of("desired-balance-index", desiredBalanceInput.index())
+            )
+        ) {
+            final var routingAllocation = desiredBalanceInput.routingAllocation().mutableCloneForSimulation();
+            final var routingNodes = routingAllocation.routingNodes();
+            final var knownNodeIds = routingNodes.getAllNodeIds();
+            final var changes = routingAllocation.changes();
+            final var ignoredShards = getIgnoredShardsWithDiscardedAllocationStatus(desiredBalanceInput.ignoredShards());
+            final var clusterInfoSimulator = new ClusterInfoSimulator(routingAllocation);
 
-                if (routingNodes.size() == 0) {
-                    return new DesiredBalance(desiredBalanceInput.index(), Map.of());
+            if (routingNodes.size() == 0) {
+                return new DesiredBalance(desiredBalanceInput.index(), Map.of());
+            }
+
+            // we assume that all ongoing recoveries will complete
+            for (final var routingNode : routingNodes) {
+                for (final var shardRouting : routingNode) {
+                    if (shardRouting.initializing()) {
+                        clusterInfoSimulator.simulateShardStarted(shardRouting);
+                        routingNodes.startShard(shardRouting, changes, 0L);
+                    }
+                }
+            }
+
+            // we are not responsible for allocating unassigned primaries of existing shards, and we're only responsible for allocating
+            // unassigned replicas if the ReplicaShardAllocator gives up, so we must respect these ignored shards
+            final var unassignedPrimaries = new HashSet<ShardId>();
+            final var shardRoutings = new HashMap<ShardId, ShardRoutings>();
+            for (final var primary : new boolean[] { true, false }) {
+                final RoutingNodes.UnassignedShards unassigned = routingNodes.unassigned();
+                for (final var iterator = unassigned.iterator(); iterator.hasNext();) {
+                    final var shardRouting = iterator.next();
+                    if (shardRouting.primary() == primary) {
+                        var lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
+                        if (knownNodeIds.contains(lastAllocatedNodeId)
+                            || ignoredShards.contains(discardAllocationStatus(shardRouting)) == false) {
+                            shardRoutings.computeIfAbsent(shardRouting.shardId(), ShardRoutings::new).unassigned().add(shardRouting);
+                        } else {
+                            iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, changes);
+                            if (shardRouting.primary()) {
+                                unassignedPrimaries.add(shardRouting.shardId());
+                            }
+                        }
+                    }
+                }
+            }
+
+            for (final var assigned : routingNodes.getAssignedShards().entrySet()) {
+                shardRoutings.computeIfAbsent(assigned.getKey(), ShardRoutings::new).assigned().addAll(assigned.getValue());
+            }
+
+            // we can assume that all possible shards will be allocated/relocated to one of their desired locations
+            final var unassignedShardsToInitialize = new HashMap<ShardRouting, LinkedList<String>>();
+            for (final var entry : shardRoutings.entrySet()) {
+                final var shardId = entry.getKey();
+                final var routings = entry.getValue();
+
+                // treemap (keyed by node ID) so that we are consistent about the order of future relocations
+                final var shardsToRelocate = new TreeMap<String, ShardRouting>();
+                final var assignment = previousDesiredBalance.getAssignment(shardId);
+
+                // treeset (ordered by node ID) so that we are consistent about the order of future relocations
+                final var targetNodes = assignment != null ? new TreeSet<>(assignment.nodeIds()) : new TreeSet<String>();
+                targetNodes.retainAll(knownNodeIds);
+
+                // preserving last known shard location as a starting point to avoid unnecessary relocations
+                for (ShardRouting shardRouting : routings.unassigned()) {
+                    var lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
+                    if (knownNodeIds.contains(lastAllocatedNodeId)) {
+                        targetNodes.add(lastAllocatedNodeId);
+                    }
                 }
 
-                // we assume that all ongoing recoveries will complete
+                for (final var shardRouting : routings.assigned()) {
+                    assert shardRouting.started();
+                    if (targetNodes.remove(shardRouting.currentNodeId()) == false) {
+                        final var previousShard = shardsToRelocate.put(shardRouting.currentNodeId(), shardRouting);
+                        assert previousShard == null : "duplicate shards to relocate: " + shardRouting + " vs " + previousShard;
+                    }
+                }
+
+                final var targetNodesIterator = targetNodes.iterator();
+
+                // Here existing shards are moved to desired locations before initializing unassigned shards because we prefer not to
+                // leave
+                // immovable shards allocated to undesirable locations (e.g. a node that is shutting down or an allocation filter which
+                // was
+                // only recently applied). In contrast, reconciliation prefers to initialize the unassigned shards first.
+                relocateToDesiredLocation: for (final var shardRouting : shardsToRelocate.values()) {
+                    assert shardRouting.started();
+
+                    while (targetNodesIterator.hasNext()) {
+                        final var targetNodeId = targetNodesIterator.next();
+                        final var targetNode = routingNodes.node(targetNodeId);
+                        if (targetNode != null
+                            && routingAllocation.deciders()
+                                .canAllocate(shardRouting, targetNode, routingAllocation)
+                                .type() != Decision.Type.NO) {
+                            final var shardToRelocate = routingNodes.relocateShard(shardRouting, targetNodeId, 0L, "computation", changes)
+                                .v2();
+                            clusterInfoSimulator.simulateShardStarted(shardToRelocate);
+                            routingNodes.startShard(shardToRelocate, changes, 0L);
+                            continue relocateToDesiredLocation;
+                        }
+                    }
+                }
+
+                for (final var shardRouting : routings.unassigned()) {
+                    assert shardRouting.unassigned();
+                    if (targetNodesIterator.hasNext()) {
+                        unassignedShardsToInitialize.computeIfAbsent(shardRouting, ignored -> new LinkedList<>())
+                            .add(targetNodesIterator.next());
+                    } else {
+                        break;
+                    }
+                }
+            }
+
+            final var unassignedPrimaryIterator = routingNodes.unassigned().iterator();
+            while (unassignedPrimaryIterator.hasNext()) {
+                final var shardRouting = unassignedPrimaryIterator.next();
+                if (shardRouting.primary()) {
+                    final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
+                    if (nodeIds != null && nodeIds.isEmpty() == false) {
+                        final var nodeId = nodeIds.removeFirst();
+                        final var routingNode = routingNodes.node(nodeId);
+                        if (routingNode != null
+                            && routingAllocation.deciders()
+                                .canAllocate(shardRouting, routingNode, routingAllocation)
+                                .type() != Decision.Type.NO) {
+                            final var shardToInitialize = unassignedPrimaryIterator.initialize(nodeId, null, 0L, changes);
+                            clusterInfoSimulator.simulateShardStarted(shardToInitialize);
+                            routingNodes.startShard(shardToInitialize, changes, 0L);
+                        }
+                    }
+                }
+            }
+
+            final var unassignedReplicaIterator = routingNodes.unassigned().iterator();
+            while (unassignedReplicaIterator.hasNext()) {
+                final var shardRouting = unassignedReplicaIterator.next();
+                if (unassignedPrimaries.contains(shardRouting.shardId()) == false) {
+                    final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
+                    if (nodeIds != null && nodeIds.isEmpty() == false) {
+                        final var nodeId = nodeIds.removeFirst();
+                        final var routingNode = routingNodes.node(nodeId);
+                        if (routingNode != null
+                            && routingAllocation.deciders()
+                                .canAllocate(shardRouting, routingNode, routingAllocation)
+                                .type() != Decision.Type.NO) {
+                            final var shardToInitialize = unassignedReplicaIterator.initialize(nodeId, null, 0L, changes);
+                            clusterInfoSimulator.simulateShardStarted(shardToInitialize);
+                            routingNodes.startShard(shardToInitialize, changes, 0L);
+                        }
+                    }
+                }
+            }
+
+            List<MoveAllocationCommand> commands;
+            while ((commands = pendingDesiredBalanceMoves.poll()) != null) {
+                for (MoveAllocationCommand command : commands) {
+                    try {
+                        command.execute(routingAllocation, false);
+                    } catch (RuntimeException e) {
+                        logger.debug(
+                            () -> "move shard ["
+                                + command.index()
+                                + ":"
+                                + command.shardId()
+                                + "] command failed during applying it to the desired balance",
+                            e
+                        );
+                    }
+                }
+            }
+
+            final int iterationCountReportInterval = computeIterationCountReportInterval(routingAllocation);
+            final long timeWarningInterval = progressLogInterval.millis();
+            final long computationStartedTime = threadPool.relativeTimeInMillis();
+            long nextReportTime = computationStartedTime + timeWarningInterval;
+
+            int i = 0;
+            boolean hasChanges = false;
+            while (true) {
+                if (hasChanges) {
+                    // Not the first iteration, so every remaining unassigned shard has been ignored, perhaps due to throttling. We must
+                    // bring
+                    // them all back out of the ignored list to give the allocator another go...
+                    routingNodes.unassigned().resetIgnored();
+
+                    // ... but not if they're ignored because they're out of scope for allocation
+                    for (final var iterator = routingNodes.unassigned().iterator(); iterator.hasNext();) {
+                        final var shardRouting = iterator.next();
+                        if (ignoredShards.contains(discardAllocationStatus(shardRouting))) {
+                            iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, changes);
+                        }
+                    }
+                }
+
+                routingAllocation.setSimulatedClusterInfo(clusterInfoSimulator.getClusterInfo());
+                try (var nestedSpan = TracerSpan.span(threadPool, tracer, "running-delegate-allocator")) {
+                    logger.trace("running delegate allocator");
+                    delegateAllocator.allocate(routingAllocation);
+                    assert routingNodes.unassigned().isEmpty(); // any unassigned shards should now be ignored
+                }
+
+                hasChanges = false;
                 for (final var routingNode : routingNodes) {
                     for (final var shardRouting : routingNode) {
                         if (shardRouting.initializing()) {
+                            hasChanges = true;
                             clusterInfoSimulator.simulateShardStarted(shardRouting);
                             routingNodes.startShard(shardRouting, changes, 0L);
                         }
                     }
                 }
 
-                // we are not responsible for allocating unassigned primaries of existing shards, and we're only responsible for allocating
-                // unassigned replicas if the ReplicaShardAllocator gives up, so we must respect these ignored shards
-                final var unassignedPrimaries = new HashSet<ShardId>();
-                final var shardRoutings = new HashMap<ShardId, ShardRoutings>();
-                for (final var primary : new boolean[] { true, false }) {
-                    final RoutingNodes.UnassignedShards unassigned = routingNodes.unassigned();
-                    for (final var iterator = unassigned.iterator(); iterator.hasNext();) {
-                        final var shardRouting = iterator.next();
-                        if (shardRouting.primary() == primary) {
-                            var lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
-                            if (knownNodeIds.contains(lastAllocatedNodeId)
-                                || ignoredShards.contains(discardAllocationStatus(shardRouting)) == false) {
-                                shardRoutings.computeIfAbsent(shardRouting.shardId(), ShardRoutings::new).unassigned().add(shardRouting);
-                            } else {
-                                iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, changes);
-                                if (shardRouting.primary()) {
-                                    unassignedPrimaries.add(shardRouting.shardId());
-                                }
-                            }
-                        }
-                    }
+                i++;
+                final int iterations = i;
+                final long currentTime = threadPool.relativeTimeInMillis();
+                final boolean reportByTime = nextReportTime <= currentTime;
+                final boolean reportByIterationCount = i % iterationCountReportInterval == 0;
+                if (reportByTime || reportByIterationCount) {
+                    nextReportTime = currentTime + timeWarningInterval;
                 }
 
-                for (final var assigned : routingNodes.getAssignedShards().entrySet()) {
-                    shardRoutings.computeIfAbsent(assigned.getKey(), ShardRoutings::new).assigned().addAll(assigned.getValue());
-                }
-
-                // we can assume that all possible shards will be allocated/relocated to one of their desired locations
-                final var unassignedShardsToInitialize = new HashMap<ShardRouting, LinkedList<String>>();
-                for (final var entry : shardRoutings.entrySet()) {
-                    final var shardId = entry.getKey();
-                    final var routings = entry.getValue();
-
-                    // treemap (keyed by node ID) so that we are consistent about the order of future relocations
-                    final var shardsToRelocate = new TreeMap<String, ShardRouting>();
-                    final var assignment = previousDesiredBalance.getAssignment(shardId);
-
-                    // treeset (ordered by node ID) so that we are consistent about the order of future relocations
-                    final var targetNodes = assignment != null ? new TreeSet<>(assignment.nodeIds()) : new TreeSet<String>();
-                    targetNodes.retainAll(knownNodeIds);
-
-                    // preserving last known shard location as a starting point to avoid unnecessary relocations
-                    for (ShardRouting shardRouting : routings.unassigned()) {
-                        var lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
-                        if (knownNodeIds.contains(lastAllocatedNodeId)) {
-                            targetNodes.add(lastAllocatedNodeId);
-                        }
-                    }
-
-                    for (final var shardRouting : routings.assigned()) {
-                        assert shardRouting.started();
-                        if (targetNodes.remove(shardRouting.currentNodeId()) == false) {
-                            final var previousShard = shardsToRelocate.put(shardRouting.currentNodeId(), shardRouting);
-                            assert previousShard == null : "duplicate shards to relocate: " + shardRouting + " vs " + previousShard;
-                        }
-                    }
-
-                    final var targetNodesIterator = targetNodes.iterator();
-
-                    // Here existing shards are moved to desired locations before initializing unassigned shards because we prefer not to
-                    // leave
-                    // immovable shards allocated to undesirable locations (e.g. a node that is shutting down or an allocation filter which
-                    // was
-                    // only recently applied). In contrast, reconciliation prefers to initialize the unassigned shards first.
-                    relocateToDesiredLocation: for (final var shardRouting : shardsToRelocate.values()) {
-                        assert shardRouting.started();
-
-                        while (targetNodesIterator.hasNext()) {
-                            final var targetNodeId = targetNodesIterator.next();
-                            final var targetNode = routingNodes.node(targetNodeId);
-                            if (targetNode != null
-                                && routingAllocation.deciders()
-                                    .canAllocate(shardRouting, targetNode, routingAllocation)
-                                    .type() != Decision.Type.NO) {
-                                final var shardToRelocate = routingNodes.relocateShard(
-                                    shardRouting,
-                                    targetNodeId,
-                                    0L,
-                                    "computation",
-                                    changes
-                                ).v2();
-                                clusterInfoSimulator.simulateShardStarted(shardToRelocate);
-                                routingNodes.startShard(shardToRelocate, changes, 0L);
-                                continue relocateToDesiredLocation;
-                            }
-                        }
-                    }
-
-                    for (final var shardRouting : routings.unassigned()) {
-                        assert shardRouting.unassigned();
-                        if (targetNodesIterator.hasNext()) {
-                            unassignedShardsToInitialize.computeIfAbsent(shardRouting, ignored -> new LinkedList<>())
-                                .add(targetNodesIterator.next());
-                        } else {
-                            break;
-                        }
-                    }
-                }
-
-                final var unassignedPrimaryIterator = routingNodes.unassigned().iterator();
-                while (unassignedPrimaryIterator.hasNext()) {
-                    final var shardRouting = unassignedPrimaryIterator.next();
-                    if (shardRouting.primary()) {
-                        final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
-                        if (nodeIds != null && nodeIds.isEmpty() == false) {
-                            final var nodeId = nodeIds.removeFirst();
-                            final var routingNode = routingNodes.node(nodeId);
-                            if (routingNode != null
-                                && routingAllocation.deciders()
-                                    .canAllocate(shardRouting, routingNode, routingAllocation)
-                                    .type() != Decision.Type.NO) {
-                                final var shardToInitialize = unassignedPrimaryIterator.initialize(nodeId, null, 0L, changes);
-                                clusterInfoSimulator.simulateShardStarted(shardToInitialize);
-                                routingNodes.startShard(shardToInitialize, changes, 0L);
-                            }
-                        }
-                    }
-                }
-
-                final var unassignedReplicaIterator = routingNodes.unassigned().iterator();
-                while (unassignedReplicaIterator.hasNext()) {
-                    final var shardRouting = unassignedReplicaIterator.next();
-                    if (unassignedPrimaries.contains(shardRouting.shardId()) == false) {
-                        final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
-                        if (nodeIds != null && nodeIds.isEmpty() == false) {
-                            final var nodeId = nodeIds.removeFirst();
-                            final var routingNode = routingNodes.node(nodeId);
-                            if (routingNode != null
-                                && routingAllocation.deciders()
-                                    .canAllocate(shardRouting, routingNode, routingAllocation)
-                                    .type() != Decision.Type.NO) {
-                                final var shardToInitialize = unassignedReplicaIterator.initialize(nodeId, null, 0L, changes);
-                                clusterInfoSimulator.simulateShardStarted(shardToInitialize);
-                                routingNodes.startShard(shardToInitialize, changes, 0L);
-                            }
-                        }
-                    }
-                }
-
-                List<MoveAllocationCommand> commands;
-                while ((commands = pendingDesiredBalanceMoves.poll()) != null) {
-                    for (MoveAllocationCommand command : commands) {
-                        try {
-                            command.execute(routingAllocation, false);
-                        } catch (RuntimeException e) {
-                            logger.debug(
-                                () -> "move shard ["
-                                    + command.index()
-                                    + ":"
-                                    + command.shardId()
-                                    + "] command failed during applying it to the desired balance",
-                                e
-                            );
-                        }
-                    }
-                }
-
-                final int iterationCountReportInterval = computeIterationCountReportInterval(routingAllocation);
-                final long timeWarningInterval = progressLogInterval.millis();
-                final long computationStartedTime = threadPool.relativeTimeInMillis();
-                long nextReportTime = computationStartedTime + timeWarningInterval;
-
-                int i = 0;
-                boolean hasChanges = false;
-                while (true) {
-                    if (hasChanges) {
-                        // Not the first iteration, so every remaining unassigned shard has been ignored, perhaps due to throttling. We must
-                        // bring
-                        // them all back out of the ignored list to give the allocator another go...
-                        routingNodes.unassigned().resetIgnored();
-
-                        // ... but not if they're ignored because they're out of scope for allocation
-                        for (final var iterator = routingNodes.unassigned().iterator(); iterator.hasNext();) {
-                            final var shardRouting = iterator.next();
-                            if (ignoredShards.contains(discardAllocationStatus(shardRouting))) {
-                                iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, changes);
-                            }
-                        }
-                    }
-
-                    routingAllocation.setSimulatedClusterInfo(clusterInfoSimulator.getClusterInfo());
-                    TracerSpan.span(threadPool, tracer, "running-delegate-allocator", () -> {
-                        logger.trace("running delegate allocator");
-                        delegateAllocator.allocate(routingAllocation);
-                        assert routingNodes.unassigned().isEmpty(); // any unassigned shards should now be ignored
-                    });
-
-                    hasChanges = false;
-                    for (final var routingNode : routingNodes) {
-                        for (final var shardRouting : routingNode) {
-                            if (shardRouting.initializing()) {
-                                hasChanges = true;
-                                clusterInfoSimulator.simulateShardStarted(shardRouting);
-                                routingNodes.startShard(shardRouting, changes, 0L);
-                            }
-                        }
-                    }
-
-                    i++;
-                    final int iterations = i;
-                    final long currentTime = threadPool.relativeTimeInMillis();
-                    final boolean reportByTime = nextReportTime <= currentTime;
-                    final boolean reportByIterationCount = i % iterationCountReportInterval == 0;
-                    if (reportByTime || reportByIterationCount) {
-                        nextReportTime = currentTime + timeWarningInterval;
-                    }
-
-                    if (hasChanges == false) {
-                        logger.debug(
-                            "Desired balance computation for [{}] converged after [{}] and [{}] iterations",
-                            desiredBalanceInput.index(),
-                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
-                            i
-                        );
-                        break;
-                    }
-                    if (isFresh.test(desiredBalanceInput) == false) {
-                        // we run at least one iteration, but if another reroute happened meanwhile
-                        // then publish the interim state and restart the calculation
-                        logger.debug(
-                            "Desired balance computation for [{}] is interrupted after [{}] "
-                                + "and [{}] iterations as newer cluster state received. "
-                                + "Publishing intermediate desired balance and restarting computation",
-                            desiredBalanceInput.index(),
-                            i,
-                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString()
-                        );
-                        break;
-                    }
-
-                    logger.log(
-                        reportByIterationCount || reportByTime ? Level.INFO : i % 100 == 0 ? Level.DEBUG : Level.TRACE,
-                        () -> Strings.format(
-                            "Desired balance computation for [%d] is still not converged after [%s] and [%d] iterations",
-                            desiredBalanceInput.index(),
-                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
-                            iterations
-                        )
+                if (hasChanges == false) {
+                    logger.debug(
+                        "Desired balance computation for [{}] converged after [{}] and [{}] iterations",
+                        desiredBalanceInput.index(),
+                        TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
+                        i
                     );
+                    break;
                 }
-                iterations.inc(i);
-
-                final var assignments = collectShardAssignments(routingNodes);
-
-                for (var shard : routingNodes.unassigned().ignored()) {
-                    var info = shard.unassignedInfo();
-                    assert info != null
-                        && (info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO
-                            || info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.NO_ATTEMPT
-                            || info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED)
-                        : "Unexpected stats in: " + info;
-
-                    if (hasChanges == false && info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED) {
-                        // Simulation could not progress due to missing information in any of the deciders.
-                        // Currently, this could happen if `HasFrozenCacheAllocationDecider` is still fetching the data.
-                        // Progress would be made after the followup reroute call.
-                        hasChanges = true;
-                    }
-
-                    var ignored = shard.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 0 : 1;
-                    assignments.compute(
-                        shard.shardId(),
-                        (key, oldValue) -> oldValue == null
-                            ? new ShardAssignment(Set.of(), 1, 1, ignored)
-                            : new ShardAssignment(
-                                oldValue.nodeIds(),
-                                oldValue.total() + 1,
-                                oldValue.unassigned() + 1,
-                                oldValue.ignored() + ignored
-                            )
+                if (isFresh.test(desiredBalanceInput) == false) {
+                    // we run at least one iteration, but if another reroute happened meanwhile
+                    // then publish the interim state and restart the calculation
+                    logger.debug(
+                        "Desired balance computation for [{}] is interrupted after [{}] "
+                            + "and [{}] iterations as newer cluster state received. "
+                            + "Publishing intermediate desired balance and restarting computation",
+                        desiredBalanceInput.index(),
+                        i,
+                        TimeValue.timeValueMillis(currentTime - computationStartedTime).toString()
                     );
+                    break;
                 }
 
-                long lastConvergedIndex = hasChanges ? previousDesiredBalance.lastConvergedIndex() : desiredBalanceInput.index();
-                return new DesiredBalance(lastConvergedIndex, assignments);
+                logger.log(
+                    reportByIterationCount || reportByTime ? Level.INFO : i % 100 == 0 ? Level.DEBUG : Level.TRACE,
+                    () -> Strings.format(
+                        "Desired balance computation for [%d] is still not converged after [%s] and [%d] iterations",
+                        desiredBalanceInput.index(),
+                        TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
+                        iterations
+                    )
+                );
             }
-        );
+            iterations.inc(i);
+
+            final var assignments = collectShardAssignments(routingNodes);
+
+            for (var shard : routingNodes.unassigned().ignored()) {
+                var info = shard.unassignedInfo();
+                assert info != null
+                    && (info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO
+                        || info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.NO_ATTEMPT
+                        || info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED)
+                    : "Unexpected stats in: " + info;
+
+                if (hasChanges == false && info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED) {
+                    // Simulation could not progress due to missing information in any of the deciders.
+                    // Currently, this could happen if `HasFrozenCacheAllocationDecider` is still fetching the data.
+                    // Progress would be made after the followup reroute call.
+                    hasChanges = true;
+                }
+
+                var ignored = shard.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 0 : 1;
+                assignments.compute(
+                    shard.shardId(),
+                    (key, oldValue) -> oldValue == null
+                        ? new ShardAssignment(Set.of(), 1, 1, ignored)
+                        : new ShardAssignment(
+                            oldValue.nodeIds(),
+                            oldValue.total() + 1,
+                            oldValue.unassigned() + 1,
+                            oldValue.ignored() + ignored
+                        )
+                );
+            }
+
+            long lastConvergedIndex = hasChanges ? previousDesiredBalance.lastConvergedIndex() : desiredBalanceInput.index();
+            return new DesiredBalance(lastConvergedIndex, assignments);
+        }
     }
 
     private static Map<ShardId, ShardAssignment> collectShardAssignments(RoutingNodes routingNodes) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -25,6 +25,8 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.telemetry.tracing.Tracer;
+import org.elasticsearch.telemetry.tracing.TracerSpan;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
@@ -49,6 +51,7 @@ public class DesiredBalanceComputer {
     private static final Logger logger = LogManager.getLogger(DesiredBalanceComputer.class);
 
     private final ThreadPool threadPool;
+    private final Tracer tracer;
     private final ShardsAllocator delegateAllocator;
 
     // stats
@@ -64,8 +67,14 @@ public class DesiredBalanceComputer {
 
     private TimeValue progressLogInterval;
 
-    public DesiredBalanceComputer(ClusterSettings clusterSettings, ThreadPool threadPool, ShardsAllocator delegateAllocator) {
+    public DesiredBalanceComputer(
+        ClusterSettings clusterSettings,
+        ThreadPool threadPool,
+        Tracer tracer,
+        ShardsAllocator delegateAllocator
+    ) {
         this.threadPool = threadPool;
+        this.tracer = tracer;
         this.delegateAllocator = delegateAllocator;
         clusterSettings.initializeAndWatch(PROGRESS_LOG_INTERVAL_SETTING, value -> this.progressLogInterval = value);
     }
@@ -90,285 +99,309 @@ public class DesiredBalanceComputer {
             logger.debug("Recomputing desired balance for [{}]", desiredBalanceInput.index());
         }
 
-        final var routingAllocation = desiredBalanceInput.routingAllocation().mutableCloneForSimulation();
-        final var routingNodes = routingAllocation.routingNodes();
-        final var knownNodeIds = routingNodes.getAllNodeIds();
-        final var changes = routingAllocation.changes();
-        final var ignoredShards = getIgnoredShardsWithDiscardedAllocationStatus(desiredBalanceInput.ignoredShards());
-        final var clusterInfoSimulator = new ClusterInfoSimulator(routingAllocation);
+        return TracerSpan.span(
+            threadPool,
+            tracer,
+            "compute-desired-balance",
+            Map.of("desired-balance-index", desiredBalanceInput.index()),
+            () -> {
+                final var routingAllocation = desiredBalanceInput.routingAllocation().mutableCloneForSimulation();
+                final var routingNodes = routingAllocation.routingNodes();
+                final var knownNodeIds = routingNodes.getAllNodeIds();
+                final var changes = routingAllocation.changes();
+                final var ignoredShards = getIgnoredShardsWithDiscardedAllocationStatus(desiredBalanceInput.ignoredShards());
+                final var clusterInfoSimulator = new ClusterInfoSimulator(routingAllocation);
 
-        if (routingNodes.size() == 0) {
-            return new DesiredBalance(desiredBalanceInput.index(), Map.of());
-        }
-
-        // we assume that all ongoing recoveries will complete
-        for (final var routingNode : routingNodes) {
-            for (final var shardRouting : routingNode) {
-                if (shardRouting.initializing()) {
-                    clusterInfoSimulator.simulateShardStarted(shardRouting);
-                    routingNodes.startShard(shardRouting, changes, 0L);
+                if (routingNodes.size() == 0) {
+                    return new DesiredBalance(desiredBalanceInput.index(), Map.of());
                 }
-            }
-        }
 
-        // we are not responsible for allocating unassigned primaries of existing shards, and we're only responsible for allocating
-        // unassigned replicas if the ReplicaShardAllocator gives up, so we must respect these ignored shards
-        final var unassignedPrimaries = new HashSet<ShardId>();
-        final var shardRoutings = new HashMap<ShardId, ShardRoutings>();
-        for (final var primary : new boolean[] { true, false }) {
-            final RoutingNodes.UnassignedShards unassigned = routingNodes.unassigned();
-            for (final var iterator = unassigned.iterator(); iterator.hasNext();) {
-                final var shardRouting = iterator.next();
-                if (shardRouting.primary() == primary) {
-                    var lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
-                    if (knownNodeIds.contains(lastAllocatedNodeId)
-                        || ignoredShards.contains(discardAllocationStatus(shardRouting)) == false) {
-                        shardRoutings.computeIfAbsent(shardRouting.shardId(), ShardRoutings::new).unassigned().add(shardRouting);
-                    } else {
-                        iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, changes);
-                        if (shardRouting.primary()) {
-                            unassignedPrimaries.add(shardRouting.shardId());
+                // we assume that all ongoing recoveries will complete
+                for (final var routingNode : routingNodes) {
+                    for (final var shardRouting : routingNode) {
+                        if (shardRouting.initializing()) {
+                            clusterInfoSimulator.simulateShardStarted(shardRouting);
+                            routingNodes.startShard(shardRouting, changes, 0L);
                         }
                     }
                 }
-            }
-        }
 
-        for (final var assigned : routingNodes.getAssignedShards().entrySet()) {
-            shardRoutings.computeIfAbsent(assigned.getKey(), ShardRoutings::new).assigned().addAll(assigned.getValue());
-        }
-
-        // we can assume that all possible shards will be allocated/relocated to one of their desired locations
-        final var unassignedShardsToInitialize = new HashMap<ShardRouting, LinkedList<String>>();
-        for (final var entry : shardRoutings.entrySet()) {
-            final var shardId = entry.getKey();
-            final var routings = entry.getValue();
-
-            // treemap (keyed by node ID) so that we are consistent about the order of future relocations
-            final var shardsToRelocate = new TreeMap<String, ShardRouting>();
-            final var assignment = previousDesiredBalance.getAssignment(shardId);
-
-            // treeset (ordered by node ID) so that we are consistent about the order of future relocations
-            final var targetNodes = assignment != null ? new TreeSet<>(assignment.nodeIds()) : new TreeSet<String>();
-            targetNodes.retainAll(knownNodeIds);
-
-            // preserving last known shard location as a starting point to avoid unnecessary relocations
-            for (ShardRouting shardRouting : routings.unassigned()) {
-                var lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
-                if (knownNodeIds.contains(lastAllocatedNodeId)) {
-                    targetNodes.add(lastAllocatedNodeId);
-                }
-            }
-
-            for (final var shardRouting : routings.assigned()) {
-                assert shardRouting.started();
-                if (targetNodes.remove(shardRouting.currentNodeId()) == false) {
-                    final var previousShard = shardsToRelocate.put(shardRouting.currentNodeId(), shardRouting);
-                    assert previousShard == null : "duplicate shards to relocate: " + shardRouting + " vs " + previousShard;
-                }
-            }
-
-            final var targetNodesIterator = targetNodes.iterator();
-
-            // Here existing shards are moved to desired locations before initializing unassigned shards because we prefer not to leave
-            // immovable shards allocated to undesirable locations (e.g. a node that is shutting down or an allocation filter which was
-            // only recently applied). In contrast, reconciliation prefers to initialize the unassigned shards first.
-            relocateToDesiredLocation: for (final var shardRouting : shardsToRelocate.values()) {
-                assert shardRouting.started();
-
-                while (targetNodesIterator.hasNext()) {
-                    final var targetNodeId = targetNodesIterator.next();
-                    final var targetNode = routingNodes.node(targetNodeId);
-                    if (targetNode != null
-                        && routingAllocation.deciders()
-                            .canAllocate(shardRouting, targetNode, routingAllocation)
-                            .type() != Decision.Type.NO) {
-                        final var shardToRelocate = routingNodes.relocateShard(shardRouting, targetNodeId, 0L, "computation", changes).v2();
-                        clusterInfoSimulator.simulateShardStarted(shardToRelocate);
-                        routingNodes.startShard(shardToRelocate, changes, 0L);
-                        continue relocateToDesiredLocation;
+                // we are not responsible for allocating unassigned primaries of existing shards, and we're only responsible for allocating
+                // unassigned replicas if the ReplicaShardAllocator gives up, so we must respect these ignored shards
+                final var unassignedPrimaries = new HashSet<ShardId>();
+                final var shardRoutings = new HashMap<ShardId, ShardRoutings>();
+                for (final var primary : new boolean[] { true, false }) {
+                    final RoutingNodes.UnassignedShards unassigned = routingNodes.unassigned();
+                    for (final var iterator = unassigned.iterator(); iterator.hasNext();) {
+                        final var shardRouting = iterator.next();
+                        if (shardRouting.primary() == primary) {
+                            var lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
+                            if (knownNodeIds.contains(lastAllocatedNodeId)
+                                || ignoredShards.contains(discardAllocationStatus(shardRouting)) == false) {
+                                shardRoutings.computeIfAbsent(shardRouting.shardId(), ShardRoutings::new).unassigned().add(shardRouting);
+                            } else {
+                                iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, changes);
+                                if (shardRouting.primary()) {
+                                    unassignedPrimaries.add(shardRouting.shardId());
+                                }
+                            }
+                        }
                     }
                 }
-            }
 
-            for (final var shardRouting : routings.unassigned()) {
-                assert shardRouting.unassigned();
-                if (targetNodesIterator.hasNext()) {
-                    unassignedShardsToInitialize.computeIfAbsent(shardRouting, ignored -> new LinkedList<>())
-                        .add(targetNodesIterator.next());
-                } else {
-                    break;
+                for (final var assigned : routingNodes.getAssignedShards().entrySet()) {
+                    shardRoutings.computeIfAbsent(assigned.getKey(), ShardRoutings::new).assigned().addAll(assigned.getValue());
                 }
-            }
-        }
 
-        final var unassignedPrimaryIterator = routingNodes.unassigned().iterator();
-        while (unassignedPrimaryIterator.hasNext()) {
-            final var shardRouting = unassignedPrimaryIterator.next();
-            if (shardRouting.primary()) {
-                final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
-                if (nodeIds != null && nodeIds.isEmpty() == false) {
-                    final var nodeId = nodeIds.removeFirst();
-                    final var routingNode = routingNodes.node(nodeId);
-                    if (routingNode != null
-                        && routingAllocation.deciders()
-                            .canAllocate(shardRouting, routingNode, routingAllocation)
-                            .type() != Decision.Type.NO) {
-                        final var shardToInitialize = unassignedPrimaryIterator.initialize(nodeId, null, 0L, changes);
-                        clusterInfoSimulator.simulateShardStarted(shardToInitialize);
-                        routingNodes.startShard(shardToInitialize, changes, 0L);
+                // we can assume that all possible shards will be allocated/relocated to one of their desired locations
+                final var unassignedShardsToInitialize = new HashMap<ShardRouting, LinkedList<String>>();
+                for (final var entry : shardRoutings.entrySet()) {
+                    final var shardId = entry.getKey();
+                    final var routings = entry.getValue();
+
+                    // treemap (keyed by node ID) so that we are consistent about the order of future relocations
+                    final var shardsToRelocate = new TreeMap<String, ShardRouting>();
+                    final var assignment = previousDesiredBalance.getAssignment(shardId);
+
+                    // treeset (ordered by node ID) so that we are consistent about the order of future relocations
+                    final var targetNodes = assignment != null ? new TreeSet<>(assignment.nodeIds()) : new TreeSet<String>();
+                    targetNodes.retainAll(knownNodeIds);
+
+                    // preserving last known shard location as a starting point to avoid unnecessary relocations
+                    for (ShardRouting shardRouting : routings.unassigned()) {
+                        var lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
+                        if (knownNodeIds.contains(lastAllocatedNodeId)) {
+                            targetNodes.add(lastAllocatedNodeId);
+                        }
+                    }
+
+                    for (final var shardRouting : routings.assigned()) {
+                        assert shardRouting.started();
+                        if (targetNodes.remove(shardRouting.currentNodeId()) == false) {
+                            final var previousShard = shardsToRelocate.put(shardRouting.currentNodeId(), shardRouting);
+                            assert previousShard == null : "duplicate shards to relocate: " + shardRouting + " vs " + previousShard;
+                        }
+                    }
+
+                    final var targetNodesIterator = targetNodes.iterator();
+
+                    // Here existing shards are moved to desired locations before initializing unassigned shards because we prefer not to
+                    // leave
+                    // immovable shards allocated to undesirable locations (e.g. a node that is shutting down or an allocation filter which
+                    // was
+                    // only recently applied). In contrast, reconciliation prefers to initialize the unassigned shards first.
+                    relocateToDesiredLocation: for (final var shardRouting : shardsToRelocate.values()) {
+                        assert shardRouting.started();
+
+                        while (targetNodesIterator.hasNext()) {
+                            final var targetNodeId = targetNodesIterator.next();
+                            final var targetNode = routingNodes.node(targetNodeId);
+                            if (targetNode != null
+                                && routingAllocation.deciders()
+                                    .canAllocate(shardRouting, targetNode, routingAllocation)
+                                    .type() != Decision.Type.NO) {
+                                final var shardToRelocate = routingNodes.relocateShard(
+                                    shardRouting,
+                                    targetNodeId,
+                                    0L,
+                                    "computation",
+                                    changes
+                                ).v2();
+                                clusterInfoSimulator.simulateShardStarted(shardToRelocate);
+                                routingNodes.startShard(shardToRelocate, changes, 0L);
+                                continue relocateToDesiredLocation;
+                            }
+                        }
+                    }
+
+                    for (final var shardRouting : routings.unassigned()) {
+                        assert shardRouting.unassigned();
+                        if (targetNodesIterator.hasNext()) {
+                            unassignedShardsToInitialize.computeIfAbsent(shardRouting, ignored -> new LinkedList<>())
+                                .add(targetNodesIterator.next());
+                        } else {
+                            break;
+                        }
                     }
                 }
-            }
-        }
 
-        final var unassignedReplicaIterator = routingNodes.unassigned().iterator();
-        while (unassignedReplicaIterator.hasNext()) {
-            final var shardRouting = unassignedReplicaIterator.next();
-            if (unassignedPrimaries.contains(shardRouting.shardId()) == false) {
-                final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
-                if (nodeIds != null && nodeIds.isEmpty() == false) {
-                    final var nodeId = nodeIds.removeFirst();
-                    final var routingNode = routingNodes.node(nodeId);
-                    if (routingNode != null
-                        && routingAllocation.deciders()
-                            .canAllocate(shardRouting, routingNode, routingAllocation)
-                            .type() != Decision.Type.NO) {
-                        final var shardToInitialize = unassignedReplicaIterator.initialize(nodeId, null, 0L, changes);
-                        clusterInfoSimulator.simulateShardStarted(shardToInitialize);
-                        routingNodes.startShard(shardToInitialize, changes, 0L);
+                final var unassignedPrimaryIterator = routingNodes.unassigned().iterator();
+                while (unassignedPrimaryIterator.hasNext()) {
+                    final var shardRouting = unassignedPrimaryIterator.next();
+                    if (shardRouting.primary()) {
+                        final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
+                        if (nodeIds != null && nodeIds.isEmpty() == false) {
+                            final var nodeId = nodeIds.removeFirst();
+                            final var routingNode = routingNodes.node(nodeId);
+                            if (routingNode != null
+                                && routingAllocation.deciders()
+                                    .canAllocate(shardRouting, routingNode, routingAllocation)
+                                    .type() != Decision.Type.NO) {
+                                final var shardToInitialize = unassignedPrimaryIterator.initialize(nodeId, null, 0L, changes);
+                                clusterInfoSimulator.simulateShardStarted(shardToInitialize);
+                                routingNodes.startShard(shardToInitialize, changes, 0L);
+                            }
+                        }
                     }
                 }
-            }
-        }
 
-        List<MoveAllocationCommand> commands;
-        while ((commands = pendingDesiredBalanceMoves.poll()) != null) {
-            for (MoveAllocationCommand command : commands) {
-                try {
-                    command.execute(routingAllocation, false);
-                } catch (RuntimeException e) {
-                    logger.debug(
-                        () -> "move shard ["
-                            + command.index()
-                            + ":"
-                            + command.shardId()
-                            + "] command failed during applying it to the desired balance",
-                        e
+                final var unassignedReplicaIterator = routingNodes.unassigned().iterator();
+                while (unassignedReplicaIterator.hasNext()) {
+                    final var shardRouting = unassignedReplicaIterator.next();
+                    if (unassignedPrimaries.contains(shardRouting.shardId()) == false) {
+                        final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
+                        if (nodeIds != null && nodeIds.isEmpty() == false) {
+                            final var nodeId = nodeIds.removeFirst();
+                            final var routingNode = routingNodes.node(nodeId);
+                            if (routingNode != null
+                                && routingAllocation.deciders()
+                                    .canAllocate(shardRouting, routingNode, routingAllocation)
+                                    .type() != Decision.Type.NO) {
+                                final var shardToInitialize = unassignedReplicaIterator.initialize(nodeId, null, 0L, changes);
+                                clusterInfoSimulator.simulateShardStarted(shardToInitialize);
+                                routingNodes.startShard(shardToInitialize, changes, 0L);
+                            }
+                        }
+                    }
+                }
+
+                List<MoveAllocationCommand> commands;
+                while ((commands = pendingDesiredBalanceMoves.poll()) != null) {
+                    for (MoveAllocationCommand command : commands) {
+                        try {
+                            command.execute(routingAllocation, false);
+                        } catch (RuntimeException e) {
+                            logger.debug(
+                                () -> "move shard ["
+                                    + command.index()
+                                    + ":"
+                                    + command.shardId()
+                                    + "] command failed during applying it to the desired balance",
+                                e
+                            );
+                        }
+                    }
+                }
+
+                final int iterationCountReportInterval = computeIterationCountReportInterval(routingAllocation);
+                final long timeWarningInterval = progressLogInterval.millis();
+                final long computationStartedTime = threadPool.relativeTimeInMillis();
+                long nextReportTime = computationStartedTime + timeWarningInterval;
+
+                int i = 0;
+                boolean hasChanges = false;
+                while (true) {
+                    if (hasChanges) {
+                        // Not the first iteration, so every remaining unassigned shard has been ignored, perhaps due to throttling. We must
+                        // bring
+                        // them all back out of the ignored list to give the allocator another go...
+                        routingNodes.unassigned().resetIgnored();
+
+                        // ... but not if they're ignored because they're out of scope for allocation
+                        for (final var iterator = routingNodes.unassigned().iterator(); iterator.hasNext();) {
+                            final var shardRouting = iterator.next();
+                            if (ignoredShards.contains(discardAllocationStatus(shardRouting))) {
+                                iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, changes);
+                            }
+                        }
+                    }
+
+                    routingAllocation.setSimulatedClusterInfo(clusterInfoSimulator.getClusterInfo());
+                    TracerSpan.span(threadPool, tracer, "running-delegate-allocator", () -> {
+                        logger.trace("running delegate allocator");
+                        delegateAllocator.allocate(routingAllocation);
+                        assert routingNodes.unassigned().isEmpty(); // any unassigned shards should now be ignored
+                    });
+
+                    hasChanges = false;
+                    for (final var routingNode : routingNodes) {
+                        for (final var shardRouting : routingNode) {
+                            if (shardRouting.initializing()) {
+                                hasChanges = true;
+                                clusterInfoSimulator.simulateShardStarted(shardRouting);
+                                routingNodes.startShard(shardRouting, changes, 0L);
+                            }
+                        }
+                    }
+
+                    i++;
+                    final int iterations = i;
+                    final long currentTime = threadPool.relativeTimeInMillis();
+                    final boolean reportByTime = nextReportTime <= currentTime;
+                    final boolean reportByIterationCount = i % iterationCountReportInterval == 0;
+                    if (reportByTime || reportByIterationCount) {
+                        nextReportTime = currentTime + timeWarningInterval;
+                    }
+
+                    if (hasChanges == false) {
+                        logger.debug(
+                            "Desired balance computation for [{}] converged after [{}] and [{}] iterations",
+                            desiredBalanceInput.index(),
+                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
+                            i
+                        );
+                        break;
+                    }
+                    if (isFresh.test(desiredBalanceInput) == false) {
+                        // we run at least one iteration, but if another reroute happened meanwhile
+                        // then publish the interim state and restart the calculation
+                        logger.debug(
+                            "Desired balance computation for [{}] interrupted after [{}] and [{}] iterations as newer cluster state received. "
+                                + "Publishing intermediate desired balance and restarting computation",
+                            desiredBalanceInput.index(),
+                            i,
+                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString()
+                        );
+                        break;
+                    }
+
+                    logger.log(
+                        reportByIterationCount || reportByTime ? Level.INFO : i % 100 == 0 ? Level.DEBUG : Level.TRACE,
+                        () -> Strings.format(
+                            "Desired balance computation for [%d] is still not converged after [%s] and [%d] iterations",
+                            desiredBalanceInput.index(),
+                            TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
+                            iterations
+                        )
                     );
                 }
-            }
-        }
+                iterations.inc(i);
 
-        final int iterationCountReportInterval = computeIterationCountReportInterval(routingAllocation);
-        final long timeWarningInterval = progressLogInterval.millis();
-        final long computationStartedTime = threadPool.relativeTimeInMillis();
-        long nextReportTime = computationStartedTime + timeWarningInterval;
+                final var assignments = collectShardAssignments(routingNodes);
 
-        int i = 0;
-        boolean hasChanges = false;
-        while (true) {
-            if (hasChanges) {
-                // Not the first iteration, so every remaining unassigned shard has been ignored, perhaps due to throttling. We must bring
-                // them all back out of the ignored list to give the allocator another go...
-                routingNodes.unassigned().resetIgnored();
+                for (var shard : routingNodes.unassigned().ignored()) {
+                    var info = shard.unassignedInfo();
+                    assert info != null
+                        && (info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO
+                            || info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.NO_ATTEMPT
+                            || info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED)
+                        : "Unexpected stats in: " + info;
 
-                // ... but not if they're ignored because they're out of scope for allocation
-                for (final var iterator = routingNodes.unassigned().iterator(); iterator.hasNext();) {
-                    final var shardRouting = iterator.next();
-                    if (ignoredShards.contains(discardAllocationStatus(shardRouting))) {
-                        iterator.removeAndIgnore(UnassignedInfo.AllocationStatus.NO_ATTEMPT, changes);
-                    }
-                }
-            }
-
-            routingAllocation.setSimulatedClusterInfo(clusterInfoSimulator.getClusterInfo());
-            logger.trace("running delegate allocator");
-            delegateAllocator.allocate(routingAllocation);
-            assert routingNodes.unassigned().isEmpty(); // any unassigned shards should now be ignored
-
-            hasChanges = false;
-            for (final var routingNode : routingNodes) {
-                for (final var shardRouting : routingNode) {
-                    if (shardRouting.initializing()) {
+                    if (hasChanges == false && info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED) {
+                        // Simulation could not progress due to missing information in any of the deciders.
+                        // Currently, this could happen if `HasFrozenCacheAllocationDecider` is still fetching the data.
+                        // Progress would be made after the followup reroute call.
                         hasChanges = true;
-                        clusterInfoSimulator.simulateShardStarted(shardRouting);
-                        routingNodes.startShard(shardRouting, changes, 0L);
                     }
+
+                    var ignored = shard.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 0 : 1;
+                    assignments.compute(
+                        shard.shardId(),
+                        (key, oldValue) -> oldValue == null
+                            ? new ShardAssignment(Set.of(), 1, 1, ignored)
+                            : new ShardAssignment(
+                                oldValue.nodeIds(),
+                                oldValue.total() + 1,
+                                oldValue.unassigned() + 1,
+                                oldValue.ignored() + ignored
+                            )
+                    );
                 }
+
+                long lastConvergedIndex = hasChanges ? previousDesiredBalance.lastConvergedIndex() : desiredBalanceInput.index();
+                return new DesiredBalance(lastConvergedIndex, assignments);
             }
-
-            i++;
-            final int iterations = i;
-            final long currentTime = threadPool.relativeTimeInMillis();
-            final boolean reportByTime = nextReportTime <= currentTime;
-            final boolean reportByIterationCount = i % iterationCountReportInterval == 0;
-            if (reportByTime || reportByIterationCount) {
-                nextReportTime = currentTime + timeWarningInterval;
-            }
-
-            if (hasChanges == false) {
-                logger.debug(
-                    "Desired balance computation for [{}] converged after [{}] and [{}] iterations",
-                    desiredBalanceInput.index(),
-                    TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
-                    i
-                );
-                break;
-            }
-            if (isFresh.test(desiredBalanceInput) == false) {
-                // we run at least one iteration, but if another reroute happened meanwhile
-                // then publish the interim state and restart the calculation
-                logger.debug(
-                    "Desired balance computation for [{}] interrupted after [{}] and [{}] iterations as newer cluster state received. "
-                        + "Publishing intermediate desired balance and restarting computation",
-                    desiredBalanceInput.index(),
-                    i,
-                    TimeValue.timeValueMillis(currentTime - computationStartedTime).toString()
-                );
-                break;
-            }
-
-            logger.log(
-                reportByIterationCount || reportByTime ? Level.INFO : i % 100 == 0 ? Level.DEBUG : Level.TRACE,
-                () -> Strings.format(
-                    "Desired balance computation for [%d] is still not converged after [%s] and [%d] iterations",
-                    desiredBalanceInput.index(),
-                    TimeValue.timeValueMillis(currentTime - computationStartedTime).toString(),
-                    iterations
-                )
-            );
-        }
-        iterations.inc(i);
-
-        final var assignments = collectShardAssignments(routingNodes);
-
-        for (var shard : routingNodes.unassigned().ignored()) {
-            var info = shard.unassignedInfo();
-            assert info != null
-                && (info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO
-                    || info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.NO_ATTEMPT
-                    || info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED)
-                : "Unexpected stats in: " + info;
-
-            if (hasChanges == false && info.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED) {
-                // Simulation could not progress due to missing information in any of the deciders.
-                // Currently, this could happen if `HasFrozenCacheAllocationDecider` is still fetching the data.
-                // Progress would be made after the followup reroute call.
-                hasChanges = true;
-            }
-
-            var ignored = shard.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 0 : 1;
-            assignments.compute(
-                shard.shardId(),
-                (key, oldValue) -> oldValue == null
-                    ? new ShardAssignment(Set.of(), 1, 1, ignored)
-                    : new ShardAssignment(oldValue.nodeIds(), oldValue.total() + 1, oldValue.unassigned() + 1, oldValue.ignored() + ignored)
-            );
-        }
-
-        long lastConvergedIndex = hasChanges ? previousDesiredBalance.lastConvergedIndex() : desiredBalanceInput.index();
-        return new DesiredBalance(lastConvergedIndex, assignments);
+        );
     }
 
     private static Map<ShardId, ShardAssignment> collectShardAssignments(RoutingNodes routingNodes) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -346,7 +346,8 @@ public class DesiredBalanceComputer {
                         // we run at least one iteration, but if another reroute happened meanwhile
                         // then publish the interim state and restart the calculation
                         logger.debug(
-                            "Desired balance computation for [{}] interrupted after [{}] and [{}] iterations as newer cluster state received. "
+                            "Desired balance computation for [{}] is interrupted after [{}] "
+                                + "and [{}] iterations as newer cluster state received. "
                                 + "Publishing intermediate desired balance and restarting computation",
                             desiredBalanceInput.index(),
                             i,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -89,7 +89,7 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
             delegateAllocator,
             threadPool,
             clusterService,
-            new DesiredBalanceComputer(clusterSettings, threadPool, delegateAllocator),
+            new DesiredBalanceComputer(clusterSettings, threadPool, telemetryProvider.getTracer(), delegateAllocator),
             reconciler,
             telemetryProvider
         );
@@ -110,7 +110,8 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
         this.desiredBalanceReconciler = new DesiredBalanceReconciler(
             clusterService.getClusterSettings(),
             threadPool,
-            telemetryProvider.getMeterRegistry()
+            telemetryProvider.getMeterRegistry(),
+            telemetryProvider.getTracer()
         );
         this.desiredBalanceComputation = new ContinuousComputation<>(threadPool.generic()) {
 

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -552,7 +552,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
         for (ClusterStateApplier applier : clusterStateAppliers) {
             logger.trace("calling [{}] with change to version [{}]", applier, clusterChangedEvent.state().version());
             final String name = applier.toString();
-            TracerSpan.span(threadPool, tracer, "ClusterStateApplier:" + name, () -> {
+            TracerSpan.span(threadPool, tracer, "cluster-state-applier:" + name, () -> {
                 try (Releasable ignored = stopWatch.record(name)) {
                     applier.applyClusterState(clusterChangedEvent);
                 }
@@ -574,7 +574,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
         for (ClusterStateListener listener : listeners) {
             logger.trace("calling [{}] with change to version [{}]", listener, clusterChangedEvent.state().version());
             final String name = listener.toString();
-            TracerSpan.span(threadPool, tracer, "ClusterStateListener:" + name, () -> {
+            TracerSpan.span(threadPool, tracer, "cluster-state-listener:" + name, () -> {
                 try (Releasable ignored = stopWatch.record(name)) {
                     listener.clusterChanged(clusterChangedEvent);
                 } catch (Exception ex) {

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -102,12 +102,7 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
 
     private NodeConnectionsService nodeConnectionsService;
 
-    public ClusterApplierService(
-        String nodeName,
-        Settings settings,
-        ClusterSettings clusterSettings,
-        ThreadPool threadPool
-    ) {
+    public ClusterApplierService(String nodeName, Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool) {
         this(nodeName, settings, clusterSettings, threadPool, Tracer.NOOP);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -63,7 +63,7 @@ public class ClusterService extends AbstractLifecycleComponent {
         this(
             settings,
             clusterSettings,
-            new MasterService(settings, clusterSettings, threadPool, taskManager),
+            new MasterService(settings, clusterSettings, threadPool, taskManager, tracer),
             new ClusterApplierService(Node.NODE_NAME_SETTING.get(settings), settings, clusterSettings, threadPool, tracer)
         );
     }

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterService.java
@@ -49,12 +49,7 @@ public class ClusterService extends AbstractLifecycleComponent {
     private final OperationRouting operationRouting;
     private final ClusterApplierService clusterApplierService;
 
-    public ClusterService(
-        Settings settings,
-        ClusterSettings clusterSettings,
-        ThreadPool threadPool,
-        TaskManager taskManager
-    ) {
+    public ClusterService(Settings settings, ClusterSettings clusterSettings, ThreadPool threadPool, TaskManager taskManager) {
         this(settings, clusterSettings, threadPool, taskManager, Tracer.NOOP);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -238,15 +238,13 @@ public class MasterService extends AbstractLifecycleComponent {
         }
 
         final long computationStartTime = threadPool.rawRelativeTimeInMillis();
-        final var newClusterState = TracerSpan.span(
-            threadPool,
-            tracer,
-            "computing-cluster-state:" + executor,
-            () -> patchVersions(
+        ClusterState newClusterState;
+        try (var span = TracerSpan.span(threadPool, tracer, "computing-cluster-state:" + executor)) {
+            newClusterState = patchVersions(
                 previousClusterState,
                 executeTasks(previousClusterState, executionResults, executor, summary, threadPool.getThreadContext())
-            )
-        );
+            );
+        }
         final TimeValue computationTime = getTimeSince(computationStartTime);
         logExecutionTime(computationTime, "compute cluster state update", summary);
 

--- a/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeConstruction.java
@@ -652,7 +652,7 @@ class NodeConstruction {
             telemetryProvider.getTracer()
         );
 
-        ClusterService clusterService = createClusterService(settingsModule, threadPool, taskManager);
+        ClusterService clusterService = createClusterService(settingsModule, threadPool, taskManager, telemetryProvider.getTracer());
         clusterService.addStateApplier(scriptService);
 
         modules.bindToInstance(DocumentParsingProvider.class, documentParsingProvider);
@@ -1163,12 +1163,18 @@ class NodeConstruction {
         postInjection(clusterModule, actionModule, clusterService, transportService, featureService);
     }
 
-    private ClusterService createClusterService(SettingsModule settingsModule, ThreadPool threadPool, TaskManager taskManager) {
+    private ClusterService createClusterService(
+        SettingsModule settingsModule,
+        ThreadPool threadPool,
+        TaskManager taskManager,
+        Tracer tracer
+    ) {
         ClusterService clusterService = new ClusterService(
             settingsModule.getSettings(),
             settingsModule.getClusterSettings(),
             threadPool,
-            taskManager
+            taskManager,
+            tracer
         );
         resourcesToClose.add(clusterService);
 

--- a/server/src/main/java/org/elasticsearch/telemetry/tracing/Tracer.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/tracing/Tracer.java
@@ -33,6 +33,11 @@ import java.util.Map;
 public interface Tracer {
 
     /**
+     * @return {@code if service is enabled}
+     */
+    boolean isEnabled();
+
+    /**
      * Called when a span starts.
      * @param traceContext the current context. Required for tracing parent/child span activity.
      * @param traceable provides a unique identifier for the activity, and will not be sent to the tracing system. Add the ID
@@ -144,6 +149,12 @@ public interface Tracer {
      * in order to avoid null checks everywhere.
      */
     Tracer NOOP = new Tracer() {
+
+        @Override
+        public boolean isEnabled() {
+            return false;
+        }
+
         @Override
         public void startTrace(TraceContext traceContext, Traceable traceable, String name, Map<String, Object> attributes) {}
 

--- a/server/src/main/java/org/elasticsearch/telemetry/tracing/TracerSpan.java
+++ b/server/src/main/java/org/elasticsearch/telemetry/tracing/TracerSpan.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.telemetry.tracing;
+
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Map;
+
+public class TracerSpan {
+
+    private record Span(String spanId) implements Traceable {
+
+        @Override
+        public String getSpanId() {
+            return spanId;
+        }
+
+        public static Span create() {
+            return new Span(UUIDs.randomBase64UUID());
+        }
+    }
+
+    public static void span(ThreadPool threadPool, Tracer tracer, String name, Runnable action) {
+        var span = Span.create();
+        try (var ctx = threadPool.getThreadContext().newTraceContext()) {
+            tracer.startTrace(threadPool.getThreadContext(), span, name, Map.of());
+            action.run();
+        } finally {
+            tracer.stopTrace(span);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportDeleteDesiredBalanceActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/TransportDeleteDesiredBalanceActionTests.java
@@ -38,6 +38,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.MockUtils;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
@@ -100,7 +101,7 @@ public class TransportDeleteDesiredBalanceActionTests extends ESAllocationTestCa
         var clusterSettings = ClusterSettings.createBuiltInClusterSettings(settings);
 
         var delegate = new BalancedShardsAllocator();
-        var computer = new DesiredBalanceComputer(clusterSettings, threadPool, delegate) {
+        var computer = new DesiredBalanceComputer(clusterSettings, threadPool, Tracer.NOOP, delegate) {
 
             final AtomicReference<DesiredBalance> lastComputationInput = new AtomicReference<>();
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -78,7 +78,7 @@ public class JoinHelperTests extends ESTestCase {
         );
         JoinHelper joinHelper = new JoinHelper(
             null,
-            new MasterService(Settings.EMPTY, clusterSettings, threadPool, taskManger),
+            new MasterService(Settings.EMPTY, clusterSettings, threadPool, taskManger, Tracer.NOOP),
             new NoOpClusterApplier(),
             transportService,
             () -> 0L,
@@ -246,7 +246,7 @@ public class JoinHelperTests extends ESTestCase {
         AtomicReference<StatusInfo> nodeHealthServiceStatus = new AtomicReference<>(new StatusInfo(UNHEALTHY, "unhealthy-info"));
         JoinHelper joinHelper = new JoinHelper(
             null,
-            new MasterService(Settings.EMPTY, clusterSettings, threadPool, taskManger),
+            new MasterService(Settings.EMPTY, clusterSettings, threadPool, taskManger, Tracer.NOOP),
             new NoOpClusterApplier(),
             transportService,
             () -> 0L,
@@ -323,7 +323,7 @@ public class JoinHelperTests extends ESTestCase {
         );
         JoinHelper joinHelper = new JoinHelper(
             null,
-            new MasterService(Settings.EMPTY, clusterSettings, threadPool, taskManger),
+            new MasterService(Settings.EMPTY, clusterSettings, threadPool, taskManger, Tracer.NOOP),
             new NoOpClusterApplier(),
             transportService,
             () -> 1L,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.monitor.NodeHealthService;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.CapturingTransport;
@@ -148,7 +149,8 @@ public class NodeJoinTests extends ESTestCase {
             settings,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             threadPool,
-            new TaskManager(settings, threadPool, Set.of())
+            new TaskManager(settings, threadPool, Set.of()),
+            Tracer.NOOP
         );
         AtomicReference<ClusterState> clusterStateRef = new AtomicReference<>(initialState);
         masterService.setClusterStatePublisher((clusterStatePublicationEvent, publishListener, ackListener) -> {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterAllocationSimulationTests.java
@@ -48,6 +48,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -223,7 +224,8 @@ public class ClusterAllocationSimulationTests extends ESAllocationTestCase {
             settings,
             clusterSettings,
             threadPool,
-            new TaskManager(settings, threadPool, Set.of())
+            new TaskManager(settings, threadPool, Set.of()),
+            Tracer.NOOP
         ) {
             @Override
             protected ExecutorService createThreadPoolExecutor() {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -64,6 +64,7 @@ import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.snapshots.SnapshotsInfoService;
 import org.elasticsearch.telemetry.metric.MeterRegistry;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -1208,7 +1209,12 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
             new ConcurrentRebalanceAllocationDecider(clusterSettings),
             new ThrottlingAllocationDecider(clusterSettings) };
 
-        var reconciler = new DesiredBalanceReconciler(clusterSettings, mock(ThreadPool.class), mock(MeterRegistry.class));
+        var reconciler = new DesiredBalanceReconciler(
+            clusterSettings,
+            mock(ThreadPool.class),
+            mock(MeterRegistry.class),
+            mock(Tracer.class)
+        );
 
         var totalOutgoingMoves = new HashMap<String, AtomicInteger>();
         for (int i = 0; i < numberOfNodes; i++) {
@@ -1277,7 +1283,12 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
         var threadPool = mock(ThreadPool.class);
         when(threadPool.relativeTimeInMillis()).thenReturn(1L).thenReturn(2L).thenReturn(3L);
 
-        var reconciler = new DesiredBalanceReconciler(createBuiltInClusterSettings(), threadPool, mock(MeterRegistry.class));
+        var reconciler = new DesiredBalanceReconciler(
+            createBuiltInClusterSettings(),
+            threadPool,
+            mock(MeterRegistry.class),
+            mock(Tracer.class)
+        );
 
         var expectedWarningMessage = "[100%] of assigned shards ("
             + shardCount
@@ -1317,10 +1328,8 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
     }
 
     private static void reconcile(RoutingAllocation routingAllocation, DesiredBalance desiredBalance) {
-        new DesiredBalanceReconciler(createBuiltInClusterSettings(), mock(ThreadPool.class), mock(MeterRegistry.class)).reconcile(
-            desiredBalance,
-            routingAllocation
-        );
+        new DesiredBalanceReconciler(createBuiltInClusterSettings(), mock(ThreadPool.class), mock(MeterRegistry.class), mock(Tracer.class))
+            .reconcile(desiredBalance, routingAllocation);
     }
 
     private static boolean isReconciled(RoutingNode node, DesiredBalance balance) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
@@ -51,6 +51,7 @@ import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
 import org.elasticsearch.telemetry.TelemetryProvider;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.threadpool.TestThreadPool;
 
@@ -365,7 +366,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             shardsAllocator,
             threadPool,
             clusterService,
-            new DesiredBalanceComputer(clusterSettings, threadPool, shardsAllocator) {
+            new DesiredBalanceComputer(clusterSettings, threadPool, Tracer.NOOP, shardsAllocator) {
                 @Override
                 public DesiredBalance compute(
                     DesiredBalance previousDesiredBalance,
@@ -468,7 +469,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             shardsAllocator,
             threadPool,
             clusterService,
-            new DesiredBalanceComputer(clusterSettings, threadPool, shardsAllocator) {
+            new DesiredBalanceComputer(clusterSettings, threadPool, Tracer.NOOP, shardsAllocator) {
                 @Override
                 public DesiredBalance compute(
                     DesiredBalance previousDesiredBalance,
@@ -555,7 +556,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
         var delegateAllocator = createShardsAllocator();
         var clusterSettings = createBuiltInClusterSettings();
 
-        var desiredBalanceComputer = new DesiredBalanceComputer(clusterSettings, threadPool, delegateAllocator) {
+        var desiredBalanceComputer = new DesiredBalanceComputer(clusterSettings, threadPool, Tracer.NOOP, delegateAllocator) {
 
             final AtomicReference<DesiredBalance> lastComputationInput = new AtomicReference<>();
 
@@ -623,7 +624,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
         var clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool);
 
         var delegateAllocator = createShardsAllocator();
-        var desiredBalanceComputer = new DesiredBalanceComputer(createBuiltInClusterSettings(), threadPool, delegateAllocator);
+        var desiredBalanceComputer = new DesiredBalanceComputer(createBuiltInClusterSettings(), threadPool, Tracer.NOOP, delegateAllocator);
         var desiredBalanceShardsAllocator = new DesiredBalanceShardsAllocator(
             delegateAllocator,
             threadPool,
@@ -672,7 +673,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
 
         final var resetCalled = new AtomicBoolean();
         var delegateAllocator = createShardsAllocator();
-        var desiredBalanceComputer = new DesiredBalanceComputer(createBuiltInClusterSettings(), threadPool, delegateAllocator);
+        var desiredBalanceComputer = new DesiredBalanceComputer(createBuiltInClusterSettings(), threadPool, Tracer.NOOP, delegateAllocator);
         var desiredBalanceAllocator = new DesiredBalanceShardsAllocator(
             delegateAllocator,
             threadPool,

--- a/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -86,7 +87,8 @@ public class ClusterApplierServiceTests extends ESTestCase {
             "test_node",
             Settings.builder().put("cluster.name", "ClusterApplierServiceTests").build(),
             clusterSettings,
-            threadPool
+            threadPool,
+            Tracer.NOOP
         ) {
             @Override
             protected boolean applicationMayFail() {

--- a/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/MasterServiceTests.java
@@ -50,6 +50,7 @@ import org.elasticsearch.core.Tuple;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
@@ -155,7 +156,8 @@ public class MasterServiceTests extends ESTestCase {
             settings,
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
             threadPool,
-            taskManager
+            taskManager,
+            Tracer.NOOP
         ) {
             @Override
             protected ExecutorService createThreadPoolExecutor() {
@@ -1114,7 +1116,8 @@ public class MasterServiceTests extends ESTestCase {
                 settings,
                 new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
                 threadPool,
-                new TaskManager(settings, threadPool, emptySet())
+                new TaskManager(settings, threadPool, emptySet()),
+                Tracer.NOOP
             ) {
                 @Override
                 protected boolean publicationMayFail() {

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -179,7 +179,8 @@ public class ClusterStateChanges {
             SETTINGS,
             clusterSettings,
             threadPool,
-            new TaskManager(SETTINGS, threadPool, Collections.emptySet())
+            new TaskManager(SETTINGS, threadPool, Collections.emptySet()),
+            Tracer.NOOP
         ) {
             @Override
             protected ExecutorService createThreadPoolExecutor() {

--- a/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.util.concurrent.StoppableExecutorServiceWrapper;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.tasks.TaskManager;
+import org.elasticsearch.telemetry.tracing.Tracer;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Set;
@@ -47,7 +48,7 @@ public class FakeThreadPoolMasterService extends MasterService {
         ThreadPool threadPool,
         Consumer<Runnable> taskExecutor
     ) {
-        super(settings, clusterSettings, threadPool, new TaskManager(settings, threadPool, Set.of()));
+        super(settings, clusterSettings, threadPool, new TaskManager(settings, threadPool, Set.of()), Tracer.NOOP);
         this.taskExecutor = taskExecutor;
         this.threadContext = threadPool.getThreadContext();
     }


### PR DESCRIPTION
This is a draft change that creates more detailed apm spans for a cluster state update.
This change includes timings sub-spans for:
* cluster state computation
* cluster state appliers
* cluster state listeners
* desired balance computation
* desired balance reconciliation

Before:
![Screenshot at 2024-05-31 14-33-33](https://github.com/elastic/elasticsearch/assets/1331856/951e2a01-0f3b-440b-9357-5ddac608254b)

After:
![Screenshot at 2024-05-31 14-27-13](https://github.com/elastic/elasticsearch/assets/1331856/45e1e324-8fec-4eb2-98d8-af81ffec926c)
