### PR TITLE
[DOCS] Add note that Logstash sets up data streams

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -13,9 +13,16 @@ To set up a data stream, follow these steps:
 You can also <<convert-index-alias-to-data-stream,convert an index alias to
 a data stream>>.
 
-IMPORTANT: If you use {fleet} or {agent}, skip this tutorial. {fleet} and
-{agent} set up data streams for you. See {fleet}'s
-{fleet-guide}/data-streams.html[data streams] documentation.
+[IMPORTANT] 
+--
+If you use {fleet}, {agent}, or {ls}, skip this tutorial. 
+They all set up data streams for you. 
+
+For {fleet} and {agent}, check out this {fleet-guide}/data-streams.html[data streams documentation].
+For {ls}, check out the
+{logstash-ref}/plugins-outputs-elasticsearch.html#plugins-outputs-elasticsearch-data_stream[data streams settings]
+for the `elasticsearch output` plugin.
+--
 
 [discrete]
 [[create-index-lifecycle-policy]]


### PR DESCRIPTION
A note in the Elasticsearch [data streams tutorial ](https://www.elastic.co/guide/en/elasticsearch/reference/current/set-up-a-data-stream.html)states that Fleet and Elastic Agent set up data streams for you. 
Logstash also sets up data streams. The PR updates the note accordingly. 