### PR TITLE
[Transform] Reset max page size to settings value (#109449)

### DIFF
--- a/docs/changelog/109449.yaml
+++ b/docs/changelog/109449.yaml
@@ -1,6 +1,0 @@
-pr: 109449
-summary: Reset max page size to settings value
-area: Transform
-type: bug
-issues:
- - 109308

--- a/docs/changelog/109449.yaml
+++ b/docs/changelog/109449.yaml
@@ -1,0 +1,6 @@
+pr: 109449
+summary: Reset max page size to settings value
+area: Transform
+type: bug
+issues:
+ - 109308

--- a/docs/changelog/109532.yaml
+++ b/docs/changelog/109532.yaml
@@ -1,0 +1,6 @@
+pr: 109532
+summary: Reset max page size to settings value
+area: Transform
+type: bug
+issues:
+ - 109308

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -45,6 +45,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformProgress;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
 import org.elasticsearch.xpack.core.transform.utils.ExceptionsHelper;
+import org.elasticsearch.xpack.transform.Transform;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
 import org.elasticsearch.xpack.transform.notifications.TransformAuditor;
@@ -543,7 +544,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
     private void finalizeCheckpoint(ActionListener<Void> listener) {
         try {
             // reset the page size, so we do not memorize a low page size forever
-            context.setPageSize(function.getInitialPageSize());
+            resetPageSize();
             // reset the changed bucket to free memory
             if (changeCollector != null) {
                 changeCollector.clear();
@@ -1221,12 +1222,17 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
 
     private void configurePageSize(Integer newPageSize) {
         initialConfiguredPageSize = newPageSize;
+        resetPageSize();
+    }
 
-        // if the user explicitly set a page size, take it from the config, otherwise let the function decide
+    private void resetPageSize() {
         if (initialConfiguredPageSize != null && initialConfiguredPageSize > 0) {
             context.setPageSize(initialConfiguredPageSize);
-        } else {
+        } else if (function != null) {
             context.setPageSize(function.getInitialPageSize());
+        } else {
+            // we should never be in a state where both initialConfiguredPageSize and function are null, but just in case...
+            context.setPageSize(Transform.DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE);
         }
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -19,6 +19,8 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
@@ -35,6 +37,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
 import org.elasticsearch.xpack.core.indexing.IterationResult;
 import org.elasticsearch.xpack.core.transform.action.ValidateTransformAction;
+import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TimeRetentionPolicyConfigTests;
 import org.elasticsearch.xpack.core.transform.transforms.TimeSyncConfig;
 import org.elasticsearch.xpack.core.transform.transforms.TransformCheckpoint;
@@ -43,6 +46,7 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerPositio
 import org.elasticsearch.xpack.core.transform.transforms.TransformIndexerStats;
 import org.elasticsearch.xpack.core.transform.transforms.TransformState;
 import org.elasticsearch.xpack.core.transform.transforms.TransformTaskState;
+import org.elasticsearch.xpack.transform.Transform;
 import org.elasticsearch.xpack.transform.TransformNode;
 import org.elasticsearch.xpack.transform.TransformServices;
 import org.elasticsearch.xpack.transform.checkpoint.CheckpointProvider;
@@ -59,7 +63,9 @@ import org.junit.Before;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -107,8 +113,12 @@ public class TransformIndexerTests extends ESTestCase {
         private CountDownLatch searchLatch;
         private CountDownLatch doProcessLatch;
         private CountDownLatch doSaveStateLatch;
+        private CountDownLatch afterFinishOrFailureLatch;
 
         private AtomicBoolean saveStateInProgress = new AtomicBoolean(false);
+
+        private BlockingDeque<Exception> searchExceptions = new LinkedBlockingDeque<>();
+        private BlockingDeque<Runnable> runBeforeOnFinish = new LinkedBlockingDeque<>();
 
         // how many loops to execute until reporting done
         private int numberOfLoops;
@@ -211,7 +221,11 @@ public class TransformIndexerTests extends ESTestCase {
                     throw new IllegalStateException(e);
                 }
             }
-            threadPool.generic().execute(() -> nextPhase.onResponse(ONE_HIT_SEARCH_RESPONSE));
+            if (searchExceptions.isEmpty() == false) {
+                nextPhase.onFailure(searchExceptions.poll());
+            } else {
+                threadPool.generic().execute(() -> nextPhase.onResponse(ONE_HIT_SEARCH_RESPONSE));
+            }
         }
 
         @Override
@@ -261,6 +275,22 @@ public class TransformIndexerTests extends ESTestCase {
             listener.onResponse(null);
         }
 
+        @Override
+        protected void onFinish(ActionListener<Void> listener) {
+            while (runBeforeOnFinish.isEmpty() == false) {
+                runBeforeOnFinish.poll().run();
+            }
+            super.onFinish(listener);
+        }
+
+        @Override
+        protected void afterFinishOrFailure() {
+            super.afterFinishOrFailure();
+            if (afterFinishOrFailureLatch != null) {
+                afterFinishOrFailureLatch.countDown();
+            }
+        }
+
         public boolean waitingForNextSearch() {
             return super.getScheduledNextSearch() != null;
         }
@@ -277,6 +307,14 @@ public class TransformIndexerTests extends ESTestCase {
         @Override
         void validate(ActionListener<ValidateTransformAction.Response> listener) {
             listener.onResponse(null);
+        }
+
+        public void addAfterFinishOrFailureLatch() {
+            afterFinishOrFailureLatch = new CountDownLatch(1);
+        }
+
+        public void waitForAfterFinishOrFailureLatch(long timeout, TimeUnit unit) throws InterruptedException {
+            assertTrue(afterFinishOrFailureLatch.await(timeout, unit));
         }
     }
 
@@ -437,6 +475,135 @@ public class TransformIndexerTests extends ESTestCase {
 
         // after the indexer has shutdown, it should check for stop at checkpoint and shutdown
         assertBusy(() -> assertEquals(IndexerState.STOPPED, indexer.getState()), 5, TimeUnit.SECONDS);
+    }
+
+    public void testMaxPageSearchSizeIsResetToDefaultValue() throws Exception {
+        TransformConfig config = new TransformConfig(
+            randomAlphaOfLength(10),
+            randomSourceConfig(),
+            randomDestConfig(),
+            null,
+            new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)),
+            null,
+            randomPivotConfig(),
+            null,
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STARTED);
+
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+        final MockedTransformIndexer indexer = createMockIndexer(
+            1,
+            config,
+            state,
+            null,
+            threadPool,
+            auditor,
+            new TransformIndexerStats(),
+            context
+        );
+
+        // add latches
+        CountDownLatch searchLatch = indexer.createAwaitForSearchLatch(1);
+        indexer.addAfterFinishOrFailureLatch();
+
+        indexer.start();
+        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertEquals(indexer.getState(), IndexerState.INDEXING);
+
+        // set circuit breaker to 50%
+        indexer.searchExceptions.offer(new CircuitBreakingException("hello", 2, 1, CircuitBreaker.Durability.TRANSIENT));
+        indexer.runBeforeOnFinish.offer(() -> {
+            assertEquals(Math.round(Transform.DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE / 2.0), context.getPageSize());
+        });
+        assertFalse(indexer.runBeforeOnFinish.isEmpty());
+
+        // run and wait
+        searchLatch.countDown();
+        indexer.waitForAfterFinishOrFailureLatch(5, TimeUnit.SECONDS);
+
+        // rerun, don't throw an exception this time
+        searchLatch = indexer.createAwaitForSearchLatch(1);
+        indexer.addAfterFinishOrFailureLatch();
+        assertBusy(() -> assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis())));
+        searchLatch.countDown();
+        indexer.waitForAfterFinishOrFailureLatch(5, TimeUnit.SECONDS);
+
+        // verify that we checked the pageSize decreased
+        assertTrue(indexer.runBeforeOnFinish.isEmpty());
+        // verify that the pageSize reset
+        assertEquals(Transform.DEFAULT_INITIAL_MAX_PAGE_SEARCH_SIZE.intValue(), context.getPageSize());
+    }
+
+    public void testMaxPageSearchSizeIsResetToConfiguredValue() throws Exception {
+        TransformConfig config = new TransformConfig(
+            randomAlphaOfLength(10),
+            randomSourceConfig(),
+            randomDestConfig(),
+            null,
+            new TimeSyncConfig("timestamp", TimeValue.timeValueSeconds(1)),
+            null,
+            randomPivotConfig(),
+            null,
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 1000),
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        AtomicReference<IndexerState> state = new AtomicReference<>(IndexerState.STARTED);
+
+        TransformContext context = new TransformContext(TransformTaskState.STARTED, "", 0, mock(TransformContext.Listener.class));
+        final MockedTransformIndexer indexer = createMockIndexer(
+            1,
+            config,
+            state,
+            null,
+            threadPool,
+            auditor,
+            new TransformIndexerStats(),
+            context
+        );
+
+        // add latches
+        CountDownLatch searchLatch = indexer.createAwaitForSearchLatch(1);
+        indexer.addAfterFinishOrFailureLatch();
+
+        indexer.start();
+        assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis()));
+        assertEquals(indexer.getState(), IndexerState.INDEXING);
+
+        var configuredMaxPageSearchSize = 20_000;
+        indexer.applyNewSettings(
+            new SettingsConfig.Builder(SettingsConfig.EMPTY).setMaxPageSearchSize(configuredMaxPageSearchSize).build()
+        );
+
+        // set circuit breaker to 50%
+        indexer.searchExceptions.offer(new CircuitBreakingException("hello", 2, 1, CircuitBreaker.Durability.TRANSIENT));
+        indexer.runBeforeOnFinish.offer(() -> { assertEquals(Math.round(configuredMaxPageSearchSize / 2.0), context.getPageSize()); });
+        assertFalse(indexer.runBeforeOnFinish.isEmpty());
+
+        // run and wait
+        searchLatch.countDown();
+        indexer.waitForAfterFinishOrFailureLatch(5, TimeUnit.SECONDS);
+
+        // rerun, don't throw an exception this time
+        searchLatch = indexer.createAwaitForSearchLatch(1);
+        indexer.addAfterFinishOrFailureLatch();
+        assertBusy(() -> assertTrue(indexer.maybeTriggerAsyncJob(System.currentTimeMillis())));
+        searchLatch.countDown();
+        indexer.waitForAfterFinishOrFailureLatch(5, TimeUnit.SECONDS);
+
+        // verify that we checked the pageSize decreased
+        assertTrue(indexer.runBeforeOnFinish.isEmpty());
+        // verify that the pageSize reset
+        assertEquals(configuredMaxPageSearchSize, context.getPageSize());
     }
 
     private MockedTransformIndexer createMockIndexer(


### PR DESCRIPTION
When a circuit breaker exception causes the transform checkpoint to fail, the transform will reduce the max page size to the value specified by the circuit breaker.  Transform will retry the checkpoint until the search succeeds.

When the search succeeds, the Transform will now reset the max search size to the value specified in the Transform settings rather than the now-deprecated value in the Latest/Pivot config.

Fix #109308
