### PR TITLE
ES 8.14.0 fails due start when encountering unreadable directories on the library path

### DIFF
--- a/docs/reference/release-notes/8.14.0.asciidoc
+++ b/docs/reference/release-notes/8.14.0.asciidoc
@@ -3,6 +3,16 @@
 
 Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
 
+[[known-issues-8.14.0]]
+[float]
+=== Known issues
+* If encountering directories on the Java library path the Elasticsearch process does not have permission to access,
+  the process fails to boot with a NullPointerException:
+  `Cannot invoke "org.elasticsearch.nativeaccess.Systemd.notify_ready()" because "this.systemd" is null.` +
+  This only affects on-prem installations of Elasticsearch, environments running Elasticsearch in a container are not affected, nor is Elastic Cloud. +
+  The workaround is to grant Elasticsearch read access to the directory mentioned in the `java.nio.file.AccessDeniedException` as observed in the logs
+  and repeat this until the process starts up properly. With 8.14.1 the workaround won't be necessary anymore and original permissions can be restored.
+
 [[breaking-8.14.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/8.14.0.asciidoc
+++ b/docs/reference/release-notes/8.14.0.asciidoc
@@ -11,7 +11,8 @@ Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
   `Cannot invoke "org.elasticsearch.nativeaccess.Systemd.notify_ready()" because "this.systemd" is null.` +
   This only affects on-prem installations of Elasticsearch, environments running Elasticsearch in a container are not affected, nor is Elastic Cloud. +
   The workaround is to grant Elasticsearch read access to the directory mentioned in the `java.nio.file.AccessDeniedException` as observed in the logs
-  and repeat this until the process starts up properly. With 8.14.1 the workaround won't be necessary anymore and original permissions can be restored.
+  and repeat this until the process starts up properly, see https://support.elastic.dev/knowledge/view/5979309d[here] for further details.
+  With 8.14.1 the workaround won't be necessary anymore and original permissions can be restored.
 
 [[breaking-8.14.0]]
 [float]


### PR DESCRIPTION
Document known issue for 8.14.0 in the release notes