### PR TITLE
Do not use nested arrays as malformed values in scaled_float and unsigned_long synthetic source tests

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
@@ -413,8 +413,7 @@ public class ScaledFloatFieldMapperTests extends NumberFieldMapperTests {
             if (ignoreMalformedEnabled && randomBoolean()) {
                 List<Supplier<Object>> choices = List.of(
                     () -> randomAlphaOfLengthBetween(1, 10),
-                    () -> Map.of(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)),
-                    () -> List.of(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10))
+                    () -> Map.of(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10))
                 );
                 var malformedInput = randomFrom(choices).get();
                 return new Value(malformedInput, null, malformedInput);

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -461,8 +461,7 @@ public class UnsignedLongFieldMapperTests extends WholeNumberFieldMapperTests {
             if (ignoreMalformedEnabled && randomBoolean()) {
                 List<Supplier<Object>> choices = List.of(
                     () -> randomAlphaOfLengthBetween(1, 10),
-                    () -> Map.of(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)),
-                    () -> List.of(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10))
+                    () -> Map.of(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10))
                 );
                 var malformedInput = randomFrom(choices).get();
                 return new Value(malformedInput, null, malformedInput);


### PR DESCRIPTION
They don't provide any additional value because arrays are parsed at the level above and tests already cover arrays.

Fixes #109649.