### PR TITLE
[8.14] Unmute AggsIT (#109372)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -2,9 +2,7 @@ tests:
 - class: "org.elasticsearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109318"
   method: "test {yaml=analysis-common/50_char_filters/pattern_replace error handling (too complex pattern)}"
-- class: org.elasticsearch.upgrades.AggregationsIT
-  method: testTerms
-  issue: https://github.com/elastic/elasticsearch/issues/109322
+
 # Examples:
 #
 #  Mute a single test case in a YAML test suite:


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Unmute AggsIT (#109372)](https://github.com/elastic/elasticsearch/pull/109372)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)