### PR TITLE
[ML] Default the HF service to cosine similarity

### DIFF
--- a/docs/changelog/109967.yaml
+++ b/docs/changelog/109967.yaml
@@ -1,0 +1,5 @@
+pr: 109967
+summary: Default the HF service to cosine similarity
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceService.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.inference.ChunkedInferenceServiceResults;
 import org.elasticsearch.inference.ChunkingOptions;
 import org.elasticsearch.inference.InputType;
 import org.elasticsearch.inference.Model;
+import org.elasticsearch.inference.SimilarityMeasure;
 import org.elasticsearch.inference.TaskType;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.inference.common.EmbeddingRequestChunker;
@@ -78,9 +79,14 @@ public class HuggingFaceService extends HuggingFaceBaseService {
     }
 
     private static HuggingFaceEmbeddingsModel updateModelWithEmbeddingDetails(HuggingFaceEmbeddingsModel model, int embeddingSize) {
+        // default to cosine similarity
+        var similarity = model.getServiceSettings().similarity() == null
+            ? SimilarityMeasure.COSINE
+            : model.getServiceSettings().similarity();
+
         var serviceSettings = new HuggingFaceServiceSettings(
             model.getServiceSettings().uri(),
-            model.getServiceSettings().similarity(), // we don't know the similarity but use whatever the user specified
+            similarity,
             embeddingSize,
             model.getTokenLimit(),
             model.getServiceSettings().rateLimitSettings()

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/services/huggingface/HuggingFaceServiceTests.java
@@ -528,12 +528,15 @@ public class HuggingFaceServiceTests extends ESTestCase {
                 """;
             webServer.enqueue(new MockResponse().setResponseCode(200).setBody(responseJson));
 
-            var model = HuggingFaceEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1);
+            var model = HuggingFaceEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1, 1, SimilarityMeasure.DOT_PRODUCT);
             PlainActionFuture<Model> listener = new PlainActionFuture<>();
             service.checkModelConfig(model, listener);
 
             var result = listener.actionGet(TIMEOUT);
-            assertThat(result, is(HuggingFaceEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1, 1)));
+            assertThat(
+                result,
+                is(HuggingFaceEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1, 1, SimilarityMeasure.DOT_PRODUCT))
+            );
         }
     }
 
@@ -565,7 +568,7 @@ public class HuggingFaceServiceTests extends ESTestCase {
         }
     }
 
-    public void testCheckModelConfig_LeavesSimilarityAsNull_WhenUnspecified() throws IOException {
+    public void testCheckModelConfig_DefaultsSimilarityToCosine() throws IOException {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 
         try (var service = new HuggingFaceService(senderFactory, createWithEmptySettings(threadPool))) {
@@ -586,11 +589,13 @@ public class HuggingFaceServiceTests extends ESTestCase {
             service.checkModelConfig(model, listener);
 
             var result = listener.actionGet(TIMEOUT);
-            assertThat(result, is(HuggingFaceEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1, 1, null)));
+            assertThat(
+                result,
+                is(HuggingFaceEmbeddingsModelTests.createModel(getUrl(webServer), "secret", 1, 1, SimilarityMeasure.COSINE))
+            );
         }
     }
 
-    // TODO
     public void testChunkedInfer_CallsInfer_TextEmbedding_ConvertsFloatResponse() throws IOException {
         var senderFactory = HttpRequestSenderTests.createSenderFactory(threadPool, clientManager);
 


### PR DESCRIPTION
Semantic text requires a similarity measure to be set, if not specified by the user the default is Cosine for HuggingFace embedding models