### PR TITLE
WIP: Populated event.ingested min/max ranges for existing searchable snapshots

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -1347,6 +1347,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         return timestampRange;
     }
 
+    // TODO: bogus placeholder until I can merge the first PR for event.ingested
+    public IndexLongFieldRange getEventIngestedRange() {
+        return timestampRange;
+    }
+
     /**
      * @return whether this index has a time series timestamp range
      */
@@ -2091,6 +2096,12 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
         public Builder timestampRange(IndexLongFieldRange timestampRange) {
             this.timestampRange = timestampRange;
+            return this;
+        }
+
+        // TODO: bogus placeholder until I can merge the first PR
+        public Builder eventIngestedRange(IndexLongFieldRange timestampRange) {
+            // this.timestampRange = timestampRange;
             return this;
         }
 

--- a/server/src/main/java/org/elasticsearch/indices/cluster/EventIngestedRangeClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/EventIngestedRangeClusterStateService.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.cluster;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionListenerResponseHandler;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateApplier;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexService;
+import org.elasticsearch.index.shard.IndexLongFieldRange;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardLongFieldRange;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.TransportResponseHandler;
+import org.elasticsearch.transport.TransportService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * TODO LIST (Priority Order)
+ *  ✓ Rearrange skeleton to have the Task submission only run on master
+ *  ✓ Change code to properly screen for frozen shards only
+ *  ✓ Determine how to update cluster state with the new index min/max ranges in TaskExecutor.execute
+ *  ¤ Start writing UNIT tests for the above - are there similar unit tests for ShardStateAction.execute?
+ *  ¤ Is there a way I can do manual testing of above?
+ *  ¤
+ *  ¤ Figure out what Writeable data structures need to go into the UpdateEventIngestedRangeRequest - implement that and manual testing
+ *  ¤
+ *  ¤ Design error handling and bwc - what if the master is older and doesn't have the transport action? (or any other TA error occurs)
+ *  ¤ Fork shard min/max range lookups to background on data nodes?
+ *  ¤ Pull TransportUpdateSettingsAction out to separate class file?
+ *  ¤ Any basic unit tests to write? (compare to SnapshotsService and MetadataUpdateSettingsService)
+ *  ¤ Start writing IT tests
+ *  ¤ Deal with isDedicatedFrozenNode in the doStart check - remove this? Better way to detect if you have frozen indices?
+ *  ¤
+ *  ¤
+ */
+
+/**
+ * TODO: DOCUMENT ME
+ * Runs only on data nodes.
+ * Sends event.ingested range to the master node via the TimestampRangeTransportAction
+ */
+// TODO: maybe rename to TimestampRangeClusterStateService ?
+// TODO: other idea: add this functionality to IndicesClusterStateService?
+// TODO: when can we remove this listener? when all frozen indices have complete event.ingested ranges in cluster state
+// TODO: move to ClusterStateListener
+public class EventIngestedRangeClusterStateService extends AbstractLifecycleComponent implements ClusterStateApplier {
+    private static final Logger logger = LogManager.getLogger(EventIngestedRangeClusterStateService.class);
+
+    private final Settings settings;
+    private final ClusterService clusterService;
+    private final TransportService transportService;
+    private final IndicesService indicesService;
+
+    public EventIngestedRangeClusterStateService(
+        Settings settings,
+        ClusterService clusterService,
+        TransportService transportService,
+        IndicesService indicesService
+    ) {
+        this.settings = settings;
+        this.clusterService = clusterService;
+        this.transportService = transportService;
+        this.indicesService = indicesService;
+
+        logger.warn("XXX EventIngestedRangeClusterStateService constructor");
+    }
+
+    @Override
+    protected void doStart() {
+        logger.warn(
+            "XXX EventIngestedRangeClusterStateService.doStart called: canContainData: {}; dedicated frozen: {}; can I get local node:? {}",
+            DiscoveryNode.canContainData(settings),
+            DiscoveryNode.isDedicatedFrozenNode(settings),
+            this.transportService.getLocalNode() != null
+        );
+
+        // MP TODO: There is the method DataTier.isFrozen(DiscoveryNode node) method but I don't know how to get the local DiscoveryNode
+        // MP TODO: can't do "transportService.getLocalNode().canContainData()"; NPE since getLocalNode() returns null
+
+        // only run this service on data nodes (for example, master has no frozen shards to access)
+        // TODO: is DiscoveryNode.isDedicatedFrozenNode(settings) too restrictive?
+        // TODO: what is the best way to limit this to nodes that have a frozen shards?
+        if (DiscoveryNode.canContainData(settings) && DiscoveryNode.isDedicatedFrozenNode(settings)) {
+            logger.warn("XXX doStart 1");
+            clusterService.addStateApplier(this);
+        } else {
+            logger.warn("XXX doStart 2");
+            clusterService.addStateApplier(this);  // MP TODO: remove after manual testing done
+        }
+    }
+
+    @Override
+    protected void doStop() {
+        if (DiscoveryNode.canContainData(settings)) {
+            clusterService.removeApplier(this);
+        }
+    }
+
+    @Override
+    protected void doClose() throws IOException {}
+
+    /**
+     * Runs on data nodes.
+     * If a cluster version upgrade is detected (e.g., moving from 8.15.0 to 8.16.0), then a Task
+     * will be launched to determine whether any searchable snapshot shards "owned" by this
+     * data node need to have their 'event.ingested' min/max range updated in cluster state.
+     */
+    @Override
+    public void applyClusterState(ClusterChangedEvent event) {
+        // only run this task when a cluster has upgraded to a new version
+        // TODO: how is this going to work in serverless? will event.state().nodes().getMinNodeVersion() return useful info?
+        if (clusterVersionUpgrade(event)) {
+            Iterator<ShardRouting> shardRoutingIterator = event.state()
+                .getRoutingNodes()
+                .node(event.state().nodes().getLocalNodeId())
+                .iterator();
+
+            logger.warn(
+                "XXX EventIngestedRangeClusterStateService.applyClusterState DEBUG 2. Created iterator: {}",
+                shardRoutingIterator.hasNext()
+            );
+
+            List<ShardRouting> shardsForLookup = new ArrayList<>();
+            while (shardRoutingIterator.hasNext()) {
+                ShardRouting shardRouting = shardRoutingIterator.next();
+                Settings indexSettings = event.state().metadata().index(shardRouting.index()).getSettings();
+                if (isFrozenIndex(indexSettings)) {
+                    shardsForLookup.add(shardRouting);
+                }
+            }
+
+            logger.warn("XXX EventIngestedRangeClusterStateService.applyClusterState DEBUG 3. shardsForLookup: {}", shardsForLookup.size());
+
+            // TODO: should the key be String or Index?
+            Map<Index, List<ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
+
+            // MP TODO - bogus entry to have something for initial testing -- start
+            // Index mpidx = new Index("mpidx", UUID.randomUUID().toString());
+            // List<ShardRangeInfo> shardRangeList = new ArrayList<>();
+            // shardRangeList.add(new ShardRangeInfo(new ShardId(mpidx, 22), ShardLongFieldRange.UNKNOWN));
+            // eventIngestedRangeMap.put(mpidx, shardRangeList);
+            // MP TODO - bogus entry to have something for initial testing -- end
+
+            // TODO: this min/max lookup logic likely needs to be forked to background (how do I do that?)
+
+            // TODO: create new list or map here of shards/indexes and new min/max range to update
+            for (ShardRouting shardRouting : shardsForLookup) {
+                IndexService indexService = indicesService.indexService(shardRouting.index());
+                IndicesClusterStateService.Shard shard = indexService.getShardOrNull(shardRouting.shardId().id());
+                // TODO: the above can return null - what do I do in that case?
+                // TODO: ^^ speaks to the larger issue of error handling - what if on this pass not all the shards can't be
+                // TODO: inspected for some reason - then the event.ingested range remains unusable until the next version upgrade?
+                if (shard != null) {
+                    // TODO: should I call metadata.index(String) or metadata.index(Index)? The latter doesn't work in my other test
+                    IndexMetadata indexMetadata = event.state().metadata().index(shardRouting.index());
+                    // TODO: is indexMetadata guaranteed to never be null here?
+                    IndexLongFieldRange clusterStateEventIngestedRange = indexMetadata.getEventIngestedRange();
+
+                    // MP TODO: is this the right check for whether to get min/max range from a shard?
+                    if (shard.getEventIngestedRange() != ShardLongFieldRange.UNKNOWN
+                        && clusterStateEventIngestedRange.containsAllShardRanges() == false) {
+                        // MP TODO: it would be nice to be able to call getMax and getMin on the range in cluster state to avoid
+                        // TODO unnecessary network calls,
+                        // TODO but we aren't allowed to call those unless all shards are accounted for (so nothing left to update)
+
+                        List<ShardRangeInfo> rangeInfoList = eventIngestedRangeMap.get(shardRouting.index());
+                        if (rangeInfoList == null) {
+                            rangeInfoList = new ArrayList<>();
+                            eventIngestedRangeMap.put(shardRouting.index(), rangeInfoList);
+                        }
+                        rangeInfoList.add(new ShardRangeInfo(shard.shardId(), shard.getEventIngestedRange()));
+                    }
+                }
+            }
+
+            if (eventIngestedRangeMap.isEmpty() == false) {
+
+                UpdateEventIngestedRangeRequest request = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
+
+                ActionListener<ActionResponse.Empty> execListener = new ActionListener<>() {
+                    @Override
+                    public void onResponse(ActionResponse.Empty response) {
+                        try {
+                            logger.warn("XXX YYY TaskExecutor.ActionListener onResponse: {}", response);
+                        } catch (Exception e) {
+                            onFailure(e);
+                        }
+                    }
+
+                    // TODO: what do we do on failure? Should we set a flag in the service stating that next time
+                    // >>TODO: applyClusterState is called to try again regardless of whether there was a cluster version upgrade?
+                    @Override
+                    public void onFailure(Exception e) {
+                        logger.warn("XXX YYY TaskExecutor.ActionListener onFailure: {}", e.getMessage());
+                    }
+
+                    @Override
+                    public String toString() {
+                        return "My temp exec listener in TaskExecutor";
+                    }
+                };
+
+                logger.warn(
+                    "XXX About to send to Master {}. request: {}",
+                    UpdateEventIngestedRangeTransportAction.UPDATE_EVENT_INGESTED_RANGE_ACTION_NAME,
+                    request
+                );
+                // MP TODO: need to add tests around the Transport Service
+                transportService.sendRequest(
+                    transportService.getLocalNode(),
+                    UpdateEventIngestedRangeTransportAction.UPDATE_EVENT_INGESTED_RANGE_ACTION_NAME,
+                    request,
+                    // TODO: do I need something better than this response handler?
+                    // TODO: is it useful if all I'm getting is an ack that doesn't guarantee that cluster state was updated?
+                    new ActionListenerResponseHandler<>(
+                        execListener.safeMap(r -> null),
+                        in -> ActionResponse.Empty.INSTANCE,
+                        TransportResponseHandler.TRANSPORT_WORKER
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Determine whether a cluster version upgrade has just happened.
+     */
+    private boolean clusterVersionUpgrade(ClusterChangedEvent event) {
+        logger.warn("XXX clusterVersionUpgrade: event.nodesChanged(): " + event.nodesChanged());
+        logger.warn("XXX clusterVersionUpgrade: event.state().nodes().getMinNodeVersion(): " + event.state().nodes().getMinNodeVersion());
+        logger.warn("XXX clusterVersionUpgrade: event.state().nodes().getMaxNodeVersion(): " + event.state().nodes().getMaxNodeVersion());
+        // return event.nodesChanged() &&
+        // event.state().nodes().getMinNodeVersion() == event.state().nodes().getMaxNodeVersion() &&
+        // event.previousState().nodes().getMinNodeVersion() == event.state().nodes().getMinNodeVersion();
+        return event.nodesChanged() || event.nodesRemoved();  // MP FIXME
+    }
+
+    // TODO: copied from FrozenUtils - should that one move to core/server rather than be in xpack?
+    public static boolean isFrozenIndex(Settings indexSettings) {
+        return true;  // MP FIXME
+        // String tierPreference = DataTier.TIER_PREFERENCE_SETTING.get(indexSettings);
+        // List<String> preferredTiers = DataTier.parseTierList(tierPreference);
+        // if (preferredTiers.isEmpty() == false && preferredTiers.get(0).equals(DataTier.DATA_FROZEN)) {
+        // assert preferredTiers.size() == 1 : "frozen tier preference must be frozen only";
+        // return true;
+        // } else {
+        // return false;
+        // }
+    }
+
+    public static class ShardRangeInfo extends TransportRequest {
+        final ShardId shardId;
+        final ShardLongFieldRange eventIngestedRange;
+
+        ShardRangeInfo(StreamInput in) throws IOException {
+            super(in);
+            this.shardId = new ShardId(in);
+            this.eventIngestedRange = ShardLongFieldRange.readFrom(in);
+        }
+
+        public ShardRangeInfo(ShardId shardId, ShardLongFieldRange eventIngestedRange) {
+            this.shardId = shardId;
+            this.eventIngestedRange = eventIngestedRange;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            shardId.writeTo(out);
+            eventIngestedRange.writeTo(out);
+        }
+
+        @Override
+        public String toString() {
+            return Strings.format(
+                "EventIngestedRangeService.ShardRangeInfo{shardId [%s], eventIngestedRange [%s]}",
+                shardId,
+                eventIngestedRange
+            );
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ShardRangeInfo that = (ShardRangeInfo) o;
+            return shardId.equals(that.shardId) && eventIngestedRange.equals(that.eventIngestedRange);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(shardId, eventIngestedRange);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/cluster/EventIngestedRangeClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/EventIngestedRangeClusterStateService.java
@@ -238,7 +238,7 @@ public class EventIngestedRangeClusterStateService extends AbstractLifecycleComp
                     // TODO: is it useful if all I'm getting is an ack that doesn't guarantee that cluster state was updated?
                     new ActionListenerResponseHandler<>(
                         execListener.safeMap(r -> null),
-                        in -> ActionResponse.Empty.INSTANCE,
+                        in -> ActionResponse.Empty.INSTANCE,  // TODO: there is a way to wait for the TaskExecutor to finish
                         TransportResponseHandler.TRANSPORT_WORKER
                     )
                 );

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -1123,6 +1123,11 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         @Nullable
         ShardLongFieldRange getTimestampRange();
 
+        // TODO: bogus impl until first PR merges
+        default ShardLongFieldRange getEventIngestedRange() {
+            return ShardLongFieldRange.UNKNOWN;
+        }
+
         /**
          * Updates the shard state based on an incoming cluster state:
          * - Updates and persists the new routing value.

--- a/server/src/main/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeRequest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.cluster;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+// modelled after UpdateIndexShardSnapshotStatusRequest
+
+/**
+ * Internal request that is used to send changes in event.ingested min/max cluster state ranges (per index) to master
+ */
+public class UpdateEventIngestedRangeRequest extends MasterNodeRequest<UpdateEventIngestedRangeRequest> {
+    private static final Logger logger = LogManager.getLogger(UpdateEventIngestedRangeRequest.class);
+
+    private Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap;
+
+    protected UpdateEventIngestedRangeRequest(Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> rangeMap) {
+        super(TimeValue.MAX_VALUE); // By default, keep trying to post updates to avoid snapshot processes getting stuck // TODO: this ok?
+        this.eventIngestedRangeMap = rangeMap;
+    }
+
+    protected UpdateEventIngestedRangeRequest(StreamInput in) throws IOException {
+        // TODO: likely need put TransportVersion guards here like we did for _resolve/cluster?
+        super(in);
+        logger.warn("LLL: DEBUG 1 READ from StreamInput of UpdateEventIngestedRangeRequest");
+        this.eventIngestedRangeMap = in.readMap(
+            Index::new,
+            i -> i.readCollectionAsList(EventIngestedRangeClusterStateService.ShardRangeInfo::new)
+        );
+        logger.warn(
+            "LLL: successfully DEBUG 2 READ from StreamInput of UpdateEventIngestedRangeRequest; dummyMap: {}",
+            eventIngestedRangeMap
+        );
+    }
+
+    public Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> getEventIngestedRangeMap() {
+        return eventIngestedRangeMap;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        // TODO: likely need put TransportVersion guards here like we did for _resolve/cluster?
+        logger.warn("LLL: DEBUG 1 WROTE to StreamOutput of UpdateEventIngestedRangeRequest");
+        out.writeMap(eventIngestedRangeMap, StreamOutput::writeWriteable, StreamOutput::writeCollection);
+        logger.warn("LLL: successfully DEBUG 2 WROTE to StreamOutput of UpdateEventIngestedRangeRequest");
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public String getDescription() {
+        return "update event.ingested min/max range request"; // MP TODO: remove this?
+    }
+
+    @Override
+    public String toString() {
+        return "UpdateEventIngestedRangeRequest{" + eventIngestedRangeMap + "}";
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportAction.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.cluster;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.IndexLongFieldRange;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class UpdateEventIngestedRangeTransportAction extends TransportMasterNodeAction<
+    UpdateEventIngestedRangeRequest,
+    ActionResponse.Empty> {
+    private static final Logger logger = LogManager.getLogger(UpdateEventIngestedRangeTransportAction.class);
+
+    // TODO: move this to top of file or to its own class
+    public static final String UPDATE_EVENT_INGESTED_RANGE_ACTION_NAME = "internal:cluster/snapshot/update_event_ingested_range";
+
+    public static final ActionType<ActionResponse.Empty> TYPE = new ActionType<>(UPDATE_EVENT_INGESTED_RANGE_ACTION_NAME);
+
+    // TODO: move the Action class to its own top level class?
+    // transport action to send info about updated min/max 'event.ingested' range info to master
+    // modelled after SnapshotsService.UpdateSnapshotStatusAction
+    // TransportMasterNodeAction ensures this will run on the master node
+
+    private final MasterServiceTaskQueue<EventIngestedRangeTask> masterServiceTaskQueue;
+
+    @Inject
+    public UpdateEventIngestedRangeTransportAction(
+        TransportService transportService,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ActionFilters actionFilters,
+        IndexNameExpressionResolver indexNameExpressionResolver  // MP TODO: hmm - probably don't need this?
+    ) {
+        super(
+            UPDATE_EVENT_INGESTED_RANGE_ACTION_NAME,
+            false,
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            UpdateEventIngestedRangeRequest::new,
+            indexNameExpressionResolver,
+            in -> ActionResponse.Empty.INSTANCE,
+            EsExecutors.DIRECT_EXECUTOR_SERVICE
+        );
+
+        this.masterServiceTaskQueue = clusterService.createTaskQueue(
+            "event-ingested-range-cluster-state-service",
+            Priority.NORMAL,
+            new TaskExecutor()
+        );
+
+        // TODO: Hmm, I'm seeing this created on data-only nodes - is that OK?
+        logger.warn("XXX YYY: UpdateEventIngestedRangeAction ctor");
+    }
+
+    // MP TODO: why is this method passed ClusterState? what is it allowed to do? Can it update cluster state?
+    @Override
+    protected void masterOperation(
+        Task task,
+        UpdateEventIngestedRangeRequest request,
+        ClusterState state,
+        ActionListener<ActionResponse.Empty> listener
+    ) {
+        logger.warn("XXX YYY UpdateEventIngestedRangeAction.masterOperation NOW SUBMITTING TASK. Request: {}", request);
+
+        masterServiceTaskQueue.submitTask(
+            "update-event-ingested-in-cluster-state",
+            new CreateEventIngestedRangeTask(request),
+            TimeValue.MAX_VALUE
+        );
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(UpdateEventIngestedRangeRequest request, ClusterState state) {
+        return null;
+    }
+
+    // runs on the master node only (called from masterOperation of UpdateEventIngestedRangeAction
+    public static class TaskExecutor implements ClusterStateTaskExecutor<EventIngestedRangeTask> {
+        @Override
+        public ClusterState execute(BatchExecutionContext<EventIngestedRangeTask> batchExecutionContext) throws Exception {
+            ClusterState state = batchExecutionContext.initialState();
+            final Map<Index, IndexLongFieldRange> updatedEventIngestedRanges = new HashMap<>();
+            for (var taskContext : batchExecutionContext.taskContexts()) {
+                EventIngestedRangeTask task = taskContext.getTask();
+                if (task instanceof CreateEventIngestedRangeTask rangeTask) {
+                    Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> rangeMap = rangeTask.rangeUpdateRequest()
+                        .getEventIngestedRangeMap();
+
+                    for (Map.Entry<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> entry : rangeMap.entrySet()) {
+                        Index index = entry.getKey();
+                        List<EventIngestedRangeClusterStateService.ShardRangeInfo> shardRangeList = entry.getValue();
+
+                        // TODO: why does state.getMetadata().index(index) return null in my tests but
+                        // state.getMetadata().index(index.getName()) does not?
+                        // TODO: is it realistic to assume that IndexMetadata would never be null here?
+                        IndexMetadata indexMetadata = state.getMetadata().index(index.getName());
+
+                        // get the latest EventIngestedRange either from the map outside this loop (first choice) or from cluster state
+                        IndexLongFieldRange currentEventIngestedRange = updatedEventIngestedRanges.get(index);
+                        if (currentEventIngestedRange == null && indexMetadata != null) {
+                            currentEventIngestedRange = indexMetadata.getEventIngestedRange();
+                        }
+                        // is this guaranteed to be not null? - it will be UNKNOWN if not set in cluster state (?), but for safety ...
+                        // TODO: can we remove the null checks and look for UNKNOWN instead; must look for UNKNOWN (?)
+                        // TODO: on prev PR, all shards should be UNKNOWN on mixed clusters - add assertion for that in prev PR
+                        if (currentEventIngestedRange == null) {
+                            currentEventIngestedRange = IndexLongFieldRange.NO_SHARDS;
+                        }
+                        IndexLongFieldRange newEventIngestedRange = currentEventIngestedRange;
+                        for (EventIngestedRangeClusterStateService.ShardRangeInfo shardRange : shardRangeList) {
+                            newEventIngestedRange = newEventIngestedRange.extendWithShardRange(
+                                shardRange.shardId.id(),
+                                indexMetadata.getNumberOfShards(),
+                                shardRange.eventIngestedRange
+                            );
+                        }
+
+                        // TODO: or should we use .equals rather than '==' ?? (the .equals method on this class is very strange IMO)
+                        if (newEventIngestedRange != currentEventIngestedRange) {
+                            updatedEventIngestedRanges.put(index, newEventIngestedRange);
+                        }
+                    }
+                }
+            }
+            if (updatedEventIngestedRanges.size() > 0) {
+                Metadata.Builder metadataBuilder = Metadata.builder(state.metadata());
+                for (Map.Entry<Index, IndexLongFieldRange> entry : updatedEventIngestedRanges.entrySet()) {
+                    Index index = entry.getKey();
+                    IndexLongFieldRange range = entry.getValue();
+
+                    metadataBuilder.put(IndexMetadata.builder(metadataBuilder.get(index.getName())).eventIngestedRange(range));
+                    // TODO: again, builder.getSafe(index)) returns null, but builder.get(index.getName())) does not - why?
+                    // metadataBuilder.put(IndexMetadata.builder(metadataBuilder.getSafe(index)).eventIngestedRange(range));
+                }
+
+                // MP TODO: Hmm, not sure this should be inside the for loop - it is NOT in ShardStateAction.execute :-(
+                // can you just (re)build state like this iteratively and have it work? // TODO: need to have a test for this
+                state = ClusterState.builder(state).metadata(metadataBuilder).build();
+            }
+
+            for (var taskContext : batchExecutionContext.taskContexts()) {
+                // TODO: am I supposed to do something in this success callback?
+                taskContext.success(() -> {}); // TODO: need an error handler to call taskContext.onFailure() ??
+            }
+            return state;
+        }
+
+        @Override
+        public boolean runOnlyOnMaster() {
+            return true;
+        }
+
+        @Override
+        public void clusterStatePublished(ClusterState newClusterState) {
+            // TODO: need this?
+        }
+
+        @Override
+        public String describeTasks(List<EventIngestedRangeTask> tasks) {
+            // TODO: override this or just use the default?
+            return ClusterStateTaskExecutor.super.describeTasks(tasks);
+        }
+    }
+
+    interface EventIngestedRangeTask extends ClusterStateTaskListener {}
+
+    // TODO: other things to override
+    record CreateEventIngestedRangeTask(UpdateEventIngestedRangeRequest rangeUpdateRequest) implements EventIngestedRangeTask {
+        @Override
+        public void onFailure(Exception e) {
+            if (e != null) {
+                logger.info(
+                    "Unable to update event.ingested range in cluster state from index/shard XXX due to error: {}: {}",
+                    e.getMessage(),
+                    e
+                );
+            }
+
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportAction.java
@@ -11,13 +11,13 @@ package org.elasticsearch.indices.cluster;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
+import org.elasticsearch.cluster.SimpleBatchedExecutor;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -28,25 +28,26 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Transport action to send info about updated min/max 'event.ingested' range info to master node.
  */
+// TODO: impl AcknowledgedTransportMasterNodeAction instead?
 public class UpdateEventIngestedRangeTransportAction extends TransportMasterNodeAction<
     UpdateEventIngestedRangeRequest,
-    ActionResponse.Empty> {
+    AcknowledgedResponse> {
     private static final Logger logger = LogManager.getLogger(UpdateEventIngestedRangeTransportAction.class);
     public static final String UPDATE_EVENT_INGESTED_RANGE_ACTION_NAME = "internal:cluster/snapshot/update_event_ingested_range";
-    public static final ActionType<ActionResponse.Empty> TYPE = new ActionType<>(UPDATE_EVENT_INGESTED_RANGE_ACTION_NAME);
+    public static final ActionType<AcknowledgedResponse> TYPE = new ActionType<>(UPDATE_EVENT_INGESTED_RANGE_ACTION_NAME);
     private final MasterServiceTaskQueue<EventIngestedRangeTask> masterServiceTaskQueue;
 
     @Inject
@@ -66,14 +67,14 @@ public class UpdateEventIngestedRangeTransportAction extends TransportMasterNode
             actionFilters,
             UpdateEventIngestedRangeRequest::new,
             indexNameExpressionResolver,
-            in -> ActionResponse.Empty.INSTANCE,
+            AcknowledgedResponse::readFrom,
             EsExecutors.DIRECT_EXECUTOR_SERVICE
         );
 
         this.masterServiceTaskQueue = clusterService.createTaskQueue(
             "event-ingested-range-cluster-state-service",
             Priority.NORMAL,
-            new TaskExecutor()
+            EVENT_INGESTED_UPDATE_TASK_EXECUTOR
         );
 
         logger.warn("XXX YYY: UpdateEventIngestedRangeAction ctor");
@@ -85,16 +86,26 @@ public class UpdateEventIngestedRangeTransportAction extends TransportMasterNode
         Task task,
         UpdateEventIngestedRangeRequest request,
         ClusterState state,
-        ActionListener<ActionResponse.Empty> listener
+        ActionListener<AcknowledgedResponse> responseListener
     ) {
         logger.warn("XXX YYY UpdateEventIngestedRangeAction.masterOperation NOW SUBMITTING TASK. Request: {}", request);
 
-        masterServiceTaskQueue.submitTask(
-            "update-event-ingested-in-cluster-state",
-            new EventIngestedRangeTask(request),
-            TimeValue.MAX_VALUE
+        // TODO: is this the better way to do it rather than how I had it below (now commented out)?
+        ActionListener.run(
+            responseListener,
+            listener -> masterServiceTaskQueue.submitTask(
+                "update-event-ingested-in-cluster-state",
+                new EventIngestedRangeTask(request, listener),
+                TimeValue.MAX_VALUE
+            )
         );
-        listener.onResponse(ActionResponse.Empty.INSTANCE); // TODO: defer this response until the tasks have finished
+
+        // masterServiceTaskQueue.submitTask(
+        // "update-event-ingested-in-cluster-state",
+        // new EventIngestedRangeTask(request, listener),
+        // TimeValue.MAX_VALUE
+        // );
+        // // the ActionListener will get called by the task when it has completed or failed, so no need to call it here
     }
 
     @Override
@@ -102,87 +113,9 @@ public class UpdateEventIngestedRangeTransportAction extends TransportMasterNode
         return null;
     }
 
-    // runs on the master node only (called from masterOperation of UpdateEventIngestedRangeAction
-    public static class TaskExecutor implements ClusterStateTaskExecutor<EventIngestedRangeTask> {
-        @Override
-        public ClusterState execute(BatchExecutionContext<EventIngestedRangeTask> batchExecutionContext) throws Exception {
-            ClusterState state = batchExecutionContext.initialState();
-            final Map<Index, IndexLongFieldRange> updatedEventIngestedRangesMap = new HashMap<>();
-            for (var taskContext : batchExecutionContext.taskContexts()) {
-                EventIngestedRangeTask task = taskContext.getTask();
-                Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> rangeMap = task.rangeUpdateRequest()
-                    .getEventIngestedRangeMap();
-
-                for (Map.Entry<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> entry : rangeMap.entrySet()) {
-                    Index index = entry.getKey();
-                    List<EventIngestedRangeClusterStateService.ShardRangeInfo> shardRangeList = entry.getValue();
-
-                    // TODO: is it realistic to assume that IndexMetadata would never be null here?
-                    IndexMetadata indexMetadata = state.getMetadata().index(index);
-
-                    // get the latest EventIngestedRange either from the map outside this loop (first choice) or from cluster state
-                    IndexLongFieldRange currentEventIngestedRange = updatedEventIngestedRangesMap.get(index);
-                    if (currentEventIngestedRange == null && indexMetadata != null) {
-                        currentEventIngestedRange = indexMetadata.getEventIngestedRange();
-                    }
-                    if (currentEventIngestedRange == IndexLongFieldRange.UNKNOWN) {
-                        // UNKNOWN.extendWithShardRange is a no-op, so switch it to NO_SHARDS
-                        currentEventIngestedRange = IndexLongFieldRange.NO_SHARDS;
-                    }
-                    IndexLongFieldRange newEventIngestedRange = currentEventIngestedRange;
-                    for (EventIngestedRangeClusterStateService.ShardRangeInfo shardRange : shardRangeList) {
-                        newEventIngestedRange = newEventIngestedRange.extendWithShardRange(
-                            shardRange.shardId.id(),
-                            indexMetadata.getNumberOfShards(),
-                            shardRange.eventIngestedRange
-                        );
-                    }
-
-                    // TODO: or should we use .equals rather than '==' ?? (the .equals method on this class is very strange IMO)
-                    if (newEventIngestedRange != currentEventIngestedRange) {
-                        updatedEventIngestedRangesMap.put(index, newEventIngestedRange);
-                    }
-                }
-            }
-            if (updatedEventIngestedRangesMap.size() > 0) {
-                Metadata.Builder metadataBuilder = Metadata.builder(state.metadata());
-                for (Map.Entry<Index, IndexLongFieldRange> entry : updatedEventIngestedRangesMap.entrySet()) {
-                    Index index = entry.getKey();
-                    IndexLongFieldRange range = entry.getValue();
-                    metadataBuilder.put(IndexMetadata.builder(metadataBuilder.getSafe(index)).eventIngestedRange(range));
-                }
-
-                // MP TODO: Hmm, not sure this should be inside the for loop - it is NOT in ShardStateAction.execute :-(
-                // can you just (re)build state like this iteratively and have it work? // TODO: need to have a test for this
-                state = ClusterState.builder(state).metadata(metadataBuilder).build();
-            }
-
-            for (var taskContext : batchExecutionContext.taskContexts()) {
-                // TODO: am I supposed to do something in this success callback?
-                taskContext.success(() -> {}); // TODO: need an error handler to call taskContext.onFailure() ??
-            }
-            return state;
-        }
-
-        @Override
-        public boolean runOnlyOnMaster() {
-            return true;
-        }
-
-        @Override
-        public void clusterStatePublished(ClusterState newClusterState) {
-            // TODO: need this?
-        }
-
-        @Override
-        public String describeTasks(List<EventIngestedRangeTask> tasks) {
-            // TODO: override this or just use the default?
-            return ClusterStateTaskExecutor.super.describeTasks(tasks);
-        }
-    }
-
-    // TODO: other things to override?
-    record EventIngestedRangeTask(UpdateEventIngestedRangeRequest rangeUpdateRequest) implements ClusterStateTaskListener {
+    record EventIngestedRangeTask(UpdateEventIngestedRangeRequest rangeUpdateRequest, ActionListener<AcknowledgedResponse> listener)
+        implements
+            ClusterStateTaskListener {
 
         @Override
         public void onFailure(Exception e) {
@@ -193,6 +126,48 @@ public class UpdateEventIngestedRangeTransportAction extends TransportMasterNode
                     e
                 );
             }
+            listener.onFailure(e);  // TODO: want this inside the if-null check?
         }
     }
+
+    static final SimpleBatchedExecutor<EventIngestedRangeTask, Void> EVENT_INGESTED_UPDATE_TASK_EXECUTOR = new SimpleBatchedExecutor<>() {
+        @Override
+        public Tuple<ClusterState, Void> executeTask(EventIngestedRangeTask rangeTask, ClusterState clusterState) throws Exception {
+
+            ClusterState state = clusterState;
+            var rangeMap = rangeTask.rangeUpdateRequest().getEventIngestedRangeMap();
+            for (Map.Entry<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> entry : rangeMap.entrySet()) {
+                Index index = entry.getKey();
+                List<EventIngestedRangeClusterStateService.ShardRangeInfo> shardRangeList = entry.getValue();
+
+                // TODO: is it realistic to assume that IndexMetadata would never be null here?
+                IndexMetadata indexMetadata = state.getMetadata().index(index);
+
+                IndexLongFieldRange currentEventIngestedRange = indexMetadata.getEventIngestedRange();
+                if (currentEventIngestedRange == IndexLongFieldRange.UNKNOWN) {
+                    // UNKNOWN.extendWithShardRange is a no-op, so switch it to NO_SHARDS
+                    currentEventIngestedRange = IndexLongFieldRange.NO_SHARDS;
+                }
+                IndexLongFieldRange newRange = currentEventIngestedRange;
+                for (EventIngestedRangeClusterStateService.ShardRangeInfo shardRange : shardRangeList) {
+                    newRange = newRange.extendWithShardRange(
+                        shardRange.shardId.id(),
+                        indexMetadata.getNumberOfShards(),
+                        shardRange.eventIngestedRange
+                    );
+                }
+                if (newRange != currentEventIngestedRange) {
+                    Metadata.Builder metadataBuilder = Metadata.builder(state.metadata());
+                    metadataBuilder.put(IndexMetadata.builder(metadataBuilder.getSafe(index)).eventIngestedRange(newRange));
+                    state = ClusterState.builder(state).metadata(metadataBuilder).build();
+                }
+            }
+            return Tuple.tuple(state, null);
+        }
+
+        @Override
+        public void taskSucceeded(EventIngestedRangeTask rangeTask, Void unused) {
+            rangeTask.listener().onResponse(AcknowledgedResponse.TRUE);
+        }
+    };
 }

--- a/server/src/main/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportAction.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportAction.java
@@ -117,8 +117,6 @@ public class UpdateEventIngestedRangeTransportAction extends TransportMasterNode
                     Index index = entry.getKey();
                     List<EventIngestedRangeClusterStateService.ShardRangeInfo> shardRangeList = entry.getValue();
 
-                    // TODO: why does state.getMetadata().index(index) return null in my tests but
-                    // state.getMetadata().index(index.getName()) does not?
                     // TODO: is it realistic to assume that IndexMetadata would never be null here?
                     IndexMetadata indexMetadata = state.getMetadata().index(index);
 
@@ -151,10 +149,7 @@ public class UpdateEventIngestedRangeTransportAction extends TransportMasterNode
                 for (Map.Entry<Index, IndexLongFieldRange> entry : updatedEventIngestedRangesMap.entrySet()) {
                     Index index = entry.getKey();
                     IndexLongFieldRange range = entry.getValue();
-
-                    metadataBuilder.put(IndexMetadata.builder(metadataBuilder.get(index.getName())).eventIngestedRange(range));
-                    // TODO: again, builder.getSafe(index)) returns null, but builder.get(index.getName())) does not - why?
-                    // metadataBuilder.put(IndexMetadata.builder(metadataBuilder.getSafe(index)).eventIngestedRange(range));
+                    metadataBuilder.put(IndexMetadata.builder(metadataBuilder.getSafe(index)).eventIngestedRange(range));
                 }
 
                 // MP TODO: Hmm, not sure this should be inside the for loop - it is NOT in ShardStateAction.execute :-(

--- a/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
@@ -62,10 +62,9 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
 
         clusterState2 = executeTasks(clusterState1, List.of(eventIngestedRangeTask));
         assertNotSame(clusterState1, clusterState2);
+        // TODO: change this to blogsIndex
         IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
 
-        // TODO: why does the index(Index) return null?
-        // IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex).getEventIngestedRange();
         assertEquals(1000L, eventIngestedRange.getMin());
         assertEquals(2000L, eventIngestedRange.getMax());
     }
@@ -79,13 +78,15 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
         ClusterState clusterState4;  // cluster state after third task batch runs (building on clusterState3)
         ClusterState clusterState5;  // cluster state after fourth task batch runs (building on clusterState4)
 
-        Index blogsIndex = new Index("blogs", UUID.randomUUID().toString());
+        String indexName = "blogs";
+        Index blogsIndex;
 
         // first task with eventIngestedRange of NO_SHARDS in IndexMetadata for "blogs" index
         {
             // TODO: do I need to try other ShardRoutingStates here, like RELOCATING, UNASSIGNED or INITIALIZING?
             // ClusterState clusterState = state(blogsIndex, true, ShardRoutingState.STARTED);
-            clusterState1 = state(1, new String[] { blogsIndex.getName() }, 6);
+            clusterState1 = state(1, new String[] { indexName }, 6);
+            blogsIndex = clusterState1.metadata().index(indexName).getIndex();
 
             Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
             EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfo = new EventIngestedRangeClusterStateService.ShardRangeInfo(
@@ -184,14 +185,18 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
         ClusterState clusterState1;  // initial cluster state
         ClusterState clusterState2;  // cluster state after first task batch runs (building on clusterState1)
 
-        Index blogsIndex = new Index("blogs", UUID.randomUUID().toString());
-        Index webTrafficIndex = new Index("web_traffic", UUID.randomUUID().toString());
+        String blogsIndexName = "blogs";
+        String webTrafficIndexName = "web_traffic";
+        Index blogsIndex;
+        Index webTrafficIndex;
 
         // first task with eventIngestedRange of NO_SHARDS in IndexMetadata for "blogs" index
         {
             // TODO: do I need to try other ShardRoutingStates here, like RELOCATING, UNASSIGNED or INITIALIZING?
             // ClusterState clusterState = state(blogsIndex, true, ShardRoutingState.STARTED);
-            clusterState1 = state(1, new String[] { blogsIndex.getName(), webTrafficIndex.getName() }, 3);
+            clusterState1 = state(1, new String[] { blogsIndexName, webTrafficIndexName }, 3);
+            blogsIndex = clusterState1.metadata().index(blogsIndexName).getIndex();
+            webTrafficIndex = clusterState1.metadata().index(webTrafficIndexName).getIndex();
 
             Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap1 = new HashMap<>();
             var shardRangeInfoBlogs1A = new EventIngestedRangeClusterStateService.ShardRangeInfo(

--- a/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.cluster;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.IndexLongFieldRange;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardLongFieldRange;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.state;
+import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithNoShard;
+import static org.hamcrest.Matchers.containsString;
+
+// TODO: add tests with failure conditions (onFailure callback) - how will I induce failure?
+public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ESTestCase {
+
+    private UpdateEventIngestedRangeTransportAction.TaskExecutor executor;
+
+    public void testEmptyTaskListProducesSameClusterState() throws Exception {
+        executor = new UpdateEventIngestedRangeTransportAction.TaskExecutor();
+        ClusterState stateBefore = stateWithNoShard();
+        assertSame(stateBefore, executeTasks(stateBefore, List.of()));
+    }
+
+    public void testTaskWithSingleIndexAndShard() throws Exception {
+        executor = new UpdateEventIngestedRangeTransportAction.TaskExecutor();
+
+        ClusterState clusterState1;  // initial cluster state
+        ClusterState clusterState2;  // cluster state after first task runs (building on clusterState1)
+
+        Index blogsIndex = new Index("blogs", UUID.randomUUID().toString());
+
+        // TODO: do I need to try other ShardRoutingStates here, like RELOCATING, UNASSIGNED or INITIALIZING?
+        // ClusterState clusterState = state(blogsIndex, true, ShardRoutingState.STARTED);
+        clusterState1 = state(1, new String[] { blogsIndex.getName() }, 1);
+
+        Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
+        EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfo = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+            new ShardId(blogsIndex, 0),
+            ShardLongFieldRange.of(1000, 2000)
+        );
+        eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
+
+        UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
+        var createEventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(rangeUpdateRequest);
+
+        clusterState2 = executeTasks(clusterState1, List.of(createEventIngestedRangeTask));
+        assertNotSame(clusterState1, clusterState2);
+        IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
+
+        // TODO: why does the index(Index) return null?
+        // IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex).getEventIngestedRange();
+        assertEquals(1000L, eventIngestedRange.getMin());
+        assertEquals(2000L, eventIngestedRange.getMax());
+    }
+
+    public void testTasksWithSingleIndexAndMultipleShards() throws Exception {
+        executor = new UpdateEventIngestedRangeTransportAction.TaskExecutor();
+
+        ClusterState clusterState1;  // initial cluster state
+        ClusterState clusterState2;  // cluster state after first task batch runs (building on clusterState1)
+        ClusterState clusterState3;  // cluster state after second task batch runs (building on clusterState2)
+        ClusterState clusterState4;  // cluster state after third task batch runs (building on clusterState3)
+        ClusterState clusterState5;  // cluster state after fourth task batch runs (building on clusterState4)
+
+        Index blogsIndex = new Index("blogs", UUID.randomUUID().toString());
+
+        // first task with eventIngestedRange of NO_SHARDS in IndexMetadata for "blogs" index
+        {
+            // TODO: do I need to try other ShardRoutingStates here, like RELOCATING, UNASSIGNED or INITIALIZING?
+            // ClusterState clusterState = state(blogsIndex, true, ShardRoutingState.STARTED);
+            clusterState1 = state(1, new String[] { blogsIndex.getName() }, 6);
+
+            Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
+            EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfo = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(blogsIndex, 0),
+                ShardLongFieldRange.of(1000, 2000)
+            );
+            eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
+
+            UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
+            var createEventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(rangeUpdateRequest);
+
+            clusterState2 = executeTasks(clusterState1, List.of(createEventIngestedRangeTask));
+            assertNotSame(clusterState1, clusterState2);
+            IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
+            // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
+            assertThat(eventIngestedRange.toString(), containsString("1000-2000"));
+        }
+
+        // second task with eventIngestedRange of [1000, 2000] in IndexMetadata for "blogs" index should expand to range to [1000, 3000]
+        {
+            Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
+            EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfo = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(blogsIndex, 1),
+                ShardLongFieldRange.of(1000, 3000)
+            );
+            eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
+            UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
+            var createEventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(rangeUpdateRequest);
+
+            clusterState3 = executeTasks(clusterState2, List.of(createEventIngestedRangeTask));
+            assertNotSame(clusterState2, clusterState3);
+            IndexLongFieldRange eventIngestedRange = clusterState3.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
+            // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
+            assertThat(eventIngestedRange.toString(), containsString("1000-3000"));
+        }
+
+        // run two tasks in this batch - should expand range to [500, 4000]
+        {
+            // first task has two shards
+            Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMapTask1 = new HashMap<>();
+            List<EventIngestedRangeClusterStateService.ShardRangeInfo> shardRangeInfos = new ArrayList<>(3);
+            shardRangeInfos.add(
+                new EventIngestedRangeClusterStateService.ShardRangeInfo(new ShardId(blogsIndex, 2), ShardLongFieldRange.of(500, 650))
+            );
+            shardRangeInfos.add(
+                new EventIngestedRangeClusterStateService.ShardRangeInfo(new ShardId(blogsIndex, 3), ShardLongFieldRange.of(2000, 3800))
+            );
+            shardRangeInfos.add(
+                new EventIngestedRangeClusterStateService.ShardRangeInfo(new ShardId(blogsIndex, 4), ShardLongFieldRange.of(700, 4000))
+            );
+            Randomness.shuffle(shardRangeInfos);
+
+            eventIngestedRangeMapTask1.put(blogsIndex, shardRangeInfos.subList(0, 2));
+            UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMapTask1);
+            var createEventIngestedRangeTask1 = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(
+                rangeUpdateRequest
+            );
+
+            // second task has one shard
+            Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMapTask2 = new HashMap<>();
+            eventIngestedRangeMapTask2.put(blogsIndex, shardRangeInfos.subList(2, 3));
+            var createEventIngestedRangeTask2 = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMapTask2)
+            );
+
+            clusterState4 = executeTasks(clusterState3, List.of(createEventIngestedRangeTask1, createEventIngestedRangeTask2));
+            assertNotSame(clusterState3, clusterState4);
+            IndexLongFieldRange eventIngestedRange = clusterState4.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
+            // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
+            assertThat(eventIngestedRange.toString(), containsString("500-4000"));
+        }
+
+        // final task batch - all shard ranges are within that set already so event.ingested range should not change
+        {
+            Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
+            EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfoA = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(blogsIndex, 5),
+                ShardLongFieldRange.of(1000, 3000)
+            );
+            EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfoB = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(blogsIndex, 5),
+                ShardLongFieldRange.of(2500, 3500)
+            );
+            eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfoA, shardRangeInfoB));
+            UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
+            var createEventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(rangeUpdateRequest);
+
+            clusterState5 = executeTasks(clusterState4, List.of(createEventIngestedRangeTask));
+            IndexLongFieldRange eventIngestedRange = clusterState5.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
+            assertEquals(500L, eventIngestedRange.getMin());
+            assertEquals(4000L, eventIngestedRange.getMax());
+        }
+    }
+
+    public void testTasksWithMultipleIndices() throws Exception {
+        executor = new UpdateEventIngestedRangeTransportAction.TaskExecutor();
+
+        ClusterState clusterState1;  // initial cluster state
+        ClusterState clusterState2;  // cluster state after first task batch runs (building on clusterState1)
+
+        Index blogsIndex = new Index("blogs", UUID.randomUUID().toString());
+        Index webTrafficIndex = new Index("web_traffic", UUID.randomUUID().toString());
+
+        // first task with eventIngestedRange of NO_SHARDS in IndexMetadata for "blogs" index
+        {
+            // TODO: do I need to try other ShardRoutingStates here, like RELOCATING, UNASSIGNED or INITIALIZING?
+            // ClusterState clusterState = state(blogsIndex, true, ShardRoutingState.STARTED);
+            clusterState1 = state(1, new String[] { blogsIndex.getName(), webTrafficIndex.getName() }, 3);
+
+            Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap1 = new HashMap<>();
+            var shardRangeInfoBlogs1A = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(blogsIndex, 1),
+                ShardLongFieldRange.of(1000, 2000)
+            );
+            var shardRangeInfoBlogs1B = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(blogsIndex, 0),
+                ShardLongFieldRange.of(2500, 99999)
+            );
+            var shardRangeInfoWeb1A = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(webTrafficIndex, 0),
+                ShardLongFieldRange.of(1_000_000, 5_000_000)
+            );
+            eventIngestedRangeMap1.put(blogsIndex, List.of(shardRangeInfoBlogs1A, shardRangeInfoBlogs1B));
+            eventIngestedRangeMap1.put(webTrafficIndex, List.of(shardRangeInfoWeb1A));
+
+            UpdateEventIngestedRangeRequest rangeUpdateRequest1 = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap1);
+            var createEventIngestedRangeTask1 = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(
+                rangeUpdateRequest1
+            );
+
+            Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap2 = new HashMap<>();
+            var shardRangeInfoBlogs2A = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(blogsIndex, 2),
+                ShardLongFieldRange.of(2000, 2500)
+            );
+            var shardRangeInfoWeb2A = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(webTrafficIndex, 2),
+                ShardLongFieldRange.of(5_000_000, 10_000_000)
+            );
+            var shardRangeInfoWeb2B = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+                new ShardId(webTrafficIndex, 1),
+                ShardLongFieldRange.of(6_000_000, 11_000_000)
+            );
+            eventIngestedRangeMap2.put(blogsIndex, List.of(shardRangeInfoBlogs2A));
+            eventIngestedRangeMap2.put(webTrafficIndex, List.of(shardRangeInfoWeb2A, shardRangeInfoWeb2B));
+
+            var createEventIngestedRangeTask2 = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMap2)
+            );
+
+            var taskList = new ArrayList<UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask>();
+            taskList.add(createEventIngestedRangeTask1);
+            taskList.add(createEventIngestedRangeTask2);
+            Randomness.shuffle(taskList);
+            clusterState2 = executeTasks(clusterState1, taskList);
+            assertNotSame(clusterState1, clusterState2);
+
+            IndexLongFieldRange eventIngestedRangeBlogs = clusterState2.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
+            assertEquals(1000L, eventIngestedRangeBlogs.getMin());
+            assertEquals(99999L, eventIngestedRangeBlogs.getMax());
+
+            IndexLongFieldRange eventIngestedRangeWebTraffic = clusterState2.getMetadata()
+                .index(webTrafficIndex.getName())
+                .getEventIngestedRange();
+            assertEquals(1000000L, eventIngestedRangeWebTraffic.getMin());
+            assertEquals(11000000L, eventIngestedRangeWebTraffic.getMax());
+        }
+    }
+
+    private ClusterState executeTasks(ClusterState state, List<UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask> tasks)
+        throws Exception {
+        return ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(state, executor, tasks);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
@@ -8,7 +8,10 @@
 
 package org.elasticsearch.indices.cluster;
 
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.index.Index;
@@ -21,6 +24,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.state;
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithNoShard;
@@ -29,17 +34,15 @@ import static org.hamcrest.Matchers.containsString;
 // TODO: add tests with failure conditions (onFailure callback) - how will I induce failure?
 public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ESTestCase {
 
-    private UpdateEventIngestedRangeTransportAction.TaskExecutor executor;
+    private ClusterStateTaskExecutor<UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask> executor =
+        UpdateEventIngestedRangeTransportAction.EVENT_INGESTED_UPDATE_TASK_EXECUTOR;
 
     public void testEmptyTaskListProducesSameClusterState() throws Exception {
-        executor = new UpdateEventIngestedRangeTransportAction.TaskExecutor();
         ClusterState stateBefore = stateWithNoShard();
         assertSame(stateBefore, executeTasks(stateBefore, List.of()));
     }
 
     public void testTaskWithSingleIndexAndShard() throws Exception {
-        executor = new UpdateEventIngestedRangeTransportAction.TaskExecutor();
-
         ClusterState clusterState1;  // initial cluster state
         ClusterState clusterState2;  // cluster state after first task runs (building on clusterState1)
 
@@ -58,8 +61,21 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
         );
         eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
 
-        UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
-        var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
+        AtomicReference<AcknowledgedResponse> ackedResponseFromCallback = new AtomicReference<>(null);
+        var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
+            new UpdateEventIngestedRangeRequest(eventIngestedRangeMap),
+            new ActionListener<>() {
+                @Override
+                public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                    ackedResponseFromCallback.set(acknowledgedResponse);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail("onFailure should not have been called but received: " + e);
+                }
+            }
+        );
 
         clusterState2 = executeTasks(clusterState1, List.of(eventIngestedRangeTask));
         assertNotSame(clusterState1, clusterState2);
