### PR TITLE
Fix for duplicate key during map initialization

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -59,9 +59,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvAppendTests
   method: testEvaluateBlockWithoutNulls {TestCase=<cartesian_shape>, <cartesian_shape>}
   issue: https://github.com/elastic/elasticsearch/issues/109409
-- class: org.elasticsearch.search.rank.RankFeatureShardPhaseTests
-  method: testProcessFetch
-  issue: https://github.com/elastic/elasticsearch/issues/109428
 
 # Examples:
 #

--- a/server/src/test/java/org/elasticsearch/search/rank/RankFeatureShardPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rank/RankFeatureShardPhaseTests.java
@@ -266,7 +266,7 @@ public class RankFeatureShardPhaseTests extends ESTestCase {
 
     public void testProcessFetch() {
         final String fieldName = "some_field";
-        int numDocs = randomIntBetween(10, 30);
+        int numDocs = randomIntBetween(15, 30);
         Map<Integer, String> expectedFieldData = Map.of(4, "doc_4_aardvark", 9, "doc_9_aardvark", numDocs - 1, "last_doc_aardvark");
 
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();


### PR DESCRIPTION
The following exception was thrown in `RankFeatureShardPhaseTests`: 
```
java.lang.IllegalArgumentException: duplicate key: 9

  at __randomizedtesting.SeedInfo.seed([8F1F83307DA6AB36:56F95903A48793E3]:0)
  at java.util.ImmutableCollections$MapN.<init>(ImmutableCollections.java:1196)
  at java.util.Map.of(Map.java:1406)
  at org.elasticsearch.search.rank.RankFeatureShardPhaseTests.testProcessFetch(RankFeatureShardPhaseTests.java:270)
  at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
```

This was due to having a randomized `numDocs` in `[10, 30)` range, and then having `9` as a hard-coded key for the map.
```
   int numDocs = randomIntBetween(10, 30);
        Map<Integer, String> expectedFieldData = Map.of(4, "doc_4_aardvark", 9, "doc_9_aardvark", numDocs - 1, "last_doc_aardvark");
``` 

Closes https://github.com/elastic/elasticsearch/issues/109428