### PR TITLE
DenseVectorMappingUpdateIT BWC fix

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -59,8 +59,6 @@ tests:
 - class: org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.MvAppendTests
   method: testEvaluateBlockWithoutNulls {TestCase=<cartesian_shape>, <cartesian_shape>}
   issue: https://github.com/elastic/elasticsearch/issues/109409
-- class: DenseVectorMappingUpdateIT
-  issue: "https://github.com/elastic/elasticsearch/issues/109571"
 
 # Examples:
 #

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/DenseVectorMappingUpdateIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/DenseVectorMappingUpdateIT.java
@@ -13,7 +13,6 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
-import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;

--- a/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/DenseVectorMappingUpdateIT.java
+++ b/qa/rolling-upgrade/src/javaRestTest/java/org/elasticsearch/upgrades/DenseVectorMappingUpdateIT.java
@@ -13,6 +13,7 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -91,9 +92,13 @@ public class DenseVectorMappingUpdateIT extends AbstractRollingUpgradeTestCase {
                     .startObject("properties")
                     .startObject("embedding")
                     .field("type", "dense_vector")
+                    .field("index", "true")
                     .field("dims", 4)
+                    .field("similarity", "cosine")
                     .startObject("index_options")
                     .field("type", "hnsw")
+                    .field("m", "16")
+                    .field("ef_construction", "100")
                     .endObject()
                     .endObject()
                     .endObject()
@@ -109,7 +114,7 @@ public class DenseVectorMappingUpdateIT extends AbstractRollingUpgradeTestCase {
 
             int expectedCount = 10;
 
-            assertCount("test_index", expectedCount);
+            assertCount(indexName, expectedCount);
 
             if (isUpgradedCluster() && clusterSupportsDenseVectorTypeUpdate()) {
                 Request updateMapping = new Request("PUT", "/" + indexName + "/_mapping");
@@ -118,9 +123,13 @@ public class DenseVectorMappingUpdateIT extends AbstractRollingUpgradeTestCase {
                     .startObject("properties")
                     .startObject("embedding")
                     .field("type", "dense_vector")
+                    .field("index", "true")
                     .field("dims", 4)
+                    .field("similarity", "cosine")
                     .startObject("index_options")
                     .field("type", "int8_hnsw")
+                    .field("m", "16")
+                    .field("ef_construction", "100")
                     .endObject()
                     .endObject()
                     .endObject()
@@ -132,7 +141,7 @@ public class DenseVectorMappingUpdateIT extends AbstractRollingUpgradeTestCase {
                 index.setJsonEntity(BULK2);
                 assertOK(client().performRequest(index));
                 expectedCount = 20;
-                assertCount("test_index", expectedCount);
+                assertCount(indexName, expectedCount);
             }
         }
     }
@@ -152,7 +161,7 @@ public class DenseVectorMappingUpdateIT extends AbstractRollingUpgradeTestCase {
         Map<?, ?> response = entityAsMap(client().performRequest(new Request("GET", "_nodes")));
         Map<?, ?> nodes = (Map<?, ?>) response.get("nodes");
 
-        Predicate<Map<?, ?>> nodeSupportsBulkApi = n -> Version.fromString(n.get("version").toString()).onOrAfter(Version.V_8_14_0);
+        Predicate<Map<?, ?>> nodeSupportsBulkApi = n -> Version.fromString(n.get("version").toString()).onOrAfter(Version.V_8_15_0);
 
         return nodes.values().stream().map(o -> (Map<?, ?>) o).allMatch(nodeSupportsBulkApi);
     }


### PR DESCRIPTION
Fixed `DenseVectorMappingUpdateIT` to work with a rolling upgrade scenario (unmuted test).
The following shouldn't fail anymore:
`./gradlew ':qa:rolling-upgrade:v8.7.1#bwcTest' -Dtests.class="org.elasticsearch.upgrades.DenseVectorMappingUpdateIT" -Dtests.method="testDenseVectorMappingUpdateOnOldCluster {upgradedNodes=0}" -Dtests.seed=DF24937B39856EB -Dtests.bwc=true -Dtests.locale=ar-LB -Dtests.timezone=Brazil/Acre -Druntime.java=22`