### PR TITLE
[8.14] Ingest geoip new databases release highlight

### DIFF
--- a/docs/changelog/107377.yaml
+++ b/docs/changelog/107377.yaml
@@ -4,7 +4,7 @@ area: Ingest Node
 type: enhancement
 issues: []
 highlight:
-  title: "Preview: Support for the 'Anonymous IP' and 'Enterprise' databases to the geoip processor"
+  title: "Preview: Support for the 'Anonymous IP' and 'Enterprise' databases in the geoip processor"
   body: |-
     As a Technical Preview, the `geoip` processor can now use the commercial
     https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/enterprise-database[GeoIP2 'Enterprise']

--- a/docs/changelog/107377.yaml
+++ b/docs/changelog/107377.yaml
@@ -3,3 +3,11 @@ summary: Add support for the 'Enterprise' database to the geoip processor
 area: Ingest Node
 type: enhancement
 issues: []
+highlight:
+  title: "Preview: Support for the 'Anonymous IP' and 'Enterprise' databases to the geoip processor"
+  body: |-
+    As a Technical Preview, the `geoip` processor can now use the commercial
+    https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/enterprise-database[GeoIP2 'Enterprise']
+    and
+    https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/anonymous-ip-database[GeoIP2 'Anonymous IP']
+    databases from MaxMind.

--- a/docs/changelog/107377.yaml
+++ b/docs/changelog/107377.yaml
@@ -6,7 +6,7 @@ issues: []
 highlight:
   title: "Preview: Support for the 'Anonymous IP' and 'Enterprise' databases in the geoip processor"
   body: |-
-    As a Technical Preview, the `geoip` processor can now use the commercial
+    As a Technical Preview, the {ref}/geoip-processor.html[`geoip`] processor can now use the commercial
     https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/enterprise-database[GeoIP2 'Enterprise']
     and
     https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/anonymous-ip-database[GeoIP2 'Anonymous IP']

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -64,7 +64,7 @@ depend on what has been found and which properties were configured in `propertie
 `organization_name`, `network`, `hosting_provider`, `tor_exit_node`, `anonymous_vpn`, `anonymous`, `public_proxy`, and `residential_proxy`.
 The fields actually added depend on what has been found and which properties were configured in `properties`.
 
-preview::["Do not use the GeoIP2 Anonymous IP and GeoIP2 Enterprise databases on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
+preview::["Do not use the GeoIP2 Anonymous IP and GeoIP2 Enterprise databases in production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 Here is an example that uses the default city database and adds the geographical information to the `geoip` field based on the `ip` field:
 

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -64,9 +64,7 @@ depend on what has been found and which properties were configured in `propertie
 `organization_name`, `network`, `hosting_provider`, `tor_exit_node`, `anonymous_vpn`, `anonymous`, `public_proxy`, and `residential_proxy`.
 The fields actually added depend on what has been found and which properties were configured in `properties`.
 
