### PR TITLE
Change `reindex.remote.whitelist` from string to array in example

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -1035,7 +1035,7 @@ ignored, only the host and port are used. For example:
 
 [source,yaml]
 --------------------------------------------------
-reindex.remote.whitelist: "otherhost:9200, another:9200, 127.0.10.*:9200, localhost:*"
+reindex.remote.whitelist: [otherhost:9200, another:9200, 127.0.10.*:9200, localhost:*"]
 --------------------------------------------------
 
 The list of allowed hosts must be configured on any nodes that will coordinate the reindex.


### PR DESCRIPTION
According to @BasileMartin, the shape of the reindex.remote.whitelist is not allowed to be a string, it is only allowed to be a list 

fixed example so it's an array

tested as valid in cloud env