### PR TITLE
Adjust packaging test exit code assertion

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -67,8 +67,6 @@ tests:
 - class: "org.elasticsearch.xpack.shutdown.NodeShutdownReadinessIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109838"
   method: "testShutdownReadinessService"
-- class: "org.elasticsearch.packaging.test.PackageTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/109852"
 
 # Examples:
 #

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -194,7 +194,7 @@ public class PackageTests extends PackagingTestCase {
             }
 
             assertThat(sh.runIgnoreExitCode("systemctl status elasticsearch.service").exitCode(), is(statusExitCode));
-            assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode(), is(1));
+            assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode(), not(0));
 
         }
 

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -28,6 +28,7 @@ import static org.elasticsearch.packaging.util.Packages.remove;
 import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
 import static org.elasticsearch.packaging.util.Platforms.isSystemd;
 import static org.elasticsearch.packaging.util.ServerUtils.enableGeoIpDownloader;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeTrue;
 
@@ -78,7 +79,7 @@ public class RpmPreservationTests extends PackagingTestCase {
         assertRemoved(distribution());
 
         if (isSystemd()) {
-            assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode(), is(1));
+            assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode(), not(0));
         }
 
         assertPathsDoNotExist(

--- a/qa/packaging/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/packaging/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -29,7 +29,6 @@ import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallatio
 import static org.elasticsearch.packaging.util.Platforms.isSystemd;
 import static org.elasticsearch.packaging.util.ServerUtils.enableGeoIpDownloader;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assume.assumeTrue;
 
 public class RpmPreservationTests extends PackagingTestCase {


### PR DESCRIPTION
Some new version of `systemctl` must have changed exit codes. We don't really need to assert on a specific code, only that the return code is non-zero.

Closes #109852