### PR TITLE
Fix for TopNOperatorTests for Float.NaN

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -75,9 +75,6 @@ tests:
   method: "testFetchAllEntities"
 - class: "org.elasticsearch.xpack.ml.integration.AutodetectMemoryLimitIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109904"
-- class: "org.elasticsearch.compute.operator.topn.TopNOperatorTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/109915"
-  method: "testRandomMultiValuesTopN"
 
 
 # Examples:

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockTestUtils.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/data/BlockTestUtils.java
@@ -17,6 +17,7 @@ import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
 import static org.elasticsearch.test.ESTestCase.between;
 import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomDouble;
+import static org.elasticsearch.test.ESTestCase.randomFloat;
 import static org.elasticsearch.test.ESTestCase.randomInt;
 import static org.elasticsearch.test.ESTestCase.randomLong;
 import static org.elasticsearch.test.ESTestCase.randomRealisticUnicodeOfCodepointLengthBetween;
@@ -31,7 +32,7 @@ public class BlockTestUtils {
         return switch (e) {
             case INT -> randomInt();
             case LONG -> randomLong();
-            case FLOAT -> Float.intBitsToFloat(randomInt());
+            case FLOAT -> randomFloat();
             case DOUBLE -> randomDouble();
             case BYTES_REF -> new BytesRef(randomRealisticUnicodeOfCodepointLengthBetween(0, 5));   // TODO: also test spatial WKB
             case BOOLEAN -> randomBoolean();


### PR DESCRIPTION
Fix for TopNOperatorTests. Previous generation of random float leads easily to NaN, which is not liked by topn ordering.

closes #109915