### PR TITLE
Fix test->testAutomatonPatterns dependency

### DIFF
--- a/x-pack/plugin/core/build.gradle
+++ b/x-pack/plugin/core/build.gradle
@@ -191,5 +191,6 @@ tasks.register('testAutomatonPatterns', Test) {
 
 tasks.named('test').configure {
   exclude '**/AutomatonPatternsTests.class'
-  dependsOn testAutomatonPatterns //to ensure testAutomatonPatterns are run with the test task
 }
+
+tasks.named("check").configure { dependsOn "testAutomatonPatterns" }


### PR DESCRIPTION
As-is, the testAutomatonPatterns test(s) always runs before any other test task. This made sense thinking about the entire test suite, but is annoying when trying to run an isolated single unit test, where both tests end up running. 

This commit runs the testAutomatonPatterns with the `check` task instead of the `test` task. 

related: https://github.com/elastic/elasticsearch/pull/108590