### PR TITLE
Revert "Mark data streams stats API as internal-only (#108745)"

### DIFF
--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestDataStreamsStatsAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/rest/RestDataStreamsStatsAction.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestDataStreamsStatsAction extends BaseRestHandler {
     @Override
     public String getName() {


### PR DESCRIPTION
This reverts commit 4b1709587e000164e5805f5e5177c958bdad9c44.

Kibana still depends on this API without internal credentials in some places. It will still go through after those have been resolved.