### PR TITLE
Add `@UpdateForV9` to `IndexSettingDeprecatedInV7AndRemovedInV8`

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -149,6 +149,7 @@ public class Setting<T> implements ToXContentObject {
          * Indicates that this index-level setting was deprecated in {@link Version#V_7_17_0} and is
          * forbidden in indices created from {@link Version#V_8_0_0} onwards.
          */
+        @UpdateForV9 // introduce IndexSettingDeprecatedInV8AndRemovedInV9 to replace this constant
         IndexSettingDeprecatedInV7AndRemovedInV8,
 
         /**


### PR DESCRIPTION
This setting property is not applicable in v9, but we'll need an
equivalent one for the 8-to-9 transition. This commit adds the
`@UpdateForV9` annotation as a reminder.