### PR TITLE
Ensure 41_knn_search_byte_quantized is on a single shard for repeatability

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized.yml
@@ -247,6 +247,9 @@ setup:
       indices.create:
         index: mip
         body:
+          settings:
+            index:
+              number_of_shards: 1
           mappings:
             properties:
               name:
@@ -403,6 +406,10 @@ setup:
   - do:
       indices.create:
         index: hnsw_byte_quantized_merge_cosine
+        body:
+          settings:
+            index:
+              number_of_shards: 1
 
   - do:
       indices.put_mapping:
@@ -476,6 +483,10 @@ setup:
   - do:
       indices.create:
         index: hnsw_byte_quantized_merge_dot_product
+        body:
+          settings:
+            index:
+              number_of_shards: 1
 
   - do:
       indices.put_mapping:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/41_knn_search_byte_quantized.yml
@@ -6,6 +6,9 @@ setup:
       indices.create:
         index: hnsw_byte_quantized
         body:
+          settings:
+            index:
+              number_of_shards: 1
           mappings:
             properties:
               name:
@@ -17,7 +20,6 @@ setup:
                 similarity: l2_norm
                 index_options:
                   type: int8_hnsw
-                  confidence_interval: 0.9
               another_vector:
                 type: dense_vector
                 dims: 5
@@ -25,7 +27,6 @@ setup:
                 similarity: l2_norm
                 index_options:
                   type: int8_hnsw
-                  confidence_interval: 0.9
 
   - do:
       index:
@@ -35,6 +36,10 @@ setup:
           name: cow.jpg
           vector: [230.0, 300.33, -34.8988, 15.555, -200.0]
           another_vector: [130.0, 115.0, -1.02, 15.555, -100.0]
+  # Flush in order to provoke a merge later
+  - do:
+      indices.flush:
+        index: hnsw_byte_quantized
 
   - do:
       index:
@@ -44,6 +49,10 @@ setup:
           name: moose.jpg
           vector: [-0.5, 100.0, -13, 14.8, -156.0]
           another_vector: [-0.5, 50.0, -1, 1, 120]
+  # Flush in order to provoke a merge later
+  - do:
+      indices.flush:
+        index: hnsw_byte_quantized
 
   - do:
       index:
@@ -53,12 +62,15 @@ setup:
           name: rabbit.jpg
           vector: [0.5, 111.3, -13.0, 14.8, -156.0]
           another_vector: [-0.5, 11.0, 0, 12, 111.0]
+  # Flush in order to provoke a merge later
+  - do:
+      indices.flush:
+        index: hnsw_byte_quantized
 
   - do:
       indices.forcemerge:
         index: hnsw_byte_quantized
         max_num_segments: 1
-
 ---
 "kNN search only":
   - do:
@@ -85,8 +97,8 @@ setup:
         body:
           fields: [ "name" ]
           knn:
-           - {field: vector, query_vector: [-0.5, 90.0, -10, 14.8, -156.0], k: 2, num_candidates: 3}
-           - {field: another_vector, query_vector: [-0.5, 11.0, 0, 12, 111.0], k: 2, num_candidates: 3}
+            - {field: vector, query_vector: [-0.5, 90.0, -10, 14.8, -156.0], k: 2, num_candidates: 3}
+            - {field: another_vector, query_vector: [-0.5, 11.0, 0, 12, 111.0], k: 2, num_candidates: 3}
 
   - match: {hits.hits.0._id: "3"}
   - match: {hits.hits.0.fields.name.0: "rabbit.jpg"}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int8_flat.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search.vectors/42_knn_search_int8_flat.yml
@@ -6,6 +6,9 @@ setup:
       indices.create:
         index: int8_flat
         body:
+          settings:
+            index:
+              number_of_shards: 1
           mappings:
             properties:
               name:


### PR DESCRIPTION
Since we are only indexing 3 docs, we need to ensure its a single shard for score repeatability.

Additionally, adding back all the flushes that were removed to ensure we exercise the merging paths. 