### PR TITLE
Include component templates in retention validaiton

### DIFF
--- a/docs/changelog/109779.yaml
+++ b/docs/changelog/109779.yaml
@@ -1,0 +1,5 @@
+pr: 109779
+summary: Include component templates in retention validaiton
+area: Data streams
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -805,9 +805,7 @@ public class MetadataIndexTemplateService {
         ComposableIndexTemplate template,
         @Nullable DataStreamGlobalRetention globalRetention
     ) {
-        DataStreamLifecycle lifecycle = template.template() != null && template.template().lifecycle() != null
-            ? template.template().lifecycle()
-            : resolveLifecycle(template, metadata.componentTemplates());
+        DataStreamLifecycle lifecycle = resolveLifecycle(template, metadata.componentTemplates());
         if (lifecycle != null) {
             if (template.getDataStreamTemplate() == null) {
                 throw new IllegalArgumentException(


### PR DESCRIPTION
We shouldn't disregard a component template's lifecycle configuration if the index template has one during retention validation.