### PR TITLE
Remove `TransportRequest.Empty`

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/common/network/ThreadWatchdogIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/common/network/ThreadWatchdogIT.java
@@ -35,7 +35,7 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
-import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 
@@ -137,7 +137,7 @@ public class ThreadWatchdogIT extends ESIntegTestCase {
         targetTransportService.registerRequestHandler(
             "internal:slow",
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
-            TransportRequest.Empty::new,
+            EmptyRequest::new,
             (request, channel, task) -> {
                 blockAndWaitForWatchdogLogs();
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);
@@ -149,7 +149,7 @@ public class ThreadWatchdogIT extends ESIntegTestCase {
                 l -> sourceTransportService.sendRequest(
                     targetTransportService.getLocalNode(),
                     "internal:slow",
-                    new TransportRequest.Empty(),
+                    new EmptyRequest(),
                     new ActionListenerResponseHandler<TransportResponse>(
                         l,
                         in -> TransportResponse.Empty.INSTANCE,

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -178,7 +178,7 @@ public class SearchTransportService {
         transportService.sendRequest(
             connection,
             CLEAR_SCROLL_CONTEXTS_ACTION_NAME,
-            TransportRequest.Empty.INSTANCE,
+            new ClearScrollContextsRequest(),
             TransportRequestOptions.EMPTY,
             new ActionListenerResponseHandler<>(
                 listener,
@@ -369,6 +369,14 @@ public class SearchTransportService {
 
     }
 
+    private static class ClearScrollContextsRequest extends TransportRequest {
+        ClearScrollContextsRequest() {}
+
+        ClearScrollContextsRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
+
     static class SearchFreeContextRequest extends ScrollFreeContextRequest implements IndicesRequest {
         private final OriginalIndices originalIndices;
 
@@ -456,7 +464,7 @@ public class SearchTransportService {
         transportService.registerRequestHandler(
             CLEAR_SCROLL_CONTEXTS_ACTION_NAME,
             transportService.getThreadPool().generic(),
-            TransportRequest.Empty::new,
+            ClearScrollContextsRequest::new,
             instrumentedHandler(CLEAR_SCROLL_CONTEXTS_ACTION_METRIC, transportService, searchTransportMetrics, (request, channel, task) -> {
                 searchService.freeAllScrollContexts();
                 channel.sendResponse(TransportResponse.Empty.INSTANCE);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -72,7 +72,6 @@ import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
 import org.elasticsearch.transport.NodeDisconnectedException;
-import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportResponseHandler;
@@ -759,7 +758,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         transportService.sendRequest(
             discoveryNode,
             JoinHelper.JOIN_PING_ACTION_NAME,
-            TransportRequest.Empty.INSTANCE,
+            new JoinHelper.JoinPingRequest(),
             TransportRequestOptions.of(null, channelType),
             TransportResponseHandler.empty(clusterCoordinationExecutor, listener.delegateResponse((l, e) -> {
                 logger.warn(() -> format("failed to ping joining node [%s] on channel type [%s]", discoveryNode, channelType), e);

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinHelper.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.Releasable;
@@ -47,6 +48,7 @@ import org.elasticsearch.transport.TransportResponse.Empty;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -154,7 +156,7 @@ public class JoinHelper {
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
             false,
             false,
-            TransportRequest.Empty::new,
+            JoinPingRequest::new,
             (request, channel, task) -> channel.sendResponse(Empty.INSTANCE)
         );
     }
@@ -606,4 +608,12 @@ public class JoinHelper {
     static final String PENDING_JOIN_WAITING_STATE = "waiting to receive cluster state";
     static final String PENDING_JOIN_CONNECT_FAILED = "failed to connect";
     static final String PENDING_JOIN_FAILED = "failed";
+
+    static class JoinPingRequest extends TransportRequest {
+        JoinPingRequest() {}
+
+        JoinPingRequest(StreamInput in) throws IOException {
+            super(in);
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
@@ -37,7 +37,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BytesTransportRequest;
 import org.elasticsearch.transport.NodeNotConnectedException;
 import org.elasticsearch.transport.Transport;
-import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponseHandler;
@@ -207,7 +206,7 @@ public class JoinValidationService {
             transportService.sendRequest(
                 connection,
                 JoinHelper.JOIN_PING_ACTION_NAME,
-                TransportRequest.Empty.INSTANCE,
+                new JoinHelper.JoinPingRequest(),
                 REQUEST_OPTIONS,
                 responseHandler
             );
@@ -357,7 +356,7 @@ public class JoinValidationService {
                 transportService.sendRequest(
                     connection,
                     JoinHelper.JOIN_PING_ACTION_NAME,
-                    TransportRequest.Empty.INSTANCE,
+                    new JoinHelper.JoinPingRequest(),
                     REQUEST_OPTIONS,
                     TransportResponseHandler.empty(responseExecutor, listener)
                 );

--- a/server/src/main/java/org/elasticsearch/transport/TransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportRequest.java
@@ -16,16 +16,6 @@ import org.elasticsearch.tasks.TaskId;
 import java.io.IOException;
 
 public abstract class TransportRequest extends TransportMessage implements TaskAwareRequest {
-    public static class Empty extends TransportRequest {
-        public static final Empty INSTANCE = new Empty();
-
-        public Empty() {}
-
-        public Empty(StreamInput in) throws IOException {
-            super(in);
-        }
-    }
-
     /**
      * Parent of this request. Defaults to {@link TaskId#EMPTY_TASK_ID}, meaning "no parent".
      */

--- a/server/src/test/java/org/elasticsearch/index/shard/SearchOperationListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/SearchOperationListenerTests.java
@@ -12,8 +12,8 @@ import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TestSearchContext;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.TransportRequest;
-import org.elasticsearch.transport.TransportRequest.Empty;
 
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
@@ -269,11 +269,11 @@ public class SearchOperationListenerTests extends ESTestCase {
             assertEquals(0, validateSearchContext.get());
 
             if (throwingListeners == 0) {
-                compositeListener.validateReaderContext(mock(ReaderContext.class), Empty.INSTANCE);
+                compositeListener.validateReaderContext(mock(ReaderContext.class), new EmptyRequest());
             } else {
                 RuntimeException expected = expectThrows(
                     RuntimeException.class,
-                    () -> compositeListener.validateReaderContext(mock(ReaderContext.class), Empty.INSTANCE)
+                    () -> compositeListener.validateReaderContext(mock(ReaderContext.class), new EmptyRequest())
                 );
                 assertNull(expected.getMessage());
                 assertEquals(throwingListeners - 1, expected.getSuppressed().length);

--- a/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/BanFailureLoggingTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.test.transport.StubbableTransport;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.AbstractSimpleTransportTestCase;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.NodeDisconnectedException;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportRequest;
@@ -131,7 +132,7 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
             childTransportService.registerRequestHandler(
                 "internal:testAction[c]",
                 threadPool.executor(ThreadPool.Names.MANAGEMENT), // busy-wait for cancellation but not on a transport thread
-                (StreamInput in) -> new TransportRequest.Empty(in) {
+                (StreamInput in) -> new TransportRequest(in) {
                     @Override
                     public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
                         return new CancellableTask(id, type, action, "", parentTaskId, headers);
@@ -163,7 +164,7 @@ public class BanFailureLoggingTests extends TaskManagerTestCase {
             parentTransportService.sendChildRequest(
                 childTransportService.getLocalDiscoNode(),
                 "internal:testAction[c]",
-                TransportRequest.Empty.INSTANCE,
+                new EmptyRequest(),
                 parentTask,
                 TransportRequestOptions.EMPTY,
                 new ChildResponseHandler(() -> parentTransportService.getTaskManager().unregister(parentTask))

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -761,7 +761,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                                         .sendRequest(
                                             randomNonNegativeLong(),
                                             "arbitrary",
-                                            TransportRequest.Empty.INSTANCE,
+                                            new EmptyRequest(),
                                             TransportRequestOptions.of(null, type)
                                         )
                                 ).getMessage(),

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -500,8 +500,8 @@ public class TransportActionProxyTests extends ESTestCase {
     }
 
     public void testIsProxyRequest() {
-        assertTrue(TransportActionProxy.isProxyRequest(new TransportActionProxy.ProxyRequest<>(TransportRequest.Empty.INSTANCE, null)));
-        assertFalse(TransportActionProxy.isProxyRequest(TransportRequest.Empty.INSTANCE));
+        assertTrue(TransportActionProxy.isProxyRequest(new TransportActionProxy.ProxyRequest<>(new EmptyRequest(), null)));
+        assertFalse(TransportActionProxy.isProxyRequest(new EmptyRequest()));
     }
 
     static class CapturingTransportChannel implements TransportChannel {

--- a/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportLoggerTests.java
@@ -71,7 +71,7 @@ public class TransportLoggerTests extends ESTestCase {
         try (RecyclerBytesStreamOutput bytesStreamOutput = new RecyclerBytesStreamOutput(recycler)) {
             OutboundMessage.Request request = new OutboundMessage.Request(
                 new ThreadContext(Settings.EMPTY),
-                new TransportRequest.Empty(),
+                new EmptyRequest(),
                 TransportVersion.current(),
                 "internal:test",
                 randomInt(30),

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
@@ -69,7 +69,7 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
         transportService.registerRequestHandler(
             testActionName,
             EsExecutors.DIRECT_EXECUTOR_SERVICE,
-            TransportRequest.Empty::new,
+            EmptyRequest::new,
             (request, channel, task) -> channel.sendResponse(TransportResponse.Empty.INSTANCE)
         );
 
@@ -86,7 +86,7 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
             transportService.sendRequest(
                 otherNode,
                 testActionName,
-                TransportRequest.Empty.INSTANCE,
+                new EmptyRequest(),
                 TransportRequestOptions.EMPTY,
                 new TransportResponseHandler<TransportResponse.Empty>() {
                     @Override
@@ -151,7 +151,7 @@ public class TransportServiceDeserializationFailureTests extends ESTestCase {
             transportService.sendChildRequest(
                 otherNode,
                 testActionName,
-                TransportRequest.Empty.INSTANCE,
+                new EmptyRequest(),
                 parentTask,
                 TransportRequestOptions.EMPTY,
                 new TransportResponseHandler<TransportResponse.Empty>() {

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceLifecycleTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceLifecycleTests.java
@@ -77,7 +77,7 @@ public class TransportServiceLifecycleTests extends ESTestCase {
                             nodeB.transportService.sendRequest(
                                 randomFrom(random, nodeA, nodeB).transportService.getLocalNode(),
                                 TestNode.randomActionName(random),
-                                TransportRequest.Empty.INSTANCE,
+                                new EmptyRequest(),
                                 new TransportResponseHandler<TransportResponse.Empty>() {
 
                                     final AtomicBoolean completed = new AtomicBoolean();
@@ -135,7 +135,7 @@ public class TransportServiceLifecycleTests extends ESTestCase {
             nodeA.transportService.sendRequest(
                 nodeA.getThrowingConnection(),
                 TestNode.randomActionName(random()),
-                new TransportRequest.Empty(),
+                new EmptyRequest(),
                 TransportRequestOptions.EMPTY,
                 new ActionListenerResponseHandler<>(future, unusedReader(), deterministicTaskQueue::scheduleNow)
             );
@@ -154,7 +154,7 @@ public class TransportServiceLifecycleTests extends ESTestCase {
             nodeA.transportService.sendRequest(
                 nodeA.getThrowingConnection(),
                 TestNode.randomActionName(random()),
-                new TransportRequest.Empty(),
+                new EmptyRequest(),
                 TransportRequestOptions.EMPTY,
                 new ActionListenerResponseHandler<>(future.delegateResponse((l, e) -> {
                     assertThat(Thread.currentThread().getName(), containsString("[" + ThreadPool.Names.GENERIC + "]"));
@@ -183,7 +183,7 @@ public class TransportServiceLifecycleTests extends ESTestCase {
                 nodeA.transportService.sendRequest(
                     nodeA.getThrowingConnection(),
                     TestNode.randomActionName(random()),
-                    new TransportRequest.Empty(),
+                    new EmptyRequest(),
                     TransportRequestOptions.EMPTY,
                     new ActionListenerResponseHandler<>(future.delegateResponse((l, e) -> {
                         assertThat(Thread.currentThread().getName(), containsString("[" + Executors.FIXED_BOUNDED_QUEUE + "]"));
@@ -209,7 +209,7 @@ public class TransportServiceLifecycleTests extends ESTestCase {
         nodeA.transportService.sendRequest(
             nodeA.getThrowingConnection(),
             TestNode.randomActionName(random()),
-            new TransportRequest.Empty(),
+            new EmptyRequest(),
             TransportRequestOptions.EMPTY,
             new ActionListenerResponseHandler<>(future.delegateResponse((l, e) -> {
                 assertSame(testThread, Thread.currentThread());
@@ -256,7 +256,7 @@ public class TransportServiceLifecycleTests extends ESTestCase {
             nodeA.transportService.sendRequest(
                 connection,
                 TestNode.randomActionName(random()),
-                new TransportRequest.Empty(),
+                new EmptyRequest(),
                 TransportRequestOptions.EMPTY,
                 new ActionListenerResponseHandler<>(
                     ActionListener.assertOnce(ActionTestUtils.assertNoSuccessListener(future::onResponse).delegateResponse((l, e) -> {
@@ -361,7 +361,7 @@ public class TransportServiceLifecycleTests extends ESTestCase {
                 transportService.registerRequestHandler(
                     ACTION_NAME_PREFIX + executorName,
                     getExecutor(executorName),
-                    TransportRequest.Empty::new,
+                    EmptyRequest::new,
                     (request, channel, task) -> {
                         if (randomBoolean()) {
                             channel.sendResponse(TransportResponse.Empty.INSTANCE);

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -514,7 +514,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     }
 
     public void testMessageListeners() throws Exception {
-        final TransportRequestHandler<TransportRequest.Empty> requestHandler = (request, channel, task) -> {
+        final TransportRequestHandler<EmptyRequest> requestHandler = (request, channel, task) -> {
             try {
                 if (randomBoolean()) {
                     channel.sendResponse(TransportResponse.Empty.INSTANCE);
@@ -527,8 +527,8 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             }
         };
         final String ACTION = "internal:action";
-        serviceA.registerRequestHandler(ACTION, threadPool.executor(ThreadPool.Names.GENERIC), TransportRequest.Empty::new, requestHandler);
-        serviceB.registerRequestHandler(ACTION, threadPool.executor(ThreadPool.Names.GENERIC), TransportRequest.Empty::new, requestHandler);
+        serviceA.registerRequestHandler(ACTION, threadPool.executor(ThreadPool.Names.GENERIC), EmptyRequest::new, requestHandler);
+        serviceB.registerRequestHandler(ACTION, threadPool.executor(ThreadPool.Names.GENERIC), EmptyRequest::new, requestHandler);
 
         class CountingListener implements TransportMessageListener {
             AtomicInteger requestsReceived = new AtomicInteger();
@@ -585,7 +585,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         serviceB.addMessageListener(tracerB);
 
         try {
-            submitRequest(serviceA, nodeB, ACTION, TransportRequest.Empty.INSTANCE, NOOP_HANDLER).get();
+            submitRequest(serviceA, nodeB, ACTION, new EmptyRequest(), NOOP_HANDLER).get();
         } catch (ExecutionException e) {
             assertThat(e.getCause(), instanceOf(ElasticsearchException.class));
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
@@ -604,7 +604,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         });
 
         try {
-            submitRequest(serviceB, nodeA, ACTION, TransportRequest.Empty.INSTANCE, NOOP_HANDLER).get();
+            submitRequest(serviceB, nodeA, ACTION, new EmptyRequest(), NOOP_HANDLER).get();
         } catch (ExecutionException e) {
             assertThat(e.getCause(), instanceOf(ElasticsearchException.class));
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
@@ -624,7 +624,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
         // use assert busy as callbacks are called on a different thread
         try {
-            submitRequest(serviceA, nodeA, ACTION, TransportRequest.Empty.INSTANCE, NOOP_HANDLER).get();
+            submitRequest(serviceA, nodeA, ACTION, new EmptyRequest(), NOOP_HANDLER).get();
         } catch (ExecutionException e) {
             assertThat(e.getCause(), instanceOf(ElasticsearchException.class));
             assertThat(ExceptionsHelper.unwrapCause(e.getCause()).getMessage(), equalTo("simulated"));
@@ -648,7 +648,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             serviceA.registerRequestHandler(
                 "internal:sayHello",
                 threadPool.executor(ThreadPool.Names.GENERIC),
-                TransportRequest.Empty::new,
+                EmptyRequest::new,
                 (request, channel, task) -> {
                     try {
                         channel.sendResponse(TransportResponse.Empty.INSTANCE);
@@ -673,7 +673,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 serviceC,
                 nodeA,
                 "internal:sayHello",
-                TransportRequest.Empty.INSTANCE,
+                new EmptyRequest(),
                 new TransportResponseHandler<>() {
                     @Override
                     public TransportResponse.Empty read(StreamInput in) {
@@ -3185,48 +3185,38 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
     public void testChannelToString() {
         final String ACTION = "internal:action";
-        serviceA.registerRequestHandler(
-            ACTION,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE,
-            TransportRequest.Empty::new,
-            (request, channel, task) -> {
-                assertThat(
-                    channel.toString(),
-                    allOf(
-                        containsString("DirectResponseChannel"),
-                        containsString('{' + ACTION + '}'),
-                        containsString("TaskTransportChannel{task=" + task.getId() + '}')
-                    )
-                );
-                assertThat(new ChannelActionListener<>(channel).toString(), containsString(channel.toString()));
-                channel.sendResponse(TransportResponse.Empty.INSTANCE);
-            }
-        );
-        serviceB.registerRequestHandler(
-            ACTION,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE,
-            TransportRequest.Empty::new,
-            (request, channel, task) -> {
-                assertThat(
-                    channel.toString(),
-                    allOf(
-                        containsString("TcpTransportChannel"),
-                        containsString('{' + ACTION + '}'),
-                        containsString("TaskTransportChannel{task=" + task.getId() + '}'),
-                        containsString("localAddress="),
-                        containsString(serviceB.getLocalNode().getAddress().toString())
-                    )
-                );
-                channel.sendResponse(TransportResponse.Empty.INSTANCE);
-            }
-        );
+        serviceA.registerRequestHandler(ACTION, EsExecutors.DIRECT_EXECUTOR_SERVICE, EmptyRequest::new, (request, channel, task) -> {
+            assertThat(
+                channel.toString(),
+                allOf(
+                    containsString("DirectResponseChannel"),
+                    containsString('{' + ACTION + '}'),
+                    containsString("TaskTransportChannel{task=" + task.getId() + '}')
+                )
+            );
+            assertThat(new ChannelActionListener<>(channel).toString(), containsString(channel.toString()));
+            channel.sendResponse(TransportResponse.Empty.INSTANCE);
+        });
+        serviceB.registerRequestHandler(ACTION, EsExecutors.DIRECT_EXECUTOR_SERVICE, EmptyRequest::new, (request, channel, task) -> {
+            assertThat(
+                channel.toString(),
+                allOf(
+                    containsString("TcpTransportChannel"),
+                    containsString('{' + ACTION + '}'),
+                    containsString("TaskTransportChannel{task=" + task.getId() + '}'),
+                    containsString("localAddress="),
+                    containsString(serviceB.getLocalNode().getAddress().toString())
+                )
+            );
+            channel.sendResponse(TransportResponse.Empty.INSTANCE);
+        });
 
         PlainActionFuture.get(
             f -> submitRequest(
                 serviceA,
                 serviceA.getLocalNode(),
                 ACTION,
-                TransportRequest.Empty.INSTANCE,
+                new EmptyRequest(),
                 new ActionListenerResponseHandler<>(
                     f,
                     ignored -> TransportResponse.Empty.INSTANCE,
@@ -3242,7 +3232,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
                 serviceA,
                 serviceB.getLocalNode(),
                 ACTION,
-                TransportRequest.Empty.INSTANCE,
+                new EmptyRequest(),
                 new ActionListenerResponseHandler<>(
                     f,
                     ignored -> TransportResponse.Empty.INSTANCE,
@@ -3360,23 +3350,18 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         final var barrier = new CyclicBarrier(2);
         final var threadNameFuture = new PlainActionFuture<String>();
         final var actionName = "internal:action";
-        serviceA.registerRequestHandler(
-            actionName,
-            EsExecutors.DIRECT_EXECUTOR_SERVICE,
-            TransportRequest.Empty::new,
-            (request, channel, task) -> {
-                threadNameFuture.onResponse(Thread.currentThread().getName());
-                safeAwait(barrier);
-                channel.sendResponse(TransportResponse.Empty.INSTANCE);
-            }
-        );
+        serviceA.registerRequestHandler(actionName, EsExecutors.DIRECT_EXECUTOR_SERVICE, EmptyRequest::new, (request, channel, task) -> {
+            threadNameFuture.onResponse(Thread.currentThread().getName());
+            safeAwait(barrier);
+            channel.sendResponse(TransportResponse.Empty.INSTANCE);
+        });
 
         final var responseLatch = new CountDownLatch(1);
         submitRequest(
             serviceB,
             nodeA,
             actionName,
-            new TransportRequest.Empty(),
+            new EmptyRequest(),
             new ActionListenerResponseHandler<TransportResponse>(
                 ActionTestUtils.assertNoFailureListener(t -> responseLatch.countDown()),
                 in -> TransportResponse.Empty.INSTANCE,
@@ -3470,7 +3455,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
             serviceC.sendRequest(
                 connection,
                 "fail-to-send-action",
-                TransportRequest.Empty.INSTANCE,
+                new EmptyRequest(),
                 TransportRequestOptions.EMPTY,
                 new TransportResponseHandler.Empty() {
                     @Override

--- a/test/framework/src/main/java/org/elasticsearch/transport/EmptyRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/EmptyRequest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+/**
+ * A transport request with an empty payload. Not really entirely empty: all transport requests include the parent task ID, a request ID,
+ * and the remote address (if applicable).
+ */
+public final class EmptyRequest extends TransportRequest {
+    public EmptyRequest() {}
+
+    public EmptyRequest(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/SecuritySearchOperationListenerTests.java
@@ -21,8 +21,8 @@ import org.elasticsearch.search.internal.LegacyReaderContext;
 import org.elasticsearch.search.internal.ShardSearchContextId;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.TransportRequest;
-import org.elasticsearch.transport.TransportRequest.Empty;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
@@ -134,7 +134,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
                     .realmRef(new RealmRef("realm", "file", "node"))
                     .build(false);
                 authentication.writeToContext(threadContext);
-                listener.validateReaderContext(readerContext, Empty.INSTANCE);
+                listener.validateReaderContext(readerContext, new EmptyRequest());
                 assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), is(indicesAccessControl));
                 verifyNoMoreInteractions(auditTrail);
             }
@@ -147,7 +147,7 @@ public class SecuritySearchOperationListenerTests extends ESSingleNodeTestCase {
                     .realmRef(new RealmRef(realmName, "file", nodeName))
                     .build(false);
                 authentication.writeToContext(threadContext);
-                listener.validateReaderContext(readerContext, Empty.INSTANCE);
+                listener.validateReaderContext(readerContext, new EmptyRequest());
                 assertThat(threadContext.getTransient(AuthorizationServiceField.INDICES_PERMISSIONS_KEY), is(indicesAccessControl));
                 verifyNoMoreInteractions(auditTrail);
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -126,6 +126,7 @@ import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPool.Names;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.TransportActionProxy;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -3158,7 +3159,7 @@ public class AuthorizationServiceTests extends ESTestCase {
     }
 
     public void testProxyRequestFailsOnNonProxyAction() {
-        TransportRequest request = TransportRequest.Empty.INSTANCE;
+        TransportRequest request = new EmptyRequest();
         DiscoveryNode node = DiscoveryNodeUtils.create("foo");
         TransportRequest transportRequest = TransportActionProxy.wrapRequest(node, request);
         final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
@@ -3177,7 +3178,7 @@ public class AuthorizationServiceTests extends ESTestCase {
     }
 
     public void testProxyRequestFailsOnNonProxyRequest() {
-        TransportRequest request = TransportRequest.Empty.INSTANCE;
+        TransportRequest request = new EmptyRequest();
         User user = new User("test user", "role");
         AuditUtil.getOrGenerateRequestId(threadContext);
         ElasticsearchSecurityException ese = expectThrows(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -228,7 +228,6 @@ import static org.elasticsearch.xpack.security.support.SecuritySystemIndices.SEC
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -236,7 +235,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -3162,38 +3160,35 @@ public class AuthorizationServiceTests extends ESTestCase {
         TransportRequest request = new EmptyRequest();
         DiscoveryNode node = DiscoveryNodeUtils.create("foo");
         TransportRequest transportRequest = TransportActionProxy.wrapRequest(node, request);
-        final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
+        AuditUtil.getOrGenerateRequestId(threadContext);
         User user = new User("test user", "role");
-        ElasticsearchSecurityException ese = expectThrows(
-            ElasticsearchSecurityException.class,
-            () -> authorize(createAuthentication(user), "indices:some/action", transportRequest)
+        final var authentication = createAuthentication(user);
+        assertEquals(
+            """
+                originalRequest is a proxy request for: [org.elasticsearch.transport.EmptyRequest/unset] \
+                but action: [indices:some/action] isn't""",
+            expectThrows(
+                ElasticsearchSecurityException.class,
+                IllegalStateException.class,
+                () -> authorize(authentication, "indices:some/action", transportRequest)
+            ).getMessage()
         );
-        assertThat(ese.getCause(), instanceOf(IllegalStateException.class));
-        IllegalStateException illegalStateException = (IllegalStateException) ese.getCause();
-        assertThat(
-            illegalStateException.getMessage(),
-            startsWith("originalRequest is a proxy request for: [org.elasticsearch.transport.TransportRequest$")
-        );
-        assertThat(illegalStateException.getMessage(), endsWith("] but action: [indices:some/action] isn't"));
     }
 
     public void testProxyRequestFailsOnNonProxyRequest() {
         TransportRequest request = new EmptyRequest();
         User user = new User("test user", "role");
         AuditUtil.getOrGenerateRequestId(threadContext);
-        ElasticsearchSecurityException ese = expectThrows(
-            ElasticsearchSecurityException.class,
-            () -> authorize(createAuthentication(user), TransportActionProxy.getProxyAction("indices:some/action"), request)
-        );
-        assertThat(ese.getCause(), instanceOf(IllegalStateException.class));
-        IllegalStateException illegalStateException = (IllegalStateException) ese.getCause();
-        assertThat(
-            illegalStateException.getMessage(),
-            startsWith("originalRequest is not a proxy request: [org.elasticsearch.transport.TransportRequest$")
-        );
-        assertThat(
-            illegalStateException.getMessage(),
-            endsWith("] but action: [internal:transport/proxy/indices:some/action] is a proxy action")
+        final var authentication = createAuthentication(user);
+        assertEquals(
+            """
+                originalRequest is not a proxy request: [org.elasticsearch.transport.EmptyRequest/unset] \
+                but action: [internal:transport/proxy/indices:some/action] is a proxy action""",
+            expectThrows(
+                ElasticsearchSecurityException.class,
+                IllegalStateException.class,
+                () -> authorize(authentication, TransportActionProxy.getProxyAction("indices:some/action"), request)
+            ).getMessage()
         );
     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizedIndicesTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
@@ -393,7 +394,7 @@ public class AuthorizedIndicesTests extends ESTestCase {
     }
 
     public static AuthorizationEngine.RequestInfo getRequestInfo(String action) {
-        return getRequestInfo(TransportRequest.Empty.INSTANCE, action);
+        return getRequestInfo(new EmptyRequest(), action);
     }
 
     public static AuthorizationEngine.RequestInfo getRequestInfo(TransportRequest request, String action) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/IndicesAndAliasesResolverTests.java
@@ -58,6 +58,7 @@ import org.elasticsearch.protocol.xpack.graph.GraphExploreRequest;
 import org.elasticsearch.search.internal.ShardSearchRequest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.NoSuchRemoteClusterException;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.graph.action.GraphExploreAction;
@@ -2541,7 +2542,7 @@ public class IndicesAndAliasesResolverTests extends ESTestCase {
     }
 
     private AuthorizedIndices buildAuthorizedIndices(User user, String action) {
-        return buildAuthorizedIndices(user, action, TransportRequest.Empty.INSTANCE);
+        return buildAuthorizedIndices(user, action, new EmptyRequest());
     }
 
     private AuthorizedIndices buildAuthorizedIndices(User user, String action, TransportRequest request) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStoreTests.java
@@ -49,8 +49,8 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
 import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.TransportRequest;
-import org.elasticsearch.transport.TransportRequest.Empty;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackPlugin;
@@ -2079,7 +2079,7 @@ public class CompositeRolesStoreTests extends ESTestCase {
         PlainActionFuture<Role> roleFuture = new PlainActionFuture<>();
         compositeRolesStore.getRole(authentication.getEffectiveSubject(), roleFuture);
         Role role = roleFuture.actionGet();
-        assertThat(role.checkClusterAction("cluster:admin/foo", Empty.INSTANCE, AuthenticationTestHelper.builder().build()), is(false));
+        assertThat(role.checkClusterAction("cluster:admin/foo", new EmptyRequest(), AuthenticationTestHelper.builder().build()), is(false));
         assertThat(effectiveRoleDescriptors.get(), is(nullValue()));
         if (version == TransportVersion.current()) {
             verify(apiKeyService).parseRoleDescriptorsBytes(

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4ServerTransportAuthenticationTests.java
@@ -37,6 +37,7 @@ import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BytesRefRecycler;
 import org.elasticsearch.transport.Compression;
+import org.elasticsearch.transport.EmptyRequest;
 import org.elasticsearch.transport.ProxyConnectionStrategy;
 import org.elasticsearch.transport.RemoteClusterPortSettings;
 import org.elasticsearch.transport.RemoteClusterService;
@@ -332,7 +333,7 @@ public class SecurityNetty4ServerTransportAuthenticationTests extends ESTestCase
         try (Socket socket = new MockSocket(remoteIngressTransportAddress.getAddress(), remoteIngressTransportAddress.getPort())) {
             TestOutboundRequestMessage message = new TestOutboundRequestMessage(
                 threadPool.getThreadContext(),
-                TransportRequest.Empty.INSTANCE,
+                new EmptyRequest(),
                 TransportVersion.current(),
                 "internal:whatever",
                 randomNonNegativeLong(),


### PR DESCRIPTION
Transport requests are never really empty, they always carry at least a
parent task, a request ID, and a remote address. Moreover there's only
really two usages of this type in production. This commit introduces
more specific types for the two production usages, moves the generic
"empty" request type to `:test:framework`, and drops its static
`INSTANCE` field since transport requests are mutable so definitely not
safe to use as singletons.