### PR TITLE
Make hot-threads request payload immutable

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRes
 import org.elasticsearch.action.admin.cluster.node.hotthreads.TransportNodesHotThreadsAction;
 import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.ChunkedLoggingStreamTestUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.monitor.jvm.HotThreads;
@@ -48,18 +49,23 @@ public class HotThreadsIT extends ESIntegTestCase {
         final int iters = scaledRandomIntBetween(2, 20);
         final AtomicBoolean hasErrors = new AtomicBoolean(false);
         for (int i = 0; i < iters; i++) {
-            final NodesHotThreadsRequest request = new NodesHotThreadsRequest();
-            if (randomBoolean()) {
-                TimeValue timeValue = new TimeValue(rarely() ? randomIntBetween(500, 5000) : randomIntBetween(20, 500));
-                request.interval(timeValue);
-            }
-            if (randomBoolean()) {
-                request.threads(rarely() ? randomIntBetween(500, 5000) : randomIntBetween(1, 500));
-            }
-            request.ignoreIdleThreads(randomBoolean());
-            if (randomBoolean()) {
-                request.type(HotThreads.ReportType.of(randomFrom("block", "mem", "cpu", "wait")));
-            }
+            final NodesHotThreadsRequest request = new NodesHotThreadsRequest(
+                Strings.EMPTY_ARRAY,
+                new HotThreads.RequestOptions(
+                    randomBoolean() ? HotThreads.RequestOptions.DEFAULT.threads()
+                        : rarely() ? randomIntBetween(500, 5000)
+                        : randomIntBetween(1, 500),
+                    randomBoolean()
+                        ? HotThreads.RequestOptions.DEFAULT.reportType()
+                        : HotThreads.ReportType.of(randomFrom("block", "mem", "cpu", "wait")),
+                    HotThreads.RequestOptions.DEFAULT.sortOrder(),
+                    randomBoolean()
+                        ? HotThreads.RequestOptions.DEFAULT.interval()
+                        : TimeValue.timeValueMillis(rarely() ? randomIntBetween(500, 5000) : randomIntBetween(20, 500)),
+                    HotThreads.RequestOptions.DEFAULT.snapshots(),
+                    randomBoolean()
+                )
+            );
             final CountDownLatch latch = new CountDownLatch(1);
             client().execute(TransportNodesHotThreadsAction.TYPE, request, new ActionListener<>() {
                 @Override
@@ -125,7 +131,17 @@ public class HotThreadsIT extends ESIntegTestCase {
             SubscribableListener.<Integer>newForked(
                 l -> client().execute(
                     TransportNodesHotThreadsAction.TYPE,
-                    new NodesHotThreadsRequest().ignoreIdleThreads(false).threads(Integer.MAX_VALUE),
+                    new NodesHotThreadsRequest(
+                        Strings.EMPTY_ARRAY,
+                        new HotThreads.RequestOptions(
+                            Integer.MAX_VALUE,
+                            HotThreads.RequestOptions.DEFAULT.reportType(),
+                            HotThreads.RequestOptions.DEFAULT.sortOrder(),
+                            HotThreads.RequestOptions.DEFAULT.interval(),
+                            HotThreads.RequestOptions.DEFAULT.snapshots(),
+                            false
+                        )
+                    ),
                     l.map(response -> {
                         int length = 0;
                         for (NodeHotThreads node : response.getNodesMap().values()) {
@@ -139,7 +155,17 @@ public class HotThreadsIT extends ESIntegTestCase {
         );
 
         // Second time, do ignore idle threads:
-        final var request = new NodesHotThreadsRequest().threads(Integer.MAX_VALUE);
+        final var request = new NodesHotThreadsRequest(
+            Strings.EMPTY_ARRAY,
+            new HotThreads.RequestOptions(
+                Integer.MAX_VALUE,
+                HotThreads.RequestOptions.DEFAULT.reportType(),
+                HotThreads.RequestOptions.DEFAULT.sortOrder(),
+                HotThreads.RequestOptions.DEFAULT.interval(),
+                HotThreads.RequestOptions.DEFAULT.snapshots(),
+                HotThreads.RequestOptions.DEFAULT.ignoreIdleThreads()
+            )
+        );
         // Make sure default is true:
         assertTrue(request.ignoreIdleThreads());
         final var totSizeIgnoreIdle = safeAwait(
@@ -160,26 +186,30 @@ public class HotThreadsIT extends ESIntegTestCase {
     public void testTimestampAndParams() {
         safeAwait(
             SubscribableListener.<Void>newForked(
-                l -> client().execute(TransportNodesHotThreadsAction.TYPE, new NodesHotThreadsRequest(), l.map(response -> {
-                    if (Constants.FREE_BSD) {
-                        for (NodeHotThreads node : response.getNodesMap().values()) {
-                            assertThat(node.getHotThreads(), containsString("hot_threads is not supported"));
+                l -> client().execute(
+                    TransportNodesHotThreadsAction.TYPE,
+                    new NodesHotThreadsRequest(Strings.EMPTY_ARRAY, HotThreads.RequestOptions.DEFAULT),
+                    l.map(response -> {
+                        if (Constants.FREE_BSD) {
+                            for (NodeHotThreads node : response.getNodesMap().values()) {
+                                assertThat(node.getHotThreads(), containsString("hot_threads is not supported"));
+                            }
+                        } else {
+                            for (NodeHotThreads node : response.getNodesMap().values()) {
+                                assertThat(
+                                    node.getHotThreads(),
+                                    allOf(
+                                        containsString("Hot threads at"),
+                                        containsString("interval=500ms"),
+                                        containsString("busiestThreads=3"),
+                                        containsString("ignoreIdleThreads=true")
+                                    )
+                                );
+                            }
                         }
-                    } else {
-                        for (NodeHotThreads node : response.getNodesMap().values()) {
-                            assertThat(
-                                node.getHotThreads(),
-                                allOf(
-                                    containsString("Hot threads at"),
-                                    containsString("interval=500ms"),
-                                    containsString("busiestThreads=3"),
-                                    containsString("ignoreIdleThreads=true")
-                                )
-                            );
-                        }
-                    }
-                    return null;
-                }))
+                        return null;
+                    })
+                )
             )
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/NodesHotThreadsRequest.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.node.hotthreads;
 
-import org.elasticsearch.TransportVersions;
 import org.elasticsearch.action.support.nodes.BaseNodesRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -17,109 +16,60 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.monitor.jvm.HotThreads;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 public class NodesHotThreadsRequest extends BaseNodesRequest<NodesHotThreadsRequest> {
 
-    int threads = 3;
-    HotThreads.ReportType type = HotThreads.ReportType.CPU;
-    HotThreads.SortOrder sortOrder = HotThreads.SortOrder.TOTAL;
-    TimeValue interval = new TimeValue(500, TimeUnit.MILLISECONDS);
-    int snapshots = 10;
-    boolean ignoreIdleThreads = true;
+    final HotThreads.RequestOptions requestOptions;
 
-    // for serialization
     public NodesHotThreadsRequest(StreamInput in) throws IOException {
         super(in);
-        threads = in.readInt();
-        ignoreIdleThreads = in.readBoolean();
-        type = HotThreads.ReportType.of(in.readString());
-        interval = in.readTimeValue();
-        snapshots = in.readInt();
-        if (in.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)) {
-            sortOrder = HotThreads.SortOrder.of(in.readString());
-        }
+        requestOptions = HotThreads.RequestOptions.readFrom(in);
     }
 
     /**
      * Get hot threads from nodes based on the nodes ids specified. If none are passed, hot
      * threads for all nodes is used.
      */
-    public NodesHotThreadsRequest(String... nodesIds) {
+    public NodesHotThreadsRequest(String[] nodesIds, HotThreads.RequestOptions requestOptions) {
         super(nodesIds);
+        this.requestOptions = requestOptions;
     }
 
     /**
      * Get hot threads from the given node, for use if the node isn't a stable member of the cluster.
      */
-    public NodesHotThreadsRequest(DiscoveryNode node) {
+    public NodesHotThreadsRequest(DiscoveryNode node, HotThreads.RequestOptions requestOptions) {
         super(node);
+        this.requestOptions = requestOptions;
     }
 
     public int threads() {
-        return this.threads;
-    }
-
-    public NodesHotThreadsRequest threads(int threads) {
-        this.threads = threads;
-        return this;
+        return requestOptions.threads();
     }
 
     public boolean ignoreIdleThreads() {
-        return this.ignoreIdleThreads;
-    }
-
-    public NodesHotThreadsRequest ignoreIdleThreads(boolean ignoreIdleThreads) {
-        this.ignoreIdleThreads = ignoreIdleThreads;
-        return this;
-    }
-
-    public NodesHotThreadsRequest type(HotThreads.ReportType type) {
-        this.type = type;
-        return this;
+        return requestOptions.ignoreIdleThreads();
     }
 
     public HotThreads.ReportType type() {
-        return this.type;
-    }
-
-    public NodesHotThreadsRequest sortOrder(HotThreads.SortOrder sortOrder) {
-        this.sortOrder = sortOrder;
-        return this;
+        return requestOptions.reportType();
     }
 
     public HotThreads.SortOrder sortOrder() {
-        return this.sortOrder;
-    }
-
-    public NodesHotThreadsRequest interval(TimeValue interval) {
-        this.interval = interval;
-        return this;
+        return requestOptions.sortOrder();
     }
 
     public TimeValue interval() {
-        return this.interval;
+        return requestOptions.interval();
     }
 
     public int snapshots() {
-        return this.snapshots;
-    }
-
-    public NodesHotThreadsRequest snapshots(int snapshots) {
-        this.snapshots = snapshots;
-        return this;
+        return requestOptions.snapshots();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeInt(threads);
-        out.writeBoolean(ignoreIdleThreads);
-        out.writeString(type.getTypeValue());
-        out.writeTimeValue(interval);
-        out.writeInt(snapshots);
-        if (out.getTransportVersion().onOrAfter(TransportVersions.V_7_16_0)) {
-            out.writeString(sortOrder.getOrderValue());
-        }
+        requestOptions.writeTo(out);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/hotthreads/TransportNodesHotThreadsAction.java
@@ -79,12 +79,12 @@ public class TransportNodesHotThreadsAction extends TransportNodesAction<
 
     @Override
     protected NodeHotThreads nodeOperation(NodeRequest request, Task task) {
-        final var hotThreads = new HotThreads().busiestThreads(request.request.threads)
-            .type(request.request.type)
-            .sortOrder(request.request.sortOrder)
-            .interval(request.request.interval)
-            .threadElementsSnapshotCount(request.request.snapshots)
-            .ignoreIdleThreads(request.request.ignoreIdleThreads);
+        final var hotThreads = new HotThreads().busiestThreads(request.request.threads())
+            .type(request.request.type())
+            .sortOrder(request.request.sortOrder())
+            .interval(request.request.interval())
+            .threadElementsSnapshotCount(request.request.snapshots())
+            .ignoreIdleThreads(request.request.ignoreIdleThreads());
         final var out = transportService.newNetworkBytesStream();
         final var trackedResource = LeakTracker.wrap(out);
         var success = false;

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LagDetector.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LagDetector.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.monitor.jvm.HotThreads;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.TransportService;
@@ -274,7 +275,17 @@ public class LagDetector {
                             threadContext.markAsSystemContext();
                             client.execute(
                                 TransportNodesHotThreadsAction.TYPE,
-                                new NodesHotThreadsRequest(discoveryNode).threads(500),
+                                new NodesHotThreadsRequest(
+                                    discoveryNode,
+                                    new HotThreads.RequestOptions(
+                                        500,
+                                        HotThreads.RequestOptions.DEFAULT.reportType(),
+                                        HotThreads.RequestOptions.DEFAULT.sortOrder(),
+                                        HotThreads.RequestOptions.DEFAULT.interval(),
+                                        HotThreads.RequestOptions.DEFAULT.snapshots(),
+                                        HotThreads.RequestOptions.DEFAULT.ignoreIdleThreads()
+                                    )
+                                ),
                                 ActionListener.runBefore(debugListener, () -> Releasables.close(releasable))
                             );
                             success = true;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
@@ -103,15 +103,17 @@ public class RestNodesHotThreadsAction extends BaseRestHandler {
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
         String[] nodesIds = Strings.splitStringByCommaToArray(request.param("nodeId"));
-        NodesHotThreadsRequest nodesHotThreadsRequest = new NodesHotThreadsRequest(nodesIds);
-        nodesHotThreadsRequest.threads(request.paramAsInt("threads", nodesHotThreadsRequest.threads()));
-        nodesHotThreadsRequest.ignoreIdleThreads(request.paramAsBoolean("ignore_idle_threads", nodesHotThreadsRequest.ignoreIdleThreads()));
-        nodesHotThreadsRequest.type(HotThreads.ReportType.of(request.param("type", nodesHotThreadsRequest.type().getTypeValue())));
-        nodesHotThreadsRequest.sortOrder(
-            HotThreads.SortOrder.of(request.param("sort", nodesHotThreadsRequest.sortOrder().getOrderValue()))
+        NodesHotThreadsRequest nodesHotThreadsRequest = new NodesHotThreadsRequest(
+            nodesIds,
+            new HotThreads.RequestOptions(
+                request.paramAsInt("threads", HotThreads.RequestOptions.DEFAULT.threads()),
+                HotThreads.ReportType.of(request.param("type", HotThreads.RequestOptions.DEFAULT.reportType().getTypeValue())),
+                HotThreads.SortOrder.of(request.param("sort", HotThreads.RequestOptions.DEFAULT.sortOrder().getOrderValue())),
+                request.paramAsTime("interval", HotThreads.RequestOptions.DEFAULT.interval()),
+                request.paramAsInt("snapshots", HotThreads.RequestOptions.DEFAULT.snapshots()),
+                request.paramAsBoolean("ignore_idle_threads", HotThreads.RequestOptions.DEFAULT.ignoreIdleThreads())
+            )
         );
-        nodesHotThreadsRequest.interval(request.paramAsTime("interval", nodesHotThreadsRequest.interval()));
-        nodesHotThreadsRequest.snapshots(request.paramAsInt("snapshots", nodesHotThreadsRequest.snapshots()));
         nodesHotThreadsRequest.timeout(getTimeout(request));
         return channel -> client.execute(TransportNodesHotThreadsAction.TYPE, nodesHotThreadsRequest, new RestResponseListener<>(channel) {
             @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/hotthreads/NodesHotThreadsRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/hotthreads/NodesHotThreadsRequestTests.java
@@ -25,12 +25,17 @@ public class NodesHotThreadsRequestTests extends ESTestCase {
     public void testBWCSerialization() throws IOException {
         TimeValue sampleInterval = new TimeValue(50, TimeUnit.MINUTES);
 
-        NodesHotThreadsRequest request = new NodesHotThreadsRequest("123");
-        request.threads(4);
-        request.ignoreIdleThreads(false);
-        request.type(HotThreads.ReportType.BLOCK);
-        request.interval(sampleInterval);
-        request.snapshots(3);
+        NodesHotThreadsRequest request = new NodesHotThreadsRequest(
+            new String[] { "123" },
+            new HotThreads.RequestOptions(
+                4,
+                HotThreads.ReportType.BLOCK,
+                HotThreads.RequestOptions.DEFAULT.sortOrder(),
+                sampleInterval,
+                3,
+                false
+            )
+        );
 
         TransportVersion latest = TransportVersion.current();
         TransportVersion previous = TransportVersionUtils.randomVersionBetween(


### PR DESCRIPTION
There's no need for these fields to be mutable, and by encapsulating
them in their own object we can more easily address #100878 for this
request.