### PR TITLE
[7.17] [ci] Bump disk size for agents to 250GB (#109975)

### DIFF
--- a/.buildkite/pipelines/dra-workflow.yml
+++ b/.buildkite/pipelines/dra-workflow.yml
@@ -7,6 +7,7 @@ steps:
       image: family/elasticsearch-ubuntu-2204
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   # The hadoop build depends on the ES artifact
   # So let's trigger the hadoop build any time we build a new staging artifact

--- a/.buildkite/pipelines/intake.template.yml
+++ b/.buildkite/pipelines/intake.template.yml
@@ -7,6 +7,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart1
@@ -16,6 +17,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart2
     timeout_in_minutes: 300

--- a/.buildkite/pipelines/intake.yml
+++ b/.buildkite/pipelines/intake.yml
@@ -8,6 +8,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - wait
   - label: part1
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart1
@@ -17,6 +18,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n1-standard-32
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: part2
     command: .ci/scripts/run-gradle.sh -Dbwc.checkout.align=true -Dorg.elasticsearch.build.cache.push=true -Dignore.tests.seed -Dscan.capture-task-input-files checkPart2
     timeout_in_minutes: 300

--- a/.buildkite/pipelines/periodic-packaging.bwc.template.yml
+++ b/.buildkite/pipelines/periodic-packaging.bwc.template.yml
@@ -11,5 +11,6 @@
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: $BWC_VERSION

--- a/.buildkite/pipelines/periodic-packaging.yml
+++ b/.buildkite/pipelines/periodic-packaging.yml
@@ -46,6 +46,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.0.1
 
@@ -62,6 +63,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.1.4
 
@@ -78,6 +80,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.2.4
 
@@ -94,6 +97,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.3.2
 
@@ -110,6 +114,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.4.3
 
@@ -126,6 +131,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.5.4
 
@@ -142,6 +148,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.6.2
 
@@ -158,6 +165,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.7.2
 
@@ -174,6 +182,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.8.23
 
@@ -190,6 +199,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.0.1
 
@@ -206,6 +216,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.1.1
 
@@ -222,6 +233,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.2.1
 
@@ -238,6 +250,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.3.2
 
@@ -254,6 +267,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.4.2
 
@@ -270,6 +284,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.5.2
 
@@ -286,6 +301,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.6.2
 
@@ -302,6 +318,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.7.1
 
@@ -318,6 +335,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.8.1
 
@@ -334,6 +352,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.9.3
 
@@ -350,6 +369,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.10.2
 
@@ -366,6 +386,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.11.2
 
@@ -382,6 +403,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.12.1
 
@@ -398,6 +420,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.13.4
 
@@ -414,6 +437,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.14.2
 
@@ -430,6 +454,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.15.2
 
@@ -446,6 +471,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.16.3
 
@@ -462,6 +488,7 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.17.22
 

--- a/.buildkite/pipelines/periodic-platform-support.yml
+++ b/.buildkite/pipelines/periodic-platform-support.yml
@@ -30,6 +30,7 @@ steps:
           localSsds: 1
           localSsdInterface: nvme
           machineType: custom-32-98304
+          diskSizeGb: 250
         env: {}
   - group: platform-support-windows
     steps:

--- a/.buildkite/pipelines/periodic.bwc.template.yml
+++ b/.buildkite/pipelines/periodic.bwc.template.yml
@@ -7,6 +7,7 @@
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: $BWC_VERSION
         retry:

--- a/.buildkite/pipelines/periodic.template.yml
+++ b/.buildkite/pipelines/periodic.template.yml
@@ -17,6 +17,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: example-plugins
     command: |-
       cd $$WORKSPACE/plugins/examples
@@ -28,6 +29,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - group: java-fips-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / java-fips-matrix"
@@ -42,6 +44,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
   - group: java-matrix
@@ -72,6 +75,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
   - label: release-tests
@@ -98,6 +102,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / azure
         command: |
           export azure_storage_container=elasticsearch-ci-thirdparty
@@ -112,6 +117,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / gcs
         command: |
           export google_storage_bucket=elasticsearch-ci-thirdparty
@@ -126,6 +132,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / geoip
         command: |
           .ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
@@ -135,6 +142,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / s3
         command: |
           export amazon_s3_bucket=elasticsearch-ci.us-west-2
@@ -149,6 +157,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
   - label: Upload Snyk Dependency Graph
     command: .ci/scripts/run-gradle.sh uploadSnykDependencyGraph -PsnykTargetReference=$BUILDKITE_BRANCH
     env:
@@ -159,6 +168,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
     if: build.branch == "main" || build.branch == "7.17"
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
@@ -167,6 +177,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-2
+      diskSizeGb: 250
   - label: check-branch-protection-rules
     command: .buildkite/scripts/branch-protection.sh
     timeout_in_minutes: 5

--- a/.buildkite/pipelines/periodic.yml
+++ b/.buildkite/pipelines/periodic.yml
@@ -11,6 +11,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.0.1
         retry:
@@ -30,6 +31,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.1.4
         retry:
@@ -49,6 +51,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.2.4
         retry:
@@ -68,6 +71,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.3.2
         retry:
@@ -87,6 +91,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.4.3
         retry:
@@ -106,6 +111,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.5.4
         retry:
@@ -125,6 +131,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.6.2
         retry:
@@ -144,6 +151,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.7.2
         retry:
@@ -163,6 +171,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 6.8.23
         retry:
@@ -182,6 +191,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.0.1
         retry:
@@ -201,6 +211,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.1.1
         retry:
@@ -220,6 +231,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.2.1
         retry:
@@ -239,6 +251,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.3.2
         retry:
@@ -258,6 +271,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.4.2
         retry:
@@ -277,6 +291,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.5.2
         retry:
@@ -296,6 +311,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.6.2
         retry:
@@ -315,6 +331,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.7.1
         retry:
@@ -334,6 +351,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.8.1
         retry:
@@ -353,6 +371,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.9.3
         retry:
@@ -372,6 +391,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.10.2
         retry:
@@ -391,6 +411,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.11.2
         retry:
@@ -410,6 +431,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.12.1
         retry:
@@ -429,6 +451,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.13.4
         retry:
@@ -448,6 +471,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.14.2
         retry:
@@ -467,6 +491,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.15.2
         retry:
@@ -486,6 +511,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.16.3
         retry:
@@ -505,6 +531,7 @@ steps:
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
           preemptible: true
+          diskSizeGb: 250
         env:
           BWC_VERSION: 7.17.22
         retry:
@@ -531,6 +558,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - label: example-plugins
     command: |-
       cd $$WORKSPACE/plugins/examples
@@ -542,6 +570,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
   - group: java-fips-matrix
     steps:
       - label: "{{matrix.ES_RUNTIME_JAVA}} / java-fips-matrix"
@@ -556,6 +585,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
   - group: java-matrix
@@ -586,6 +616,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n1-standard-32
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           ES_RUNTIME_JAVA: "{{matrix.ES_RUNTIME_JAVA}}"
   - label: release-tests
@@ -612,6 +643,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / azure
         command: |
           export azure_storage_container=elasticsearch-ci-thirdparty
@@ -626,6 +658,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / gcs
         command: |
           export google_storage_bucket=elasticsearch-ci-thirdparty
@@ -640,6 +673,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / geoip
         command: |
           .ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dtests.jvm.argline="-Dgeoip_use_service=true"
@@ -649,6 +683,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
       - label: third-party / s3
         command: |
           export amazon_s3_bucket=elasticsearch-ci.us-west-2
@@ -663,6 +698,7 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: n2-standard-8
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
   - label: Upload Snyk Dependency Graph
     command: .ci/scripts/run-gradle.sh uploadSnykDependencyGraph -PsnykTargetReference=$BUILDKITE_BRANCH
     env:
@@ -673,6 +709,7 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-8
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250
     if: build.branch == "main" || build.branch == "7.17"
   - label: check-branch-consistency
     command: .ci/scripts/run-gradle.sh branchConsistency
@@ -681,6 +718,7 @@ steps:
       provider: gcp
       image: family/elasticsearch-ubuntu-2004
       machineType: n2-standard-2
+      diskSizeGb: 250
   - label: check-branch-protection-rules
     command: .buildkite/scripts/branch-protection.sh
     timeout_in_minutes: 5

--- a/.buildkite/pipelines/pull-request/build-benchmark.yml
+++ b/.buildkite/pipelines/pull-request/build-benchmark.yml
@@ -22,3 +22,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/cloud-deploy.yml
+++ b/.buildkite/pipelines/pull-request/cloud-deploy.yml
@@ -11,3 +11,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/docs-check.yml
+++ b/.buildkite/pipelines/pull-request/docs-check.yml
@@ -12,3 +12,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/eql-correctness.yml
+++ b/.buildkite/pipelines/pull-request/eql-correctness.yml
@@ -7,3 +7,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/example-plugins.yml
+++ b/.buildkite/pipelines/pull-request/example-plugins.yml
@@ -16,3 +16,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/full-bwc.yml
+++ b/.buildkite/pipelines/pull-request/full-bwc.yml
@@ -13,3 +13,4 @@ steps:
           image: family/elasticsearch-ubuntu-2004
           machineType: custom-32-98304
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
+++ b/.buildkite/pipelines/pull-request/packaging-upgrade-tests.yml
@@ -18,5 +18,6 @@ steps:
           image: family/elasticsearch-{{matrix.image}}
           machineType: custom-16-32768
           buildDirectory: /dev/shm/bk
+          diskSizeGb: 250
         env:
           BWC_VERSION: $BWC_VERSION

--- a/.buildkite/pipelines/pull-request/part-1-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-1-fips.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-1.yml
+++ b/.buildkite/pipelines/pull-request/part-1.yml
@@ -7,3 +7,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-2-fips.yml
+++ b/.buildkite/pipelines/pull-request/part-2-fips.yml
@@ -9,3 +9,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/part-2.yml
+++ b/.buildkite/pipelines/pull-request/part-2.yml
@@ -7,3 +7,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/precommit.yml
+++ b/.buildkite/pipelines/pull-request/precommit.yml
@@ -10,3 +10,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250

--- a/.buildkite/pipelines/pull-request/validate-changelogs.yml
+++ b/.buildkite/pipelines/pull-request/validate-changelogs.yml
@@ -7,3 +7,4 @@ steps:
       image: family/elasticsearch-ubuntu-2004
       machineType: custom-32-98304
       buildDirectory: /dev/shm/bk
+      diskSizeGb: 250


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[ci] Bump disk size for agents to 250GB (#109975)](https://github.com/elastic/elasticsearch/pull/109975)

<!--- Backport version: 9.2.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)