### PR TITLE
Split RoutingDimensions and DimensionHasher from TimeSeriesIdFieldMapper

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
@@ -12,7 +12,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.PriorityQueue;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
+import org.elasticsearch.index.mapper.DimensionHasher;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.AggregatorReducer;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -67,7 +67,7 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
 
         @Override
         public Map<String, Object> getKey() {
-            return TimeSeriesIdFieldMapper.decodeTsidAsMap(key);
+            return DimensionHasher.decodeAsMap(key);
         }
 
         @Override

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
@@ -12,6 +12,7 @@ import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
+import org.elasticsearch.index.mapper.RoutingDimensions;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
@@ -160,11 +161,11 @@ public class TimeSeriesAggregator extends BucketsAggregator {
                 if (currentTsidOrd == aggCtx.getTsidHashOrd()) {
                     tsid = currentTsid;
                 } else {
-                    TimeSeriesIdFieldMapper.TimeSeriesIdBuilder tsidBuilder = new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder(null);
+                    RoutingDimensions routingDimensions = new RoutingDimensions(null);
                     for (TsidConsumer consumer : dimensionConsumers.values()) {
-                        consumer.accept(doc, tsidBuilder);
+                        consumer.accept(doc, routingDimensions);
                     }
-                    currentTsid = tsid = tsidBuilder.buildLegacyTsid().toBytesRef();
+                    currentTsid = tsid = TimeSeriesIdFieldMapper.buildLegacyTsid(routingDimensions).toBytesRef();
                 }
                 long bucketOrdinal = bucketOrds.add(bucket, tsid);
                 if (bucketOrdinal < 0) { // already seen
@@ -188,6 +189,6 @@ public class TimeSeriesAggregator extends BucketsAggregator {
 
     @FunctionalInterface
     interface TsidConsumer {
-        void accept(int docId, TimeSeriesIdFieldMapper.TimeSeriesIdBuilder tsidBuilder) throws IOException;
+        void accept(int docId, RoutingDimensions tsidBuilder) throws IOException;
     }
 }

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeriesTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeriesTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.aggregations.bucket.timeseries.InternalTimeSeries.Inter
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.index.mapper.RoutingDimensions;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
@@ -41,12 +42,12 @@ public class InternalTimeSeriesTests extends AggregationMultiBucketAggregationTe
         List<Map<String, Object>> keys = randomKeys(bucketKeys(randomIntBetween(1, 4)), numberOfBuckets);
         for (int j = 0; j < numberOfBuckets; j++) {
             long docCount = randomLongBetween(0, Long.MAX_VALUE / (20L * numberOfBuckets));
-            var builder = new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder(null);
+            var routingDimensions = new RoutingDimensions(null);
             for (var entry : keys.get(j).entrySet()) {
-                builder.addString(entry.getKey(), (String) entry.getValue());
+                routingDimensions.addString(entry.getKey(), (String) entry.getValue());
             }
             try {
-                var key = builder.buildLegacyTsid().toBytesRef();
+                var key = TimeSeriesIdFieldMapper.buildLegacyTsid(routingDimensions).toBytesRef();
                 bucketList.add(new InternalBucket(key, docCount, aggregations, keyed));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);

--- a/server/src/main/java/org/elasticsearch/index/IndexMode.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexMode.java
@@ -25,6 +25,7 @@ import org.elasticsearch.index.mapper.MappingLookup;
 import org.elasticsearch.index.mapper.MetadataFieldMapper;
 import org.elasticsearch.index.mapper.NestedLookup;
 import org.elasticsearch.index.mapper.ProvidedIdFieldMapper;
+import org.elasticsearch.index.mapper.RoutingDimensions;
 import org.elasticsearch.index.mapper.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
@@ -202,7 +203,7 @@ public enum IndexMode {
         @Override
         public DocumentDimensions buildDocumentDimensions(IndexSettings settings) {
             IndexRouting.ExtractFromSource routing = (IndexRouting.ExtractFromSource) settings.getIndexRouting();
-            return new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder(routing.builder());
+            return new RoutingDimensions(routing.builder());
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/DimensionHasher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DimensionHasher.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.StringHelper;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.hash.Murmur3Hasher;
+import org.elasticsearch.common.hash.MurmurHash3;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.util.ByteUtils;
+import org.elasticsearch.search.DocValueFormat;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Tracks dimension fields and uses their values to build a byte array containing a representative hash value.
+ */
+public class DimensionHasher {
+
+    private static final Base64.Encoder BASE64_ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    private static final int SEED = 0;
+
+    public static final int MAX_DIMENSIONS = 512;
+
+    private static final int MAX_HASH_LEN_BYTES = 2;
+
+    static {
+        assert MAX_HASH_LEN_BYTES == StreamOutput.putVInt(new byte[2], hashLen(MAX_DIMENSIONS), 0);
+    }
+
+    private static int hashLen(int numberOfDimensions) {
+        return 16 + 16 + 4 * numberOfDimensions;
+    }
+
+    /**
+     * Here we build the hash of the tsid using a similarity function so that we have a result
+     * with the following pattern:
+     *
+     * hash128(catenate(dimension field names)) +
+     * foreach(dimension field value, limit = MAX_DIMENSIONS) { hash32(dimension field value) } +
+     * hash128(catenate(dimension field values))
+     *
+     * The idea is to be able to place similar groups of dimension values close to each other.
+     */
+    public static BytesReference build(RoutingDimensions routingDimensions) {
+        var dimensions = routingDimensions.dimensions();
+        Murmur3Hasher hasher = new Murmur3Hasher(SEED);
+
+        // NOTE: hash all dimension field names
+        int numberOfDimensions = Math.min(MAX_DIMENSIONS, dimensions.size());
+        int len = hashLen(numberOfDimensions);
+        // either one or two bytes are occupied by the vint since we're bounded by #MAX_DIMENSIONS
+        byte[] bytes = new byte[MAX_HASH_LEN_BYTES + len];
+        int index = StreamOutput.putVInt(bytes, len, 0);
+
+        hasher.reset();
+        for (final RoutingDimensions.Dimension dimension : dimensions) {
+            hasher.update(dimension.name().bytes);
+        }
+        index = writeHash128(hasher.digestHash(), bytes, index);
+
+        // NOTE: concatenate all dimension value hashes up to a certain number of dimensions
+        int startIndex = index;
+        for (final RoutingDimensions.Dimension dimension : dimensions) {
+            if ((index - startIndex) >= 4 * numberOfDimensions) {
+                break;
+            }
+            final BytesRef value = dimension.value().toBytesRef();
+            ByteUtils.writeIntLE(StringHelper.murmurhash3_x86_32(value.bytes, value.offset, value.length, SEED), bytes, index);
+            index += 4;
+        }
+
+        // NOTE: hash all dimension field values
+        hasher.reset();
+        for (final RoutingDimensions.Dimension dimension : dimensions) {
+            hasher.update(dimension.value().toBytesRef().bytes);
+        }
+        index = writeHash128(hasher.digestHash(), bytes, index);
+
+        return new BytesArray(bytes, 0, index);
+    }
+
+    private static int writeHash128(final MurmurHash3.Hash128 hash128, byte[] buffer, int tsidHashIndex) {
+        ByteUtils.writeLongLE(hash128.h1, buffer, tsidHashIndex);
+        tsidHashIndex += 8;
+        ByteUtils.writeLongLE(hash128.h2, buffer, tsidHashIndex);
+        tsidHashIndex += 8;
+        return tsidHashIndex;
+    }
+
+    static Object encode(StreamInput in) {
+        try {
+            return base64Encode(in.readSlicedBytesReference().toBytesRef());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to read tsid");
+        }
+    }
+
+    public static Object encode(final BytesRef bytesRef) {
+        return base64Encode(bytesRef);
+    }
+
+    private static String base64Encode(final BytesRef bytesRef) {
+        byte[] bytes = new byte[bytesRef.length];
+        System.arraycopy(bytesRef.bytes, bytesRef.offset, bytes, 0, bytesRef.length);
+        return BASE64_ENCODER.encodeToString(bytes);
+    }
+
+    public static Map<String, Object> decodeAsMap(BytesRef bytesRef) {
+        try (StreamInput input = new BytesArray(bytesRef).streamInput()) {
+            return decodeAsMap(input);
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Dimension field cannot be deserialized.", ex);
+        }
+    }
+
+    public static Map<String, Object> decodeAsMap(StreamInput in) throws IOException {
+        int size = in.readVInt();
+        Map<String, Object> result = new LinkedHashMap<>(size);
+
+        for (int i = 0; i < size; i++) {
+            String name = null;
+            try {
+                name = in.readSlicedBytesReference().utf8ToString();
+            } catch (AssertionError ae) {
+                throw new IllegalArgumentException("Error parsing keyword dimension: " + ae.getMessage(), ae);
+            }
+
+            int type = in.read();
+            switch (type) {
+                case (byte) 's' -> {
+                    // parse a string
+                    try {
+                        result.put(name, in.readSlicedBytesReference().utf8ToString());
+                    } catch (AssertionError ae) {
+                        throw new IllegalArgumentException("Error parsing keyword dimension: " + ae.getMessage(), ae);
+                    }
+                }
+                case (byte) 'l' -> // parse a long
+                    result.put(name, in.readLong());
+                case (byte) 'u' -> { // parse an unsigned_long
+                    Object ul = DocValueFormat.UNSIGNED_LONG_SHIFTED.format(in.readLong());
+                    result.put(name, ul);
+                }
+                case (byte) 'd' -> // parse a double
+                    result.put(name, in.readDouble());
+                default -> throw new IllegalArgumentException("Cannot parse [" + name + "]: Unknown type [" + type + "]");
+            }
+        }
+        return result;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/RoutingDimensions.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RoutingDimensions.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.routing.IndexRouting;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.network.NetworkAddress;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.IndexSettings;
+import org.elasticsearch.search.DocValueFormat;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Tracks dimension fields and uses their values to build a byte array containing a representative hash value.
+ */
+public class RoutingDimensions implements DocumentDimensions {
+
+    record Dimension(BytesRef name, BytesReference value) {}
+
+    /**
+     * A sorted set of the serialized values of dimension fields that will be used
+     * for calculating the hash value.
+     */
+    private final SortedSet<Dimension> dimensions = new TreeSet<>(Comparator.comparing(o -> o.name));
+
+    /**
+     * Adds dimension values to routing id calculations.
+     */
+    @Nullable
+    private final IndexRouting.ExtractFromSource.Builder routingBuilder;
+
+    public RoutingDimensions(@Nullable IndexRouting.ExtractFromSource.Builder routingBuilder) {
+        this.routingBuilder = routingBuilder;
+    }
+
+    final Collection<Dimension> dimensions() {
+        return Collections.unmodifiableCollection(dimensions);
+    }
+
+    final IndexRouting.ExtractFromSource.Builder routingBuilder() {
+        return routingBuilder;
+    }
+
+    @Override
+    public DocumentDimensions addString(String fieldName, BytesRef utf8Value) {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.write((byte) 's');
+            /*
+             * Write in utf8 instead of StreamOutput#writeString which is utf-16-ish
+             * so it's easier for folks to reason about the space taken up. Mostly
+             * it'll be smaller too.
+             */
+            out.writeBytesRef(utf8Value);
+            add(fieldName, out.bytes());
+
+            if (routingBuilder != null) {
+                routingBuilder.addMatching(fieldName, utf8Value);
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Dimension field cannot be serialized.", e);
+        }
+        return this;
+    }
+
+    @Override
+    public DocumentDimensions addIp(String fieldName, InetAddress value) {
+        return addString(fieldName, NetworkAddress.format(value));
+    }
+
+    @Override
+    public DocumentDimensions addLong(String fieldName, long value) {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.write((byte) 'l');
+            out.writeLong(value);
+            add(fieldName, out.bytes());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Dimension field cannot be serialized.", e);
+        }
+        return this;
+    }
+
+    @Override
+    public DocumentDimensions addUnsignedLong(String fieldName, long value) {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            Object ul = DocValueFormat.UNSIGNED_LONG_SHIFTED.format(value);
+            if (ul instanceof Long l) {
+                out.write((byte) 'l');
+                out.writeLong(l);
+            } else {
+                out.write((byte) 'u');
+                out.writeLong(value);
+            }
+            add(fieldName, out.bytes());
+            return this;
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Dimension field cannot be serialized.", e);
+        }
+    }
+
+    @Override
+    public DocumentDimensions validate(final IndexSettings settings) {
+        return this;
+    }
+
+    private void add(String fieldName, BytesReference encoded) throws IOException {
+        if (dimensions.add(new Dimension(new BytesRef(fieldName), encoded)) == false) {
+            throw new IllegalArgumentException("Dimension field [" + fieldName + "] cannot be a multi-valued field.");
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
@@ -167,7 +167,7 @@ public class TsidExtractingIdFieldMapper extends IdFieldMapper {
     }
 
     private static String tsidDescription(IndexableField tsidField) {
-        String tsid = TimeSeriesIdFieldMapper.encodeTsid(tsidField.binaryValue()).toString();
+        String tsid = DimensionHasher.encode(tsidField.binaryValue()).toString();
         if (tsid.length() <= DESCRIPTION_TSID_LIMIT) {
             return tsid;
         }

--- a/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapperTests.java
@@ -100,7 +100,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
         );
         assertThat(doc.rootDoc().getField("a").binaryValue(), equalTo(new BytesRef("value")));
         assertThat(doc.rootDoc().getField("b").numericValue(), equalTo(100L));
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes)), "AWE");
+        assertEquals(DimensionHasher.encode(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes)), "AWE");
     }
 
     public void testDisabledInStandardMode() throws Exception {
@@ -145,7 +145,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
             docMapper,
             b -> b.field("a", "foo").field("b", "bar").field("c", "baz").startObject("o").field("e", "bort").endObject()
         );
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new BytesArray(tsid).streamInput()), "AWE");
+        assertEquals(DimensionHasher.encode(new BytesArray(tsid).streamInput()), "AWE");
     }
 
     @SuppressWarnings("unchecked")
