### PR TITLE
[8.14] Renable test suite, muting bad test (#109366)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,10 +1,10 @@
 tests:
-- class: org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT
-  issue: https://github.com/elastic/elasticsearch/issues/109266
+- class: "org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT"
+  issue: "https://github.com/elastic/elasticsearch/issues/109318"
+  method: "test {yaml=analysis-common/50_char_filters/pattern_replace error handling (too complex pattern)}"
 - class: org.elasticsearch.upgrades.AggregationsIT
   method: testTerms
   issue: https://github.com/elastic/elasticsearch/issues/109322
-
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Renable test suite, muting bad test (#109366)](https://github.com/elastic/elasticsearch/pull/109366)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)