### PR TITLE
Make ErrorReportingTestListener Gradle configuration cache compatible

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/ErrorReportingTestListener.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/ErrorReportingTestListener.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.gradle.internal.test;
 
-import org.elasticsearch.gradle.internal.ElasticsearchTestBasePlugin;
 import org.gradle.api.internal.tasks.testing.logging.FullExceptionFormatter;
 import org.gradle.api.internal.tasks.testing.logging.TestExceptionFormatter;
 import org.gradle.api.logging.Logger;
@@ -39,19 +38,22 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ErrorReportingTestListener implements TestOutputListener, TestListener {
     private static final String REPRODUCE_WITH_PREFIX = "REPRODUCE WITH";
 
-    private final Test testTask;
     private final TestExceptionFormatter formatter;
     private final File outputDirectory;
     private final Logger taskLogger;
     private Map<Descriptor, EventWriter> eventWriters = new ConcurrentHashMap<>();
     private Map<Descriptor, Deque<String>> reproductionLines = new ConcurrentHashMap<>();
     private Set<Descriptor> failedTests = new LinkedHashSet<>();
+    private boolean dumpOutputOnFailure = true;
 
     public ErrorReportingTestListener(Test testTask, File outputDirectory) {
-        this.testTask = testTask;
         this.formatter = new FullExceptionFormatter(testTask.getTestLogging());
         this.taskLogger = testTask.getLogger();
         this.outputDirectory = outputDirectory;
+    }
+
+    public void setDumpOutputOnFailure(boolean dumpOutputOnFailure) {
+        this.dumpOutputOnFailure = dumpOutputOnFailure;
     }
 
     @Override
@@ -83,7 +85,7 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
         Descriptor descriptor = Descriptor.of(suite);
 
         try {
-            if (isDumpOutputEnabled()) {
+            if (dumpOutputOnFailure) {
                 // if the test suite failed, report all captured output
                 if (result.getResultType().equals(TestResult.ResultType.FAILURE)) {
                     EventWriter eventWriter = eventWriters.get(descriptor);
@@ -255,12 +257,5 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
             // there's no need to keep this stuff on disk after suite execution
             outputFile.delete();
         }
-    }
-
-    private boolean isDumpOutputEnabled() {
-        return (Boolean) testTask.getExtensions()
-            .getExtraProperties()
-            .getProperties()
-            .getOrDefault(ElasticsearchTestBasePlugin.DUMP_OUTPUT_ON_FAILURE_PROP_NAME, true);
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -18,9 +18,9 @@ import org.elasticsearch.gradle.Version;
 import org.elasticsearch.gradle.VersionProperties;
 import org.elasticsearch.gradle.distribution.ElasticsearchDistributionTypes;
 import org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin;
-import org.elasticsearch.gradle.internal.ElasticsearchTestBasePlugin;
 import org.elasticsearch.gradle.internal.InternalDistributionDownloadPlugin;
 import org.elasticsearch.gradle.internal.info.BuildParams;
+import org.elasticsearch.gradle.internal.test.ErrorReportingTestListener;
 import org.elasticsearch.gradle.internal.test.HistoricalFeaturesMetadataPlugin;
 import org.elasticsearch.gradle.plugin.BasePluginBuildPlugin;
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin;
@@ -167,7 +167,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
             nonInputSystemProperties.systemProperty(TESTS_MAX_PARALLEL_FORKS_SYSPROP, () -> String.valueOf(task.getMaxParallelForks()));
 
             // Disable test failure reporting since this stuff is now captured in build scans
-            task.getExtensions().getExtraProperties().set(ElasticsearchTestBasePlugin.DUMP_OUTPUT_ON_FAILURE_PROP_NAME, false);
+            task.getExtensions().getByType(ErrorReportingTestListener.class).setDumpOutputOnFailure(false);
 
             // Disable the security manager and syscall filter since the test framework needs to fork processes
             task.systemProperty("tests.security.manager", "false");


### PR DESCRIPTION
and make it a bit simpler too