### PR TITLE
[ML] Add dry run and force to json spec for Delete Inference endpoint

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
@@ -1,16 +1,18 @@
 {
-  "inference.delete":{
-    "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference-api.html",
-      "description":"Delete an inference endpoint"
+  "inference.delete": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-inference-api.html",
+      "description": "Delete an inference endpoint"
     },
-    "stability":"experimental",
-    "visibility":"public",
-    "headers":{
-      "accept": [ "application/json"]
+    "stability": "experimental",
+    "visibility": "public",
+    "headers": {
+      "accept": [
+        "application/json"
+      ]
     },
-    "url":{
-      "paths":[
+    "url": {
+      "paths": [
         {
           "path": "/_inference/{inference_id}",
           "methods": [
@@ -24,22 +26,34 @@
           }
         },
         {
-          "path":"/_inference/{task_type}/{inference_id}",
-          "methods":[
+          "path": "/_inference/{task_type}/{inference_id}",
+          "methods": [
             "DELETE"
           ],
-          "parts":{
-            "task_type":{
-              "type":"string",
-              "description":"The task type"
+          "parts": {
+            "task_type": {
+              "type": "string",
+              "description": "The task type"
             },
-            "inference_id":{
-              "type":"string",
-              "description":"The inference Id"
+            "inference_id": {
+              "type": "string",
+              "description": "The inference Id"
             }
           }
         }
       ]
+    },
+    "params": {
+      "dry_run": {
+        "type": "boolean",
+        "description": "If true the endpoint will not be deleted and a list of ingest processors which reference this endpoint will be returned.",
+        "required": false
+      },
+      "force": {
+        "type": "boolean",
+        "description": "True if the endpoint should be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields).",
+        "required": false
+      }
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/inference.delete.json
@@ -51,7 +51,7 @@
       },
       "force": {
         "type": "boolean",
-        "description": "True if the endpoint should be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields).",
+        "description": "If true the endpoint will be forcefully stopped (regardless of whether or not it is referenced by any ingest processors or semantic text fields).",
         "required": false
       }
     }


### PR DESCRIPTION
Following on https://github.com/elastic/elasticsearch/pull/109123 and https://github.com/elastic/elasticsearch/pull/109384, this change updates the elasticsearch json spec to include the dry_run and force options for the Delete Inference Endpoint API.