### PR TITLE
[Inference API] Extend AbstractBWCWireSerializingTestCase for AzureAiStudioChatCompletionTaskSettingsTests

### DIFF
--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionTaskSettingsTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/azureaistudio/completion/AzureAiStudioChatCompletionTaskSettingsTests.java
@@ -7,13 +7,15 @@
 
 package org.elasticsearch.xpack.inference.services.azureaistudio.completion;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.ValidationException;
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ml.AbstractBWCWireSerializationTestCase;
 import org.hamcrest.MatcherAssert;
 
 import java.io.IOException;
@@ -27,7 +29,8 @@ import static org.elasticsearch.xpack.inference.services.azureaistudio.AzureAiSt
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-public class AzureAiStudioChatCompletionTaskSettingsTests extends ESTestCase {
+public class AzureAiStudioChatCompletionTaskSettingsTests extends AbstractBWCWireSerializationTestCase<
+    AzureAiStudioChatCompletionTaskSettings> {
 
     public void testFromMap_AllValues() {
         var taskMap = getTaskSettingsMap(1.0, 2.0, true, 512);
@@ -182,5 +185,37 @@ public class AzureAiStudioChatCompletionTaskSettingsTests extends ESTestCase {
         }
 
         return map;
+    }
+
+    @Override
+    protected Writeable.Reader<AzureAiStudioChatCompletionTaskSettings> instanceReader() {
+        return AzureAiStudioChatCompletionTaskSettings::new;
+    }
+
+    @Override
+    protected AzureAiStudioChatCompletionTaskSettings createTestInstance() {
+        return createRandom();
+    }
+
+    @Override
+    protected AzureAiStudioChatCompletionTaskSettings mutateInstance(AzureAiStudioChatCompletionTaskSettings instance) throws IOException {
+        return randomValueOtherThan(instance, AzureAiStudioChatCompletionTaskSettingsTests::createRandom);
+    }
+
+    @Override
+    protected AzureAiStudioChatCompletionTaskSettings mutateInstanceForVersion(
+        AzureAiStudioChatCompletionTaskSettings instance,
+        TransportVersion version
+    ) {
+        return instance;
+    }
+
+    private static AzureAiStudioChatCompletionTaskSettings createRandom() {
+        return new AzureAiStudioChatCompletionTaskSettings(
+            randomFrom(new Double[] { null, randomDouble() }),
+            randomFrom(new Double[] { null, randomDouble() }),
+            randomFrom(randomFrom(new Boolean[] { null, randomBoolean() })),
+            randomFrom(new Integer[] { null, randomNonNegativeInt() })
+        );
     }
 }


### PR DESCRIPTION
Same reasoning as https://github.com/elastic/elasticsearch/pull/109919