### PR TITLE
[Query Rules] Require Enterprise License for Query Rules

### DIFF
--- a/docs/changelog/109634.yaml
+++ b/docs/changelog/109634.yaml
@@ -1,0 +1,5 @@
+pr: 109634
+summary: "[Query Rules] Require Enterprise License for Query Rules"
+area: Relevance
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/XPackLicenseState.java
@@ -58,7 +58,10 @@ public class XPackLicenseState {
         messages.put(XPackField.DEPRECATION, new String[] { "Deprecation APIs are disabled" });
         messages.put(XPackField.UPGRADE, new String[] { "Upgrade API is disabled" });
         messages.put(XPackField.SQL, new String[] { "SQL support is disabled" });
-        messages.put(XPackField.ENTERPRISE_SEARCH, new String[] { "Search Applications and behavioral analytics will be disabled" });
+        messages.put(
+            XPackField.ENTERPRISE_SEARCH,
+            new String[] { "Search Applications, query rules and behavioral analytics will be disabled" }
+        );
         messages.put(
             XPackField.ROLLUP,
             new String[] {
@@ -222,11 +225,16 @@ public class XPackLicenseState {
             case STANDARD:
             case GOLD:
                 switch (currentMode) {
-                    case TRIAL:
                     case PLATINUM:
+                        return new String[] {
+                            "Search Applications and behavioral analytics will be disabled.",
+                            "Elastic Web crawler will be disabled.",
+                            "Connector clients require at least a platinum license." };
+                    case TRIAL:
                     case ENTERPRISE:
                         return new String[] {
                             "Search Applications and behavioral analytics will be disabled.",
+                            "Query rules will be disabled.",
                             "Elastic Web crawler will be disabled.",
                             "Connector clients require at least a platinum license." };
                 }

--- a/x-pack/plugin/ent-search/src/main/java/module-info.java
+++ b/x-pack/plugin/ent-search/src/main/java/module-info.java
@@ -37,6 +37,7 @@ module org.elasticsearch.application {
     exports org.elasticsearch.xpack.application.connector.action;
     exports org.elasticsearch.xpack.application.connector.syncjob;
     exports org.elasticsearch.xpack.application.connector.syncjob.action;
+    exports org.elasticsearch.xpack.application.utils;
 
     provides org.elasticsearch.features.FeatureSpecification with org.elasticsearch.xpack.application.EnterpriseSearchFeatures;
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandler.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchBaseRestHandler.java
@@ -26,7 +26,7 @@ public abstract class EnterpriseSearchBaseRestHandler extends BaseRestHandler {
     }
 
     protected final BaseRestHandler.RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        if (LicenseUtils.supportedLicense(this.licenseState)) {
+        if (LicenseUtils.supportedLicense(this.product, this.licenseState)) {
             return innerPrepareRequest(request, client);
         } else {
             // We need to consume parameters and content from the REST request in order to bypass unrecognized param errors

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchInfoTransportAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchInfoTransportAction.java
@@ -43,7 +43,7 @@ public class EnterpriseSearchInfoTransportAction extends XPackInfoFeatureTranspo
 
     @Override
     public boolean available() {
-        return LicenseUtils.LICENSED_ENT_SEARCH_FEATURE.checkWithoutTracking(licenseState);
+        return LicenseUtils.PLATINUM_LICENSED_FEATURE.checkWithoutTracking(licenseState);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchUsageTransportAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearchUsageTransportAction.java
@@ -97,7 +97,7 @@ public class EnterpriseSearchUsageTransportAction extends XPackUsageFeatureTrans
     ) {
         if (enabled == false) {
             EnterpriseSearchFeatureSetUsage usage = new EnterpriseSearchFeatureSetUsage(
-                LicenseUtils.LICENSED_ENT_SEARCH_FEATURE.checkWithoutTracking(licenseState),
+                LicenseUtils.PLATINUM_LICENSED_FEATURE.checkWithoutTracking(licenseState),
                 enabled,
                 Collections.emptyMap(),
                 Collections.emptyMap(),
@@ -121,7 +121,7 @@ public class EnterpriseSearchUsageTransportAction extends XPackUsageFeatureTrans
             listener.onResponse(
                 new XPackUsageFeatureResponse(
                     new EnterpriseSearchFeatureSetUsage(
-                        LicenseUtils.LICENSED_ENT_SEARCH_FEATURE.checkWithoutTracking(licenseState),
+                        LicenseUtils.PLATINUM_LICENSED_FEATURE.checkWithoutTracking(licenseState),
                         enabled,
                         searchApplicationsUsage,
                         analyticsCollectionsUsage,
@@ -133,7 +133,7 @@ public class EnterpriseSearchUsageTransportAction extends XPackUsageFeatureTrans
             listener.onResponse(
                 new XPackUsageFeatureResponse(
                     new EnterpriseSearchFeatureSetUsage(
-                        LicenseUtils.LICENSED_ENT_SEARCH_FEATURE.checkWithoutTracking(licenseState),
+                        LicenseUtils.PLATINUM_LICENSED_FEATURE.checkWithoutTracking(licenseState),
                         enabled,
                         Collections.emptyMap(),
                         analyticsCollectionsUsage,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
@@ -14,43 +14,63 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.XPackField;
 
+import java.util.Locale;
+
 public final class LicenseUtils {
     public enum Product {
-        SEARCH_APPLICATION("search application"),
-        BEHAVIORAL_ANALYTICS("behavioral analytics"),
-        QUERY_RULES("query rules");
+        SEARCH_APPLICATION("search application", License.OperationMode.PLATINUM),
+        BEHAVIORAL_ANALYTICS("behavioral analytics", License.OperationMode.PLATINUM),
+        QUERY_RULES("query rules", License.OperationMode.ENTERPRISE),;
 
         private final String name;
+        private final License.OperationMode requiredLicense;
 
-        Product(String name) {
+        Product(String name, License.OperationMode requiredLicense) {
             this.name = name;
+            this.requiredLicense = requiredLicense;
         }
 
         public String getName() {
             return name;
         }
+
+        public LicensedFeature.Momentary getLicensedFeature() {
+            return switch (requiredLicense) {
+                case PLATINUM -> PLATINUM_LICENSED_FEATURE;
+                case ENTERPRISE -> ENTERPRISE_LICENSED_FEATURE;
+                default -> throw new IllegalStateException("Unknown license operation mode: " + requiredLicense);
+            };
+        }
     }
 
-    public static final LicensedFeature.Momentary LICENSED_ENT_SEARCH_FEATURE = LicensedFeature.momentary(
+    public static final LicensedFeature.Momentary PLATINUM_LICENSED_FEATURE = LicensedFeature.momentary(
         null,
         XPackField.ENTERPRISE_SEARCH,
         License.OperationMode.PLATINUM
     );
 
-    public static boolean supportedLicense(XPackLicenseState licenseState) {
-        return LICENSED_ENT_SEARCH_FEATURE.check(licenseState);
+    public static final LicensedFeature.Momentary ENTERPRISE_LICENSED_FEATURE = LicensedFeature.momentary(
+        null,
+        XPackField.ENTERPRISE_SEARCH,
+        License.OperationMode.ENTERPRISE
+    );
+
+    public static boolean supportedLicense(Product product, XPackLicenseState licenseState) {
+        return product.getLicensedFeature().check(licenseState);
     }
 
     public static ElasticsearchSecurityException newComplianceException(XPackLicenseState licenseState, Product product) {
         String licenseStatus = licenseState.statusDescription();
+        String requiredLicenseStatus = product.requiredLicense.toString().toLowerCase(Locale.ROOT);
 
         ElasticsearchSecurityException e = new ElasticsearchSecurityException(
             "Current license is non-compliant for "
                 + product.getName()
                 + ". Current license is {}. "
-                + "This feature requires an active trial, platinum or enterprise license.",
+                + "This feature requires an active trial, {}, or higher license.",
             RestStatus.FORBIDDEN,
-            licenseStatus
+            licenseStatus,
+            requiredLicenseStatus
         );
         return e;
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/AnalyticsTransportActionTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/AnalyticsTransportActionTestUtils.java
@@ -33,7 +33,7 @@ public class AnalyticsTransportActionTestUtils {
     public static MockLicenseState mockLicenseState(boolean supported) {
         MockLicenseState licenseState = mock(MockLicenseState.class);
 
-        when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(supported);
+        when(licenseState.isAllowed(LicenseUtils.PLATINUM_LICENSED_FEATURE)).thenReturn(supported);
         when(licenseState.isActive()).thenReturn(supported);
         when(licenseState.statusDescription()).thenReturn("invalid license");
 


### PR DESCRIPTION
When we GA query rules we plan to offer it under an Enterprise License. This PR refactors the Enterprise Search module licensing to support different licenses for different products. 

Here are some sample errors when trying to send requests to search applications (platinum license) or query rules (enterprise license) when using a basic license: 

```
{
  "error": {
    "root_cause": [
      {
        "type": "security_exception",
        "reason": "Current license is non-compliant for search application. Current license is active basic license. This feature requires an active trial, platinum, or higher license."
      }
    ],
    "type": "security_exception",
    "reason": "Current license is non-compliant for search application. Current license is active basic license. This feature requires an active trial, platinum, or higher license."
  },
  "status": 403
}

{
  "error": {
    "root_cause": [
      {
        "type": "security_exception",
        "reason": "Current license is non-compliant for query rules. Current license is active basic license. This feature requires an active trial, enterprise, or higher license."
      }
    ],
    "type": "security_exception",
    "reason": "Current license is non-compliant for query rules. Current license is active basic license. This feature requires an active trial, enterprise, or higher license."
  },
  "status": 403
}
```

Additionally, here is the error message when trying to access query rules using a platinum license: 

```
{
  "error": {
    "root_cause": [
      {
        "type": "security_exception",
        "reason": "Current license is non-compliant for query rules. Current license is active platinum license. This feature requires an active trial, enterprise, or higher license."
      }
    ],
    "type": "security_exception",
    "reason": "Current license is non-compliant for query rules. Current license is active platinum license. This feature requires an active trial, enterprise, or higher license."
  },
  "status": 403
}
```