### PR TITLE
[8.13] [DOCS] Clarify behavior of the generic `data` node role (#106375)

### DIFF
--- a/docs/reference/modules/node.asciidoc
+++ b/docs/reference/modules/node.asciidoc
@@ -68,8 +68,8 @@ A node that has the `master` role, which makes it eligible to be
 
 <<data-node,Data node>>::
 
-A node that has the `data` role. Data nodes hold data and perform data
-related operations such as CRUD, search, and aggregations. A node with the `data` role can fill any of the specialised data node roles.
+A node that has one of several data roles. Data nodes hold data and perform data
+related operations such as CRUD, search, and aggregations. A node with a generic `data` role can fill any of the specialized data node roles.
 
 <<node-ingest-node,Ingest node>>::
 
@@ -220,7 +220,7 @@ therefore ensure that the storage and networking available to the nodes in your
 cluster are good enough to meet your performance goals.
 
 [[data-node]]
-==== Data node
+==== Data nodes
 
 Data nodes hold the shards that contain the documents you have indexed. Data
 nodes handle data related operations like CRUD, search, and aggregations.
@@ -230,20 +230,27 @@ monitor these resources and to add more data nodes if they are overloaded.
 The main benefit of having dedicated data nodes is the separation of the master
 and data roles.
 
-To create a dedicated data node, set:
+In a multi-tier deployment architecture, you use specialized data roles to
+assign data nodes to specific tiers: `data_content`,`data_hot`, `data_warm`,
+`data_cold`, or `data_frozen`. A node can belong to multiple tiers. 
+
+If you want to include a node in all tiers, or if your cluster does not use multiple tiers, then you can use the generic `data` role.
+
+WARNING: If you assign a node to a specific tier using a specialized data role, then you shouldn't also assign it the generic `data` role. The generic `data` role takes precedence over specialized data roles.
+
+[[generic-data-node]]
+===== Generic data node
+
+Generic data nodes are included in all content tiers. 
+
+To create a dedicated generic data node, set:
 [source,yaml]
 ----
 node.roles: [ data ]
 ----
 
-In a multi-tier deployment architecture, you use specialized data roles to
-assign data nodes to specific tiers: `data_content`,`data_hot`, `data_warm`,
-`data_cold`, or `data_frozen`. A node can belong to multiple tiers, but a node
-that has one of the specialized data roles cannot have the generic `data` role.
-
-[role="xpack"]
 [[data-content-node]]
-==== Content data node
+===== Content data node
 
 Content data nodes are part of the content tier.
 include::{es-repo-dir}/datatiers.asciidoc[tag=content-tier]
@@ -254,9 +261,8 @@ To create a dedicated content node, set:
 node.roles: [ data_content ]
 ----
 
-[role="xpack"]
 [[data-hot-node]]
-==== Hot data node
+===== Hot data node
 
 Hot data nodes are part of the hot tier.
 include::{es-repo-dir}/datatiers.asciidoc[tag=hot-tier]
@@ -267,9 +273,8 @@ To create a dedicated hot node, set:
 node.roles: [ data_hot ]
 ----
 
-[role="xpack"]
 [[data-warm-node]]
-==== Warm data node
+===== Warm data node
 
 Warm data nodes are part of the warm tier.
 include::{es-repo-dir}/datatiers.asciidoc[tag=warm-tier]
@@ -280,9 +285,8 @@ To create a dedicated warm node, set:
 node.roles: [ data_warm ]
 ----
 
-[role="xpack"]
 [[data-cold-node]]
-==== Cold data node
+===== Cold data node
 
 Cold data nodes are part of the cold tier.
 include::{es-repo-dir}/datatiers.asciidoc[tag=cold-tier]
@@ -293,9 +297,8 @@ To create a dedicated cold node, set:
 node.roles: [ data_cold ]
 ----
 
-[role="xpack"]
 [[data-frozen-node]]
-==== Frozen data node
+===== Frozen data node
 
 Frozen data nodes are part of the frozen tier.
 include::{es-repo-dir}/datatiers.asciidoc[tag=frozen-tier]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[DOCS] Clarify behavior of the generic &#x60;data&#x60; node role (#106375)](https://github.com/elastic/elasticsearch/pull/106375)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)