### PR TITLE
ESQL: Warn about division

### DIFF
--- a/docs/reference/esql/functions/binary.asciidoc
+++ b/docs/reference/esql/functions/binary.asciidoc
@@ -65,6 +65,9 @@ include::types/mul.asciidoc[]
 [.text-center]
 image::esql/functions/signature/div.svg[Embedded,opts=inline]
 
+NOTE: Division of two integer types will yield an integer result, rounding towards 0.
+      If you need floating point division, <<esql-cast-operator>> one of the arguments to a `DOUBLE`.
+
 include::types/div.asciidoc[]
 
 ==== Modulus `%`


### PR DESCRIPTION
When you divide two integers or two longs we round towards 0. Like Postgres or Java or Rust or C. Other systems, like MySQL or SPL or Javascript or Python always produce a floating point number. We should warn folks about this. It's genuinely unexpected for some folks. OTOH, converting into a floating point number would be unexpected for other folks. Oh well, let's document what we've got.
