### PR TITLE
Make `BaseNodesRequest#nodeIds` final

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -65,9 +65,8 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         SecureString password,
         ActionListener<NodesReloadSecureSettingsResponse> listener
     ) {
-        final var request = new NodesReloadSecureSettingsRequest();
+        final var request = new NodesReloadSecureSettingsRequest(nodeIds);
         try {
-            request.nodesIds(nodeIds);
             request.setSecureStorePassword(password);
             client().execute(TransportNodesReloadSecureSettingsAction.TYPE, request, listener);
         } finally {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexRecoveryIT.java
@@ -322,8 +322,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
      * @param isRecoveryThrottlingNode whether to expect throttling to have occurred on the node
      */
     public void assertNodeHasThrottleTimeAndNoRecoveries(String nodeName, Boolean isRecoveryThrottlingNode) {
-        NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats()
-            .setNodesIds(nodeName)
+        NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats(nodeName)
             .clear()
             .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
             .get();
@@ -612,8 +611,7 @@ public class IndexRecoveryIT extends AbstractIndexRecoveryIntegTestCase {
         validateIndexRecoveryState(recoveryStates.get(0).getIndex());
 
         Consumer<String> assertNodeHasThrottleTimeAndNoRecoveries = nodeName -> {
-            NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats()
-                .setNodesIds(nodeName)
+            NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats(nodeName)
                 .clear()
                 .setIndices(new CommonStatsFlags(CommonStatsFlags.Flag.Recovery))
                 .get();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoRequestBuilder.java
@@ -14,8 +14,8 @@ import org.elasticsearch.client.internal.ElasticsearchClient;
 // TODO: This class's interface should match that of NodesInfoRequest
 public class NodesInfoRequestBuilder extends NodesOperationRequestBuilder<NodesInfoRequest, NodesInfoResponse, NodesInfoRequestBuilder> {
 
-    public NodesInfoRequestBuilder(ElasticsearchClient client) {
-        super(client, TransportNodesInfoAction.TYPE, new NodesInfoRequest());
+    public NodesInfoRequestBuilder(ElasticsearchClient client, String[] nodeIds) {
+        super(client, TransportNodesInfoAction.TYPE, new NodesInfoRequest(nodeIds));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/NodesReloadSecureSettingsRequest.java
@@ -44,8 +44,8 @@ public class NodesReloadSecureSettingsRequest extends BaseNodesRequest<NodesRelo
 
     private final RefCounted refs = LeakTracker.wrap(AbstractRefCounted.of(() -> Releasables.close(secureSettingsPassword)));
 
-    public NodesReloadSecureSettingsRequest() {
-        super((String[]) null);
+    public NodesReloadSecureSettingsRequest(String[] nodeIds) {
+        super(nodeIds);
     }
 
     public void setSecureStorePassword(SecureString secureStorePassword) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsRequestBuilder.java
@@ -17,8 +17,8 @@ public class NodesStatsRequestBuilder extends NodesOperationRequestBuilder<
     NodesStatsResponse,
     NodesStatsRequestBuilder> {
 
-    public NodesStatsRequestBuilder(ElasticsearchClient client) {
-        super(client, TransportNodesStatsAction.TYPE, new NodesStatsRequest());
+    public NodesStatsRequestBuilder(ElasticsearchClient client, String[] nodeIds) {
+        super(client, TransportNodesStatsAction.TYPE, new NodesStatsRequest(nodeIds));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
@@ -24,12 +25,10 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
      * the list of nodesIds that will be used to resolve this request and {@link #concreteNodes}
      * will be populated. Note that if {@link #concreteNodes} is not null, it will be used and nodeIds
      * will be ignored.
-     *
+     * <p>
      * See {@link DiscoveryNodes#resolveNodes} for a full description of the options.
-     *
-     * TODO: we can get rid of this and resolve it to concrete nodes in the rest layer
      **/
-    private String[] nodesIds;
+    private final String[] nodesIds;
 
     /**
      * once {@link #nodesIds} are resolved this will contain the concrete nodes that are part of this request. If set, {@link #nodesIds}
@@ -37,6 +36,7 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
      * */
     private DiscoveryNode[] concreteNodes;
 
+    @Nullable // if no timeout
     private TimeValue timeout;
 
     protected BaseNodesRequest(String... nodesIds) {
@@ -50,12 +50,6 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
 
     public final String[] nodesIds() {
         return nodesIds;
-    }
-
-    @SuppressWarnings("unchecked")
-    public final Request nodesIds(String... nodesIds) {
-        this.nodesIds = nodesIds;
-        return (Request) this;
     }
 
     public TimeValue timeout() {

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/NodesOperationRequestBuilder.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/NodesOperationRequestBuilder.java
@@ -25,12 +25,6 @@ public abstract class NodesOperationRequestBuilder<
     }
 
     @SuppressWarnings("unchecked")
-    public final RequestBuilder setNodesIds(String... nodesIds) {
-        request.nodesIds(nodesIds);
-        return (RequestBuilder) this;
-    }
-
-    @SuppressWarnings("unchecked")
     public RequestBuilder setTimeout(TimeValue timeout) {
         request.timeout(timeout);
         return (RequestBuilder) this;

--- a/server/src/main/java/org/elasticsearch/client/internal/ClusterAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/ClusterAdminClient.java
@@ -208,7 +208,7 @@ public class ClusterAdminClient implements ElasticsearchClient {
     }
 
     public NodesInfoRequestBuilder prepareNodesInfo(String... nodesIds) {
-        return new NodesInfoRequestBuilder(this).setNodesIds(nodesIds);
+        return new NodesInfoRequestBuilder(this, nodesIds);
     }
 
     public void clusterStats(ClusterStatsRequest request, ActionListener<ClusterStatsResponse> listener) {
@@ -228,7 +228,7 @@ public class ClusterAdminClient implements ElasticsearchClient {
     }
 
     public NodesStatsRequestBuilder prepareNodesStats(String... nodesIds) {
-        return new NodesStatsRequestBuilder(this).setNodesIds(nodesIds);
+        return new NodesStatsRequestBuilder(this, nodesIds);
     }
 
     public ActionFuture<NodesCapabilitiesResponse> nodesCapabilities(final NodesCapabilitiesRequest request) {

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestClusterStatsAction.java
@@ -41,7 +41,7 @@ public class RestClusterStatsAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient client) throws IOException {
-        ClusterStatsRequest clusterStatsRequest = new ClusterStatsRequest().nodesIds(request.paramAsStringArray("nodeId", null));
+        ClusterStatsRequest clusterStatsRequest = new ClusterStatsRequest(request.paramAsStringArray("nodeId", null));
         clusterStatsRequest.timeout(getTimeout(request));
         return channel -> new RestCancellableNodeClient(client, request.getHttpChannel()).admin()
             .cluster()

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestReloadSecureSettingsAction.java
@@ -62,8 +62,9 @@ public final class RestReloadSecureSettingsAction extends BaseRestHandler implem
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        final NodesReloadSecureSettingsRequest reloadSecureSettingsRequest = new NodesReloadSecureSettingsRequest();
-        reloadSecureSettingsRequest.nodesIds(Strings.splitStringByCommaToArray(request.param("nodeId")));
+        final NodesReloadSecureSettingsRequest reloadSecureSettingsRequest = new NodesReloadSecureSettingsRequest(
+            Strings.splitStringByCommaToArray(request.param("nodeId"))
+        );
         reloadSecureSettingsRequest.timeout(getTimeout(request));
         request.withContentOrSourceParamParserOrNull(parser -> {
             if (parser != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlPlatformArchitecturesUtil.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/utils/MlPlatformArchitecturesUtil.java
@@ -54,7 +54,7 @@ public class MlPlatformArchitecturesUtil {
     }
 
     static NodesInfoRequestBuilder getNodesInfoBuilderWithMlNodeArchitectureInfo(Client client) {
-        return client.admin().cluster().prepareNodesInfo().clear().setNodesIds("ml:true").setOs(true).setPlugins(true);
+        return client.admin().cluster().prepareNodesInfo("ml:true").clear().setOs(true).setPlugins(true);
     }
 
     private static Set<String> getArchitecturesSetFromNodesInfoResponse(NodesInfoResponse nodesInfoResponse) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGenerator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGenerator.java
@@ -64,8 +64,10 @@ public class InternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
      */
     public void maybeCreateNodeEnrollmentToken(Consumer<String> consumer, Iterator<TimeValue> backoff) {
         // the enrollment token can only be used against the node that generated it
-        final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().nodesIds("_local")
-            .addMetrics(NodesInfoMetrics.Metric.HTTP.metricName(), NodesInfoMetrics.Metric.TRANSPORT.metricName());
+        final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest("_local").addMetrics(
+            NodesInfoMetrics.Metric.HTTP.metricName(),
+            NodesInfoMetrics.Metric.TRANSPORT.metricName()
+        );
 
         client.execute(TransportNodesInfoAction.TYPE, nodesInfoRequest, ActionListener.wrap(response -> {
             assert response.getNodes().size() == 1;
@@ -132,8 +134,7 @@ public class InternalEnrollmentTokenGenerator extends BaseEnrollmentTokenGenerat
      */
     public void createKibanaEnrollmentToken(Consumer<EnrollmentToken> consumer, Iterator<TimeValue> backoff) {
         // the enrollment token can only be used against the node that generated it
-        final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest().nodesIds("_local")
-            .addMetric(NodesInfoMetrics.Metric.HTTP.metricName());
+        final NodesInfoRequest nodesInfoRequest = new NodesInfoRequest("_local").addMetric(NodesInfoMetrics.Metric.HTTP.metricName());
         client.execute(TransportNodesInfoAction.TYPE, nodesInfoRequest, ActionListener.wrap(response -> {
             assert response.getNodes().size() == 1;
             NodeInfo nodeInfo = response.getNodes().get(0);

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/webhook/WebhookTokenIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/webhook/WebhookTokenIntegrationTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.watcher.actions.webhook;
 import org.elasticsearch.action.admin.cluster.node.reload.NodesReloadSecureSettingsRequest;
 import org.elasticsearch.action.admin.cluster.node.reload.TransportNodesReloadSecureSettingsAction;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.KeyStoreWrapper;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureString;
@@ -99,7 +100,7 @@ public class WebhookTokenIntegrationTests extends AbstractWatcherIntegrationTest
             ksw.save(configPath, "".toCharArray(), false);
         }
         // Reload the keystore to load the new settings
-        NodesReloadSecureSettingsRequest reloadReq = new NodesReloadSecureSettingsRequest();
+        NodesReloadSecureSettingsRequest reloadReq = new NodesReloadSecureSettingsRequest(Strings.EMPTY_ARRAY);
         try {
             reloadReq.setSecureStorePassword(new SecureString("".toCharArray()));
             client().execute(TransportNodesReloadSecureSettingsAction.TYPE, reloadReq).get();


### PR DESCRIPTION
This field is always known at construction time, no need for it to be
mutable.