### PR TITLE
Fix fragment flag in `BaseNodesXContentResponse`

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponse.java
@@ -11,8 +11,8 @@ package org.elasticsearch.action.support.nodes;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.collect.Iterators;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.xcontent.ToXContent;
 
@@ -21,7 +21,7 @@ import java.util.List;
 
 public abstract class BaseNodesXContentResponse<TNodeResponse extends BaseNodeResponse> extends BaseNodesResponse<TNodeResponse>
     implements
-        ChunkedToXContent {
+        ChunkedToXContentObject {
 
     protected BaseNodesXContentResponse(ClusterName clusterName, List<TNodeResponse> nodes, List<FailedNodeException> failures) {
         super(clusterName, nodes, failures);

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponseTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.support.nodes;
+
+import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class BaseNodesXContentResponseTests extends ESTestCase {
+    public void testFragmentFlag() {
+        final var node = DiscoveryNodeUtils.create("test");
+
+        class TestNodeResponse extends BaseNodeResponse {
+            protected TestNodeResponse(DiscoveryNode node) {
+                super(node);
+            }
+        }
+
+        final var fullResponse = new BaseNodesXContentResponse<>(ClusterName.DEFAULT, List.of(new TestNodeResponse(node)), List.of()) {
+            @Override
+            protected Iterator<? extends ToXContent> xContentChunks(ToXContent.Params outerParams) {
+                return ChunkedToXContentHelper.singleChunk((b, p) -> b.startObject("content").endObject());
+            }
+
+            @Override
+            protected List<TestNodeResponse> readNodesFrom(StreamInput in) {
+                return TransportAction.localOnly();
+            }
+
+            @Override
+            protected void writeNodesTo(StreamOutput out, List<TestNodeResponse> nodes) {
+                TransportAction.localOnly();
+            }
+        };
+
+        assertFalse(fullResponse.isFragment());
+
+        assertEquals("""
+            {
+              "_nodes" : {
+                "total" : 1,
+                "successful" : 1,
+                "failed" : 0
+              },
+              "cluster_name" : "elasticsearch",
+              "content" : { }
+            }""", Strings.toString(fullResponse, true, false));
+    }
+}


### PR DESCRIPTION
This response is a full object, not a fragment, so must implement
`ChunkedToXContentObject`.