### PR TITLE
Speedup Murmur3HashFunction

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/Murmur3HashFunction.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/Murmur3HashFunction.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing;
 
 import org.apache.lucene.util.StringHelper;
+import org.elasticsearch.common.util.ByteUtils;
 
 /**
  * Hash function based on the Murmur3 algorithm, which is the default as of Elasticsearch 2.0.
@@ -19,16 +20,26 @@ public final class Murmur3HashFunction {
         // no instance
     }
 
+    private static final int MAX_SCRATCH_SIZE = 1024;
+    private static final ThreadLocal<byte[]> scratch = ThreadLocal.withInitial(() -> new byte[MAX_SCRATCH_SIZE]);
+
     public static int hash(String routing) {
-        final byte[] bytesToHash = new byte[routing.length() * 2];
+        assert assertHashWithoutInformationLoss(routing);
+        final int strLen = routing.length();
+        final byte[] bytesToHash = strLen * 2 <= MAX_SCRATCH_SIZE ? scratch.get() : new byte[strLen * 2];
+        for (int i = 0; i < strLen; ++i) {
+            ByteUtils.LITTLE_ENDIAN_CHAR.set(bytesToHash, 2 * i, routing.charAt(i));
+        }
+        return hash(bytesToHash, 0, strLen * 2);
+    }
+
+    private static boolean assertHashWithoutInformationLoss(String routing) {
         for (int i = 0; i < routing.length(); ++i) {
             final char c = routing.charAt(i);
             final byte b1 = (byte) c, b2 = (byte) (c >>> 8);
             assert ((b1 & 0xFF) | ((b2 & 0xFF) << 8)) == c; // no information loss
-            bytesToHash[i * 2] = b1;
-            bytesToHash[i * 2 + 1] = b2;
         }
-        return hash(bytesToHash, 0, bytesToHash.length);
+        return true;
     }
 
     public static int hash(byte[] bytes, int offset, int length) {

--- a/server/src/main/java/org/elasticsearch/common/util/ByteUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/ByteUtils.java
@@ -17,6 +17,8 @@ import java.nio.ByteOrder;
 public enum ByteUtils {
     ;
 
+    public static final VarHandle LITTLE_ENDIAN_CHAR = MethodHandles.byteArrayViewVarHandle(char[].class, ByteOrder.LITTLE_ENDIAN);
+
     public static final VarHandle LITTLE_ENDIAN_INT = MethodHandles.byteArrayViewVarHandle(int[].class, ByteOrder.LITTLE_ENDIAN);
 
     public static final VarHandle LITTLE_ENDIAN_LONG = MethodHandles.byteArrayViewVarHandle(long[].class, ByteOrder.LITTLE_ENDIAN);


### PR DESCRIPTION
Allocating a fresh `byte[]` to copy the string to before hashing causes GBs of allocations in benchmarks like http_logs where many small documents are indexed append only. We can use a thread-local for the intermediary byte array and make the char to byte conversion faster via a `VarHandle`, saving a couple more cycles.
This saves those GBs in allocations and for the http_logs track results in about a 50% speedup for this method.