### PR TITLE
[ML] Fix serialising inference delete response 

### DIFF
--- a/docs/changelog/109384.yaml
+++ b/docs/changelog/109384.yaml
@@ -1,0 +1,5 @@
+pr: 109384
+summary: Fix serialising inference delete response
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/DeleteInferenceEndpointAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/DeleteInferenceEndpointAction.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.Set;
 
-public class DeleteInferenceEndpointAction extends ActionType<AcknowledgedResponse> {
+public class DeleteInferenceEndpointAction extends ActionType<DeleteInferenceEndpointAction.Response> {
 
     public static final DeleteInferenceEndpointAction INSTANCE = new DeleteInferenceEndpointAction();
     public static final String NAME = "cluster:admin/xpack/inference/delete";


### PR DESCRIPTION
Deleting a inference endpoint with `DELETE _inference/sparse_embedding/my-elser-model?dry_run` could cause this error in a multinode cluster

```
      {
        "type": "response_handler_failure_transport_exception",
        "reason": "java.lang.IllegalStateException: Message not fully read (response) for requestId [56307], handler [ContextRestoreResponseHandler[[org.elasticsearch.action.ActionListenerImplementations$RunBeforeActionListener/org.elasticsearch.action.ActionListenerImplementations$MappedActionListener/org.elasticsearch.action.support.ContextPreservingActionListener/org.elasticsearch.action.ActionListenerImplementations$RunBeforeActionListener/org.elasticsearch.tasks.TaskManager$1{org.elasticsearch.rest.action.RestToXContentListener@8f509fb}{Task{id=113523, type='transport', action='cluster:admin/xpack/inference/delete', description='', parentTask=unset, startTime=1717541647705, startTimeNanos=27749457773913751}}/org.elasticsearch.action.support.TransportAction$$Lambda/0x00007fe728721b20@13d97a3e/org.elasticsearch.xpack.security.action.filter.SecurityActionFilter$$Lambda/0x00007fe728727620@4a9aa4ec/org.elasticsearch.action.support.master.TransportMasterNodeAction$$Lambda/0x00007fe728722180@f434f0a]]], error [false]; resetting"
      }
```

Deletion is a master node operation, if the response is streamed to the coordinating node the above error occurred. The problem occurred after the response class was changed in #109123.

I've labelled the PR a bug even though the change that introduced is it only 5 days it may be present in serverless. 