### PR TITLE
Change UnassignedInfo class to record

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -100,10 +100,10 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
 
         // verify unassigned info
         assertNotNull(unassignedInfo);
-        assertEquals(Reason.NODE_LEFT, unassignedInfo.getReason());
+        assertEquals(Reason.NODE_LEFT, unassignedInfo.reason());
         assertTrue(
-            unassignedInfo.getLastAllocationStatus() == AllocationStatus.FETCHING_SHARD_DATA
-                || unassignedInfo.getLastAllocationStatus() == AllocationStatus.NO_VALID_SHARD_COPY
+            unassignedInfo.lastAllocationStatus() == AllocationStatus.FETCHING_SHARD_DATA
+                || unassignedInfo.lastAllocationStatus() == AllocationStatus.NO_VALID_SHARD_COPY
         );
 
         // verify cluster info
@@ -190,8 +190,8 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
 
         // verify unassigned info
         assertNotNull(unassignedInfo);
-        assertEquals(Reason.NODE_LEFT, unassignedInfo.getReason());
-        assertEquals(AllocationStatus.NO_ATTEMPT, unassignedInfo.getLastAllocationStatus());
+        assertEquals(Reason.NODE_LEFT, unassignedInfo.reason());
+        assertEquals(AllocationStatus.NO_ATTEMPT, unassignedInfo.lastAllocationStatus());
 
         // verify cluster info
         verifyClusterInfo(clusterInfo, includeDiskInfo, 2);
@@ -320,8 +320,8 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
 
         // verify unassigned info
         assertNotNull(unassignedInfo);
-        assertEquals(Reason.NODE_LEFT, unassignedInfo.getReason());
-        assertEquals(AllocationStatus.NO_ATTEMPT, unassignedInfo.getLastAllocationStatus());
+        assertEquals(Reason.NODE_LEFT, unassignedInfo.reason());
+        assertEquals(AllocationStatus.NO_ATTEMPT, unassignedInfo.lastAllocationStatus());
 
         // verify cluster info
         verifyClusterInfo(clusterInfo, includeDiskInfo, 3);
@@ -432,8 +432,8 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
 
         // verify unassigned info
         assertNotNull(unassignedInfo);
-        assertEquals(Reason.INDEX_CREATED, unassignedInfo.getReason());
-        assertEquals(AllocationStatus.DECIDERS_NO, unassignedInfo.getLastAllocationStatus());
+        assertEquals(Reason.INDEX_CREATED, unassignedInfo.reason());
+        assertEquals(AllocationStatus.DECIDERS_NO, unassignedInfo.lastAllocationStatus());
 
         // verify cluster info
         verifyClusterInfo(clusterInfo, includeDiskInfo, 2);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -386,9 +386,9 @@ public class ShrinkIndexIT extends ESIntegTestCase {
             assertTrue(routingTables.index("target").shard(0).shard(0).unassigned());
             assertEquals(
                 UnassignedInfo.Reason.ALLOCATION_FAILED,
-                routingTables.index("target").shard(0).shard(0).unassignedInfo().getReason()
+                routingTables.index("target").shard(0).shard(0).unassignedInfo().reason()
             );
-            assertEquals(1, routingTables.index("target").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
+            assertEquals(1, routingTables.index("target").shard(0).shard(0).unassignedInfo().failedAllocations());
         });
         // now relocate them all to the right node
         updateIndexSettings(Settings.builder().put("index.routing.allocation.require._name", mergeNode), "source");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
@@ -113,7 +113,7 @@ public class AllocationIdIT extends ESIntegTestCase {
             final ClusterState state = clusterAdmin().prepareState().get().getState();
             final ShardRouting shardRouting = state.routingTable().index(indexName).shard(shardId.id()).primaryShard();
             assertThat(shardRouting.state(), equalTo(ShardRoutingState.UNASSIGNED));
-            assertThat(shardRouting.unassignedInfo().getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
+            assertThat(shardRouting.unassignedInfo().reason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
         });
 
         internalCluster().stopNode(node1);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -202,7 +202,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
                 .shard(0)
                 .primaryShard()
                 .unassignedInfo()
-                .getReason(),
+                .reason(),
             equalTo(UnassignedInfo.Reason.NODE_LEFT)
         );
 
@@ -227,7 +227,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
                 .shard(0)
                 .primaryShard()
                 .unassignedInfo()
-                .getReason(),
+                .reason(),
             equalTo(UnassignedInfo.Reason.NODE_LEFT)
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -114,7 +114,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                 @Override
                 public Decision canForceAllocatePrimary(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
                     // once a primary is cancelled it _stays_ cancelled
-                    if (shardRouting.unassignedInfo().getReason() == UnassignedInfo.Reason.REROUTE_CANCELLED) {
+                    if (shardRouting.unassignedInfo().reason() == UnassignedInfo.Reason.REROUTE_CANCELLED) {
                         return Decision.NO;
                     }
                     return super.canForceAllocatePrimary(shardRouting, node, allocation);
@@ -450,7 +450,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                         shardRouting.role().isPromotableToPrimary()
                             ? UnassignedInfo.Reason.REROUTE_CANCELLED
                             : UnassignedInfo.Reason.UNPROMOTABLE_REPLICA,
-                        shardRouting.unassignedInfo().getReason()
+                        shardRouting.unassignedInfo().reason()
                     );
                 }
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -403,9 +403,9 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                 assertTrue(shardRoutingTable.primaryShard().unassigned());
                 assertEquals(
                     UnassignedInfo.AllocationStatus.DECIDERS_NO,
-                    shardRoutingTable.primaryShard().unassignedInfo().getLastAllocationStatus()
+                    shardRoutingTable.primaryShard().unassignedInfo().lastAllocationStatus()
                 );
-                assertThat(shardRoutingTable.primaryShard().unassignedInfo().getNumFailedAllocations(), greaterThan(0));
+                assertThat(shardRoutingTable.primaryShard().unassignedInfo().failedAllocations(), greaterThan(0));
             }
         }, 60, TimeUnit.SECONDS);
         indicesAdmin().prepareClose("test").get();
@@ -472,9 +472,9 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                 assertTrue(shardRoutingTable.primaryShard().unassigned());
                 assertEquals(
                     UnassignedInfo.AllocationStatus.DECIDERS_NO,
-                    shardRoutingTable.primaryShard().unassignedInfo().getLastAllocationStatus()
+                    shardRoutingTable.primaryShard().unassignedInfo().lastAllocationStatus()
                 );
