### PR TITLE
Do not auto publish build scans if server is not configured

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -26,6 +26,10 @@ develocity {
     if (jenkinsUrl?.host?.endsWith('elastic.co') || jenkinsUrl?.host?.endsWith('elastic.dev') || System.getenv('BUILDKITE') == 'true') {
       publishing.onlyIf { true }
       server = 'https://gradle-enterprise.elastic.co'
+    } else {
+      publishing.onlyIf {
+        server.isPresent();
+      }
     }
 
 


### PR DESCRIPTION
build scan plugin always publish default behaviour has changed to 'true' which causes issues if there is not build scan plugin and develocity server configured trying to publish to scans.gradle.com.
This change now only allows publishing automatically if a server is configured.