### PR TITLE
[DOCS] Expands DELETE inference API docs

### DIFF
--- a/docs/reference/inference/delete-inference.asciidoc
+++ b/docs/reference/inference/delete-inference.asciidoc
@@ -43,6 +43,7 @@ The unique identifier of the {infer} endpoint to delete.
 The type of {infer} task that the model performs.
 
 
+[discrete]
 [[delete-inference-query-parms]]
 == {api-query-parms-title}
 

--- a/docs/reference/inference/delete-inference.asciidoc
+++ b/docs/reference/inference/delete-inference.asciidoc
@@ -43,6 +43,20 @@ The unique identifier of the {infer} endpoint to delete.
 The type of {infer} task that the model performs.
 
 
+[[delete-inference-query-parms]]
+== {api-query-parms-title}
+
+`dry_run`::
+(Optional, Boolean)
+When `true`, checks the {infer} processors that reference the endpoint and
+returns them in a list, but does not deletes the endpoint. Defaults to `false`.
+
+`force`::
+(Optional, Boolean)
+Deletes the endpoint regardless if it's used in an {infer} pipeline or a in a
+`semantic_text` field.
+
+
 [discrete]
 [[delete-inference-api-example]]
 ==== {api-examples-title}


### PR DESCRIPTION
## Overview

This PR adds the `dry_run` and `force` parameters to the DELETE inference API docs.

### Preview

[DELETE inference](https://elasticsearch_bk_109282.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/delete-inference-api.html)