### PR TITLE
Make XContentType.xContent() a getter

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentType.java
@@ -24,7 +24,7 @@ public enum XContentType implements MediaType {
     /**
      * A JSON based content type.
      */
-    JSON(0) {
+    JSON(0, JsonXContent.jsonXContent) {
         @Override
         public String mediaTypeWithoutParameters() {
             return "application/json";
@@ -41,11 +41,6 @@ public enum XContentType implements MediaType {
         }
 
         @Override
-        public XContent xContent() {
-            return JsonXContent.jsonXContent;
-        }
-
-        @Override
         public Set<HeaderValue> headerValues() {
             return Set.of(new HeaderValue("application/json"), new HeaderValue("application/x-ndjson"), new HeaderValue("application/*"));
         }
@@ -53,7 +48,7 @@ public enum XContentType implements MediaType {
     /**
      * The jackson based smile binary format. Fast and compact binary format.
      */
-    SMILE(1) {
+    SMILE(1, SmileXContent.smileXContent) {
         @Override
         public String mediaTypeWithoutParameters() {
             return "application/smile";
@@ -65,11 +60,6 @@ public enum XContentType implements MediaType {
         }
 
         @Override
-        public XContent xContent() {
-            return SmileXContent.smileXContent;
-        }
-
-        @Override
         public Set<HeaderValue> headerValues() {
             return Set.of(new HeaderValue("application/smile"));
         }
@@ -77,7 +67,7 @@ public enum XContentType implements MediaType {
     /**
      * A YAML based content type.
      */
-    YAML(2) {
+    YAML(2, YamlXContent.yamlXContent) {
         @Override
         public String mediaTypeWithoutParameters() {
             return "application/yaml";
@@ -89,11 +79,6 @@ public enum XContentType implements MediaType {
         }
 
         @Override
-        public XContent xContent() {
-            return YamlXContent.yamlXContent;
-        }
-
-        @Override
         public Set<HeaderValue> headerValues() {
             return Set.of(new HeaderValue("application/yaml"));
         }
@@ -101,7 +86,7 @@ public enum XContentType implements MediaType {
     /**
      * A CBOR based content type.
      */
-    CBOR(3) {
+    CBOR(3, CborXContent.cborXContent) {
         @Override
         public String mediaTypeWithoutParameters() {
             return "application/cbor";
@@ -113,11 +98,6 @@ public enum XContentType implements MediaType {
         }
 
         @Override
-        public XContent xContent() {
-            return CborXContent.cborXContent;
-        }
-
-        @Override
         public Set<HeaderValue> headerValues() {
             return Set.of(new HeaderValue("application/cbor"));
         }
@@ -125,7 +105,7 @@ public enum XContentType implements MediaType {
     /**
      * A versioned JSON based content type.
      */
-    VND_JSON(4) {
+    VND_JSON(4, JsonXContent.jsonXContent) {
         @Override
         public String mediaTypeWithoutParameters() {
             return VENDOR_APPLICATION_PREFIX + "json";
@@ -134,11 +114,6 @@ public enum XContentType implements MediaType {
         @Override
         public String queryParameter() {
             return "vnd_json";
-        }
-
-        @Override
-        public XContent xContent() {
-            return JsonXContent.jsonXContent;
         }
 
         @Override
@@ -157,7 +132,7 @@ public enum XContentType implements MediaType {
     /**
      * Versioned jackson based smile binary format. Fast and compact binary format.
      */
-    VND_SMILE(5) {
+    VND_SMILE(5, SmileXContent.smileXContent) {
         @Override
         public String mediaTypeWithoutParameters() {
             return VENDOR_APPLICATION_PREFIX + "smile";
@@ -166,11 +141,6 @@ public enum XContentType implements MediaType {
         @Override
         public String queryParameter() {
             return "vnd_smile";
-        }
-
-        @Override
-        public XContent xContent() {
-            return SmileXContent.smileXContent;
         }
 
         @Override
@@ -186,7 +156,7 @@ public enum XContentType implements MediaType {
     /**
      * A Versioned YAML based content type.
      */
-    VND_YAML(6) {
+    VND_YAML(6, YamlXContent.yamlXContent) {
         @Override
         public String mediaTypeWithoutParameters() {
             return VENDOR_APPLICATION_PREFIX + "yaml";
@@ -195,11 +165,6 @@ public enum XContentType implements MediaType {
         @Override
         public String queryParameter() {
             return "vnd_yaml";
-        }
-
-        @Override
-        public XContent xContent() {
-            return YamlXContent.yamlXContent;
         }
 
         @Override
@@ -215,7 +180,7 @@ public enum XContentType implements MediaType {
     /**
      * A Versioned CBOR based content type.
      */
-    VND_CBOR(7) {
+    VND_CBOR(7, CborXContent.cborXContent) {
         @Override
         public String mediaTypeWithoutParameters() {
             return VENDOR_APPLICATION_PREFIX + "cbor";
@@ -224,11 +189,6 @@ public enum XContentType implements MediaType {
         @Override
         public String queryParameter() {
             return "vnd_cbor";
-        }
-
-        @Override
-        public XContent xContent() {
-            return CborXContent.cborXContent;
         }
 
         @Override
@@ -275,8 +235,11 @@ public enum XContentType implements MediaType {
 
     private final int index;
 
-    XContentType(int index) {
+    private final XContent xContent;
+
+    XContentType(int index, XContent xContent) {
         this.index = index;
+        this.xContent = xContent;
     }
 
     public static Byte parseVersion(String mediaType) {
@@ -296,7 +259,9 @@ public enum XContentType implements MediaType {
         return mediaTypeWithoutParameters();
     }
 
-    public abstract XContent xContent();
+    public final XContent xContent() {
+        return xContent;
+    }
 
     public abstract String mediaTypeWithoutParameters();
 


### PR DESCRIPTION
Seen this come up in some profiling, wasting some cycles. If we do a method per type here instead of a getter + field, we pay for a megamorphic callsite potentially. It's faster and uses less code anyway to just use a field + getter here.
