### PR TITLE
DocsStats: Add human readable bytesize

### DIFF
--- a/docs/changelog/109720.yaml
+++ b/docs/changelog/109720.yaml
@@ -1,0 +1,5 @@
+pr: 109720
+summary: "DocsStats: Add human readable bytesize"
+area: Stats
+type: enhancement
+issues: []

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -227,6 +227,10 @@ space of deleted Lucene documents when a segment is merged.
 `total_size_in_bytes`::
 (integer)
 Total size in bytes across all primary shards assigned to selected nodes.
+
+`total_size`::
+(string)
+Total size across all primary shards assigned to selected nodes, as a human-readable string.
 =====
 
 `store`::
@@ -1600,6 +1604,7 @@ The API returns the following response:
          "count": 10,
          "deleted": 0,
          "total_size_in_bytes": 8833
+         "total_size": "8.6kb"
       },
       "store": {
          "size": "16.2kb",

--- a/docs/reference/cluster/stats.asciidoc
+++ b/docs/reference/cluster/stats.asciidoc
@@ -1603,8 +1603,8 @@ The API returns the following response:
       "docs": {
          "count": 10,
          "deleted": 0,
+         "total_size": "8.6kb",
          "total_size_in_bytes": 8833
-         "total_size": "8.6kb"
       },
       "store": {
          "size": "16.2kb",

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
@@ -32,6 +32,15 @@
 
 ---
 "cluster stats with human flag returns docs as human readable size":
+  - requires:
+      capabilities:
+        - method: GET
+          path: /_cluster/stats
+          capabilities:
+            - "human-readable-total-docs-size"
+      test_runner_feature: [capabilities]
+      reason: Capability required to run test
+
   - do:
       index:
         index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
@@ -33,13 +33,13 @@
 ---
 "cluster stats with human flag returns docs as human readable size":
   - requires:
+      test_runner_features: [capabilities]
       capabilities:
         - method: GET
           path: /_cluster/stats
           capabilities:
             - "human-readable-total-docs-size"
-      test_runner_feature: [capabilities]
-      reason: Capability required to run test
+      reason: "Capability required to run test"
 
   - do:
       index:
@@ -53,8 +53,8 @@
       cluster.stats:
         human: true
 
-  - is_true: indices.docs.total_size_in_bytes
-  - is_true: indices.docs.total_size
+  - exists: indices.docs.total_size_in_bytes
+  - exists: indices.docs.total_size
 
 ---
 "get cluster stats returns cluster_uuid at the top level":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.stats/10_basic.yml
@@ -31,6 +31,23 @@
   - is_true: nodes.network_types
 
 ---
+"cluster stats with human flag returns docs as human readable size":
+  - do:
+      index:
+        index: test
+        id: "1"
+        refresh: true
+        body:
+          foo: bar
+
+  - do:
+      cluster.stats:
+        human: true
+
+  - is_true: indices.docs.total_size_in_bytes
+  - is_true: indices.docs.total_size
+
+---
 "get cluster stats returns cluster_uuid at the top level":
 
   - do:

--- a/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/DocsStats.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.shard;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -81,7 +82,7 @@ public class DocsStats implements Writeable, ToXContentFragment {
         builder.startObject(Fields.DOCS);
         builder.field(Fields.COUNT, count);
         builder.field(Fields.DELETED, deleted);
-        builder.field(Fields.TOTAL_SIZE_IN_BYTES, totalSizeInBytes);
+        builder.humanReadableField(Fields.TOTAL_SIZE_IN_BYTES, Fields.TOTAL_SIZE, ByteSizeValue.ofBytes(totalSizeInBytes));
         builder.endObject();
         return builder;
     }
@@ -104,5 +105,6 @@ public class DocsStats implements Writeable, ToXContentFragment {
         static final String COUNT = "count";
         static final String DELETED = "deleted";
         static final String TOTAL_SIZE_IN_BYTES = "total_size_in_bytes";
+        static final String TOTAL_SIZE = "total_size";
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -19,12 +19,15 @@ import org.elasticsearch.rest.action.RestCancellableNodeClient;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestUtils.getTimeout;
 
 @ServerlessScope(Scope.INTERNAL)
 public class RestClusterStatsAction extends BaseRestHandler {
+
+    private static final Set<String> SUPPORTED_CAPABILITIES = Set.of("human-readable-total-docs-size");
 
     @Override
     public List<Route> routes() {
@@ -48,5 +51,10 @@ public class RestClusterStatsAction extends BaseRestHandler {
     @Override
     public boolean canTripCircuitBreaker() {
         return false;
+    }
+
+    @Override
+    public Set<String> supportedCapabilities() {
+        return SUPPORTED_CAPABILITIES;
     }
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
@@ -180,7 +180,7 @@ public class IndicesStatsMonitoringDocTests extends BaseFilteredMonitoringDocTes
 
     private CommonStats mockCommonStats() {
         final CommonStats commonStats = new CommonStats(CommonStatsFlags.ALL);
-        commonStats.getDocs().add(new DocsStats(1L, 0L, randomNonNegativeLong()));
+        commonStats.getDocs().add(new DocsStats(1L, 0L, randomNonNegativeLong() >> 8)); // >> 8 to avoid overflow - we add these things up
         commonStats.getStore().add(new StoreStats(2L, 0L, 0L));
 
         final IndexingStats.Stats indexingStats = new IndexingStats.Stats(3L, 4L, 0L, 0L, 0L, 0L, 0L, 0L, true, 5L, 0, 0);


### PR DESCRIPTION
This adds support for the `human` parameter for DocsStats, as it was missing. Sample

```
GET _cluster/stats?human&filter_path=indices.docs
```
