### PR TITLE
[ESQL] Migrate TyperResolutionTests out of core

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/TyperResolutionTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/TyperResolutionTests.java
@@ -5,12 +5,13 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.esql.core.expression;
+package org.elasticsearch.xpack.esql.expression;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.esql.core.TestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Expression.TypeResolution;
-import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.Mul;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mul;
 
 import static org.elasticsearch.xpack.esql.core.tree.Source.EMPTY;
 


### PR DESCRIPTION
The `TyperResolutionTests` were pointing to the core version of `Mul`; This PR changes them to refer to the code we actually run.