### PR TITLE
[ESQL] Migrate SimplifyComparisonArithmetics optimization

### DIFF
--- a/docs/changelog/109256.yaml
+++ b/docs/changelog/109256.yaml
@@ -1,0 +1,7 @@
+pr: 109256
+summary: "[ESQL] Migrate `SimplifyComparisonArithmetics` optimization"
+area: ES|QL
+type: bug
+issues:
+ - 108388
+ - 108743

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/optimizer/OptimizerRules.java
@@ -29,10 +29,6 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNull;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.ArithmeticOperation;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Neg;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Sub;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.GreaterThan;
@@ -49,12 +45,10 @@ import org.elasticsearch.xpack.esql.core.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.core.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.core.plan.logical.OrderBy;
 import org.elasticsearch.xpack.esql.core.rule.Rule;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.core.util.ReflectionUtils;
 
-import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -66,8 +60,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 
-import static java.lang.Math.signum;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.xpack.esql.core.expression.Literal.FALSE;
 import static org.elasticsearch.xpack.esql.core.expression.Literal.TRUE;
@@ -77,12 +69,6 @@ import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.
 import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.splitAnd;
 import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.splitOr;
 import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.subtract;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.ADD;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.DIV;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.MOD;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.MUL;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.SUB;
-import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 import static org.elasticsearch.xpack.esql.core.util.CollectionUtils.combine;
 
 public final class OptimizerRules {
@@ -1279,216 +1265,6 @@ public final class OptimizerRules {
                 e = ((SurrogateFunction) e).substitute();
             }
             return e;
-        }
-    }
-
-    // Simplifies arithmetic expressions with BinaryComparisons and fixed point fields, such as: (int + 2) / 3 > 4 => int > 10
-    public static final class SimplifyComparisonsArithmetics extends OptimizerExpressionRule<BinaryComparison> {
-        BiFunction<DataType, DataType, Boolean> typesCompatible;
-
-        public SimplifyComparisonsArithmetics(BiFunction<DataType, DataType, Boolean> typesCompatible) {
-            super(TransformDirection.UP);
-            this.typesCompatible = typesCompatible;
-        }
-
-        @Override
-        protected Expression rule(BinaryComparison bc) {
-            // optimize only once the expression has a literal on the right side of the binary comparison
-            if (bc.right() instanceof Literal) {
-                if (bc.left() instanceof ArithmeticOperation) {
-                    return simplifyBinaryComparison(bc);
-                }
-                if (bc.left() instanceof Neg) {
-                    return foldNegation(bc);
-                }
-            }
-            return bc;
-        }
-
-        private Expression simplifyBinaryComparison(BinaryComparison comparison) {
-            ArithmeticOperation operation = (ArithmeticOperation) comparison.left();
-            // Use symbol comp: SQL operations aren't available in this package (as dependencies)
-            String opSymbol = operation.symbol();
-            // Modulo can't be simplified.
-            if (opSymbol.equals(MOD.symbol())) {
-                return comparison;
-            }
-            OperationSimplifier simplification = null;
-            if (isMulOrDiv(opSymbol)) {
-                simplification = new MulDivSimplifier(comparison);
-            } else if (opSymbol.equals(ADD.symbol()) || opSymbol.equals(SUB.symbol())) {
-                simplification = new AddSubSimplifier(comparison);
-            }
-
-            return (simplification == null || simplification.isUnsafe(typesCompatible)) ? comparison : simplification.apply();
-        }
-
-        private static boolean isMulOrDiv(String opSymbol) {
-            return opSymbol.equals(MUL.symbol()) || opSymbol.equals(DIV.symbol());
-        }
-
-        private static Expression foldNegation(BinaryComparison bc) {
-            Literal bcLiteral = (Literal) bc.right();
-            Expression literalNeg = tryFolding(new Neg(bcLiteral.source(), bcLiteral));
-            return literalNeg == null ? bc : bc.reverse().replaceChildren(asList(((Neg) bc.left()).field(), literalNeg));
-        }
-
-        private static Expression tryFolding(Expression expression) {
-            if (expression.foldable()) {
-                try {
-                    expression = new Literal(expression.source(), expression.fold(), expression.dataType());
-                } catch (ArithmeticException | DateTimeException e) {
-                    // null signals that folding would result in an over-/underflow (such as Long.MAX_VALUE+1); the optimisation is skipped.
-                    expression = null;
-                }
-            }
-            return expression;
-        }
-
-        private abstract static class OperationSimplifier {
-            final BinaryComparison comparison;
-            final Literal bcLiteral;
-            final ArithmeticOperation operation;
-            final Expression opLeft;
-            final Expression opRight;
-            final Literal opLiteral;
-
-            OperationSimplifier(BinaryComparison comparison) {
-                this.comparison = comparison;
-                operation = (ArithmeticOperation) comparison.left();
-                bcLiteral = (Literal) comparison.right();
-
-                opLeft = operation.left();
-                opRight = operation.right();
-
-                if (opLeft instanceof Literal) {
-                    opLiteral = (Literal) opLeft;
-                } else if (opRight instanceof Literal) {
-                    opLiteral = (Literal) opRight;
-                } else {
-                    opLiteral = null;
-                }
-            }
-
-            // can it be quickly fast-tracked that the operation can't be reduced?
-            final boolean isUnsafe(BiFunction<DataType, DataType, Boolean> typesCompatible) {
-                if (opLiteral == null) {
-                    // one of the arithm. operands must be a literal, otherwise the operation wouldn't simplify anything
-                    return true;
-                }
-
-                // Only operations on fixed point literals are supported, since optimizing float point operations can also change the
-                // outcome of the filtering:
-                // x + 1e18 > 1e18::long will yield different results with a field value in [-2^6, 2^6], optimised vs original;
-                // x * (1 + 1e-15d) > 1 : same with a field value of (1 - 1e-15d)
-                // so consequently, int fields optimisation requiring FP arithmetic isn't possible either: (x - 1e-15) * (1 + 1e-15) > 1.
-                if (opLiteral.dataType().isRational() || bcLiteral.dataType().isRational()) {
-                    return true;
-                }
-
-                // the Literal will be moved to the right of the comparison, but only if data-compatible with what's there
-                if (typesCompatible.apply(bcLiteral.dataType(), opLiteral.dataType()) == false) {
-                    return true;
-                }
-
-                return isOpUnsafe();
-            }
-
-            final Expression apply() {
-                // force float point folding for FlP field
-                Literal bcl = operation.dataType().isRational()
-                    ? Literal.of(bcLiteral, ((Number) bcLiteral.value()).doubleValue())
-                    : bcLiteral;
-
-                Expression bcRightExpression = ((BinaryComparisonInversible) operation).binaryComparisonInverse()
-                    .create(bcl.source(), bcl, opRight);
-                bcRightExpression = tryFolding(bcRightExpression);
-                return bcRightExpression != null
-                    ? postProcess((BinaryComparison) comparison.replaceChildren(List.of(opLeft, bcRightExpression)))
-                    : comparison;
-            }
-
-            // operation-specific operations:
-            // - fast-tracking of simplification unsafety
-            abstract boolean isOpUnsafe();
-
-            // - post optimisation adjustments
-            Expression postProcess(BinaryComparison binaryComparison) {
-                return binaryComparison;
-            }
-        }
-
-        private static class AddSubSimplifier extends OperationSimplifier {
-
-            AddSubSimplifier(BinaryComparison comparison) {
-                super(comparison);
-            }
-
-            @Override
-            boolean isOpUnsafe() {
-                // no ADD/SUB with floating fields
-                if (operation.dataType().isRational()) {
-                    return true;
-                }
-
-                if (operation.symbol().equals(SUB.symbol()) && opRight instanceof Literal == false) { // such as: 1 - x > -MAX
-                    // if next simplification step would fail on overflow anyways, skip the optimisation already
-                    return tryFolding(new Sub(EMPTY, opLeft, bcLiteral)) == null;
-                }
-
-                return false;
-            }
-        }
-
-        private static class MulDivSimplifier extends OperationSimplifier {
-
-            private final boolean isDiv; // and not MUL.
-            private final int opRightSign; // sign of the right operand in: (left) (op) (right) (comp) (literal)
-
-            MulDivSimplifier(BinaryComparison comparison) {
-                super(comparison);
-                isDiv = operation.symbol().equals(DIV.symbol());
-                opRightSign = sign(opRight);
-            }
-
-            @Override
-            boolean isOpUnsafe() {
-                // Integer divisions are not safe to optimise: x / 5 > 1 <=/=> x > 5 for x in [6, 9]; same for the `==` comp
-                if (operation.dataType().isInteger() && isDiv) {
-                    return true;
-                }
-
-                // If current operation is a multiplication, it's inverse will be a division: safe only if outcome is still integral.
-                if (isDiv == false && opLeft.dataType().isInteger()) {
-                    long opLiteralValue = ((Number) opLiteral.value()).longValue();
-                    return opLiteralValue == 0 || ((Number) bcLiteral.value()).longValue() % opLiteralValue != 0;
-                }
-
-                // can't move a 0 in Mul/Div comparisons
-                return opRightSign == 0;
-            }
-
-            @Override
-            Expression postProcess(BinaryComparison binaryComparison) {
-                // negative multiplication/division changes the direction of the comparison
-                return opRightSign < 0 ? binaryComparison.reverse() : binaryComparison;
-            }
-
-            private static int sign(Object obj) {
-                int sign = 1;
-                if (obj instanceof Number) {
-                    sign = (int) signum(((Number) obj).doubleValue());
-                } else if (obj instanceof Literal) {
-                    sign = sign(((Literal) obj).value());
-                } else if (obj instanceof Neg) {
-                    sign = -sign(((Neg) obj).field());
-                } else if (obj instanceof ArithmeticOperation operation) {
-                    if (isMulOrDiv(operation.symbol())) {
-                        sign = sign(operation.left()) * sign(operation.right());
-                    }
-                }
-                return sign;
-            }
         }
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -61,7 +61,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesFunction;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
-import org.elasticsearch.xpack.esql.optimizer.OptimizerRules.SimplifyComparisonsArithmetics;
+import org.elasticsearch.xpack.esql.optimizer.rules.SimplifyComparisonsArithmetics;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizer.java
@@ -38,7 +38,6 @@ import org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.ConstantFoldin
 import org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.LiteralsOnTheRight;
 import org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.PruneLiteralsInOrderBy;
 import org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.SetAsOptimized;
-import org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.SimplifyComparisonsArithmetics;
 import org.elasticsearch.xpack.esql.core.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.core.plan.logical.Limit;
 import org.elasticsearch.xpack.esql.core.plan.logical.LogicalPlan;
@@ -62,6 +61,7 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesFunction;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
+import org.elasticsearch.xpack.esql.optimizer.OptimizerRules.SimplifyComparisonsArithmetics;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Enrich;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRules.java
@@ -19,14 +19,9 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogic;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.ArithmeticOperation;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Neg;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Sub;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.plan.QueryPlan;
 import org.elasticsearch.xpack.esql.core.plan.logical.LogicalPlan;
-import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
@@ -60,7 +55,6 @@ import org.elasticsearch.xpack.esql.plan.physical.RegexExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.RowExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
 
-import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -70,21 +64,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 
-import static java.lang.Math.signum;
-import static java.util.Arrays.asList;
 import static org.elasticsearch.xpack.esql.core.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.Literal.FALSE;
 import static org.elasticsearch.xpack.esql.core.expression.Literal.TRUE;
 import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.combineOr;
 import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.splitOr;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.ADD;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.DIV;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.MOD;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.MUL;
-import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.SUB;
-import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 
 class OptimizerRules {
 
@@ -626,219 +611,6 @@ class OptimizerRules {
             }
 
             return updated ? Predicates.combineOr(CollectionUtils.combine(exps, equals, notEquals, inequalities, ranges)) : or;
-        }
-    }
-
-    /**
-     * Simplifies arithmetic expressions with BinaryComparisons and fixed point fields, such as: (int + 2) / 3 > 4 => int > 10
-     */
-    public static final class SimplifyComparisonsArithmetics extends
-        org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.OptimizerExpressionRule<BinaryComparison> {
-        BiFunction<DataType, DataType, Boolean> typesCompatible;
-
-        SimplifyComparisonsArithmetics(BiFunction<DataType, DataType, Boolean> typesCompatible) {
-            super(org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.TransformDirection.UP);
-            this.typesCompatible = typesCompatible;
-        }
-
-        @Override
-        protected Expression rule(BinaryComparison bc) {
-            // optimize only once the expression has a literal on the right side of the binary comparison
-            if (bc.right() instanceof Literal) {
-                if (bc.left() instanceof ArithmeticOperation) {
-                    return simplifyBinaryComparison(bc);
-                }
-                if (bc.left() instanceof Neg) {
-                    return foldNegation(bc);
-                }
-            }
-            return bc;
-        }
-
-        private Expression simplifyBinaryComparison(BinaryComparison comparison) {
-            ArithmeticOperation operation = (ArithmeticOperation) comparison.left();
-            // Use symbol comp: SQL operations aren't available in this package (as dependencies)
-            String opSymbol = operation.symbol();
-            // Modulo can't be simplified.
-            if (opSymbol.equals(MOD.symbol())) {
-                return comparison;
-            }
-            OperationSimplifier simplification = null;
-            if (isMulOrDiv(opSymbol)) {
-                simplification = new MulDivSimplifier(comparison);
-            } else if (opSymbol.equals(ADD.symbol()) || opSymbol.equals(SUB.symbol())) {
-                simplification = new AddSubSimplifier(comparison);
-            }
-
-            return (simplification == null || simplification.isUnsafe(typesCompatible)) ? comparison : simplification.apply();
-        }
-
-        private static boolean isMulOrDiv(String opSymbol) {
-            return opSymbol.equals(MUL.symbol()) || opSymbol.equals(DIV.symbol());
-        }
-
-        private static Expression foldNegation(BinaryComparison bc) {
-            Literal bcLiteral = (Literal) bc.right();
-            Expression literalNeg = tryFolding(new Neg(bcLiteral.source(), bcLiteral));
-            return literalNeg == null ? bc : bc.reverse().replaceChildren(asList(((Neg) bc.left()).field(), literalNeg));
-        }
-
-        private static Expression tryFolding(Expression expression) {
-            if (expression.foldable()) {
-                try {
-                    expression = new Literal(expression.source(), expression.fold(), expression.dataType());
-                } catch (ArithmeticException | DateTimeException e) {
-                    // null signals that folding would result in an over-/underflow (such as Long.MAX_VALUE+1); the optimisation is skipped.
-                    expression = null;
-                }
-            }
-            return expression;
-        }
-
-        private abstract static class OperationSimplifier {
-            final BinaryComparison comparison;
-            final Literal bcLiteral;
-            final ArithmeticOperation operation;
-            final Expression opLeft;
-            final Expression opRight;
-            final Literal opLiteral;
-
-            OperationSimplifier(BinaryComparison comparison) {
-                this.comparison = comparison;
-                operation = (ArithmeticOperation) comparison.left();
-                bcLiteral = (Literal) comparison.right();
-
-                opLeft = operation.left();
-                opRight = operation.right();
-
-                if (opLeft instanceof Literal) {
-                    opLiteral = (Literal) opLeft;
-                } else if (opRight instanceof Literal) {
-                    opLiteral = (Literal) opRight;
-                } else {
-                    opLiteral = null;
-                }
-            }
-
-            // can it be quickly fast-tracked that the operation can't be reduced?
-            final boolean isUnsafe(BiFunction<DataType, DataType, Boolean> typesCompatible) {
-                if (opLiteral == null) {
-                    // one of the arithm. operands must be a literal, otherwise the operation wouldn't simplify anything
-                    return true;
-                }
-
-                // Only operations on fixed point literals are supported, since optimizing float point operations can also change the
-                // outcome of the filtering:
-                // x + 1e18 > 1e18::long will yield different results with a field value in [-2^6, 2^6], optimised vs original;
-                // x * (1 + 1e-15d) > 1 : same with a field value of (1 - 1e-15d)
-                // so consequently, int fields optimisation requiring FP arithmetic isn't possible either: (x - 1e-15) * (1 + 1e-15) > 1.
-                if (opLiteral.dataType().isRational() || bcLiteral.dataType().isRational()) {
-                    return true;
-                }
-
-                // the Literal will be moved to the right of the comparison, but only if data-compatible with what's there
-                if (typesCompatible.apply(bcLiteral.dataType(), opLiteral.dataType()) == false) {
-                    return true;
-                }
-
-                return isOpUnsafe();
-            }
-
-            final Expression apply() {
-                // force float point folding for FlP field
-                Literal bcl = operation.dataType().isRational()
-                    ? Literal.of(bcLiteral, ((Number) bcLiteral.value()).doubleValue())
-                    : bcLiteral;
-
-                Expression bcRightExpression = ((BinaryComparisonInversible) operation).binaryComparisonInverse()
-                    .create(bcl.source(), bcl, opRight);
-                bcRightExpression = tryFolding(bcRightExpression);
-                return bcRightExpression != null
-                    ? postProcess((BinaryComparison) comparison.replaceChildren(List.of(opLeft, bcRightExpression)))
-                    : comparison;
-            }
-
-            // operation-specific operations:
-            // - fast-tracking of simplification unsafety
-            abstract boolean isOpUnsafe();
-
-            // - post optimisation adjustments
-            Expression postProcess(BinaryComparison binaryComparison) {
-                return binaryComparison;
-            }
-        }
-
-        private static class AddSubSimplifier extends OperationSimplifier {
-
-            AddSubSimplifier(BinaryComparison comparison) {
-                super(comparison);
-            }
-
-            @Override
-            boolean isOpUnsafe() {
-                // no ADD/SUB with floating fields
-                if (operation.dataType().isRational()) {
-                    return true;
-                }
-
-                if (operation.symbol().equals(SUB.symbol()) && opRight instanceof Literal == false) { // such as: 1 - x > -MAX
-                    // if next simplification step would fail on overflow anyways, skip the optimisation already
-                    return tryFolding(new Sub(EMPTY, opLeft, bcLiteral)) == null;
-                }
-
-                return false;
-            }
-        }
-
-        private static class MulDivSimplifier extends OperationSimplifier {
-
-            private final boolean isDiv; // and not MUL.
-            private final int opRightSign; // sign of the right operand in: (left) (op) (right) (comp) (literal)
-
-            MulDivSimplifier(BinaryComparison comparison) {
-                super(comparison);
-                isDiv = operation.symbol().equals(DIV.symbol());
-                opRightSign = sign(opRight);
-            }
-
-            @Override
-            boolean isOpUnsafe() {
-                // Integer divisions are not safe to optimise: x / 5 > 1 <=/=> x > 5 for x in [6, 9]; same for the `==` comp
-                if (operation.dataType().isInteger() && isDiv) {
-                    return true;
-                }
-
-                // If current operation is a multiplication, it's inverse will be a division: safe only if outcome is still integral.
-                if (isDiv == false && opLeft.dataType().isInteger()) {
-                    long opLiteralValue = ((Number) opLiteral.value()).longValue();
-                    return opLiteralValue == 0 || ((Number) bcLiteral.value()).longValue() % opLiteralValue != 0;
-                }
-
-                // can't move a 0 in Mul/Div comparisons
-                return opRightSign == 0;
-            }
-
-            @Override
-            Expression postProcess(BinaryComparison binaryComparison) {
-                // negative multiplication/division changes the direction of the comparison
-                return opRightSign < 0 ? binaryComparison.reverse() : binaryComparison;
-            }
-
-            private static int sign(Object obj) {
-                int sign = 1;
-                if (obj instanceof Number) {
-                    sign = (int) signum(((Number) obj).doubleValue());
-                } else if (obj instanceof Literal) {
-                    sign = sign(((Literal) obj).value());
-                } else if (obj instanceof Neg) {
-                    sign = -sign(((Neg) obj).field());
-                } else if (obj instanceof ArithmeticOperation operation) {
-                    if (isMulOrDiv(operation.symbol())) {
-                        sign = sign(operation.left()) * sign(operation.right());
-                    }
-                }
-                return sign;
-            }
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRules.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/OptimizerRules.java
@@ -19,9 +19,14 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.logical.And;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogic;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Not;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.ArithmeticOperation;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Neg;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Sub;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.plan.QueryPlan;
 import org.elasticsearch.xpack.esql.core.plan.logical.LogicalPlan;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
 import org.elasticsearch.xpack.esql.core.util.CollectionUtils;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
@@ -55,6 +60,7 @@ import org.elasticsearch.xpack.esql.plan.physical.RegexExtractExec;
 import org.elasticsearch.xpack.esql.plan.physical.RowExec;
 import org.elasticsearch.xpack.esql.plan.physical.ShowExec;
 
+import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -64,12 +70,21 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 
+import static java.lang.Math.signum;
+import static java.util.Arrays.asList;
 import static org.elasticsearch.xpack.esql.core.common.Failure.fail;
 import static org.elasticsearch.xpack.esql.core.expression.Literal.FALSE;
 import static org.elasticsearch.xpack.esql.core.expression.Literal.TRUE;
 import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.combineOr;
 import static org.elasticsearch.xpack.esql.core.expression.predicate.Predicates.splitOr;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.ADD;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.DIV;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.MOD;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.MUL;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.SUB;
+import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 
 class OptimizerRules {
 
@@ -611,6 +626,219 @@ class OptimizerRules {
             }
 
             return updated ? Predicates.combineOr(CollectionUtils.combine(exps, equals, notEquals, inequalities, ranges)) : or;
+        }
+    }
+
+    /**
+     * Simplifies arithmetic expressions with BinaryComparisons and fixed point fields, such as: (int + 2) / 3 > 4 => int > 10
+     */
+    public static final class SimplifyComparisonsArithmetics extends
+        org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.OptimizerExpressionRule<BinaryComparison> {
+        BiFunction<DataType, DataType, Boolean> typesCompatible;
+
+        SimplifyComparisonsArithmetics(BiFunction<DataType, DataType, Boolean> typesCompatible) {
+            super(org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.TransformDirection.UP);
+            this.typesCompatible = typesCompatible;
+        }
+
+        @Override
+        protected Expression rule(BinaryComparison bc) {
+            // optimize only once the expression has a literal on the right side of the binary comparison
+            if (bc.right() instanceof Literal) {
+                if (bc.left() instanceof ArithmeticOperation) {
+                    return simplifyBinaryComparison(bc);
+                }
+                if (bc.left() instanceof Neg) {
+                    return foldNegation(bc);
+                }
+            }
+            return bc;
+        }
+
+        private Expression simplifyBinaryComparison(BinaryComparison comparison) {
+            ArithmeticOperation operation = (ArithmeticOperation) comparison.left();
+            // Use symbol comp: SQL operations aren't available in this package (as dependencies)
+            String opSymbol = operation.symbol();
+            // Modulo can't be simplified.
+            if (opSymbol.equals(MOD.symbol())) {
+                return comparison;
+            }
+            OperationSimplifier simplification = null;
+            if (isMulOrDiv(opSymbol)) {
+                simplification = new MulDivSimplifier(comparison);
+            } else if (opSymbol.equals(ADD.symbol()) || opSymbol.equals(SUB.symbol())) {
+                simplification = new AddSubSimplifier(comparison);
+            }
+
+            return (simplification == null || simplification.isUnsafe(typesCompatible)) ? comparison : simplification.apply();
+        }
+
+        private static boolean isMulOrDiv(String opSymbol) {
+            return opSymbol.equals(MUL.symbol()) || opSymbol.equals(DIV.symbol());
+        }
+
+        private static Expression foldNegation(BinaryComparison bc) {
+            Literal bcLiteral = (Literal) bc.right();
+            Expression literalNeg = tryFolding(new Neg(bcLiteral.source(), bcLiteral));
+            return literalNeg == null ? bc : bc.reverse().replaceChildren(asList(((Neg) bc.left()).field(), literalNeg));
+        }
+
+        private static Expression tryFolding(Expression expression) {
+            if (expression.foldable()) {
+                try {
+                    expression = new Literal(expression.source(), expression.fold(), expression.dataType());
+                } catch (ArithmeticException | DateTimeException e) {
+                    // null signals that folding would result in an over-/underflow (such as Long.MAX_VALUE+1); the optimisation is skipped.
+                    expression = null;
+                }
+            }
+            return expression;
+        }
+
+        private abstract static class OperationSimplifier {
+            final BinaryComparison comparison;
+            final Literal bcLiteral;
+            final ArithmeticOperation operation;
+            final Expression opLeft;
+            final Expression opRight;
+            final Literal opLiteral;
+
+            OperationSimplifier(BinaryComparison comparison) {
+                this.comparison = comparison;
+                operation = (ArithmeticOperation) comparison.left();
+                bcLiteral = (Literal) comparison.right();
+
+                opLeft = operation.left();
+                opRight = operation.right();
+
+                if (opLeft instanceof Literal) {
+                    opLiteral = (Literal) opLeft;
+                } else if (opRight instanceof Literal) {
+                    opLiteral = (Literal) opRight;
+                } else {
+                    opLiteral = null;
+                }
+            }
+
+            // can it be quickly fast-tracked that the operation can't be reduced?
+            final boolean isUnsafe(BiFunction<DataType, DataType, Boolean> typesCompatible) {
+                if (opLiteral == null) {
+                    // one of the arithm. operands must be a literal, otherwise the operation wouldn't simplify anything
+                    return true;
+                }
+
+                // Only operations on fixed point literals are supported, since optimizing float point operations can also change the
+                // outcome of the filtering:
+                // x + 1e18 > 1e18::long will yield different results with a field value in [-2^6, 2^6], optimised vs original;
+                // x * (1 + 1e-15d) > 1 : same with a field value of (1 - 1e-15d)
+                // so consequently, int fields optimisation requiring FP arithmetic isn't possible either: (x - 1e-15) * (1 + 1e-15) > 1.
+                if (opLiteral.dataType().isRational() || bcLiteral.dataType().isRational()) {
+                    return true;
+                }
+
+                // the Literal will be moved to the right of the comparison, but only if data-compatible with what's there
+                if (typesCompatible.apply(bcLiteral.dataType(), opLiteral.dataType()) == false) {
+                    return true;
+                }
+
+                return isOpUnsafe();
+            }
+
+            final Expression apply() {
+                // force float point folding for FlP field
+                Literal bcl = operation.dataType().isRational()
+                    ? Literal.of(bcLiteral, ((Number) bcLiteral.value()).doubleValue())
+                    : bcLiteral;
+
+                Expression bcRightExpression = ((BinaryComparisonInversible) operation).binaryComparisonInverse()
+                    .create(bcl.source(), bcl, opRight);
+                bcRightExpression = tryFolding(bcRightExpression);
+                return bcRightExpression != null
+                    ? postProcess((BinaryComparison) comparison.replaceChildren(List.of(opLeft, bcRightExpression)))
+                    : comparison;
+            }
+
+            // operation-specific operations:
+            // - fast-tracking of simplification unsafety
+            abstract boolean isOpUnsafe();
+
+            // - post optimisation adjustments
+            Expression postProcess(BinaryComparison binaryComparison) {
+                return binaryComparison;
+            }
+        }
+
+        private static class AddSubSimplifier extends OperationSimplifier {
+
+            AddSubSimplifier(BinaryComparison comparison) {
+                super(comparison);
+            }
+
+            @Override
+            boolean isOpUnsafe() {
+                // no ADD/SUB with floating fields
+                if (operation.dataType().isRational()) {
+                    return true;
+                }
+
+                if (operation.symbol().equals(SUB.symbol()) && opRight instanceof Literal == false) { // such as: 1 - x > -MAX
+                    // if next simplification step would fail on overflow anyways, skip the optimisation already
+                    return tryFolding(new Sub(EMPTY, opLeft, bcLiteral)) == null;
+                }
+
+                return false;
+            }
+        }
+
+        private static class MulDivSimplifier extends OperationSimplifier {
+
+            private final boolean isDiv; // and not MUL.
+            private final int opRightSign; // sign of the right operand in: (left) (op) (right) (comp) (literal)
+
+            MulDivSimplifier(BinaryComparison comparison) {
+                super(comparison);
+                isDiv = operation.symbol().equals(DIV.symbol());
+                opRightSign = sign(opRight);
+            }
+
+            @Override
+            boolean isOpUnsafe() {
+                // Integer divisions are not safe to optimise: x / 5 > 1 <=/=> x > 5 for x in [6, 9]; same for the `==` comp
+                if (operation.dataType().isInteger() && isDiv) {
+                    return true;
+                }
+
+                // If current operation is a multiplication, it's inverse will be a division: safe only if outcome is still integral.
+                if (isDiv == false && opLeft.dataType().isInteger()) {
+                    long opLiteralValue = ((Number) opLiteral.value()).longValue();
+                    return opLiteralValue == 0 || ((Number) bcLiteral.value()).longValue() % opLiteralValue != 0;
+                }
+
+                // can't move a 0 in Mul/Div comparisons
+                return opRightSign == 0;
+            }
+
+            @Override
+            Expression postProcess(BinaryComparison binaryComparison) {
+                // negative multiplication/division changes the direction of the comparison
+                return opRightSign < 0 ? binaryComparison.reverse() : binaryComparison;
+            }
+
+            private static int sign(Object obj) {
+                int sign = 1;
+                if (obj instanceof Number) {
+                    sign = (int) signum(((Number) obj).doubleValue());
+                } else if (obj instanceof Literal) {
+                    sign = sign(((Literal) obj).value());
+                } else if (obj instanceof Neg) {
+                    sign = -sign(((Neg) obj).field());
+                } else if (obj instanceof ArithmeticOperation operation) {
+                    if (isMulOrDiv(operation.symbol())) {
+                        sign = sign(operation.left()) * sign(operation.right());
+                    }
+                }
+                return sign;
+            }
         }
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/SimplifyComparisonsArithmetics.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/SimplifyComparisonsArithmetics.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmeti
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Sub;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.type.DataTypes;
 
 import java.time.DateTimeException;
 import java.util.List;
@@ -146,7 +147,9 @@ public final class SimplifyComparisonsArithmetics extends
 
         final Expression apply() {
             // force float point folding for FlP field
-            Literal bcl = operation.dataType().isRational() ? Literal.of(bcLiteral, ((Number) bcLiteral.value()).doubleValue()) : bcLiteral;
+            Literal bcl = operation.dataType().isRational()
+                ? new Literal(bcLiteral.source(), ((Number) bcLiteral.value()).doubleValue(), DataTypes.DOUBLE)
+                : bcLiteral;
 
             Expression bcRightExpression = ((BinaryComparisonInversible) operation).binaryComparisonInverse()
                 .create(bcl.source(), bcl, opRight);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/SimplifyComparisonsArithmetics.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/SimplifyComparisonsArithmetics.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.optimizer.rules;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.ArithmeticOperation;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Neg;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Sub;
+import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+
+import java.time.DateTimeException;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import static java.lang.Math.signum;
+import static java.util.Arrays.asList;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.ADD;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.DIV;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.MOD;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.MUL;
+import static org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.DefaultBinaryArithmeticOperation.SUB;
+import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
+
+/**
+ * Simplifies arithmetic expressions with BinaryComparisons and fixed point fields, such as: (int + 2) / 3 > 4 => int > 10
+ */
+public final class SimplifyComparisonsArithmetics extends
+    org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.OptimizerExpressionRule<BinaryComparison> {
+    BiFunction<DataType, DataType, Boolean> typesCompatible;
+
+    public SimplifyComparisonsArithmetics(BiFunction<DataType, DataType, Boolean> typesCompatible) {
+        super(org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules.TransformDirection.UP);
+        this.typesCompatible = typesCompatible;
+    }
+
+    @Override
+    protected Expression rule(BinaryComparison bc) {
+        // optimize only once the expression has a literal on the right side of the binary comparison
+        if (bc.right() instanceof Literal) {
+            if (bc.left() instanceof ArithmeticOperation) {
+                return simplifyBinaryComparison(bc);
+            }
+            if (bc.left() instanceof Neg) {
+                return foldNegation(bc);
+            }
+        }
+        return bc;
+    }
+
+    private Expression simplifyBinaryComparison(BinaryComparison comparison) {
+        ArithmeticOperation operation = (ArithmeticOperation) comparison.left();
+        // Use symbol comp: SQL operations aren't available in this package (as dependencies)
+        String opSymbol = operation.symbol();
+        // Modulo can't be simplified.
+        if (opSymbol.equals(MOD.symbol())) {
+            return comparison;
+        }
+        OperationSimplifier simplification = null;
+        if (isMulOrDiv(opSymbol)) {
+            simplification = new MulDivSimplifier(comparison);
+        } else if (opSymbol.equals(ADD.symbol()) || opSymbol.equals(SUB.symbol())) {
+            simplification = new AddSubSimplifier(comparison);
+        }
+
+        return (simplification == null || simplification.isUnsafe(typesCompatible)) ? comparison : simplification.apply();
+    }
+
+    private static boolean isMulOrDiv(String opSymbol) {
+        return opSymbol.equals(MUL.symbol()) || opSymbol.equals(DIV.symbol());
+    }
+
+    private static Expression foldNegation(BinaryComparison bc) {
+        Literal bcLiteral = (Literal) bc.right();
+        Expression literalNeg = tryFolding(new Neg(bcLiteral.source(), bcLiteral));
+        return literalNeg == null ? bc : bc.reverse().replaceChildren(asList(((Neg) bc.left()).field(), literalNeg));
+    }
+
+    private static Expression tryFolding(Expression expression) {
+        if (expression.foldable()) {
+            try {
+                expression = new Literal(expression.source(), expression.fold(), expression.dataType());
+            } catch (ArithmeticException | DateTimeException e) {
+                // null signals that folding would result in an over-/underflow (such as Long.MAX_VALUE+1); the optimisation is skipped.
+                expression = null;
+            }
+        }
+        return expression;
+    }
+
+    private abstract static class OperationSimplifier {
+        final BinaryComparison comparison;
+        final Literal bcLiteral;
+        final ArithmeticOperation operation;
+        final Expression opLeft;
+        final Expression opRight;
+        final Literal opLiteral;
+
+        OperationSimplifier(BinaryComparison comparison) {
+            this.comparison = comparison;
+            operation = (ArithmeticOperation) comparison.left();
+            bcLiteral = (Literal) comparison.right();
+
+            opLeft = operation.left();
+            opRight = operation.right();
+
+            if (opLeft instanceof Literal) {
+                opLiteral = (Literal) opLeft;
+            } else if (opRight instanceof Literal) {
+                opLiteral = (Literal) opRight;
+            } else {
+                opLiteral = null;
+            }
+        }
+
+        // can it be quickly fast-tracked that the operation can't be reduced?
+        final boolean isUnsafe(BiFunction<DataType, DataType, Boolean> typesCompatible) {
+            if (opLiteral == null) {
+                // one of the arithm. operands must be a literal, otherwise the operation wouldn't simplify anything
+                return true;
+            }
+
+            // Only operations on fixed point literals are supported, since optimizing float point operations can also change the
+            // outcome of the filtering:
+            // x + 1e18 > 1e18::long will yield different results with a field value in [-2^6, 2^6], optimised vs original;
+            // x * (1 + 1e-15d) > 1 : same with a field value of (1 - 1e-15d)
+            // so consequently, int fields optimisation requiring FP arithmetic isn't possible either: (x - 1e-15) * (1 + 1e-15) > 1.
+            if (opLiteral.dataType().isRational() || bcLiteral.dataType().isRational()) {
+                return true;
+            }
+
+            // the Literal will be moved to the right of the comparison, but only if data-compatible with what's there
+            if (typesCompatible.apply(bcLiteral.dataType(), opLiteral.dataType()) == false) {
+                return true;
+            }
+
+            return isOpUnsafe();
+        }
+
+        final Expression apply() {
+            // force float point folding for FlP field
+            Literal bcl = operation.dataType().isRational() ? Literal.of(bcLiteral, ((Number) bcLiteral.value()).doubleValue()) : bcLiteral;
+
+            Expression bcRightExpression = ((BinaryComparisonInversible) operation).binaryComparisonInverse()
+                .create(bcl.source(), bcl, opRight);
+            bcRightExpression = tryFolding(bcRightExpression);
+            return bcRightExpression != null
+                ? postProcess((BinaryComparison) comparison.replaceChildren(List.of(opLeft, bcRightExpression)))
+                : comparison;
+        }
+
+        // operation-specific operations:
+        // - fast-tracking of simplification unsafety
+        abstract boolean isOpUnsafe();
+
+        // - post optimisation adjustments
+        Expression postProcess(BinaryComparison binaryComparison) {
+            return binaryComparison;
+        }
+    }
+
+    private static class AddSubSimplifier extends OperationSimplifier {
+
+        AddSubSimplifier(BinaryComparison comparison) {
+            super(comparison);
+        }
+
+        @Override
+        boolean isOpUnsafe() {
+            // no ADD/SUB with floating fields
+            if (operation.dataType().isRational()) {
+                return true;
+            }
+
+            if (operation.symbol().equals(SUB.symbol()) && opRight instanceof Literal == false) { // such as: 1 - x > -MAX
+                // if next simplification step would fail on overflow anyways, skip the optimisation already
+                return tryFolding(new Sub(EMPTY, opLeft, bcLiteral)) == null;
+            }
+
+            return false;
+        }
+    }
+
+    private static class MulDivSimplifier extends OperationSimplifier {
+
+        private final boolean isDiv; // and not MUL.
+        private final int opRightSign; // sign of the right operand in: (left) (op) (right) (comp) (literal)
+
+        MulDivSimplifier(BinaryComparison comparison) {
+            super(comparison);
+            isDiv = operation.symbol().equals(DIV.symbol());
+            opRightSign = sign(opRight);
+        }
+
+        @Override
+        boolean isOpUnsafe() {
+            // Integer divisions are not safe to optimise: x / 5 > 1 <=/=> x > 5 for x in [6, 9]; same for the `==` comp
+            if (operation.dataType().isInteger() && isDiv) {
+                return true;
+            }
+
+            // If current operation is a multiplication, it's inverse will be a division: safe only if outcome is still integral.
+            if (isDiv == false && opLeft.dataType().isInteger()) {
+                long opLiteralValue = ((Number) opLiteral.value()).longValue();
+                return opLiteralValue == 0 || ((Number) bcLiteral.value()).longValue() % opLiteralValue != 0;
+            }
+
+            // can't move a 0 in Mul/Div comparisons
+            return opRightSign == 0;
+        }
+
+        @Override
+        Expression postProcess(BinaryComparison binaryComparison) {
+            // negative multiplication/division changes the direction of the comparison
+            return opRightSign < 0 ? binaryComparison.reverse() : binaryComparison;
+        }
+
+        private static int sign(Object obj) {
+            int sign = 1;
+            if (obj instanceof Number) {
+                sign = (int) signum(((Number) obj).doubleValue());
+            } else if (obj instanceof Literal) {
+                sign = sign(((Literal) obj).value());
+            } else if (obj instanceof Neg) {
+                sign = -sign(((Neg) obj).field());
+            } else if (obj instanceof ArithmeticOperation operation) {
+                if (isMulOrDiv(operation.symbol())) {
+                    sign = sign(operation.left()) * sign(operation.right());
+                }
+            }
+            return sign;
+        }
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/SimplifyComparisonsArithmetics.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/SimplifyComparisonsArithmetics.java
@@ -11,11 +11,11 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.ArithmeticOperation;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.BinaryComparisonInversible;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Neg;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Sub;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.comparison.BinaryComparison;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.type.DataTypes;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Neg;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Sub;
 
 import java.time.DateTimeException;
 import java.util.List;

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -4577,17 +4577,14 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
         doTestSimplifyComparisonArithmetics("((integer + 1) * 2 - 4) * 4 >= 16", "integer", GTE, 3);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108743")
     public void testSimplifyComparisonArithmeticWithFieldNegation() {
         doTestSimplifyComparisonArithmetics("12 * (-integer - 5) >= -120", "integer", LTE, 5);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108743")
     public void testSimplifyComparisonArithmeticWithFieldDoubleNegation() {
         doTestSimplifyComparisonArithmetics("12 * -(-integer - 5) <= 120", "integer", LTE, 5);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108743")
     public void testSimplifyComparisonArithmeticWithConjunction() {
         doTestSimplifyComparisonArithmetics("12 * (-integer - 5) == -120 AND integer < 6 ", "integer", EQ, 5);
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LogicalPlanOptimizerTests.java
@@ -4554,7 +4554,6 @@ public class LogicalPlanOptimizerTests extends ESTestCase {
 
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/108388")
     public void testSimplifyComparisonArithmeticsWithFloatingPoints() {
         doTestSimplifyComparisonArithmetics("float / 2 > 4", "float", GT, 8d);
     }


### PR DESCRIPTION
This pulls the SimplifyComparisonArithmetics optimization into ESQL proper, from core, and in doing so resolves two of the issues we uncovered with that optimization.  

Rather than moving this into a sub-class of `OptimzierRules`, I've opted to create a new package `optimizer.rules`, and put this as a top level class there. I have another PR open that migrates a bunch of other rules into `OptimizerRules`, and that's in general an area of the code that's being touched a lot lately.  Having top level classes in a package, rather than sub-classes in a single class file, will create fewer conflicts while working on things that are actually unrelated in this type of situation.

Although this is a bugfix, I did not mark it for backporting to 8.14.  To my knowledge, no users have reported the associated bugs (we found them through migrating tests), and this fix depends on tests and refactorings that were not backported to 8.14.  It would be possible to write an 8.14 version of this, but IMHO it's easier to do as a fresh ticket than as a backport and conflict resolution process. If we think that's important, I'm happy to do so, but at the moment I think fixing it for 8.15 is fine.

Note that this is a re-application of the changes in https://github.com/elastic/elasticsearch/pull/108200 after we did other refactoring, which that was closed to enable.

Resolves https://github.com/elastic/elasticsearch/issues/108388
Resolves https://github.com/elastic/elasticsearch/issues/108743
