### PR TITLE
Always fork to the generic threadpool for _msearch requests

### DIFF
--- a/docs/changelog/109474.yaml
+++ b/docs/changelog/109474.yaml
@@ -1,0 +1,5 @@
+pr: 109474
+summary: Always fork to the generic threadpool for `_msearch` requests
+area: Search
+type: bug
+issues: []


### PR DESCRIPTION
closes: https://github.com/elastic/elasticsearch/issues/109447