### PR TITLE
Fork TransportSearchAction to search coordination pool

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/ShardLock.java
+++ b/server/src/main/java/org/elasticsearch/env/ShardLock.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.env;
 
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.transport.Transports;
 
 import java.io.Closeable;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -38,6 +39,7 @@ public abstract class ShardLock implements Closeable {
 
     @Override
     public final void close() {
+        assert Transports.assertNotTransportThread("shard lock should not have been acquired on a transport thread");
         if (this.closed.compareAndSet(false, true)) {
             closeInternal();
         }

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -763,6 +763,7 @@ public abstract class Engine implements Closeable {
 
                 @Override
                 protected void doClose() {
+                    assert Transports.assertNotTransportThread("releasing from the reference manager and/or store may block");
                     try {
                         referenceManager.release(acquire);
                     } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -67,6 +67,7 @@ import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
+import org.elasticsearch.transport.Transports;
 
 import java.io.Closeable;
 import java.io.EOFException;
@@ -431,6 +432,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
     }
 
     private void closeInternal() {
+        assert Transports.assertNotTransportThread("store closing must not happen on the transport thread");
         // Leverage try-with-resources to close the shard lock for us
         try (Closeable c = shardLock) {
             try {


### PR DESCRIPTION
We can run into situations where this action releases a store reference which can block for up to seconds -> fork to search coordination to make absolutely sure this won't cause transport threads to get blocked.

Marking this draft for now, I'd like to discuss this with a wider group before moving ahead. We certainly need to do something to fix the blocking issue here, but we could technically be more selective than just always forking and only do this when coming from a transport thread.

Relates #109481