### PR TITLE
[Test] Fix FrozenIndexInputTests testRandomReads

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.blobcache.BlobCacheMetrics;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.blobcache.shared.SharedBytes;
+import org.elasticsearch.common.lucene.store.ByteArrayIndexInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Tuple;
@@ -44,6 +45,7 @@ import static org.elasticsearch.core.IOUtils.WINDOWS;
 import static org.elasticsearch.xpack.searchablesnapshots.cache.full.CacheService.resolveSnapshotCache;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 
 public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
@@ -137,9 +139,13 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
 
             // validate clone copies cache file object
             indexInput.seek(randomLongBetween(0, fileData.length - 1));
-            FrozenIndexInput clone = (FrozenIndexInput) indexInput.clone();
-            assertThat(clone.cacheFile(), not(equalTo(((FrozenIndexInput) indexInput).cacheFile())));
-            assertThat(clone.getFilePointer(), equalTo(indexInput.getFilePointer()));
+            final IndexInput indexInputClone = indexInput.clone();
+            if (indexInputClone instanceof FrozenIndexInput clone) {
+                assertThat(clone.cacheFile(), not(equalTo(((FrozenIndexInput) indexInput).cacheFile())));
+                assertThat(clone.getFilePointer(), equalTo(indexInput.getFilePointer()));
+            } else {
+                assertThat(indexInputClone, isA(ByteArrayIndexInput.class));
+            }
 
             indexInput.close();
         }


### PR DESCRIPTION
Since #106794, FrozenIndexInput#clone can return a ByteArrayIndexInput if the content is fully covered by its internal buffer. This PR ensures the assertion handle this case.

Resolves: #109171
