### PR TITLE
[8.14] change  from string to array in example (#109263)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -1035,7 +1035,7 @@ ignored, only the host and port are used. For example:
 
 [source,yaml]
 --------------------------------------------------
-reindex.remote.whitelist: "otherhost:9200, another:9200, 127.0.10.*:9200, localhost:*"
+reindex.remote.whitelist: [otherhost:9200, another:9200, 127.0.10.*:9200, localhost:*"]
 --------------------------------------------------
 
 The list of allowed hosts must be configured on any nodes that will coordinate the reindex.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [change  from string to array in example (#109263)](https://github.com/elastic/elasticsearch/pull/109263)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)