### PR TITLE
[8.14] [DOCS] Remove ESQL demo env link from 8.14+ (#109562)

### DIFF
--- a/docs/reference/esql/esql-get-started.asciidoc
+++ b/docs/reference/esql/esql-get-started.asciidoc
@@ -15,10 +15,9 @@ This getting started is also available as an https://github.com/elastic/elastics
 [[esql-getting-started-prerequisites]]
 === Prerequisites
 
-To follow along with the queries in this guide, you can either set up your own
-deployment, or use Elastic's public {esql} demo environment.
+To follow along with the queries in this guide, you'll need an {es} deployment with our sample data.
 
-include::{es-ref-dir}/tab-widgets/esql/esql-getting-started-widget-sample-data.asciidoc[]
+include::{es-ref-dir}/tab-widgets/esql/esql-getting-started-sample-data.asciidoc[tag=own-deployment]
 
 [discrete]
 [[esql-getting-started-running-queries]]
@@ -269,7 +268,8 @@ Before you can use `ENRICH`, you first need to
 <<esql-create-enrich-policy,create>> and <<esql-execute-enrich-policy,execute>>
 an <<esql-enrich-policy,enrich policy>>.
 
-include::{es-ref-dir}/tab-widgets/esql/esql-getting-started-widget-enrich-policy.asciidoc[]
+include::{es-ref-dir}/tab-widgets/esql/esql-getting-started-enrich-policy.asciidoc[tag=own-deployment]
+
 
 After creating and executing a policy, you can use it with the `ENRICH`
 command:

--- a/docs/reference/tab-widgets/esql/esql-getting-started-sample-data.asciidoc
+++ b/docs/reference/tab-widgets/esql/esql-getting-started-sample-data.asciidoc
@@ -1,6 +1,6 @@
 // tag::own-deployment[]
 
-First ingest some sample data. In {kib}, open the main menu and select *Dev
+First, you'll need to ingest the sample data. In {kib}, open the main menu and select *Dev
 Tools*. Run the following two requests:
 
 [source,console]


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [DOCS] Remove ESQL demo env link from 8.14+ (#109562)