### PR TITLE
Opt `scripted_metric` out of parallelization

### DIFF
--- a/docs/changelog/109597.yaml
+++ b/docs/changelog/109597.yaml
@@ -1,0 +1,5 @@
+pr: 109597
+summary: Opt `scripted_metric` out of parallelization
+area: Aggregations
+type: feature
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregationBuilder.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.ToLongFunction;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
@@ -265,6 +266,11 @@ public class ScriptedMetricAggregationBuilder extends AbstractAggregationBuilder
     @Override
     public TransportVersion getMinimalSupportedVersion() {
         return TransportVersions.ZERO;
+    }
+
+    @Override
+    public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
+        return false;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregatorTests.java
@@ -65,6 +65,12 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
         "reduceScript",
         Collections.emptyMap()
     );
+    private static final Script REDUCE_SCRIPT_COUNT_STATES = new Script(
+        ScriptType.INLINE,
+        MockScriptEngine.NAME,
+        "reduceScriptCountStates",
+        Collections.emptyMap()
+    );
 
     private static final Script INIT_SCRIPT_SCORE = new Script(
         ScriptType.INLINE,
@@ -169,6 +175,10 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
         SCRIPTS.put("reduceScript", params -> {
             List<?> states = (List<?>) params.get("states");
             return states.stream().filter(a -> a instanceof Number).map(a -> (Number) a).mapToInt(Number::intValue).sum();
+        });
+        SCRIPTS.put("reduceScriptCountStates", params -> {
+            List<?> states = (List<?>) params.get("states");
+            return states.size();
         });
 
         SCRIPTS.put("initScriptScore", params -> {
@@ -350,6 +360,31 @@ public class ScriptedMetricAggregatorTests extends AggregatorTestCase {
                 assertEquals(AGG_NAME, scriptedMetric.getName());
                 assertNotNull(scriptedMetric.aggregation());
                 assertEquals(numDocs, scriptedMetric.aggregation());
+            }
+        }
+    }
+
+    public void testNoParallelization() throws IOException {
+        try (Directory directory = newDirectory()) {
+            int numDocs = randomInt(100);
+            try (RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory)) {
+                for (int i = 0; i < numDocs; i++) {
+                    indexWriter.addDocument(singleton(new SortedNumericDocValuesField("number", i)));
+                }
+            }
+            try (DirectoryReader indexReader = DirectoryReader.open(directory)) {
+                ScriptedMetricAggregationBuilder aggregationBuilder = new ScriptedMetricAggregationBuilder(AGG_NAME);
+                aggregationBuilder.initScript(INIT_SCRIPT)
+                    .mapScript(MAP_SCRIPT)
+                    .combineScript(COMBINE_SCRIPT)
+                    .reduceScript(REDUCE_SCRIPT_COUNT_STATES);
+                ScriptedMetric scriptedMetric = searchAndReduce(
+                    indexReader,
+                    new AggTestConfig(aggregationBuilder).withSplitLeavesIntoSeperateAggregators(false)
+                );
+                assertEquals(AGG_NAME, scriptedMetric.getName());
+                assertNotNull(scriptedMetric.aggregation());
+                assertEquals(1, scriptedMetric.aggregation());
             }
         }
     }


### PR DESCRIPTION
`scripted_metric` can use a lot of memory and agg parallelization can use a lot of memory. One of the few techniques we have for controlling memory is knowing how the execution works up front - and we can't with automatic parallelization. So this turns that off.
