### PR TITLE
Add rolling upgrade test for the index.mapper.dynamic index setting bug.

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
@@ -10,7 +10,10 @@ package org.elasticsearch.upgrades;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
+
+import java.io.IOException;
 
 public class MappingIT extends AbstractRollingTestCase {
     /**
@@ -48,4 +51,18 @@ public class MappingIT extends AbstractRollingTestCase {
                 break;
         }
     }
+
+    public void testMapperDynamicIndexSetting() throws IOException {
+        switch (CLUSTER_TYPE) {
+            case OLD:
+                createIndex("my-index", Settings.EMPTY);
+                updateIndexSettings("my-index", Settings.builder().put("index.mapper.dynamic", true));
+                break;
+            case MIXED:
+            case UPGRADED:
+                ensureGreen("my-index");
+                break;
+        }
+    }
+
 }

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.upgrades;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 
@@ -56,7 +57,17 @@ public class MappingIT extends AbstractRollingTestCase {
         switch (CLUSTER_TYPE) {
             case OLD:
                 createIndex("my-index", Settings.EMPTY);
-                updateIndexSettings("my-index", Settings.builder().put("index.mapper.dynamic", true));
+
+                Request request = new Request("PUT", "/my-index/_settings");
+                request.setJsonEntity(Strings.toString(Settings.builder().put("index.mapper.dynamic", true).build()));
+                request.setOptions(
+                    expectWarnings(
+                        "[index.mapper.dynamic] setting was deprecated in Elasticsearch and will be removed in a future release! "
+                            + "See the breaking changes documentation for the next major version."
+                    )
+                );
+                client().performRequest(request);
+
                 break;
             case MIXED:
             case UPGRADED:

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
@@ -67,8 +67,7 @@ public class MappingIT extends AbstractRollingTestCase {
                             + "See the breaking changes documentation for the next major version."
                     )
                 );
-                client().performRequest(request);
-
+                assertOK(client().performRequest(request));
                 break;
             case MIXED:
             case UPGRADED:

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MappingIT.java
@@ -54,6 +54,7 @@ public class MappingIT extends AbstractRollingTestCase {
     }
 
     public void testMapperDynamicIndexSetting() throws IOException {
+        assumeTrue("Setting not removed before 7.0", UPGRADE_FROM_VERSION.onOrAfter(Version.V_7_0_0));
         switch (CLUSTER_TYPE) {
             case OLD:
                 createIndex("my-index", Settings.EMPTY);

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -831,8 +831,10 @@ public class RecoveryIT extends AbstractRollingTestCase {
             // There is a bug (fixed in 7.17.9 and 8.7.0 where deprecation warnings could leak into ClusterApplierService#applyChanges)
             // Below warnings are set (and leaking) from an index in this test case
             request.setOptions(expectVersionSpecificWarnings(v -> {
-                v.compatible("[index.mapper.dynamic] setting was deprecated in Elasticsearch and will be removed in a future release! "
-                    + "See the breaking changes documentation for the next major version.");
+                v.compatible(
+                    "[index.mapper.dynamic] setting was deprecated in Elasticsearch and will be removed in a future release! "
+                        + "See the breaking changes documentation for the next major version."
+                );
             }));
         }
         assertOK(client().performRequest(request));

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/RecoveryIT.java
@@ -823,4 +823,18 @@ public class RecoveryIT extends AbstractRollingTestCase {
         ensureGreen(indexName);
         indexDocs(indexName, randomInt(100), randomInt(100));
     }
+
+    protected static void updateIndexSettings(String index, Settings.Builder settings) throws IOException {
+        Request request = new Request("PUT", "/" + index + "/_settings");
+        request.setJsonEntity(Strings.toString(settings.build()));
+        if (UPGRADE_FROM_VERSION.before(Version.V_7_17_9)) {
+            // There is a bug (fixed in 7.17.9 and 8.7.0 where deprecation warnings could leak into ClusterApplierService#applyChanges)
+            // Below warnings are set (and leaking) from an index in this test case
+            request.setOptions(expectVersionSpecificWarnings(v -> {
+                v.compatible("[index.mapper.dynamic] setting was deprecated in Elasticsearch and will be removed in a future release! "
+                    + "See the breaking changes documentation for the next major version.");
+            }));
+        }
+        assertOK(client().performRequest(request));
+    }
 }


### PR DESCRIPTION
This is for 7.17 branch only. The test in main branch would be a little bit different.

Relates to #109160 and #96075