### PR TITLE
ESQL: Unmute MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests testMulitvaluedNullGroup

### DIFF
--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/GroupingAggregatorFunctionTestCase.java
@@ -276,7 +276,7 @@ public abstract class GroupingAggregatorFunctionTestCase extends ForkingOperator
         assertSimpleOutput(origInput, results);
     }
 
-    public void testMulitvaluedNullGroup() {
+    public final void testMulitvaluedNullGroup() {
         DriverContext driverContext = driverContext();
         BlockFactory blockFactory = driverContext.blockFactory();
         int end = between(1, 2);  // TODO revert

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/aggregation/MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests.java
@@ -76,9 +76,4 @@ public class MedianAbsoluteDeviationDoubleGroupingAggregatorFunctionTests extend
         int c = data.length / 2;
         return data.length % 2 == 0 ? (data[c - 1] + data[c]) / 2 : data[c];
     }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/101569")
-    public void testMulitvaluedNullGroup() {
-        // only here for muting it
-    }
 }


### PR DESCRIPTION
This was fixed in https://github.com/elastic/elasticsearch/pull/100556 and the associated [issue ](https://github.com/elastic/elasticsearch/issues/101569) closed. The unmute was performed in the [backport](https://github.com/elastic/elasticsearch/pull/101614) of the fix, but I think we forgot to unmute in main.