### PR TITLE
Remove hash and equals override from UnassignedInfo

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/ShrinkIndexIT.java
@@ -388,7 +388,7 @@ public class ShrinkIndexIT extends ESIntegTestCase {
                 UnassignedInfo.Reason.ALLOCATION_FAILED,
                 routingTables.index("target").shard(0).shard(0).unassignedInfo().reason()
             );
-            assertEquals(1, routingTables.index("target").shard(0).shard(0).unassignedInfo().failedAllocations());
+            assertEquals(1, routingTables.index("target").shard(0).shard(0).unassignedInfo().failureCount());
         });
         // now relocate them all to the right node
         updateIndexSettings(Settings.builder().put("index.routing.allocation.require._name", mergeNode), "source");

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -405,7 +405,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                     UnassignedInfo.AllocationStatus.DECIDERS_NO,
                     shardRoutingTable.primaryShard().unassignedInfo().lastAllocationStatus()
                 );
-                assertThat(shardRoutingTable.primaryShard().unassignedInfo().failedAllocations(), greaterThan(0));
+                assertThat(shardRoutingTable.primaryShard().unassignedInfo().failureCount(), greaterThan(0));
             }
         }, 60, TimeUnit.SECONDS);
         indicesAdmin().prepareClose("test").get();
@@ -474,7 +474,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
                     UnassignedInfo.AllocationStatus.DECIDERS_NO,
                     shardRoutingTable.primaryShard().unassignedInfo().lastAllocationStatus()
                 );
-                assertThat(shardRoutingTable.primaryShard().unassignedInfo().failedAllocations(), greaterThan(0));
+                assertThat(shardRoutingTable.primaryShard().unassignedInfo().failureCount(), greaterThan(0));
             }
         }, 60, TimeUnit.SECONDS);
         indicesAdmin().prepareClose("test").get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -464,8 +464,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 final var replicaShards = indexRoutingTable.shard(shardId).replicaShards();
                 if (replicaShards.isEmpty()
-                    || replicaShards.stream()
-                        .anyMatch(sr -> sr.unassigned() == false || sr.unassignedInfo().failedAllocations() < maxRetries)) {
+                    || replicaShards.stream().anyMatch(sr -> sr.unassigned() == false || sr.unassignedInfo().failureCount() < maxRetries)) {
                     return false;
                 }
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
@@ -61,7 +61,7 @@ public class ShardLockFailureIT extends ESIntegTestCase {
                         .routingTable()
                         .shardRoutingTable(shardId)
                         .allShards()
-                        .noneMatch(sr -> sr.unassigned() && sr.unassignedInfo().failedAllocations() > 0)
+                        .noneMatch(sr -> sr.unassigned() && sr.unassignedInfo().failureCount() > 0)
                 );
             } catch (IndexNotFoundException e) {
                 // ok

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -580,7 +580,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
         Consumer<UnassignedInfo> checkUnassignedInfo = unassignedInfo -> {
             assertThat(unassignedInfo.reason(), equalTo(UnassignedInfo.Reason.ALLOCATION_FAILED));
-            assertThat(unassignedInfo.failedAllocations(), anyOf(equalTo(maxRetries), equalTo(1)));
+            assertThat(unassignedInfo.failureCount(), anyOf(equalTo(maxRetries), equalTo(1)));
         };
 
         unrestorableUseCase(indexName, createIndexSettings, repositorySettings, Settings.EMPTY, checkUnassignedInfo, () -> {});

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanation.java
@@ -228,8 +228,8 @@ public final class ClusterAllocationExplanation implements ChunkedToXContentObje
         builder.startObject("unassigned_info");
         builder.field("reason", unassignedInfo.reason());
         builder.field("at", UnassignedInfo.DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(unassignedInfo.unassignedTimeMillis())));
-        if (unassignedInfo.failedAllocations() > 0) {
-            builder.field("failed_allocation_attempts", unassignedInfo.failedAllocations());
+        if (unassignedInfo.failureCount() > 0) {
+            builder.field("failed_allocation_attempts", unassignedInfo.failureCount());
         }
         String details = unassignedInfo.details();
         if (details != null) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/health/TransportClusterHealthAction.java
@@ -455,7 +455,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
                 clusterState,
                 numberOfPendingTasks,
                 numberOfInFlightFetch,
-                UnassignedInfo.getNumberOfDelayedUnassigned(clusterState),
+                UnassignedInfo.numberOfDelayedUnassigned(clusterState),
                 pendingTaskTimeInQueue
             );
             response.setStatus(ClusterHealthStatus.RED);
