### PR TITLE
[Connector API] Support resetting connector error with null

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/100_connector_update_error.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/100_connector_update_error.yml
@@ -30,6 +30,36 @@ setup:
 
   - match: { error: "some error" }
 
+
+---
+"Reset Connector Error":
+
+  # Set error
+  - do:
+      connector.update_error:
+        connector_id: test-connector
+        body:
+          error: "some error"
+
+
+  - match: { result: updated }
+
+  # Reset error to null
+  - do:
+      connector.update_error:
+        connector_id: test-connector
+        body:
+          error: null
+
+
+  - match: { result: updated }
+
+  - do:
+      connector.get:
+        connector_id: test-connector
+
+  - match: { error: null }
+
 ---
 "Update Connector Error - 404 when connector doesn't exist":
   - do:

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportUpdateConnectorErrorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/TransportUpdateConnectorErrorAction.java
@@ -41,6 +41,10 @@ public class TransportUpdateConnectorErrorAction extends HandledTransportAction<
         UpdateConnectorErrorAction.Request request,
         ActionListener<ConnectorUpdateActionResponse> listener
     ) {
-        connectorIndexService.updateConnectorError(request, listener.map(r -> new ConnectorUpdateActionResponse(r.getResult())));
+        connectorIndexService.updateConnectorError(
+            request.getConnectorId(),
+            request.getError(),
+            listener.map(r -> new ConnectorUpdateActionResponse(r.getResult()))
+        );
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorErrorAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/action/UpdateConnectorErrorAction.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
-import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
 public class UpdateConnectorErrorAction {
 
@@ -81,7 +81,7 @@ public class UpdateConnectorErrorAction {
         );
 
         static {
-            PARSER.declareStringOrNull(optionalConstructorArg(), Connector.ERROR_FIELD);
+            PARSER.declareStringOrNull(constructorArg(), Connector.ERROR_FIELD);
         }
 
         public static UpdateConnectorErrorAction.Request fromXContentBytes(

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorIndexServiceTests.java
@@ -725,6 +725,21 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(updateErrorRequest.getError(), equalTo(indexedConnector.getError()));
     }
 
+    public void testUpdateConnectorError_resetWithNull() throws Exception {
+        Connector connector = ConnectorTestUtils.getRandomConnector();
+        String connectorId = randomUUID();
+        ConnectorCreateActionResponse resp = awaitCreateConnector(connectorId, connector);
+        assertThat(resp.status(), anyOf(equalTo(RestStatus.CREATED), equalTo(RestStatus.OK)));
+
+        UpdateConnectorErrorAction.Request updateErrorRequest = new UpdateConnectorErrorAction.Request(connectorId, null);
+
+        DocWriteResponse updateResponse = awaitUpdateConnectorError(updateErrorRequest);
+        assertThat(updateResponse.status(), equalTo(RestStatus.OK));
+
+        Connector indexedConnector = awaitGetConnector(connectorId);
+        assertThat(updateErrorRequest.getError(), equalTo(indexedConnector.getError()));
+    }
+
     public void testUpdateConnectorNameOrDescription() throws Exception {
         Connector connector = ConnectorTestUtils.getRandomConnector();
         String connectorId = randomUUID();
@@ -1336,7 +1351,7 @@ public class ConnectorIndexServiceTests extends ESSingleNodeTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<UpdateResponse> resp = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
-        connectorIndexService.updateConnectorError(updatedError, new ActionListener<>() {
+        connectorIndexService.updateConnectorError(updatedError.getConnectorId(), updatedError.getError(), new ActionListener<>() {
             @Override
             public void onResponse(UpdateResponse indexResponse) {
                 resp.set(indexResponse);


### PR DESCRIPTION
### Changes

Support resetting connector error back to `null` to indicate that it's again in healthy state. The use of `Map.of(... , null)` would fail normally before.

We can reset the connector error with:

```
PUT _connector/{}/_error
{
  "error": null
}
```

This functionality is required by connector protocol in the connector framework (error needs to be reset at the beginning of a new sync).

### Validation
- Added unit tests and yaml e2e tests
- Manual test