### PR TITLE
Log more data for PrevalidateShardPathIT#testCheckShards

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -69,9 +69,6 @@ tests:
   method: "testShutdownReadinessService"
 - class: "org.elasticsearch.packaging.test.PackageTests"
   issue: "https://github.com/elastic/elasticsearch/issues/109852"
-- class: "org.elasticsearch.cluster.PrevalidateShardPathIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/104807"
-  method: "testCheckShards"
 
 # Examples:
 #

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -67,8 +67,6 @@ tests:
 - class: "org.elasticsearch.xpack.shutdown.NodeShutdownReadinessIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109838"
   method: "testShutdownReadinessService"
-- class: "org.elasticsearch.packaging.test.PackageTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/109852"
 
 # Examples:
 #

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateShardPathIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateShardPathIT.java
@@ -42,7 +42,7 @@ public class PrevalidateShardPathIT extends ESIntegTestCase {
 
     @TestLogging(
         value = "org.elasticsearch.cluster.service.MasterService:DEBUG",
-        reason = "https://github.com/elastic/elasticsearch-serverless/pull/2068"
+        reason = "https://github.com/elastic/elasticsearch/issues/104807"
     )
     public void testCheckShards() throws Exception {
         internalCluster().startMasterOnlyNode();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateShardPathIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateShardPathIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.HashSet;
 import java.util.List;
@@ -39,6 +40,7 @@ import static org.hamcrest.Matchers.equalTo;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class PrevalidateShardPathIT extends ESIntegTestCase {
 
+    @TestLogging(value = "org.elasticsearch.cluster.service.MasterService:DEBUG", reason = "https://github.com/elastic/elasticsearch-serverless/pull/2068")
     public void testCheckShards() throws Exception {
         internalCluster().startMasterOnlyNode();
         String node1 = internalCluster().startDataOnlyNode();
@@ -95,7 +97,6 @@ public class PrevalidateShardPathIT extends ESIntegTestCase {
                         .allShards()
                         .filter(s -> s.getIndexName().equals(indexName))
                         .filter(s -> node2ShardIds.contains(s.shardId()))
-                        .filter(s -> s.currentNodeId().equals(node2Id))
                         .toList();
                     logger.info("Found {} shards on the relocation source node {} in the cluster state", node2Shards, node2Id);
                     for (var node2Shard : node2Shards) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateShardPathIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateShardPathIT.java
@@ -40,7 +40,10 @@ import static org.hamcrest.Matchers.equalTo;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
 public class PrevalidateShardPathIT extends ESIntegTestCase {
 
-    @TestLogging(value = "org.elasticsearch.cluster.service.MasterService:DEBUG", reason = "https://github.com/elastic/elasticsearch-serverless/pull/2068")
+    @TestLogging(
+        value = "org.elasticsearch.cluster.service.MasterService:DEBUG",
+        reason = "https://github.com/elastic/elasticsearch-serverless/pull/2068"
+    )
     public void testCheckShards() throws Exception {
         internalCluster().startMasterOnlyNode();
         String node1 = internalCluster().startDataOnlyNode();


### PR DESCRIPTION
`PrevalidateShardPathIT#testCheckShards` still keeps failing on CI, so we need more logging.

* Add debug logging for `MasterService` events to verify that a cluster service update is triggered.
* Log explanation for stuck shards regardless whether they are located on node_2 in the cluster state.

See #104807