### PR TITLE
Fix ESQL cancellation for exchange requests

### DIFF
--- a/docs/changelog/109695.yaml
+++ b/docs/changelog/109695.yaml
@@ -1,0 +1,5 @@
+pr: 109695
+summary: Fix ESQL cancellation for exchange requests
+area: ES|QL
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
@@ -212,7 +212,7 @@ public class TaskCancellationService {
                     @Override
                     public void handleException(TransportException exp) {
                         final Throwable cause = ExceptionsHelper.unwrapCause(exp);
-                        assert cause instanceof ElasticsearchSecurityException == false;
+                        assert cause instanceof ElasticsearchSecurityException == false : new AssertionError(exp);
                         if (isUnimportantBanFailure(cause)) {
                             logger.debug(
                                 () -> format("cannot send ban for tasks with the parent [%s] on connection [%s]", taskId, connection),
@@ -261,7 +261,7 @@ public class TaskCancellationService {
                     @Override
                     public void handleException(TransportException exp) {
                         final Throwable cause = ExceptionsHelper.unwrapCause(exp);
-                        assert cause instanceof ElasticsearchSecurityException == false;
+                        assert cause instanceof ElasticsearchSecurityException == false : new AssertionError(exp);
                         if (isUnimportantBanFailure(cause)) {
                             logger.debug(
                                 () -> format(

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/exchange/ExchangeService.java
@@ -25,7 +25,9 @@ import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BlockStreamInput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportChannel;
@@ -198,13 +200,15 @@ public final class ExchangeService extends AbstractLifecycleComponent {
 
     private class ExchangeTransportAction implements TransportRequestHandler<ExchangeRequest> {
         @Override
-        public void messageReceived(ExchangeRequest request, TransportChannel channel, Task task) {
+        public void messageReceived(ExchangeRequest request, TransportChannel channel, Task exchangeTask) {
             final String exchangeId = request.exchangeId();
             ActionListener<ExchangeResponse> listener = new ChannelActionListener<>(channel);
             final ExchangeSinkHandler sinkHandler = sinks.get(exchangeId);
             if (sinkHandler == null) {
                 listener.onResponse(new ExchangeResponse(blockFactory, null, true));
             } else {
+                final CancellableTask task = (CancellableTask) exchangeTask;
+                task.addListener(() -> sinkHandler.onFailure(new TaskCancelledException("request cancelled " + task.getReasonCancelled())));
                 sinkHandler.fetchPageAsync(request.sourcesFinished(), listener);
             }
         }

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -43,6 +43,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         .distribution(DistributionType.DEFAULT)
         .setting("xpack.license.self_generated.type", "trial")
         .setting("xpack.security.enabled", "true")
+        .setting("xpack.ml.enabled", "false")
         .rolesFile(Resource.fromClasspath("roles.yml"))
         .user("test-admin", "x-pack-test-password", "test-admin", true)
         .user("user1", "x-pack-test-password", "user1", false)
@@ -51,6 +52,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
         .user("user4", "x-pack-test-password", "user4", false)
         .user("user5", "x-pack-test-password", "user5", false)
         .user("fls_user", "x-pack-test-password", "fls_user", false)
+        .user("metadata1_read2", "x-pack-test-password", "metadata1_read2", false)
         .build();
 
     @Override
@@ -133,6 +135,21 @@ public class EsqlSecurityIT extends ESRestTestCase {
 
         error = expectThrows(ResponseException.class, () -> runESQLCommand("user2", "from index-user1 | stats sum(value)"));
         assertThat(error.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+    }
+
+    public void testInsufficientPrivilege() {
+        Exception error = expectThrows(
+            Exception.class,
+            () -> runESQLCommand("metadata1_read2", "FROM index-user1,index-user2 | STATS sum=sum(value)")
+        );
+        assertThat(
+            error.getMessage(),
+            containsString(
+                "unauthorized for user [test-admin] run as [metadata1_read2] "
+                    + "with effective roles [metadata1_read2] on indices [index-user1], "
+                    + "this action is granted by the index privileges [read,all]"
+            )
+        );
     }
 
     public void testDocumentLevelSecurity() throws Exception {

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/resources/roles.yml
@@ -32,6 +32,14 @@ user2:
         - create_index
         - indices:admin/refresh
 
+metadata1_read2:
+  cluster: []
+  indices:
+    - names: [ 'index-user1' ]
+      privileges: [ 'view_index_metadata' ]
+    - names: [ 'index-user2' ]
+      privileges: [ 'read' ]
+
 user3:
   cluster: []
   indices:


### PR DESCRIPTION
Currently, we do not register task cancellations for exchange requests, which leads to a long delay in failing the main request when a data-node request is rejected.