### PR TITLE
Mark Query Rules as GA

### DIFF
--- a/docs/changelog/110004.yaml
+++ b/docs/changelog/110004.yaml
@@ -1,0 +1,11 @@
+pr: 110004
+summary: Mark Query Rules as GA
+area: Relevance
+type: feature
+issues: []
+highlight:
+  title: Mark Query Rules as GA
+  body: |-
+    This PR marks query rules as Generally Available. All APIs are no longer
+    in tech preview.
+  notable: true

--- a/docs/reference/query-dsl/rule-query.asciidoc
+++ b/docs/reference/query-dsl/rule-query.asciidoc
@@ -6,8 +6,6 @@
 <titleabbrev>Rule</titleabbrev>
 ++++
 
-preview::[]
-
 [WARNING]
 ====
 `rule_query` was renamed to `rule` in 8.15.0.

--- a/docs/reference/query-rules/apis/delete-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/delete-query-ruleset.asciidoc
@@ -2,8 +2,6 @@
 [[delete-query-ruleset]]
 === Delete query ruleset
 
-preview::[]
-
 ++++
 <titleabbrev>Delete query ruleset</titleabbrev>
 ++++

--- a/docs/reference/query-rules/apis/get-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/get-query-ruleset.asciidoc
@@ -2,8 +2,6 @@
 [[get-query-ruleset]]
 === Get query ruleset
 
-preview::[]
-
 ++++
 <titleabbrev>Get query ruleset</titleabbrev>
 ++++

--- a/docs/reference/query-rules/apis/index.asciidoc
+++ b/docs/reference/query-rules/apis/index.asciidoc
@@ -1,8 +1,6 @@
 [[query-rules-apis]]
 == Query rules APIs
 
-preview::[]
-
 ++++
 <titleabbrev>Query rules APIs</titleabbrev>
 ++++
@@ -27,4 +25,3 @@ include::put-query-ruleset.asciidoc[]
 include::get-query-ruleset.asciidoc[]
 include::list-query-rulesets.asciidoc[]
 include::delete-query-ruleset.asciidoc[]
-

--- a/docs/reference/query-rules/apis/list-query-rulesets.asciidoc
+++ b/docs/reference/query-rules/apis/list-query-rulesets.asciidoc
@@ -2,8 +2,6 @@
 [[list-query-rulesets]]
 === List query rulesets
 
-preview::[]
-
 ++++
 <titleabbrev>List query rulesets</titleabbrev>
 ++++

--- a/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
+++ b/docs/reference/query-rules/apis/put-query-ruleset.asciidoc
@@ -2,8 +2,6 @@
 [[put-query-ruleset]]
 === Create or update query ruleset
 
-preview::[]
-
 ++++
 <titleabbrev>Create or update query ruleset</titleabbrev>
 ++++

--- a/docs/reference/search/search-your-data/search-using-query-rules.asciidoc
+++ b/docs/reference/search/search-your-data/search-using-query-rules.asciidoc
@@ -6,8 +6,6 @@
 ++++
 
 [[query-rules]]
-preview::[]
-
 _Query rules_ allow customization of search results for queries that match specified criteria metadata.
 This allows for more control over results, for example ensuring that promoted documents that match defined criteria are returned at the top of the result list.
 Metadata is defined in the query rule, and is matched against the query criteria.

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rule.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rule.delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-rule.html",
       "description": "Deletes an individual query rule within a ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rule.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rule.get.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-rule.html",
       "description": "Returns the details about an individual query rule within a ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rule.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rule.put.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-rule.html",
       "description": "Creates or updates a query rule within a ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-query-ruleset.html",
       "description": "Deletes a query ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.get.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-query-ruleset.html",
       "description": "Returns the details about a query ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.list.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-query-rulesets.html",
       "description": "Lists query rulesets."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.put.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-query-ruleset.html",
       "description": "Creates or updates a query ruleset."
     },
-    "stability": "experimental",
+    "stability": "stable",
     "visibility": "public",
     "headers": {
       "accept": [


### PR DESCRIPTION
This PR marks query rules as Generally Available. All APIs are no longer in tech preview. 