### PR TITLE
[ML] Propagate accurate deployment timeout

### DIFF
--- a/docs/changelog/109534.yaml
+++ b/docs/changelog/109534.yaml
@@ -1,0 +1,6 @@
+pr: 109534
+summary: Propagate accurate deployment timeout
+area: Machine Learning
+type: bug
+issues:
+ - 109407

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/time/RemainingTime.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/time/RemainingTime.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.common.time;
+
+import org.elasticsearch.core.TimeValue;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.function.Supplier;
+
+public interface RemainingTime extends Supplier<TimeValue> {
+    static RemainingTime from(Supplier<Instant> currentTime, TimeValue remainingTime) {
+        var timeout = currentTime.get().plus(remainingTime.duration(), remainingTime.timeUnit().toChronoUnit());
+        var maxRemainingTime = remainingTime.nanos();
+        return () -> {
+            var remainingNanos = ChronoUnit.NANOS.between(currentTime.get(), timeout);
+            return TimeValue.timeValueNanos(Math.max(0, Math.min(remainingNanos, maxRemainingTime)));
+        };
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/time/RemainingTime.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/common/time/RemainingTime.java
@@ -14,6 +14,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.function.Supplier;
 
 public interface RemainingTime extends Supplier<TimeValue> {
+    /**
+     * Create a {@link Supplier} that returns a decreasing {@link TimeValue} on each invocation, representing the amount of time until
+     * the call times out.  The timer starts when this method is called and counts down from remainingTime to 0.
+     * currentTime should return the most up-to-date system time, for example Instant.now() or Clock.instant().
+     */
     static RemainingTime from(Supplier<Instant> currentTime, TimeValue remainingTime) {
         var timeout = currentTime.get().plus(remainingTime.duration(), remainingTime.timeUnit().toChronoUnit());
         var maxRemainingTime = remainingTime.nanos();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/time/RemainingTimeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/time/RemainingTimeTests.java
@@ -34,6 +34,7 @@ public class RemainingTimeTests extends ESTestCase {
 
     // always add the first value, which is read when RemainingTime.from is called, then add the test values
     private Supplier<Instant> times(Instant... instants) {
-        return Stream.concat(Stream.of(Instant.now()), Arrays.stream(instants)).iterator()::next;
+        var startTime = Stream.of(Instant.now());
+        return Stream.concat(startTime, Arrays.stream(instants)).iterator()::next;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/time/RemainingTimeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/time/RemainingTimeTests.java
@@ -18,10 +18,7 @@ import java.util.stream.Stream;
 
 public class RemainingTimeTests extends ESTestCase {
     public void testRemainingTime() {
-        var remainingTime = RemainingTime.from(
-            times(Instant.now(), Instant.now().plusSeconds(60)),
-            TimeValue.timeValueSeconds(30)
-        );
+        var remainingTime = RemainingTime.from(times(Instant.now(), Instant.now().plusSeconds(60)), TimeValue.timeValueSeconds(30));
         assertThat(remainingTime.get(), Matchers.greaterThan(TimeValue.ZERO));
         assertThat(remainingTime.get(), Matchers.equalTo(TimeValue.ZERO));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/time/RemainingTimeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/time/RemainingTimeTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.common.time;
+
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.Matchers;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+public class RemainingTimeTests extends ESTestCase {
+    public void testRemainingTime() {
+        var remainingTime = RemainingTime.from(
+            times(Instant.now(), Instant.now().plusSeconds(60)),
+            TimeValue.timeValueSeconds(30)
+        );
+        assertThat(remainingTime.get(), Matchers.greaterThan(TimeValue.ZERO));
+        assertThat(remainingTime.get(), Matchers.equalTo(TimeValue.ZERO));
+    }
+
+    public void testRemainingTimeMaxValue() {
+        var remainingTime = RemainingTime.from(
+            times(Instant.now().minusSeconds(60), Instant.now().plusSeconds(60)),
+            TimeValue.timeValueSeconds(30)
+        );
+        assertThat(remainingTime.get(), Matchers.equalTo(TimeValue.timeValueSeconds(30)));
+        assertThat(remainingTime.get(), Matchers.equalTo(TimeValue.ZERO));
+    }
+
+    // always add the first value, which is read when RemainingTime.from is called, then add the test values
+    private Supplier<Instant> times(Instant... instants) {
+        return Stream.concat(Stream.of(Instant.now()), Arrays.stream(instants)).iterator()::next;
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -45,6 +45,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.XPackField;
+import org.elasticsearch.xpack.core.common.time.RemainingTime;
 import org.elasticsearch.xpack.core.inference.action.GetInferenceModelAction;
 import org.elasticsearch.xpack.core.ml.MachineLearningField;
 import org.elasticsearch.xpack.core.ml.action.CreateTrainedModelAssignmentAction;
@@ -70,6 +71,7 @@ import org.elasticsearch.xpack.ml.notifications.InferenceAuditor;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.utils.TaskRetriever;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -137,6 +139,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         ClusterState state,
         ActionListener<CreateTrainedModelAssignmentAction.Response> listener
     ) throws Exception {
+        var remainingTime = RemainingTime.from(Instant::now, request.getTimeout());
         logger.debug(() -> "[" + request.getDeploymentId() + "] received deploy request for model [" + request.getModelId() + "]");
         if (MachineLearningField.ML_API_FEATURE.check(licenseState) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
@@ -181,7 +184,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         AtomicLong perAllocationMemoryBytes = new AtomicLong();
 
         ActionListener<CreateTrainedModelAssignmentAction.Response> waitForDeploymentToStart = ActionListener.wrap(
-            modelAssignment -> waitForDeploymentState(request.getDeploymentId(), request.getTimeout(), request.getWaitForState(), listener),
+            modelAssignment -> waitForDeploymentState(request, remainingTime.get(), listener),
             e -> {
                 logger.warn(
                     () -> "[" + request.getDeploymentId() + "] creating new assignment for model [" + request.getModelId() + "] failed",
@@ -268,7 +271,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                 error -> {
                     if (ExceptionsHelper.unwrapCause(error) instanceof ResourceNotFoundException) {
                         // no name clash, continue with the deployment
-                        checkFullModelDefinitionIsPresent(client, trainedModelConfig, true, request.getTimeout(), modelSizeListener);
+                        checkFullModelDefinitionIsPresent(client, trainedModelConfig, true, remainingTime.get(), modelSizeListener);
                     } else {
                         listener.onFailure(error);
                     }
@@ -280,7 +283,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
             if (request.getModelId().equals(request.getDeploymentId()) == false) {
                 client.execute(GetTrainedModelsAction.INSTANCE, getModelWithDeploymentId, checkDeploymentIdDoesntAlreadyExist);
             } else {
-                checkFullModelDefinitionIsPresent(client, trainedModelConfig, true, request.getTimeout(), modelSizeListener);
+                checkFullModelDefinitionIsPresent(client, trainedModelConfig, true, remainingTime.get(), modelSizeListener);
             }
 
         }, listener::onFailure);
@@ -315,16 +318,16 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
     }
 
     private void waitForDeploymentState(
-        String deploymentId,
-        TimeValue timeout,
-        AllocationStatus.State state,
+        StartTrainedModelDeploymentAction.Request request,
+        TimeValue remainingTime,
         ActionListener<CreateTrainedModelAssignmentAction.Response> listener
     ) {
-        DeploymentStartedPredicate predicate = new DeploymentStartedPredicate(deploymentId, state);
+        var deploymentId = request.getDeploymentId();
+        DeploymentStartedPredicate predicate = new DeploymentStartedPredicate(deploymentId, request.getWaitForState());
         trainedModelAssignmentService.waitForAssignmentCondition(
             deploymentId,
             predicate,
-            timeout,
+            remainingTime,
             new TrainedModelAssignmentService.WaitForAssignmentListener() {
                 @Override
                 public void onResponse(TrainedModelAssignment assignment) {
@@ -339,6 +342,18 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                 @Override
                 public void onFailure(Exception e) {
                     listener.onFailure(e);
+                }
+
+                @Override
+                public void onTimeout(TimeValue timeout) {
+                    onFailure(
+                        new ElasticsearchStatusException(
+                            "Timed out after [{}] waiting for model deployment to finish. "
+                                + "Use the trained model stats API to track the state of the deployment.",
+                            RestStatus.REQUEST_TIMEOUT,
+                            request.getTimeout() // use the full request timeout in the error message
+                        )
+                    );
                 }
             }
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -348,7 +348,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                 public void onTimeout(TimeValue timeout) {
                     onFailure(
                         new ElasticsearchStatusException(
-                            "Timed out after [{}] waiting for model deployment to finish. "
+                            "Timed out after [{}] waiting for model deployment to start. "
                                 + "Use the trained model stats API to track the state of the deployment.",
                             RestStatus.REQUEST_TIMEOUT,
                             request.getTimeout() // use the full request timeout in the error message


### PR DESCRIPTION
When a user sets a request timeout, reduce the timeout for each consumption of that value so that the end-to-end time is more accurate to that value.

Fix #109407
