### PR TITLE
[Gradle] Let testImplementation not extendfrom compileOnly

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaPlugin.java
@@ -55,8 +55,8 @@ public class ElasticsearchJavaPlugin implements Plugin<Project> {
     private static void testCompileOnlyDeps(Project project) {
         // we want to test compileOnly deps!
         Configuration compileOnlyConfig = project.getConfigurations().getByName(JavaPlugin.COMPILE_ONLY_CONFIGURATION_NAME);
-        Configuration testImplementationConfig = project.getConfigurations().getByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME);
-        testImplementationConfig.extendsFrom(compileOnlyConfig);
+        Configuration testCompileOnly = project.getConfigurations().getByName(JavaPlugin.TEST_COMPILE_ONLY_CONFIGURATION_NAME);
+        testCompileOnly.extendsFrom(compileOnlyConfig);
     }
 
     /**

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/TestingConventionsPrecommitPlugin.java
@@ -105,6 +105,7 @@ public class TestingConventionsPrecommitPlugin extends PrecommitPlugin {
                 .register(taskName, TestingConventionsCheckTask.class, task -> {
                     task.getTestClassesDirs().from(sourceSet.getOutput().getClassesDirs());
                     task.getClasspath().from(sourceSet.getRuntimeClasspath());
+                    task.getClasspath().from(sourceSet.getCompileClasspath());
                 });
             register.configure(config);
         });


### PR DESCRIPTION
To keep the test classpath closer to runtime we do not want to pull in compileOnly dependencies by default
by the test classpath