### PR TITLE
Fix XContent for _score column response

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
@@ -166,6 +166,14 @@ abstract class PositionToXContent {
                     }
                 }
             };
+            case "float" -> new PositionToXContent(block) {
+                @Override
+                protected XContentBuilder valueToXContent(XContentBuilder builder, ToXContent.Params params, int valueIndex)
+                    throws IOException {
+                    Float val = Float.intBitsToFloat(((IntBlock) block).getInt(valueIndex));
+                    return builder.value(val);
+                }
+            };
             default -> throw new IllegalArgumentException("can't convert values of type [" + columnInfo.type() + "]");
         };
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -388,6 +388,32 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
         }
     }
 
+    public void testScoreColumnXContent() {
+        try (
+            EsqlQueryResponse response = new EsqlQueryResponse(
+                List.of(new ColumnInfo("_score", "float")),
+                List.of(
+                    new Page(
+                        blockFactory.newIntArrayVector(new int[] { Float.floatToIntBits(5.1F), Float.floatToIntBits(2.1F) }, 2).asBlock()
+                    )
+                ),
+                null,
+                false,
+                null,
+                false,
+                false
+            )
+        ) {
+            assertThat(
+                Strings.toString(wrapAsToXContent(response), new ToXContent.MapParams(Map.of(DROP_NULL_COLUMNS_OPTION, "true"))),
+                equalTo("{" + """
+                    "all_columns":[{"name":"_score","type":"float"}],""" + """
+                    "columns":[{"name":"_score","type":"float"}],""" + """
+                    "values":[[5.1],[2.1]]}""")
+            );
+        }
+    }
+
     public void testNullColumnsXContentDropNulls() {
         try (
             EsqlQueryResponse response = new EsqlQueryResponse(


### PR DESCRIPTION
Right now we see an error being returned when using the `SEARCH` command:

```
POST _query
{
  "query": """
  SEARCH books [|WHERE page_count > 100] | LIMIT 10
  """
}  

Response
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "can't convert values of type [float]"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "can't convert values of type [float]"
  },
  "status": 400
}
```

The exception is raised in:

https://github.com/elastic/elasticsearch/blob/366c0b16bf80807063df971da5afc2986d5c0e41/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java#L169

because `_score` column is defined as a float which cannot be currently handled in `PositionToXContent`.

This is because ESQL converts float mapping fields to double, but `_score` is not a mapping field (it's currently treated as a metadata field).
