### PR TITLE
[8.14] [Data streams] Fix the source of a lazy rollover task (#109629)

### DIFF
--- a/docs/changelog/109629.yaml
+++ b/docs/changelog/109629.yaml
@@ -1,0 +1,5 @@
+pr: 109629
+summary: "[Data streams] Fix the description of the lazy rollover task"
+area: Data streams
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/LazyRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/LazyRolloverAction.java
@@ -118,7 +118,7 @@ public final class LazyRolloverAction extends ActionType<RolloverResponse> {
                 false
             );
 
-            String source = "lazy_rollover source [" + trialRolloverIndexName + "] to target [" + trialRolloverIndexName + "]";
+            String source = "lazy_rollover source [" + trialSourceIndexName + "] to target [" + trialRolloverIndexName + "]";
             // We create a new rollover request to ensure that it doesn't contain any other parameters apart from the data stream name
             // This will provide a more resilient user experience
             RolloverTask rolloverTask = new RolloverTask(


### PR DESCRIPTION
Backports the following commits to 8.14:
 - [Data streams] Fix the source of a lazy rollover task (#109629)