@@ -468,7 +468,7 @@ public class TransportClusterHealthAction extends TransportMasterNodeReadAction<
             clusterState,
             numberOfPendingTasks,
             numberOfInFlightFetch,
-            UnassignedInfo.getNumberOfDelayedUnassigned(clusterState),
+            UnassignedInfo.numberOfDelayedUnassigned(clusterState),
             pendingTaskTimeInQueue
         );
     }

--- a/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
+++ b/server/src/main/java/org/elasticsearch/cluster/health/ClusterShardHealth.java
@@ -168,7 +168,7 @@ public final class ClusterShardHealth implements Writeable, ToXContentFragment {
         final UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
         RecoverySource.Type recoveryType = shardRouting.recoverySource().getType();
         if (unassignedInfo.lastAllocationStatus() != AllocationStatus.DECIDERS_NO
-            && unassignedInfo.failedAllocations() == 0
+            && unassignedInfo.failureCount() == 0
             && (recoveryType == RecoverySource.Type.EMPTY_STORE
                 || recoveryType == RecoverySource.Type.LOCAL_SHARDS
                 || recoveryType == RecoverySource.Type.SNAPSHOT)) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/DelayedAllocationService.java
@@ -209,7 +209,7 @@ public class DelayedAllocationService extends AbstractLifecycleComponent impleme
                 logger.info(
                     "scheduling reroute for delayed shards in [{}] ({} delayed shards)",
                     nextDelay,
-                    UnassignedInfo.getNumberOfDelayedUnassigned(state)
+                    UnassignedInfo.numberOfDelayedUnassigned(state)
                 );
                 DelayedRerouteTask currentTask = delayedRerouteTask.getAndSet(newTask);
                 assert existingTask == currentTask || currentTask == null;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexRoutingTable.java
@@ -577,7 +577,7 @@ public class IndexRoutingTable implements SimpleDiffable<IndexRoutingTable> {
                     unassignedInfo.reason(),
                     unassignedInfo.message(),
                     unassignedInfo.failure(),
-                    unassignedInfo.failedAllocations(),
+                    unassignedInfo.failureCount(),
                     unassignedInfo.unassignedTimeNanos(),
                     unassignedInfo.unassignedTimeMillis(),
                     unassignedInfo.delayed(),

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -975,7 +975,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
                         currInfo.reason(),
                         currInfo.message(),
                         currInfo.failure(),
-                        currInfo.failedAllocations(),
+                        currInfo.failureCount(),
                         currInfo.unassignedTimeNanos(),
                         currInfo.unassignedTimeMillis(),
                         currInfo.delayed(),
@@ -1283,7 +1283,7 @@ public class RoutingNodes implements Iterable<RoutingNode> {
             UnassignedInfo unassignedInfo = shardRouting.unassignedInfo();
             unassignedIterator.updateUnassigned(
                 new UnassignedInfo(
-                    unassignedInfo.failedAllocations() > 0 ? UnassignedInfo.Reason.MANUAL_ALLOCATION : unassignedInfo.reason(),
+                    unassignedInfo.failureCount() > 0 ? UnassignedInfo.Reason.MANUAL_ALLOCATION : unassignedInfo.reason(),
                     unassignedInfo.message(),
                     unassignedInfo.failure(),
                     0,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/AllocationService.java
@@ -215,7 +215,7 @@ public class AllocationService {
                         failedShard
                     );
                 }
-                int failedAllocations = failedShard.unassignedInfo() != null ? failedShard.unassignedInfo().failedAllocations() : 0;
+                int failedAllocations = failedShard.unassignedInfo() != null ? failedShard.unassignedInfo().failureCount() : 0;
                 final Set<String> failedNodeIds;
                 if (failedShard.unassignedInfo() != null) {
                     failedNodeIds = Sets.newHashSetWithExpectedSize(failedShard.unassignedInfo().failedNodeIds().size() + 1);
@@ -437,7 +437,7 @@ public class AllocationService {
                                 unassignedInfo.reason(),
                                 unassignedInfo.message(),
                                 unassignedInfo.failure(),
-                                unassignedInfo.failedAllocations(),
+                                unassignedInfo.failureCount(),
                                 unassignedInfo.unassignedTimeNanos(),
                                 unassignedInfo.unassignedTimeMillis(),
                                 false,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -226,7 +226,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
                         unassignedInfo.reason(),
                         unassignedInfo.message(),
                         unassignedInfo.failure(),
-                        unassignedInfo.failedAllocations(),
+                        unassignedInfo.failureCount(),
                         unassignedInfo.unassignedTimeNanos(),
                         unassignedInfo.unassignedTimeMillis(),
                         unassignedInfo.delayed(),

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -406,7 +406,7 @@ public class DesiredBalanceComputer {
             info.reason(),
             info.message(),
             info.failure(),
-            info.failedAllocations(),
+            info.failureCount(),
             info.unassignedTimeNanos(),
             info.unassignedTimeMillis(),
             info.delayed(),

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconciler.java
@@ -232,7 +232,7 @@ public class DesiredBalanceReconciler {
                             unassignedInfo.reason(),
                             unassignedInfo.message(),
                             unassignedInfo.failure(),
-                            unassignedInfo.failedAllocations(),
+                            unassignedInfo.failureCount(),
                             unassignedInfo.unassignedTimeNanos(),
                             unassignedInfo.unassignedTimeMillis(),
                             unassignedInfo.delayed(),

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -50,7 +50,7 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
 
         final int maxRetries = SETTING_ALLOCATION_MAX_RETRY.get(allocation.metadata().getIndexSafe(shardRouting.index()).getSettings());
         final var unassignedInfo = shardRouting.unassignedInfo();
-        final int numFailedAllocations = unassignedInfo == null ? 0 : unassignedInfo.failedAllocations();
+        final int numFailedAllocations = unassignedInfo == null ? 0 : unassignedInfo.failureCount();
         if (numFailedAllocations > 0) {
             final var decision = numFailedAllocations >= maxRetries ? Decision.NO : Decision.YES;
             return allocation.debugDecision() ? debugDecision(decision, unassignedInfo, numFailedAllocations, maxRetries) : decision;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -162,7 +162,7 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
     private void assertStateAndFailedAllocations(IndexRoutingTable indexRoutingTable, ShardRoutingState state, int failedAllocations) {
         assertThat(indexRoutingTable.size(), equalTo(1));
         assertThat(indexRoutingTable.shard(0).shard(0).state(), equalTo(state));
-        assertThat(indexRoutingTable.shard(0).shard(0).unassignedInfo().failedAllocations(), equalTo(failedAllocations));
+        assertThat(indexRoutingTable.shard(0).shard(0).unassignedInfo().failureCount(), equalTo(failedAllocations));
     }
 
     private ClusterState createInitialClusterState(AllocationService service) {

--- a/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/health/ClusterStateHealthTests.java
@@ -559,7 +559,7 @@ public class ClusterStateHealthTests extends ESTestCase {
                     && primaryShard.recoverySource().getType() == RecoverySource.Type.EXISTING_STORE) {
                     return false;
                 }
-                if (primaryShard.unassignedInfo().failedAllocations() > 0) {
+                if (primaryShard.unassignedInfo().failureCount() > 0) {
                     return false;
                 }
                 if (primaryShard.unassignedInfo().lastAllocationStatus() == UnassignedInfo.AllocationStatus.DECIDERS_NO) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/DelayedAllocationServiceTests.java
@@ -167,7 +167,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         clusterState = allocationService.disassociateDeadNodes(clusterState, true, "reroute");
         ClusterState stateWithDelayedShard = clusterState;
         // make sure the replica is marked as delayed (i.e. not reallocated)
-        assertEquals(1, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithDelayedShard));
+        assertEquals(1, UnassignedInfo.numberOfDelayedUnassigned(stateWithDelayedShard));
         ShardRouting delayedShard = stateWithDelayedShard.getRoutingNodes().unassigned().iterator().next();
         assertEquals(baseTimestampNanos, delayedShard.unassignedInfo().unassignedTimeNanos());
 
@@ -205,7 +205,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         // apply cluster state
         ClusterState stateWithRemovedDelay = clusterStateUpdateTask.get().execute(stateWithDelayedShard);
         // check that shard is not delayed anymore
-        assertEquals(0, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithRemovedDelay));
+        assertEquals(0, UnassignedInfo.numberOfDelayedUnassigned(stateWithRemovedDelay));
         // check that task is now removed
         assertNull(delayedAllocationService.delayedRerouteTask.get());
 
@@ -316,7 +316,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         allocationService.setNanoTimeOverride(baseTimestampNanos);
         clusterState = allocationService.disassociateDeadNodes(clusterState, true, "reroute");
         final ClusterState stateWithDelayedShards = clusterState;
-        assertEquals(2, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithDelayedShards));
+        assertEquals(2, UnassignedInfo.numberOfDelayedUnassigned(stateWithDelayedShards));
         RoutingNodes.UnassignedShards.UnassignedIterator iter = stateWithDelayedShards.getRoutingNodes().unassigned().iterator();
         assertEquals(baseTimestampNanos, iter.next().unassignedInfo().unassignedTimeNanos());
         assertEquals(baseTimestampNanos, iter.next().unassignedInfo().unassignedTimeNanos());
@@ -361,7 +361,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         // apply cluster state
         ClusterState stateWithOnlyOneDelayedShard = clusterStateUpdateTask1.get().execute(stateWithDelayedShards);
         // check that shard is not delayed anymore
-        assertEquals(1, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithOnlyOneDelayedShard));
+        assertEquals(1, UnassignedInfo.numberOfDelayedUnassigned(stateWithOnlyOneDelayedShard));
         // check that task is now removed
         assertNull(delayedAllocationService.delayedRerouteTask.get());
 
@@ -405,7 +405,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         // apply cluster state
         ClusterState stateWithNoDelayedShards = clusterStateUpdateTask2.get().execute(stateWithOnlyOneDelayedShard);
         // check that shard is not delayed anymore
-        assertEquals(0, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithNoDelayedShards));
+        assertEquals(0, UnassignedInfo.numberOfDelayedUnassigned(stateWithNoDelayedShards));
         // check that task is now removed
         assertNull(delayedAllocationService.delayedRerouteTask.get());
 
@@ -489,7 +489,7 @@ public class DelayedAllocationServiceTests extends ESAllocationTestCase {
         clusterState = allocationService.disassociateDeadNodes(clusterState, true, "fake node left");
         ClusterState stateWithDelayedShard = clusterState;
         // make sure the replica is marked as delayed (i.e. not reallocated)
-        assertEquals(1, UnassignedInfo.getNumberOfDelayedUnassigned(stateWithDelayedShard));
+        assertEquals(1, UnassignedInfo.numberOfDelayedUnassigned(stateWithDelayedShard));
         ShardRouting delayedShard = stateWithDelayedShard.getRoutingNodes().unassigned().iterator().next();
         assertEquals(nodeLeftTimestampNanos, delayedShard.unassignedInfo().unassignedTimeNanos());
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/UnassignedInfoTests.java
@@ -142,7 +142,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
         assertThat(read.unassignedTimeMillis(), equalTo(meta.unassignedTimeMillis()));
         assertThat(read.message(), equalTo(meta.message()));
         assertThat(read.details(), equalTo(meta.details()));
-        assertThat(read.failedAllocations(), equalTo(meta.failedAllocations()));
+        assertThat(read.failureCount(), equalTo(meta.failureCount()));
         assertThat(read.failedNodeIds(), equalTo(meta.failedNodeIds()));
         assertThat(read.lastAllocatedNodeId(), equalTo(meta.lastAllocatedNodeId()));
     }
@@ -798,7 +798,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
             .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")))
             .build();
         clusterState = allocation.reroute(clusterState, "reroute", ActionListener.noop());
-        assertThat(UnassignedInfo.getNumberOfDelayedUnassigned(clusterState), equalTo(0));
+        assertThat(UnassignedInfo.numberOfDelayedUnassigned(clusterState), equalTo(0));
         // starting primaries
         clusterState = startInitializingShardsAndReroute(allocation, clusterState);
         // starting replicas
@@ -808,7 +808,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
         clusterState = ClusterState.builder(clusterState).nodes(DiscoveryNodes.builder(clusterState.nodes()).remove("node2")).build();
         // make sure both replicas are marked as delayed (i.e. not reallocated)
         clusterState = allocation.disassociateDeadNodes(clusterState, true, "reroute");
-        assertThat(clusterState.toString(), UnassignedInfo.getNumberOfDelayedUnassigned(clusterState), equalTo(2));
+        assertThat(clusterState.toString(), UnassignedInfo.numberOfDelayedUnassigned(clusterState), equalTo(2));
     }
 
     public void testFindNextDelayedAllocation() {
@@ -848,7 +848,7 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
             .nodes(DiscoveryNodes.builder().add(newNode("node1")).add(newNode("node2")))
             .build();
         clusterState = allocation.reroute(clusterState, "reroute", ActionListener.noop());
-        assertThat(UnassignedInfo.getNumberOfDelayedUnassigned(clusterState), equalTo(0));
+        assertThat(UnassignedInfo.numberOfDelayedUnassigned(clusterState), equalTo(0));
         // starting primaries
         clusterState = startInitializingShardsAndReroute(allocation, clusterState);
         // starting replicas
@@ -924,8 +924,8 @@ public class UnassignedInfoTests extends ESAllocationTestCase {
             summary,
             containsString("at[" + UnassignedInfo.DATE_TIME_FORMATTER.format(Instant.ofEpochMilli(info.unassignedTimeMillis())) + ']')
         );
-        if (info.failedAllocations() > 0) {
-            assertThat("failed_allocations", summary, containsString("failed_attempts[" + info.failedAllocations() + ']'));
+        if (info.failureCount() > 0) {
+            assertThat("failed_allocations", summary, containsString("failed_attempts[" + info.failureCount() + ']'));
         }
         if (info.failedNodeIds().isEmpty() == false) {
             assertThat("failed_nodes", summary, containsString("failed_nodes[" + info.failedNodeIds() + ']'));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/MaxRetryAllocationDeciderTests.java
@@ -91,7 +91,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
             assertEquals(routingTable.index("idx").shard(0).shard(0).state(), INITIALIZING);
-            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations(), i + 1);
+            assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().failureCount(), i + 1);
             assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom" + i));
         }
         // now we go and check that we are actually stick to unassigned on the next failure
@@ -100,7 +100,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         clusterState = newState;
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations(), retries);
+        assertEquals(routingTable.index("idx").shard(0).shard(0).unassignedInfo().failureCount(), retries);
         assertEquals(routingTable.index("idx").shard(0).shard(0).state(), UNASSIGNED);
         assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom"));
 
@@ -112,7 +112,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
 
         clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(0, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations());
+        assertEquals(0, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failureCount());
         assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shard(0).state());
         assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom"));
 
@@ -123,7 +123,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             clusterState = newState;
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
-            assertEquals(i + 1, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations());
+            assertEquals(i + 1, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failureCount());
             assertEquals(INITIALIZING, routingTable.index("idx").shard(0).shard(0).state());
             assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom"));
         }
@@ -134,7 +134,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         clusterState = newState;
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
-        assertEquals(retries, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failedAllocations());
+        assertEquals(retries, routingTable.index("idx").shard(0).shard(0).unassignedInfo().failureCount());
         assertEquals(UNASSIGNED, routingTable.index("idx").shard(0).shard(0).state());
         assertThat(routingTable.index("idx").shard(0).shard(0).unassignedInfo().message(), containsString("boom"));
     }
@@ -152,7 +152,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             assertEquals(routingTable.index("idx").size(), 1);
             ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
             assertEquals(unassignedPrimary.state(), INITIALIZING);
-            assertEquals(unassignedPrimary.unassignedInfo().failedAllocations(), i + 1);
+            assertEquals(unassignedPrimary.unassignedInfo().failureCount(), i + 1);
             assertThat(unassignedPrimary.unassignedInfo().message(), containsString("boom" + i));
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return YES decisions because canAllocate returns YES here
             assertEquals(
@@ -168,7 +168,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
             routingTable = newState.routingTable();
             assertEquals(routingTable.index("idx").size(), 1);
             ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
-            assertEquals(unassignedPrimary.unassignedInfo().failedAllocations(), retries);
+            assertEquals(unassignedPrimary.unassignedInfo().failureCount(), retries);
             assertEquals(unassignedPrimary.state(), UNASSIGNED);
             assertThat(unassignedPrimary.unassignedInfo().message(), containsString("boom"));
             // MaxRetryAllocationDecider#canForceAllocatePrimary should return a NO decision because canAllocate returns NO here
@@ -211,7 +211,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         // good we are initializing and we are maintaining failure information
         assertEquals(routingTable.index("idx").size(), 1);
         ShardRouting unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
-        assertEquals(unassignedPrimary.unassignedInfo().failedAllocations(), retries);
+        assertEquals(unassignedPrimary.unassignedInfo().failureCount(), retries);
         assertEquals(unassignedPrimary.state(), INITIALIZING);
         assertThat(unassignedPrimary.unassignedInfo().message(), containsString("boom"));
         // bumped up the max retry count, so canForceAllocatePrimary should return a YES decision
@@ -236,7 +236,7 @@ public class MaxRetryAllocationDeciderTests extends ESAllocationTestCase {
         routingTable = newState.routingTable();
         assertEquals(routingTable.index("idx").size(), 1);
         unassignedPrimary = routingTable.index("idx").shard(0).shard(0);
-        assertEquals(unassignedPrimary.unassignedInfo().failedAllocations(), 1);
+        assertEquals(unassignedPrimary.unassignedInfo().failureCount(), 1);
         assertEquals(unassignedPrimary.state(), UNASSIGNED);
         assertThat(unassignedPrimary.unassignedInfo().message(), containsString("ZOOOMG"));
         // Counter reset, so MaxRetryAllocationDecider#canForceAllocatePrimary should return a YES decision

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -1304,7 +1304,7 @@ public class DesiredBalanceComputerTests extends ESAllocationTestCase {
                     unassignedInfo.reason(),
                     unassignedInfo.message(),
                     unassignedInfo.failure(),
-                    unassignedInfo.failedAllocations(),
+                    unassignedInfo.failureCount(),
                     unassignedInfo.unassignedTimeNanos(),
                     unassignedInfo.unassignedTimeMillis(),
                     unassignedInfo.delayed(),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -138,7 +138,7 @@ public class DesiredBalanceReconcilerTests extends ESAllocationTestCase {
                         unassignedInfo.reason(),
                         unassignedInfo.message(),
                         unassignedInfo.failure(),
-                        unassignedInfo.failedAllocations(),
+                        unassignedInfo.failureCount(),
                         unassignedInfo.unassignedTimeNanos(),
                         unassignedInfo.unassignedTimeMillis(),
                         unassignedInfo.delayed(),

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/RestoreInProgressAllocationDeciderTests.java
@@ -114,7 +114,7 @@ public class RestoreInProgressAllocationDeciderTests extends ESAllocationTestCas
                 currentInfo.reason(),
                 currentInfo.message(),
                 new IOException("i/o failure"),
-                currentInfo.failedAllocations(),
+                currentInfo.failureCount(),
                 currentInfo.unassignedTimeNanos(),
                 currentInfo.unassignedTimeMillis(),
                 currentInfo.delayed(),

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -254,7 +254,7 @@ public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
             List<ShardRouting> unassignedShards = shardsWithState(allocation.routingNodes(), ShardRoutingState.UNASSIGNED);
             assertThat(unassignedShards, hasSize(1));
             assertThat(unassignedShards.get(0).shardId(), equalTo(shardId));
-            assertThat(unassignedShards.get(0).unassignedInfo().failedAllocations(), equalTo(0));
+            assertThat(unassignedShards.get(0).unassignedInfo().failureCount(), equalTo(0));
             assertThat(unassignedShards.get(0).unassignedInfo().failedNodeIds(), equalTo(failedNodeIds));
         } else {
             assertThat(allocation.routingNodesChanged(), equalTo(false));


### PR DESCRIPTION
Follow up #109363. 
- Remove overrides for hash and equals. Currently `unassignedTimeNanos` is not part of it, it used in tests only. This change will include nano time with record provided hash and equals methods.
- Rename `failedAllocations` to `failureCount`
- Rename `getNumberOfDelayedUnassigned` to `numberOfDelayedUnassigned`