### PR TITLE
Consider error_trace supported by all endpoints

### DIFF
--- a/docs/changelog/109613.yaml
+++ b/docs/changelog/109613.yaml
@@ -1,0 +1,6 @@
+pr: 109613
+summary: Consider `error_trace` supported by all endpoints
+area: Infra/REST API
+type: bug
+issues:
+ - 109612

--- a/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
+++ b/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
@@ -135,6 +135,15 @@ public final class Sets {
         return union;
     }
 
+    @SafeVarargs
+    public static <T> Set<T> union(Set<T> first, Set<T>... others) {
+        Set<T> union = new HashSet<>(first);
+        for (Set<T> other : others) {
+            union.addAll(other);
+        }
+        return union;
+    }
+
     /**
      * The intersection of two sets. Namely, the resulting set contains all the elements that are in both sets.
      * Neither input is mutated by this operation, an entirely new set is returned.

--- a/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
+++ b/server/src/main/java/org/elasticsearch/rest/BaseRestHandler.java
@@ -83,7 +83,7 @@ public abstract class BaseRestHandler implements RestHandler {
         // check if the query has any parameters that are not in the supported set (if declared)
         Set<String> supported = allSupportedParameters();
         if (supported != null) {
-            var allSupported = Sets.union(ALWAYS_SUPPORTED, supported);
+            var allSupported = Sets.union(RestResponse.RESPONSE_PARAMS, ALWAYS_SUPPORTED, supported);
             if (allSupported.containsAll(request.params().keySet()) == false) {
                 Set<String> unsupported = Sets.difference(request.params().keySet(), allSupported);
                 throw new IllegalArgumentException(unrecognized(request, unsupported, allSupported, "parameter"));
@@ -97,6 +97,7 @@ public abstract class BaseRestHandler implements RestHandler {
             // use a sorted set so the unconsumed parameters appear in a reliable sorted order
             final SortedSet<String> unconsumedParams = request.unconsumedParams()
                 .stream()
+                .filter(p -> RestResponse.RESPONSE_PARAMS.contains(p) == false)
                 .filter(p -> responseParams(request.getRestApiVersion()).contains(p) == false)
                 .collect(Collectors.toCollection(TreeSet::new));
 

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -37,6 +37,7 @@ import static org.elasticsearch.rest.RestController.ELASTIC_PRODUCT_HTTP_HEADER;
 public final class RestResponse implements Releasable {
 
     public static final String TEXT_CONTENT_TYPE = "text/plain; charset=UTF-8";
+    public static final Set<String> RESPONSE_PARAMS = Set.of("error_trace");
 
     static final String STATUS = "status";
 

--- a/server/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/BaseRestHandlerTests.java
@@ -235,6 +235,7 @@ public class BaseRestHandlerTests extends ESTestCase {
         params.put("filter_path", randomAlphaOfLength(8));
         params.put("pretty", randomFrom("true", "false", "", null));
         params.put("human", null);
+        params.put("error_trace", randomFrom("true", "false", null));
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withParams(params).build();
         RestChannel channel = new FakeRestChannel(request, randomBoolean(), 1);
         handler.handleRequest(request, channel, mockClient);


### PR DESCRIPTION
Closes #109612

I had a go at fixing this, I can see why `error_trace` wasn't included in the first place, the other `ALWAYS_SUPPORTED` parameters are all consumed by `AbstractRestChannel`. `error_trace` isn't consumed until we create the `RestResponse`, so it won't be listed as consumed when we check for unconsumed parameters.

There is API for specifying response parameters (which we exclude from the unconsumed check) but it's overridable, so I don't know the ideal place to put the parameter(s) that `RestResponse` consumes.

This is one approach, feel free to suggest a better one. 
