### PR TITLE
Fix Gradle cache cacheability in ThirdPartyAuditTask

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
@@ -116,7 +116,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         project.getPluginManager().apply("nebula.info-broker");
         project.getPluginManager().apply("nebula.info-basic");
         project.getPluginManager().apply("nebula.info-java");
-//        project.getPluginManager().apply("nebula.info-jar");
+        project.getPluginManager().apply("nebula.info-jar");
     }
 
     private static void configureJavadoc(Project project) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
@@ -116,7 +116,7 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
         project.getPluginManager().apply("nebula.info-broker");
         project.getPluginManager().apply("nebula.info-basic");
         project.getPluginManager().apply("nebula.info-java");
-        project.getPluginManager().apply("nebula.info-jar");
+//        project.getPluginManager().apply("nebula.info-jar");
     }
 
     private static void configureJavadoc(Project project) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
@@ -119,7 +120,7 @@ public abstract class ThirdPartyAuditTask extends DefaultTask {
     }
 
     @Classpath
-    @PathSensitive(PathSensitivity.NAME_ONLY)
+    @InputFiles
     public abstract ConfigurableFileCollection getForbiddenAPIsClasspath();
 
     @InputFile

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
@@ -119,7 +119,7 @@ public abstract class ThirdPartyAuditTask extends DefaultTask {
         return targetCompatibility;
     }
 
-    @InputFiles
+    @Classpath
     @PathSensitive(PathSensitivity.NAME_ONLY)
     public abstract ConfigurableFileCollection getForbiddenAPIsClasspath();
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
@@ -54,7 +54,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
 import javax.inject.Inject;
 
 import static org.gradle.api.JavaVersion.VERSION_20;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
@@ -28,7 +28,6 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
@@ -54,6 +54,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
 import javax.inject.Inject;
 
 import static org.gradle.api.JavaVersion.VERSION_20;


### PR DESCRIPTION
Turns out forbiddenAPIsClasspath property makes ThirdpartyTask never cacheable as we have some custom manifest data in our jars that are never the same across builds. 

Before: https://gradle-enterprise.elastic.co/s/awvkz5f74qexq/timeline?type=org.elasticsearch.gradle.internal.precommit.ThirdPartyAuditTask

After: https://gradle-enterprise.elastic.co/s/dirw7wcohqomq/timeline?type=org.elasticsearch.gradle.internal.precommit.ThirdPartyAuditTask

This is a simple fix specific to ThirdpartyTask. 
We might want to reconsider if all those custom manifest in our attributes are really necessary