### PR TITLE
[8.14] Add publish plugin to ES|QL projects (#109441)

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -3,6 +3,8 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.string-templates'
+apply plugin: 'elasticsearch.publish'
+
 esplugin {
   name 'x-pack-esql'
   description 'The plugin that powers ESQL for Elasticsearch'

--- a/x-pack/plugin/esql/compute/ann/build.gradle
+++ b/x-pack/plugin/esql/compute/ann/build.gradle
@@ -1,4 +1,9 @@
 apply plugin: 'elasticsearch.build'
+apply plugin: 'elasticsearch.publish'
+
+base {
+  archivesName = 'x-pack-esql-compute-ann'
+}
 
 tasks.named('forbiddenApisMain').configure {
   // doesn't depend on anything

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -1,5 +1,10 @@
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.string-templates'
+apply plugin: 'elasticsearch.publish'
+
+base {
+  archivesName = 'x-pack-esql-compute'
+}
 
 dependencies {
   compileOnly project(':server')


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Add publish plugin to ES|QL projects (#109441)