### PR TITLE
FIx misleading repository-s3 type

### DIFF
--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -539,7 +539,7 @@ VPC's internet gateway and not be bandwidth limited by the VPC's NAT instance.
 ==== S3-compatible services
 
 There are a number of storage systems that provide an S3-compatible API, and
-the `repository-s3` type allows you to use these systems in place of AWS S3.
+the `s3` type allows you to use these systems in place of AWS S3.
 To do so, you should set the `s3.client.CLIENT_NAME.endpoint` setting to the
 system's endpoint. This setting accepts IP addresses and hostnames and may
 include a port. For example, the endpoint may be `172.17.0.2` or
@@ -552,7 +552,7 @@ you wish to use unsecured HTTP communication instead of HTTPS, set
 `s3.client.CLIENT_NAME.protocol` to `http`.
 
 https://minio.io[MinIO] is an example of a storage system that provides an
-S3-compatible API. The `repository-s3` type allows {es} to work with
+S3-compatible API. The `s3` type allows {es} to work with
 MinIO-backed repositories as well as repositories stored on AWS S3. Other
 S3-compatible storage systems may also work with {es}, but these are not
 covered by the {es} test suite.
@@ -562,7 +562,7 @@ which claim to offer an S3-compatible API despite failing to emulate S3's
 behaviour in full. If you are using such a system for your snapshots, consider
 using a <<snapshots-filesystem-repository,shared filesystem repository>> based
 on a standardized protocol such as NFS to access your storage system instead.
-The `repository-s3` type requires full compatibility with S3. In particular it
+The `s3` type requires full compatibility with S3. In particular it
 must support the same set of API endpoints, with the same parameters, return
 the same errors in case of failures, and offer consistency and performance at
 least as good as S3 even when accessed concurrently by multiple nodes. You will

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -539,7 +539,7 @@ VPC's internet gateway and not be bandwidth limited by the VPC's NAT instance.
 ==== S3-compatible services
 
 There are a number of storage systems that provide an S3-compatible API, and
-the `s3` type allows you to use these systems in place of AWS S3.
+the `s3` repository type allows you to use these systems in place of AWS S3.
 To do so, you should set the `s3.client.CLIENT_NAME.endpoint` setting to the
 system's endpoint. This setting accepts IP addresses and hostnames and may
 include a port. For example, the endpoint may be `172.17.0.2` or
@@ -552,7 +552,7 @@ you wish to use unsecured HTTP communication instead of HTTPS, set
 `s3.client.CLIENT_NAME.protocol` to `http`.
 
 https://minio.io[MinIO] is an example of a storage system that provides an
-S3-compatible API. The `s3` type allows {es} to work with
+S3-compatible API. The `s3` repository type allows {es} to work with
 MinIO-backed repositories as well as repositories stored on AWS S3. Other
 S3-compatible storage systems may also work with {es}, but these are not
 covered by the {es} test suite.
@@ -562,7 +562,7 @@ which claim to offer an S3-compatible API despite failing to emulate S3's
 behaviour in full. If you are using such a system for your snapshots, consider
 using a <<snapshots-filesystem-repository,shared filesystem repository>> based
 on a standardized protocol such as NFS to access your storage system instead.
-The `s3` type requires full compatibility with S3. In particular it
+The `s3` repository type requires full compatibility with S3. In particular it
 must support the same set of API endpoints, with the same parameters, return
 the same errors in case of failures, and offer consistency and performance at
 least as good as S3 even when accessed concurrently by multiple nodes. You will


### PR DESCRIPTION
in 8.x, `repository-s3` type has been replaced by `s3` type. Fixing remaining reference to `repository-s3` in the documentation.