@@ -67,11 +83,11 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
 
         assertEquals(1000L, eventIngestedRange.getMin());
         assertEquals(2000L, eventIngestedRange.getMax());
+        assertNotNull("onResponse should have been called", ackedResponseFromCallback.get());
+        assertTrue("AcknowledgedResponse should have true setting", ackedResponseFromCallback.get().isAcknowledged());
     }
 
     public void testTasksWithSingleIndexAndMultipleShards() throws Exception {
-        executor = new UpdateEventIngestedRangeTransportAction.TaskExecutor();
-
         ClusterState clusterState1;  // initial cluster state
         ClusterState clusterState2;  // cluster state after first task batch runs (building on clusterState1)
         ClusterState clusterState3;  // cluster state after second task batch runs (building on clusterState2)
@@ -95,14 +111,29 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             );
             eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
 
-            UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
-            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
+            AtomicReference<AcknowledgedResponse> ackedResponseFromCallback = new AtomicReference<>(null);
+            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMap),
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        ackedResponseFromCallback.set(acknowledgedResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail("onFailure should not have been called but received: " + e);
+                    }
+                }
+            );
 
             clusterState2 = executeTasks(clusterState1, List.of(eventIngestedRangeTask));
             assertNotSame(clusterState1, clusterState2);
             IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
             // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
             assertThat(eventIngestedRange.toString(), containsString("1000-2000"));
