### PR TITLE
[Inference API] Extend AbstractBWCWireSerializingTestCase for AzureAiStudioChatCompletionServiceSettingsTests

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionServiceSettingsTests.java
@@ -7,12 +7,13 @@
 
 package org.elasticsearch.xpack.inference.services.azureaistudio.completion;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioEndpointType;
 import org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioProvider;
@@ -29,7 +30,7 @@ import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiSt
 import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.TARGET_FIELD;
 import static org.hamcrest.Matchers.is;
 
-public class AzureAiStudioChatCompletionServiceSettingsTests extends AbstractWireSerializingTestCase<
+public class AzureAiStudioChatCompletionServiceSettingsTests extends AbstractBWCWireSerializationTestCase<
     AzureAiStudioChatCompletionServiceSettings> {
     public void testFromMap_Request_CreatesSettingsCorrectly() {
         var target = "http://sometarget.local";
@@ -139,6 +140,14 @@ public class AzureAiStudioChatCompletionServiceSettingsTests extends AbstractWir
         return randomValueOtherThan(instance, AzureAiStudioChatCompletionServiceSettingsTests::createRandom);
     }
 
+    @Override
+    protected AzureAiStudioChatCompletionServiceSettings mutateInstanceForVersion(
+        AzureAiStudioChatCompletionServiceSettings instance,
+        TransportVersion version
+    ) {
+        return instance;
+    }
+
     private static AzureAiStudioChatCompletionServiceSettings createRandom() {
         return new AzureAiStudioChatCompletionServiceSettings(
             randomAlphaOfLength(10),
@@ -147,4 +156,5 @@ public class AzureAiStudioChatCompletionServiceSettingsTests extends AbstractWir
             RateLimitSettingsTests.createRandom()
         );
     }
+
 }

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionServiceSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionServiceSettingsTests.java
@@ -8,7 +8,8 @@
 package org.elasticsearch.xpack.inference.services.azureaistudio.completion;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
@@ -16,6 +17,7 @@ import org.elasticsearch.xpack.inference.services.ConfigurationParseContext;
 import org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioEndpointType;
 import org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioProvider;
 import org.elasticsearch.xpack.inference.services.settings.RateLimitSettings;
+import org.elasticsearch.xpack.inference.services.settings.RateLimitSettingsTests;
 import org.hamcrest.CoreMatchers;
 
 import java.io.IOException;
@@ -27,7 +29,8 @@ import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiSt
 import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiStudioConstants.TARGET_FIELD;
 import static org.hamcrest.Matchers.is;
 
-public class AzureAiStudioChatCompletionServiceSettingsTests extends ESTestCase {
+public class AzureAiStudioChatCompletionServiceSettingsTests extends AbstractWireSerializingTestCase<
+    AzureAiStudioChatCompletionServiceSettings> {
     public void testFromMap_Request_CreatesSettingsCorrectly() {
         var target = "http://sometarget.local";
         var provider = "openai";
@@ -118,5 +121,30 @@ public class AzureAiStudioChatCompletionServiceSettingsTests extends ESTestCase 
 
     public static HashMap<String, Object> createRequestSettingsMap(String target, String provider, String endpointType) {
         return new HashMap<>(Map.of(TARGET_FIELD, target, PROVIDER_FIELD, provider, ENDPOINT_TYPE_FIELD, endpointType));
+    }
+
+    @Override
+    protected Writeable.Reader<AzureAiStudioChatCompletionServiceSettings> instanceReader() {
+        return AzureAiStudioChatCompletionServiceSettings::new;
+    }
+
+    @Override
+    protected AzureAiStudioChatCompletionServiceSettings createTestInstance() {
+        return createRandom();
+    }
+
+    @Override
+    protected AzureAiStudioChatCompletionServiceSettings mutateInstance(AzureAiStudioChatCompletionServiceSettings instance)
+        throws IOException {
+        return randomValueOtherThan(instance, AzureAiStudioChatCompletionServiceSettingsTests::createRandom);
+    }
+
+    private static AzureAiStudioChatCompletionServiceSettings createRandom() {
+        return new AzureAiStudioChatCompletionServiceSettings(
+            randomAlphaOfLength(10),
+            randomFrom(AzureAiStudioProvider.values()),
+            randomFrom(AzureAiStudioEndpointType.values()),
+            RateLimitSettingsTests.createRandom()
+        );
     }
 }


### PR DESCRIPTION
Found out that we sometimes missed implementing `AbstractBWCWireSerializingTestCase` for named writeables, which can be serialized over the wire. Therefore adding the missing tests.