### PR TITLE
Fix sql JdbcDocCsvSpecIT test {docs.testFilterToday} failing

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -21,8 +21,7 @@ tests:
   method: "testGuessIsDayFirstFromLocale"
 - class: "org.elasticsearch.test.rest.ClientYamlTestSuiteIT"
   issue: "https://github.com/elastic/elasticsearch/issues/108857"
-  method: "test {yaml=search/180_locale_dependent_mapping/Test Index and Search locale\
-    \ dependent mappings / dates}"
+  method: "test {yaml=search/180_locale_dependent_mapping/Test Index and Search locale dependent mappings / dates}"
 - class: "org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT"
   issue: "https://github.com/elastic/elasticsearch/issues/108950"
   method: "test {p0=health/10_basic/cluster health basic test}"
@@ -37,8 +36,7 @@ tests:
   method: "testTrainedModelInference"
 - class: "org.elasticsearch.xpack.security.CoreWithSecurityClientYamlTestSuiteIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109188"
-  method: "test {yaml=search/180_locale_dependent_mapping/Test Index and Search locale\
-    \ dependent mappings / dates}"
+  method: "test {yaml=search/180_locale_dependent_mapping/Test Index and Search locale dependent mappings / dates}"
 - class: "org.elasticsearch.xpack.esql.qa.mixed.EsqlClientYamlIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109189"
   method: "test {p0=esql/70_locale/Date format with Italian locale}"
@@ -57,9 +55,6 @@ tests:
 - class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
   method: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
   issue: https://github.com/elastic/elasticsearch/issues/109266
-- class: "org.elasticsearch.xpack.sql.qa.single_node.JdbcDocCsvSpecIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/109273"
-  method: "test {docs.testFilterToday}"
 
 # Examples:
 #

--- a/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/docs/docs.csv-spec
@@ -3351,9 +3351,9 @@ SELECT first_name FROM emp WHERE hire_date > TODAY() - INTERVAL 35 YEARS ORDER B
 ------------
 Alejandro
 Amabile
-Anneke
 Anoosh
 Basil
+Bojan
 // end::filterToday
 ;
 


### PR DESCRIPTION
This commit fixes an SQL test that hardcodes expected results based on today's date. The docs.testFilterToday test needs to be updated since June 2 2024, because Anneke's hire-date of 1989-06-02 (35 years ago as of time of writing) affects the expected output.



closes #109273