### PR TITLE
[Connector API] Include sync_cursor in last sync endpoint

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/80_connector_update_last_sync_stats.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/80_connector_update_last_sync_stats.yml
@@ -76,6 +76,33 @@ setup:
 
 
 ---
+"Update Connector Last Sync Stats - Supports sync_cursor updates":
+  - do:
+      connector.last_sync:
+        connector_id: test-connector
+        body:
+          last_deleted_document_count: 123
+
+  - match: { result: updated }
+
+  - do:
+      connector.last_sync:
+        connector_id: test-connector
+        body:
+          sync_cursor: { pointer: 42 }
+
+  - match: { result: updated }
+
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { sync_cursor: { pointer: 42 } }
+  - match: { last_deleted_document_count: 123 }
+
+
+---
 "Update Connector Last Sync Stats - Connector doesn't exist":
   - do:
       catch: "missing"

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -224,7 +224,7 @@ public class Connector implements NamedWriteable, ToXContentObject {
     public static final ParseField SCHEDULING_FIELD = new ParseField("scheduling");
     public static final ParseField SERVICE_TYPE_FIELD = new ParseField("service_type");
     public static final ParseField STATUS_FIELD = new ParseField("status");
-    static final ParseField SYNC_CURSOR_FIELD = new ParseField("sync_cursor");
+    public static final ParseField SYNC_CURSOR_FIELD = new ParseField("sync_cursor");
     static final ParseField SYNC_NOW_FIELD = new ParseField("sync_now");
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorLastSyncStatsAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorLastSyncStatsAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -22,6 +23,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncInfo;
 import org.elasticsearch.xpack.application.connector.ConnectorSyncStatus;
 import org.elasticsearch.xpack.application.connector.ConnectorUtils;
@@ -45,16 +47,20 @@ public class UpdateConnectorLastSyncStatsAction {
         private final String connectorId;
 
         private final ConnectorSyncInfo syncInfo;
+        @Nullable
+        private final Object syncCursor;
 
-        public Request(String connectorId, ConnectorSyncInfo syncInfo) {
+        private Request(String connectorId, ConnectorSyncInfo syncInfo, Object syncCursor) {
             this.connectorId = connectorId;
             this.syncInfo = syncInfo;
+            this.syncCursor = syncCursor;
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
             this.connectorId = in.readString();
             this.syncInfo = in.readOptionalWriteable(ConnectorSyncInfo::new);
+            this.syncCursor = in.readGenericValue();
         }
 
         public String getConnectorId() {
@@ -63,6 +69,10 @@ public class UpdateConnectorLastSyncStatsAction {
 
         public ConnectorSyncInfo getSyncInfo() {
             return syncInfo;
+        }
+
+        public Object getSyncCursor() {
+            return syncCursor;
         }
 
         @Override
@@ -79,20 +89,22 @@ public class UpdateConnectorLastSyncStatsAction {
         private static final ConstructingObjectParser<UpdateConnectorLastSyncStatsAction.Request, String> PARSER =
             new ConstructingObjectParser<>("connector_update_last_sync_stats_request", false, ((args, connectorId) -> {
                 int i = 0;
-                return new UpdateConnectorLastSyncStatsAction.Request(
-                    connectorId,
-                    new ConnectorSyncInfo.Builder().setLastAccessControlSyncError((String) args[i++])
-                        .setLastAccessControlSyncScheduledAt((Instant) args[i++])
-                        .setLastAccessControlSyncStatus((ConnectorSyncStatus) args[i++])
-                        .setLastDeletedDocumentCount((Long) args[i++])
-                        .setLastIncrementalSyncScheduledAt((Instant) args[i++])
-                        .setLastIndexedDocumentCount((Long) args[i++])
-                        .setLastSyncError((String) args[i++])
-                        .setLastSyncScheduledAt((Instant) args[i++])
-                        .setLastSyncStatus((ConnectorSyncStatus) args[i++])
-                        .setLastSynced((Instant) args[i++])
-                        .build()
-                );
+                return new Builder().setConnectorId(connectorId)
+                    .setSyncInfo(
+                        new ConnectorSyncInfo.Builder().setLastAccessControlSyncError((String) args[i++])
+                            .setLastAccessControlSyncScheduledAt((Instant) args[i++])
+                            .setLastAccessControlSyncStatus((ConnectorSyncStatus) args[i++])
+                            .setLastDeletedDocumentCount((Long) args[i++])
+                            .setLastIncrementalSyncScheduledAt((Instant) args[i++])
+                            .setLastIndexedDocumentCount((Long) args[i++])
+                            .setLastSyncError((String) args[i++])
+                            .setLastSyncScheduledAt((Instant) args[i++])
+                            .setLastSyncStatus((ConnectorSyncStatus) args[i++])
+                            .setLastSynced((Instant) args[i++])
+                            .build()
+                    )
+                    .setSyncCursor(args[i])
+                    .build();
             }));
 
         static {
@@ -142,6 +154,7 @@ public class UpdateConnectorLastSyncStatsAction {
                 ConnectorSyncInfo.LAST_SYNCED_FIELD,
                 ObjectParser.ValueType.STRING_OR_NULL
             );
+            PARSER.declareObjectOrNull(optionalConstructorArg(), (p, c) -> p.map(), null, Connector.SYNC_CURSOR_FIELD);
         }
 
         public static UpdateConnectorLastSyncStatsAction.Request fromXContentBytes(
@@ -166,6 +179,9 @@ public class UpdateConnectorLastSyncStatsAction {
             builder.startObject();
             {
                 syncInfo.toXContent(builder, params);
+                if (syncCursor != null) {
+                    builder.field(Connector.SYNC_CURSOR_FIELD.getPreferredName(), syncCursor);
+                }
             }
             builder.endObject();
             return builder;
@@ -176,6 +192,7 @@ public class UpdateConnectorLastSyncStatsAction {
             super.writeTo(out);
             out.writeString(connectorId);
             out.writeOptionalWriteable(syncInfo);
+            out.writeGenericValue(syncCursor);
         }
 
         @Override
@@ -183,12 +200,41 @@ public class UpdateConnectorLastSyncStatsAction {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
-            return Objects.equals(connectorId, request.connectorId) && Objects.equals(syncInfo, request.syncInfo);
+            return Objects.equals(connectorId, request.connectorId)
+                && Objects.equals(syncInfo, request.syncInfo)
+                && Objects.equals(syncCursor, request.syncCursor);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(connectorId, syncInfo);
+            return Objects.hash(connectorId, syncInfo, syncCursor);
         }
+
+        public static class Builder {
+
+            private String connectorId;
+            private ConnectorSyncInfo syncInfo;
+            private Object syncCursor;
+
+            public Builder setConnectorId(String connectorId) {
+                this.connectorId = connectorId;
+                return this;
+            }
+
+            public Builder setSyncInfo(ConnectorSyncInfo syncInfo) {
+                this.syncInfo = syncInfo;
+                return this;
+            }
+
+            public Builder setSyncCursor(Object syncCursor) {
+                this.syncCursor = syncCursor;
+                return this;
+            }
+
+            public Request build() {
+                return new Request(connectorId, syncInfo, syncCursor);
+            }
+        }
+
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorLastSyncStatsActionRequestBWCSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorLastSyncStatsActionRequestBWCSerializingTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.application.connector.action;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.application.connector.ConnectorTestUtils;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
@@ -28,7 +29,10 @@ public class UpdateConnectorLastSyncStatsActionRequestBWCSerializingTests extend
     @Override
     protected UpdateConnectorLastSyncStatsAction.Request createTestInstance() {
         this.connectorId = randomUUID();
-        return new UpdateConnectorLastSyncStatsAction.Request(connectorId, ConnectorTestUtils.getRandomConnectorSyncInfo());
+        return new UpdateConnectorLastSyncStatsAction.Request.Builder().setConnectorId(connectorId)
+            .setSyncInfo(ConnectorTestUtils.getRandomConnectorSyncInfo())
+            .setSyncCursor(randomMap(0, 3, () -> new Tuple<>(randomAlphaOfLength(4), randomAlphaOfLength(4))))
+            .build();
     }
 
     @Override


### PR DESCRIPTION
### Changes

Extend `_last_sync` endpoint to accept `sync_cursor` as the optional request payload. 

Sync cursor is updated in the connector doc only at the end of the successful sync, so it makes sense from the lifecycle perspective to include the sync cursor in this request. 

The `sync_cursor` property of connector references the cursor from the last incremental sync, so it's similar to updating last status, last indexed doc count, etc.. that are parts of this request.

The request would look like:
```
PUT _connector/<id>/_last_sync
{
  "sync_cursor": <sync cursor map>,
  ... any other sync stats
}
```


### Validation
- tested locally
- unit tests
- yaml e2e tests