### PR TITLE
Make `BaseNodesRequest#concreteNodes` final

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/reload/TransportNodesReloadSecureSettingsAction.java
@@ -12,11 +12,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.nodes.TransportNodesAction;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
@@ -88,20 +88,15 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
     }
 
     @Override
-    protected void doExecute(
-        Task task,
-        NodesReloadSecureSettingsRequest request,
-        ActionListener<NodesReloadSecureSettingsResponse> listener
-    ) {
-        if (request.hasPassword() && isNodeLocal(request) == false && isNodeTransportTLSEnabled() == false) {
-            listener.onFailure(
-                new ElasticsearchException(
-                    "Secure settings cannot be updated cluster wide when TLS for the transport layer"
-                        + " is not enabled. Enable TLS or use the API with a `_local` filter on each node."
-                )
-            );
+    protected DiscoveryNode[] resolveRequest(NodesReloadSecureSettingsRequest request, ClusterState clusterState) {
+        final var concreteNodes = super.resolveRequest(request, clusterState);
+        final var isNodeLocal = concreteNodes.length == 1 && concreteNodes[0].getId().equals(clusterState.nodes().getLocalNodeId());
+        if (request.hasPassword() && isNodeLocal == false && isNodeTransportTLSEnabled() == false) {
+            throw new ElasticsearchException("""
+                Secure settings cannot be updated cluster wide when TLS for the transport layer is not enabled. Enable TLS or use the API \
+                with a `_local` filter on each node.""");
         } else {
-            super.doExecute(task, request, listener);
+            return concreteNodes;
         }
     }
 
@@ -147,14 +142,5 @@ public class TransportNodesReloadSecureSettingsAction extends TransportNodesActi
      */
     private boolean isNodeTransportTLSEnabled() {
         return transportService.isTransportSecure();
-    }
-
-    private boolean isNodeLocal(NodesReloadSecureSettingsRequest request) {
-        if (null == request.concreteNodes()) {
-            resolveRequest(request, clusterService.state());
-            assert request.concreteNodes() != null;
-        }
-        final DiscoveryNode[] nodes = request.concreteNodes();
-        return nodes.length == 1 && nodes[0].getId().equals(clusterService.localNode().getId());
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesRequest.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.support.nodes;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -18,29 +19,28 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Objects;
 
 public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>> extends ActionRequest {
 
     /**
-     * the list of nodesIds that will be used to resolve this request and {@link #concreteNodes}
-     * will be populated. Note that if {@link #concreteNodes} is not null, it will be used and nodeIds
-     * will be ignored.
-     * <p>
-     * See {@link DiscoveryNodes#resolveNodes} for a full description of the options.
+     * Sequence of node specifications that describe the nodes that this request should target. See {@link DiscoveryNodes#resolveNodes} for
+     * a full description of the options. If set, {@link #concreteNodes} is {@code null} and ignored.
      **/
     private final String[] nodesIds;
 
     /**
-     * once {@link #nodesIds} are resolved this will contain the concrete nodes that are part of this request. If set, {@link #nodesIds}
-     * will be ignored and this will be used.
-     * */
-    private DiscoveryNode[] concreteNodes;
+     * The exact nodes that this request should target. If set, {@link #nodesIds} is {@code null} and ignored.
+     **/
+    private final DiscoveryNode[] concreteNodes;
 
     @Nullable // if no timeout
     private TimeValue timeout;
 
-    protected BaseNodesRequest(String... nodesIds) {
+    protected BaseNodesRequest(String[] nodesIds) {
         this.nodesIds = nodesIds;
+        this.concreteNodes = null;
     }
 
     protected BaseNodesRequest(DiscoveryNode... concreteNodes) {
@@ -62,14 +62,6 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
         return (Request) this;
     }
 
-    public DiscoveryNode[] concreteNodes() {
-        return concreteNodes;
-    }
-
-    public void setConcreteNodes(DiscoveryNode[] concreteNodes) {
-        this.concreteNodes = concreteNodes;
-    }
-
     @Override
     public ActionRequestValidationException validate() {
         return null;
@@ -80,5 +72,16 @@ public abstract class BaseNodesRequest<Request extends BaseNodesRequest<Request>
         // `BaseNodesRequest` is rather heavyweight, especially all those `DiscoveryNodes` objects in larger clusters, and there is no need
         // to send it out over the wire. Use a dedicated transport request just for the bits you need.
         TransportAction.localOnly();
+    }
+
+    /**
+     * @return the nodes to which this request should fan out.
+     */
+    DiscoveryNode[] resolveNodes(ClusterState clusterState) {
+        assert nodesIds == null || concreteNodes == null;
+        return Objects.requireNonNullElseGet(
+            concreteNodes,
+            () -> Arrays.stream(clusterState.nodes().resolveNodes(nodesIds)).map(clusterState.nodes()::get).toArray(DiscoveryNode[]::new)
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -391,8 +391,8 @@ public class TransportNodesActionTests extends ESTestCase {
         }
 
         @Override
-        protected void resolveRequest(TestNodesRequest request, ClusterState clusterState) {
-            request.setConcreteNodes(clusterState.nodes().getDataNodes().values().toArray(DiscoveryNode[]::new));
+        protected DiscoveryNode[] resolveRequest(TestNodesRequest request, ClusterState clusterState) {
+            return clusterState.nodes().getDataNodes().values().toArray(DiscoveryNode[]::new);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoAction.java
@@ -35,13 +35,16 @@ public class TrainedModelCacheInfoAction extends ActionType<TrainedModelCacheInf
 
     public static class Request extends BaseNodesRequest<Request> {
 
+        private final DiscoveryNode[] concreteNodes;
+
         public Request(DiscoveryNode... concreteNodes) {
             super(concreteNodes);
+            this.concreteNodes = concreteNodes;
         }
 
         @Override
         public int hashCode() {
-            return Arrays.hashCode(concreteNodes());
+            return Arrays.hashCode(concreteNodes);
         }
 
         @Override
@@ -53,7 +56,7 @@ public class TrainedModelCacheInfoAction extends ActionType<TrainedModelCacheInf
                 return false;
             }
             Request other = (Request) obj;
-            return Arrays.deepEquals(concreteNodes(), other.concreteNodes());
+            return Arrays.deepEquals(concreteNodes, other.concreteNodes);
         }
     }
 

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
@@ -131,9 +131,8 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
         }
 
         @Override
-        protected void resolveRequest(Request request, ClusterState clusterState) {
-            DiscoveryNode[] ingestNodes = clusterState.getNodes().getIngestNodes().values().toArray(DiscoveryNode[]::new);
-            request.setConcreteNodes(ingestNodes);
+        protected DiscoveryNode[] resolveRequest(Request request, ClusterState clusterState) {
+            return clusterState.getNodes().getIngestNodes().values().toArray(DiscoveryNode[]::new);
         }
 
         @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlStatsAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlStatsAction.java
@@ -61,13 +61,13 @@ public class TransportEsqlStatsAction extends TransportNodesAction<
     }
 
     @Override
-    protected void resolveRequest(EsqlStatsRequest request, ClusterState clusterState) {
+    protected DiscoveryNode[] resolveRequest(EsqlStatsRequest request, ClusterState clusterState) {
         if (featureService.clusterHasFeature(clusterState, ESQL_STATS_FEATURE)) {
             // use the whole cluster
-            super.resolveRequest(request, clusterState);
+            return super.resolveRequest(request, clusterState);
         } else {
             // not all nodes in the cluster have upgraded to esql - just use this node for now
-            request.setConcreteNodes(new DiscoveryNode[] { clusterService.localNode() });
+            return new DiscoveryNode[] { clusterService.localNode() };
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -97,7 +97,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
     }
 
     @Override
-    protected void resolveRequest(NodesRequest request, ClusterState clusterState) {
+    protected DiscoveryNode[] resolveRequest(NodesRequest request, ClusterState clusterState) {
         final Map<String, DiscoveryNode> dataNodes = clusterState.getNodes().getDataNodes();
 
         final DiscoveryNode[] resolvedNodes;
@@ -109,7 +109,7 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
                 .map(dataNodes::get)
                 .toArray(DiscoveryNode[]::new);
         }
-        request.setConcreteNodes(resolvedNodes);
+        return resolvedNodes;
     }
 
     @Override


### PR DESCRIPTION
Today this field is mutable so it can be populated at some point during
the processing of the request. But really there's no need, we can just
hold the actual concrete nodes in a local variable since it's all in the
scope of a single method, and with that change (and a bit of shuffling
around in `TransportNodesReloadSecureSettingsAction`) we can make this
field immutable.