### PR TITLE
Improve error message when resource leaks are detected in test clusters

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/ElasticsearchNode.java
@@ -1139,7 +1139,7 @@ public class ElasticsearchNode implements TestClusterConfiguration {
             }
         }
         if (foundLeaks) {
-            throw new TestClustersException("Found resource leaks in node logs.");
+            throw new TestClustersException("Found resource leaks in node log: " + from);
         }
     }
 


### PR DESCRIPTION
We throw an error when we detect resource leaks in cluster logs but we don't provide any indication of which cluster, or which log. This change logs the path to the log file in question so you can investigate.