### PR TITLE
[ML] Swallow the model size stats allocation bytes field

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStats.java
@@ -48,6 +48,7 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
     public static final ParseField BUCKET_ALLOCATION_FAILURES_COUNT_FIELD = new ParseField("bucket_allocation_failures_count");
     public static final ParseField MEMORY_STATUS_FIELD = new ParseField("memory_status");
     public static final ParseField ASSIGNMENT_MEMORY_BASIS_FIELD = new ParseField("assignment_memory_basis");
+    public static final ParseField OUTPUT_MEMORY_ALLOCATOR_BYTES_FIELD = new ParseField("output_memory_allocator_bytes");
     public static final ParseField CATEGORIZED_DOC_COUNT_FIELD = new ParseField("categorized_doc_count");
     public static final ParseField TOTAL_CATEGORY_COUNT_FIELD = new ParseField("total_category_count");
     public static final ParseField FREQUENT_CATEGORY_COUNT_FIELD = new ParseField("frequent_category_count");
@@ -85,6 +86,9 @@ public class ModelSizeStats implements ToXContentObject, Writeable {
             ASSIGNMENT_MEMORY_BASIS_FIELD,
             ValueType.STRING
         );
+        // The anomaly detection process will write this field in 8.14 but it is not handled
+        // in Elasticsearch. Accept and discard the field to satisfy the strict parser.
+        parser.declareLong(((builder, aLong) -> { ; }), OUTPUT_MEMORY_ALLOCATOR_BYTES_FIELD);
         parser.declareLong(Builder::setCategorizedDocCount, CATEGORIZED_DOC_COUNT_FIELD);
         parser.declareLong(Builder::setTotalCategoryCount, TOTAL_CATEGORY_COUNT_FIELD);
         parser.declareLong(Builder::setFrequentCategoryCount, FREQUENT_CATEGORY_COUNT_FIELD);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/process/autodetect/state/ModelSizeStatsTests.java
@@ -156,6 +156,17 @@ public class ModelSizeStatsTests extends AbstractXContentSerializingTestCase<Mod
         }
     }
 
+    public void testParser_IngoresMemoryAllocatorBytes() throws IOException {
+        String json = "{\"job_id\":\"job_1\", \"output_memory_allocator_bytes\":500}";
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            ModelSizeStats.STRICT_PARSER.apply(parser, null);
+        }
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {
+            ModelSizeStats.LENIENT_PARSER.apply(parser, null);
+        }
+    }
+
     public void testLenientParser() throws IOException {
         String json = "{\"job_id\":\"job_1\", \"foo\":\"bar\"}";
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, json)) {


### PR DESCRIPTION
#109833 added handling for the new `output_memory_allocator_bytes` field in the anomaly detection model size stats. The change was reverted due to an incompatibility in the wire protocol but the C++ side will still write the `output_memory_allocator_bytes` field and it must be parsed by Elasticsearch. This change reintroduces the parsing of the field but it is discarded without any further processing.  