### PR TITLE
Wrap lucene queries in GeoGridQueryBuilder with ConstantScoreQuery

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilder.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilder.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.spatial.index.query;
 
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.geo.LatLonGeometry;
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
@@ -284,7 +285,7 @@ public class GeoGridQueryBuilder extends AbstractQueryBuilder<GeoGridQueryBuilde
                 throw new QueryShardException(context, "failed to find geo field [" + fieldName + "]");
             }
         }
-        return grid.toQuery(context, fieldName, fieldType, gridId);
+        return new ConstantScoreQuery(grid.toQuery(context, fieldName, fieldType, gridId));
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilderTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.spatial.index.query;
 
+import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -118,8 +119,11 @@ public class GeoGridQueryBuilderTests extends AbstractQueryTestCase<GeoGridQuery
         final MappedFieldType fieldType = context.getFieldType(queryBuilder.fieldName());
         if (fieldType == null) {
             assertTrue("Found no indexed geo query.", query instanceof MatchNoDocsQuery);
-        } else if (fieldType.hasDocValues()) {
-            assertEquals(IndexOrDocValuesQuery.class, query.getClass());
+        } else {
+            assertEquals(ConstantScoreQuery.class, query.getClass());
+            if (fieldType.hasDocValues()) {
+                assertEquals(IndexOrDocValuesQuery.class, ((ConstantScoreQuery) query).getQuery().getClass());
+            }
         }
     }
 


### PR DESCRIPTION
This makes sure the queries can be cache at lucene level via LRU cache.