### PR TITLE
[8.14] [ci] Bump disk size for agents to 250GB (#109975)

### DIFF
--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -7,6 +7,7 @@ steps:
       image: family/elasticsearch-ubuntu-2204
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   # The hadoop build depends on the ES artifact
   # So let's trigger the hadoop build any time we build a new staging artifact

--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -7,6 +7,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart1
@@ -16,6 +17,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart2
     timeout_in_minutes: 300
@@ -24,6 +26,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part3
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart3
     timeout_in_minutes: 300
@@ -32,6 +35,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part4
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart4
     timeout_in_minutes: 300
@@ -40,6 +44,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part5
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart5
     timeout_in_minutes: 300
@@ -48,6 +53,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - group: bwc-snapshots
     steps:
       - label: "{{matrix.BWC_VERSION}} / bwc-snapshots"
@@ -61,6 +67,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: custom-32-98304
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
   - label: rest-compat
@@ -71,6 +78,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   - trigger: elasticsearch-dra-workflow
     label: Trigger DRA snapshot workflow

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -8,6 +8,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart1
@@ -17,6 +18,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart2
     timeout_in_minutes: 300
@@ -25,6 +27,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part3
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart3
     timeout_in_minutes: 300
@@ -33,6 +36,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part4
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart4
     timeout_in_minutes: 300
@@ -41,6 +45,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part5
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart5
     timeout_in_minutes: 300
@@ -49,6 +54,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - group: bwc-snapshots
     steps:
       - label: "{{matrix.BWC_VERSION}} / bwc-snapshots"
@@ -62,6 +68,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: custom-32-98304
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
   - label: rest-compat
@@ -72,6 +79,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   - trigger: elasticsearch-dra-workflow
     label: Trigger DRA snapshot workflow

--- a/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
+++ b/.buildkite/pipelines/lucene-snapshot/build-snapshot.yml
@@ -15,6 +15,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   - trigger: "elasticsearch-lucene-snapshot-tests"
     build:

--- a/.buildkite/pipelines/lucene-snapshot/run-tests.yml
+++ b/.buildkite/pipelines/lucene-snapshot/run-tests.yml
@@ -7,6 +7,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait: null
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart1
@@ -16,6 +17,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart2
     timeout_in_minutes: 300
@@ -24,6 +26,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part3
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart3
     timeout_in_minutes: 300
@@ -32,6 +35,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part4
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart4
     timeout_in_minutes: 300
@@ -40,6 +44,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part5
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart5
     timeout_in_minutes: 300
@@ -48,6 +53,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - group: bwc-snapshots
     steps:
       - label: "{{matrix.BWC_VERSION}} / bwc-snapshots"
@@ -64,6 +70,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: custom-32-98304
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
   - label: rest-compat
@@ -74,3 +81,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/periodic-packaging.bwc.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.bwc.template.yml
@@ -11,5 +11,6 @@
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: $BWC_VERSION

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -46,6 +46,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.0.1
 
@@ -62,6 +63,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.1.1
 
@@ -78,6 +80,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.2.1
 
@@ -94,6 +97,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.3.2
 
@@ -110,6 +114,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.4.2
 
@@ -126,6 +131,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.5.2
 
@@ -142,6 +148,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.6.2
 
@@ -158,6 +165,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.7.1
 
@@ -174,6 +182,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.8.1
 
@@ -190,6 +199,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.9.3
 
@@ -206,6 +216,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.10.2
 
@@ -222,6 +233,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.11.2
 
@@ -238,6 +250,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.12.1
 
@@ -254,6 +267,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.13.4
 
@@ -270,6 +284,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.14.2
 
@@ -286,6 +301,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.15.2
 
@@ -302,6 +318,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.16.3
 
@@ -318,6 +335,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.17.23
 
@@ -334,6 +352,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.0.1
 
@@ -350,6 +369,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.1.3
 
@@ -366,6 +386,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.2.3
 
@@ -382,6 +403,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.3.3
 
@@ -398,6 +420,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.4.3
 
@@ -414,6 +437,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.5.3
 
@@ -430,6 +454,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.6.2
 
@@ -446,6 +471,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.7.1
 
@@ -462,6 +488,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.8.2
 
@@ -478,6 +505,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.9.2
 
@@ -494,6 +522,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.10.4
 
@@ -510,6 +539,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.11.4
 
@@ -526,6 +556,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.12.2
 
@@ -542,6 +573,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.13.4
 
@@ -558,6 +590,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.14.2
 

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -30,6 +30,7 @@ steps:
           localSsds: 1
           localSsdInterface: nvme
           machineType: custom-32-98304
+          diskSizeGb: 250
         env: {}
   - group: platform-support-windows
     steps:

--- a/.buildkite/pipelines/periodic.bwc.template.yml
+++ b/.buildkite/pipelines/periodic.bwc.template.yml
@@ -7,6 +7,7 @@
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: $BWC_VERSION
         retry:

--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -25,6 +25,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: example-plugins
     command: |-
       cd $$WORKSPACE/plugins/examples
@@ -36,6 +37,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - group: java-fips-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-fips-matrix"
@@ -57,6 +59,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
@@ -73,6 +76,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
@@ -100,6 +104,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
@@ -119,6 +124,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
@@ -154,6 +160,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / azure
         command: |
           export azure_storage_container=elasticsearch-ci-thirdparty
@@ -168,6 +175,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / gcs
         command: |
           export google_storage_bucket=elasticsearch-ci-thirdparty
@@ -182,6 +190,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / geoip
         command: |
           .ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
@@ -191,6 +200,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / s3
         command: |
           export amazon_s3_bucket=elasticsearch-ci.us-west-2
@@ -205,6 +215,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
   - label: Upload Snyk Dependency Graph
     command: .ci/scripts/run-gradle.sh uploadSnykDependencyGraph -PsnykTargetReference=$BUILDKITE_BRANCH
     env:
@@ -215,6 +226,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
     if: build.branch == "main" || build.branch == "7.17"
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
@@ -223,6 +235,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-2
+      diskSizeGb: 250
   - label: check-branch-protection-rules
     command: .buildkite/scripts/branch-protection.sh
     timeout_in_minutes: 5

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -11,6 +11,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.0.1
         retry:
@@ -30,6 +31,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.1.1
         retry:
@@ -49,6 +51,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.2.1
         retry:
@@ -68,6 +71,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.3.2
         retry:
@@ -87,6 +91,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.4.2
         retry:
@@ -106,6 +111,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.5.2
         retry:
@@ -125,6 +131,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.6.2
         retry:
@@ -144,6 +151,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.7.1
         retry:
@@ -163,6 +171,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.8.1
         retry:
@@ -182,6 +191,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.9.3
         retry:
@@ -201,6 +211,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.10.2
         retry:
@@ -220,6 +231,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.11.2
         retry:
@@ -239,6 +251,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.12.1
         retry:
@@ -258,6 +271,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.13.4
         retry:
@@ -277,6 +291,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.14.2
         retry:
@@ -296,6 +311,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.15.2
         retry:
@@ -315,6 +331,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.16.3
         retry:
@@ -334,6 +351,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.17.23
         retry:
@@ -353,6 +371,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.0.1
         retry:
@@ -372,6 +391,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.1.3
         retry:
@@ -391,6 +411,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.2.3
         retry:
@@ -410,6 +431,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.3.3
         retry:
@@ -429,6 +451,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.4.3
         retry:
@@ -448,6 +471,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.5.3
         retry:
@@ -467,6 +491,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.6.2
         retry:
@@ -486,6 +511,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.7.1
         retry:
@@ -505,6 +531,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.8.2
         retry:
@@ -524,6 +551,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.9.2
         retry:
@@ -543,6 +571,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.10.4
         retry:
@@ -562,6 +591,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.11.4
         retry:
@@ -581,6 +611,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.12.2
         retry:
@@ -600,6 +631,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.13.4
         retry:
@@ -619,6 +651,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 8.14.2
         retry:
@@ -653,6 +686,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: example-plugins
     command: |-
       cd $$WORKSPACE/plugins/examples
@@ -664,6 +698,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - group: java-fips-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / {{matrix.GRADLE_TASK}} / java-fips-matrix"
@@ -685,6 +720,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
@@ -701,6 +737,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
@@ -728,6 +765,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           GRADLE_TASK: "{{matrix.GRADLE_TASK}}"
@@ -747,6 +785,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
           BWC_VERSION: "{{matrix.BWC_VERSION}}"
@@ -782,6 +821,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / azure
         command: |
           export azure_storage_container=elasticsearch-ci-thirdparty
@@ -796,6 +836,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / gcs
         command: |
           export google_storage_bucket=elasticsearch-ci-thirdparty
@@ -810,6 +851,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / geoip
         command: |
           .ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
@@ -819,6 +861,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / s3
         command: |
           export amazon_s3_bucket=elasticsearch-ci.us-west-2
@@ -833,6 +876,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
   - label: Upload Snyk Dependency Graph
     command: .ci/scripts/run-gradle.sh uploadSnykDependencyGraph -PsnykTargetReference=$BUILDKITE_BRANCH
     env:
@@ -843,6 +887,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
     if: build.branch == "main" || build.branch == "7.17"
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
@@ -851,6 +896,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-2
+      diskSizeGb: 250
   - label: check-branch-protection-rules
     command: .buildkite/scripts/branch-protection.sh
     timeout_in_minutes: 5

--- a/.buildkite/pipelines/pull-request/build-benchmark.yml
+++ b/.buildkite/pipelines/pull-request/build-benchmark.yml
@@ -22,3 +22,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/bwc-snapshots.yml
+++ b/.buildkite/pipelines/pull-request/bwc-snapshots.yml
@@ -18,3 +18,4 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/cloud-deploy.yml
+++ b/.buildkite/pipelines/pull-request/cloud-deploy.yml
@@ -11,3 +11,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/docs-check.yml
+++ b/.buildkite/pipelines/pull-request/docs-check.yml
@@ -12,3 +12,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/eql-correctness.yml
+++ b/.buildkite/pipelines/pull-request/eql-correctness.yml
@@ -7,3 +7,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -16,3 +16,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/full-bwc.yml
+++ b/.buildkite/pipelines/pull-request/full-bwc.yml
@@ -13,3 +13,4 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: custom-32-98304
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
+++ b/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
@@ -18,5 +18,6 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: $BWC_VERSION

--- a/.buildkite/pipelines/pull-request/part-1-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-1.yml
+++ b/.buildkite/pipelines/pull-request/part-1.yml
@@ -7,3 +7,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-2-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-2.yml
+++ b/.buildkite/pipelines/pull-request/part-2.yml
@@ -7,3 +7,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-3-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-3-fips.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-3.yml
+++ b/.buildkite/pipelines/pull-request/part-3.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-4-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-4-fips.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-4.yml
+++ b/.buildkite/pipelines/pull-request/part-4.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-5-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-5-fips.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-5.yml
+++ b/.buildkite/pipelines/pull-request/part-5.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/precommit.yml
+++ b/.buildkite/pipelines/pull-request/precommit.yml
@@ -10,3 +10,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/rest-compatibility.yml
+++ b/.buildkite/pipelines/pull-request/rest-compatibility.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/validate-changelogs.yml
+++ b/.buildkite/pipelines/pull-request/validate-changelogs.yml
@@ -7,3 +7,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[ci] Bump disk size for agents to 250GB (#109975)](https://github.com/elastic/elasticsearch/pull/109975)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)