### PR TITLE
Some minor authz optimizations

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestCacheDisablingInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/interceptor/SearchRequestCacheDisablingInterceptor.java
@@ -39,12 +39,11 @@ public class SearchRequestCacheDisablingInterceptor implements RequestIntercepto
         AuthorizationEngine.AuthorizationInfo authorizationInfo,
         ActionListener<Void> listener
     ) {
-        final boolean isDlsLicensed = DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
-        final boolean isFlsLicensed = FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState);
         if (requestInfo.getRequest() instanceof SearchRequest searchRequest
             && false == TransportActionProxy.isProxyAction(requestInfo.getAction())
             && hasRemoteIndices(searchRequest)
-            && (isDlsLicensed || isFlsLicensed)) {
+            && (DOCUMENT_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState)
+                || FIELD_LEVEL_SECURITY_FEATURE.checkWithoutTracking(licenseState))) {
             final IndicesAccessControl indicesAccessControl = threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY);
             if (indicesAccessControl.getFieldAndDocumentLevelSecurityUsage() != IndicesAccessControl.DlsFlsUsage.NONE) {
                 searchRequest.requestCache(false);


### PR DESCRIPTION
Two things in here that I found by benchmarking indexing performance:
1. Use `.delegateFailureAndWrap` more to save some allocations on the hot transport path (relative to `wrap` which allocates more)
2. Every request goes through the interceptors, layout the code a little clearer to make the common path where nothing gets intercepted smaller.
