### PR TITLE
[8.14] [DOCS] Expand context about `xpack.security.enabled` setting (#109575)

### DIFF
--- a/docs/reference/settings/security-settings.asciidoc
+++ b/docs/reference/settings/security-settings.asciidoc
@@ -23,7 +23,9 @@ For more information about creating and updating the {es} keystore, see
 ==== General security settings
 `xpack.security.enabled`::
 (<<static-cluster-setting,Static>>)
-Defaults to `true`, which enables {es} {security-features} on the node. +
+Defaults to `true`, which enables {es} {security-features} on the node. 
+This setting must be enabled to use Elasticsearch's authentication, 
+authorization and audit features. +
 +
 --
 If set to `false`, {security-features} are disabled, which is not recommended.


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [DOCS] Expand context about `xpack.security.enabled` setting (#109575)