+            assertNotNull("onResponse should have been called", ackedResponseFromCallback.get());
+            assertTrue("AcknowledgedResponse should have true setting", ackedResponseFromCallback.get().isAcknowledged());
         }
 
         // second task with eventIngestedRange of [1000, 2000] in IndexMetadata for "blogs" index should expand to range to [1000, 3000]
@@ -113,14 +144,29 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
                 ShardLongFieldRange.of(1000, 3000)
             );
             eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
-            UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
-            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
+            AtomicReference<AcknowledgedResponse> ackedResponseFromCallback = new AtomicReference<>(null);
+            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMap),
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        ackedResponseFromCallback.set(acknowledgedResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail("onFailure should not have been called but received: " + e);
+                    }
+                }
+            );
 
             clusterState3 = executeTasks(clusterState2, List.of(eventIngestedRangeTask));
             assertNotSame(clusterState2, clusterState3);
             IndexLongFieldRange eventIngestedRange = clusterState3.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
             // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
             assertThat(eventIngestedRange.toString(), containsString("1000-3000"));
+            assertNotNull("onResponse should have been called", ackedResponseFromCallback.get());
+            assertTrue("AcknowledgedResponse should have true setting", ackedResponseFromCallback.get().isAcknowledged());
         }
 
         // run two tasks in this batch - should expand range to [500, 4000]
