### PR TITLE
Check array size before returning array item in script doc values

### DIFF
--- a/docs/changelog/109824.yaml
+++ b/docs/changelog/109824.yaml
@@ -1,0 +1,6 @@
+pr: 109824
+summary: Check array size before returning array item in script doc values
+area: Infra/Scripting
+type: bug
+issues:
+ - 104998

--- a/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/ScriptDocValues.java
@@ -95,6 +95,12 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         }
     }
 
+    protected void throwIfBeyondLength(int i) {
+        if (i >= size()) {
+            throw new IndexOutOfBoundsException("A document doesn't have a value for a field at position [" + i + "]!");
+        }
+    }
+
     public static class Longs extends ScriptDocValues<Long> {
 
         public Longs(Supplier<Long> supplier) {
@@ -108,6 +114,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         @Override
         public Long get(int index) {
             throwIfEmpty();
+            throwIfBeyondLength(index);
             return supplier.getInternal(index);
         }
 
@@ -133,12 +140,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
         @Override
         public ZonedDateTime get(int index) {
-            if (supplier.size() == 0) {
-                throw new IllegalStateException(
-                    "A document doesn't have a value for a field! "
-                        + "Use doc[<field>].size()==0 to check if a document is missing a field!"
-                );
-            }
+            throwIfEmpty();
             if (index >= supplier.size()) {
                 throw new IndexOutOfBoundsException(
                     "attempted to fetch the [" + index + "] date when there are only [" + supplier.size() + "] dates."
@@ -207,12 +209,8 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
         @Override
         public Double get(int index) {
-            if (supplier.size() == 0) {
-                throw new IllegalStateException(
-                    "A document doesn't have a value for a field! "
-                        + "Use doc[<field>].size()==0 to check if a document is missing a field!"
-                );
-            }
+            throwIfEmpty();
+            throwIfBeyondLength(index);
             return supplier.getInternal(index);
         }
 
@@ -312,12 +310,8 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
         @Override
         public GeoPoint get(int index) {
-            if (supplier.size() == 0) {
-                throw new IllegalStateException(
-                    "A document doesn't have a value for a field! "
-                        + "Use doc[<field>].size()==0 to check if a document is missing a field!"
-                );
-            }
+            throwIfEmpty();
+            throwIfBeyondLength(index);
             final GeoPoint point = supplier.getInternal(index);
             return new GeoPoint(point.lat(), point.lon());
         }
@@ -408,6 +402,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         @Override
         public Boolean get(int index) {
             throwIfEmpty();
+            throwIfBeyondLength(index);
             return supplier.getInternal(index);
         }
 
@@ -484,12 +479,8 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
 
         @Override
         public String get(int index) {
-            if (supplier.size() == 0) {
-                throw new IllegalStateException(
-                    "A document doesn't have a value for a field! "
-                        + "Use doc[<field>].size()==0 to check if a document is missing a field!"
-                );
-            }
+            throwIfEmpty();
+            throwIfBeyondLength(index);
             return supplier.getInternal(index);
         }
 
@@ -513,6 +504,7 @@ public abstract class ScriptDocValues<T> extends AbstractList<T> {
         @Override
         public BytesRef get(int index) {
             throwIfEmpty();
+            throwIfBeyondLength(index);
             return supplier.getInternal(index);
         }
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesGeoPointsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesGeoPointsTests.java
@@ -122,6 +122,8 @@ public class ScriptDocValuesGeoPointsTests extends ESTestCase {
             geoPoints.getSupplier().setNextDocId(d);
             if (points[d].length > 0) {
                 assertEquals(points[d][0], geoPoints.getValue());
+                Exception e = expectThrows(IndexOutOfBoundsException.class, () -> geoPoints.get(geoPoints.size()));
+                assertEquals("A document doesn't have a value for a field at position [" + geoPoints.size() + "]!", e.getMessage());
             } else {
                 Exception e = expectThrows(IllegalStateException.class, () -> geoPoints.getValue());
                 assertEquals(

--- a/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesLongsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/ScriptDocValuesLongsTests.java
@@ -35,6 +35,9 @@ public class ScriptDocValuesLongsTests extends ESTestCase {
                 assertEquals(values[d][0], (long) longs.get(0));
                 assertEquals(values[d][0], longField.get(Long.MIN_VALUE));
                 assertEquals(values[d][0], longField.get(0, Long.MIN_VALUE));
+
+                Exception e = expectThrows(IndexOutOfBoundsException.class, () -> { long l = longs.get(longs.size()); });
+                assertEquals("A document doesn't have a value for a field at position [" + longs.size() + "]!", e.getMessage());
             } else {
                 Exception e = expectThrows(IllegalStateException.class, longs::getValue);
                 assertEquals(

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongScriptDocValues.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongScriptDocValues.java
@@ -22,6 +22,7 @@ public class UnsignedLongScriptDocValues extends ScriptDocValues<Long> {
     @Override
     public Long get(int index) {
         throwIfEmpty();
+        throwIfBeyondLength(index);
         return supplier.getInternal(index);
     }
 


### PR DESCRIPTION
When accessing array elements from a script, if the backing array has enough items, meaning that there has previously been a doc with enough values, we let the request go through, and we end up returning items from the previous doc that had a value at that position if the current doc does not have enough elements.

We should instead validate the length of the array for the current doc and eventually throw an error if the index goes over the available number of values.

Closes #104998
