### PR TITLE
Make CsvTests consistent with integration tests for capabilities

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -119,6 +119,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assume.assumeThat;
 
 /**
  * CSV-based unit testing.
@@ -224,7 +225,7 @@ public class CsvTests extends ESTestCase {
             assumeTrue("Test " + testName + " is not enabled", isEnabled(testName, Version.CURRENT));
 
             if (Build.current().isSnapshot()) {
-                assertThat(
+                assumeThat(
                     "nonexistent capabilities declared as required",
                     testCase.requiredCapabilities,
                     everyItem(in(EsqlCapabilities.CAPABILITIES))


### PR DESCRIPTION
The integration tests do not fail the tests if the capability does not even exist on cluster nodes, instead the tests are ignored. The same behaviour should happen with CsvTests for consistency.

This issue arose within the union-types PR which has a muted test that is targeting a followup fix. The muting works as expected on all integration tests, but fails with exception in CsvTests due to this inconsistency in behaviour.

I've fixed this in the union-types PR, but since the concept is independent of that work, I thought it better to have a separate PR here.