### PR TITLE
Fix detection of invalid mixed sort fields

### DIFF
--- a/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/30_sort.yml
+++ b/x-pack/plugin/mapper-constant-keyword/src/yamlRestTest/resources/rest-api-spec/test/30_sort.yml
@@ -1,0 +1,65 @@
+setup:
+  - do:
+      indices.create:
+        index:  test
+        body:
+          mappings:
+            properties:
+              keyword:
+                type: keyword
+
+  - do:
+      indices.create:
+        index: test_numeric
+        body:
+          mappings:
+            properties:
+              keyword:
+                type: long
+
+  - do:
+      indices.create:
+        index: test_constant
+        body:
+          mappings:
+            properties:
+              keyword:
+                type: constant_keyword
+                value: value
+
+  - do:
+      bulk:
+        refresh: true
+        body: |
+          { "index": {"_index" : "test", "_id": 3} }
+          { "keyword": "abc" }
+          { "index": {"_index" : "test_numeric", "_id": 2} }
+          { "keyword": 42 }
+          { "index": {"_index" : "test_constant", "_id": 1} }
+          {}
+
+---
+"constant_keyword mixed sort":
+  - do:
+      search:
+        index: test,test_constant
+        body:
+          sort: keyword
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id:  "3" }
+  - match: { hits.hits.1._id:  "1" }
+
+---
+"constant_keyword invalid mixed sort":
+  - requires:
+      cluster_features: [ "gte_v8.15.0" ]
+      reason: Better error message in 8.15.0
+
+  - do:
+      catch: /Can't sort on field \[keyword\]\; the field has incompatible sort types/
+      search:
+        index: test*
+        body:
+          sort: keyword
+


### PR DESCRIPTION
Sort fields are usually rewritten into their merge form during transport serialization. For searches where all shards are local to the coordinating node, this serialization is not applied, and sort fields remain in their original form. This is typically not an issue except when checking sort compatibility, as we rely on the primary type of the sort field.

This change ensures we extract the correct type even if the sort field is in its primary form (with a CUSTOM type) using the original comparator source. The only field type that benefits from this change afaik is the constant_keyword field type. When a sort field is a mix of numeric and constant_keyword, this change ensures the discrepancy is correctly reported to the user.