### PR TITLE
[ML] Inference API clarifying the docs around the cohere input_type field

### DIFF
--- a/docs/reference/inference/post-inference.asciidoc
+++ b/docs/reference/inference/post-inference.asciidoc
@@ -85,6 +85,10 @@ single string as input.
 (Required, string)
 Only for `rerank` {infer} endpoints. The search query text.
 
+`task_settings`::
+(Optional, object)
+Task settings for the individual {infer} request.
+These settings are specific to the `<task_type>` you specified and override the task settings specified when initializing the service.
 
 [discrete]
 [[post-inference-api-example]]
@@ -228,6 +232,60 @@ The API returns the following response:
       (...)
     },
     (...)
+  ]
+}
+------------------------------------------------------------
+// NOTCONSOLE
+
+[discrete]
+[[inference-example-text-embedding]]
+===== Text embedding example
+
+The following example performs text embedding on the example sentence using the Cohere integration.
+
+
+[source,console]
+------------------------------------------------------------
+POST _inference/text_embedding/my-cohere-endpoint
+{
+  "input": "The sky above the port was the color of television tuned to a dead channel.",
+  "task_settings": {
+    "input_type": "ingest"
+  }
+}
+------------------------------------------------------------
+// TEST[skip:TBD]
+
+
+The API returns the following response:
+
+
+[source,console-result]
+------------------------------------------------------------
+{
+  "text_embedding": [
+    {
+      "embedding": [
+        {
+          0.018569946,
+          -0.036895752,
+          0.01486969,
+          -0.0045204163,
+          -0.04385376,
+          0.0075950623,
+          0.04260254,
+          -0.004005432,
+          0.007865906,
+          0.030792236,
+          -0.050476074,
+          0.011795044,
+          -0.011642456,
+          -0.010070801,
+          (...)
+        },
+        (...)
+      ]
+    }
   ]
 }
 ------------------------------------------------------------

--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -502,6 +502,8 @@ Valid values are:
 * `clusterning`: use it for the embeddings run through a clustering algorithm.
 * `ingest`: use it for storing document embeddings in a vector database.
 * `search`: use it for storing embeddings of search queries run against a vector database to find relevant documents.
++
+IMPORTANT: The `input_type` field is required when using embedding models `v3` and higher.
 
 `truncate`:::
 (Optional, string)


### PR DESCRIPTION
This PR updates the docs to clarify when the `input_type` field is required and gives an example of how to use it.