### PR TITLE
Extend validity of synthetic version features on 8.14

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -89,7 +89,7 @@ class ESRestTestFeatureService implements TestFeatureService {
                     Strings.format(
                         "Synthetic version features are only available before [%s] for migration purposes! "
                             + "Please add a cluster feature to an appropriate FeatureSpecification; test-only historical-features  "
-                            + "can be supplied via ESRestTestCase#additionalTestOnlyHistoricalFeatures()",
+                            + "can be supplied via ESRestTestCase#createAdditionalFeatureSpecifications()",
                         "8.15.0"
                     )
                 );

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -81,16 +81,15 @@ class ESRestTestFeatureService implements TestFeatureService {
         Matcher matcher = VERSION_FEATURE_PATTERN.matcher(featureId);
         if (matcher.matches()) {
             Version extractedVersion = Version.fromString(matcher.group(1));
-            if (Version.fromString("8.15.0").before(extractedVersion)) {
+            if (Version.CURRENT.before(extractedVersion)) {
                 // As of version 8.14.0 REST tests have been migrated to use features only.
-                // For migration purposes we provide a synthetic version feature gte_vX.Y.Z for any version at or before 8.15.0
-                // allowing for some transition period.
+                // For migration purposes we provide a synthetic version feature gte_vX.Y.Z for any version at or before CURRENT (8.14.x).
                 throw new IllegalArgumentException(
                     Strings.format(
                         "Synthetic version features are only available before [%s] for migration purposes! "
                             + "Please add a cluster feature to an appropriate FeatureSpecification; test-only historical-features  "
                             + "can be supplied via ESRestTestCase#createAdditionalFeatureSpecifications()",
-                        "8.15.0"
+                        Version.CURRENT
                     )
                 );
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestFeatureService.java
@@ -81,15 +81,16 @@ class ESRestTestFeatureService implements TestFeatureService {
         Matcher matcher = VERSION_FEATURE_PATTERN.matcher(featureId);
         if (matcher.matches()) {
             Version extractedVersion = Version.fromString(matcher.group(1));
-            if (Version.V_8_14_0.before(extractedVersion)) {
+            if (Version.fromString("8.15.0").before(extractedVersion)) {
                 // As of version 8.14.0 REST tests have been migrated to use features only.
-                // For migration purposes we provide a synthetic version feature gte_vX.Y.Z for any version at or before 8.14.0.
+                // For migration purposes we provide a synthetic version feature gte_vX.Y.Z for any version at or before 8.15.0
+                // allowing for some transition period.
                 throw new IllegalArgumentException(
                     Strings.format(
                         "Synthetic version features are only available before [%s] for migration purposes! "
-                            + "Please add a cluster feature to an appropriate FeatureSpecification; features only necessary for "
-                            + "testing can be supplied via ESRestTestCase#createAdditionalFeatureSpecifications()",
-                        Version.V_8_14_0
+                            + "Please add a cluster feature to an appropriate FeatureSpecification; test-only historical-features  "
+                            + "can be supplied via ESRestTestCase#additionalTestOnlyHistoricalFeatures()",
+                        "8.15.0"
                     )
                 );
             }


### PR DESCRIPTION
On main we've already extended synthetic features to be valid <= 8.15.0.
This backports the change to 8.14.
