### PR TITLE
[DOCS] Modifies semantic search-related docs to refer to the `semantic_text` workflow

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -13,6 +13,8 @@ query.
 The instructions in this tutorial shows you how to use ELSER to perform semantic
 search on your data.
 
+IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
+
 NOTE: Only the first 512 extracted tokens per field are considered during
 semantic search with ELSER. Refer to
 {ml-docs}/ml-nlp-limitations.html#ml-nlp-elser-v1-limit-512[this page] for more

--- a/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-inference.asciidoc
@@ -5,10 +5,12 @@
 <titleabbrev>Semantic search with the {infer} API</titleabbrev>
 ++++
 
-The instructions in this tutorial shows you how to use the {infer} API with various services to perform semantic search on your data.
+The instructions in this tutorial shows you how to use the {infer} API workflow with various services to perform semantic search on your data.
+
+IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
+
 The following examples use Cohere's `embed-english-v3.0` model, the `all-mpnet-base-v2` model from HuggingFace, and OpenAI's `text-embedding-ada-002` second generation embedding model.
-You can use any Cohere and OpenAI models, they are all supported by the
-{infer} API.
+You can use any Cohere and OpenAI models, they are all supported by the {infer} API.
 For a list of supported models available on HuggingFace, refer to
 <<inference-example-hugging-face-supported-models, the supported model list>>.
 

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -1,25 +1,29 @@
 [[semantic-search]]
 == Semantic search
 
-Semantic search is a search method that helps you find data based on the intent
-and contextual meaning of a search query, instead of a match on query terms
+Semantic search is a search method that helps you find data based on the intent and contextual meaning of a search query, instead of a match on query terms
 (lexical search).
 
-{es} provides semantic search capabilities using {ml-docs}/ml-nlp.html[natural
-language processing (NLP)] and vector search. Deploying an NLP model to {es}
-enables it to extract text embeddings out of text. Embeddings are vectors that
-provide a numeric representation of a text. Pieces of content with similar
-meaning have similar representations. 
+{es} provides various semantic search capabilities using {ml-docs}/ml-nlp.html[natural language processing (NLP)] and vector search.
+Using an NLP model enables you to extract text embeddings out of text.
+Embeddings are vectors that provide a numeric representation of a text.
+Pieces of content with similar meaning have similar representations. 
+NLP models can be used in the {stack} various ways, you can:
+
+* deploy models in {es}
+* use the <<semantic-search-semantic-text, `semantic_text` workflow>> (recommended)
+* use the <<semantic-search-inference, {infer} API workflow>>
+
 
 [[semantic-search-diagram]]
 .A simplified representation of encoding textual concepts as vectors
 image::images/search/vector-search-oversimplification.png[A simplified representation of encoding textual concepts as vectors,align="center"]
 
-At query time, {es} can use the same NLP model to convert a query into
-embeddings, enabling you to find documents with similar text embeddings.
+At query time, {es} can use the same NLP model to convert a query into embeddings, enabling you to find documents with similar text embeddings.
 
-This guide shows you how to implement semantic search with {es}, from selecting
-an NLP model, to writing queries.
+This guide shows you how to implement semantic search with {es}, from selecting an NLP model, to writing queries.
+
+IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
 
 [discrete]
 [[semantic-search-select-nlp-model]]

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -21,7 +21,7 @@ image::images/search/vector-search-oversimplification.png[A simplified represent
 
 At query time, {es} can use the same NLP model to convert a query into embeddings, enabling you to find documents with similar text embeddings.
 
-This guide shows you how to implement semantic search with {es}, from selecting an NLP model, to writing queries.
+This guide shows you how to implement semantic search with {es}: From selecting an NLP model, to writing queries.
 
 IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer to the <<semantic-search-semantic-text, `semantic_text`>> end-to-end tutorial.
 


### PR DESCRIPTION
## Overview

This PR amends the semantic search tutorials to contain a reference to the new, recommended `semantic_text` workflow.
