### PR TITLE
Enable fallback synthetic source for `point` and `shape`

### DIFF
--- a/docs/changelog/109312.yaml
+++ b/docs/changelog/109312.yaml
@@ -1,0 +1,5 @@
+pr: 109312
+summary: Enable fallback synthetic source for `point` and `shape`
+area: Mapping
+type: feature
+issues: []

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -180,6 +180,11 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
         return new Builder(simpleName(), builder.ignoreMalformed.getDefaultValue().value()).init(this);
     }
 
+    @Override
+    protected SyntheticSourceMode syntheticSourceMode() {
+        return SyntheticSourceMode.FALLBACK;
+    }
+
     public static class PointFieldType extends AbstractPointFieldType<CartesianPoint> implements ShapeQueryable {
 
         private final ShapeQueryPointProcessor queryProcessor;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -249,6 +249,11 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
         return (ShapeFieldType) super.fieldType();
     }
 
+    @Override
+    protected SyntheticSourceMode syntheticSourceMode() {
+        return SyntheticSourceMode.FALLBACK;
+    }
+
     public static class CartesianShapeDocValuesField extends AbstractScriptFieldFactory<CartesianShapeValues.CartesianShapeValue>
         implements
             Field<CartesianShapeValues.CartesianShapeValue>,

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/CartesianFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/CartesianFieldMapperTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperTestCase;
 import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
