### PR TITLE
Do not create Weights concurrently in ES|QL lucene operator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneOperator.java
@@ -140,7 +140,7 @@ public abstract class LuceneOperator extends SourceOperator {
             logger.trace("Starting {}", partialLeaf);
             final LeafReaderContext leaf = partialLeaf.leafReaderContext();
             if (currentScorer == null || currentScorer.leafReaderContext() != leaf) {
-                final Weight weight = currentSlice.weight().get();
+                final Weight weight = currentSlice.weight();
                 processedQueries.add(weight.getQuery());
                 currentScorer = new LuceneScorer(currentSlice.shardContext(), weight, leaf);
             }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSlice.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSlice.java
@@ -10,12 +10,11 @@ package org.elasticsearch.compute.lucene;
 import org.apache.lucene.search.Weight;
 
 import java.util.List;
-import java.util.function.Supplier;
 
 /**
  * Holds a list of multiple partial Lucene segments
  */
-public record LuceneSlice(ShardContext shardContext, List<PartialLeafReaderContext> leaves, Supplier<Weight> weight) {
+public record LuceneSlice(ShardContext shardContext, List<PartialLeafReaderContext> leaves, Weight weight) {
     int numLeaves() {
         return leaves.size();
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/LuceneSliceQueue.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * Shared Lucene slices between Lucene operators.
@@ -64,16 +63,7 @@ public final class LuceneSliceQueue {
                 case SEGMENT -> segmentSlices(leafContexts);
                 case DOC -> docSlices(ctx.searcher().getIndexReader(), taskConcurrency);
             };
-            final Weight[] cachedWeight = new Weight[1];
-            final Supplier<Weight> weight = () -> {
-                if (cachedWeight[0] == null) {
-                    cachedWeight[0] = weightFunction.apply(ctx);
-                }
-                return cachedWeight[0];
-            };
-            if (groups.size() > 1) {
-                weight.get(); // eagerly build Weight once
-            }
+            final Weight weight = weightFunction.apply(ctx);
             for (List<PartialLeafReaderContext> group : groups) {
                 if (group.isEmpty() == false) {
                     slices.add(new LuceneSlice(ctx, group, weight));

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
@@ -246,7 +246,7 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
 
             TimeSeriesIterator(LuceneSlice slice) throws IOException {
                 this.slice = slice;
-                Weight weight = slice.weight().get();
+                Weight weight = slice.weight();
                 if (slice.numLeaves() == 1) {
                     queue = null;
                     leaf = new Leaf(weight, slice.getLeaf(0).leafReaderContext());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlannerTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.cache.query.TrivialQueryCachingPolicy;
 import org.elasticsearch.index.mapper.MapperServiceTestCase;
+import org.elasticsearch.search.internal.AliasFilter;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.xpack.esql.TestBlockFactory;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -164,7 +165,7 @@ public class LocalExecutionPlannerTests extends MapperServiceTestCase {
                 new EsPhysicalOperationProviders.DefaultShardContext(
                     i,
                     createSearchExecutionContext(createMapperService(mapping(b -> {})), searcher),
-                    null
+                    AliasFilter.EMPTY
                 )
             );
         }


### PR DESCRIPTION
There is currently an optimisation to execute create lucene weights in the worker threads if the weight only applies to one segment. While theoretically that might work it seems to make the code more difficult to reason about because the execution pattern differs from what the classical search is doing and it creates some differences in the benchmarks.

In particular this execution patterns seems to create contention on the LRU cache in some situations. This commit proposes to remove this optimisation to bring search and esql with the same query execution path. We can think later if this optimisation is really worthy and bring it to both code paths. At the moment, it seems this is causing more issues in the nightly benchmarks.