@@ -140,14 +186,40 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             Randomness.shuffle(shardRangeInfos);
 
             eventIngestedRangeMapTask1.put(blogsIndex, shardRangeInfos.subList(0, 2));
-            UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMapTask1);
-            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
+            AtomicReference<AcknowledgedResponse> ackedResponseFromCallback = new AtomicReference<>(null);
+            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMapTask1),
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        ackedResponseFromCallback.set(acknowledgedResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail("onFailure should not have been called but received: " + e);
+                    }
+                }
+            );
 
             // second task has one shard
             Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMapTask2 = new HashMap<>();
             eventIngestedRangeMapTask2.put(blogsIndex, shardRangeInfos.subList(2, 3));
+
+            AtomicReference<AcknowledgedResponse> ackedResponseFromCallback2 = new AtomicReference<>(null);
             var eventIngestedRangeTask2 = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
-                new UpdateEventIngestedRangeRequest(eventIngestedRangeMapTask2)
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMapTask2),
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        ackedResponseFromCallback2.set(acknowledgedResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail("onFailure should not have been called but received: " + e);
+                    }
+                }
             );
 
             clusterState4 = executeTasks(clusterState3, List.of(eventIngestedRangeTask, eventIngestedRangeTask2));
@@ -155,6 +227,10 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             IndexLongFieldRange eventIngestedRange = clusterState4.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
             // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
             assertThat(eventIngestedRange.toString(), containsString("500-4000"));