@@ -158,7 +158,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
         }));
 
         ParsedDocument doc = parseDocument(docMapper, b -> b.field(fire, "hot").field(coffee, "good"));
-        Object tsid = TimeSeriesIdFieldMapper.encodeTsid(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes));
+        Object tsid = DimensionHasher.encode(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes));
         assertEquals(tsid, "A-I");
     }
 
@@ -169,7 +169,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
         }));
 
         ParsedDocument doc = parseDocument(docMapper, b -> b.field("a", "more_than_1024_bytes".repeat(52)));
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes)), "AQ");
+        assertEquals(DimensionHasher.encode(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes)), "AQ");
     }
 
     @SuppressWarnings("unchecked")
@@ -180,7 +180,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
 
         String theWordLong = "長い";
         ParsedDocument doc = parseDocument(docMapper, b -> b.field("a", theWordLong.repeat(200)));
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes)), "AQ");
+        assertEquals(DimensionHasher.encode(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes)), "AQ");
     }
 
     public void testKeywordNull() throws IOException {
@@ -219,7 +219,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
             b.field("c", "baz");
             b.startObject("o").field("e", 1234).endObject();
         });
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new BytesArray(tsid).streamInput()), "AWFs");
+        assertEquals(DimensionHasher.encode(new BytesArray(tsid).streamInput()), "AWFs");
     }
 
     public void testLongInvalidString() throws IOException {
@@ -271,7 +271,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
             b.field("c", "baz");
             b.startObject("o").field("e", Integer.MIN_VALUE).endObject();
         });
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new BytesArray(tsid).streamInput()), "AWFs");
+        assertEquals(DimensionHasher.encode(new BytesArray(tsid).streamInput()), "AWFs");
     }
 
     public void testIntegerInvalidString() throws IOException {
@@ -327,7 +327,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
             b.field("c", "baz");
             b.startObject("o").field("e", Short.MIN_VALUE).endObject();
         });
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new BytesArray(tsid).streamInput()), "AWFs");
+        assertEquals(DimensionHasher.encode(new BytesArray(tsid).streamInput()), "AWFs");
     }
 
     public void testShortInvalidString() throws IOException {
@@ -383,7 +383,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
             b.field("c", "baz");
             b.startObject("o").field("e", (int) Byte.MIN_VALUE).endObject();
         });
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new BytesArray(tsid).streamInput()), "AWFs");
+        assertEquals(DimensionHasher.encode(new BytesArray(tsid).streamInput()), "AWFs");
     }
 
     public void testByteInvalidString() throws IOException {
@@ -439,7 +439,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
             b.field("c", "baz");
             b.startObject("o").field("e", "255.255.255.1").endObject();
         });
