### PR TITLE
Fail cluster state API if blocked

### DIFF
--- a/docs/changelog/109618.yaml
+++ b/docs/changelog/109618.yaml
@@ -1,0 +1,6 @@
+pr: 109618
+summary: Fail cluster state API if blocked
+area: Cluster Coordination
+type: bug
+issues:
+ - 107503

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
@@ -7,7 +7,9 @@
  */
 package org.elasticsearch.action.admin.cluster.state;
 
+import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.coordination.ClusterBootstrapService;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -16,6 +18,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
+import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -33,6 +36,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 0, scope = ESIntegTestCase.Scope.TEST)
@@ -48,6 +52,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
             final ClusterStateRequestBuilder clusterStateRequestBuilder = clusterAdmin().prepareState()
                 .clear()
                 .setNodes(true)
+                .setBlocks(true)
                 .setMasterNodeTimeout(TimeValue.timeValueMillis(100));
             final ClusterStateResponse clusterStateResponse;
             try {
@@ -68,6 +73,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
                 .clear()
                 .setLocal(true)
                 .setNodes(true)
+                .setBlocks(true)
                 .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
                 .get()
                 .getState()
@@ -96,6 +102,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
                 .clear()
                 .setNodes(true)
                 .setMetadata(true)
+                .setBlocks(true)
                 .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
                 .setWaitForTimeOut(TimeValue.timeValueMillis(100))
                 .setWaitForMetadataVersion(waitForMetadataVersion);
@@ -128,6 +135,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
                 .clear()
                 .setLocal(true)
                 .setMetadata(true)
+                .setBlocks(true)
                 .setWaitForMetadataVersion(waitForMetadataVersion)
                 .setMasterNodeTimeout(TimeValue.timeValueMillis(100))
                 .setWaitForTimeOut(TimeValue.timeValueMillis(100))
@@ -151,6 +159,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
                 clusterAdmin().prepareState()
                     .clear()
                     .setMetadata(true)
+                    .setBlocks(true)
                     .get()
                     .getState()
                     .getLastCommittedConfiguration()
@@ -212,6 +221,22 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
         assertingThread.join();
         updatingThread.join();
         internalCluster().close();
+    }
+
+    public void testFailsWithBlockExceptionIfBlockedAndBlocksNotRequested() {
+        internalCluster().startMasterOnlyNode(Settings.builder().put(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 1).build());
+        final var state = safeGet(clusterAdmin().prepareState().clear().setBlocks(true).execute()).getState();
+        assertTrue(state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK));
+
+        assertThat(
+            safeAwaitFailure(SubscribableListener.<ClusterStateResponse>newForked(l -> clusterAdmin().prepareState().clear().execute(l))),
+            instanceOf(ClusterBlockException.class)
+        );
+
+        internalCluster().startDataOnlyNode();
+
+        final var recoveredState = safeGet(clusterAdmin().prepareState().clear().setBlocks(randomBoolean()).execute()).getState();
+        assertFalse(recoveredState.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK));
     }
 
 }


### PR DESCRIPTION
It is important for callers of the cluster state API to be aware of any
blocks in place, particularly because the `STATE_NOT_RECOVERED_BLOCK`
means that the rest of the state is hidden from view. Yet if the caller
asks to suppress the `blocks` component of the response then they cannot
make this distinction. Thus, in this situation, we fail the request with
a block exception.

Fixes #107503