### PR TITLE
ESQL/Search: Fix scoring when RANK and WHERE are both specified

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlSearchActionIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlSearchActionIT.java
@@ -54,8 +54,8 @@ public class EsqlSearchActionIT extends AbstractEsqlIntegTestCase {
             assertThat(resp.columns().stream().map(ColumnInfo::type).toList(), contains("integer", "float"));
             // values
             List<List<Object>> values = getValuesList(resp);
-            assertThat(values.get(0), contains(3, 2.0f));
-            assertThat(values.get(1), contains(4, 2.0f));
+            assertThat(values.get(0), contains(3, 0.0f));
+            assertThat(values.get(1), contains(4, 0.0f));
         }
     }
 
@@ -173,7 +173,6 @@ public class EsqlSearchActionIT extends AbstractEsqlIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "") // TODO: all scores are 0.0 ? why? fix this
     public void testRankMatchWithPrefilter() {
         var query = """
             SEARCH test [

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -221,7 +221,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
                 if (pushable.size() > 0) { // update the executable with pushable conditions
                     Query queryDSL = TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(pushable));
                     QueryBuilder planQuery = queryDSL.asBuilder();
-                    var baseQuery = queryExec.query() != null ? queryExec.query() : new BoolQueryBuilder();
+                    var baseQuery = queryExec.scoring() && queryExec.query() == null ? new BoolQueryBuilder() : queryExec.query();
                     var query = Queries.combine(Clause.FILTER, asList(baseQuery, planQuery));
                     queryExec = new EsQueryExec(
                         queryExec.source(),

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.esql.optimizer;
 
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.esql.VerificationException;
@@ -220,7 +221,8 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
                 if (pushable.size() > 0) { // update the executable with pushable conditions
                     Query queryDSL = TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(pushable));
                     QueryBuilder planQuery = queryDSL.asBuilder();
-                    var query = Queries.combine(Clause.FILTER, asList(queryExec.query(), planQuery));
+                    var baseQuery = queryExec.query() != null ? queryExec.query() : new BoolQueryBuilder();
+                    var query = Queries.combine(Clause.FILTER, asList(baseQuery, planQuery));
                     queryExec = new EsQueryExec(
                         queryExec.source(),
                         queryExec.index(),
@@ -324,7 +326,9 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             if (child instanceof EsQueryExec queryExec) {
                 Query queryDSL = TRANSLATOR_HANDLER.asQuery(Predicates.combineAnd(rankExec.expressions())); // HEGO: why expressions
                 QueryBuilder planQuery = queryDSL.asBuilder();
-                var query = Queries.combine(Clause.FILTER, asList(queryExec.query(), planQuery));
+                var baseQuery = queryExec.query() != null ? queryExec.query() : new BoolQueryBuilder();
+                BoolQueryBuilder query = (BoolQueryBuilder) Queries.combine(Clause.SHOULD, asList(baseQuery, planQuery));
+                query.minimumShouldMatch(1);
                 var esQueryExec = new EsQueryExec(
                     queryExec.source(),
                     queryExec.index(),


### PR DESCRIPTION
DRAFT: WIP needs more tests


Fixes the following issues:

- A query like ` SEARCH test [ | WHERE id > 2 AND id <= 4 ]` returned scores > 0 - in this case we are only filtering the results, which has no effect on scoring, hence the return scores should all be `0`.
- A query where we combined `RANK` and `WHERE` returned scores equal to `0`- for example ` SEARCH test [ | WHERE id > 2 | RANK MATCH(content, "quick brown dog")]`

This happened because of the way we were forming the boolean query.
`PushRankToSource` now translates the `RANK` expression as a `SHOULD` clause, instead of `FILTER`.
Both `PushRankToSource` and `PushFiltersToSource` used `Queries.combine` which receives the type of clause to use and the a list of queries. If the list of queries contains a single non-null query, it simply returns that query - it will not actually construct a boolean query. Furthermore `QueriesCombine` will check if the first query from the list is a boolean query and it will attempt to reuse it.
To work around this behaviour we made sure that the first query that is being sent to `QueriesCombine` is always a boolean query.
Furthermore, I had to put the `minimumShouldMatch: 1` - so that when `RANK` is used,  we return documents that match the `RANK` expression.

 