### PR TITLE
Fix RRF example for semantic query

### DIFF
--- a/docs/reference/query-dsl/semantic-query.asciidoc
+++ b/docs/reference/query-dsl/semantic-query.asciidoc
@@ -101,9 +101,11 @@ GET my-index/_search
         },
         {
           "standard": {
-            "semantic": {
-              "field": "semantic_field",
-              "query": "shoes"
+            "query": {
+              "semantic": {
+                "field": "semantic_field",
+                "query": "shoes"
+              }
             }
           }
         }


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch/pull/109433, fix appropriately this time the semantic query example with RRF.