### PR TITLE
Reformat function descriptions for spatial search

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContains.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContains.java
@@ -118,20 +118,14 @@ public class SpatialContains extends SpatialRelatesFunction {
     )
     public SpatialContains(
         Source source,
-        @Param(
-            name = "geomA",
-            type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" },
-            description = "Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`. "
-                + "If `null`, the function returns `null`."
-        ) Expression left,
-        @Param(
-            name = "geomB",
-            type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" },
-            description = "Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`. "
-                + "If `null`, the function returns `null`.\n"
-                + "The second parameter must also have the same coordinate system as the first.\n"
-                + "This means it is not possible to combine `geo_*` and `cartesian_*` parameters."
-        ) Expression right
+        @Param(name = "geomA", type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" }, description = """
+            Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`.
+            If `null`, the function returns `null`.""") Expression left,
+        @Param(name = "geomB", type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" }, description = """
+            Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`.
+            If `null`, the function returns `null`.
+            The second parameter must also have the same coordinate system as the first.
+            This means it is not possible to combine `geo_*` and `cartesian_*` parameters.""") Expression right
     ) {
         this(source, left, right, false, false);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjoint.java
@@ -73,20 +73,14 @@ public class SpatialDisjoint extends SpatialRelatesFunction {
     )
     public SpatialDisjoint(
         Source source,
-        @Param(
-            name = "geomA",
-            type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" },
-            description = "Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`. "
-                + "If `null`, the function returns `null`."
-        ) Expression left,
-        @Param(
-            name = "geomB",
-            type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" },
-            description = "Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`. "
-                + "If `null`, the function returns `null`.\n"
-                + "The second parameter must also have the same coordinate system as the first.\n"
-                + "This means it is not possible to combine `geo_*` and `cartesian_*` parameters."
-        ) Expression right
+        @Param(name = "geomA", type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" }, description = """
+            Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`.
+            If `null`, the function returns `null`.""") Expression left,
+        @Param(name = "geomB", type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" }, description = """
+            Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`.
+            If `null`, the function returns `null`.
+            The second parameter must also have the same coordinate system as the first.
+            This means it is not possible to combine `geo_*` and `cartesian_*` parameters.""") Expression right
     ) {
         this(source, left, right, false, false);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersects.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersects.java
@@ -71,20 +71,14 @@ public class SpatialIntersects extends SpatialRelatesFunction {
         In mathematical terms: ST_Intersects(A, B) ⇔ A ⋂ B ≠ ∅""", examples = @Example(file = "spatial", tag = "st_intersects-airports"))
     public SpatialIntersects(
         Source source,
-        @Param(
-            name = "geomA",
-            type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" },
-            description = "Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`. "
-                + "If `null`, the function returns `null`."
-        ) Expression left,
-        @Param(
-            name = "geomB",
-            type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" },
-            description = "Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`. "
-                + "If `null`, the function returns `null`.\n"
-                + "The second parameter must also have the same coordinate system as the first.\n"
-                + "This means it is not possible to combine `geo_*` and `cartesian_*` parameters."
-        ) Expression right
+        @Param(name = "geomA", type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" }, description = """
+            Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`.
+            If `null`, the function returns `null`.""") Expression left,
+        @Param(name = "geomB", type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" }, description = """
+            Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`.
+            If `null`, the function returns `null`.
+            The second parameter must also have the same coordinate system as the first.
+            This means it is not possible to combine `geo_*` and `cartesian_*` parameters.""") Expression right
     ) {
         this(source, left, right, false, false);
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithin.java
@@ -73,20 +73,14 @@ public class SpatialWithin extends SpatialRelatesFunction implements SurrogateEx
     )
     public SpatialWithin(
         Source source,
-        @Param(
-            name = "geomA",
-            type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" },
-            description = "Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`. "
-                + "If `null`, the function returns `null`."
-        ) Expression left,
-        @Param(
-            name = "geomB",
-            type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" },
-            description = "Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`. "
-                + "If `null`, the function returns `null`.\n"
-                + "The second parameter must also have the same coordinate system as the first.\n"
-                + "This means it is not possible to combine `geo_*` and `cartesian_*` parameters."
-        ) Expression right
+        @Param(name = "geomA", type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" }, description = """
+            Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`.
+            If `null`, the function returns `null`.""") Expression left,
+        @Param(name = "geomB", type = { "geo_point", "cartesian_point", "geo_shape", "cartesian_shape" }, description = """
+            Expression of type `geo_point`, `cartesian_point`, `geo_shape` or `cartesian_shape`.
+            If `null`, the function returns `null`.
+            The second parameter must also have the same coordinate system as the first.
+            This means it is not possible to combine `geo_*` and `cartesian_*` parameters.""") Expression right
     ) {
         this(source, left, right, false, false);
     }


### PR DESCRIPTION
We use the triple-quote because it looks nicer.
This was motivated by observing other functions moving to use triple-quotes