### PR TITLE
[GRADLE] Fix build caching for esql compile tasks

### DIFF
--- a/x-pack/plugin/esql/build.gradle
+++ b/x-pack/plugin/esql/build.gradle
@@ -44,9 +44,9 @@ dependencies {
 }
 
 tasks.named("compileJava").configure {
-  options.compilerArgs.addAll(["-s", "${projectDir}/src/main/generated"])
+  options.compilerArgs.addAll(["-s", "src/main/generated"])
   // IntelliJ sticks generated files here and we can't stop it....
-  exclude { it.file.toString().startsWith("${projectDir}/src/main/generated-src/generated") }
+  exclude { it.file.toString().contains("src/main/generated-src/generated") }
 }
 
 interface Injected {

--- a/x-pack/plugin/esql/compute/build.gradle
+++ b/x-pack/plugin/esql/compute/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 }
 
 tasks.named("compileJava").configure {
-  options.compilerArgs.addAll(["-s", "${projectDir}/src/main/generated"])
+  options.compilerArgs.addAll(["-s", "src/main/generated"])
 }
 
 tasks.named('checkstyleMain').configure {


### PR DESCRIPTION
- remove absolute paths in compile args

before: https://gradle-enterprise.elastic.co/s/euogizmf4nsrc/timeline?end=1718796575409&project=:x-pack:plugin:esql,:x-pack:plugin:esql:compute&show=details&start=1718796565179&type=org.gradle.api.tasks.compile.JavaCompile

after: https://gradle-enterprise.elastic.co/s/pnlprupvuzwks/timeline?project=:x-pack:plugin:esql,:x-pack:plugin:esql:compute&type=org.gradle.api.tasks.compile.JavaCompile