### PR TITLE
Install systemd-sysvcompat package on opensuse systems

### DIFF
--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -3,7 +3,7 @@
 # opensuse 15 has a missing dep for systemd
 
 if which zypper > /dev/null ; then
-    sudo zypper install -y insserv-compat
+    sudo zypper install -y insserv-compat systemd-sysvcompat
 fi
 
 if [ -e /etc/sysctl.d/99-gce.conf ]; then

--- a/distribution/packages/src/common/scripts/postinst
+++ b/distribution/packages/src/common/scripts/postinst
@@ -119,4 +119,9 @@ if [ "$RESTART_ON_UPGRADE" = "true" ]; then
     echo " OK"
 fi
 
+# For SysV compatibility on systemd systems ensure that all rc*.d directories exist
+if [ -x /usr/lib/systemd/systemd-sysv-install ]; then
+    mkdir -p /etc/init.d/rc{0..6}.d
+fi
+
 @scripts.footer@

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/PackageTests.java
@@ -200,7 +200,7 @@ public class PackageTests extends PackagingTestCase {
             }
 
             assertThat(sh.runIgnoreExitCode("systemctl status elasticsearch.service").exitCode, is(statusExitCode));
-            assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode, is(1));
+            assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode, not(0));
 
         }
 

--- a/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
+++ b/qa/os/src/test/java/org/elasticsearch/packaging/test/RpmPreservationTests.java
@@ -29,7 +29,7 @@ import static org.elasticsearch.packaging.util.Packages.remove;
 import static org.elasticsearch.packaging.util.Packages.verifyPackageInstallation;
 import static org.elasticsearch.packaging.util.Platforms.isSystemd;
 import static org.elasticsearch.packaging.util.ServerUtils.enableGeoIpDownloader;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeTrue;
 
 public class RpmPreservationTests extends PackagingTestCase {
@@ -85,7 +85,7 @@ public class RpmPreservationTests extends PackagingTestCase {
         assertRemoved(distribution());
 
         if (isSystemd()) {
-            assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode, is(1));
+            assertThat(sh.runIgnoreExitCode("systemctl is-enabled elasticsearch.service").exitCode, not(0));
         }
 
         assertPathsDoNotExist(


### PR DESCRIPTION
The `systemd-sysv-install` utility is now provided by the `systemd-sysvcompat` package. Ensure it's installed when running packaging tests.

Closes #109831