### PR TITLE
ESQL: Limit the size of shapes in MV_SLICE tests

### DIFF
--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSliceTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/multivalue/MvSliceTests.java
@@ -306,7 +306,16 @@ public class MvSliceTests extends AbstractFunctionTestCase {
         }));
 
         suppliers.add(new TestCaseSupplier(List.of(DataType.GEO_SHAPE, DataType.INTEGER, DataType.INTEGER), () -> {
-            List<Object> field = randomList(1, 5, () -> new BytesRef(GEO.asWkt(GeometryTestUtils.randomGeometry(randomBoolean()))));
+            var pointCounter = new MvAppendTests.GeometryPointCountVisitor();
+            List<Object> field = randomList(
+                1,
+                5,
+                () -> new BytesRef(
+                    GEO.asWkt(
+                        randomValueOtherThanMany(g -> g.visit(pointCounter) > 500, () -> GeometryTestUtils.randomGeometry(randomBoolean()))
+                    )
+                )
+            );
             int length = field.size();
             int start = randomIntBetween(0, length - 1);
             int end = randomIntBetween(start, length - 1);
@@ -323,7 +332,16 @@ public class MvSliceTests extends AbstractFunctionTestCase {
         }));
 
         suppliers.add(new TestCaseSupplier(List.of(DataType.CARTESIAN_SHAPE, DataType.INTEGER, DataType.INTEGER), () -> {
-            List<Object> field = randomList(1, 5, () -> new BytesRef(CARTESIAN.asWkt(ShapeTestUtils.randomGeometry(randomBoolean()))));
+            var pointCounter = new MvAppendTests.GeometryPointCountVisitor();
+            List<Object> field = randomList(
+                1,
+                5,
+                () -> new BytesRef(
+                    CARTESIAN.asWkt(
+                        randomValueOtherThanMany(g -> g.visit(pointCounter) > 500, () -> GeometryTestUtils.randomGeometry(randomBoolean()))
+                    )
+                )
+            );
             int length = field.size();
             int start = randomIntBetween(0, length - 1);
             int end = randomIntBetween(start, length - 1);


### PR DESCRIPTION
This limits the size of the data used to test MV_SLICE so we don't run out of memory when testing it.

Closes #109697
