### PR TITLE
ES|QL: Fix flaky MV_APPEND test

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/floats.csv-spec
@@ -534,7 +534,8 @@ FROM employees
        i2 = mv_append(emp_no, salary_change.int),
        i3 = mv_append(emp_no, emp_no),  
        s = mv_append(salary_change.keyword, salary_change.keyword)
-| KEEP emp_no, salary_change, d, i, i2, i3, s;
+| KEEP emp_no, salary_change, d, i, i2, i3, s
+| SORT emp_no;
 
 emp_no:integer | salary_change:double    | d:double                                       | i:integer              | i2:integer         | i3:integer     | s:keyword
 10008          | [-2.92,0.75,3.54,12.68] | [-2.92,0.75,3.54,12.68,-2.92,0.75,3.54,12.68]  | [-2,0,3,12,-2,0,3,12]  | [10008,-2,0,3,12]  | [10008, 10008] | [-2.92,0.75,12.68,3.54,-2.92,0.75,12.68,3.54]


### PR DESCRIPTION
Fixing a test that failed randomly due to non-deterministic result order.