### PR TITLE
Add searchable snapshots details to `GET _cat/indices`

### DIFF
--- a/docs/changelog/109906.yaml
+++ b/docs/changelog/109906.yaml
@@ -1,0 +1,5 @@
+pr: 109906
+summary: Add searchable snapshots details to `GET _cat/indices`
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/docs/reference/cat.asciidoc
+++ b/docs/reference/cat.asciidoc
@@ -129,7 +129,7 @@ The API returns the following response:
 
 [source,txt]
 ----
-health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size dataset.size
+health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size dataset.size searchable_snapshots.storage_type
 yellow open   my-index-000001  u8FNjxh8Rfy_awN11oDKYQ   1   1       1200            0      72171         72171         72171
 green  open   my-index-000002  nYFWZEO7TUiOjLQXBaYJpA   1   0          0            0        230          230            230
 ----
@@ -188,7 +188,8 @@ For example:
     "rep": "1",
     "docs.count": "0",
     "docs.deleted": "0",
-    "store.size": "650b"
+    "store.size": "650b",
+    "searchable_snapshots.storage_type": null
   }
 ]
 ----

--- a/docs/reference/cat/indices.asciidoc
+++ b/docs/reference/cat/indices.asciidoc
@@ -116,7 +116,7 @@ The API returns the following response:
 
 [source,txt]
 --------------------------------------------------
-health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size dataset.size
+health status index            uuid                   pri rep docs.count docs.deleted store.size pri.store.size dataset.size searchable_snapshots.storage_type
 yellow open   my-index-000001  u8FNjxh8Rfy_awN11oDKYQ   1   1       1200            0     88.1kb         88.1kb       88.1kb
 green  open   my-index-000002  nYFWZEO7TUiOjLQXBaYJpA   1   0          0            0       260b           260b         260b
 --------------------------------------------------

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.Scope;
 import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestResponseListener;
+import org.elasticsearch.snapshots.SearchableSnapshotsSettings;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -520,6 +521,25 @@ public class RestIndicesAction extends AbstractCatAction {
         );
         table.addCell("pri.sparse_vector.value_count", "default:false;text-align:right;desc:total count of indexed sparse vectors");
 
+        table.addCell("searchable_snapshots.storage_type", """
+            default:true;\
+            desc:for searchable snapshot indices, indicates the mount storage type""");
+        table.addCell("searchable_snapshots.repository_name", """
+            default:false;\
+            desc:for searchable snapshot indices, the original name of the snapshot repository which contains the underlying data""");
+        table.addCell("searchable_snapshots.repository_uuid", """
+            default:false;\
+            desc:for searchable snapshot indices, the UUID of the snapshot repository which contains the underlying data""");
+        table.addCell("searchable_snapshots.snapshot_name", """
+            default:false;\
+            desc:for searchable snapshot indices, the name of the snapshot which contains the underlying data""");
+        table.addCell("searchable_snapshots.snapshot_uuid", """
+            default:false;\
+            desc:for searchable snapshot indices, the UUID of the snapshot which contains the underlying data""");
+        table.addCell("searchable_snapshots.index_name", """
+            default:false;\
+            desc:for searchable snapshot indices, the name of the index in the snapshot which contains the underlying data""");
+
         table.endHeaders();
         return table;
     }
@@ -799,6 +819,18 @@ public class RestIndicesAction extends AbstractCatAction {
 
             table.addCell(totalStats.getSparseVectorStats() == null ? null : totalStats.getSparseVectorStats().getValueCount());
             table.addCell(primaryStats.getSparseVectorStats() == null ? null : primaryStats.getSparseVectorStats().getValueCount());
+
+            final var indexSettings = indexMetadata.getSettings();
+            table.addCell(
+                SearchableSnapshotsSettings.isSearchableSnapshotStore(indexSettings)
+                    ? SearchableSnapshotsSettings.isPartialSearchableSnapshotIndex(indexSettings) ? "shared_cache" : "full_copy"
+                    : null
+            );
+            table.addCell(indexSettings.get(SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_REPOSITORY_NAME_SETTING_KEY));
+            table.addCell(indexSettings.get(SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_REPOSITORY_UUID_SETTING_KEY));
+            table.addCell(indexSettings.get(SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_SNAPSHOT_NAME_SETTING_KEY));
+            table.addCell(indexSettings.get(SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOTS_SNAPSHOT_UUID_SETTING_KEY));
+            table.addCell(indexSettings.get(SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_INDEX_NAME_SETTING_KEY));
 
             table.endRow();
         });


### PR DESCRIPTION
Adds a default column showing the mount type, and other optional columns
showing the details of the underlying snapshot.