@@ -20,6 +21,7 @@ import org.elasticsearch.xpack.spatial.LocalStateSpatialPlugin;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
@@ -32,7 +34,15 @@ public abstract class CartesianFieldMapperTests extends MapperTestCase {
 
     @Override
     protected Collection<Plugin> getPlugins() {
-        return Collections.singletonList(new LocalStateSpatialPlugin());
+        var plugin = new LocalStateSpatialPlugin();
+        plugin.loadExtensions(new ExtensiblePlugin.ExtensionLoader() {
+            @Override
+            public <T> List<T> loadExtensions(Class<T> extensionPointType) {
+                return List.of();
+            }
+        });
+
+        return Collections.singletonList(plugin);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -9,10 +9,7 @@ package org.elasticsearch.xpack.spatial.index.mapper;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.geo.GeoJson;
-import org.elasticsearch.common.geo.GeometryNormalizer;
 import org.elasticsearch.common.geo.Orientation;
-import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.utils.GeometryValidator;
 import org.elasticsearch.geometry.utils.WellKnownBinary;
@@ -30,17 +27,14 @@ import org.elasticsearch.index.mapper.MapperParsingException;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SourceToParse;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.index.IndexVersionUtils;
 import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -434,144 +428,7 @@ public class GeoShapeWithDocValuesFieldMapperTests extends GeoFieldMapperTests {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
-        // Almost like GeoShapeType but no circles
-        enum ShapeType {
-            POINT,
-            LINESTRING,
-            POLYGON,
-            MULTIPOINT,
-            MULTILINESTRING,
-            MULTIPOLYGON,
-            GEOMETRYCOLLECTION,
-            ENVELOPE
-        }
-
-        return new SyntheticSourceSupport() {
-            @Override
-            public boolean preservesExactSource() {
-                return true;
-            }
-
-            @Override
-            public SyntheticSourceExample example(int maxValues) throws IOException {
-                if (randomBoolean()) {
-                    Value v = generateValue();
-                    if (v.blockLoaderOutput != null) {
-                        return new SyntheticSourceExample(v.input, v.output, v.blockLoaderOutput, this::mapping);
-                    }
-                    return new SyntheticSourceExample(v.input, v.output, this::mapping);
-                }
-
-                List<Value> values = randomList(1, maxValues, this::generateValue);
-                List<Object> in = values.stream().map(Value::input).toList();
-                List<Object> out = values.stream().map(Value::output).toList();
-
-                // Block loader infrastructure will never return nulls
-                List<Object> outBlockList = values.stream()
-                    .filter(v -> v.input != null)
-                    .map(v -> v.blockLoaderOutput != null ? v.blockLoaderOutput : v.output)
-                    .toList();
-                var outBlock = outBlockList.size() == 1 ? outBlockList.get(0) : outBlockList;
-
-                return new SyntheticSourceExample(in, out, outBlock, this::mapping);
-            }
-
-            private record Value(Object input, Object output, String blockLoaderOutput) {
-                Value(Object input, Object output) {
-                    this(input, output, null);
-                }
-            }
-
-            private Value generateValue() {
-                if (ignoreMalformed && randomBoolean()) {
-                    List<Supplier<Object>> choices = List.of(
-                        () -> randomAlphaOfLength(3),
-                        ESTestCase::randomInt,
-                        ESTestCase::randomLong,
-                        ESTestCase::randomFloat,
-                        ESTestCase::randomDouble
-                    );
-                    Object v = randomFrom(choices).get();
-                    return new Value(v, v);
-                }
-                if (randomBoolean()) {
-                    return new Value(null, null);
-                }
-
-                var type = randomFrom(ShapeType.values());
-                var isGeoJson = randomBoolean();
-
-                switch (type) {
-                    case POINT -> {
-                        var point = GeometryTestUtils.randomPoint(false);
-                        return value(point, isGeoJson);
-                    }
-                    case LINESTRING -> {
-                        var line = GeometryTestUtils.randomLine(false);
-                        return value(line, isGeoJson);
-                    }
-                    case POLYGON -> {
-                        var polygon = GeometryTestUtils.randomPolygon(false);
-                        return value(polygon, isGeoJson);
-                    }
-                    case MULTIPOINT -> {
-                        var multiPoint = GeometryTestUtils.randomMultiPoint(false);
-                        return value(multiPoint, isGeoJson);
-                    }
-                    case MULTILINESTRING -> {
-                        var multiPoint = GeometryTestUtils.randomMultiLine(false);
-                        return value(multiPoint, isGeoJson);
-                    }
-                    case MULTIPOLYGON -> {
-                        var multiPolygon = GeometryTestUtils.randomMultiPolygon(false);
-                        return value(multiPolygon, isGeoJson);
-                    }
-                    case GEOMETRYCOLLECTION -> {
-                        var multiPolygon = GeometryTestUtils.randomGeometryCollectionWithoutCircle(false);
-                        return value(multiPolygon, isGeoJson);
-                    }
-                    case ENVELOPE -> {
-                        var rectangle = GeometryTestUtils.randomRectangle();
-                        var wktString = WellKnownText.toWKT(rectangle);
-
-                        return new Value(wktString, wktString);
-                    }
-                    default -> throw new UnsupportedOperationException("Unsupported shape");
-                }
-            }
-
-            private static Value value(Geometry geometry, boolean isGeoJson) {
-                var wktString = WellKnownText.toWKT(geometry);
-                var normalizedWktString = GeometryNormalizer.needsNormalize(Orientation.RIGHT, geometry)
-                    ? WellKnownText.toWKT(GeometryNormalizer.apply(Orientation.RIGHT, geometry))
-                    : wktString;
-
-                if (isGeoJson) {
-                    var map = GeoJson.toMap(geometry);
-                    return new Value(map, map, normalizedWktString);
-                }
-
-                return new Value(wktString, wktString, normalizedWktString);
-            }
-
-            private void mapping(XContentBuilder b) throws IOException {
-                b.field("type", "geo_shape");
-                if (rarely()) {
-                    b.field("index", false);
-                }
-                if (rarely()) {
-                    b.field("doc_values", false);
-                }
-                if (ignoreMalformed) {
-                    b.field("ignore_malformed", true);
-                }
-            }
-
-            @Override
-            public List<SyntheticSourceInvalidExample> invalidExample() throws IOException {
-                return List.of();
-            }
-        };
+        return new GeometricShapeSyntheticSourceSupport(ignoreMalformed);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeometricShapeSyntheticSourceSupport.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeometricShapeSyntheticSourceSupport.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.spatial.index.mapper;
+
+import org.elasticsearch.common.geo.GeoJson;
+import org.elasticsearch.common.geo.GeometryNormalizer;
+import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.ShapeType;
+import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.index.mapper.MapperTestCase;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.apache.lucene.tests.util.LuceneTestCase.rarely;
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLength;
+import static org.elasticsearch.test.ESTestCase.randomBoolean;
+import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.randomList;
+
+/**
+ * Synthetic source support for fields the index geometry shapes: shape, geo_shape.
+ */
+public class GeometricShapeSyntheticSourceSupport implements MapperTestCase.SyntheticSourceSupport {
+    private final boolean ignoreMalformed;
+
+    public GeometricShapeSyntheticSourceSupport(boolean ignoreMalformed) {
+        this.ignoreMalformed = ignoreMalformed;
+    }
+
+    @Override
+    public boolean preservesExactSource() {
+        return true;
+    }
+
+    @Override
+    public MapperTestCase.SyntheticSourceExample example(int maxValues) throws IOException {
+        if (randomBoolean()) {
+            Value v = generateValue();
+            if (v.blockLoaderOutput != null) {
+                return new MapperTestCase.SyntheticSourceExample(v.input, v.output, v.blockLoaderOutput, this::mapping);
+            }
+            return new MapperTestCase.SyntheticSourceExample(v.input, v.output, this::mapping);
+        }
+
+        List<Value> values = randomList(1, maxValues, this::generateValue);
+        List<Object> in = values.stream().map(Value::input).toList();
+        List<Object> out = values.stream().map(Value::output).toList();
+
+        // Block loader infrastructure will never return nulls
+        List<Object> outBlockList = values.stream()
+            .filter(v -> v.input != null)
+            .map(v -> v.blockLoaderOutput != null ? v.blockLoaderOutput : v.output)
+            .toList();
+        var outBlock = outBlockList.size() == 1 ? outBlockList.get(0) : outBlockList;
+
+        return new MapperTestCase.SyntheticSourceExample(in, out, outBlock, this::mapping);
+    }
+
+    private record Value(Object input, Object output, String blockLoaderOutput) {
+        Value(Object input, Object output) {
+            this(input, output, null);
+        }
+    }
+
+    private Value generateValue() {
+        if (ignoreMalformed && randomBoolean()) {
+            List<Supplier<Object>> choices = List.of(
+                () -> randomAlphaOfLength(3),
+                ESTestCase::randomInt,
+                ESTestCase::randomLong,
+                ESTestCase::randomFloat,
+                ESTestCase::randomDouble
+            );
+            Object v = randomFrom(choices).get();
+            return new Value(v, v);
+        }
+        if (randomBoolean()) {
+            return new Value(null, null);
+        }
+
+        var type = randomFrom(ShapeType.values());
+        var isGeoJson = randomBoolean();
+
+        return switch (type) {
+            // LINEARRING and CIRCLE are not supported as inputs to fields so just return points
+            case POINT, LINEARRING, CIRCLE -> {
+                var point = GeometryTestUtils.randomPoint(false);
+                yield value(point, isGeoJson);
+            }
+            case MULTIPOINT -> {
+                var multiPoint = GeometryTestUtils.randomMultiPoint(false);
+                yield value(multiPoint, isGeoJson);
+            }
+            case LINESTRING -> {
+                var line = GeometryTestUtils.randomLine(false);
+                yield value(line, isGeoJson);
+            }
+            case MULTILINESTRING -> {
+                var multiPoint = GeometryTestUtils.randomMultiLine(false);
+                yield value(multiPoint, isGeoJson);
+            }
+            case POLYGON -> {
+                var polygon = GeometryTestUtils.randomPolygon(false);
+                yield value(polygon, isGeoJson);
+            }
+            case MULTIPOLYGON -> {
+                var multiPolygon = GeometryTestUtils.randomMultiPolygon(false);
+                yield value(multiPolygon, isGeoJson);
+            }
+            case GEOMETRYCOLLECTION -> {
+                var multiPolygon = GeometryTestUtils.randomGeometryCollectionWithoutCircle(false);
+                yield value(multiPolygon, isGeoJson);
+            }
+            case ENVELOPE -> {
+                var rectangle = GeometryTestUtils.randomRectangle();
+                var wktString = WellKnownText.toWKT(rectangle);
+
+                yield new Value(wktString, wktString);
+            }
+        };
+    }
+
+    private static Value value(Geometry geometry, boolean isGeoJson) {
+        var wktString = WellKnownText.toWKT(geometry);
+        var normalizedWktString = GeometryNormalizer.needsNormalize(Orientation.RIGHT, geometry)
+            ? WellKnownText.toWKT(GeometryNormalizer.apply(Orientation.RIGHT, geometry))
+            : wktString;
+
+        if (isGeoJson) {
+            var map = GeoJson.toMap(geometry);
+            return new Value(map, map, normalizedWktString);
+        }
+
+        return new Value(wktString, wktString, normalizedWktString);
+    }
+
+    private void mapping(XContentBuilder b) throws IOException {
+        b.field("type", "geo_shape");
+        if (rarely()) {
+            b.field("index", false);
+        }
+        if (rarely()) {
+            b.field("doc_values", false);
+        }
+        if (ignoreMalformed) {
+            b.field("ignore_malformed", true);
+        }
+    }
+
+    @Override
+    public List<MapperTestCase.SyntheticSourceInvalidExample> invalidExample() throws IOException {
+        return List.of();
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
@@ -6,14 +6,11 @@
  */
 package org.elasticsearch.xpack.spatial.index.mapper;
 
-import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.XYDocValuesField;
 import org.apache.lucene.document.XYPointField;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.geo.GeoPoint;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
@@ -465,12 +462,21 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
 
                 if (columnReader) {
                     // When reading doc-values, the block is a list of encoded longs
-                    List<Long> outBlockList = values.stream().map(Value::point).filter(Objects::nonNull).map(this::encode).sorted().toList();
+                    List<Long> outBlockList = values.stream()
+                        .map(Value::point)
+                        .filter(Objects::nonNull)
+                        .map(this::encode)
+                        .sorted()
+                        .toList();
                     Object outBlock = outBlockList.size() == 1 ? outBlockList.get(0) : outBlockList;
                     return new SyntheticSourceExample(representations, representations, outBlock, this::mapping);
                 } else {
                     // When reading row-stride, the block is a list of WKT encoded BytesRefs
-                    List<String> outBlockList = values.stream().map(Value::point).filter(Objects::nonNull).map(CartesianPoint::toWKT).toList();
+                    List<String> outBlockList = values.stream()
+                        .map(Value::point)
+                        .filter(Objects::nonNull)
+                        .map(CartesianPoint::toWKT)
+                        .toList();
                     Object outBlock = outBlockList.size() == 1 ? outBlockList.get(0) : outBlockList;
                     return new SyntheticSourceExample(representations, representations, outBlock, this::mapping);
                 }
@@ -487,10 +493,7 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
                     // #exampleMalformedValues() covers a lot of cases
 
                     // nice complex object
-                    return new Value(
-                        null,
-                        Map.of("one", 1, "two", List.of(2, 22,222), "three", Map.of("three", 33))
-                    );
+                    return new Value(null, Map.of("one", 1, "two", List.of(2, 22, 222), "three", Map.of("three", 33)));
                 }
 
                 CartesianPoint point = randomCartesianPoint();

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
@@ -6,9 +6,20 @@
  */
 package org.elasticsearch.xpack.spatial.index.mapper;
 
+import org.apache.lucene.document.LatLonDocValuesField;
+import org.apache.lucene.document.XYDocValuesField;
 import org.apache.lucene.document.XYPointField;
+import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.GeoPoint;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.geo.GeometryTestUtils;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.utils.GeometryValidator;
+import org.elasticsearch.geometry.utils.WellKnownBinary;
+import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.DocumentParsingException;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -22,7 +33,11 @@ import org.elasticsearch.xpack.spatial.common.CartesianPoint;
 import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.hamcrest.Matchers.containsString;
@@ -419,7 +434,126 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
-        throw new AssumptionViolatedException("not supported");
+        return syntheticSourceSupport(ignoreMalformed, false);
+    }
+
+    @Override
+    protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed, boolean columnReader) {
+        return new SyntheticSourceSupport() {
+            private final boolean ignoreZValue = usually();
+            private final CartesianPoint nullValue = usually() ? null : randomCartesianPoint();
+
+            @Override
+            public boolean preservesExactSource() {
+                return true;
+            }
+
+            @Override
+            public SyntheticSourceExample example(int maxVals) {
+                if (randomBoolean()) {
+                    Value v = generateValue();
+
+                    if (v.point == null) {
+                        return new SyntheticSourceExample(v.representation(), v.representation(), null, this::mapping);
+                    } else if (columnReader) {
+                        return new SyntheticSourceExample(v.representation(), v.representation(), encode(v.point()), this::mapping);
+                    }
+                    return new SyntheticSourceExample(v.representation(), v.representation(), v.point().toWKT(), this::mapping);
+                }
+                List<Value> values = randomList(1, maxVals, this::generateValue);
+                var representations = values.stream().map(Value::representation).toList();
+
+                if (columnReader) {
+                    // When reading doc-values, the block is a list of encoded longs
+                    List<Long> outBlockList = values.stream().map(Value::point).filter(Objects::nonNull).map(this::encode).sorted().toList();
+                    Object outBlock = outBlockList.size() == 1 ? outBlockList.get(0) : outBlockList;
+                    return new SyntheticSourceExample(representations, representations, outBlock, this::mapping);
+                } else {
+                    // When reading row-stride, the block is a list of WKT encoded BytesRefs
+                    List<String> outBlockList = values.stream().map(Value::point).filter(Objects::nonNull).map(CartesianPoint::toWKT).toList();
+                    Object outBlock = outBlockList.size() == 1 ? outBlockList.get(0) : outBlockList;
+                    return new SyntheticSourceExample(representations, representations, outBlock, this::mapping);
+                }
+            }
+
+            private record Value(CartesianPoint point, Object representation) {}
+
+            private Value generateValue() {
+                if (nullValue != null && randomBoolean()) {
+                    return new Value(nullValue, null);
+                }
+
+                if (ignoreMalformed) {
+                    // #exampleMalformedValues() covers a lot of cases
+
+                    // nice complex object
+                    return new Value(
+                        null,
+                        Map.of("one", 1, "two", List.of(2, 22,222), "three", Map.of("three", 33))
+                    );
+                }
+
+                CartesianPoint point = randomCartesianPoint();
+                return new Value(point, randomInputFormat(point));
+            }
+
+            private CartesianPoint randomCartesianPoint() {
+                Point point = GeometryTestUtils.randomPoint(false);
+                return decode(encode(new CartesianPoint(point.getLat(), point.getLon())));
+            }
+
+            private Object randomInputFormat(CartesianPoint point) {
+                return switch (randomInt(4)) {
+                    case 0 -> Map.of("x", point.getX(), "y", point.getY());
+                    case 1 -> new double[] { point.getX(), point.getY() };
+                    case 2 -> "POINT( " + point.getX() + " " + point.getY() + " )";
+                    case 3 -> point.toString();
+                    default -> {
+                        List<Double> coords = new ArrayList<>();
+                        coords.add(point.getX());
+                        coords.add(point.getY());
+                        if (ignoreZValue) {
+                            coords.add(randomDouble());
+                        }
+                        yield Map.of("coordinates", coords, "type", "point");
+                    }
+                };
+            }
+
+            private long encode(CartesianPoint point) {
+                return new XYDocValuesField("f", (float) point.getX(), (float) point.getY()).numericValue().longValue();
+            }
+
+            private CartesianPoint decode(long point) {
+                double lat = GeoEncodingUtils.decodeLatitude((int) (point >> 32));
+                double lon = GeoEncodingUtils.decodeLongitude((int) (point & 0xFFFFFFFF));
+                return new CartesianPoint(lat, lon);
+            }
+
+            private void mapping(XContentBuilder b) throws IOException {
+                b.field("type", "point");
+                if (ignoreZValue == false || rarely()) {
+                    b.field("ignore_z_value", ignoreZValue);
+                }
+                if (nullValue != null) {
+                    b.field("null_value", randomInputFormat(nullValue));
+                }
+                if (rarely()) {
+                    b.field("index", false);
+                }
+                if (rarely()) {
+                    b.field("store", false);
+                }
+                if (ignoreMalformed) {
+                    b.field("ignore_malformed", true);
+                }
+            }
+
+            @Override
+            public List<SyntheticSourceInvalidExample> invalidExample() throws IOException {
+                return List.of();
+            }
+        };
     }
 
     @Override
@@ -428,10 +562,35 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
     }
 
     @Override
+    protected Function<Object, Object> loadBlockExpected(BlockReaderSupport blockReaderSupport, boolean columnReader) {
+        if (columnReader) {
+            // When using column reader, we expect the output to be doc-values (which means encoded longs)
+            return v -> asJacksonNumberOutput(((Number) v).longValue());
+        } else {
+            // When using row-stride reader, we expect the output to be WKT encoded BytesRef
+            return v -> asWKT((BytesRef) v);
+        }
+    }
+
+    protected static Object asJacksonNumberOutput(long l) {
+        // Cast to int to mimic jackson-core behaviour in NumberOutput.outputLong()
+        // that is called when deserializing expected value in SyntheticSourceExample.
+        if (l < 0 && l >= Integer.MIN_VALUE || l >= 0 && l <= Integer.MAX_VALUE) {
+            return (int) l;
+        } else {
+            return l;
+        }
+    }
+
+    protected static Object asWKT(BytesRef value) {
+        // Internally we use WKB in BytesRef, but for test assertions we want to use WKT for readability
+        Geometry geometry = WellKnownBinary.fromWKB(GeometryValidator.NOOP, false, value.bytes);
+        return WellKnownText.toWKT(geometry);
+    }
+
+    @Override
     protected BlockReaderSupport getSupportedReaders(MapperService mapper, String loaderFieldName) {
-        // TODO: Support testing both reading from source as well as reading from doc-values
         MappedFieldType ft = mapper.fieldType(loaderFieldName);
-        PointFieldMapper.PointFieldType point = (PointFieldMapper.PointFieldType) ft;
-        return new BlockReaderSupport(point.isIndexed() == false && ft.hasDocValues(), false, mapper, loaderFieldName);
+        return new BlockReaderSupport(ft.hasDocValues(), false, mapper, loaderFieldName);
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
@@ -8,8 +8,13 @@ package org.elasticsearch.xpack.spatial.index.mapper;
 
 import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.GeometryValidator;
+import org.elasticsearch.geometry.utils.WellKnownBinary;
+import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.mapper.AbstractGeometryFieldMapper;
@@ -29,6 +34,7 @@ import org.junit.AssumptionViolatedException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.hamcrest.Matchers.containsString;
@@ -362,7 +368,24 @@ public class ShapeFieldMapperTests extends CartesianFieldMapperTests {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
-        throw new AssumptionViolatedException("not supported");
+        return new GeometricShapeSyntheticSourceSupport(ignoreMalformed);
+    }
+
+    @Override
+    protected Function<Object, Object> loadBlockExpected(BlockReaderSupport blockReaderSupport, boolean columnReader) {
+        return v -> asWKT((BytesRef) v);
+    }
+
+    protected static Object asWKT(BytesRef value) {
+        // Internally we use WKB in BytesRef, but for test assertions we want to use WKT for readability
+        Geometry geometry = WellKnownBinary.fromWKB(GeometryValidator.NOOP, false, value.bytes);
+        return WellKnownText.toWKT(geometry);
+    }
+
+    @Override
+    protected BlockReaderSupport getSupportedReaders(MapperService mapper, String loaderFieldName) {
+        // Synthetic source is currently not supported.
+        return new BlockReaderSupport(false, false, mapper, loaderFieldName);
     }
 
     @Override

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/140_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/140_synthetic_source.yml
@@ -1,5 +1,9 @@
 ---
 "geo_shape":
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_fallback"]
+      reason: introduced in 8.15.0
+
   - do:
       indices.create:
         index: test
@@ -62,6 +66,10 @@
 
 ---
 "geo_shape with ignore_malformed":
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_fallback"]
+      reason: introduced in 8.15.0
+
   - do:
       indices.create:
         index: test
@@ -141,6 +149,10 @@
 
 ---
 "shape":
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_fallback"]
+      reason: introduced in 8.15.0
+
   - do:
       indices.create:
         index: test
@@ -203,6 +215,10 @@
 
 ---
 "shape with ignore_malformed":
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_fallback"]
+      reason: introduced in 8.15.0
+
   - do:
       indices.create:
         index: test
@@ -282,6 +298,10 @@
 
 ---
 "geo_point":
+  - requires:
+      cluster_features: ["gte_v8.3.0"]
+      reason: introduced in 8.3.0
+
   - do:
       indices.create:
         index: test
@@ -393,6 +413,10 @@
 
 ---
 "point":
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_fallback"]
+      reason: introduced in 8.15.0
+
   - do:
       indices.create:
         index: test
@@ -485,6 +509,10 @@
 
 ---
 "point with ignore_malformed":
+  - requires:
+      cluster_features: ["mapper.source.synthetic_source_fallback"]
+      reason: introduced in 8.15.0
+
   - do:
       indices.create:
         index: test

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/140_synthetic_source.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/140_synthetic_source.yml
@@ -140,6 +140,147 @@
   - match: { _source.shape: ["POINT (-77.03653 1000)", "POINT (-71.34 41.12)"] }
 
 ---
+"shape":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              shape:
+                type: shape
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        body:
+          shape:
+            type: "Polygon"
+            coordinates: [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]], [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]]
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        body:
+          shape: "POLYGON ((100.0 0.0, 101.0 0.0, 101.0 1.0, 100.0 1.0, 100.0 0.0), (100.2 0.2, 100.8 0.2, 100.8 0.8, 100.2 0.8, 100.2 0.2))"
+
+  - do:
+      index:
+        index: test
+        id: "3"
+        body:
+          shape: ["POINT (-77.03653 38.897676)", {"type" : "LineString", "coordinates" : [[-77.03653, 38.897676], [-77.009051, 38.889939]]}]
+
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      get:
+        index: test
+        id: "1"
+
+  - match: { _source.shape.type: "Polygon" }
+  - match: { _source.shape.coordinates: [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]], [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8], [100.2, 0.2]]] }
+
+  - do:
+      get:
+        index: test
+        id: "2"
+
+  - match: { _source.shape: "POLYGON ((100.0 0.0, 101.0 0.0, 101.0 1.0, 100.0 1.0, 100.0 0.0), (100.2 0.2, 100.8 0.2, 100.8 0.8, 100.2 0.8, 100.2 0.2))" }
+
+  - do:
+      get:
+        index: test
+        id: "3"
+
+  - match: { _source.shape: ["POINT (-77.03653 38.897676)", {"type" : "LineString", "coordinates" : [[-77.03653, 38.897676], [-77.009051, 38.889939]]}] }
+
+---
+"shape with ignore_malformed":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              shape:
+                type: shape
+                ignore_malformed: true
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        body:
+          shape: 500
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        body:
+          shape:
+            string: "string"
+            array: [{ "a": 1 }, { "b": 2 }]
+            object: { "foo": "bar" }
+
+  - do:
+      index:
+        index: test
+        id: "3"
+        body:
+          shape: ["POINT (-77.03653 38.897676)", "potato", "POINT (-71.34 41.12)"]
+
+  - do:
+      index:
+        index: test
+        id: "4"
+        body:
+          shape: ["POINT (-77.03653 1000)", "POINT (-71.34 41.12)"]
+
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      get:
+        index: test
+        id: "1"
+
+  - match: { _source.shape: 500 }
+
+  - do:
+      get:
+        index: test
+        id: "2"
+
+  - match: { _source.shape.string: "string" }
+  - match: { _source.shape.array: [{ "a": 1 }, { "b": 2 }] }
+  - match: { _source.shape.object: { "foo": "bar" } }
+
+  - do:
+      get:
+        index: test
+        id: "3"
+
+  - match: { _source.shape: ["POINT (-77.03653 38.897676)", "potato", "POINT (-71.34 41.12)"] }
+
+  - do:
+      get:
+        index: test
+        id: "4"
+
+  - match: { _source.shape: ["POINT (-77.03653 1000)", "POINT (-71.34 41.12)"] }
+
+---
 "geo_point":
   - do:
       indices.create:
@@ -249,3 +390,159 @@
 
   - match: { _source.point.lon: -71.34000029414892 }
   - match: { _source.point.lat: 41.119999922811985 }
+
+---
+"point":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              point:
+                type: point
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        body:
+          point:
+            type: "Point"
+            coordinates: [-71.34, 41.12]
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        body:
+          point: "POINT (-71.34 41.12)"
+
+  - do:
+      index:
+        index: test
+        id: "3"
+        body:
+          point:
+            x: -71.34
+            y: 41.12
+
+  - do:
+      index:
+        index: test
+        id: "4"
+        body:
+          point: [ -71.34, 41.12 ]
+
+  - do:
+      index:
+        index: test
+        id: "5"
+        body:
+          point: "41.12,-71.34"
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      get:
+        index: test
+        id: "1"
+
+  - match: { _source.point.type: "Point" }
+  - match: { _source.point.coordinates: [-71.34, 41.12] }
+
+  - do:
+      get:
+        index: test
+        id: "2"
+
+  - match: { _source.point: "POINT (-71.34 41.12)" }
+
+  - do:
+      get:
+        index: test
+        id: "3"
+
+  - match: { _source.point.x: -71.34 }
+  - match: { _source.point.y: 41.12 }
+
+  - do:
+      get:
+        index: test
+        id: "4"
+
+  - match: { _source.point: [ -71.34, 41.12 ] }
+
+  - do:
+      get:
+        index: test
+        id: "5"
+
+  - match: { _source.point: "41.12,-71.34" }
+
+---
+"point with ignore_malformed":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              point:
+                type: point
+                ignore_malformed: true
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        body:
+          point:
+            string: "string"
+            array: [{ "a": 1 }, { "b": 2 }]
+            object: { "foo": "bar" }
+
+  - do:
+      index:
+        index: test
+        id: "2"
+        body:
+          point: ["POINT (-77.03653 38.897676)", "potato", "POINT (-71.34 41.12)"]
+
+  - do:
+      index:
+        index: test
+        id: "3"
+        body:
+          point: ["POINT (-77.03653 1000)", "POINT (-71.34 41.12)"]
+
+  - do:
+      indices.refresh: {}
+
+  - do:
+      get:
+        index: test
+        id: "1"
+
+  - match: { _source.point.string: "string" }
+  - match: { _source.point.array: [{ "a": 1 }, { "b": 2 }] }
+  - match: { _source.point.object: { "foo": "bar" } }
+
+  - do:
+      get:
+        index: test
+        id: "2"
+
+  - match: { _source.point: ["POINT (-77.03653 38.897676)", "potato", "POINT (-71.34 41.12)"] }
+
+  - do:
+      get:
+        index: test
+        id: "3"
+
+  - match: { _source.point: ["POINT (-77.03653 1000)", "POINT (-71.34 41.12)"] }


### PR DESCRIPTION
This PR enables fallback synthetic source for `point` and `shape` fields and adds appropriate tests.

Contributes to #106460.