### PR TITLE
[8.14] Correct how hex strings are handled when dynamically updating vector dims (#109423)

### DIFF
--- a/docs/changelog/109423.yaml
+++ b/docs/changelog/109423.yaml
@@ -1,0 +1,5 @@
+pr: 109423
+summary: Correct how hex strings are handled when dynamically updating vector dims
+area: Vector Search
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/170_knn_search_hex_encoded_byte_vectors.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/170_knn_search_hex_encoded_byte_vectors.yml
@@ -161,3 +161,43 @@ setup:
   - match: { hits.hits.0._id: "3" }
   - match: { hits.hits.1._id: "2" }
   - match: { hits.hits.2._id: "1" }
+---
+"Dynamic dimensions for hex-encoded string":
+  - requires:
+      cluster_features: "gte_v8.15.0"
+      reason: 'hex encoding for byte vectors fixed in 8.15'
+
+  - do:
+      indices.create:
+        index: knn_hex_vector_index_dyn_dims
+        body:
+          settings:
+            number_of_shards: 1
+          mappings:
+            properties:
+              my_vector_byte:
+                type: dense_vector
+                index : false
+                element_type: byte
+              my_vector_byte_indexed:
+                type: dense_vector
+                index: true
+                element_type: byte
+                similarity : l2_norm
+
+  # [-128, 127, 10] - is encoded as '807f0a'
+  - do:
+      index:
+        index: knn_hex_vector_index_dyn_dims
+        id: "1"
+        body:
+          my_vector_byte: "807f0a"
+          my_vector_byte_indexed: "807f0a"
+
+  # assert the index is created with 3 dimensions
+  - do:
+      indices.get_mapping:
+        index: knn_hex_vector_index_dyn_dims
+
+  - match: { knn_hex_vector_index_dyn_dims.mappings.properties.my_vector_byte.dims: 3 }
+  - match: { knn_hex_vector_index_dyn_dims.mappings.properties.my_vector_byte_indexed.dims: 3 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/170_knn_search_hex_encoded_byte_vectors.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/170_knn_search_hex_encoded_byte_vectors.yml
@@ -164,8 +164,8 @@ setup:
 ---
 "Dynamic dimensions for hex-encoded string":
   - requires:
-      cluster_features: "gte_v8.15.0"
-      reason: 'hex encoding for byte vectors fixed in 8.15'
+      cluster_features: "gte_v8.14.1"
+      reason: 'hex encoding for byte vectors fixed in 8.14.1'
 
   - do:
       indices.create:

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -457,6 +457,28 @@ public class DenseVectorFieldMapper extends FieldMapper {
             ByteBuffer createByteBuffer(IndexVersion indexVersion, int numBytes) {
                 return ByteBuffer.wrap(new byte[numBytes]);
             }
+
+            @Override
+            int parseDimensionCount(DocumentParserContext context) throws IOException {
+                XContentParser.Token currentToken = context.parser().currentToken();
+                return switch (currentToken) {
+                    case START_ARRAY -> {
+                        int index = 0;
+                        for (Token token = context.parser().nextToken(); token != Token.END_ARRAY; token = context.parser().nextToken()) {
+                            index++;
+                        }
+                        yield index;
+                    }
+                    case VALUE_STRING -> {
+                        byte[] decodedVector = HexFormat.of().parseHex(context.parser().text());
+                        yield decodedVector.length;
+                    }
+                    default -> throw new ParsingException(
+                        context.parser().getTokenLocation(),
+                        format("Unsupported type [%s] for provided value [%s]", currentToken, context.parser().text())
+                    );
+                };
+            }
         },
 
         FLOAT(4) {


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Correct how hex strings are handled when dynamically updating vector dims (#109423)