-        assertEquals(TimeSeriesIdFieldMapper.encodeTsid(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes)), "AWFz");
+        assertEquals(DimensionHasher.encode(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes)), "AWFz");
     }
 
     public void testIpInvalidString() throws IOException {
@@ -474,7 +474,7 @@ public class TimeSeriesIdFieldMapperTests extends MetadataMapperTestCase {
             }
         });
 
-        Object tsid = TimeSeriesIdFieldMapper.encodeTsid(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes));
+        Object tsid = DimensionHasher.encode(new ByteArrayStreamInput(doc.rootDoc().getBinaryValue("_tsid").bytes));
         assertEquals(
             tsid,
             "AWJzA2ZvbwJkMHPwBm1hbnkgd29yZHMgbWFueSB3b3JkcyBtYW55IHdvcmRzIG1hbnkgd29yZHMgbWFueSB3b3JkcyBtYW55IHdvcmRzIG1hbnkgd"

--- a/server/src/test/java/org/elasticsearch/search/DocValueFormatTests.java
+++ b/server/src/test/java/org/elasticsearch/search/DocValueFormatTests.java
@@ -18,7 +18,8 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.mapper.DateFieldMapper.Resolution;
-import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper.TimeSeriesIdBuilder;
+import org.elasticsearch.index.mapper.DimensionHasher;
+import org.elasticsearch.index.mapper.RoutingDimensions;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -374,11 +375,11 @@ public class DocValueFormatTests extends ESTestCase {
     }
 
     public void testParseTsid() throws IOException {
-        TimeSeriesIdBuilder timeSeriesIdBuilder = new TimeSeriesIdBuilder(null);
-        timeSeriesIdBuilder.addString("string", randomAlphaOfLength(10));
-        timeSeriesIdBuilder.addLong("long", randomLong());
-        timeSeriesIdBuilder.addUnsignedLong("ulong", randomLong());
-        BytesRef expected = timeSeriesIdBuilder.buildTsidHash().toBytesRef();
+        var routingDimensions = new RoutingDimensions(null);
+        routingDimensions.addString("string", randomAlphaOfLength(10));
+        routingDimensions.addLong("long", randomLong());
+        routingDimensions.addUnsignedLong("ulong", randomLong());
+        BytesRef expected = DimensionHasher.build(routingDimensions).toBytesRef();
         byte[] expectedBytes = new byte[expected.length];
         System.arraycopy(expected.bytes, 0, expectedBytes, 0, expected.length);
         BytesRef actual = DocValueFormat.TIME_SERIES_ID.parseBytesRef(expected);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregatorTests.java
@@ -20,11 +20,12 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.DimensionHasher;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
-import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
+import org.elasticsearch.index.mapper.RoutingDimensions;
 import org.elasticsearch.index.mapper.TimeSeriesParams;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregatorTestCase;
@@ -163,9 +164,9 @@ public class TimeSeriesRateAggregatorTests extends AggregatorTestCase {
     }
 
     private static BytesReference tsid(String dim) throws IOException {
-        TimeSeriesIdFieldMapper.TimeSeriesIdBuilder idBuilder = new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder(null);
-        idBuilder.addString("dim", dim);
-        return idBuilder.buildTsidHash();
+        var routingDimensions = new RoutingDimensions(null);
+        routingDimensions.addString("dim", dim);
+        return DimensionHasher.build(routingDimensions);
     }
 
     private Document doc(long timestamp, BytesReference tsid, long counterValue, String dim) {

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.RoutingDimensions;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.hamcrest.Matcher;
 import org.junit.After;
@@ -314,12 +315,12 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         final List<IndexableField> fields = new ArrayList<>();
         fields.add(new SortedNumericDocValuesField(DataStreamTimestampFieldMapper.DEFAULT_PATH, timestamp));
         fields.add(new LongPoint(DataStreamTimestampFieldMapper.DEFAULT_PATH, timestamp));
-        final TimeSeriesIdFieldMapper.TimeSeriesIdBuilder builder = new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder(null);
+        final RoutingDimensions routingDimensions = new RoutingDimensions(null);
         for (int i = 0; i < dimensions.length; i += 2) {
             if (dimensions[i + 1] instanceof Number n) {
-                builder.addLong(dimensions[i].toString(), n.longValue());
+                routingDimensions.addLong(dimensions[i].toString(), n.longValue());
             } else {
-                builder.addString(dimensions[i].toString(), dimensions[i + 1].toString());
+                routingDimensions.addString(dimensions[i].toString(), dimensions[i + 1].toString());
                 fields.add(new SortedSetDocValuesField(dimensions[i].toString(), new BytesRef(dimensions[i + 1].toString())));
             }
         }
@@ -333,7 +334,9 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
             }
         }
         // Use legacy tsid to make tests easier to understand:
-        fields.add(new SortedDocValuesField(TimeSeriesIdFieldMapper.NAME, builder.buildLegacyTsid().toBytesRef()));
+        fields.add(
+            new SortedDocValuesField(TimeSeriesIdFieldMapper.NAME, TimeSeriesIdFieldMapper.buildLegacyTsid(routingDimensions).toBytesRef())
+        );
         iw.addDocument(fields);
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
@@ -41,11 +41,13 @@ import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
+import org.elasticsearch.index.mapper.DimensionHasher;
 import org.elasticsearch.index.mapper.GeoPointFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperBuilderContext;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
+import org.elasticsearch.index.mapper.RoutingDimensions;
 import org.elasticsearch.index.mapper.TimeSeriesIdFieldMapper;
 import org.elasticsearch.plugins.SearchPlugin;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -797,12 +799,12 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
                 ArrayList<GeoPoint> points = testData.pointsForGroup(g);
                 ArrayList<Long> timestamps = testData.timestampsForGroup(g);
                 for (int i = 0; i < points.size(); i++) {
-                    final TimeSeriesIdFieldMapper.TimeSeriesIdBuilder builder = new TimeSeriesIdFieldMapper.TimeSeriesIdBuilder(null);
-                    builder.addString("group_id", testData.groups[g]);
+                    final var routingDimensions = new RoutingDimensions(null);
+                    routingDimensions.addString("group_id", testData.groups[g]);
                     ArrayList<Field> fields = new ArrayList<>(
                         Arrays.asList(
                             new SortedDocValuesField("group_id", new BytesRef(testData.groups[g])),
-                            new SortedDocValuesField(TimeSeriesIdFieldMapper.NAME, builder.buildTsidHash().toBytesRef())
+                            new SortedDocValuesField(TimeSeriesIdFieldMapper.NAME, DimensionHasher.build(routingDimensions).toBytesRef())
                         )
                     );
                     GeoPoint point = points.get(i);


### PR DESCRIPTION
Paves the ground for using the routing path in logs mode.