### PR TITLE
[8.13] [DOCS] Add azure storage secure settings while the node is running (#107163)

### DIFF
--- a/docs/reference/setup/secure-settings.asciidoc
+++ b/docs/reference/setup/secure-settings.asciidoc
@@ -25,7 +25,11 @@ are node-specific settings that must have the same value on every node.
 Just like the settings values in `elasticsearch.yml`, changes to the keystore
 contents are not automatically applied to the running {es} node. Re-reading
 settings requires a node restart. However, certain secure settings are marked as
-*reloadable*. Such settings can be <<cluster-nodes-reload-secure-settings, re-read and applied on a running node>>.
+*reloadable*. Such settings can be re-read and applied on a running node.
+
+You can define these settings before the node is started, 
+or call the <<cluster-nodes-reload-secure-settings,Nodes reload secure settings API>> 
+after the settings are defined to apply them to a running node. 
 
 The values of all secure settings, *reloadable* or not, must be identical
 across all cluster nodes. After making the desired secure settings changes,

--- a/docs/reference/snapshot-restore/repository-azure.asciidoc
+++ b/docs/reference/snapshot-restore/repository-azure.asciidoc
@@ -6,8 +6,10 @@ You can use https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-i
 [[repository-azure-usage]]
 ==== Setup
 
-To enable Azure repositories, you have first to define your azure storage settings as
-{ref}/secure-settings.html[secure settings], before starting up the node:
+To enable Azure repositories, you have first to define your Azure storage settings as
+{ref}/secure-settings.html[secure settings].
+
+You can define these settings before the node is started, or call the <<cluster-nodes-reload-secure-settings,Nodes reload secure settings API>> after the settings are defined to apply them to a running node.
 
 [source,sh]
 ----------------------------------------------------------------

--- a/docs/reference/snapshot-restore/repository-gcs.asciidoc
+++ b/docs/reference/snapshot-restore/repository-gcs.asciidoc
@@ -117,6 +117,10 @@ PUT _snapshot/my_gcs_repository
 // TEST[skip:we don't have gcs setup while testing this]
 
 The `credentials_file` settings are {ref}/secure-settings.html#reloadable-secure-settings[reloadable].
+You can define these settings before the node is started, 
+or call the <<cluster-nodes-reload-secure-settings,Nodes reload secure settings API>> 
+after the settings are defined to apply them to a running node.
+
 After you reload the settings, the internal `gcs` clients, which are used to
 transfer the snapshot contents, utilize the latest settings from the keystore.
 

--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -56,7 +56,7 @@ For more information about creating and updating the {es} keystore, see
 {ref}/secure-settings.html[Secure settings].
 
 For example, if you want to use specific credentials to access S3 then run the
-following commands to add these credentials to the keystore:
+following commands to add these credentials to the keystore.
 
 [source,sh]
 ----
@@ -80,8 +80,12 @@ bin/elasticsearch-keystore remove s3.client.default.session_token
 ----
 
 *All* client secure settings of this repository type are
-{ref}/secure-settings.html#reloadable-secure-settings[reloadable]. After you
-reload the settings, the internal `s3` clients, used to transfer the snapshot
+{ref}/secure-settings.html#reloadable-secure-settings[reloadable]. 
+You can define these settings before the node is started, 
+or call the <<cluster-nodes-reload-secure-settings,Nodes reload secure settings API>> 
+after the settings are defined to apply them to a running node. 
+
+After you reload the settings, the internal `s3` clients, used to transfer the snapshot
 contents, will utilize the latest settings from the keystore. Any existing `s3`
 repositories, as well as any newly created ones, will pick up the new values
 stored in the keystore.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[DOCS] Add azure storage secure settings while the node is running (#107163)](https://github.com/elastic/elasticsearch/pull/107163)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)