### PR TITLE
Add `monitor_inference` cluster privilege to kibana system user

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/KibanaOwnedReservedRoleDescriptors.java
@@ -63,6 +63,7 @@ class KibanaOwnedReservedRoleDescriptors {
             name,
             new String[] {
                 "monitor",
+                "monitor_inference",
                 "manage_index_templates",
                 MonitoringBulkAction.NAME,
                 "manage_saml",


### PR DESCRIPTION
This adds `monitor_inference` cluster privilege to the Kibana system user. This is needed in order to [get inference endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/master/get-inference-api.html) information and ought be possible to retrieve with the kibana system user.

Right now to work around this, all operations in Kibana that require knowledge about the inference endpoint cannot run in the background, and must be explicitly invoked by an end-user with the `monitor_inference` privilege.
One example of this is the ability to delay ingest to an index, until the inference endpoint has been setup correctly, to ensure that embeddings are created for ingested documents.