### PR TITLE
semantic_text docs - Fix retrievers example

### DIFF
--- a/docs/reference/query-dsl/semantic-query.asciidoc
+++ b/docs/reference/query-dsl/semantic-query.asciidoc
@@ -100,9 +100,11 @@ GET my-index/_search
           }
         },
         {
-          "semantic": {
-            "field": "semantic_field",
-            "query": "shoes"
+          "standard": {
+            "semantic": {
+              "field": "semantic_field",
+              "query": "shoes"
+            }
           }
         }
       ],


### PR DESCRIPTION
Fix a retrievers example that doesn't work, as there is no `semantic` retriever (yet)