+            assertNotNull("onResponse CB1 should have been called", ackedResponseFromCallback.get());
+            assertTrue("AcknowledgedResponse CB1 should have true setting", ackedResponseFromCallback.get().isAcknowledged());
+            assertNotNull("onResponse CB2 should have been called", ackedResponseFromCallback2.get());
+            assertTrue("AcknowledgedResponse CB2 should have true setting", ackedResponseFromCallback2.get().isAcknowledged());
         }
 
         // final task batch - all shard ranges are within that set already so event.ingested range should not change
@@ -169,19 +245,32 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
                 ShardLongFieldRange.of(2500, 3500)
             );
             eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfoA, shardRangeInfoB));
-            UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
-            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
+            AtomicReference<AcknowledgedResponse> ackedResponseFromCallback = new AtomicReference<>(null);
+            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMap),
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        ackedResponseFromCallback.set(acknowledgedResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail("onFailure should not have been called but received: " + e);
+                    }
+                }
+            );
 
             clusterState5 = executeTasks(clusterState4, List.of(eventIngestedRangeTask));
             IndexLongFieldRange eventIngestedRange = clusterState5.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
             assertEquals(500L, eventIngestedRange.getMin());
             assertEquals(4000L, eventIngestedRange.getMax());
+            assertNotNull("onResponse should have been called", ackedResponseFromCallback.get());
+            assertTrue("AcknowledgedResponse should have true setting", ackedResponseFromCallback.get().isAcknowledged());
         }
     }
 
     public void testTasksWithMultipleIndices() throws Exception {
-        executor = new UpdateEventIngestedRangeTransportAction.TaskExecutor();
-
         ClusterState clusterState1;  // initial cluster state
         ClusterState clusterState2;  // cluster state after first task batch runs (building on clusterState1)
 
@@ -214,8 +303,21 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             eventIngestedRangeMap1.put(blogsIndex, List.of(shardRangeInfoBlogs1A, shardRangeInfoBlogs1B));
             eventIngestedRangeMap1.put(webTrafficIndex, List.of(shardRangeInfoWeb1A));
 
-            UpdateEventIngestedRangeRequest rangeUpdateRequest1 = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap1);
-            var eventIngestedRangeTask1 = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest1);
+            AtomicReference<AcknowledgedResponse> ackedResponseFromCallback = new AtomicReference<>(null);
+            var eventIngestedRangeTask1 = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMap1),
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        ackedResponseFromCallback.set(acknowledgedResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail("onFailure should not have been called but received: " + e);
+                    }
+                }
+            );
 
             Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap2 = new HashMap<>();
             var shardRangeInfoBlogs2A = new EventIngestedRangeClusterStateService.ShardRangeInfo(
@@ -233,8 +335,20 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             eventIngestedRangeMap2.put(blogsIndex, List.of(shardRangeInfoBlogs2A));
             eventIngestedRangeMap2.put(webTrafficIndex, List.of(shardRangeInfoWeb2A, shardRangeInfoWeb2B));
 
+            AtomicReference<AcknowledgedResponse> ackedResponseFromCallback2 = new AtomicReference<>(null);
             var eventIngestedRangeTask2 = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
-                new UpdateEventIngestedRangeRequest(eventIngestedRangeMap2)
+                new UpdateEventIngestedRangeRequest(eventIngestedRangeMap2),
+                new ActionListener<>() {
+                    @Override
+                    public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                        ackedResponseFromCallback2.set(acknowledgedResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        fail("onFailure should not have been called but received: " + e);
+                    }
+                }
             );
 
             var taskList = new ArrayList<UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask>();
