### PR TITLE
Index version upgrade is not possible when '_source' is disabled

### DIFF
--- a/docs/reference/mapping/fields/source-field.asciidoc
+++ b/docs/reference/mapping/fields/source-field.asciidoc
@@ -43,7 +43,7 @@ available then a number of features are not supported:
 * The <<docs-update,`update`>>, <<docs-update-by-query,`update_by_query`>>,
 and <<docs-reindex,`reindex`>> APIs.
 
-* In the {kib} link:{kibana-ref}/discover.html[Discover] application, field data will not be displayed. 
+* In the {kib} link:{kibana-ref}/discover.html[Discover] application, field data will not be displayed.
 
 * On the fly <<highlighting,highlighting>>.
 
@@ -56,6 +56,8 @@ and <<docs-reindex,`reindex`>> APIs.
 
 * Potentially in the future, the ability to repair index corruption
   automatically.
+
+* Unable to upgrade to the next Elasticsearch version in the future
 ==================================================
 
 TIP: If disk space is a concern, rather increase the


### PR DESCRIPTION
It is important to note that disabling '_source' will prevent index upgrades. This will also be found as an issue by the upgrade assistant when upgrading future versions of elasticsearch and will not be upgradable unless the index is cleared, so it should be included in the warning statement for that option.

