### PR TITLE
[8.14] Mute all collapse tests for 8.13 (#109594)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/10_standard_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/10_standard_retriever.yml
@@ -473,6 +473,11 @@ setup:
 
 ---
 "standard retriever collapse":
+  - skip:
+      reason: "https://github.com/elastic/elasticsearch/issues/109476"
+      known_issues:
+        - cluster_feature: "gte_v8.13.0"
+          fixed_by: "gte_v8.14.0"
   - do:
       search:
         index: animals

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/10_standard_retriever.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.retrievers/10_standard_retriever.yml
@@ -475,9 +475,7 @@ setup:
 "standard retriever collapse":
   - skip:
       reason: "https://github.com/elastic/elasticsearch/issues/109476"
-      known_issues:
-        - cluster_feature: "gte_v8.13.0"
-          fixed_by: "gte_v8.14.0"
+      version: "8.13.0 - 8.13.5"
   - do:
       search:
         index: animals

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -1,4 +1,9 @@
 setup:
+  - skip:
+      reason: "https://github.com/elastic/elasticsearch/issues/109476"
+      known_issues:
+        - cluster_feature: "gte_v8.13.0"
+          fixed_by: "gte_v8.14.0"
   - do:
       indices.create:
         index:  test
@@ -85,7 +90,6 @@ setup:
 
 ---
 "field collapsing and from":
-
   - do:
       search:
         rest_total_hits_as_int: true

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/110_field_collapsing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/110_field_collapsing.yml
@@ -1,9 +1,7 @@
 setup:
   - skip:
       reason: "https://github.com/elastic/elasticsearch/issues/109476"
-      known_issues:
-        - cluster_feature: "gte_v8.13.0"
-          fixed_by: "gte_v8.14.0"
+      version: "8.13.0 - 8.13.5"
   - do:
       indices.create:
         index:  test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/111_field_collapsing_with_max_score.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/111_field_collapsing_with_max_score.yml
@@ -1,4 +1,9 @@
 setup:
+  - skip:
+      reason: "https://github.com/elastic/elasticsearch/issues/109476"
+      known_issues:
+        - cluster_feature: "gte_v8.13.0"
+          fixed_by: "gte_v8.14.0"
   - requires:
       cluster_features: ["gte_v8.10.0"]
       reason: Collapse with max score was fixed in 8.10.0

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/111_field_collapsing_with_max_score.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/111_field_collapsing_with_max_score.yml
@@ -1,9 +1,7 @@
 setup:
   - skip:
       reason: "https://github.com/elastic/elasticsearch/issues/109476"
-      known_issues:
-        - cluster_feature: "gte_v8.13.0"
-          fixed_by: "gte_v8.14.0"
+      version: "8.13.0 - 8.13.5"
   - requires:
       cluster_features: ["gte_v8.10.0"]
       reason: Collapse with max score was fixed in 8.10.0

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/115_multiple_field_collapsing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/115_multiple_field_collapsing.yml
@@ -1,3 +1,9 @@
+setup:
+  - skip:
+      reason: "https://github.com/elastic/elasticsearch/issues/109476"
+      known_issues:
+        - cluster_feature: "gte_v8.13.0"
+          fixed_by: "gte_v8.14.0"
 ---
 "two levels fields collapsing":
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/115_multiple_field_collapsing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/115_multiple_field_collapsing.yml
@@ -1,9 +1,7 @@
 setup:
   - skip:
       reason: "https://github.com/elastic/elasticsearch/issues/109476"
-      known_issues:
-        - cluster_feature: "gte_v8.13.0"
-          fixed_by: "gte_v8.14.0"
+      version: "8.13.0 - 8.13.5"
 ---
 "two levels fields collapsing":
 

--- a/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/60_collapse.yml
+++ b/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/60_collapse.yml
@@ -1,5 +1,9 @@
 setup:
-
+  - skip:
+      reason: "https://github.com/elastic/elasticsearch/issues/109476"
+      known_issues:
+        - cluster_feature: "gte_v8.13.0"
+          fixed_by: "gte_v8.14.0"
   - requires:
       cluster_features: ["gte_v8.0.0"]
       reason: "collapse on unsigned_long was added in 8.0"

--- a/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/60_collapse.yml
+++ b/x-pack/plugin/mapper-unsigned-long/src/yamlRestTest/resources/rest-api-spec/test/60_collapse.yml
@@ -1,9 +1,7 @@
 setup:
   - skip:
       reason: "https://github.com/elastic/elasticsearch/issues/109476"
-      known_issues:
-        - cluster_feature: "gte_v8.13.0"
-          fixed_by: "gte_v8.14.0"
+      version: "8.13.0 - 8.13.5"
   - requires:
       cluster_features: ["gte_v8.0.0"]
       reason: "collapse on unsigned_long was added in 8.0"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Mute all collapse tests for 8.13 (#109594)](https://github.com/elastic/elasticsearch/pull/109594)

<!--- Backport version: 9.4.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)