### PR TITLE
[ML] Log when and where pending inference requests are notified at shutdown

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchResultProcessor.java
@@ -141,6 +141,9 @@ public class PyTorchResultProcessor {
     }
 
     private void notifyAndClearPendingResults(ErrorResult errorResult) {
+        if (pendingResults.size() > 0) {
+            logger.warn(format("[%s] clearing [%d] requests pending results", modelId, pendingResults.size()));
+        }
         pendingResults.forEach(
             (id, pendingResult) -> pendingResult.listener.onResponse(new PyTorchResult(id, null, null, null, null, null, errorResult))
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
@@ -26,6 +26,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static org.elasticsearch.core.Strings.format;
+
 /**
  * A worker service that executes runnables sequentially in
  * a single worker thread.
@@ -139,6 +141,10 @@ public abstract class AbstractProcessWorkerExecutorService<T extends Runnable> e
         assert isShutdown() : "Queue runnables should only be drained and notified after the worker is shutdown";
 
         if (queue.isEmpty() == false) {
+            logger.warn(
+                format("[%s] notifying [%d] queued requests that have not been processed before shutdown", processName, queue.size())
+            );
+
             List<Runnable> notExecuted = new ArrayList<>();
             queue.drainTo(notExecuted);
 


### PR DESCRIPTION
When a model deployment is stopped log if there are queued requests and/or if there are requests awaiting results