### PR TITLE
Remove time_interval from time series source operator

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorFactory.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.compute.lucene;
 
-import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
@@ -18,7 +17,6 @@ import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.PriorityQueue;
-import org.elasticsearch.common.Rounding;
 import org.elasticsearch.compute.data.BlockFactory;
 import org.elasticsearch.compute.data.BytesRefVector;
 import org.elasticsearch.compute.data.DocVector;
@@ -29,8 +27,6 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.DriverContext;
 import org.elasticsearch.compute.operator.SourceOperator;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -52,25 +48,21 @@ import java.util.function.Function;
 public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factory {
 
     private final int maxPageSize;
-    private final TimeValue timeSeriesPeriod;
 
     private TimeSeriesSortedSourceOperatorFactory(
         List<? extends ShardContext> contexts,
         Function<ShardContext, Query> queryFunction,
         int taskConcurrency,
         int maxPageSize,
-        TimeValue timeSeriesPeriod,
         int limit
     ) {
         super(contexts, queryFunction, DataPartitioning.SHARD, taskConcurrency, limit, ScoreMode.COMPLETE_NO_SCORES);
         this.maxPageSize = maxPageSize;
-        this.timeSeriesPeriod = timeSeriesPeriod;
     }
 
     @Override
     public SourceOperator get(DriverContext driverContext) {
-        var rounding = timeSeriesPeriod.equals(TimeValue.ZERO) == false ? Rounding.builder(timeSeriesPeriod).build() : null;
-        return new Impl(driverContext.blockFactory(), sliceQueue, maxPageSize, limit, rounding);
+        return new Impl(driverContext.blockFactory(), sliceQueue, maxPageSize, limit);
     }
 
     @Override
@@ -82,18 +74,10 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
         int limit,
         int maxPageSize,
         int taskConcurrency,
-        TimeValue timeSeriesPeriod,
         List<? extends ShardContext> searchContexts,
         Function<ShardContext, Query> queryFunction
     ) {
-        return new TimeSeriesSortedSourceOperatorFactory(
-            searchContexts,
-            queryFunction,
-            taskConcurrency,
-            maxPageSize,
-            timeSeriesPeriod,
-            limit
-        );
+        return new TimeSeriesSortedSourceOperatorFactory(searchContexts, queryFunction, taskConcurrency, maxPageSize, limit);
     }
 
     static final class Impl extends SourceOperator {
@@ -101,20 +85,18 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
         private final int maxPageSize;
         private final BlockFactory blockFactory;
         private final LuceneSliceQueue sliceQueue;
-        private final Rounding.Prepared rounding;
         private int currentPagePos = 0;
         private int remainingDocs;
         private boolean doneCollecting;
         private IntVector.Builder docsBuilder;
         private IntVector.Builder segmentsBuilder;
         private LongVector.Builder timestampsBuilder;
-        private LongVector.Builder intervalsBuilder;
         // TODO: add an ordinal block for tsid hashes
         // (This allows for efficiently grouping by tsid locally, no need to use bytes representation of tsid hash)
         private BytesRefVector.Builder tsHashesBuilder;
         private TimeSeriesIterator iterator;
 
-        Impl(BlockFactory blockFactory, LuceneSliceQueue sliceQueue, int maxPageSize, int limit, Rounding rounding) {
+        Impl(BlockFactory blockFactory, LuceneSliceQueue sliceQueue, int maxPageSize, int limit) {
             this.maxPageSize = maxPageSize;
             this.blockFactory = blockFactory;
             this.remainingDocs = limit;
@@ -123,27 +105,6 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
             this.timestampsBuilder = blockFactory.newLongVectorBuilder(Math.min(limit, maxPageSize));
             this.tsHashesBuilder = blockFactory.newBytesRefVectorBuilder(Math.min(limit, maxPageSize));
             this.sliceQueue = sliceQueue;
-            if (rounding != null) {
-                try {
-                    long minTimestamp = Long.MAX_VALUE;
-                    long maxTimestamp = Long.MIN_VALUE;
-                    for (var slice : sliceQueue.getSlices()) {
-                        for (var leaf : slice.leaves()) {
-                            var pointValues = leaf.leafReaderContext().reader().getPointValues(DataStreamTimestampFieldMapper.DEFAULT_PATH);
-                            long segmentMin = LongPoint.decodeDimension(pointValues.getMinPackedValue(), 0);
-                            minTimestamp = Math.min(segmentMin, minTimestamp);
-                            long segmentMax = LongPoint.decodeDimension(pointValues.getMaxPackedValue(), 0);
-                            maxTimestamp = Math.max(segmentMax, maxTimestamp);
-                        }
-                    }
-                    this.rounding = rounding.prepare(minTimestamp, maxTimestamp);
-                    this.intervalsBuilder = blockFactory.newLongVectorBuilder(Math.min(limit, maxPageSize));
-                } catch (IOException ioe) {
-                    throw new UncheckedIOException(ioe);
-                }
-            } else {
-                this.rounding = null;
-            }
         }
 
         @Override
@@ -172,7 +133,6 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
             IntVector leaf = null;
             IntVector docs = null;
             LongVector timestamps = null;
-            LongVector intervals = null;
             BytesRefVector tsids = null;
             try {
                 if (iterator == null) {
@@ -201,20 +161,13 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
 
                 timestamps = timestampsBuilder.build();
                 timestampsBuilder = blockFactory.newLongVectorBuilder(Math.min(remainingDocs, maxPageSize));
-                if (rounding != null) {
-                    intervals = intervalsBuilder.build();
-                    intervalsBuilder = blockFactory.newLongVectorBuilder(Math.min(remainingDocs, maxPageSize));
-                } else {
-                    intervals = blockFactory.newConstantLongVector(0, timestamps.getPositionCount());
-                }
                 tsids = tsHashesBuilder.build();
                 tsHashesBuilder = blockFactory.newBytesRefVectorBuilder(Math.min(remainingDocs, maxPageSize));
                 page = new Page(
                     currentPagePos,
                     new DocVector(shard.asVector(), leaf, docs, leaf.isConstant()).asBlock(),
                     tsids.asBlock(),
-                    timestamps.asBlock(),
-                    intervals.asBlock()
+                    timestamps.asBlock()
                 );
 
                 currentPagePos = 0;
@@ -225,7 +178,7 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
                 throw new UncheckedIOException(e);
             } finally {
                 if (page == null) {
-                    Releasables.closeExpectNoException(shard, leaf, docs, timestamps, tsids, intervals);
+                    Releasables.closeExpectNoException(shard, leaf, docs, timestamps, tsids);
                 }
             }
             return page;
@@ -233,7 +186,7 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
 
         @Override
         public void close() {
-            Releasables.closeExpectNoException(docsBuilder, segmentsBuilder, timestampsBuilder, intervalsBuilder, tsHashesBuilder);
+            Releasables.closeExpectNoException(docsBuilder, segmentsBuilder, timestampsBuilder, tsHashesBuilder);
         }
 
         class TimeSeriesIterator {
@@ -289,9 +242,6 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
                         segmentsBuilder.appendInt(leaf.segmentOrd);
                         docsBuilder.appendInt(leaf.iterator.docID());
                         timestampsBuilder.appendLong(leaf.timestamp);
-                        if (rounding != null) {
-                            intervalsBuilder.appendLong(rounding.round(leaf.timestamp));
-                        }
                         tsHashesBuilder.appendBytesRef(currentTsid);
                         final Leaf newTop;
                         if (leaf.nextDoc()) {
@@ -318,9 +268,6 @@ public class TimeSeriesSortedSourceOperatorFactory extends LuceneOperator.Factor
                     while (leaf.nextDoc()) {
                         tsHashesBuilder.appendBytesRef(leaf.timeSeriesHash);
                         timestampsBuilder.appendLong(leaf.timestamp);
-                        if (rounding != null) {
-                            intervalsBuilder.appendLong(rounding.round(leaf.timestamp));
-                        }
                         // Don't append segment ord, because there is only one segment.
                         docsBuilder.appendInt(leaf.iterator.docID());
                         currentPagePos++;

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/lucene/TimeSeriesSortedSourceOperatorTests.java
@@ -41,7 +41,6 @@ import org.elasticsearch.compute.operator.OperatorTestCase;
 import org.elasticsearch.compute.operator.TestResultPageSinkOperator;
 import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.IOUtils;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.mapper.DataStreamTimestampFieldMapper;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.KeywordFieldMapper;
@@ -85,12 +84,12 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         // for now we emit at most one time series each page
         int offset = 0;
         for (Page page : results) {
-            assertThat(page.getBlockCount(), equalTo(6));
+            assertThat(page.getBlockCount(), equalTo(5));
             DocVector docVector = (DocVector) page.getBlock(0).asVector();
             BytesRefVector tsidVector = (BytesRefVector) page.getBlock(1).asVector();
             LongVector timestampVector = (LongVector) page.getBlock(2).asVector();
-            LongVector voltageVector = (LongVector) page.getBlock(4).asVector();
-            BytesRefVector hostnameVector = (BytesRefVector) page.getBlock(5).asVector();
+            LongVector voltageVector = (LongVector) page.getBlock(3).asVector();
+            BytesRefVector hostnameVector = (BytesRefVector) page.getBlock(4).asVector();
             for (int i = 0; i < page.getPositionCount(); i++) {
                 int expectedTsidOrd = offset / numSamplesPerTS;
                 String expectedHostname = String.format(Locale.ROOT, "host-%02d", expectedTsidOrd);
@@ -115,7 +114,7 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         List<Page> results = runDriver(limit, randomIntBetween(1, 1024), randomBoolean(), numTimeSeries, numSamplesPerTS, timestampStart);
         assertThat(results, hasSize(1));
         Page page = results.get(0);
-        assertThat(page.getBlockCount(), equalTo(6));
+        assertThat(page.getBlockCount(), equalTo(5));
 
         DocVector docVector = (DocVector) page.getBlock(0).asVector();
         assertThat(docVector.getPositionCount(), equalTo(limit));
@@ -126,10 +125,10 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         LongVector timestampVector = (LongVector) page.getBlock(2).asVector();
         assertThat(timestampVector.getPositionCount(), equalTo(limit));
 
-        LongVector voltageVector = (LongVector) page.getBlock(4).asVector();
+        LongVector voltageVector = (LongVector) page.getBlock(3).asVector();
         assertThat(voltageVector.getPositionCount(), equalTo(limit));
 
-        BytesRefVector hostnameVector = (BytesRefVector) page.getBlock(5).asVector();
+        BytesRefVector hostnameVector = (BytesRefVector) page.getBlock(4).asVector();
         assertThat(hostnameVector.getPositionCount(), equalTo(limit));
 
         assertThat(docVector.shards().getInt(0), equalTo(0));
@@ -161,7 +160,6 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
             limit,
             maxPageSize,
             randomBoolean(),
-            TimeValue.ZERO,
             writer -> {
                 Randomness.shuffle(docs);
                 for (Doc doc : docs) {
@@ -194,11 +192,11 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
                 assertThat(page.getPositionCount(), lessThanOrEqualTo(limit));
                 assertThat(page.getPositionCount(), lessThanOrEqualTo(maxPageSize));
             }
-            assertThat(page.getBlockCount(), equalTo(5));
+            assertThat(page.getBlockCount(), equalTo(4));
             DocVector docVector = (DocVector) page.getBlock(0).asVector();
             BytesRefVector tsidVector = (BytesRefVector) page.getBlock(1).asVector();
             LongVector timestampVector = (LongVector) page.getBlock(2).asVector();
-            LongVector metricVector = (LongVector) page.getBlock(4).asVector();
+            LongVector metricVector = (LongVector) page.getBlock(3).asVector();
             for (int i = 0; i < page.getPositionCount(); i++) {
                 Doc doc = docs.get(offset);
                 offset++;
@@ -242,7 +240,6 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
                     Integer.MAX_VALUE,
                     randomIntBetween(1, 1024),
                     1,
-                    TimeValue.ZERO,
                     List.of(ctx),
                     unused -> query
                 );
@@ -264,7 +261,7 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
 
     @Override
     protected Operator.OperatorFactory simple() {
-        return createTimeSeriesSourceOperator(directory, r -> this.reader = r, 1, 1, false, TimeValue.ZERO, writer -> {
+        return createTimeSeriesSourceOperator(directory, r -> this.reader = r, 1, 1, false, writer -> {
             long timestamp = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parseMillis("2024-01-01T00:00:00Z");
             writeTS(writer, timestamp, new Object[] { "hostname", "host-01" }, new Object[] { "voltage", 2 });
             return 1;
@@ -289,7 +286,6 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
             limit,
             maxPageSize,
             forceMerge,
-            TimeValue.ZERO,
             writer -> {
                 long timestamp = timestampStart;
                 for (int i = 0; i < numSamplesPerTS; i++) {
@@ -333,7 +329,6 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         int limit,
         int maxPageSize,
         boolean forceMerge,
-        TimeValue timeValue,
         CheckedFunction<RandomIndexWriter, Integer, IOException> indexingLogic
     ) {
         Sort sort = new Sort(
@@ -361,7 +356,7 @@ public class TimeSeriesSortedSourceOperatorTests extends AnyOperatorTestCase {
         }
         var ctx = new LuceneSourceOperatorTests.MockShardContext(reader, 0);
         Function<ShardContext, Query> queryFunction = c -> new MatchAllDocsQuery();
-        return TimeSeriesSortedSourceOperatorFactory.create(limit, maxPageSize, 1, timeValue, List.of(ctx), queryFunction);
+        return TimeSeriesSortedSourceOperatorFactory.create(limit, maxPageSize, 1, List.of(ctx), queryFunction);
     }
 
     public static void writeTS(RandomIndexWriter iw, long timestamp, Object[] dimensions, Object[] metrics) throws IOException {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EsQueryExec.java
@@ -31,7 +31,6 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
     static final EsField DOC_ID_FIELD = new EsField("_doc", DataType.DOC_DATA_TYPE, Map.of(), false);
     static final EsField TSID_FIELD = new EsField("_tsid", DataType.TSID_DATA_TYPE, Map.of(), true);
     static final EsField TIMESTAMP_FIELD = new EsField("@timestamp", DataType.DATETIME, Map.of(), true);
-    static final EsField INTERVAL_FIELD = new EsField("@timestamp_interval", DataType.DATETIME, Map.of(), true);
 
     private final EsIndex index;
     private final IndexMode indexMode;
@@ -86,8 +85,7 @@ public class EsQueryExec extends LeafExec implements EstimatesRowSize {
             case TIME_SERIES -> List.of(
                 new FieldAttribute(source, DOC_ID_FIELD.getName(), DOC_ID_FIELD),
                 new FieldAttribute(source, TSID_FIELD.getName(), TSID_FIELD),
-                new FieldAttribute(source, TIMESTAMP_FIELD.getName(), TIMESTAMP_FIELD),
-                new FieldAttribute(source, INTERVAL_FIELD.getName(), INTERVAL_FIELD)
+                new FieldAttribute(source, TIMESTAMP_FIELD.getName(), TIMESTAMP_FIELD)
             );
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -32,7 +32,6 @@ import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.compute.operator.Operator;
 import org.elasticsearch.compute.operator.OrdinalsGroupingOperator;
 import org.elasticsearch.compute.operator.SourceOperator;
-import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.BlockLoader;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
@@ -184,7 +183,6 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
                     limit,
                     context.pageSize(rowEstimatedSize),
                     context.queryPragmas().taskConcurrency(),
-                    TimeValue.ZERO,
                     shardContexts,
                     querySupplier(esQueryExec.query())
                 );


### PR DESCRIPTION
This change removes the time_bucket from the time-series source operator. This should simplify the planner. Running a separate date trunc eval specified by bucket should yield the same output and performance.

Spin-off from #109979