-                assertThat(shardRoutingTable.primaryShard().unassignedInfo().getNumFailedAllocations(), greaterThan(0));
+                assertThat(shardRoutingTable.primaryShard().unassignedInfo().failedAllocations(), greaterThan(0));
             }
         }, 60, TimeUnit.SECONDS);
         indicesAdmin().prepareClose("test").get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -311,8 +311,8 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         // all shards should be failed due to a corrupted translog
         assertBusy(() -> {
             final UnassignedInfo unassignedInfo = getClusterAllocationExplanation(client(), indexName, 0, true).getUnassignedInfo();
-            assertThat(unassignedInfo.getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
-            assertThat(ExceptionsHelper.unwrap(unassignedInfo.getFailure(), TranslogCorruptedException.class), not(nullValue()));
+            assertThat(unassignedInfo.reason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
+            assertThat(ExceptionsHelper.unwrap(unassignedInfo.failure(), TranslogCorruptedException.class), not(nullValue()));
         });
 
         // have to shut down primary node - otherwise node lock is present

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -465,7 +465,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
                 final var replicaShards = indexRoutingTable.shard(shardId).replicaShards();
                 if (replicaShards.isEmpty()
                     || replicaShards.stream()
-                        .anyMatch(sr -> sr.unassigned() == false || sr.unassignedInfo().getNumFailedAllocations() < maxRetries)) {
+                        .anyMatch(sr -> sr.unassigned() == false || sr.unassignedInfo().failedAllocations() < maxRetries)) {
                     return false;
                 }
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -83,8 +83,8 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
             final var description = Strings.toString(allocationExplainResponse);
             final var unassignedInfo = allocationExplainResponse.getUnassignedInfo();
             assertThat(description, unassignedInfo, not(nullValue()));
-            assertThat(description, unassignedInfo.getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
-            var failure = unassignedInfo.getFailure();
+            assertThat(description, unassignedInfo.reason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
+            var failure = unassignedInfo.failure();
             assertNotNull(failure);
             final Throwable cause = ExceptionsHelper.unwrap(failure, TranslogCorruptedException.class);
             if (cause != null) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
@@ -61,7 +61,7 @@ public class ShardLockFailureIT extends ESIntegTestCase {
                         .routingTable()
                         .shardRoutingTable(shardId)
                         .allShards()
-                        .noneMatch(sr -> sr.unassigned() && sr.unassignedInfo().getNumFailedAllocations() > 0)
+                        .noneMatch(sr -> sr.unassigned() && sr.unassignedInfo().failedAllocations() > 0)
                 );
             } catch (IndexNotFoundException e) {
                 // ok

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -579,8 +579,8 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             .build();
 
         Consumer<UnassignedInfo> checkUnassignedInfo = unassignedInfo -> {
-            assertThat(unassignedInfo.getReason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
-            assertThat(unassignedInfo.getNumFailedAllocations(), anyOf(equalTo(maxRetries), equalTo(1)));
+            assertThat(unassignedInfo.reason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
+            assertThat(unassignedInfo.failedAllocations(), anyOf(equalTo(maxRetries), equalTo(1)));
         };
 
         unrestorableUseCase(indexName, createIndexSettings, repositorySettings, Settings.EMPTY, checkUnassignedInfo, () -> {});
@@ -605,7 +605,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             Settings.EMPTY,
             Settings.EMPTY,
             restoreIndexSettings,
-            unassignedInfo -> assertThat(unassignedInfo.getReason(), equalTo(UnassignedInfo.Reason.NEW_INDEX_RESTORED)),
+            unassignedInfo -> assertThat(unassignedInfo.reason(), equalTo(UnassignedInfo.Reason.NEW_INDEX_RESTORED)),
             fixupAction
         );
     }
@@ -670,7 +670,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
             if (shard.primary()) {
                 assertThat(shard.state(), equalTo(ShardRoutingState.UNASSIGNED));
                 assertThat(shard.recoverySource().getType(), equalTo(RecoverySource.Type.SNAPSHOT));
-                assertThat(shard.unassignedInfo().getLastAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.DECIDERS_NO));
+                assertThat(shard.unassignedInfo().lastAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.DECIDERS_NO));
                 checkUnassignedInfo.accept(shard.unassignedInfo());
             }
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
@@ -226,16 +226,16 @@ public final class ClusterAllocationExplanation implements ChunkedToXContentObje
     private static XContentBuilder unassignedInfoToXContent(UnassignedInfo unassignedInfo, XContentBuilder builder) throws IOException {
 
         builder.startObject("unassigned_info");
-        builder.field("reason", unassignedInfo.getReason());
-        builder.field("at", UnassignedInfo.DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(unassignedInfo.getUnassignedTimeInMillis())));
-        if (unassignedInfo.getNumFailedAllocations() > 0) {
-            builder.field("failed_allocation_attempts", unassignedInfo.getNumFailedAllocations());
+        builder.field("reason", unassignedInfo.reason());
+        builder.field("at", UnassignedInfo.DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(unassignedInfo.unassignedTimeMillis())));
+        if (unassignedInfo.failedAllocations() > 0) {
+            builder.field("failed_allocation_attempts", unassignedInfo.failedAllocations());
         }
-        String details = unassignedInfo.getDetails();
+        String details = unassignedInfo.details();
         if (details != null) {
             builder.field("details", details);
         }
-        builder.field("last_allocation_status", AllocationDecision.fromAllocationStatus(unassignedInfo.getLastAllocationStatus()));
+        builder.field("last_allocation_status", AllocationDecision.fromAllocationStatus(unassignedInfo.lastAllocationStatus()));
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -167,8 +167,8 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
         assert shardRouting.recoverySource() != null : "cannot invoke on a shard that has no recovery source" + shardRouting;
         final UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
         RecoverySource.Type recoveryType = shardRouting.recoverySource().getType();
-        if (unassignedInfo.getLastAllocationStatus() != AllocationStatus.DECIDERS_NO
-            && unassignedInfo.getNumFailedAllocations() == 0
+        if (unassignedInfo.lastAllocationStatus() != AllocationStatus.DECIDERS_NO
+            && unassignedInfo.failedAllocations() == 0
             && (recoveryType == RecoverySource.Type.EMPTY_STORE
                 || recoveryType == RecoverySource.Type.LOCAL_SHARDS
                 || recoveryType == RecoverySource.Type.SNAPSHOT)) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -574,15 +574,15 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
             return previousNodes == null || previousNodes.size() <= shardCopy
                 ? unassignedInfo
                 : new UnassignedInfo(
-                    unassignedInfo.getReason(),
-                    unassignedInfo.getMessage(),
-                    unassignedInfo.getFailure(),
-                    unassignedInfo.getNumFailedAllocations(),
-                    unassignedInfo.getUnassignedTimeInNanos(),
-                    unassignedInfo.getUnassignedTimeInMillis(),
-                    unassignedInfo.isDelayed(),
-                    unassignedInfo.getLastAllocationStatus(),
-                    unassignedInfo.getFailedNodeIds(),
+                    unassignedInfo.reason(),
+                    unassignedInfo.message(),
+                    unassignedInfo.failure(),
+                    unassignedInfo.failedAllocations(),
+                    unassignedInfo.unassignedTimeNanos(),
+                    unassignedInfo.unassignedTimeMillis(),
+                    unassignedInfo.delayed(),
+                    unassignedInfo.lastAllocationStatus(),
+                    unassignedInfo.failedNodeIds(),
                     previousNodes.get(shardCopy)
                 );
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -563,8 +563,8 @@ public class RoutingNodes implements Iterable<RoutingNode> {
                             "primary failed while replica initializing",
                             null,
                             0,
-                            unassignedInfo.getUnassignedTimeInNanos(),
-                            unassignedInfo.getUnassignedTimeInMillis(),
+                            unassignedInfo.unassignedTimeNanos(),
+                            unassignedInfo.unassignedTimeMillis(),
                             false,
                             AllocationStatus.NO_ATTEMPT,
                             Collections.emptySet(),
@@ -644,11 +644,11 @@ public class RoutingNodes implements Iterable<RoutingNode> {
                     unpromotableReplica,
                     new UnassignedInfo(
                         UnassignedInfo.Reason.UNPROMOTABLE_REPLICA,
-                        unassignedInfo.getMessage(),
-                        unassignedInfo.getFailure(),
+                        unassignedInfo.message(),
+                        unassignedInfo.failure(),
                         0,
-                        unassignedInfo.getUnassignedTimeInNanos(),
-                        unassignedInfo.getUnassignedTimeInMillis(),
+                        unassignedInfo.unassignedTimeNanos(),
+                        unassignedInfo.unassignedTimeMillis(),
                         false, // TODO debatable, but do we want to delay reassignment of unpromotable replicas tho?
                         AllocationStatus.NO_ATTEMPT,
                         Set.of(),
@@ -970,18 +970,18 @@ public class RoutingNodes implements Iterable<RoutingNode> {
                 ignoredPrimaries++;
                 UnassignedInfo currInfo = shard.unassignedInfo();
                 assert currInfo != null;
-                if (allocationStatus.equals(currInfo.getLastAllocationStatus()) == false) {
+                if (allocationStatus.equals(currInfo.lastAllocationStatus()) == false) {
                     UnassignedInfo newInfo = new UnassignedInfo(
-                        currInfo.getReason(),
-                        currInfo.getMessage(),
-                        currInfo.getFailure(),
-                        currInfo.getNumFailedAllocations(),
-                        currInfo.getUnassignedTimeInNanos(),
-                        currInfo.getUnassignedTimeInMillis(),
-                        currInfo.isDelayed(),
+                        currInfo.reason(),
+                        currInfo.message(),
+                        currInfo.failure(),
+                        currInfo.failedAllocations(),
+                        currInfo.unassignedTimeNanos(),
+                        currInfo.unassignedTimeMillis(),
+                        currInfo.delayed(),
                         allocationStatus,
-                        currInfo.getFailedNodeIds(),
-                        currInfo.getLastAllocatedNodeId()
+                        currInfo.failedNodeIds(),
+                        currInfo.lastAllocatedNodeId()
                     );
                     ShardRouting updatedShard = shard.updateUnassigned(newInfo, shard.recoverySource());
                     changes.unassignedInfoUpdated(shard, newInfo);
@@ -1283,16 +1283,16 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
             unassignedIterator.updateUnassigned(
                 new UnassignedInfo(
-                    unassignedInfo.getNumFailedAllocations() > 0 ? UnassignedInfo.Reason.MANUAL_ALLOCATION : unassignedInfo.getReason(),
-                    unassignedInfo.getMessage(),
-                    unassignedInfo.getFailure(),
+                    unassignedInfo.failedAllocations() > 0 ? UnassignedInfo.Reason.MANUAL_ALLOCATION : unassignedInfo.reason(),
+                    unassignedInfo.message(),
+                    unassignedInfo.failure(),
                     0,
-                    unassignedInfo.getUnassignedTimeInNanos(),
-                    unassignedInfo.getUnassignedTimeInMillis(),
-                    unassignedInfo.isDelayed(),
-                    unassignedInfo.getLastAllocationStatus(),
+                    unassignedInfo.unassignedTimeNanos(),
+                    unassignedInfo.unassignedTimeMillis(),
+                    unassignedInfo.delayed(),
+                    unassignedInfo.lastAllocationStatus(),
                     Collections.emptySet(),
-                    unassignedInfo.getLastAllocatedNodeId()
+                    unassignedInfo.lastAllocatedNodeId()
                 ),
                 shardRouting.recoverySource(),
                 routingChangesObserver

--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRouting.java
@@ -342,7 +342,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
         } else {
             recoverySource = null;
         }
-        unassignedInfo = in.readOptionalWriteable(UnassignedInfo::new);
+        unassignedInfo = in.readOptionalWriteable(UnassignedInfo::fromStreamInput);
         if (in.getTransportVersion().onOrAfter(RELOCATION_FAILURE_INFO_VERSION)) {
             relocationFailureInfo = RelocationFailureInfo.readFrom(in);
         } else {
@@ -410,7 +410,7 @@ public final class ShardRouting implements Writeable, ToXContentObject {
 
     public ShardRouting updateUnassigned(UnassignedInfo unassignedInfo, RecoverySource recoverySource) {
         assert this.unassignedInfo != null : "can only update unassigned info if it is already set";
-        assert this.unassignedInfo.isDelayed() || (unassignedInfo.isDelayed() == false) : "cannot transition from non-delayed to delayed";
+        assert this.unassignedInfo.delayed() || (unassignedInfo.delayed() == false) : "cannot transition from non-delayed to delayed";
         return new ShardRouting(
             shardId,
             currentNodeId,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -41,9 +41,40 @@ import java.util.Set;
 import static org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING;
 
 /**
- * Holds additional information as to why the shard is in unassigned state.
+ * Holds additional information as to why the shard is in an unassigned state.
+ *
+ * @param reason why the shard is unassigned.
+ * @param message optional details explaining the reasons.
+ * @param failure additional failure exception details if exists.
+ * @param failedAllocations number of previously failed allocations of this shard.
+ * @param delayed true if allocation of this shard is delayed due to {@link #INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING}.
+ * @param unassignedTimeMillis The timestamp in milliseconds when the shard became unassigned, based on System.currentTimeMillis().
+ *                             Note, we use timestamp here since we want to make sure its preserved across node serializations.
+ * @param unassignedTimeNanos The timestamp in nanoseconds when the shard became unassigned, based on System.nanoTime().
+ *                            Used to calculate the delay for delayed shard allocation.
+ *                            ONLY EXPOSED FOR TESTS!
+ * @param lastAllocationStatus status for the last allocation attempt for this shard.
+ * @param failedNodeIds A set of nodeIds that failed to complete allocations for this shard.
+ *                      {@link org.elasticsearch.gateway.ReplicaShardAllocator} uses this bset to avoid repeatedly canceling ongoing
+ *                      recoveries for copies on those nodes, although they can perform noop recoveries. This set will be discarded when a
+ *                      shard moves to started. And if a shard is failed while started (i.e., from started to unassigned), the currently
+ *                      assigned node won't be added to this set.
+ *                      @see org.elasticsearch.gateway.ReplicaShardAllocator#processExistingRecoveries
+ *                      @see org.elasticsearch.cluster.routing.allocation.AllocationService#applyFailedShards(ClusterState, List, List)
+ * @param lastAllocatedNodeId ID of the node this shard was last allocated to, or null if unavailable.
  */
-public final class UnassignedInfo implements ToXContentFragment, Writeable {
+public record UnassignedInfo(
+    Reason reason,
+    @Nullable String message,
+    @Nullable Exception failure,
+    int failedAllocations,
+    long unassignedTimeNanos, // in nanoseconds, used to calculate delay for delayed shard allocation
+    long unassignedTimeMillis, // used for display and log messages, in milliseconds
+    boolean delayed, // if allocation of this shard is delayed due to INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING
+    AllocationStatus lastAllocationStatus, // result of the last allocation attempt for this shard
+    Set<String> failedNodeIds,
+    @Nullable String lastAllocatedNodeId
+) implements ToXContentFragment, Writeable {
 
     /**
      * The version that the {@code lastAllocatedNode} field was added in. Used to adapt streaming of this class as appropriate for the
@@ -218,17 +249,6 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         }
     }
 
-    private final Reason reason;
-    private final long unassignedTimeMillis; // used for display and log messages, in milliseconds
-    private final long unassignedTimeNanos; // in nanoseconds, used to calculate delay for delayed shard allocation
-    private final boolean delayed; // if allocation of this shard is delayed due to INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING
-    private final String message;
-    private final Exception failure;
-    private final int failedAllocations;
-    private final Set<String> failedNodeIds;
-    private final AllocationStatus lastAllocationStatus; // result of the last allocation attempt for this shard
-    private final String lastAllocatedNodeId;
-
     /**
      * creates an UnassignedInfo object based on **current** time
      *
@@ -261,28 +281,10 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
      * @param failedNodeIds                   a set of nodeIds that failed to complete allocations for this shard
      * @param lastAllocatedNodeId             the ID of the node this shard was last allocated to
      */
-    public UnassignedInfo(
-        Reason reason,
-        @Nullable String message,
-        @Nullable Exception failure,
-        int failedAllocations,
-        long unassignedTimeNanos,
-        long unassignedTimeMillis,
-        boolean delayed,
-        AllocationStatus lastAllocationStatus,
-        Set<String> failedNodeIds,
-        @Nullable String lastAllocatedNodeId
-    ) {
-        this.reason = Objects.requireNonNull(reason);
-        this.unassignedTimeMillis = unassignedTimeMillis;
-        this.unassignedTimeNanos = unassignedTimeNanos;
-        this.delayed = delayed;
-        this.message = message;
-        this.failure = failure;
-        this.failedAllocations = failedAllocations;
-        this.lastAllocationStatus = Objects.requireNonNull(lastAllocationStatus);
-        this.failedNodeIds = Set.copyOf(failedNodeIds);
-        this.lastAllocatedNodeId = lastAllocatedNodeId;
+    public UnassignedInfo {
+        Objects.requireNonNull(reason);
+        Objects.requireNonNull(lastAllocationStatus);
+        failedNodeIds = Set.copyOf(failedNodeIds);
         assert (failedAllocations > 0) == (reason == Reason.ALLOCATION_FAILED)
             : "failedAllocations: " + failedAllocations + " for reason " + reason;
         assert (message == null && failure != null) == false : "provide a message if a failure exception is provided";
@@ -294,24 +296,37 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
             : "last allocated node ID must be set if the shard is unassigned due to a node restarting";
     }
 
-    public UnassignedInfo(StreamInput in) throws IOException {
+    public static UnassignedInfo fromStreamInput(StreamInput in) throws IOException {
         // Because Reason.NODE_RESTARTING is new and can't be sent by older versions, there's no need to vary the deserialization behavior
-        this.reason = Reason.values()[(int) in.readByte()];
-        this.unassignedTimeMillis = in.readLong();
+        var reason = Reason.values()[(int) in.readByte()];
+        var unassignedTimeMillis = in.readLong();
         // As System.nanoTime() cannot be compared across different JVMs, reset it to now.
         // This means that in master fail-over situations, elapsed delay time is forgotten.
-        this.unassignedTimeNanos = System.nanoTime();
-        this.delayed = in.readBoolean();
-        this.message = in.readOptionalString();
-        this.failure = in.readException();
-        this.failedAllocations = in.readVInt();
-        this.lastAllocationStatus = AllocationStatus.readFrom(in);
-        this.failedNodeIds = in.readCollectionAsImmutableSet(StreamInput::readString);
+        var unassignedTimeNanos = System.nanoTime();
+        var delayed = in.readBoolean();
+        var message = in.readOptionalString();
+        var failure = in.readException();
+        var failedAllocations = in.readVInt();
+        var lastAllocationStatus = AllocationStatus.readFrom(in);
+        var failedNodeIds = in.readCollectionAsImmutableSet(StreamInput::readString);
+        String lastAllocatedNodeId;
         if (in.getTransportVersion().onOrAfter(VERSION_LAST_ALLOCATED_NODE_ADDED)) {
-            this.lastAllocatedNodeId = in.readOptionalString();
+            lastAllocatedNodeId = in.readOptionalString();
         } else {
-            this.lastAllocatedNodeId = null;
+            lastAllocatedNodeId = null;
         }
+        return new UnassignedInfo(
+            reason,
+            message,
+            failure,
+            failedAllocations,
+            unassignedTimeNanos,
+            unassignedTimeMillis,
+            delayed,
+            lastAllocationStatus,
+            failedNodeIds,
+            lastAllocatedNodeId
+        );
     }
 
     public void writeTo(StreamOutput out) throws IOException {
@@ -336,64 +351,10 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     }
 
     /**
-     * Returns the number of previously failed allocations of this shard.
-     */
-    public int getNumFailedAllocations() {
-        return failedAllocations;
-    }
-
-    /**
-     * Returns true if allocation of this shard is delayed due to {@link #INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING}
-     */
-    public boolean isDelayed() {
-        return delayed;
-    }
-
-    /**
-     * The reason why the shard is unassigned.
-     */
-    public Reason getReason() {
-        return this.reason;
-    }
-
-    /**
-     * The timestamp in milliseconds when the shard became unassigned, based on System.currentTimeMillis().
-     * Note, we use timestamp here since we want to make sure its preserved across node serializations.
-     */
-    public long getUnassignedTimeInMillis() {
-        return this.unassignedTimeMillis;
-    }
-
-    /**
-     * The timestamp in nanoseconds when the shard became unassigned, based on System.nanoTime().
-     * Used to calculate the delay for delayed shard allocation.
-     * ONLY EXPOSED FOR TESTS!
-     */
-    public long getUnassignedTimeInNanos() {
-        return this.unassignedTimeNanos;
-    }
-
-    /**
-     * Returns optional details explaining the reasons.
-     */
-    @Nullable
-    public String getMessage() {
-        return this.message;
-    }
-
-    /**
-     * Returns additional failure exception details if exists.
-     */
-    @Nullable
-    public Exception getFailure() {
-        return failure;
-    }
-
-    /**
      * Builds a string representation of the message and the failure if exists.
      */
     @Nullable
-    public String getDetails() {
+    public String details() {
         if (message == null) {
             return null;
         }
@@ -401,41 +362,13 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     }
 
     /**
-     * Gets the ID of the node this shard was last allocated to, or null if unavailable.
-     */
-    @Nullable
-    public String getLastAllocatedNodeId() {
-        return lastAllocatedNodeId;
-    }
-
-    /**
-     * Get the status for the last allocation attempt for this shard.
-     */
-    public AllocationStatus getLastAllocationStatus() {
-        return lastAllocationStatus;
-    }
-
-    /**
-     * A set of nodeIds that failed to complete allocations for this shard. {@link org.elasticsearch.gateway.ReplicaShardAllocator}
-     * uses this set to avoid repeatedly canceling ongoing recoveries for copies on those nodes although they can perform noop recoveries.
-     * This set will be discarded when a shard moves to started. And if a shard is failed while started (i.e., from started to unassigned),
-     * the currently assigned node won't be added to this set.
-     *
-     * @see org.elasticsearch.gateway.ReplicaShardAllocator#processExistingRecoveries
-     * @see org.elasticsearch.cluster.routing.allocation.AllocationService#applyFailedShards(ClusterState, List, List)
-     */
-    public Set<String> getFailedNodeIds() {
-        return failedNodeIds;
-    }
-
-    /**
      * Calculates the delay left based on current time (in nanoseconds) and the delay defined by the index settings.
-     * Only relevant if shard is effectively delayed (see {@link #isDelayed()})
+     * Only relevant if shard is effectively delayed (see {@link #delayed()})
      * Returns 0 if delay is negative
      *
      * @return calculated delay in nanoseconds
      */
-    public long getRemainingDelay(final long nanoTimeNow, final Settings indexSettings, final NodesShutdownMetadata nodesShutdownMetadata) {
+    public long remainingDelay(final long nanoTimeNow, final Settings indexSettings, final NodesShutdownMetadata nodesShutdownMetadata) {
         final long indexLevelDelay = INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexSettings).nanos();
         long delayTimeoutNanos = Optional.ofNullable(lastAllocatedNodeId)
             // If the node wasn't restarting when this became unassigned, use default delay
@@ -455,7 +388,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
     public static int getNumberOfDelayedUnassigned(ClusterState state) {
         int count = 0;
         for (ShardRouting shard : state.getRoutingNodes().unassigned()) {
-            if (shard.unassignedInfo().isDelayed()) {
+            if (shard.unassignedInfo().delayed()) {
                 count++;
             }
         }
@@ -472,10 +405,10 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         long nextDelayNanos = Long.MAX_VALUE;
         for (ShardRouting shard : state.getRoutingNodes().unassigned()) {
             UnassignedInfo unassignedInfo = shard.unassignedInfo();
-            if (unassignedInfo.isDelayed()) {
+            if (unassignedInfo.delayed()) {
                 Settings indexSettings = metadata.index(shard.index()).getSettings();
                 // calculate next time to schedule
-                final long newComputedLeftDelayNanos = unassignedInfo.getRemainingDelay(
+                final long newComputedLeftDelayNanos = unassignedInfo.remainingDelay(
                     currentNanoTime,
                     indexSettings,
                     metadata.nodeShutdowns()
@@ -502,7 +435,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         if (lastAllocatedNodeId != null) {
             sb.append(", last_node[").append(lastAllocatedNodeId).append("]");
         }
-        String details = getDetails();
+        String details = details();
         if (details != null) {
             sb.append(", details[").append(details).append("]");
         }
@@ -530,7 +463,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
         if (lastAllocatedNodeId != null) {
             builder.field("last_node", lastAllocatedNodeId);
         }
-        String details = getDetails();
+        String details = details();
         if (details != null) {
             builder.field("details", details);
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -68,10 +68,10 @@ public record UnassignedInfo(
     @Nullable String message,
     @Nullable Exception failure,
     int failedAllocations,
-    long unassignedTimeNanos, // in nanoseconds, used to calculate delay for delayed shard allocation
-    long unassignedTimeMillis, // used for display and log messages, in milliseconds
-    boolean delayed, // if allocation of this shard is delayed due to INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING
-    AllocationStatus lastAllocationStatus, // result of the last allocation attempt for this shard
+    long unassignedTimeNanos,
+    long unassignedTimeMillis,
+    boolean delayed,
+    AllocationStatus lastAllocationStatus,
     Set<String> failedNodeIds,
     @Nullable String lastAllocatedNodeId
 ) implements ToXContentFragment, Writeable {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -215,11 +215,11 @@ public class AllocationService {
                         failedShard
                     );
                 }
-                int failedAllocations = failedShard.unassignedInfo() != null ? failedShard.unassignedInfo().getNumFailedAllocations() : 0;
+                int failedAllocations = failedShard.unassignedInfo() != null ? failedShard.unassignedInfo().failedAllocations() : 0;
                 final Set<String> failedNodeIds;
                 if (failedShard.unassignedInfo() != null) {
-                    failedNodeIds = Sets.newHashSetWithExpectedSize(failedShard.unassignedInfo().getFailedNodeIds().size() + 1);
-                    failedNodeIds.addAll(failedShard.unassignedInfo().getFailedNodeIds());
+                    failedNodeIds = Sets.newHashSetWithExpectedSize(failedShard.unassignedInfo().failedNodeIds().size() + 1);
+                    failedNodeIds.addAll(failedShard.unassignedInfo().failedNodeIds());
                     failedNodeIds.add(failedShard.currentNodeId());
                 } else {
                     failedNodeIds = Collections.emptySet();
@@ -425,8 +425,8 @@ public class AllocationService {
             while (unassignedIterator.hasNext()) {
                 ShardRouting shardRouting = unassignedIterator.next();
                 UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
-                if (unassignedInfo.isDelayed()) {
-                    final long newComputedLeftDelayNanos = unassignedInfo.getRemainingDelay(
+                if (unassignedInfo.delayed()) {
+                    final long newComputedLeftDelayNanos = unassignedInfo.remainingDelay(
                         allocation.getCurrentNanoTime(),
                         metadata.getIndexSafe(shardRouting.index()).getSettings(),
                         metadata.nodeShutdowns()
@@ -434,16 +434,16 @@ public class AllocationService {
                     if (newComputedLeftDelayNanos == 0) {
                         unassignedIterator.updateUnassigned(
                             new UnassignedInfo(
-                                unassignedInfo.getReason(),
-                                unassignedInfo.getMessage(),
-                                unassignedInfo.getFailure(),
-                                unassignedInfo.getNumFailedAllocations(),
-                                unassignedInfo.getUnassignedTimeInNanos(),
-                                unassignedInfo.getUnassignedTimeInMillis(),
+                                unassignedInfo.reason(),
+                                unassignedInfo.message(),
+                                unassignedInfo.failure(),
+                                unassignedInfo.failedAllocations(),
+                                unassignedInfo.unassignedTimeNanos(),
+                                unassignedInfo.unassignedTimeMillis(),
                                 false,
-                                unassignedInfo.getLastAllocationStatus(),
-                                unassignedInfo.getFailedNodeIds(),
-                                unassignedInfo.getLastAllocatedNodeId()
+                                unassignedInfo.lastAllocationStatus(),
+                                unassignedInfo.failedNodeIds(),
+                                unassignedInfo.lastAllocatedNodeId()
                             ),
                             shardRouting.recoverySource(),
                             allocation.changes()

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardChangesObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardChangesObserver.java
@@ -36,7 +36,7 @@ public class ShardChangesObserver implements RoutingChangesObserver {
 
     @Override
     public void shardFailed(ShardRouting failedShard, UnassignedInfo unassignedInfo) {
-        logger.debug("{} has failed on [{}]: {}", shardIdentifier(failedShard), failedShard.currentNodeId(), unassignedInfo.getReason());
+        logger.debug("{} has failed on [{}]: {}", shardIdentifier(failedShard), failedShard.currentNodeId(), unassignedInfo.reason());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -220,19 +220,19 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         while (unassignedIterator.hasNext()) {
             final ShardRouting shardRouting = unassignedIterator.next();
             final UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
-            if (shardRouting.primary() && unassignedInfo.getLastAllocationStatus() == AllocationStatus.NO_ATTEMPT) {
+            if (shardRouting.primary() && unassignedInfo.lastAllocationStatus() == AllocationStatus.NO_ATTEMPT) {
                 unassignedIterator.updateUnassigned(
                     new UnassignedInfo(
-                        unassignedInfo.getReason(),
-                        unassignedInfo.getMessage(),
-                        unassignedInfo.getFailure(),
-                        unassignedInfo.getNumFailedAllocations(),
-                        unassignedInfo.getUnassignedTimeInNanos(),
-                        unassignedInfo.getUnassignedTimeInMillis(),
-                        unassignedInfo.isDelayed(),
+                        unassignedInfo.reason(),
+                        unassignedInfo.message(),
+                        unassignedInfo.failure(),
+                        unassignedInfo.failedAllocations(),
+                        unassignedInfo.unassignedTimeNanos(),
+                        unassignedInfo.unassignedTimeMillis(),
+                        unassignedInfo.delayed(),
                         AllocationStatus.DECIDERS_NO,
-                        unassignedInfo.getFailedNodeIds(),
-                        unassignedInfo.getLastAllocatedNodeId()
+                        unassignedInfo.failedNodeIds(),
+                        unassignedInfo.lastAllocatedNodeId()
                     ),
                     shardRouting.recoverySource(),
                     allocation.changes()

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -226,19 +226,19 @@ public class DesiredBalanceReconciler {
             while (unassignedIterator.hasNext()) {
                 final ShardRouting shardRouting = unassignedIterator.next();
                 final UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
-                if (shardRouting.primary() && unassignedInfo.getLastAllocationStatus() == AllocationStatus.NO_ATTEMPT) {
+                if (shardRouting.primary() && unassignedInfo.lastAllocationStatus() == AllocationStatus.NO_ATTEMPT) {
                     unassignedIterator.updateUnassigned(
                         new UnassignedInfo(
-                            unassignedInfo.getReason(),
-                            unassignedInfo.getMessage(),
-                            unassignedInfo.getFailure(),
-                            unassignedInfo.getNumFailedAllocations(),
-                            unassignedInfo.getUnassignedTimeInNanos(),
-                            unassignedInfo.getUnassignedTimeInMillis(),
-                            unassignedInfo.isDelayed(),
+                            unassignedInfo.reason(),
+                            unassignedInfo.message(),
+                            unassignedInfo.failure(),
+                            unassignedInfo.failedAllocations(),
+                            unassignedInfo.unassignedTimeNanos(),
+                            unassignedInfo.unassignedTimeMillis(),
+                            unassignedInfo.delayed(),
                             AllocationStatus.DECIDERS_NO,
-                            unassignedInfo.getFailedNodeIds(),
-                            unassignedInfo.getLastAllocatedNodeId()
+                            unassignedInfo.failedNodeIds(),
+                            unassignedInfo.lastAllocatedNodeId()
                         ),
                         shardRouting.recoverySource(),
                         allocation.changes()

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/command/AllocateEmptyPrimaryAllocationCommand.java
@@ -126,20 +126,20 @@ public class AllocateEmptyPrimaryAllocationCommand extends BasePrimaryAllocation
         }
 
         UnassignedInfo unassignedInfoToUpdate = null;
-        if (shardRouting.unassignedInfo().getReason() != UnassignedInfo.Reason.FORCED_EMPTY_PRIMARY) {
+        if (shardRouting.unassignedInfo().reason() != UnassignedInfo.Reason.FORCED_EMPTY_PRIMARY) {
             String unassignedInfoMessage = "force empty allocation from previous reason "
-                + shardRouting.unassignedInfo().getReason()
+                + shardRouting.unassignedInfo().reason()
                 + ", "
-                + shardRouting.unassignedInfo().getMessage();
+                + shardRouting.unassignedInfo().message();
             unassignedInfoToUpdate = new UnassignedInfo(
                 UnassignedInfo.Reason.FORCED_EMPTY_PRIMARY,
                 unassignedInfoMessage,
-                shardRouting.unassignedInfo().getFailure(),
+                shardRouting.unassignedInfo().failure(),
                 0,
                 System.nanoTime(),
                 System.currentTimeMillis(),
                 false,
-                shardRouting.unassignedInfo().getLastAllocationStatus(),
+                shardRouting.unassignedInfo().lastAllocationStatus(),
                 Collections.emptySet(),
                 null
             );

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -50,7 +50,7 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
 
         final int maxRetries = SETTING_ALLOCATION_MAX_RETRY.get(allocation.metadata().getIndexSafe(shardRouting.index()).getSettings());
         final var unassignedInfo = shardRouting.unassignedInfo();
-        final int numFailedAllocations = unassignedInfo == null ? 0 : unassignedInfo.getNumFailedAllocations();
+        final int numFailedAllocations = unassignedInfo == null ? 0 : unassignedInfo.failedAllocations();
         if (numFailedAllocations > 0) {
             final var decision = numFailedAllocations >= maxRetries ? Decision.NO : Decision.YES;
             return allocation.debugDecision() ? debugDecision(decision, unassignedInfo, numFailedAllocations, maxRetries) : decision;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDecider.java
@@ -55,7 +55,7 @@ public class RestoreInProgressAllocationDecider extends AllocationDecider {
                 + "to restore the snapshot again or use the reroute API to force the allocation of an empty primary shard. Details: [%s]",
             source.snapshot(),
             shardRouting.getIndexName(),
-            shardRouting.unassignedInfo().getDetails()
+            shardRouting.unassignedInfo().details()
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/shards/ShardsAvailabilityHealthIndicatorService.java
@@ -536,15 +536,15 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
 
     private static boolean isUnassignedDueToTimelyRestart(ShardRouting routing, NodesShutdownMetadata shutdowns) {
         var info = routing.unassignedInfo();
-        if (info == null || info.getReason() != UnassignedInfo.Reason.NODE_RESTARTING) {
+        if (info == null || info.reason() != UnassignedInfo.Reason.NODE_RESTARTING) {
             return false;
         }
-        var shutdown = shutdowns.get(info.getLastAllocatedNodeId(), SingleNodeShutdownMetadata.Type.RESTART);
+        var shutdown = shutdowns.get(info.lastAllocatedNodeId(), SingleNodeShutdownMetadata.Type.RESTART);
         if (shutdown == null) {
             return false;
         }
         var now = System.nanoTime();
-        var restartingAllocationDelayExpiration = info.getUnassignedTimeInNanos() + shutdown.getAllocationDelay().nanos();
+        var restartingAllocationDelayExpiration = info.unassignedTimeNanos() + shutdown.getAllocationDelay().nanos();
         return now - restartingAllocationDelayExpiration <= 0;
     }
 
@@ -567,10 +567,10 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
     List<Diagnosis.Definition> diagnoseUnassignedShardRouting(ShardRouting shardRouting, ClusterState state) {
         List<Diagnosis.Definition> diagnosisDefs = new ArrayList<>();
         LOGGER.trace("Diagnosing unassigned shard [{}] due to reason [{}]", shardRouting.shardId(), shardRouting.unassignedInfo());
-        switch (shardRouting.unassignedInfo().getLastAllocationStatus()) {
+        switch (shardRouting.unassignedInfo().lastAllocationStatus()) {
             case NO_VALID_SHARD_COPY -> diagnosisDefs.add(ACTION_RESTORE_FROM_SNAPSHOT);
             case NO_ATTEMPT -> {
-                if (shardRouting.unassignedInfo().isDelayed()) {
+                if (shardRouting.unassignedInfo().delayed()) {
                     diagnosisDefs.add(DIAGNOSIS_WAIT_FOR_OR_FIX_DELAYED_SHARDS);
                 } else {
                     diagnosisDefs.addAll(explainAllocationsAndDiagnoseDeciders(shardRouting, state));

--- a/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/ReplicaShardAllocator.java
@@ -65,7 +65,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                 }
 
                 // if we are allocating a replica because of index creation, no need to go and find a copy, there isn't one...
-                if (shard.unassignedInfo() != null && shard.unassignedInfo().getReason() == UnassignedInfo.Reason.INDEX_CREATED) {
+                if (shard.unassignedInfo() != null && shard.unassignedInfo().reason() == UnassignedInfo.Reason.INDEX_CREATED) {
                     continue;
                 }
 
@@ -103,7 +103,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                         );
                         final Set<String> failedNodeIds = shard.unassignedInfo() == null
                             ? Collections.emptySet()
-                            : shard.unassignedInfo().getFailedNodeIds();
+                            : shard.unassignedInfo().failedNodeIds();
                         UnassignedInfo unassignedInfo = new UnassignedInfo(
                             UnassignedInfo.Reason.REALLOCATED_REPLICA,
                             "existing allocation of replica to ["
@@ -138,7 +138,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
         return shard.primary() == false // must be a replica
             && shard.unassigned() // must be unassigned
             // if we are allocating a replica because of index creation, no need to go and find a copy, there isn't one...
-            && shard.unassignedInfo().getReason() != UnassignedInfo.Reason.INDEX_CREATED;
+            && shard.unassignedInfo().reason() != UnassignedInfo.Reason.INDEX_CREATED;
     }
 
     @Override
@@ -234,7 +234,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
                 // we found a match
                 return AllocateUnassignedDecision.yes(nodeWithHighestMatch.node(), null, nodeDecisions, true);
             }
-        } else if (matchingNodes.hasAnyData() == false && unassignedShard.unassignedInfo().isDelayed()) {
+        } else if (matchingNodes.hasAnyData() == false && unassignedShard.unassignedInfo().delayed()) {
             // if we didn't manage to find *any* data (regardless of matching sizes), and the replica is
             // unassigned due to a node leaving, so we delay allocation of this replica to see if the
             // node with the shard copy will rejoin so we can re-use the copy it has
@@ -262,7 +262,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
             Metadata metadata = allocation.metadata();
             IndexMetadata indexMetadata = metadata.index(unassignedShard.index());
             totalDelayMillis = INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.get(indexMetadata.getSettings()).getMillis();
-            long remainingDelayNanos = unassignedInfo.getRemainingDelay(
+            long remainingDelayNanos = unassignedInfo.remainingDelay(
                 System.nanoTime(),
                 indexMetadata.getSettings(),
                 metadata.nodeShutdowns()
@@ -357,7 +357,7 @@ public abstract class ReplicaShardAllocator extends BaseGatewayShardAllocator {
             DiscoveryNode discoNode = nodeStoreEntry.getKey();
             if (noMatchFailedNodes
                 && shard.unassignedInfo() != null
-                && shard.unassignedInfo().getFailedNodeIds().contains(discoNode.getId())) {
+                && shard.unassignedInfo().failedNodeIds().contains(discoNode.getId())) {
                 continue;
             }
             TransportNodesListShardStoreMetadata.StoreFilesMetadata storeFilesMetadata = nodeStoreEntry.getValue().storeFilesMetadata();

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestShardsAction.java
@@ -324,13 +324,13 @@ public class RestShardsAction extends AbstractCatAction {
             table.addCell(commitStats == null ? null : commitStats.getUserData().get(Engine.SYNC_COMMIT_ID));
 
             if (shard.unassignedInfo() != null) {
-                table.addCell(shard.unassignedInfo().getReason());
-                Instant unassignedTime = Instant.ofEpochMilli(shard.unassignedInfo().getUnassignedTimeInMillis());
+                table.addCell(shard.unassignedInfo().reason());
+                Instant unassignedTime = Instant.ofEpochMilli(shard.unassignedInfo().unassignedTimeMillis());
                 table.addCell(UnassignedInfo.DATE_TIME_FORMATTER.format(unassignedTime));
                 table.addCell(
-                    TimeValue.timeValueMillis(Math.max(0, System.currentTimeMillis() - shard.unassignedInfo().getUnassignedTimeInMillis()))
+                    TimeValue.timeValueMillis(Math.max(0, System.currentTimeMillis() - shard.unassignedInfo().unassignedTimeMillis()))
                 );
-                table.addCell(shard.unassignedInfo().getDetails());
+                table.addCell(shard.unassignedInfo().details());
             } else {
                 table.addCell(null);
                 table.addCell(null);

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -795,13 +795,13 @@ public final class RestoreService implements ClusterStateApplier {
                     // mark restore entry for this shard as failed when it's due to a file corruption. There is no need wait on retries
                     // to restore this shard on another node if the snapshot files are corrupt. In case where a node just left or crashed,
                     // however, we only want to acknowledge the restore operation once it has been successfully restored on another node.
-                    if (unassignedInfo.getFailure() != null && Lucene.isCorruptionException(unassignedInfo.getFailure().getCause())) {
+                    if (unassignedInfo.failure() != null && Lucene.isCorruptionException(unassignedInfo.failure().getCause())) {
                         changes(recoverySource).put(
                             failedShard.shardId(),
                             new ShardRestoreStatus(
                                 failedShard.currentNodeId(),
                                 RestoreInProgress.State.FAILURE,
-                                unassignedInfo.getFailure().getCause().getMessage()
+                                unassignedInfo.failure().getCause().getMessage()
                             )
                         );
                     }
@@ -829,7 +829,7 @@ public final class RestoreService implements ClusterStateApplier {
         public void unassignedInfoUpdated(ShardRouting unassignedShard, UnassignedInfo newUnassignedInfo) {
             RecoverySource recoverySource = unassignedShard.recoverySource();
             if (recoverySource.getType() == RecoverySource.Type.SNAPSHOT) {
-                if (newUnassignedInfo.getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
+                if (newUnassignedInfo.lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
                     String reason = "shard could not be allocated to any of the nodes";
                     changes(recoverySource).put(
                         unassignedShard.shardId(),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -103,9 +103,9 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
                     """
                         ,"unassigned_info": {"reason": "%s", "at": "%s", "last_allocation_status": "%s"}
                         """,
-                    shard.unassignedInfo().getReason(),
-                    UnassignedInfo.DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(shard.unassignedInfo().getUnassignedTimeInMillis())),
-                    AllocationDecision.fromAllocationStatus(shard.unassignedInfo().getLastAllocationStatus())
+                    shard.unassignedInfo().reason(),
+                    UnassignedInfo.DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(shard.unassignedInfo().unassignedTimeMillis())),
+                    AllocationDecision.fromAllocationStatus(shard.unassignedInfo().lastAllocationStatus())
                 )
                 : "",
             cae.getCurrentNode().getId(),

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -162,7 +162,7 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
     private void assertStateAndFailedAllocations(IndexRoutingTable indexRoutingTable, ShardRoutingState state, int failedAllocations) {
         assertThat(indexRoutingTable.size(), equalTo(1));
         assertThat(indexRoutingTable.shard(0).shard(0).state(), equalTo(state));
-        assertThat(indexRoutingTable.shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), equalTo(failedAllocations));
+        assertThat(indexRoutingTable.shard(0).shard(0).unassignedInfo().failedAllocations(), equalTo(failedAllocations));
     }
 
     private ClusterState createInitialClusterState(AllocationService service) {

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -559,10 +559,10 @@ public class ClusterStateHealthTests extends ESTestCase {
                     && primaryShard.recoverySource().getType() == RecoverySource.Type.EXISTING_STORE) {
                     return false;
                 }
-                if (primaryShard.unassignedInfo().getNumFailedAllocations() > 0) {
+                if (primaryShard.unassignedInfo().failedAllocations() > 0) {
                     return false;
                 }
-                if (primaryShard.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
+                if (primaryShard.unassignedInfo().lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {
                     return false;
                 }
             }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceTests.java
@@ -457,7 +457,7 @@ public class MetadataIndexStateServiceTests extends ESTestCase {
             assertThat(
                 RoutingNodesHelper.asStream(shardRoutingTable)
                     .map(ShardRouting::unassignedInfo)
-                    .map(UnassignedInfo::getReason)
+                    .map(UnassignedInfo::reason)
                     .allMatch(info -> info == UnassignedInfo.Reason.INDEX_CLOSED),
                 is(true)
             );

--- a/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -109,7 +109,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
             assertThat(unassignedShards.size(), equalTo(0));
         } else {
             assertThat(unassignedShards.size(), equalTo(1));
-            assertThat(unassignedShards.get(0).unassignedInfo().isDelayed(), equalTo(false));
+            assertThat(unassignedShards.get(0).unassignedInfo().delayed(), equalTo(false));
         }
 
         delayedAllocationService.clusterChanged(new ClusterChangedEvent("test", newState, prevState));
@@ -169,7 +169,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         // make sure the replica is marked as delayed (i.e. not reallocated)
         assertEquals(1, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithDelayedShard));
         ShardRouting delayedShard = stateWithDelayedShard.getRoutingNodes().unassigned().iterator().next();
-        assertEquals(baseTimestampNanos, delayedShard.unassignedInfo().getUnassignedTimeInNanos());
+        assertEquals(baseTimestampNanos, delayedShard.unassignedInfo().unassignedTimeNanos());
 
         // mock ClusterService.submitStateUpdateTask() method
         CountDownLatch latch = new CountDownLatch(1);
@@ -318,8 +318,8 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         final ClusterState stateWithDelayedShards = clusterState;
         assertEquals(2, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithDelayedShards));
         RoutingNodes.UnassignedShards.UnassignedIterator iter = stateWithDelayedShards.getRoutingNodes().unassigned().iterator();
-        assertEquals(baseTimestampNanos, iter.next().unassignedInfo().getUnassignedTimeInNanos());
-        assertEquals(baseTimestampNanos, iter.next().unassignedInfo().getUnassignedTimeInNanos());
+        assertEquals(baseTimestampNanos, iter.next().unassignedInfo().unassignedTimeNanos());
+        assertEquals(baseTimestampNanos, iter.next().unassignedInfo().unassignedTimeNanos());
 
         // mock ClusterService.submitStateUpdateTask() method
         CountDownLatch latch1 = new CountDownLatch(1);
@@ -491,7 +491,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         // make sure the replica is marked as delayed (i.e. not reallocated)
         assertEquals(1, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithDelayedShard));
         ShardRouting delayedShard = stateWithDelayedShard.getRoutingNodes().unassigned().iterator().next();
-        assertEquals(nodeLeftTimestampNanos, delayedShard.unassignedInfo().getUnassignedTimeInNanos());
+        assertEquals(nodeLeftTimestampNanos, delayedShard.unassignedInfo().unassignedTimeNanos());
 
         assertNull(delayedAllocationService.delayedRerouteTask.get());
         long delayUntilClusterChangeEvent = TimeValue.timeValueNanos(randomInt((int) shorterDelaySetting.nanos() - 1)).nanos();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/ShardRoutingTests.java
@@ -401,7 +401,7 @@ public class ShardRoutingTests extends AbstractWireSerializingTestCase<ShardRout
                     .withUnassignedInfo(
                         otherRouting.unassignedInfo() == null
                             ? new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")
-                            : new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, otherRouting.unassignedInfo().getMessage() + "_1")
+                            : new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, otherRouting.unassignedInfo().message() + "_1")
                     )
                     .build();
             }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
@@ -91,8 +91,8 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
             assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
-            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), i + 1);
-            assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom" + i));
+            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations(), i + 1);
+            assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom" + i));
         }
         // now we go and check that we are actually stick to unassigned on the next failure
         ClusterState newState = applyShardFailure(clusterState, routingTable.index("idx").shard(0).shard(0), "boom");
@@ -100,9 +100,9 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         clusterState = newState;
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations(), retries);
+        assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations(), retries);
         assertEquals(routingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
-        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom"));
+        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom"));
 
         // manual resetting of retry count
         newState = strategy.reroute(clusterState, new AllocationCommands(), false, true, false, ActionListener.noop()).clusterState();
@@ -112,9 +112,9 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
 
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(0, routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
+        assertEquals(0, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations());
         assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shard(0).state());
-        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom"));
+        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom"));
 
         // again fail it N-1 times
         for (int i = 0; i < retries - 1; i++) {
@@ -123,9 +123,9 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             clusterState = newState;
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
-            assertEquals(i + 1, routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
+            assertEquals(i + 1, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations());
             assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shard(0).state());
-            assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom"));
+            assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom"));
         }
 
         // now we go and check that we are actually stick to unassigned on the next failure
@@ -134,9 +134,9 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         clusterState = newState;
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(retries, routingTable.index("idx").shard(0).shard(0).unassignedInfo().getNumFailedAllocations());
+        assertEquals(retries, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations());
         assertEquals(UNASSIGNED, routingTable.index("idx").shard(0).shard(0).state());
-        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().getMessage(), containsString("boom"));
+        assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom"));
     }
 
     public void testFailedAllocation() {
@@ -152,8 +152,8 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             assertEquals(routingTable.index("idx").size(), 1);
             ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
             assertEquals(unassignedPrimary.state(), INITIALIZING);
-            assertEquals(unassignedPrimary.unassignedInfo().getNumFailedAllocations(), i + 1);
-            assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom" + i));
+            assertEquals(unassignedPrimary.unassignedInfo().failedAllocations(), i + 1);
+            assertThat(unassignedPrimary.unassignedInfo().message(), containsString("boom" + i));
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return YES decisions because canAllocate returns YES here
             assertEquals(
                 Decision.Type.YES,
@@ -168,9 +168,9 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
             ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
-            assertEquals(unassignedPrimary.unassignedInfo().getNumFailedAllocations(), retries);
+            assertEquals(unassignedPrimary.unassignedInfo().failedAllocations(), retries);
             assertEquals(unassignedPrimary.state(), UNASSIGNED);
-            assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom"));
+            assertThat(unassignedPrimary.unassignedInfo().message(), containsString("boom"));
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return a NO decision because canAllocate returns NO here
             final var allocation = newRoutingAllocation(clusterState);
             allocation.debugDecision(true);
@@ -211,9 +211,9 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         // good we are initializing and we are maintaining failure information
         assertEquals(routingTable.index("idx").size(), 1);
         ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
-        assertEquals(unassignedPrimary.unassignedInfo().getNumFailedAllocations(), retries);
+        assertEquals(unassignedPrimary.unassignedInfo().failedAllocations(), retries);
         assertEquals(unassignedPrimary.state(), INITIALIZING);
-        assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("boom"));
+        assertThat(unassignedPrimary.unassignedInfo().message(), containsString("boom"));
         // bumped up the max retry count, so canForceAllocatePrimary should return a YES decision
         assertEquals(
             Decision.Type.YES,
@@ -236,9 +236,9 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
         unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
-        assertEquals(unassignedPrimary.unassignedInfo().getNumFailedAllocations(), 1);
+        assertEquals(unassignedPrimary.unassignedInfo().failedAllocations(), 1);
         assertEquals(unassignedPrimary.state(), UNASSIGNED);
-        assertThat(unassignedPrimary.unassignedInfo().getMessage(), containsString("ZOOOMG"));
+        assertThat(unassignedPrimary.unassignedInfo().message(), containsString("ZOOOMG"));
         // Counter reset, so MaxRetryAllocationDecider#canForceAllocatePrimary should return a YES decision
         assertEquals(
             Decision.Type.YES,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/TrackFailedAllocationNodesTests.java
@@ -59,17 +59,14 @@ public class TrackFailedAllocationNodesTests extends ESAllocationTestCase {
                 List.of(new FailedShard(clusterState.routingTable().index("idx").shard(0).shard(0), null, null, randomBoolean())),
                 List.of()
             );
-            assertThat(
-                clusterState.routingTable().index("idx").shard(0).shard(0).unassignedInfo().getFailedNodeIds(),
-                equalTo(failedNodeIds)
-            );
+            assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).unassignedInfo().failedNodeIds(), equalTo(failedNodeIds));
         }
 
         // reroute with retryFailed=true should discard the failedNodes
         assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).state(), equalTo(ShardRoutingState.UNASSIGNED));
         clusterState = allocationService.reroute(clusterState, new AllocationCommands(), false, true, false, ActionListener.noop())
             .clusterState();
-        assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).unassignedInfo().getFailedNodeIds(), empty());
+        assertThat(clusterState.routingTable().index("idx").shard(0).shard(0).unassignedInfo().failedNodeIds(), empty());
 
         // do not track the failed nodes while shard is started
         clusterState = startInitializingShardsAndReroute(allocationService, clusterState);
@@ -79,6 +76,6 @@ public class TrackFailedAllocationNodesTests extends ESAllocationTestCase {
             List.of(new FailedShard(clusterState.routingTable().index("idx").shard(0).primaryShard(), null, null, false)),
             List.of()
         );
-        assertThat(clusterState.routingTable().index("idx").shard(0).primaryShard().unassignedInfo().getFailedNodeIds(), empty());
+        assertThat(clusterState.routingTable().index("idx").shard(0).primaryShard().unassignedInfo().failedNodeIds(), empty());
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -167,7 +167,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                         .replicaShards()
                         .get(0)
                         .unassignedInfo()
-                        .getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 1 : 2
+                        .lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 1 : 2
                 ),
                 new ShardId(index, 1),
                 new ShardAssignment(Set.of("node-0", "node-1"), 2, 0, 0)
@@ -198,7 +198,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                     Set.of("node-0"),
                     2,
                     1,
-                    originalReplicaShard.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 0 : 1
+                    originalReplicaShard.unassignedInfo().lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO ? 0 : 1
                 ),
                 new ShardId(index, 1),
                 new ShardAssignment(Set.of("node-0", "node-1"), 2, 0, 0)
@@ -1301,20 +1301,20 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
             var unassignedInfo = shardRouting.unassignedInfo();
             return shardRouting.updateUnassigned(
                 new UnassignedInfo(
-                    unassignedInfo.getReason(),
-                    unassignedInfo.getMessage(),
-                    unassignedInfo.getFailure(),
-                    unassignedInfo.getNumFailedAllocations(),
-                    unassignedInfo.getUnassignedTimeInNanos(),
-                    unassignedInfo.getUnassignedTimeInMillis(),
-                    unassignedInfo.isDelayed(),
+                    unassignedInfo.reason(),
+                    unassignedInfo.message(),
+                    unassignedInfo.failure(),
+                    unassignedInfo.failedAllocations(),
+                    unassignedInfo.unassignedTimeNanos(),
+                    unassignedInfo.unassignedTimeMillis(),
+                    unassignedInfo.delayed(),
                     randomFrom(
                         UnassignedInfo.AllocationStatus.DECIDERS_NO,
                         UnassignedInfo.AllocationStatus.NO_ATTEMPT,
                         UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED
                     ),
-                    unassignedInfo.getFailedNodeIds(),
-                    unassignedInfo.getLastAllocatedNodeId()
+                    unassignedInfo.failedNodeIds(),
+                    unassignedInfo.lastAllocatedNodeId()
                 ),
                 shardRouting.recoverySource()
             );

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -132,19 +132,19 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
             final var shardRouting = unassigned.next();
             if (shardRouting.primary() && shardRouting.shardId().id() == 1) {
                 final var unassignedInfo = shardRouting.unassignedInfo();
-                assertThat(unassignedInfo.getLastAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.NO_ATTEMPT));
+                assertThat(unassignedInfo.lastAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.NO_ATTEMPT));
                 unassigned.updateUnassigned(
                     new UnassignedInfo(
-                        unassignedInfo.getReason(),
-                        unassignedInfo.getMessage(),
-                        unassignedInfo.getFailure(),
-                        unassignedInfo.getNumFailedAllocations(),
-                        unassignedInfo.getUnassignedTimeInNanos(),
-                        unassignedInfo.getUnassignedTimeInMillis(),
-                        unassignedInfo.isDelayed(),
+                        unassignedInfo.reason(),
+                        unassignedInfo.message(),
+                        unassignedInfo.failure(),
+                        unassignedInfo.failedAllocations(),
+                        unassignedInfo.unassignedTimeNanos(),
+                        unassignedInfo.unassignedTimeMillis(),
+                        unassignedInfo.delayed(),
                         UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED,
-                        unassignedInfo.getFailedNodeIds(),
-                        unassignedInfo.getLastAllocatedNodeId()
+                        unassignedInfo.failedNodeIds(),
+                        unassignedInfo.lastAllocatedNodeId()
                     ),
                     shardRouting.recoverySource(),
                     new RoutingChangesObserver.DelegatingRoutingChangesObserver()
@@ -164,7 +164,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
         for (ShardRouting shardRouting : routingAllocation.routingNodes().unassigned()) {
             assertTrue(shardRouting.toString(), shardRouting.unassigned());
             assertThat(
-                shardRouting.unassignedInfo().getLastAllocationStatus(),
+                shardRouting.unassignedInfo().lastAllocationStatus(),
                 equalTo(
                     shardRouting.primary() && shardRouting.shardId().id() == 1
                         ? UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED
@@ -190,7 +190,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
         for (ShardRouting shardRouting : routingAllocation.routingNodes().unassigned()) {
             assertTrue(shardRouting.toString(), shardRouting.unassigned());
             assertThat(
-                shardRouting.unassignedInfo().getLastAllocationStatus(),
+                shardRouting.unassignedInfo().lastAllocationStatus(),
                 equalTo(
                     // we only update primaries, and only if currently NO_ATTEMPT
                     shardRouting.primary()
@@ -677,7 +677,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
                 .replicaShards()
                 .stream()
                 .allMatch(
-                    shardRouting -> shardRouting.unassignedInfo().getLastAllocationStatus() == UnassignedInfo.AllocationStatus.NO_ATTEMPT
+                    shardRouting -> shardRouting.unassignedInfo().lastAllocationStatus() == UnassignedInfo.AllocationStatus.NO_ATTEMPT
                 )
         );
     }
@@ -724,7 +724,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
             nonYesDecision == Decision.NO
                 ? UnassignedInfo.AllocationStatus.DECIDERS_NO
                 : UnassignedInfo.AllocationStatus.DECIDERS_THROTTLED,
-            redState.routingTable().shardRoutingTable("index-0", 0).primaryShard().unassignedInfo().getLastAllocationStatus()
+            redState.routingTable().shardRoutingTable("index-0", 0).primaryShard().unassignedInfo().lastAllocationStatus()
         );
 
         assignPrimary.set(true);
@@ -733,7 +733,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
             startInitializingShardsAndReroute(allocationService, redState)
         );
         for (final var shardRouting : yellowState.routingTable().shardRoutingTable("index-0", 0).replicaShards()) {
-            assertEquals(UnassignedInfo.AllocationStatus.NO_ATTEMPT, shardRouting.unassignedInfo().getLastAllocationStatus());
+            assertEquals(UnassignedInfo.AllocationStatus.NO_ATTEMPT, shardRouting.unassignedInfo().lastAllocationStatus());
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
@@ -100,7 +100,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
                 var shardRouting = routingTable.shardRoutingTable("test-index", 0).primaryShard();
                 assertFalse(shardRouting.assignedToNode());
                 assertThat(
-                    shardRouting.unassignedInfo().getLastAllocationStatus(),
+                    shardRouting.unassignedInfo().lastAllocationStatus(),
                     equalTo(UnassignedInfo.AllocationStatus.FETCHING_SHARD_DATA)
                 );
             }
@@ -111,7 +111,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
         testAllocate((allocation, unassignedAllocationHandler) -> {}, routingTable -> {
             var shardRouting = routingTable.shardRoutingTable("test-index", 0).primaryShard();
             assertTrue(shardRouting.assignedToNode());// assigned by a followup reconciliation
-            assertThat(shardRouting.unassignedInfo().getLastAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.NO_ATTEMPT));
+            assertThat(shardRouting.unassignedInfo().lastAllocationStatus(), equalTo(UnassignedInfo.AllocationStatus.NO_ATTEMPT));
         });
     }
 
@@ -328,7 +328,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
             var unassigned = reconciledState.getRoutingNodes().unassigned();
             assertThat(unassigned.size(), equalTo(1));
             var unassignedShard = unassigned.iterator().next();
-            assertThat(unassignedShard.unassignedInfo().isDelayed(), equalTo(true));
+            assertThat(unassignedShard.unassignedInfo().delayed(), equalTo(true));
 
         } finally {
             clusterService.close();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderTests.java
@@ -1190,13 +1190,13 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         assertThat(
             shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).stream()
                 .map(ShardRouting::unassignedInfo)
-                .allMatch(unassignedInfo -> Reason.NEW_INDEX_RESTORED.equals(unassignedInfo.getReason())),
+                .allMatch(unassignedInfo -> Reason.NEW_INDEX_RESTORED.equals(unassignedInfo.reason())),
             is(true)
         );
         assertThat(
             shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).stream()
                 .map(ShardRouting::unassignedInfo)
-                .allMatch(unassignedInfo -> AllocationStatus.NO_ATTEMPT.equals(unassignedInfo.getLastAllocationStatus())),
+                .allMatch(unassignedInfo -> AllocationStatus.NO_ATTEMPT.equals(unassignedInfo.lastAllocationStatus())),
             is(true)
         );
         assertThat(shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).size(), equalTo(1));
@@ -1218,7 +1218,7 @@ public class DiskThresholdDeciderTests extends ESAllocationTestCase {
         assertThat(
             shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).stream()
                 .map(ShardRouting::unassignedInfo)
-                .allMatch(unassignedInfo -> AllocationStatus.FETCHING_SHARD_DATA.equals(unassignedInfo.getLastAllocationStatus())),
+                .allMatch(unassignedInfo -> AllocationStatus.FETCHING_SHARD_DATA.equals(unassignedInfo.lastAllocationStatus())),
             is(true)
         );
         assertThat(shardsWithState(clusterState.getRoutingNodes(), UNASSIGNED).size(), equalTo(1));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -111,16 +111,16 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
 
             UnassignedInfo currentInfo = primary.unassignedInfo();
             UnassignedInfo newInfo = new UnassignedInfo(
-                currentInfo.getReason(),
-                currentInfo.getMessage(),
+                currentInfo.reason(),
+                currentInfo.message(),
                 new IOException("i/o failure"),
-                currentInfo.getNumFailedAllocations(),
-                currentInfo.getUnassignedTimeInNanos(),
-                currentInfo.getUnassignedTimeInMillis(),
-                currentInfo.isDelayed(),
-                currentInfo.getLastAllocationStatus(),
-                currentInfo.getFailedNodeIds(),
-                currentInfo.getLastAllocatedNodeId()
+                currentInfo.failedAllocations(),
+                currentInfo.unassignedTimeNanos(),
+                currentInfo.unassignedTimeMillis(),
+                currentInfo.delayed(),
+                currentInfo.lastAllocationStatus(),
+                currentInfo.failedNodeIds(),
+                currentInfo.lastAllocatedNodeId()
             );
             primary = primary.updateUnassigned(newInfo, primary.recoverySource());
 

--- a/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PrimaryShardAllocatorTests.java
@@ -286,7 +286,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         List<ShardRouting> ignored = allocation.routingNodes().unassigned().ignored();
         assertEquals(ignored.size(), 1);
         assertEquals(
-            ignored.get(0).unassignedInfo().getLastAllocationStatus(),
+            ignored.get(0).unassignedInfo().lastAllocationStatus(),
             forceDecisionNo ? AllocationStatus.DECIDERS_NO : AllocationStatus.DECIDERS_THROTTLED
         );
         assertTrue(shardsWithState(allocation.routingNodes(), ShardRoutingState.INITIALIZING).isEmpty());
@@ -314,7 +314,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodesChanged(), equalTo(true));
         List<ShardRouting> ignored = allocation.routingNodes().unassigned().ignored();
         assertEquals(ignored.size(), 1);
-        assertEquals(ignored.get(0).unassignedInfo().getLastAllocationStatus(), AllocationStatus.DECIDERS_THROTTLED);
+        assertEquals(ignored.get(0).unassignedInfo().lastAllocationStatus(), AllocationStatus.DECIDERS_THROTTLED);
         assertTrue(shardsWithState(allocation.routingNodes(), ShardRoutingState.INITIALIZING).isEmpty());
     }
 
@@ -454,7 +454,7 @@ public class PrimaryShardAllocatorTests extends ESAllocationTestCase {
         assertThat(allocation.routingNodesChanged(), equalTo(true));
         assertThat(allocation.routingNodes().unassigned().ignored().isEmpty(), equalTo(false));
         ShardRouting ignoredRouting = allocation.routingNodes().unassigned().ignored().get(0);
-        assertThat(ignoredRouting.unassignedInfo().getLastAllocationStatus(), equalTo(AllocationStatus.FETCHING_SHARD_DATA));
+        assertThat(ignoredRouting.unassignedInfo().lastAllocationStatus(), equalTo(AllocationStatus.FETCHING_SHARD_DATA));
         assertClusterHealthStatus(allocation, ClusterHealthStatus.YELLOW);
     }
 

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -254,8 +254,8 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             List<ShardRouting> unassignedShards = shardsWithState(allocation.routingNodes(), ShardRoutingState.UNASSIGNED);
             assertThat(unassignedShards, hasSize(1));
             assertThat(unassignedShards.get(0).shardId(), equalTo(shardId));
-            assertThat(unassignedShards.get(0).unassignedInfo().getNumFailedAllocations(), equalTo(0));
-            assertThat(unassignedShards.get(0).unassignedInfo().getFailedNodeIds(), equalTo(failedNodeIds));
+            assertThat(unassignedShards.get(0).unassignedInfo().failedAllocations(), equalTo(0));
+            assertThat(unassignedShards.get(0).unassignedInfo().failedNodeIds(), equalTo(failedNodeIds));
         } else {
             assertThat(allocation.routingNodesChanged(), equalTo(false));
             assertThat(shardsWithState(allocation.routingNodes(), ShardRoutingState.UNASSIGNED).size(), equalTo(0));

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1035,7 +1035,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                             .routingTable()
                             .shardRoutingTable(shardToRelocate.shardId())
                             .primaryShard();
-                        if (shardRouting.unassigned() && shardRouting.unassignedInfo().getReason() == UnassignedInfo.Reason.NODE_LEFT) {
+                        if (shardRouting.unassigned() && shardRouting.unassignedInfo().reason() == UnassignedInfo.Reason.NODE_LEFT) {
                             if (masterNodeCount > 1) {
                                 scheduleNow(() -> testClusterNodes.stopNode(masterNode));
                             }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -423,10 +423,10 @@ public abstract class ESAllocationTestCase extends ESTestCase {
             RoutingAllocation allocation,
             UnassignedAllocationHandler unassignedAllocationHandler
         ) {
-            if (shardRouting.primary() || shardRouting.unassignedInfo().getReason() == UnassignedInfo.Reason.INDEX_CREATED) {
+            if (shardRouting.primary() || shardRouting.unassignedInfo().reason() == UnassignedInfo.Reason.INDEX_CREATED) {
                 return;
             }
-            if (shardRouting.unassignedInfo().isDelayed()) {
+            if (shardRouting.unassignedInfo().delayed()) {
                 unassignedAllocationHandler.removeAndIgnore(UnassignedInfo.AllocationStatus.DELAYED_ALLOCATION, allocation.changes());
             }
         }

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
@@ -553,7 +553,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
             if (RestoreInProgress.get(event.state()).isEmpty() == false && event.state().routingTable().hasIndex(followerIndex)) {
                 final IndexRoutingTable indexRoutingTable = event.state().routingTable().index(followerIndex);
                 for (ShardRouting shardRouting : indexRoutingTable.shardsWithState(ShardRoutingState.UNASSIGNED)) {
-                    if (shardRouting.unassignedInfo().getLastAllocationStatus() == AllocationStatus.FETCHING_SHARD_DATA) {
+                    if (shardRouting.unassignedInfo().lastAllocationStatus() == AllocationStatus.FETCHING_SHARD_DATA) {
                         try {
                             assertBusy(() -> {
                                 final Long snapshotShardSize = snapshotsInfoService.snapshotShardSizes().getShardSize(shardRouting);
@@ -644,7 +644,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
                         assertBusy(() -> {
                             List<Long> sizes = indexRoutingTable.shardsWithState(ShardRoutingState.UNASSIGNED)
                                 .stream()
-                                .filter(shard -> shard.unassignedInfo().getLastAllocationStatus() == AllocationStatus.FETCHING_SHARD_DATA)
+                                .filter(shard -> shard.unassignedInfo().lastAllocationStatus() == AllocationStatus.FETCHING_SHARD_DATA)
                                 .sorted(Comparator.comparingInt(ShardRouting::getId))
                                 .map(shard -> snapshotsInfoService.snapshotShardSizes().getShardSize(shard))
                                 .filter(Objects::nonNull)

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefixEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefixEvaluator.java
@@ -42,12 +42,12 @@ public final class IpPrefixEvaluator implements EvalOperator.ExpressionEvaluator
       EvalOperator.ExpressionEvaluator prefixLengthV4,
       EvalOperator.ExpressionEvaluator prefixLengthV6, BytesRef scratch,
       DriverContext driverContext) {
-    this.warnings = new Warnings(source);
     this.ip = ip;
     this.prefixLengthV4 = prefixLengthV4;
     this.prefixLengthV6 = prefixLengthV6;
     this.scratch = scratch;
     this.driverContext = driverContext;
+    this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
   }
 
   @Override

--- a/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefixEvaluator.java
+++ b/x-pack/plugin/esql/src/main/generated/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefixEvaluator.java
@@ -42,12 +42,12 @@ public final class IpPrefixEvaluator implements EvalOperator.ExpressionEvaluator
       EvalOperator.ExpressionEvaluator prefixLengthV4,
       EvalOperator.ExpressionEvaluator prefixLengthV6, BytesRef scratch,
       DriverContext driverContext) {
+    this.warnings = new Warnings(source);
     this.ip = ip;
     this.prefixLengthV4 = prefixLengthV4;
     this.prefixLengthV6 = prefixLengthV6;
     this.scratch = scratch;
     this.driverContext = driverContext;
-    this.warnings = Warnings.createWarnings(driverContext.warningsMode(), source);
   }
 
   @Override

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/ClusterStateApplierOrderingTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/ClusterStateApplierOrderingTests.java
@@ -96,7 +96,7 @@ public class ClusterStateApplierOrderingTests extends BaseSearchableSnapshotsInt
                 for (RoutingNode routingNode : event.state().getRoutingNodes()) {
                     for (ShardRouting shardRouting : routingNode) {
                         if (shardRouting.unassignedInfo() != null) {
-                            unassignedReasons.add(shardRouting.unassignedInfo().getReason());
+                            unassignedReasons.add(shardRouting.unassignedInfo().reason());
                         }
                     }
                 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocator.java
@@ -332,8 +332,8 @@ public class SearchableSnapshotAllocator implements ExistingShardsAllocator {
     }
 
     private static boolean isDelayedDueToNodeRestart(RoutingAllocation allocation, ShardRouting shardRouting) {
-        if (shardRouting.unassignedInfo().isDelayed()) {
-            String lastAllocatedNodeId = shardRouting.unassignedInfo().getLastAllocatedNodeId();
+        if (shardRouting.unassignedInfo().delayed()) {
+            String lastAllocatedNodeId = shardRouting.unassignedInfo().lastAllocatedNodeId();
             if (lastAllocatedNodeId != null) {
                 return allocation.metadata().nodeShutdowns().contains(lastAllocatedNodeId, SingleNodeShutdownMetadata.Type.RESTART);
             }

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -219,7 +219,7 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             .unassigned()
             .stream()
             .peek(s -> cancellableTask.ensureNotCancelled())
-            .filter(s -> Objects.equals(s.unassignedInfo().getLastAllocatedNodeId(), nodeId))
+            .filter(s -> Objects.equals(s.unassignedInfo().lastAllocatedNodeId(), nodeId))
             .filter(s -> s.primary() || hasShardCopyOnAnotherNode(currentState, s, shuttingDownNodes) == false)
             .toList();
 


### PR DESCRIPTION
Change UnassignedInfo from class to record. 
Notable changes:
- major changes in UnassignedInfo.class, the rest is renaming
- remove getters, use record provided accessors
- changed canonical constructor to compact, [here](https://github.com/elastic/elasticsearch/compare/main...mhl-b:elasticsearch:unassigned-info-record?expand=1#diff-c9bb5d78407b3e98a1dadb9dd169c05f133c18d34ae7173edc9577dc1d60138aL264-R287)
- changed constructor from `StreamInput` to static factory method `fromStreamInput`, [here](https://github.com/elastic/elasticsearch/compare/main...mhl-b:elasticsearch:unassigned-info-record?expand=1#diff-c9bb5d78407b3e98a1dadb9dd169c05f133c18d34ae7173edc9577dc1d60138aL297-R329)

A minor modernization before reset-failures PR: #108987