### PR TITLE
Add an explicit synthetic mode for nested fields

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.create/20_synthetic_source.yml
@@ -863,18 +863,22 @@ nested object:
           - '{ "create": { } }'
           - '{ "name": "aaaa", "nested_field": {"a": 1, "b": 2}, "nested_array": [{ "a": 10, "b": 20 }, { "a": 100, "b": 200 }] }'
 
+  - match: { errors: false }
+
   - do:
       search:
         index: test
 
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._source.name: aaaa }
-  - match: { hits.hits.0._source.nested_field.a: 1 }
-  - match: { hits.hits.0._source.nested_field.b: 2 }
-  - match: { hits.hits.0._source.nested_array.0.a: 10 }
-  - match: { hits.hits.0._source.nested_array.0.b: 20 }
-  - match: { hits.hits.0._source.nested_array.1.a: 100 }
-  - match: { hits.hits.0._source.nested_array.1.b: 200 }
+  - match:  { hits.total.value: 1 }
+  - match:  { hits.hits.0._source.name: aaaa }
+  - length: { hits.hits.0._source.nested_field: 2 }
+  - match:  { hits.hits.0._source.nested_field.a: 1 }
+  - match:  { hits.hits.0._source.nested_field.b: 2 }
+  - length: { hits.hits.0._source.nested_array: 2 }
+  - match:  { hits.hits.0._source.nested_array.0.a: 10 }
+  - match:  { hits.hits.0._source.nested_array.0.b: 20 }
+  - match:  { hits.hits.0._source.nested_array.1.a: 100 }
+  - match:  { hits.hits.0._source.nested_array.1.b: 200 }
 
 
 ---
@@ -906,15 +910,201 @@ nested object next to regular:
           - '{ "create": { } }'
           - '{ "name": "aaaa", "path": { "to": { "nested": [{ "a": 10, "b": 20 }, { "a": 100, "b": 200 } ], "regular": [{ "a": 10, "b": 20 }, { "a": 100, "b": 200 } ] } } }'
 
+  - match: { errors: false }
+
   - do:
       search:
         index: test
 