@@ -253,7 +367,58 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
                 .getEventIngestedRange();
             assertEquals(1000000L, eventIngestedRangeWebTraffic.getMin());
             assertEquals(11000000L, eventIngestedRangeWebTraffic.getMax());
+
+            assertNotNull("onResponse CB1 should have been called", ackedResponseFromCallback.get());
+            assertTrue("AcknowledgedResponse CB1 should have true setting", ackedResponseFromCallback.get().isAcknowledged());
+            assertNotNull("onResponse CB2 should have been called", ackedResponseFromCallback2.get());
+            assertTrue("AcknowledgedResponse CB2 should have true setting", ackedResponseFromCallback2.get().isAcknowledged());
         }
+    }
+
+    // TODO: want to see how the onFailure callback is called
+    public void testErrorInTaskExecutor() throws Exception {
+        ClusterState clusterState1;  // initial cluster state
+        ClusterState clusterState2;  // cluster state after first task runs (building on clusterState1)
+
+        String indexName = "blogs";
+        Index blogsIndex; // TODO: LEFTOFF - change this to a self-created index
+
+        // TODO: do I need to try other ShardRoutingStates here, like RELOCATING, UNASSIGNED or INITIALIZING?
+        // ClusterState clusterState = state(blogsIndex, true, ShardRoutingState.STARTED);
+        clusterState1 = state(1, new String[] { indexName }, 1);
+        blogsIndex = clusterState1.metadata().index(indexName).getIndex();
+
+        Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
+        EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfo = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+            new ShardId(blogsIndex, 0),
+            ShardLongFieldRange.of(1000, 2000)
+        );
+        eventIngestedRangeMap.put(new Index("wrong_idx", UUID.randomUUID().toString()), List.of(shardRangeInfo));
+
+        AtomicReference<AcknowledgedResponse> ackedResponseFromCallback = new AtomicReference<>(null);
+        var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
+            new UpdateEventIngestedRangeRequest(eventIngestedRangeMap),
+            new ActionListener<>() {
+                @Override
+                public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                    ackedResponseFromCallback.set(acknowledgedResponse);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail("onFailure should not have been called but received: " + e);
+                }
+            }
+        );
+
+        clusterState2 = executeTasks(clusterState1, List.of(eventIngestedRangeTask));
+        assertNotSame(clusterState1, clusterState2);
+        IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex).getEventIngestedRange();
+
+        assertEquals(1000L, eventIngestedRange.getMin());
+        assertEquals(2000L, eventIngestedRange.getMax());
+        assertNotNull("onResponse should have been called", ackedResponseFromCallback.get());
+        assertTrue("AcknowledgedResponse should have true setting", ackedResponseFromCallback.get().isAcknowledged());
     }
 
     private ClusterState executeTasks(ClusterState state, List<UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask> tasks)

