### PR TITLE
Fix small bug in TimeSeriesSortedSourceOperatorFactory

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -64,9 +64,6 @@ tests:
   method: "test {yaml=reference/esql/processing-commands/lookup/line_31}"
 - class: DenseVectorMappingUpdateIT
   issue: "https://github.com/elastic/elasticsearch/issues/109571"
-- class: "org.elasticsearch.compute.lucene.TimeSeriesSortedSourceOperatorTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/109578"
-  method: "testMatchNone"
 
 # Examples:
 #

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
@@ -275,8 +275,8 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
 
             void consume() throws IOException {
                 if (queue != null) {
-                    currentTsid = BytesRef.deepCopyOf(queue.top().timeSeriesHash);
                     if (queue.size() > 0) {
+                        currentTsid = BytesRef.deepCopyOf(queue.top().timeSeriesHash);
                         queue.top().reinitializeIfNeeded(Thread.currentThread());
                     }
                     while (queue.size() > 0) {


### PR DESCRIPTION
Only initialize `currentTsid` variable is queue isn't empty
    
Closes #109578