### PR TITLE
ESQL: Reenable test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -62,9 +62,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvAppendTests
   method: testEvaluateBlockWithoutNulls {TestCase=<cartesian_shape>, <cartesian_shape>}
   issue: https://github.com/elastic/elasticsearch/issues/109409
-- class: "org.elasticsearch.xpack.esql.qa.multi_node.EsqlClientYamlIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/109477"
-  method: "test {p0=esql/150_lookup/multivalued keys}"
 - class: "org.elasticsearch.smoketest.DocsClientYamlTestSuiteIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109478"
   method: "test {yaml=reference/esql/processing-commands/lookup/line_31}"


### PR DESCRIPTION
We disabled this test because it failed once but it wasn't reproducable and the test logs didn't give us any hints of what happened. So this reenables is. If we're lucky it'll fail again with useful logs. If we're not lucky it'll never fail again and we'll blame cosmic rays.

Closes #109477
