### PR TITLE
[Inference] Reuse EmptySettings.INSTANCE instead of creating new object in tests

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/completion/CohereCompletionModelTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/cohere/completion/CohereCompletionModelTests.java
@@ -40,7 +40,7 @@ public class CohereCompletionModelTests extends ESTestCase {
             TaskType.COMPLETION,
             "service",
             new CohereCompletionServiceSettings(url, model, null),
-            new EmptyTaskSettings(),
+            EmptyTaskSettings.INSTANCE,
             new DefaultSecretSettings(new SecureString(apiKey.toCharArray()))
         );
     }


### PR DESCRIPTION
^See title