### PR TITLE
Permit extended plugins to share code

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
+++ b/server/src/main/java/org/elasticsearch/plugins/PluginsUtils.java
@@ -313,21 +313,12 @@ public class PluginsUtils {
                 Set<URL> pluginUrls = transitiveUrls.get(extendedPlugin);
                 assert pluginUrls != null : "transitive urls should have already been set for " + extendedPlugin;
 
-                // consistency check: extended plugins should not have duplicate codebases with each other
-                Set<URL> intersection = new HashSet<>(extendedPluginUrls);
-                intersection.retainAll(pluginUrls);
-                if (intersection.isEmpty() == false) {
-                    throw new IllegalStateException(
-                        "jar hell! extended plugins " + exts + " have duplicate codebases with each other: " + intersection
-                    );
-                }
-
                 // jar hell check: extended plugins (so far) do not have jar hell with each other
                 extendedPluginUrls.addAll(pluginUrls);
                 JarHell.checkJarHell(extendedPluginUrls, logger::debug);
 
                 // consistency check: each extended plugin should not have duplicate codebases with implementation+spi of this plugin
-                intersection = new HashSet<>(bundle.allUrls);
+                Set<URL> intersection = new HashSet<>(bundle.allUrls);
                 intersection.retainAll(pluginUrls);
                 if (intersection.isEmpty() == false) {
                     throw new IllegalStateException(

--- a/server/src/test/java/org/elasticsearch/plugins/PluginsUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginsUtilsTests.java
@@ -227,13 +227,9 @@ public class PluginsUtilsTests extends ESTestCase {
         transitiveDeps.put("dep2", Collections.singleton(dupJar.toUri().toURL()));
         PluginDescriptor info1 = newTestDescriptor("myplugin", List.of("dep1", "dep2"));
         PluginBundle bundle = new PluginBundle(info1, pluginDir);
-        IllegalStateException e = expectThrows(
-            IllegalStateException.class,
-            () -> PluginsUtils.checkBundleJarHell(JarHell.parseModulesAndClassPath(), bundle, transitiveDeps)
-        );
-        assertEquals("failed to load plugin myplugin due to jar hell", e.getMessage());
-        assertThat(e.getCause().getMessage(), containsString("jar hell!"));
-        assertThat(e.getCause().getMessage(), containsString("duplicate codebases"));
+        PluginsUtils.checkBundleJarHell(JarHell.parseModulesAndClassPath(), bundle, transitiveDeps);
+        Set<URL> transitive = transitiveDeps.get("myplugin");
+        assertThat(transitive, containsInAnyOrder(pluginJar.toUri().toURL(), dupJar.toUri().toURL()));
     }
 
     // Note: testing dup codebase with core is difficult because it requires a symlink, but we have mock filesystems and security manager


### PR DESCRIPTION
This allows the situation where a plugin A extends plugins B and C, and also B extends C. There's no actual trouble here, because there's only going to be one of each class in use at runtime, but we're currently forbidding it.