-preview::["Do not use the GeoIP2 Anonymous IP and GeoIP2 Enterprise databases on production environments. This functionality is in
-technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in
-technical preview are not subject to the support SLA of official GA features."]
+preview::["Do not use the GeoIP2 Anonymous IP and GeoIP2 Enterprise databases on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 Here is an example that uses the default city database and adds the geographical information to the `geoip` field based on the `ip` field:
 

--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -64,6 +64,9 @@ depend on what has been found and which properties were configured in `propertie
 `organization_name`, `network`, `hosting_provider`, `tor_exit_node`, `anonymous_vpn`, `anonymous`, `public_proxy`, and `residential_proxy`.
 The fields actually added depend on what has been found and which properties were configured in `properties`.
 
+preview::["Do not use the GeoIP2 Anonymous IP and GeoIP2 Enterprise databases on production environments. This functionality is in
+technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in
+technical preview are not subject to the support SLA of official GA features."]
 
 Here is an example that uses the default city database and adds the geographical information to the `geoip` field based on the `ip` field:
 

--- a/docs/reference/release-notes/8.14.0.asciidoc
+++ b/docs/reference/release-notes/8.14.0.asciidoc
@@ -19,11 +19,14 @@ Security::
 Aggregations::
 * Cross check livedocs for terms aggs when index access control list is non-null {es-pull}105714[#105714]
 * ESQL: Enable VALUES agg for datetime {es-pull}107016[#107016]
+* Fix IOOBE in TTest aggregation when using filters {es-pull}109034[#109034]
 * Validate stats formatting in standard `InternalStats` constructor {es-pull}107678[#107678] (issue: {es-issue}107671[#107671])
 
 Application::
 * [Bugfix] Connector API - fix status serialisation issue in termquery {es-pull}108365[#108365]
 * [Connector API] Fix bug with filtering validation toXContent {es-pull}107467[#107467]
+* [Connector API] Fix bug with parsing *_doc_count nullable fields {es-pull}108854[#108854]
+* [Connector API] Fix bug with with wrong target index for access control sync {es-pull}109097[#109097]
 
 Authorization::
 * Users with monitor privileges can access async_search/status endpoint even when setting keep_alive {es-pull}107383[#107383]
@@ -45,6 +48,7 @@ Data streams::
 * Add non-indexed fields to ecs templates {es-pull}106714[#106714]
 * Fix bulk NPE when retrying failure redirect after cluster block {es-pull}107598[#107598]
 * Improve error message when rolling over DS alias {es-pull}106708[#106708] (issue: {es-issue}106137[#106137])
+* Only skip deleting a downsampled index if downsampling is in progress as part of DSL retention {es-pull}109020[#109020]
 
 Downsampling::
 * Fix downsample action request serialization {es-pull}106919[#106919] (issue: {es-issue}106917[#106917])
@@ -64,6 +68,7 @@ ES|QL::
 * ES|QL: Fix usage of IN operator with TEXT fields {es-pull}106654[#106654] (issue: {es-issue}105379[#105379])
 * ES|QL: Improve support for TEXT fields in functions {es-pull}106810[#106810]
 * Fix docs generation of signatures for variadic functions {es-pull}107865[#107865]
+* [ESQL] Mark `date_diff` as requiring all three arguments {es-pull}108834[#108834] (issue: {es-issue}108383[#108383])
 
 Health::
 * Don't stop checking if the `HealthNode` persistent task is present {es-pull}105449[#105449] (issue: {es-issue}98926[#98926])
@@ -92,6 +97,7 @@ Infra/Node Lifecycle::
 * Wait indefintely for http connections on shutdown by default {es-pull}106511[#106511]
 
 Infra/Scripting::
+* Guard against a null scorer in painless execute {es-pull}109048[#109048] (issue: {es-issue}43541[#43541])
 * Painless: Apply true regex limit factor with FIND and MATCH operation {es-pull}105670[#105670]
 
 Ingest Node::
@@ -108,13 +114,14 @@ Machine Learning::
 * Fix `startOffset` must be non-negative error in XLMRoBERTa tokenizer {es-pull}107891[#107891] (issue: {es-issue}104626[#104626])
 * Fix the position of spike, dip and distribution changes bucket when the sibling aggregation includes empty buckets {es-pull}106472[#106472]
 * Make OpenAI embeddings parser more flexible {es-pull}106808[#106808]
-* Remove ineffective optimizations for duplicate strings. {ml-pull}2652[#2652] (issue: {ml-issue}2130[#2130])
 
 Mapping::
 * Dedupe terms in terms queries {es-pull}106381[#106381]
 * Extend support of `allowedFields` to `getMatchingFieldNames` and `getAllFields` {es-pull}106862[#106862]
+* Fix for raw mapping merge of fields named "properties" {es-pull}108867[#108867] (issue: {es-issue}108866[#108866])
 * Handle infinity during synthetic source construction for scaled float field {es-pull}107494[#107494] (issue: {es-issue}107101[#107101])
 * Handle pass-through subfields with deep nesting {es-pull}106767[#106767]
+* Wrap "Pattern too complex" exception into an `IllegalArgumentException` {es-pull}109173[#109173]
 
 Network::
 * Fix HTTP corner-case response leaks {es-pull}105617[#105617]
@@ -129,6 +136,7 @@ Search::
 * Fixing NPE when requesting [_none_] for `stored_fields` {es-pull}104711[#104711]
 * Fork when handling remote field-caps responses {es-pull}107370[#107370]
 * Handle parallel calls to `createWeight` when profiling is on {es-pull}108041[#108041] (issues: {es-issue}104131[#104131], {es-issue}104235[#104235])
+* Harden field-caps request dispatcher {es-pull}108736[#108736]
 * Replace `UnsupportedOperationException` with `IllegalArgumentException` for non-existing columns {es-pull}107038[#107038]
 * Unable to retrieve multiple stored field values {es-pull}106575[#106575]
 * Validate `model_id` is required when using the `learning_to_rank` rescorer {es-pull}107743[#107743]
@@ -138,6 +146,8 @@ Security::
 * Fix field caps and field level security {es-pull}106731[#106731]
 
 Snapshot/Restore::
+* Fix double-pausing shard snapshot {es-pull}109148[#109148] (issue: {es-issue}109143[#109143])
+* Treat 404 as empty register in `AzureBlobStore` {es-pull}108900[#108900] (issue: {es-issue}108504[#108504])
 * `SharedBlobCacheService.maybeFetchRegion` should use `computeCacheFileRegionSize` {es-pull}106685[#106685]
 
 TSDB::
@@ -149,6 +159,10 @@ Transform::
 * Make force-stopping the transform always remove persistent task from cluster state {es-pull}106989[#106989] (issue: {es-issue}106811[#106811])
 * Only trigger action once per thread {es-pull}107232[#107232] (issue: {es-issue}107215[#107215])
 * [Transform] Auto retry Transform start {es-pull}106243[#106243]
+
+Vector Search::
+* Fix multithreading copies in lib vec {es-pull}108802[#108802]
+* [8.14] Fix multithreading copies in lib vec {es-pull}108810[#108810]
 
 [[deprecation-8.14.0]]
 [float]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -65,3 +65,14 @@ significant improvements in merge times, approximately 3 times faster.
 // end::notable-highlights[]
 
 
+[discrete]
+[[preview_support_for_anonymous_ip_enterprise_databases_to_geoip_processor]]
+=== Preview: Support for the 'Anonymous IP' and 'Enterprise' databases to the geoip processor
+As a Technical Preview, the `geoip` processor can now use the commercial
+https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/enterprise-database[GeoIP2 'Enterprise']
+and
+https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/anonymous-ip-database[GeoIP2 'Anonymous IP']
+databases from MaxMind.
+
+{es-pull}107377[#107377]
+

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -68,7 +68,7 @@ significant improvements in merge times, approximately 3 times faster.
 [discrete]
 [[preview_support_for_anonymous_ip_enterprise_databases_in_geoip_processor]]
 === Preview: Support for the 'Anonymous IP' and 'Enterprise' databases in the geoip processor
-As a Technical Preview, the `geoip` processor can now use the commercial
+As a Technical Preview, the {ref}/geoip-processor.html[`geoip`] processor can now use the commercial
 https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/enterprise-database[GeoIP2 'Enterprise']
 and
 https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/anonymous-ip-database[GeoIP2 'Anonymous IP']

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -66,8 +66,8 @@ significant improvements in merge times, approximately 3 times faster.
 
 
 [discrete]
-[[preview_support_for_anonymous_ip_enterprise_databases_to_geoip_processor]]
-=== Preview: Support for the 'Anonymous IP' and 'Enterprise' databases to the geoip processor
+[[preview_support_for_anonymous_ip_enterprise_databases_in_geoip_processor]]
+=== Preview: Support for the 'Anonymous IP' and 'Enterprise' databases in the geoip processor
 As a Technical Preview, the `geoip` processor can now use the commercial
 https://www.maxmind.com/en/solutions/geoip2-enterprise-product-suite/enterprise-database[GeoIP2 'Enterprise']
 and


### PR DESCRIPTION
Generates the docs based on the most recent build candidate, then adds a release highlight for the newly supported geoip databases, and marks that support as a technical preview in the docs.