--- a/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
@@ -58,9 +58,9 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
         eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
 
         UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
-        var createEventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(rangeUpdateRequest);
+        var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
 
-        clusterState2 = executeTasks(clusterState1, List.of(createEventIngestedRangeTask));
+        clusterState2 = executeTasks(clusterState1, List.of(eventIngestedRangeTask));
         assertNotSame(clusterState1, clusterState2);
         IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
 
@@ -95,9 +95,9 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
 
             UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
-            var createEventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(rangeUpdateRequest);
+            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
 
-            clusterState2 = executeTasks(clusterState1, List.of(createEventIngestedRangeTask));
+            clusterState2 = executeTasks(clusterState1, List.of(eventIngestedRangeTask));
             assertNotSame(clusterState1, clusterState2);
             IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
             // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
@@ -113,9 +113,9 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             );
             eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
             UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
-            var createEventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(rangeUpdateRequest);
+            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
 
-            clusterState3 = executeTasks(clusterState2, List.of(createEventIngestedRangeTask));
+            clusterState3 = executeTasks(clusterState2, List.of(eventIngestedRangeTask));
             assertNotSame(clusterState2, clusterState3);
             IndexLongFieldRange eventIngestedRange = clusterState3.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
             // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
@@ -140,18 +140,16 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
 
             eventIngestedRangeMapTask1.put(blogsIndex, shardRangeInfos.subList(0, 2));
             UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMapTask1);
-            var createEventIngestedRangeTask1 = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(
-                rangeUpdateRequest
-            );
+            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
 
             // second task has one shard
             Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMapTask2 = new HashMap<>();
             eventIngestedRangeMapTask2.put(blogsIndex, shardRangeInfos.subList(2, 3));
-            var createEventIngestedRangeTask2 = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(
+            var eventIngestedRangeTask2 = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
                 new UpdateEventIngestedRangeRequest(eventIngestedRangeMapTask2)
             );
 
-            clusterState4 = executeTasks(clusterState3, List.of(createEventIngestedRangeTask1, createEventIngestedRangeTask2));
+            clusterState4 = executeTasks(clusterState3, List.of(eventIngestedRangeTask, eventIngestedRangeTask2));
             assertNotSame(clusterState3, clusterState4);
             IndexLongFieldRange eventIngestedRange = clusterState4.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
             // you can't actually call getMin or getMax right now - those throw errors since not all shards are accounted for
@@ -171,9 +169,9 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             );
             eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfoA, shardRangeInfoB));
             UpdateEventIngestedRangeRequest rangeUpdateRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
-            var createEventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(rangeUpdateRequest);
+            var eventIngestedRangeTask = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest);
 
-            clusterState5 = executeTasks(clusterState4, List.of(createEventIngestedRangeTask));
+            clusterState5 = executeTasks(clusterState4, List.of(eventIngestedRangeTask));
             IndexLongFieldRange eventIngestedRange = clusterState5.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
             assertEquals(500L, eventIngestedRange.getMin());
             assertEquals(4000L, eventIngestedRange.getMax());
@@ -212,9 +210,7 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             eventIngestedRangeMap1.put(webTrafficIndex, List.of(shardRangeInfoWeb1A));
 
             UpdateEventIngestedRangeRequest rangeUpdateRequest1 = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap1);
