### PR TITLE
[8.14] Fix Bulk Helpers link of Python (#108694)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -140,7 +140,7 @@ Perl::
 
 Python::
 
-    See https://elasticsearch-py.readthedocs.org/en/master/helpers.html[elasticsearch.helpers.*]
+    See https://elasticsearch-py.readthedocs.io/en/latest/helpers.html[elasticsearch.helpers.*]
 
 JavaScript::
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Fix Bulk Helpers link of Python (#108694)