### PR TITLE
Fix security policies after renaming of elasticsearch-vec

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
+++ b/test/framework/src/main/java/org/elasticsearch/bootstrap/BootstrapForTesting.java
@@ -223,7 +223,7 @@ public class BootstrapForTesting {
         addClassCodebase(codebases, "elasticsearch-core", "org.elasticsearch.core.Booleans");
         addClassCodebase(codebases, "elasticsearch-cli", "org.elasticsearch.cli.Command");
         addClassCodebase(codebases, "elasticsearch-preallocate", "org.elasticsearch.preallocate.Preallocate");
-        addClassCodebase(codebases, "elasticsearch-vec", "org.elasticsearch.simdvec.VectorScorerFactory");
+        addClassCodebase(codebases, "elasticsearch-simdvec", "org.elasticsearch.simdvec.VectorScorerFactory");
         addClassCodebase(codebases, "framework", "org.elasticsearch.test.ESTestCase");
         return codebases;
     }


### PR DESCRIPTION
Renaming in #109661 missed this part. This leads to errors when running unit tests in IntelliJ.

```
java.lang.RuntimeException: unable to install test security manager

	at org.elasticsearch.bootstrap.BootstrapForTesting.<clinit>(BootstrapForTesting.java:210)
	at org.elasticsearch.test.ESTestCase.<clinit>(ESTestCase.java:316)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:467)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:631)
Caused by: java.lang.IllegalArgumentException: Unknown codebases [codebase.elasticsearch-simdvec] in policy file
```