-            var createEventIngestedRangeTask1 = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(
-                rangeUpdateRequest1
-            );
+            var eventIngestedRangeTask1 = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(rangeUpdateRequest1);
 
             Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap2 = new HashMap<>();
             var shardRangeInfoBlogs2A = new EventIngestedRangeClusterStateService.ShardRangeInfo(
@@ -232,13 +228,13 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
             eventIngestedRangeMap2.put(blogsIndex, List.of(shardRangeInfoBlogs2A));
             eventIngestedRangeMap2.put(webTrafficIndex, List.of(shardRangeInfoWeb2A, shardRangeInfoWeb2B));
 
-            var createEventIngestedRangeTask2 = new UpdateEventIngestedRangeTransportAction.CreateEventIngestedRangeTask(
+            var eventIngestedRangeTask2 = new UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask(
                 new UpdateEventIngestedRangeRequest(eventIngestedRangeMap2)
             );
 
             var taskList = new ArrayList<UpdateEventIngestedRangeTransportAction.EventIngestedRangeTask>();
-            taskList.add(createEventIngestedRangeTask1);
-            taskList.add(createEventIngestedRangeTask2);
+            taskList.add(eventIngestedRangeTask1);
+            taskList.add(eventIngestedRangeTask2);
             Randomness.shuffle(taskList);
             clusterState2 = executeTasks(clusterState1, taskList);
             assertNotSame(clusterState1, clusterState2);

--- a/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTaskExecutorTests.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.state;
 import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.stateWithNoShard;
@@ -44,11 +43,13 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
         ClusterState clusterState1;  // initial cluster state
         ClusterState clusterState2;  // cluster state after first task runs (building on clusterState1)
 
-        Index blogsIndex = new Index("blogs", UUID.randomUUID().toString());
+        String indexName = "blogs";
+        Index blogsIndex;
 
         // TODO: do I need to try other ShardRoutingStates here, like RELOCATING, UNASSIGNED or INITIALIZING?
         // ClusterState clusterState = state(blogsIndex, true, ShardRoutingState.STARTED);
-        clusterState1 = state(1, new String[] { blogsIndex.getName() }, 1);
+        clusterState1 = state(1, new String[] { indexName }, 1);
+        blogsIndex = clusterState1.metadata().index(indexName).getIndex();
 
         Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
         EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfo = new EventIngestedRangeClusterStateService.ShardRangeInfo(
@@ -62,8 +63,7 @@ public class UpdateEventIngestedRangeTransportActionTaskExecutorTests extends ES
 
         clusterState2 = executeTasks(clusterState1, List.of(eventIngestedRangeTask));
         assertNotSame(clusterState1, clusterState2);
-        // TODO: change this to blogsIndex
-        IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex.getName()).getEventIngestedRange();
+        IndexLongFieldRange eventIngestedRange = clusterState2.getMetadata().index(blogsIndex).getEventIngestedRange();
 
         assertEquals(1000L, eventIngestedRange.getMin());
         assertEquals(2000L, eventIngestedRange.getMax());

--- a/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/UpdateEventIngestedRangeTransportActionTests.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.cluster;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterApplierService;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.FakeThreadPoolMasterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardLongFieldRange;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockUtils;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.elasticsearch.action.support.replication.ClusterStateCreationUtils.state;
+import static org.elasticsearch.common.settings.ClusterSettings.createBuiltInClusterSettings;
+import static org.mockito.Mockito.mock;
+
+public class UpdateEventIngestedRangeTransportActionTests extends ESTestCase {
+
+    // TODO: add this to a setUp method if this works
+    private DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
+
+    public void testMasterOperation() {
+        ThreadPool threadPool = deterministicTaskQueue.getThreadPool();
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+
+        // TODO: this doesn't work with a non-mock thread pool
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(mockThreadPool);
+
+        // TODO: is this going to work with a mock TransportService?
+        String indexName = "blogs";
+        ClusterState clusterState1 = state(1, new String[] { indexName }, 1);
+        Index blogsIndex = clusterState1.metadata().index(indexName).getIndex();
+        ClusterService clusterService = createClusterService(Settings.builder(), clusterState1);
+        UpdateEventIngestedRangeTransportAction transportAction = new UpdateEventIngestedRangeTransportAction(
+            transportService,
+            clusterService,
+            threadPool,
+            mock(ActionFilters.class),
+            mock(IndexNameExpressionResolver.class)
+        );
+        // TODO: how do I set this up to run?
+        Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
+        EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfo = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+            new ShardId(blogsIndex, 0),
+            ShardLongFieldRange.of(1000, 2000)
+        );
+        eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
+
+        UpdateEventIngestedRangeRequest updateRangeRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
+
+        AtomicReference<AcknowledgedResponse> ackedResponseFromCallback = new AtomicReference<>(null);
+        ActionListener<AcknowledgedResponse> responseListener = new ActionListener<>() {
+            @Override
+            public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                ackedResponseFromCallback.set(acknowledgedResponse);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("onFailure should not have been called but received: " + e);
+            }
+        };
+
+        // TODO: this test runs "successfully" (no errors), but the task never runs - how do I create a real task system?
+        transportAction.masterOperation(null, updateRangeRequest, clusterState1, responseListener);
+    }
+
+    public void testOnFailureIsCalled() {
+        ThreadPool mockThreadPool = mock(ThreadPool.class);
+
+        // TODO: this doesn't work with a non-mock thread pool
+        TransportService transportService = MockUtils.setupTransportServiceWithThreadpoolExecutor(mockThreadPool);
+
+        // TODO: is this going to work with a mock TransportService?
+        String indexName = "blogs";
+        ClusterState clusterState1 = state(1, new String[] { indexName }, 1);
+        Index blogsIndex = clusterState1.metadata().index(indexName).getIndex();
+        UpdateEventIngestedRangeTransportAction transportAction = new UpdateEventIngestedRangeTransportAction(
+            transportService,
+            mock(ClusterService.class),
+            mockThreadPool,
+            mock(ActionFilters.class),
+            mock(IndexNameExpressionResolver.class)
+        );
+        // TODO: how do I set this up to run?
+        Map<Index, List<EventIngestedRangeClusterStateService.ShardRangeInfo>> eventIngestedRangeMap = new HashMap<>();
+        EventIngestedRangeClusterStateService.ShardRangeInfo shardRangeInfo = new EventIngestedRangeClusterStateService.ShardRangeInfo(
+            new ShardId(blogsIndex, 0),
+            ShardLongFieldRange.of(1000, 2000)
+        );
+        eventIngestedRangeMap.put(blogsIndex, List.of(shardRangeInfo));
+
+        UpdateEventIngestedRangeRequest updateRangeRequest = new UpdateEventIngestedRangeRequest(eventIngestedRangeMap);
+
+        AtomicBoolean onFailureCalled = new AtomicBoolean(false);
+        ActionListener<AcknowledgedResponse> responseListener = new ActionListener<>() {
+            @Override
+            public void onResponse(AcknowledgedResponse acknowledgedResponse) {
+                fail("onResponse should not have been called");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                onFailureCalled.set(true);
+            }
+        };
+
+        transportAction.masterOperation(null, updateRangeRequest, clusterState1, responseListener);
+        // TODO: this test passes (onFailure is called) but for uninteresting reasons - namely queue.submitTask throws NPE
+        // TODO: need a better onFailure test that ideally fails while the task is running - how do that?
+        assertTrue("onFailure should have been called", onFailureCalled.get());
+    }
+
+    // copied from GatewayServiceTests
+    private ClusterService createClusterService(Settings.Builder settingsBuilder, ClusterState initialState) {
+        final var threadPool = deterministicTaskQueue.getThreadPool();
+        final var settings = settingsBuilder.build();
+        final var clusterSettings = createBuiltInClusterSettings(settings);
+
+        final var clusterService = new ClusterService(
+            settings,
+            clusterSettings,
+            new FakeThreadPoolMasterService(initialState.nodes().getLocalNodeId(), threadPool, deterministicTaskQueue::scheduleNow),
+            new ClusterApplierService(initialState.nodes().getLocalNodeId(), settings, clusterSettings, threadPool) {
+                @Override
+                protected PrioritizedEsThreadPoolExecutor createThreadPoolExecutor() {
+                    return deterministicTaskQueue.getPrioritizedEsThreadPoolExecutor();
+                }
+            }
+        );
+
+        clusterService.getClusterApplierService().setInitialState(initialState);
+        clusterService.setNodeConnectionsService(ClusterServiceUtils.createNoOpNodeConnectionsService());
+        clusterService.getMasterService()
+            .setClusterStatePublisher(ClusterServiceUtils.createClusterStatePublisher(clusterService.getClusterApplierService()));
+        clusterService.getMasterService().setClusterStateSupplier(clusterService.getClusterApplierService()::state);
+        clusterService.start();
+        return clusterService;
+    }
+}


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/106252 adds logic for adding `event.ingested` 
min/max range to IndexMetadata in cluster state for newly created searchable snapshots,
but it will not populate that value in cluster state for existing searchable snapshots.

A new service is created (EventIngestedRangeClusterStateService) that runs on data nodes,
watches for cluster state events to determine when a cluster is fully upgraded to a new version. 
It then obtains event.ingested min/max range values from each shard of "frozen" indices (searchable
snapshots) that are assigned to the current node.

Those ranges are sent to the master node via a new MasterNodeTransportAction, 
`UpdateEventIngestedRangeTransportAction`, which kicks off a task to update cluster state
with the new information.