-  - match: { hits.total.value: 1 }
-  - match: { hits.hits.0._source.name: aaaa }
-  - match: { hits.hits.0._source.path.to.nested.0.a: 10 }
-  - match: { hits.hits.0._source.path.to.nested.0.b: 20 }
-  - match: { hits.hits.0._source.path.to.nested.1.a: 100 }
-  - match: { hits.hits.0._source.path.to.nested.1.b: 200 }
-  - match: { hits.hits.0._source.path.to.regular.a: [ 10, 100 ] }
-  - match: { hits.hits.0._source.path.to.regular.b: [ 20, 200 ] }
+  - match:  { hits.total.value: 1 }
+  - match:  { hits.hits.0._source.name: aaaa }
+  - length: { hits.hits.0._source.path.to.nested: 2 }
+  - match:  { hits.hits.0._source.path.to.nested.0.a: 10 }
+  - match:  { hits.hits.0._source.path.to.nested.0.b: 20 }
+  - match:  { hits.hits.0._source.path.to.nested.1.a: 100 }
+  - match:  { hits.hits.0._source.path.to.nested.1.b: 200 }
+  - match:  { hits.hits.0._source.path.to.regular.a: [ 10, 100 ] }
+  - match:  { hits.hits.0._source.path.to.regular.b: [ 20, 200 ] }
+
+
+---
+nested object with disabled:
+  - requires:
+      cluster_features: ["mapper.track_ignored_source"]
+      reason: requires tracking ignored source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              obj_field:
+                properties:
+                  obj1:
+                    enabled: false
+                  sub_nested:
+                    type: nested
+              nested_field:
+                type: nested
+                properties:
+                  obj1:
+                    enabled: false
+              nested_array:
+                type: nested
+                properties:
+                  obj1:
+                    enabled: false
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{ "create": { } }'
+          - '{ "id": 0, "nested_field": {"a": 1, "b": 2, "obj1": { "foo": "bar", "k": [1, 2, 3]}}, "nested_array": [{ "a": 10, "b": 20, "obj1": [{"field1": 1, "field2": 2},  {"field3": 3, "field4": 4}]}, { "a": 100, "b": 200, "obj1": {"field5": 5, "field6": 6}}]}'
+          - '{ "create": { } }'
+          - '{ "id": 1, "obj_field": {"a": 1, "b": 2, "obj1": { "foo": "bar", "k": [1, 2, 3]}, "sub_nested": [{ "a": 10, "b": 20}, { "a": 100, "b": 200}]}}'
+
+  - match: { errors: false }
+
+  - do:
+      search:
+        index: test
+        sort: "id"
+
+  - match:  { hits.total.value: 2 }
+  - length: { hits.hits.0._source: 3 }
+  - match:  { hits.hits.0._source.id: 0 }
+  - length: { hits.hits.0._source.nested_field: 3 }
+  - match:  { hits.hits.0._source.nested_field.a: 1 }
+  - match:  { hits.hits.0._source.nested_field.b: 2 }
+  - length: { hits.hits.0._source.nested_field.obj1: 2 }
+  - match:  { hits.hits.0._source.nested_field.obj1.foo: "bar" }
+  - match:  { hits.hits.0._source.nested_field.obj1.k: [1, 2, 3] }
+  - length: { hits.hits.0._source.nested_array: 2 }
+  - match:  { hits.hits.0._source.nested_array.0.a: 10 }
+  - match:  { hits.hits.0._source.nested_array.0.b: 20 }
+  - length: { hits.hits.0._source.nested_array.0.obj1: 2 }
+  - match:  { hits.hits.0._source.nested_array.0.obj1.0.field1: 1 }
+  - match:  { hits.hits.0._source.nested_array.0.obj1.0.field2: 2 }
+  - match:  { hits.hits.0._source.nested_array.0.obj1.1.field3: 3 }
+  - match:  { hits.hits.0._source.nested_array.0.obj1.1.field4: 4 }
+  - length: { hits.hits.0._source.nested_array.1: 3 }
+  - match:  { hits.hits.0._source.nested_array.1.a: 100 }
+  - match:  { hits.hits.0._source.nested_array.1.b: 200 }
+  - length: { hits.hits.0._source.nested_array.1.obj1: 2 }
+  - match:  { hits.hits.0._source.nested_array.1.obj1.field5: 5 }
+  - match:  { hits.hits.0._source.nested_array.1.obj1.field6: 6 }
+  - length: { hits.hits.1._source: 2 }
+  - match:  { hits.hits.1._source.id: 1 }
+  - length: { hits.hits.1._source.obj_field: 4 }
+  - match:  { hits.hits.1._source.obj_field.a: 1 }
+  - match:  { hits.hits.1._source.obj_field.b: 2 }
+  - length: { hits.hits.1._source.obj_field.obj1: 2 }
+  - match:  { hits.hits.1._source.obj_field.obj1.foo: "bar" }
+  - match:  { hits.hits.1._source.obj_field.obj1.k: [ 1, 2, 3 ] }
+  - length: { hits.hits.1._source.obj_field.sub_nested: 2 }
+  - length: { hits.hits.1._source.obj_field.sub_nested.0: 2 }
+  - match:  { hits.hits.1._source.obj_field.sub_nested.0.a: 10 }
+  - match:  { hits.hits.1._source.obj_field.sub_nested.0.b: 20 }
+  - length: { hits.hits.1._source.obj_field.sub_nested.1: 2 }
+  - match:  { hits.hits.1._source.obj_field.sub_nested.1.a: 100 }
+  - match:  { hits.hits.1._source.obj_field.sub_nested.1.b: 200 }
+
+
+---
+doubly nested object:
+  - requires:
+      cluster_features: ["mapper.track_ignored_source"]
+      reason: requires tracking ignored source
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              obj_field:
+                properties:
+                  obj1:
+                    enabled: false
+                  sub_nested:
+                    type: nested
+              nested_field:
+                type: nested
+                properties:
+                  sub_nested_field:
+                    type: nested
+                    properties:
+                      obj1:
+                        enabled: false
+
+  - do:
+      bulk:
+        index: test
+        refresh: true
+        body:
+          - '{ "create": { } }'
+          - '{ "id": 0, "nested_field": {"a": 1, "b": 2, "sub_nested_field": {"foo": "bar", "k": [1, 2, 3]}}}'
+          - '{ "create": { } }'
+          - '{ "id": 1, "nested_field": {"a": 2, "b": 3, "sub_nested_field": [{"foo": "baz", "k": [4, 50, 6]}, {"foo": "bar"}]}}'
+          - '{ "create": { } }'
+          - '{ "id": 2, "nested_field": [{"a": 20, "b": 30, "sub_nested_field": [{"foo": "foobar", "k": [7, 8, 9]}, {"k": [400, 500, 6]}]}, {"a": 0, "b": 33, "sub_nested_field": [{"other": "value", "k": [1, 2, -3]}, {"number": 42}]}]}'
+          - '{ "create": { } }'
+          - '{ "id": 3}'
+
+  - match: { errors: false }
+
+  - do:
+      search:
+        index: test
+        sort: "id"
+
+  - match:  { hits.total.value: 4 }
+  - length: { hits.hits.0._source: 2 }
+  - match:  { hits.hits.0._source.id: 0 }
+  - length: { hits.hits.0._source.nested_field: 3 }
+  - match:  { hits.hits.0._source.nested_field.a: 1 }
+  - match:  { hits.hits.0._source.nested_field.b: 2 }
+  - length: { hits.hits.0._source.nested_field.sub_nested_field: 2 }
+  - match:  { hits.hits.0._source.nested_field.sub_nested_field.foo: "bar" }
+  - match:  { hits.hits.0._source.nested_field.sub_nested_field.k: [ 1, 2, 3 ] }
+  - length: { hits.hits.1._source: 2 }
+  - match:  { hits.hits.1._source.id: 1 }
+  - length: { hits.hits.1._source.nested_field: 3 }
+  - match:  { hits.hits.1._source.nested_field.a: 2 }
+  - match:  { hits.hits.1._source.nested_field.b: 3 }
+  - length: { hits.hits.1._source.nested_field.sub_nested_field: 2 }
+  - length: { hits.hits.1._source.nested_field.sub_nested_field.0: 2 }
+  - match:  { hits.hits.1._source.nested_field.sub_nested_field.0.foo: "baz" }
+  - match:  { hits.hits.1._source.nested_field.sub_nested_field.0.k: [ 4, 6, 50 ] }
+  - length: { hits.hits.1._source.nested_field.sub_nested_field.1: 1 }
+  - match:  { hits.hits.1._source.nested_field.sub_nested_field.1.foo: "bar" }
+  - length: { hits.hits.2._source: 2 }
+  - match:  { hits.hits.2._source.id: 2 }
+  - length: { hits.hits.2._source.nested_field: 2 }
+  - length: { hits.hits.2._source.nested_field.0: 3 }
+  - match:  { hits.hits.2._source.nested_field.0.a: 20 }
+  - match:  { hits.hits.2._source.nested_field.0.b: 30 }
+  - length: { hits.hits.2._source.nested_field.0.sub_nested_field: 2 }
+  - length: { hits.hits.2._source.nested_field.0.sub_nested_field.0: 2 }
+  - match:  { hits.hits.2._source.nested_field.0.sub_nested_field.0.foo: "foobar" }
+  - match:  { hits.hits.2._source.nested_field.0.sub_nested_field.0.k: [ 7, 8, 9 ] }
+  - length: { hits.hits.2._source.nested_field.0.sub_nested_field.1: 1 }
+  - match:  { hits.hits.2._source.nested_field.0.sub_nested_field.1.k: [6, 400, 500] }
+  - length: { hits.hits.2._source.nested_field.1: 3 }
+  - match:  { hits.hits.2._source.nested_field.1.a: 0 }
+  - match:  { hits.hits.2._source.nested_field.1.b: 33 }
+  - length: { hits.hits.2._source.nested_field.1.sub_nested_field: 2 }
+  - length: { hits.hits.2._source.nested_field.1.sub_nested_field.0: 2 }
+  - match:  { hits.hits.2._source.nested_field.1.sub_nested_field.0.other: "value" }
+  - match:  { hits.hits.2._source.nested_field.1.sub_nested_field.0.k: [ -3, 1, 2 ] }
+  - length: { hits.hits.2._source.nested_field.1.sub_nested_field.1: 1 }
+  - match:  { hits.hits.2._source.nested_field.1.sub_nested_field.1.number: 42 }
+  - length: { hits.hits.3._source: 1 }
+  - match:  { hits.hits.3._source.id: 3 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -132,7 +132,8 @@ public final class DocumentParser {
                         new IgnoredSourceFieldMapper.NameValue(
                             MapperService.SINGLE_MAPPING_NAME,
                             0,
-                            XContentDataHelper.encodeToken(context.parser())
+                            XContentDataHelper.encodeToken(context.parser()),
+                            context.doc()
                         )
                     );
                 } else {
@@ -268,7 +269,8 @@ public final class DocumentParser {
                     new IgnoredSourceFieldMapper.NameValue(
                         context.parent().fullPath(),
                         context.parent().fullPath().indexOf(currentFieldName),
-                        XContentDataHelper.encodeToken(parser)
+                        XContentDataHelper.encodeToken(parser),
+                        context.doc()
                     )
                 );
             } else {
@@ -288,13 +290,14 @@ public final class DocumentParser {
 
         if (context.parent().isNested()) {
             // Handle a nested object that doesn't contain an array. Arrays are handled in #parseNonDynamicArray.
-            if (context.mappingLookup().isSourceSynthetic() && context.getClonedSource() == false) {
+            if (context.parent().storeArraySource() && context.mappingLookup().isSourceSynthetic() && context.getClonedSource() == false) {
                 Tuple<DocumentParserContext, XContentBuilder> tuple = XContentDataHelper.cloneSubContext(context);
                 context.addIgnoredField(
                     new IgnoredSourceFieldMapper.NameValue(
                         context.parent().name(),
                         context.parent().fullPath().indexOf(context.parent().simpleName()),
-                        XContentDataHelper.encodeXContentBuilder(tuple.v2())
+                        XContentDataHelper.encodeXContentBuilder(tuple.v2()),
+                        context.doc()
                     )
                 );
                 context = tuple.v1();
@@ -661,9 +664,8 @@ public final class DocumentParser {
                 && (objectMapper.storeArraySource() || objectMapper.dynamic == ObjectMapper.Dynamic.RUNTIME);
             boolean fieldWithFallbackSyntheticSource = mapper instanceof FieldMapper fieldMapper
                 && fieldMapper.syntheticSourceMode() == FieldMapper.SyntheticSourceMode.FALLBACK;
-            boolean nestedObject = mapper instanceof NestedObjectMapper;
             boolean dynamicRuntimeContext = context.dynamic() == ObjectMapper.Dynamic.RUNTIME;
-            if (objectRequiresStoringSource || fieldWithFallbackSyntheticSource || nestedObject || dynamicRuntimeContext) {
+            if (objectRequiresStoringSource || fieldWithFallbackSyntheticSource || dynamicRuntimeContext) {
                 Tuple<DocumentParserContext, XContentBuilder> tuple = XContentDataHelper.cloneSubContext(context);
                 context.addIgnoredField(
                     IgnoredSourceFieldMapper.NameValue.fromContext(

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -24,13 +24,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * Context used when parsing incoming documents. Holds everything that is needed to parse a document as well as
@@ -106,7 +104,7 @@ public abstract class DocumentParserContext {
     private final MappingParserContext mappingParserContext;
     private final SourceToParse sourceToParse;
     private final Set<String> ignoredFields;
-    private final Set<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues;
+    private final List<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues;
     private final Map<String, List<Mapper>> dynamicMappers;
     private final DynamicMapperSize dynamicMappersSize;
     private final Map<String, ObjectMapper> dynamicObjectMappers;
@@ -128,7 +126,7 @@ public abstract class DocumentParserContext {
         MappingParserContext mappingParserContext,
         SourceToParse sourceToParse,
         Set<String> ignoreFields,
-        Set<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues,
+        List<IgnoredSourceFieldMapper.NameValue> ignoredFieldValues,
         Map<String, List<Mapper>> dynamicMappers,
         Map<String, ObjectMapper> dynamicObjectMappers,
         Map<String, List<RuntimeField>> dynamicRuntimeFields,
@@ -198,7 +196,7 @@ public abstract class DocumentParserContext {
             mappingParserContext,
             source,
             new HashSet<>(),
-            new TreeSet<>(Comparator.comparing(IgnoredSourceFieldMapper.NameValue::name)),
+            new ArrayList<>(),
             new HashMap<>(),
             new HashMap<>(),
             new HashMap<>(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapper.java
@@ -17,7 +17,10 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 /**
 
@@ -53,7 +56,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
      *    the full name of the parent field
      *  - the value, encoded as a byte array
      */
-    public record NameValue(String name, int parentOffset, BytesRef value) {
+    public record NameValue(String name, int parentOffset, BytesRef value, LuceneDocument doc) {
         /**
          * Factory method, for use with fields under the parent object. It doesn't apply to objects at root level.
          * @param context the parser context, containing a non-null parent
@@ -62,7 +65,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
          */
         public static NameValue fromContext(DocumentParserContext context, String name, BytesRef value) {
             int parentOffset = context.parent() instanceof RootObjectMapper ? 0 : context.parent().fullPath().length() + 1;
-            return new NameValue(name, parentOffset, value);
+            return new NameValue(name, parentOffset, value, context.doc());
         }
 
         String getParentFieldName() {
@@ -112,8 +115,11 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
     public void postParse(DocumentParserContext context) {
         // Ignored values are only expected in synthetic mode.
         assert context.getIgnoredFieldValues().isEmpty() || context.mappingLookup().isSourceSynthetic();
-        for (NameValue nameValue : context.getIgnoredFieldValues()) {
-            context.doc().add(new StoredField(NAME, encode(nameValue)));
+        List<NameValue> ignoredFieldValues = new ArrayList<>(context.getIgnoredFieldValues());
+        // ensure consistent ordering when retrieving synthetic source
+        Collections.sort(ignoredFieldValues, Comparator.comparing(NameValue::name));
+        for (NameValue nameValue : ignoredFieldValues) {
+            nameValue.doc().add(new StoredField(NAME, encode(nameValue)));
         }
     }
 
@@ -136,7 +142,7 @@ public class IgnoredSourceFieldMapper extends MetadataFieldMapper {
         int parentOffset = encodedSize / PARENT_OFFSET_IN_NAME_OFFSET;
         String name = new String(bytes, 4, nameSize, StandardCharsets.UTF_8);
         BytesRef value = new BytesRef(bytes, 4 + nameSize, bytes.length - nameSize - 4);
-        return new NameValue(name, parentOffset, value);
+        return new NameValue(name, parentOffset, value, null);
     }
 
     // This mapper doesn't contribute to source directly as it has no access to the object structure. Instead, its contents

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -8,19 +8,31 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.join.BitSetProducer;
+import org.apache.lucene.util.BitSet;
 import org.elasticsearch.common.Explicit;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.IndexVersions;
+import org.elasticsearch.index.fieldvisitor.LeafStoredFieldLoader;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.index.mapper.SourceFieldMetrics.NOOP;
 
 /**
  * A Mapper for nested objects
@@ -34,12 +46,12 @@ public class NestedObjectMapper extends ObjectMapper {
         private Explicit<Boolean> includeInRoot = Explicit.IMPLICIT_FALSE;
         private Explicit<Boolean> includeInParent = Explicit.IMPLICIT_FALSE;
         private final IndexVersion indexCreatedVersion;
-        private final Function<Query, BitSetProducer> bitsetProducer;
+        private final Function<Query, BitSetProducer> bitSetProducer;
 
         public Builder(String name, IndexVersion indexCreatedVersion, Function<Query, BitSetProducer> bitSetProducer) {
             super(name, Explicit.IMPLICIT_TRUE);
             this.indexCreatedVersion = indexCreatedVersion;
-            this.bitsetProducer = bitSetProducer;
+            this.bitSetProducer = bitSetProducer;
         }
 
         Builder includeInRoot(boolean includeInRoot) {
@@ -91,12 +103,13 @@ public class NestedObjectMapper extends ObjectMapper {
                 buildMappers(nestedContext),
                 enabled,
                 dynamic,
+                storeArraySource,
                 includeInParent,
                 includeInRoot,
                 parentTypeFilter,
                 nestedTypePath,
                 nestedTypeFilter,
-                bitsetProducer
+                bitSetProducer
             );
         }
     }
@@ -179,6 +192,7 @@ public class NestedObjectMapper extends ObjectMapper {
         Map<String, Mapper> mappers,
         Explicit<Boolean> enabled,
         ObjectMapper.Dynamic dynamic,
+        Explicit<Boolean> storeArraySource,
         Explicit<Boolean> includeInParent,
         Explicit<Boolean> includeInRoot,
         Query parentTypeFilter,
@@ -186,7 +200,7 @@ public class NestedObjectMapper extends ObjectMapper {
         Query nestedTypeFilter,
         Function<Query, BitSetProducer> bitsetProducer
     ) {
-        super(name, fullPath, enabled, Explicit.IMPLICIT_TRUE, Explicit.IMPLICIT_FALSE, dynamic, mappers);
+        super(name, fullPath, enabled, Explicit.IMPLICIT_TRUE, storeArraySource, dynamic, mappers);
         this.parentTypeFilter = parentTypeFilter;
         this.nestedTypePath = nestedTypePath;
         this.nestedTypeFilter = nestedTypeFilter;
@@ -246,6 +260,7 @@ public class NestedObjectMapper extends ObjectMapper {
             Map.of(),
             enabled,
             dynamic,
+            storeArraySource,
             includeInParent,
             includeInRoot,
             parentTypeFilter,
@@ -270,6 +285,9 @@ public class NestedObjectMapper extends ObjectMapper {
         }
         if (isEnabled() != Defaults.ENABLED) {
             builder.field("enabled", enabled.value());
+        }
+        if (storeArraySource != Defaults.STORE_ARRAY_SOURCE) {
+            builder.field(STORE_ARRAY_SOURCE_PARAM, storeArraySource.value());
         }
         serializeMappers(builder, params);
         return builder.endObject();
@@ -317,6 +335,7 @@ public class NestedObjectMapper extends ObjectMapper {
             mergeResult.mappers(),
             mergeResult.enabled(),
             mergeResult.dynamic(),
+            mergeResult.trackArraySource(),
             incInParent,
             incInRoot,
             parentTypeFilter,
@@ -346,7 +365,114 @@ public class NestedObjectMapper extends ObjectMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-        // IgnoredSourceFieldMapper integration takes care of writing the source for nested objects.
-        return SourceLoader.SyntheticFieldLoader.NOTHING;
+        if (storeArraySource()) {
+            // IgnoredSourceFieldMapper integration takes care of writing the source for nested objects that enabled store_array_source.
+            return SourceLoader.SyntheticFieldLoader.NOTHING;
+        }
+
+        SourceLoader sourceLoader = new SourceLoader.Synthetic(() -> super.syntheticFieldLoader(mappers.values().stream(), true), NOOP);
+        var storedFieldLoader = org.elasticsearch.index.fieldvisitor.StoredFieldLoader.create(false, sourceLoader.requiredStoredFields());
+        return new NestedSyntheticFieldLoader(
+            storedFieldLoader,
+            sourceLoader,
+            () -> bitsetProducer.apply(parentTypeFilter),
+            nestedTypeFilter
+        );
+    }
+
+    private class NestedSyntheticFieldLoader implements SourceLoader.SyntheticFieldLoader {
+        private final org.elasticsearch.index.fieldvisitor.StoredFieldLoader storedFieldLoader;
+        private final SourceLoader sourceLoader;
+        private final Supplier<BitSetProducer> parentBitSetProducer;
+        private final Query childFilter;
+
+        private LeafStoredFieldLoader leafStoredFieldLoader;
+        private SourceLoader.Leaf leafSourceLoader;
+        private final List<Integer> children = new ArrayList<>();
+
+        private NestedSyntheticFieldLoader(
+            org.elasticsearch.index.fieldvisitor.StoredFieldLoader storedFieldLoader,
+            SourceLoader sourceLoader,
+            Supplier<BitSetProducer> parentBitSetProducer,
+            Query childFilter
+        ) {
+            this.storedFieldLoader = storedFieldLoader;
+            this.sourceLoader = sourceLoader;
+            this.parentBitSetProducer = parentBitSetProducer;
+            this.childFilter = childFilter;
+        }
+
+        @Override
+        public Stream<Map.Entry<String, StoredFieldLoader>> storedFieldLoaders() {
+            return Stream.of();
+        }
+
+        @Override
+        public DocValuesLoader docValuesLoader(LeafReader leafReader, int[] docIdsInLeaf) throws IOException {
+            this.children.clear();
+            this.leafStoredFieldLoader = storedFieldLoader.getLoader(leafReader.getContext(), null);
+            this.leafSourceLoader = sourceLoader.leaf(leafReader, null);
+
+            IndexSearcher searcher = new IndexSearcher(leafReader);
+            searcher.setQueryCache(null);
+            var childScorer = searcher.createWeight(childFilter, ScoreMode.COMPLETE_NO_SCORES, 1f).scorer(leafReader.getContext());
+            if (childScorer != null) {
+                var parentDocs = parentBitSetProducer.get().getBitSet(leafReader.getContext());
+                return parentDoc -> {
+                    collectChildren(parentDoc, parentDocs, childScorer.iterator());
+                    return children.size() > 0;
+                };
+            } else {
+                return parentDoc -> false;
+            }
+        }
+
+        private List<Integer> collectChildren(int parentDoc, BitSet parentDocs, DocIdSetIterator childIt) throws IOException {
+            assert parentDocs.get(parentDoc) : "wrong context, doc " + parentDoc + " is not a parent of " + nestedTypePath;
+            final int prevParentDoc = parentDocs.prevSetBit(parentDoc - 1);
+            int childDocId = childIt.docID();
+            if (childDocId <= prevParentDoc) {
+                childDocId = childIt.advance(prevParentDoc + 1);
+            }
+
+            children.clear();
+            for (; childDocId < parentDoc; childDocId = childIt.nextDoc()) {
+                children.add(childDocId);
+            }
+            return children;
+        }
+
+        @Override
+        public boolean hasValue() {
+            return children.size() > 0;
+        }
+
+        @Override
+        public void write(XContentBuilder b) throws IOException {
+            assert (children != null && children.size() > 0);
+            switch (children.size()) {
+                case 1 -> {
+                    b.startObject(simpleName());
+                    leafStoredFieldLoader.advanceTo(children.get(0));
+                    leafSourceLoader.write(leafStoredFieldLoader, children.get(0), b);
+                    b.endObject();
+                }
+                default -> {
+                    b.startArray(simpleName());
+                    for (int childId : children) {
+                        b.startObject();
+                        leafStoredFieldLoader.advanceTo(childId);
+                        leafSourceLoader.write(leafStoredFieldLoader, childId, b);
+                        b.endObject();
+                    }
+                    b.endArray();
+                }
+            }
+        }
+
+        @Override
+        public String fieldName() {
+            return name();
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -450,23 +450,20 @@ public class NestedObjectMapper extends ObjectMapper {
         @Override
         public void write(XContentBuilder b) throws IOException {
             assert (children != null && children.size() > 0);
-            switch (children.size()) {
-                case 1 -> {
-                    b.startObject(simpleName());
-                    leafStoredFieldLoader.advanceTo(children.get(0));
-                    leafSourceLoader.write(leafStoredFieldLoader, children.get(0), b);
+            if (children.size() == 1) {
+                b.startObject(simpleName());
+                leafStoredFieldLoader.advanceTo(children.get(0));
+                leafSourceLoader.write(leafStoredFieldLoader, children.get(0), b);
+                b.endObject();
+            } else {
+                b.startArray(simpleName());
+                for (int childId : children) {
+                    b.startObject();
+                    leafStoredFieldLoader.advanceTo(childId);
+                    leafSourceLoader.write(leafStoredFieldLoader, childId, b);
                     b.endObject();
                 }
-                default -> {
-                    b.startArray(simpleName());
-                    for (int childId : children) {
-                        b.startObject();
-                        leafStoredFieldLoader.advanceTo(childId);
-                        leafSourceLoader.write(leafStoredFieldLoader, childId, b);
-                        b.endObject();
-                    }
-                    b.endArray();
-                }
+                b.endArray();
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -756,12 +756,16 @@ public class ObjectMapper extends Mapper {
 
     }
 
-    public SourceLoader.SyntheticFieldLoader syntheticFieldLoader(Stream<Mapper> mappers) {
+    protected SourceLoader.SyntheticFieldLoader syntheticFieldLoader(Stream<Mapper> mappers, boolean isFragment) {
         var fields = mappers.sorted(Comparator.comparing(Mapper::name))
             .map(Mapper::syntheticFieldLoader)
             .filter(l -> l != SourceLoader.SyntheticFieldLoader.NOTHING)
             .toList();
-        return new SyntheticSourceFieldLoader(fields);
+        return new SyntheticSourceFieldLoader(fields, isFragment);
+    }
+
+    public SourceLoader.SyntheticFieldLoader syntheticFieldLoader(Stream<Mapper> mappers) {
+        return syntheticFieldLoader(mappers, false);
     }
 
     @Override
@@ -771,11 +775,13 @@ public class ObjectMapper extends Mapper {
 
     private class SyntheticSourceFieldLoader implements SourceLoader.SyntheticFieldLoader {
         private final List<SourceLoader.SyntheticFieldLoader> fields;
+        private final boolean isFragment;
         private boolean hasValue;
         private List<IgnoredSourceFieldMapper.NameValue> ignoredValues;
 
-        private SyntheticSourceFieldLoader(List<SourceLoader.SyntheticFieldLoader> fields) {
+        private SyntheticSourceFieldLoader(List<SourceLoader.SyntheticFieldLoader> fields, boolean isFragment) {
             this.fields = fields;
+            this.isFragment = isFragment;
         }
 
         @Override
@@ -830,18 +836,21 @@ public class ObjectMapper extends Mapper {
             if (hasValue == false) {
                 return;
             }
-            if (isRoot()) {
-                if (isEnabled() == false) {
-                    // If the root object mapper is disabled, it is expected to contain
-                    // the source encapsulated within a single ignored source value.
-                    assert ignoredValues.size() == 1 : ignoredValues.size();
-                    XContentDataHelper.decodeAndWrite(b, ignoredValues.get(0).value());
-                    ignoredValues = null;
-                    return;
+            if (isRoot() && isEnabled() == false) {
+                // If the root object mapper is disabled, it is expected to contain
+                // the source encapsulated within a single ignored source value.
+                assert ignoredValues.size() == 1 : ignoredValues.size();
+                XContentDataHelper.decodeAndWrite(b, ignoredValues.get(0).value());
+                ignoredValues = null;
+                return;
+            }
+
+            if (isFragment == false) {
+                if (isRoot()) {
+                    b.startObject();
+                } else {
+                    b.startObject(simpleName());
                 }
-                b.startObject();
-            } else {
-                b.startObject(simpleName());
             }
 
             if (ignoredValues != null && ignoredValues.isEmpty() == false) {
@@ -868,7 +877,9 @@ public class ObjectMapper extends Mapper {
                 }
             }
             hasValue = false;
-            b.endObject();
+            if (isFragment == false) {
+                b.endObject();
+            }
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredSourceFieldMapperTests.java
@@ -87,8 +87,8 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         String stringValue = randomAlphaOfLength(20);
         String syntheticSource = getSyntheticSourceWithFieldLimit(b -> {
             b.field("boolean_value", booleanValue);
-            b.field("string_value", stringValue);
             b.field("int_value", intValue);
+            b.field("string_value", stringValue);
         });
         assertEquals(String.format(Locale.ROOT, """
             {"boolean_value":%s,"int_value":%s,"string_value":"%s"}""", booleanValue, intValue, stringValue), syntheticSource);
@@ -626,6 +626,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
             b.startObject("path").field("type", "nested");
             {
+                b.field("store_array_source", true);
                 b.startObject("properties");
                 {
                     b.startObject("foo").field("type", "keyword").endObject();
@@ -647,6 +648,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
         DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
             b.startObject("path").field("type", "nested");
             {
+                b.field("store_array_source", true);
                 b.startObject("properties");
                 {
                     b.startObject("foo").field("type", "keyword").endObject();
@@ -679,6 +681,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
                     b.startObject("int_value").field("type", "integer").endObject();
                     b.startObject("to").field("type", "nested");
                     {
+                        b.field("store_array_source", true);
                         b.startObject("properties");
                         {
                             b.startObject("foo").field("type", "keyword").endObject();
@@ -719,6 +722,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
                     b.startObject("int_value").field("type", "integer").endObject();
                     b.startObject("to").field("type", "nested");
                     {
+                        b.field("store_array_source", true);
                         b.startObject("properties");
                         {
                             b.startObject("foo").field("type", "keyword").endObject();
@@ -758,7 +762,7 @@ public class IgnoredSourceFieldMapperTests extends MapperServiceTestCase {
 
     public void testNestedObjectIncludeInRoot() throws IOException {
         DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
-            b.startObject("path").field("type", "nested").field("include_in_root", true);
+            b.startObject("path").field("type", "nested").field("store_array_source", true).field("include_in_root", true);
             {
                 b.startObject("properties");
                 {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -29,6 +29,7 @@ import java.io.UncheckedIOException;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.containsString;
@@ -1565,6 +1566,175 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
 
         NestedObjectMapper mapper2 = docMapper.mappers().nestedLookup().getNestedMappers().get("nested1.sub_nested");
         assertThat(mapper2.parentTypeFilter(), equalTo(mapper1.nestedTypeFilter()));
+    }
+
+    public void testStoreArraySourceinSyntheticSourceMode() throws IOException {
+        DocumentMapper mapper = createDocumentMapper(syntheticSourceMapping(b -> {
+            b.startObject("o").field("type", "nested").field(ObjectMapper.STORE_ARRAY_SOURCE_PARAM, true).endObject();
+        }));
+        assertNotNull(mapper.mapping().getRoot().getMapper("o"));
+    }
+
+    public void testStoreArraySourceThrowsInNonSyntheticSourceMode() {
+        var exception = expectThrows(MapperParsingException.class, () -> createDocumentMapper(mapping(b -> {
+            b.startObject("o").field("type", "nested").field(ObjectMapper.STORE_ARRAY_SOURCE_PARAM, true).endObject();
+        })));
+        assertEquals("Parameter [store_array_source] can only be set in synthetic source mode.", exception.getMessage());
+    }
+
+    public void testSyntheticNestedWithObject() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path").field("type", "nested");
+            {
+                b.startObject("properties");
+                {
+                    b.startObject("foo").field("type", "keyword").endObject();
+                    b.startObject("bar").field("type", "keyword").endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })).documentMapper();
+        var syntheticSource = syntheticSource(
+            documentMapper,
+            b -> { b.startObject("path").field("foo", "A").field("bar", "B").endObject(); }
+        );
+        assertEquals("""
+            {"path":{"bar":"B","foo":"A"}}""", syntheticSource);
+    }
+
+    public void testSyntheticNestedWithArray() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path").field("type", "nested");
+            {
+                b.startObject("properties");
+                {
+                    b.startObject("foo").field("type", "keyword").endObject();
+                    b.startObject("bar").field("type", "keyword").endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })).documentMapper();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.startArray("path");
+            {
+                b.startObject().field("foo", "A").field("bar", "B").endObject();
+                b.startObject().field("foo", "C").field("bar", "D").endObject();
+            }
+            b.endArray();
+        });
+        assertEquals("""
+            {"path":[{"bar":"B","foo":"A"},{"bar":"D","foo":"C"}]}""", syntheticSource);
+    }
+
+    public void testSyntheticNestedWithSubObjects() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("boolean_value").field("type", "boolean").endObject();
+            b.startObject("path");
+            {
+                b.field("type", "object");
+                b.startObject("properties");
+                {
+                    b.startObject("int_value").field("type", "integer").endObject();
+                    b.startObject("to").field("type", "nested");
+                    {
+                        b.startObject("properties");
+                        {
+                            b.startObject("foo").field("type", "keyword").endObject();
+                            b.startObject("bar").field("type", "keyword").endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })).documentMapper();
+
+        boolean booleanValue = randomBoolean();
+        int intValue = randomInt();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.field("boolean_value", booleanValue);
+            b.startObject("path");
+            {
+                b.field("int_value", intValue);
+                b.startObject("to").field("foo", "A").field("bar", "B").endObject();
+            }
+            b.endObject();
+        });
+        assertEquals(String.format(Locale.ROOT, """
+            {"boolean_value":%s,"path":{"int_value":%s,"to":{"bar":"B","foo":"A"}}}""", booleanValue, intValue), syntheticSource);
+    }
+
+    public void testSyntheticNestedWithSubArrays() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("boolean_value").field("type", "boolean").endObject();
+            b.startObject("path");
+            {
+                b.field("type", "object");
+                b.startObject("properties");
+                {
+                    b.startObject("int_value").field("type", "integer").endObject();
+                    b.startObject("to").field("type", "nested");
+                    {
+                        b.startObject("properties");
+                        {
+                            b.startObject("foo").field("type", "keyword").endObject();
+                            b.startObject("bar").field("type", "keyword").endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })).documentMapper();
+
+        boolean booleanValue = randomBoolean();
+        int intValue = randomInt();
+        var syntheticSource = syntheticSource(documentMapper, b -> {
+            b.field("boolean_value", booleanValue);
+            b.startObject("path");
+            {
+                b.field("int_value", intValue);
+                b.startArray("to");
+                {
+                    b.startObject().field("foo", "A").field("bar", "B").endObject();
+                    b.startObject().field("foo", "C").field("bar", "D").endObject();
+                }
+                b.endArray();
+            }
+            b.endObject();
+        });
+        assertEquals(
+            String.format(Locale.ROOT, """
+                {"boolean_value":%s,"path":{"int_value":%s,"to":[{"bar":"B","foo":"A"},{"bar":"D","foo":"C"}]}}""", booleanValue, intValue),
+            syntheticSource
+        );
+    }
+
+    public void testSyntheticNestedWithIncludeInRoot() throws IOException {
+        DocumentMapper documentMapper = createMapperService(syntheticSourceMapping(b -> {
+            b.startObject("path").field("type", "nested").field("include_in_root", true);
+            {
+                b.startObject("properties");
+                {
+                    b.startObject("foo").field("type", "keyword").endObject();
+                    b.startObject("bar").field("type", "keyword").endObject();
+                }
+                b.endObject();
+            }
+            b.endObject();
+        })).documentMapper();
+        var syntheticSource = syntheticSource(
+            documentMapper,
+            b -> { b.startObject("path").field("foo", "A").field("bar", "B").endObject(); }
+        );
+        assertEquals("""
+            {"path":{"bar":"B","foo":"A"}}""", syntheticSource);
     }
 
     private NestedObjectMapper createNestedObjectMapperWithAllParametersSet(CheckedConsumer<XContentBuilder, IOException> propertiesBuilder)

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -802,6 +802,7 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
         try (Directory roundTripDirectory = newDirectory()) {
             RandomIndexWriter roundTripIw = indexWriterForSyntheticSource(roundTripDirectory);
             ParsedDocument doc = mapper.parse(new SourceToParse("1", new BytesArray(syntheticSource), XContentType.JSON));
+            // Process root and nested documents in the same way as the normal indexing chain (assuming a single document)
             doc.updateSeqID(0, 0);
             doc.version().setLongValue(0);
             roundTripIw.addDocuments(doc.docs());

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.lucene.index.ElasticsearchDirectoryReader;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
@@ -34,6 +35,7 @@ import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.AnalyzerScope;
@@ -773,12 +775,14 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
     protected final String syntheticSource(DocumentMapper mapper, CheckedConsumer<XContentBuilder, IOException> build) throws IOException {
         try (Directory directory = newDirectory()) {
             RandomIndexWriter iw = indexWriterForSyntheticSource(directory);
-            LuceneDocument doc = mapper.parse(source(build)).rootDoc();
-            iw.addDocument(doc);
+            ParsedDocument doc = mapper.parse(source(build));
+            doc.updateSeqID(0, 0);
+            doc.version().setLongValue(0);
+            iw.addDocuments(doc.docs());
             iw.close();
-            try (DirectoryReader reader = DirectoryReader.open(directory)) {
-                String syntheticSource = syntheticSource(mapper, reader, 0);
-                roundTripSyntheticSource(mapper, syntheticSource, reader);
+            try (DirectoryReader indexReader = wrapInMockESDirectoryReader(DirectoryReader.open(directory))) {
+                String syntheticSource = syntheticSource(mapper, indexReader, doc.docs().size() - 1);
+                roundTripSyntheticSource(mapper, syntheticSource, indexReader);
                 return syntheticSource;
             }
         }
@@ -797,10 +801,13 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
     private void roundTripSyntheticSource(DocumentMapper mapper, String syntheticSource, DirectoryReader reader) throws IOException {
         try (Directory roundTripDirectory = newDirectory()) {
             RandomIndexWriter roundTripIw = indexWriterForSyntheticSource(roundTripDirectory);
-            roundTripIw.addDocument(mapper.parse(new SourceToParse("1", new BytesArray(syntheticSource), XContentType.JSON)).rootDoc());
+            ParsedDocument doc = mapper.parse(new SourceToParse("1", new BytesArray(syntheticSource), XContentType.JSON));
+            doc.updateSeqID(0, 0);
+            doc.version().setLongValue(0);
+            roundTripIw.addDocuments(doc.docs());
             roundTripIw.close();
-            try (DirectoryReader roundTripReader = DirectoryReader.open(roundTripDirectory)) {
-                String roundTripSyntheticSource = syntheticSource(mapper, roundTripReader, 0);
+            try (DirectoryReader roundTripReader = wrapInMockESDirectoryReader(DirectoryReader.open(roundTripDirectory))) {
+                String roundTripSyntheticSource = syntheticSource(mapper, roundTripReader, doc.docs().size() - 1);
                 assertThat(roundTripSyntheticSource, equalTo(syntheticSource));
                 validateRoundTripReader(syntheticSource, reader, roundTripReader);
             }
@@ -862,5 +869,9 @@ public abstract class MapperServiceTestCase extends FieldTypeTestCase {
             buildField.accept(b);
             b.endObject();
         });
+    }
+
+    protected static DirectoryReader wrapInMockESDirectoryReader(DirectoryReader directoryReader) throws IOException {
+        return ElasticsearchDirectoryReader.wrap(directoryReader, new ShardId(new Index("index", "_na_"), 0));
     }
 }


### PR DESCRIPTION
This change adds a synthetic mode for nested fields that recursively load nested objects from stored fields and doc values. The order of the sub-objects is preserved since they are indexed in separate Lucene documents. This change also introduces the `store_array_source` mode in the nested field options. This option is disabled by default when synthetic is used but users can opt-in for this behaviour.


I ran the [`nested`](https://github.com/elastic/rally-tracks/tree/master/nested) benchmark on my laptop using synthetic mode. The `baseline` version, based on the main branch, applies `store_array_source`. The contender version uses the new default for synthetic `nested` fields. The new strategy in this PR reduces the total index size on disk by 22%. Query latencies increased by up to 17% (from 30 to 35ms 50th latency) for the most source-heavy queries (`randomized-nested-queries-with-inner-hits_*`).

<details>
  <summary>Full results</summary>

|                                                        Metric |                                                       Task |       Baseline |      Contender |       Diff |   Unit |   Diff % |
|--------------------------------------------------------------:|-----------------------------------------------------------:|---------------:|---------------:|-----------:|-------:|---------:|
|                    Cumulative indexing time of primary shards |                                                            |   10.2031      |   10.5655      |    0.36235 |    min |   +3.55% |
|             Min cumulative indexing time across primary shard |                                                            |   10.2031      |   10.5655      |    0.36235 |    min |   +3.55% |
|          Median cumulative indexing time across primary shard |                                                            |   10.2031      |   10.5655      |    0.36235 |    min |   +3.55% |
|             Max cumulative indexing time across primary shard |                                                            |   10.2031      |   10.5655      |    0.36235 |    min |   +3.55% |
|                       Cumulative merge time of primary shards |                                                            |    2.83382     |    2.67333     |   -0.16048 |    min |   -5.66% |
|                      Cumulative merge count of primary shards |                                                            |   10           |   11           |    1       |        |  +10.00% |
|                Min cumulative merge time across primary shard |                                                            |    2.83382     |    2.67333     |   -0.16048 |    min |   -5.66% |
|             Median cumulative merge time across primary shard |                                                            |    2.83382     |    2.67333     |   -0.16048 |    min |   -5.66% |
|                Max cumulative merge time across primary shard |                                                            |    2.83382     |    2.67333     |   -0.16048 |    min |   -5.66% |
|              Cumulative merge throttle time of primary shards |                                                            |    0.5493      |    0.407383    |   -0.14192 |    min |  -25.84% |
|       Min cumulative merge throttle time across primary shard |                                                            |    0.5493      |    0.407383    |   -0.14192 |    min |  -25.84% |
|    Median cumulative merge throttle time across primary shard |                                                            |    0.5493      |    0.407383    |   -0.14192 |    min |  -25.84% |
|       Max cumulative merge throttle time across primary shard |                                                            |    0.5493      |    0.407383    |   -0.14192 |    min |  -25.84% |
|                     Cumulative refresh time of primary shards |                                                            |    0.5287      |    0.488917    |   -0.03978 |    min |   -7.52% |
|                    Cumulative refresh count of primary shards |                                                            |   20           |   25           |    5       |        |  +25.00% |
|              Min cumulative refresh time across primary shard |                                                            |    0.5287      |    0.488917    |   -0.03978 |    min |   -7.52% |
|           Median cumulative refresh time across primary shard |                                                            |    0.5287      |    0.488917    |   -0.03978 |    min |   -7.52% |
|              Max cumulative refresh time across primary shard |                                                            |    0.5287      |    0.488917    |   -0.03978 |    min |   -7.52% |
|                       Cumulative flush time of primary shards |                                                            |    0.156067    |    0.1223      |   -0.03377 |    min |  -21.64% |
|                      Cumulative flush count of primary shards |                                                            |    2           |    2           |    0       |        |    0.00% |
|                Min cumulative flush time across primary shard |                                                            |    0.156067    |    0.1223      |   -0.03377 |    min |  -21.64% |
|             Median cumulative flush time across primary shard |                                                            |    0.156067    |    0.1223      |   -0.03377 |    min |  -21.64% |
|                Max cumulative flush time across primary shard |                                                            |    0.156067    |    0.1223      |   -0.03377 |    min |  -21.64% |
|                                       Total Young Gen GC time |                                                            |    5.567       |    5.746       |    0.179   |      s |   +3.22% |
|                                      Total Young Gen GC count |                                                            |   58           |   52           |   -6       |        |  -10.34% |
|                                         Total Old Gen GC time |                                                            |    0           |    0           |    0       |      s |    0.00% |
|                                        Total Old Gen GC count |                                                            |    0           |    0           |    0       |        |    0.00% |
|                                                    Store size |                                                            |    2.36443     |    1.83452     |   -0.52991 |     GB |   -22.41% |
|                                                 Translog size |                                                            |    5.12227e-08 |    5.12227e-08 |    0       |     GB |    0.00% |
|                                                 Segment count |                                                            |    1           |    1           |    0       |        |    0.00% |
|                                                    error rate |                                               index-append |    0           |    0           |    0       |      % |    0.00% |
|                                                Min Throughput |                                  randomized-nested-queries |   19.9089      |   19.9286      |    0.01967 |  ops/s |   +0.10% |
|                                               Mean Throughput |                                  randomized-nested-queries |   19.9492      |   19.9602      |    0.01098 |  ops/s |   +0.06% |
|                                             Median Throughput |                                  randomized-nested-queries |   19.9537      |   19.9637      |    0.01002 |  ops/s |   +0.05% |
|                                                Max Throughput |                                  randomized-nested-queries |   19.9689      |   19.9756      |    0.00671 |  ops/s |   +0.03% |
|                                       50th percentile latency |                                  randomized-nested-queries |   30.6843      |   30.8571      |    0.1729  |     ms |   +0.56% |
|                                       90th percentile latency |                                  randomized-nested-queries |   46.1991      |   48.9923      |    2.7932  |     ms |   +6.05% |
|                                       99th percentile latency |                                  randomized-nested-queries |   62.1545      |   67.6189      |    5.46445 |     ms |   +8.79% |
|                                     99.9th percentile latency |                                  randomized-nested-queries |   81.924       |   74.8324      |   -7.09157 |     ms |   -8.66% |
|                                      100th percentile latency |                                  randomized-nested-queries |   86.6353      |   75.6651      |  -10.9702  |     ms |  -12.66% |
|                                  50th percentile service time |                                  randomized-nested-queries |   28.4951      |   29.1618      |    0.66669 |     ms |   +2.34% |
|                                  90th percentile service time |                                  randomized-nested-queries |   43.9812      |   47.2431      |    3.26192 |     ms |   +7.42% |
|                                  99th percentile service time |                                  randomized-nested-queries |   58.3101      |   64.3008      |    5.99073 |     ms |  +10.27% |
|                                99.9th percentile service time |                                  randomized-nested-queries |   71.2865      |   70.6799      |   -0.60651 |     ms |   -0.85% |
|                                 100th percentile service time |                                  randomized-nested-queries |   83.4997      |   74.0415      |   -9.45817 |     ms |  -11.33% |
|                                                    error rate |                                  randomized-nested-queries |    0           |    0           |    0       |      % |    0.00% |
|                                                Min Throughput |                                    randomized-term-queries |   25.0092      |   25.0036      |   -0.00557 |  ops/s |   -0.02% |
|                                               Mean Throughput |                                    randomized-term-queries |   25.0106      |   25.0063      |   -0.00427 |  ops/s |   -0.02% |
|                                             Median Throughput |                                    randomized-term-queries |   25.0104      |   25.0043      |   -0.00614 |  ops/s |   -0.02% |
|                                                Max Throughput |                                    randomized-term-queries |   25.0124      |   25.0208      |    0.0084  |  ops/s |   +0.03% |
|                                       50th percentile latency |                                    randomized-term-queries |   10.6188      |   11.6614      |    1.04258 |     ms |   +9.82% |
|                                       90th percentile latency |                                    randomized-term-queries |   15.8666      |   17.4658      |    1.59914 |     ms |  +10.08% |
|                                       99th percentile latency |                                    randomized-term-queries |   19.5808      |   22.0753      |    2.49453 |     ms |  +12.74% |
|                                      100th percentile latency |                                    randomized-term-queries |   21.3055      |   25.0843      |    3.77879 |     ms |  +17.74% |
|                                  50th percentile service time |                                    randomized-term-queries |    7.88131     |    8.3696      |    0.48829 |     ms |   +6.20% |
|                                  90th percentile service time |                                    randomized-term-queries |   11.9989      |   13.2719      |    1.27296 |     ms |  +10.61% |
|                                  99th percentile service time |                                    randomized-term-queries |   15.9581      |   17.0854      |    1.12731 |     ms |   +7.06% |
|                                 100th percentile service time |                                    randomized-term-queries |   16.9332      |   21.5602      |    4.62704 |     ms |  +27.33% |
|                                                    error rate |                                    randomized-term-queries |    0           |    0           |    0       |      % |    0.00% |
|                                                Min Throughput |                             randomized-sorted-term-queries |   15.9825      |   15.9855      |    0.00295 |  ops/s |   +0.02% |
|                                               Mean Throughput |                             randomized-sorted-term-queries |   15.9852      |   15.9877      |    0.00253 |  ops/s |   +0.02% |
|                                             Median Throughput |                             randomized-sorted-term-queries |   15.9853      |   15.9879      |    0.00259 |  ops/s |   +0.02% |
|                                                Max Throughput |                             randomized-sorted-term-queries |   15.9873      |   15.9895      |    0.00216 |  ops/s |   +0.01% |
|                                       50th percentile latency |                             randomized-sorted-term-queries |   43.253       |   46.881       |    3.62804 |     ms |   +8.39% |
|                                       90th percentile latency |                             randomized-sorted-term-queries |   76.5973      |   83.9061      |    7.3088  |     ms |   +9.54% |
|                                       99th percentile latency |                             randomized-sorted-term-queries |   96.8584      |  103.505       |    6.64656 |     ms |   +6.86% |
|                                      100th percentile latency |                             randomized-sorted-term-queries |   99.0065      |  109.878       |   10.8713  |     ms |  +10.98% |
|                                  50th percentile service time |                             randomized-sorted-term-queries |   41.7791      |   45.4535      |    3.67446 |     ms |   +8.79% |
|                                  90th percentile service time |                             randomized-sorted-term-queries |   75.1482      |   82.459       |    7.31081 |     ms |   +9.73% |
|                                  99th percentile service time |                             randomized-sorted-term-queries |   94.8862      |  101.908       |    7.02162 |     ms |   +7.40% |
|                                 100th percentile service time |                             randomized-sorted-term-queries |   96.821       |  108.225       |   11.4042  |     ms |  +11.78% |
|                                                    error rate |                             randomized-sorted-term-queries |    0           |    0           |    0       |      % |    0.00% |
|                                                Min Throughput |                                                  match-all |    5.00323     |    5.00329     |    6e-05   |  ops/s |    0.00% |
|                                               Mean Throughput |                                                  match-all |    5.00381     |    5.00388     |    8e-05   |  ops/s |    0.00% |
|                                             Median Throughput |                                                  match-all |    5.00376     |    5.00385     |    9e-05   |  ops/s |    0.00% |
|                                                Max Throughput |                                                  match-all |    5.00454     |    5.00461     |    8e-05   |  ops/s |    0.00% |
|                                       50th percentile latency |                                                  match-all |   14.337       |   11.1701      |   -3.16696 |     ms |  -22.09% |
|                                       90th percentile latency |                                                  match-all |   19.8173      |   17.8286      |   -1.98867 |     ms |  -10.04% |
|                                       99th percentile latency |                                                  match-all |   26.0467      |   22.3704      |   -3.67638 |     ms |  -14.11% |
|                                      100th percentile latency |                                                  match-all |   32.487       |   30.3585      |   -2.12842 |     ms |   -6.55% |
|                                  50th percentile service time |                                                  match-all |   10.2625      |    7.78881     |   -2.47369 |     ms |  -24.10% |
|                                  90th percentile service time |                                                  match-all |   14.6587      |   12.6556      |   -2.00307 |     ms |  -13.66% |
|                                  99th percentile service time |                                                  match-all |   21.76        |   17.2617      |   -4.49824 |     ms |  -20.67% |
|                                 100th percentile service time |                                                  match-all |   27.7462      |   24.4871      |   -3.25908 |     ms |  -11.75% |
|                                                    error rate |                                                  match-all |    0           |    0           |    0       |      % |    0.00% |
|                                                Min Throughput |                                          nested-date-histo |    0.999404    |    0.999509    |    0.0001  |  ops/s |   +0.01% |
|                                               Mean Throughput |                                          nested-date-histo |    0.99967     |    0.999725    |    5e-05   |  ops/s |    0.01% |
|                                             Median Throughput |                                          nested-date-histo |    0.9997      |    0.999749    |    5e-05   |  ops/s |    0.00% |
|                                                Max Throughput |                                          nested-date-histo |    0.999798    |    0.99983     |    3e-05   |  ops/s |    0.00% |
|                                       50th percentile latency |                                          nested-date-histo | 1030.74        |  969.823       |  -60.9199  |     ms |   -5.91% |
|                                       90th percentile latency |                                          nested-date-histo | 1057.08        |  983.384       |  -73.695   |     ms |   -6.97% |
|                                       99th percentile latency |                                          nested-date-histo | 1110.61        | 1029.32        |  -81.2943  |     ms |   -7.32% |
|                                      100th percentile latency |                                          nested-date-histo | 1288.67        | 1051.88        | -236.798   |     ms |  -18.38% |
|                                  50th percentile service time |                                          nested-date-histo | 1026.56        |  965.434       |  -61.1258  |     ms |   -5.95% |
|                                  90th percentile service time |                                          nested-date-histo | 1052.98        |  978.519       |  -74.459   |     ms |   -7.07% |
|                                  99th percentile service time |                                          nested-date-histo | 1108.27        | 1023.52        |  -84.7551  |     ms |   -7.65% |
|                                 100th percentile service time |                                          nested-date-histo | 1286.21        | 1045.59        | -240.626   |     ms |  -18.71% |
|                                                    error rate |                                          nested-date-histo |    0           |    0           |    0       |      % |    0.00% |
|                                                Min Throughput |          randomized-nested-queries-with-inner-hits_default |   17.9854      |   17.992       |    0.00659 |  ops/s |   +0.04% |
|                                               Mean Throughput |          randomized-nested-queries-with-inner-hits_default |   17.9919      |   17.9955      |    0.00363 |  ops/s |   +0.02% |
|                                             Median Throughput |          randomized-nested-queries-with-inner-hits_default |   17.9925      |   17.9959      |    0.00335 |  ops/s |   +0.02% |
|                                                Max Throughput |          randomized-nested-queries-with-inner-hits_default |   17.995       |   17.9972      |    0.00218 |  ops/s |   +0.01% |
|                                       50th percentile latency |          randomized-nested-queries-with-inner-hits_default |   32.2406      |   37.6666      |    5.42602 |     ms |  +16.83% |
|                                       90th percentile latency |          randomized-nested-queries-with-inner-hits_default |   49.7453      |   56.7533      |    7.00808 |     ms |  +14.09% |
|                                       99th percentile latency |          randomized-nested-queries-with-inner-hits_default |   69.35        |   73.8845      |    4.53459 |     ms |   +6.54% |
|                                     99.9th percentile latency |          randomized-nested-queries-with-inner-hits_default |   81.4562      |   81.1794      |   -0.27681 |     ms |   -0.34% |
|                                      100th percentile latency |          randomized-nested-queries-with-inner-hits_default |   83.0193      |   86.4119      |    3.3926  |     ms |   +4.09% |
|                                  50th percentile service time |          randomized-nested-queries-with-inner-hits_default |   30.613       |   35.9183      |    5.30531 |     ms |  +17.33% |
|                                  90th percentile service time |          randomized-nested-queries-with-inner-hits_default |   47.869       |   54.8723      |    7.0033  |     ms |  +14.63% |
|                                  99th percentile service time |          randomized-nested-queries-with-inner-hits_default |   66.0138      |   71.3553      |    5.34146 |     ms |   +8.09% |
|                                99.9th percentile service time |          randomized-nested-queries-with-inner-hits_default |   77.7197      |   79.2554      |    1.53569 |     ms |   +1.98% |
|                                 100th percentile service time |          randomized-nested-queries-with-inner-hits_default |   78.6807      |   84.1792      |    5.49846 |     ms |   +6.99% |
|                                                    error rate |          randomized-nested-queries-with-inner-hits_default |    0           |    0           |    0       |      % |    0.00% |
|                                                Min Throughput | randomized-nested-queries-with-inner-hits_default_big_size |   15.999       |   15.9971      |   -0.00185 |  ops/s |   -0.01% |
|                                               Mean Throughput | randomized-nested-queries-with-inner-hits_default_big_size |   15.9994      |   15.9984      |   -0.00104 |  ops/s |   -0.01% |
|                                             Median Throughput | randomized-nested-queries-with-inner-hits_default_big_size |   15.9994      |   15.9985      |   -0.00095 |  ops/s |   -0.01% |
|                                                Max Throughput | randomized-nested-queries-with-inner-hits_default_big_size |   15.9997      |   15.999       |   -0.00065 |  ops/s |   -0.00% |
|                                       50th percentile latency | randomized-nested-queries-with-inner-hits_default_big_size |   40.8857      |   44.8014      |    3.91575 |     ms |   +9.58% |
|                                       90th percentile latency | randomized-nested-queries-with-inner-hits_default_big_size |   56.2601      |   59.7372      |    3.4771  |     ms |   +6.18% |
|                                       99th percentile latency | randomized-nested-queries-with-inner-hits_default_big_size |   74.8791      |   83.0726      |    8.19354 |     ms |  +10.94% |
|                                     99.9th percentile latency | randomized-nested-queries-with-inner-hits_default_big_size |  105.522       |  115.59        |   10.0676  |     ms |   +9.54% |
|                                      100th percentile latency | randomized-nested-queries-with-inner-hits_default_big_size |  110.3         |  117.851       |    7.55058 |     ms |   +6.85% |
|                                  50th percentile service time | randomized-nested-queries-with-inner-hits_default_big_size |   39.3311      |   43.3765      |    4.0454  |     ms |  +10.29% |
|                                  90th percentile service time | randomized-nested-queries-with-inner-hits_default_big_size |   54.5471      |   58.3079      |    3.76075 |     ms |   +6.89% |
|                                  99th percentile service time | randomized-nested-queries-with-inner-hits_default_big_size |   73.5083      |   81.2979      |    7.78959 |     ms |  +10.60% |
|                                99.9th percentile service time | randomized-nested-queries-with-inner-hits_default_big_size |  104.033       |  113.936       |    9.90327 |     ms |   +9.52% |
|                                 100th percentile service time | randomized-nested-queries-with-inner-hits_default_big_size |  108.411       |  115.782       |    7.37017 |     ms |   +6.80% |
|                                                    error rate | randomized-nested-queries-with-inner-hits_default_big_size |    0           |    0           |    0       |      % |    0.00% |
</details>