### PR TITLE
Add a programmer friendly code to Persistent Task Assignments (#53711)

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -212,6 +212,7 @@ public class TransportVersions {
     public static final TransportVersion ML_INFERENCE_DONT_DELETE_WHEN_SEMANTIC_TEXT_EXISTS = def(8_703_00_0);
     public static final TransportVersion INFERENCE_ADAPTIVE_ALLOCATIONS = def(8_704_00_0);
     public static final TransportVersion INDEX_REQUEST_UPDATE_BY_SCRIPT_ORIGIN = def(8_705_00_0);
+    public static final TransportVersion PERSISTENT_TASK_CUSTOM_METADATA_ASSIGNMENT_REASON_ENUM = def(8_706_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,
@@ -276,7 +277,7 @@ public class TransportVersions {
      * Reference to the minimum transport version that can be used with CCS.
      * This should be the transport version used by the previous minor release.
      */
-    public static final TransportVersion MINIMUM_CCS_VERSION = SHUTDOWN_REQUEST_TIMEOUTS_FIX_8_14;
+    public static final TransportVersion MINIMUM_CCS_VERSION = V_8_13_0;
 
     static final NavigableMap<Integer, TransportVersion> VERSION_IDS = getAllVersionIds(TransportVersions.class);
 

--- a/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/health/node/selection/HealthNodeTaskExecutor.java
@@ -150,7 +150,10 @@ public final class HealthNodeTaskExecutor extends PersistentTasksExecutor<Health
         if (discoveryNode == null) {
             return NO_NODE_FOUND;
         } else {
-            return new PersistentTasksCustomMetadata.Assignment(discoveryNode.getId(), "");
+            return new PersistentTasksCustomMetadata.Assignment(
+                discoveryNode.getId(),
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/persistent/CompletionPersistentTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/CompletionPersistentTaskAction.java
@@ -7,6 +7,8 @@
  */
 package org.elasticsearch.persistent;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
@@ -36,6 +38,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
  */
 public class CompletionPersistentTaskAction extends ActionType<PersistentTaskResponse> {
 
+    private static final Logger logger = LogManager.getLogger(CompletionPersistentTaskAction.class);
     public static final CompletionPersistentTaskAction INSTANCE = new CompletionPersistentTaskAction();
     public static final String NAME = "cluster:admin/persistent/completion";
 
@@ -157,9 +160,11 @@ public class CompletionPersistentTaskAction extends ActionType<PersistentTaskRes
             if (request.localAbortReason != null) {
                 assert request.exception == null
                     : "request has both exception " + request.exception + " and local abort reason " + request.localAbortReason;
+                logger.info("Persistent task unassigned due to local abort reason: [{}]", request.localAbortReason);
                 persistentTasksClusterService.unassignPersistentTask(
                     request.taskId,
                     request.allocationId,
+                    PersistentTasksCustomMetadata.Explanation.ABORTED_LOCALLY,
                     request.localAbortReason,
                     listener.map(PersistentTaskResponse::new)
                 );

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.io.stream.VersionedNamedWriteable;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ObjectParser.NamedObjectParser;
@@ -33,10 +34,12 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +50,9 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.Metadata.ALL_CONTEXTS;
+import static org.elasticsearch.persistent.PersistentTasksCustomMetadata.Explanation.GENERIC_REASON;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
+import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstructorArg;
 
 /**
  * A cluster state record that contains a list of all running persistent tasks
@@ -56,7 +61,11 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
 
     public static final String TYPE = "persistent_tasks";
     private static final String API_CONTEXT = Metadata.XContentContext.API.toString();
-    static final Assignment LOST_NODE_ASSIGNMENT = new Assignment(null, "awaiting reassignment after node loss");
+    static final Assignment LOST_NODE_ASSIGNMENT = new Assignment(
+        null,
+        "awaiting reassignment after node loss",
+        Explanation.AWAITING_REASSIGNMENT
+    );
 
     // TODO: Implement custom Diff for tasks
     private final Map<String, PersistentTask<?>> tasks;
@@ -74,9 +83,14 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
         TaskBuilder::new
     );
 
+    @SuppressWarnings("unchecked")
     public static final ConstructingObjectParser<Assignment, Void> ASSIGNMENT_PARSER = new ConstructingObjectParser<>(
         "assignment",
-        objects -> new Assignment((String) objects[0], (String) objects[1])
+        a -> new Assignment(
+            (String) a[0],
+            (String) a[1],
+            a[2] == null ? new String[] { GENERIC_REASON.name() } : ((List<String>) a[2]).toArray(String[]::new)
+        )
     );
 
     private static final NamedObjectParser<TaskDescriptionBuilder<PersistentTaskParams>, Void> TASK_DESCRIPTION_PARSER;
@@ -103,6 +117,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
         // Assignment parser
         ASSIGNMENT_PARSER.declareStringOrNull(constructorArg(), new ParseField("executor_node"));
         ASSIGNMENT_PARSER.declareStringOrNull(constructorArg(), new ParseField("explanation"));
+        ASSIGNMENT_PARSER.declareStringArray(optionalConstructorArg(), new ParseField("explanation_codes"));
 
         // Task parser initialization
         PERSISTENT_TASK_PARSER.declareString(TaskBuilder::setId, new ParseField("id"));
@@ -131,6 +146,151 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
 
     public static PersistentTasksCustomMetadata getPersistentTasksCustomMetadata(ClusterState clusterState) {
         return clusterState.getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
+    }
+
+    /**
+     * Explanation why the persistent task has the current assignment.
+     * <p>
+     * More details can be found in the {@code Assignment.explanationDetails}.
+     * Callers might need to interpret an assignment failure to e.g. return a HTTP status code.
+     * A string is hard to interpret and therefore this an {@code Explanation} enum is provided.
+     */
+    public enum Explanation {
+        /**
+         * Persistent task assignment to this node was successful.
+         */
+        ASSIGNMENT_SUCCESSFUL,
+
+        /**
+         * Persistent task is waiting for initial assignment. This is the default when creating a new task.
+         */
+        WAITING_FOR_INITIAL_ASSIGNMENT,
+
+        /**
+         * Persistent task is awaiting reassignment after node loss.
+         */
+        AWAITING_REASSIGNMENT,
+
+        /**
+         * Persistent task assignments are not allowed due to cluster settings.
+         */
+        ASSIGNMENTS_NOT_ALLOWED,
+
+        /**
+         * Persistent task could not find appropriate nodes.
+         */
+        NO_NODES_FOUND,
+
+        /**
+         * Persistent task assignment successful but source index was removed. Task will fail during node operation.
+         */
+        SOURCE_INDEX_REMOVED,
+
+        /**
+         * Persistent task cannot be assigned during an upgrade.
+         */
+        AWAITING_UPGRADE,
+
+        /**
+         * Persistent task cannot be assigned during a feature reset.
+         */
+        FEATURE_RESET_IN_PROGRESS,
+
+        /**
+         * Persistent task was aborted locally.
+         */
+        ABORTED_LOCALLY,
+
+        /**
+         * Persistent datafeed job task state is not OPENING or OPENED.
+         */
+        DATAFEED_JOB_STATE_NOT_OPEN,
+
+        /**
+         * Persistent datafeed job task is stale.
+         */
+        DATAFEED_JOB_STALE,
+
+        /**
+         * Persistent datafeed job task index not found.
+         */
+        DATAFEED_INDEX_NOT_FOUND,
+
+        /**
+         * Persistent datafeed job task cannot start because resolving the index threw an exception.
+         */
+        DATAFEED_RESOLVING_INDEX_THREW_EXCEPTION,
+
+        /**
+         * Persistent task cannot start because indices do not have all primary shards active yet.
+         */
+        PRIMARY_SHARDS_NOT_ACTIVE,
+
+        /**
+         * Persistent task is awaiting lazy node assignment.
+         */
+        AWAITING_LAZY_ASSIGNMENT,
+
+        /**
+         * Persistent task cannot be started because job memory requirements are stale.
+         */
+        MEMORY_REQUIREMENTS_STALE,
+
+        /**
+         * Persistent task requires a node with a higher config version.
+         */
+        CONFIG_VERSION_TOO_LOW,
+
+        /**
+         * Persistent task cannot be started on a node which is not compatible with jobs of this type.
+         */
+        NODE_NOT_COMPATIBLE,
+
+        /**
+         * Persistent task cannot be started because an error occurred while detecting the load for this node.
+         */
+        ERROR_DETECTING_LOAD,
+
+        /**
+         * Persistent task cannot be started on a node that exceeds the maximum number of jobs allowed in opening state.
+         */
+        MAX_CONCURRENT_EXECUTIONS_EXCEEDED,
+
+        /**
+         * Persistent task cannot be started on a node that is full.
+         */
+        NODE_FULL,
+
+        /**
+         * Persistent task cannot be started on a node that is not providing accurate information to determine its load by memory.
+         */
+        NODE_MEMORY_LOAD_UNKNOWN,
+
+        /**
+         * Persistent task cannot be started ona node that is indicating that it has no native memory for machine learning.
+         */
+        NO_NATIVE_MEMORY_FOR_ML,
+
+        /**
+         * Persistent task cannot be started on a node that has insufficient available memory.
+         */
+        INSUFFICIENT_MEMORY,
+
+        /**
+         * Persistent task is not waiting for node assignment as estimated job size is greater than the largest possible job size.
+         */
+        LARGEST_POSSIBLE_JOB_SIZE_EXCEEDED,
+
+        /**
+         * Persistent task requires a remote connection but the node does not have the remote_cluster_client role.
+         */
+        REMOTE_NOT_ENABLED,
+
+        /**
+         * Persistent task cannot not be assigned because of a generic reason.
+         * This is mostly used in testing and for backwards compatibility.
+         */
+        GENERIC_REASON,
     }
 
     /**
@@ -258,16 +418,40 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
         @Nullable
         private final String executorNode;
         private final String explanation;
+        private final Set<PersistentTasksCustomMetadata.Explanation> explanationCodes = new HashSet<>();
 
-        public Assignment(String executorNode, String explanation) {
+        public Assignment(String executorNode, PersistentTasksCustomMetadata.Explanation explanationCode) {
+            this(executorNode, "", explanationCode);
+        }
+
+        public Assignment(String executorNode, String explanation, PersistentTasksCustomMetadata.Explanation explanationCode) {
+            this(executorNode, explanation, Collections.singleton(explanationCode));
+        }
+
+        private Assignment(String executorNode, String explanation, String[] explanationCodes) {
+            this(executorNode, explanation, Arrays.stream(explanationCodes).map(Explanation::valueOf).collect(Collectors.toSet()));
+        }
+
+        public Assignment(String executorNode, String explanation, Set<PersistentTasksCustomMetadata.Explanation> explanationCodes) {
             this.executorNode = executorNode;
             assert explanation != null;
             this.explanation = explanation;
+            assert explanationCodes != null;
+            assert explanationCodes.isEmpty() == false;
+            this.explanationCodes.addAll(explanationCodes);
         }
 
         @Nullable
         public String getExecutorNode() {
             return executorNode;
+        }
+
+        public Set<PersistentTasksCustomMetadata.Explanation> getExplanationCodes() {
+            return explanationCodes;
+        }
+
+        public String getExplanationCodesAndExplanation() {
+            return String.join("|", explanationCodes.stream().map(Enum::name).toList()) + ", details: " + explanation;
         }
 
         public String getExplanation() {
@@ -279,12 +463,14 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Assignment that = (Assignment) o;
-            return Objects.equals(executorNode, that.executorNode) && Objects.equals(explanation, that.explanation);
+            return Objects.equals(executorNode, that.executorNode)
+                && Objects.equals(explanation, that.explanation)
+                && Objects.equals(explanationCodes, that.explanationCodes);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(executorNode, explanation);
+            return Objects.hash(executorNode, explanation, explanationCodes);
         }
 
         public boolean isAssigned() {
@@ -293,11 +479,22 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
 
         @Override
         public String toString() {
-            return "node: [" + executorNode + "], explanation: [" + explanation + "]";
+            return "node: ["
+                + executorNode
+                + "], explanation: ["
+                + explanation
+                + "], explanationCodes: ["
+                + String.join("|", explanationCodes.stream().map(Enum::name).toList())
+                + "]";
         }
+
     }
 
-    public static final Assignment INITIAL_ASSIGNMENT = new Assignment(null, "waiting for initial assignment");
+    public static final Assignment INITIAL_ASSIGNMENT = new Assignment(
+        null,
+        "waiting for initial assignment",
+        Explanation.WAITING_FOR_INITIAL_ASSIGNMENT
+    );
 
     /**
      * A record that represents a single running persistent task
@@ -363,7 +560,15 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             taskName = in.readString();
             params = (P) in.readNamedWriteable(PersistentTaskParams.class);
             state = in.readOptionalNamedWriteable(PersistentTaskState.class);
-            assignment = new Assignment(in.readOptionalString(), in.readString());
+            if (in.getTransportVersion().before(TransportVersions.PERSISTENT_TASK_CUSTOM_METADATA_ASSIGNMENT_REASON_ENUM)) {
+                assignment = new Assignment(in.readOptionalString(), in.readString(), GENERIC_REASON);
+            } else {
+                assignment = new Assignment(
+                    in.readOptionalString(),
+                    in.readString(),
+                    in.readCollectionAsSet(nested_in -> nested_in.readEnum(Explanation.class))
+                );
+            }
             allocationIdOnLastStatusUpdate = in.readOptionalLong();
         }
 
@@ -376,6 +581,9 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             out.writeOptionalNamedWriteable(state);
             out.writeOptionalString(assignment.executorNode);
             out.writeString(assignment.explanation);
+            if (out.getTransportVersion().onOrAfter(TransportVersions.PERSISTENT_TASK_CUSTOM_METADATA_ASSIGNMENT_REASON_ENUM)) {
+                out.writeCollection(assignment.explanationCodes, StreamOutput::writeEnum);
+            }
             out.writeOptionalLong(allocationIdOnLastStatusUpdate);
         }
 
@@ -464,7 +672,12 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
                     builder.startObject("assignment");
                     {
                         builder.field("executor_node", assignment.executorNode);
-                        builder.field("explanation", assignment.explanation);
+                        if (builder.getRestApiVersion() == RestApiVersion.V_7) {
+                            builder.field("explanation", assignment.explanation);
+                        } else {
+                            builder.stringListField("explanation_codes", assignment.explanationCodes.stream().map(Enum::name).toList());
+                            builder.field("explanation", assignment.explanation == null ? "" : assignment.explanation);
+                        }
                     }
                     builder.endObject();
                     if (allocationIdOnLastStatusUpdate != null) {

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksExecutor.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksExecutor.java
@@ -38,7 +38,11 @@ public abstract class PersistentTasksExecutor<Params extends PersistentTaskParam
         return taskName;
     }
 
-    public static final Assignment NO_NODE_FOUND = new Assignment(null, "no appropriate nodes found for the assignment");
+    public static final Assignment NO_NODE_FOUND = new Assignment(
+        null,
+        "no appropriate nodes found for the assignment",
+        PersistentTasksCustomMetadata.Explanation.NO_NODES_FOUND
+    );
 
     /**
      * Returns the node id where the params has to be executed,
@@ -50,7 +54,7 @@ public abstract class PersistentTasksExecutor<Params extends PersistentTaskParam
         if (discoveryNode == null) {
             return NO_NODE_FOUND;
         } else {
-            return new Assignment(discoveryNode.getId(), "");
+            return new Assignment(discoveryNode.getId(), PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/persistent/decider/AssignmentDecision.java
+++ b/server/src/main/java/org/elasticsearch/persistent/decider/AssignmentDecision.java
@@ -18,12 +18,12 @@ import java.util.Objects;
  */
 public final class AssignmentDecision {
 
-    public static final AssignmentDecision YES = new AssignmentDecision(Type.YES, "");
+    public static final AssignmentDecision YES = new AssignmentDecision(Type.YES, Reason.NO_REASON);
 
     private final Type type;
-    private final String reason;
+    private final Reason reason;
 
-    public AssignmentDecision(final Type type, final String reason) {
+    public AssignmentDecision(final Type type, final Reason reason) {
         this.type = Objects.requireNonNull(type);
         this.reason = Objects.requireNonNull(reason);
     }
@@ -32,7 +32,7 @@ public final class AssignmentDecision {
         return type;
     }
 
-    public String getReason() {
+    public Reason getReason() {
         return reason;
     }
 
@@ -58,5 +58,10 @@ public final class AssignmentDecision {
         public static Type resolve(final String s) {
             return Type.valueOf(s.toUpperCase(Locale.ROOT));
         }
+    }
+
+    public enum Reason {
+        NO_REASON,
+        PERSISTENT_TASK_ASSIGNMENTS_NOT_ALLOWED
     }
 }

--- a/server/src/main/java/org/elasticsearch/persistent/decider/EnableAssignmentDecider.java
+++ b/server/src/main/java/org/elasticsearch/persistent/decider/EnableAssignmentDecider.java
@@ -15,6 +15,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.common.settings.Setting.Property.Dynamic;
 import static org.elasticsearch.common.settings.Setting.Property.NodeScope;
+import static org.elasticsearch.persistent.decider.AssignmentDecision.Reason.PERSISTENT_TASK_ASSIGNMENTS_NOT_ALLOWED;
 
 /**
  * {@link EnableAssignmentDecider} is used to allow/disallow the persistent tasks
@@ -37,7 +38,6 @@ public final class EnableAssignmentDecider {
         Dynamic,
         NodeScope
     );
-    public static final String ALLOCATION_NONE_EXPLANATION = "no persistent task assignments are allowed due to cluster settings";
 
     private volatile Allocation enableAssignment;
 
@@ -59,7 +59,7 @@ public final class EnableAssignmentDecider {
      */
     public AssignmentDecision canAssign() {
         if (enableAssignment == Allocation.NONE) {
-            return new AssignmentDecision(AssignmentDecision.Type.NO, ALLOCATION_NONE_EXPLANATION);
+            return new AssignmentDecision(AssignmentDecision.Type.NO, PERSISTENT_TASK_ASSIGNMENTS_NOT_ALLOWED);
         }
         return AssignmentDecision.YES;
     }

--- a/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationExecutor.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SystemIndexMigrationExecutor.java
@@ -106,7 +106,10 @@ public class SystemIndexMigrationExecutor extends PersistentTasksExecutor<System
         if (discoveryNode == null) {
             return NO_NODE_FOUND;
         } else {
-            return new PersistentTasksCustomMetadata.Assignment(discoveryNode.getId(), "");
+            return new PersistentTasksCustomMetadata.Assignment(
+                discoveryNode.getId(),
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            );
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
@@ -313,7 +313,11 @@ public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffabl
                 "task-id",
                 taskName,
                 emptyTaskParams(taskName),
-                new PersistentTasksCustomMetadata.Assignment("node1", "test assignment")
+                new PersistentTasksCustomMetadata.Assignment(
+                    "node1",
+                    "test assignment",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                )
             );
 
         ClusterState originalState = ClusterState.builder(new ClusterName("persistent-tasks-tests"))
@@ -341,13 +345,21 @@ public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffabl
                 "assigned-task",
                 taskName,
                 emptyTaskParams(taskName),
-                new PersistentTasksCustomMetadata.Assignment("node1", "test assignment")
+                new PersistentTasksCustomMetadata.Assignment(
+                    "node1",
+                    "test assignment",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                )
             )
             .addTask(
                 "task-on-deceased-node",
                 taskName,
                 emptyTaskParams(taskName),
-                new PersistentTasksCustomMetadata.Assignment("left-the-cluster", "test assignment")
+                new PersistentTasksCustomMetadata.Assignment(
+                    "left-the-cluster",
+                    "test assignment",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                )
             );
 
         ClusterState originalState = ClusterState.builder(new ClusterName("persistent-tasks-tests"))
@@ -396,9 +408,13 @@ public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffabl
             if (randomBoolean()) {
                 return NO_NODE_FOUND;
             } else {
-                return new Assignment(null, randomAlphaOfLength(10));
+                return new Assignment(null, randomAlphaOfLength(10), PersistentTasksCustomMetadata.Explanation.GENERIC_REASON);
             }
         }
-        return new Assignment(randomAlphaOfLength(10), randomAlphaOfLength(10));
+        return new Assignment(
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksDecidersTestCase.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksDecidersTestCase.java
@@ -95,7 +95,12 @@ public abstract class PersistentTasksDecidersTestCase extends ESTestCase {
 
         PersistentTasksCustomMetadata.Builder tasks = PersistentTasksCustomMetadata.builder();
         for (int i = 0; i < nbTasks; i++) {
-            tasks.addTask("_task_" + i, "test", null, new PersistentTasksCustomMetadata.Assignment(null, "initialized"));
+            tasks.addTask(
+                "_task_" + i,
+                "test",
+                null,
+                new PersistentTasksCustomMetadata.Assignment(null, "initialized", PersistentTasksCustomMetadata.Explanation.GENERIC_REASON)
+            );
         }
 
         Metadata metadata = Metadata.builder().putCustom(PersistentTasksCustomMetadata.TYPE, tasks.build()).build();

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
@@ -126,7 +126,11 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
                     UUIDs.base64UUID(),
                     TestPersistentTasksExecutor.NAME,
                     new TestParams("other_" + i),
-                    new Assignment("other_node_" + randomInt(nonLocalNodesCount), "test assignment on other node")
+                    new Assignment(
+                        "other_node_" + randomInt(nonLocalNodesCount),
+                        "test assignment on other node",
+                        PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                    )
                 );
                 if (added == false && randomBoolean()) {
                     added = true;
@@ -134,7 +138,11 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
                         UUIDs.base64UUID(),
                         TestPersistentTasksExecutor.NAME,
                         new TestParams("this_param"),
-                        new Assignment("this_node", "test assignment on this node")
+                        new Assignment(
+                            "this_node",
+                            "test assignment on this node",
+                            PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                        )
                     );
                 }
             }
@@ -238,7 +246,12 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
         PersistentTasksCustomMetadata.Builder tasks = PersistentTasksCustomMetadata.builder();
         String taskId = UUIDs.base64UUID();
         TestParams taskParams = new TestParams("other_0");
-        tasks.addTask(taskId, TestPersistentTasksExecutor.NAME, taskParams, new Assignment("this_node", "test assignment on other node"));
+        tasks.addTask(
+            taskId,
+            TestPersistentTasksExecutor.NAME,
+            taskParams,
+            new Assignment("this_node", "test assignment on other node", PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL)
+        );
         tasks.updateTaskState(taskId, taskState);
         Metadata.Builder metadata = Metadata.builder(state.metadata());
         metadata.putCustom(PersistentTasksCustomMetadata.TYPE, tasks.build());
@@ -517,7 +530,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
             UUIDs.base64UUID(),
             TestPersistentTasksExecutor.NAME,
             new TestParams("this_param"),
-            new Assignment("this_node", "test assignment on this node")
+            new Assignment("this_node", "test assignment on this node", PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL)
         );
 
         Metadata.Builder metadata = Metadata.builder(state.metadata());
@@ -541,7 +554,12 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
                 Metadata.builder(state.metadata())
                     .putCustom(
                         PersistentTasksCustomMetadata.TYPE,
-                        builder.addTask(UUIDs.base64UUID(), action, params, new Assignment(node, "test assignment")).build()
+                        builder.addTask(
+                            UUIDs.base64UUID(),
+                            action,
+                            params,
+                            new Assignment(node, "test assignment", PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL)
+                        ).build()
                     )
             )
             .build();
@@ -557,7 +575,10 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
                 Metadata.builder(state.metadata())
                     .putCustom(
                         PersistentTasksCustomMetadata.TYPE,
-                        builder.reassignTask(taskId, new Assignment(node, "test assignment")).build()
+                        builder.reassignTask(
+                            taskId,
+                            new Assignment(node, "test assignment", PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL)
+                        ).build()
                     )
             )
             .build();

--- a/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
+++ b/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
@@ -309,7 +309,11 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
         @Override
         public Assignment getAssignment(TestParams params, Collection<DiscoveryNode> candidateNodes, ClusterState clusterState) {
             if (nonClusterStateCondition == false) {
-                return new Assignment(null, "non cluster state condition prevents assignment");
+                return new Assignment(
+                    null,
+                    "non cluster state condition prevents assignment",
+                    PersistentTasksCustomMetadata.Explanation.GENERIC_REASON
+                );
             }
             if (params == null || params.getExecutorNodeAttr() == null) {
                 return super.getAssignment(params, candidateNodes, clusterState);
@@ -320,7 +324,11 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
                     discoveryNode -> params.getExecutorNodeAttr().equals(discoveryNode.getAttributes().get("test_attr"))
                 );
                 if (executorNode != null) {
-                    return new Assignment(executorNode.getId(), "test assignment");
+                    return new Assignment(
+                        executorNode.getId(),
+                        "test assignment",
+                        PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                    );
                 } else {
                     return NO_NODE_FOUND;
                 }

--- a/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -582,7 +582,8 @@ public class ClusterStateCreationUtils {
         PersistentTasksCustomMetadata.Builder tasks = PersistentTasksCustomMetadata.builder();
         PersistentTasksCustomMetadata.Assignment assignment = new PersistentTasksCustomMetadata.Assignment(
             healthNode.getId(),
-            randomAlphaOfLength(10)
+            randomAlphaOfLength(10),
+            PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
         );
         tasks.addTask(HealthNode.TASK_NAME, HealthNode.TASK_NAME, HealthNodeTaskParams.INSTANCE, assignment);
         return metadataBuilder.putCustom(PersistentTasksCustomMetadata.TYPE, tasks.build());

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutor.java
@@ -126,7 +126,11 @@ public final class ShardFollowTasksExecutor extends PersistentTasksExecutor<Shar
         }
     }
 
-    private static final Assignment NO_ASSIGNMENT = new Assignment(null, "no nodes found with data and remote cluster client roles");
+    private static final Assignment NO_ASSIGNMENT = new Assignment(
+        null,
+        "no nodes found with data and remote cluster client roles",
+        PersistentTasksCustomMetadata.Explanation.NO_NODES_FOUND
+    );
 
     @Override
     public Assignment getAssignment(
@@ -142,7 +146,11 @@ public final class ShardFollowTasksExecutor extends PersistentTasksExecutor<Shar
         if (node == null) {
             return NO_ASSIGNMENT;
         } else {
-            return new Assignment(node.getId(), "node is the least loaded data node and remote cluster client");
+            return new Assignment(
+                node.getId(),
+                "node is the least loaded data node and remote cluster client",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            );
         }
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutorAssignmentTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTasksExecutorAssignmentTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsModule;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -31,6 +32,8 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -60,7 +63,8 @@ public class ShardFollowTasksExecutorAssignmentTests extends ESTestCase {
     private void runNoAssignmentTest(final Set<DiscoveryNodeRole> roles) {
         runAssignmentTest(roles, 0, Set::of, (theSpecial, assignment) -> {
             assertFalse(assignment.isAssigned());
-            assertThat(assignment.getExplanation(), equalTo("no nodes found with data and remote cluster client roles"));
+            assertThat(assignment.getExplanation(), containsString("no nodes found with data and remote cluster client roles"));
+            assertThat(assignment.getExplanationCodes(), contains(PersistentTasksCustomMetadata.Explanation.NO_NODES_FOUND));
         });
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -57,11 +57,13 @@ public final class MlTasks {
 
     public static final PersistentTasksCustomMetadata.Assignment AWAITING_UPGRADE = new PersistentTasksCustomMetadata.Assignment(
         null,
-        "persistent task cannot be assigned while upgrade mode is enabled."
+        "persistent task cannot be assigned while upgrade mode is enabled.",
+        PersistentTasksCustomMetadata.Explanation.AWAITING_UPGRADE
     );
     public static final PersistentTasksCustomMetadata.Assignment RESET_IN_PROGRESS = new PersistentTasksCustomMetadata.Assignment(
         null,
-        "persistent task will not be assigned as a feature reset is in progress."
+        "persistent task will not be assigned as a feature reset is in progress.",
+        PersistentTasksCustomMetadata.Explanation.FEATURE_RESET_IN_PROGRESS
     );
 
     // When a master node action is executed and there is no master node the transport will wait

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedsStatsAction.java
@@ -378,7 +378,7 @@ public class GetDatafeedsStatsAction extends ActionType<GetDatafeedsStatsAction.
                     }
                     return statsBuilder.setNode(node)
                         .setDatafeedState(datafeedState)
-                        .setAssignmentExplanation(maybeTask != null ? maybeTask.getAssignment().getExplanation() : null)
+                        .setAssignmentExplanation(maybeTask != null ? maybeTask.getAssignment().getExplanationCodesAndExplanation() : null)
                         .setTimingStats(timingStats)
                         .setRunningState(datafeedRuntimeState.getRunningState(statsBuilder.datafeedId).orElse(null))
                         .build();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
@@ -47,7 +47,11 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("foo"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo"),
-            new PersistentTasksCustomMetadata.Assignment("bar", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "bar",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         assertEquals(JobState.OPENING, MlTasks.getJobState("foo", tasksBuilder.build()));
 
@@ -71,7 +75,11 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.datafeedTaskId("foo"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("foo", 0L),
-            new PersistentTasksCustomMetadata.Assignment("bar", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "bar",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         // A task with no state means the datafeed is starting
         assertEquals(DatafeedState.STARTING, MlTasks.getDatafeedState("foo", tasksBuilder.build()));
@@ -89,7 +97,11 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.snapshotUpgradeTaskId("foo", "1"),
             MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME,
             new SnapshotUpgradeTaskParams("foo", "1"),
-            new PersistentTasksCustomMetadata.Assignment("bar", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "bar",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         // A task with no state means the datafeed is starting
         assertEquals(SnapshotUpgradeState.LOADING_OLD_STATE, MlTasks.getSnapshotUpgradeState("foo", "1", tasksBuilder.build()));
@@ -109,7 +121,11 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("foo"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo"),
-            new PersistentTasksCustomMetadata.Assignment("bar", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "bar",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         assertNotNull(MlTasks.getJobTask("foo", tasksBuilder.build()));
@@ -124,7 +140,11 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.datafeedTaskId("foo"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("foo", 0L),
-            new PersistentTasksCustomMetadata.Assignment("bar", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "bar",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         assertNotNull(MlTasks.getDatafeedTask("foo", tasksBuilder.build()));
@@ -139,19 +159,31 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("foo-1"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-1"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.jobTaskId("bar"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("bar"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("df"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("df", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         assertThat(MlTasks.openJobIds(tasksBuilder.build()), containsInAnyOrder("foo-1", "bar"));
@@ -169,19 +201,31 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("job-1"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-1"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("df1"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("df1", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("df2"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("df2", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         assertThat(MlTasks.startedDatafeedIds(tasksBuilder.build()), containsInAnyOrder("df1", "df2"));
@@ -197,19 +241,31 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("job_with_assignment"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("job_with_assignment"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.jobTaskId("job_without_assignment"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("job_without_assignment"),
-            new PersistentTasksCustomMetadata.Assignment(null, "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                null,
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.jobTaskId("job_without_node"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("job_without_node"),
-            new PersistentTasksCustomMetadata.Assignment("dead-node", "expired node")
+            new PersistentTasksCustomMetadata.Assignment(
+                "dead-node",
+                "expired node",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         DiscoveryNodes nodes = DiscoveryNodes.builder()
@@ -227,19 +283,31 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.datafeedTaskId("datafeed_with_assignment"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("datafeed_with_assignment", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("datafeed_without_assignment"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("datafeed_without_assignment", 0L),
-            new PersistentTasksCustomMetadata.Assignment(null, "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                null,
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("datafeed_without_node"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("datafeed_without_node", 0L),
-            new PersistentTasksCustomMetadata.Assignment("dead_node", "expired node")
+            new PersistentTasksCustomMetadata.Assignment(
+                "dead_node",
+                "expired node",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         DiscoveryNodes nodes = DiscoveryNodes.builder()
@@ -262,19 +330,31 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.datafeedTaskId("df1"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("df1", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.jobTaskId("job-2"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-2"),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("df2"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("df2", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         assertThat(MlTasks.datafeedTasksOnNode(tasksBuilder.build(), "node-2"), contains(hasProperty("id", equalTo("datafeed-df2"))));
@@ -288,31 +368,51 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("job-1"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-1"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("df1"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("df1", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.jobTaskId("job-2"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-2"),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("df2"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("df2", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.jobTaskId("job-3"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-3"),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         assertThat(
@@ -329,14 +429,22 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("job-1"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-1"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-1"), new JobTaskState(JobState.FAILED, 1, "testing", Instant.now()));
         tasksBuilder.addTask(
             MlTasks.jobTaskId("job-2"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-2"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         if (randomBoolean()) {
             tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-2"), new JobTaskState(JobState.OPENED, 2, "testing", Instant.now()));
@@ -345,7 +453,11 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("job-3"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-3"),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         if (randomBoolean()) {
             tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-3"), new JobTaskState(JobState.FAILED, 3, "testing", Instant.now()));
@@ -469,25 +581,41 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.jobTaskId("ad-1"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("ad-1"),
-            new PersistentTasksCustomMetadata.Assignment(randomAlphaOfLength(5), "test")
+            new PersistentTasksCustomMetadata.Assignment(
+                randomAlphaOfLength(5),
+                "test",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.dataFrameAnalyticsTaskId("dfa-1"),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams("dfa-1", MlConfigVersion.CURRENT, true),
-            new PersistentTasksCustomMetadata.Assignment(randomAlphaOfLength(5), "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                randomAlphaOfLength(5),
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.snapshotUpgradeTaskId("snapshot-upgrade-1", "some-snapshot-id"),
             MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME,
             new SnapshotUpgradeTaskParams("snapshot-upgrade-1", "some-snapshot-id"),
-            new PersistentTasksCustomMetadata.Assignment(randomAlphaOfLength(5), "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                randomAlphaOfLength(5),
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("datafeed-1"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("datafeed-1", "now"),
-            new PersistentTasksCustomMetadata.Assignment(randomAlphaOfLength(5), "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                randomAlphaOfLength(5),
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         PersistentTasksCustomMetadata tasks = tasksBuilder.build();
 
@@ -513,7 +641,11 @@ public class MlTasksTests extends ESTestCase {
             MlTasks.dataFrameAnalyticsTaskId(jobId),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams(jobId, MlConfigVersion.CURRENT, false),
-            new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                nodeId,
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         if (state != null) {
             builder.updateTaskState(

--- a/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutor.java
+++ b/x-pack/plugin/downsample/src/main/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutor.java
@@ -139,7 +139,11 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
         var indexShardRouting = findShardRoutingTable(shardId, clusterState);
         if (indexShardRouting == null) {
             var node = selectLeastLoadedNode(clusterState, candidateNodes, DiscoveryNode::canContainData);
-            return new PersistentTasksCustomMetadata.Assignment(node.getId(), "a node to fail and stop this persistent task");
+            return new PersistentTasksCustomMetadata.Assignment(
+                node.getId(),
+                "a node to fail and stop this persistent task",
+                PersistentTasksCustomMetadata.Explanation.SOURCE_INDEX_REMOVED
+            );
         }
 
         final ShardRouting shardRouting = indexShardRouting.primaryShard();
@@ -153,7 +157,8 @@ public class DownsampleShardPersistentTaskExecutor extends PersistentTasksExecut
             .map(
                 node -> new PersistentTasksCustomMetadata.Assignment(
                     node.getId(),
-                    "downsampling using node holding shard [" + shardId + "]"
+                    "downsampling using node holding shard [" + shardId + "]",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
                 )
             )
             .orElse(NO_NODE_FOUND);

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutorTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleShardPersistentTaskExecutorTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.downsample.DownsampleShardTask;
@@ -36,6 +37,8 @@ import java.util.concurrent.Executor;
 
 import static org.elasticsearch.cluster.routing.ShardRoutingState.STARTED;
 import static org.elasticsearch.cluster.routing.TestShardRouting.shardRoutingBuilder;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 
@@ -110,7 +113,8 @@ public class DownsampleShardPersistentTaskExecutorTests extends ESTestCase {
         );
         var result = executor.getAssignment(params, Set.of(node), clusterState);
         assertThat(result.getExecutorNode(), equalTo(node.getId()));
-        assertThat(result.getExplanation(), equalTo("a node to fail and stop this persistent task"));
+        assertThat(result.getExplanation(), containsString("a node to fail and stop this persistent task"));
+        assertThat(result.getExplanationCodes(), contains(PersistentTasksCustomMetadata.Explanation.SOURCE_INDEX_REMOVED));
     }
 
     private static DiscoveryNode newNode() {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationIT.java
@@ -61,6 +61,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertResp
 import static org.elasticsearch.xpack.core.ml.MlTasks.AWAITING_UPGRADE;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
@@ -768,7 +769,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertBusy(() -> {
             try {
                 GetDataFrameAnalyticsStatsAction.Response.Stats analyticsStats = getAnalyticsStats(jobId);
-                assertThat(analyticsStats.getAssignmentExplanation(), is(equalTo(AWAITING_UPGRADE.getExplanation())));
+                assertThat(analyticsStats.getAssignmentExplanation(), containsString(AWAITING_UPGRADE.getExplanation()));
                 assertThat(analyticsStats.getNode(), is(nullValue()));
             } catch (ElasticsearchException e) {
                 logger.error(() -> "[" + jobId + "] Encountered exception while fetching analytics stats", e);
@@ -783,7 +784,7 @@ public class ClassificationIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         assertBusy(() -> {
             try {
                 GetDataFrameAnalyticsStatsAction.Response.Stats analyticsStats = getAnalyticsStats(jobId);
-                assertThat(analyticsStats.getAssignmentExplanation(), is(not(equalTo(AWAITING_UPGRADE.getExplanation()))));
+                assertThat(analyticsStats.getAssignmentExplanation(), not(containsString(AWAITING_UPGRADE.getExplanation())));
             } catch (ElasticsearchException e) {
                 logger.error(() -> "[" + jobId + "] Encountered exception while fetching analytics stats", e);
                 fail(e.getDetailedMessage());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/SetUpgradeModeIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/SetUpgradeModeIT.java
@@ -88,12 +88,12 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
 
         GetJobsStatsAction.Response.JobStats jobStats = getJobStats(jobId).get(0);
         assertThat(jobStats.getState(), is(equalTo(JobState.OPENED)));
-        assertThat(jobStats.getAssignmentExplanation(), is(equalTo(AWAITING_UPGRADE.getExplanation())));
+        assertThat(jobStats.getAssignmentExplanation(), containsString(AWAITING_UPGRADE.getExplanation()));
         assertThat(jobStats.getNode(), is(nullValue()));
 
         GetDatafeedsStatsAction.Response.DatafeedStats datafeedStats = getDatafeedStats(datafeedId);
         assertThat(datafeedStats.getDatafeedState(), is(equalTo(DatafeedState.STARTED)));
-        assertThat(datafeedStats.getAssignmentExplanation(), is(equalTo(AWAITING_UPGRADE.getExplanation())));
+        assertThat(datafeedStats.getAssignmentExplanation(), containsString(AWAITING_UPGRADE.getExplanation()));
         assertThat(datafeedStats.getNode(), is(nullValue()));
 
         // Disable the setting
@@ -117,11 +117,11 @@ public class SetUpgradeModeIT extends MlNativeAutodetectIntegTestCase {
 
         jobStats = getJobStats(jobId).get(0);
         assertThat(jobStats.getState(), is(equalTo(JobState.OPENED)));
-        assertThat(jobStats.getAssignmentExplanation(), is(not(equalTo(AWAITING_UPGRADE.getExplanation()))));
+        assertThat(jobStats.getAssignmentExplanation(), not(containsString(AWAITING_UPGRADE.getExplanation())));
 
         datafeedStats = getDatafeedStats(datafeedId);
         assertThat(datafeedStats.getDatafeedState(), is(equalTo(DatafeedState.STARTED)));
-        assertThat(datafeedStats.getAssignmentExplanation(), is(not(equalTo(AWAITING_UPGRADE.getExplanation()))));
+        assertThat(datafeedStats.getAssignmentExplanation(), not(containsString(AWAITING_UPGRADE.getExplanation())));
     }
 
     public void testJobOpenActionInUpgradeMode() {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DataFrameAnalyticsConfigProviderIT.java
@@ -381,7 +381,11 @@ public class DataFrameAnalyticsConfigProviderIT extends MlSingleNodeTestCase {
             MlTasks.dataFrameAnalyticsTaskId(analyticsId),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams(analyticsId, MlConfigVersion.CURRENT, false),
-            new PersistentTasksCustomMetadata.Assignment("node", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         builder.updateTaskState(
             MlTasks.dataFrameAnalyticsTaskId(analyticsId),

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/DatafeedConfigProviderIT.java
@@ -396,7 +396,11 @@ public class DatafeedConfigProviderIT extends MlSingleNodeTestCase {
             MlTasks.datafeedTaskId("foo-1"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("foo-1", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         PersistentTasksCustomMetadata tasks = tasksBuilder.build();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobConfigProviderIT.java
@@ -492,7 +492,11 @@ public class JobConfigProviderIT extends MlSingleNodeTestCase {
             MlTasks.jobTaskId("foo-2"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("foo-2"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         PersistentTasksCustomMetadata tasks = tasksBuilder.build();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MlAssignmentNotifier.java
@@ -157,7 +157,7 @@ public class MlAssignmentNotifier implements ClusterStateListener {
                     if (anomalyDetectionAuditor.includeNodeInfo()) {
                         anomalyDetectionAuditor.warning(
                             jobId,
-                            "No node found to open job. Reasons [" + currentAssignment.getExplanation() + "]"
+                            "No node found to open job. Reasons [" + currentAssignment.getExplanationCodesAndExplanation() + "]"
                         );
                     } else {
                         anomalyDetectionAuditor.warning(jobId, "Awaiting capacity to open job.");
@@ -189,7 +189,7 @@ public class MlAssignmentNotifier implements ClusterStateListener {
                                     "No node found to start datafeed ["
                                         + datafeedParams.getDatafeedId()
                                         + "]. Reasons ["
-                                        + currentAssignment.getExplanation()
+                                        + currentAssignment.getExplanationCodesAndExplanation()
                                         + "]"
                                 );
                             } else {
@@ -213,7 +213,7 @@ public class MlAssignmentNotifier implements ClusterStateListener {
                                 "[{}] No node found to start datafeed [{}]. Reasons [{}]",
                                 jobId,
                                 datafeedParams.getDatafeedId(),
-                                currentAssignment.getExplanation()
+                                currentAssignment.getExplanationCodesAndExplanation()
                             );
                         }
                     }
@@ -231,7 +231,7 @@ public class MlAssignmentNotifier implements ClusterStateListener {
                     if (anomalyDetectionAuditor.includeNodeInfo()) {
                         dataFrameAnalyticsAuditor.warning(
                             id,
-                            "No node found to start analytics. Reasons [" + currentAssignment.getExplanation() + "]"
+                            "No node found to start analytics. Reasons [" + currentAssignment.getExplanationCodesAndExplanation() + "]"
                         );
                     } else {
                         dataFrameAnalyticsAuditor.warning(id, "Awaiting capacity to start analytics.");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDataFrameAnalyticsStatsAction.java
@@ -375,7 +375,7 @@ public class TransportGetDataFrameAnalyticsStatsAction extends TransportTasksAct
         String assignmentExplanation = null;
         if (analyticsTask != null) {
             node = analyticsTask.getExecutorNode() != null ? clusterState.nodes().get(analyticsTask.getExecutorNode()) : null;
-            assignmentExplanation = analyticsTask.getAssignment().getExplanation();
+            assignmentExplanation = analyticsTask.getAssignment().getExplanationCodesAndExplanation();
         }
         return new GetDataFrameAnalyticsStatsAction.Response.Stats(
             concreteAnalyticsId,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobModelSnapshotsUpgradeStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobModelSnapshotsUpgradeStatsAction.java
@@ -96,7 +96,7 @@ public class TransportGetJobModelSnapshotsUpgradeStatsAction extends TransportMa
                         statsBuilder.setNode(state.getNodes().get(t.getExecutorNode()));
                     }
                     return statsBuilder.setUpgradeState(MlTasks.getSnapshotUpgradeState(t))
-                        .setAssignmentExplanation(t.getAssignment().getExplanation())
+                        .setAssignmentExplanation(t.getAssignment().getExplanationCodesAndExplanation())
                         .build();
                 })
                 .sorted(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetJobsStatsAction.java
@@ -153,7 +153,7 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<
             PersistentTasksCustomMetadata.PersistentTask<?> pTask = MlTasks.getJobTask(jobId, tasks);
             DiscoveryNode node = state.nodes().get(pTask.getExecutorNode());
             JobState jobState = MlTasks.getJobState(jobId, tasks);
-            String assignmentExplanation = pTask.getAssignment().getExplanation();
+            String assignmentExplanation = pTask.getAssignment().getExplanationCodesAndExplanation();
             TimeValue openTime = processManager.jobOpenTime(task).map(value -> TimeValue.timeValueSeconds(value.getSeconds())).orElse(null);
             jobResultsProvider.getForecastStats(jobId, parentTaskId, forecastStats -> {
                 JobStats jobStats = new JobStats(
@@ -219,7 +219,7 @@ public class TransportGetJobsStatsAction extends TransportTasksAction<
                                     PersistentTasksCustomMetadata.PersistentTask<?> pTask = MlTasks.getJobTask(jobId, tasks);
                                     String assignmentExplanation = null;
                                     if (pTask != null) {
-                                        assignmentExplanation = pTask.getAssignment().getExplanation();
+                                        assignmentExplanation = pTask.getAssignment().getExplanationCodesAndExplanation();
                                     }
                                     jobStats.set(
                                         slot,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportSetUpgradeModeAction.java
@@ -308,10 +308,12 @@ public class TransportSetUpgradeModeAction extends AcknowledgedTransportMasterNo
         );
 
         for (PersistentTask<?> task : mlTasks) {
+            assert AWAITING_UPGRADE.getExplanationCodes().size() == 1;
             chainTaskExecutor.add(
                 chainedTask -> persistentTasksClusterService.unassignPersistentTask(
                     task.getId(),
                     task.getAllocationId(),
+                    AWAITING_UPGRADE.getExplanationCodes().iterator().next(),
                     AWAITING_UPGRADE.getExplanation(),
                     chainedTask
                 )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -732,7 +732,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
                 if (assignment.equals(PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT) == false && assignment.isAssigned() == false) {
                     // Assignment has failed despite passing our "fast fail" validation
                     exception = new ElasticsearchStatusException(
-                        "Could not start datafeed, allocation explanation [" + assignment.getExplanation() + "]",
+                        "Could not start datafeed, allocation explanation [" + assignment.getExplanationCodesAndExplanation() + "]",
                         RestStatus.TOO_MANY_REQUESTS
                     );
                     return true;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/task/AbstractJobPersistentTasksExecutor.java
@@ -235,7 +235,13 @@ public abstract class AbstractJobPersistentTasksExecutor<Params extends Persiste
                 + String.join(",", unavailableIndices)
                 + "]";
             logger.debug(reason);
-            return Optional.of(new PersistentTasksCustomMetadata.Assignment(null, reason));
+            return Optional.of(
+                new PersistentTasksCustomMetadata.Assignment(
+                    null,
+                    reason,
+                    PersistentTasksCustomMetadata.Explanation.PRIMARY_SHARDS_NOT_ACTIVE
+                )
+            );
         }
         return Optional.empty();
     }
@@ -246,7 +252,13 @@ public abstract class AbstractJobPersistentTasksExecutor<Params extends Persiste
             if (scheduledRefresh) {
                 String reason = "Not opening job [" + jobId + "] because job memory requirements are stale - refresh requested";
                 logger.debug(reason);
-                return Optional.of(new PersistentTasksCustomMetadata.Assignment(null, reason));
+                return Optional.of(
+                    new PersistentTasksCustomMetadata.Assignment(
+                        null,
+                        reason,
+                        PersistentTasksCustomMetadata.Explanation.MEMORY_REQUIREMENTS_STALE
+                    )
+                );
             }
         }
         return Optional.empty();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlLifeCycleServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlLifeCycleServiceTests.java
@@ -84,25 +84,41 @@ public class MlLifeCycleServiceTests extends ESTestCase {
             MlTasks.jobTaskId("job-1"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("job-1"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.datafeedTaskId("df1"),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams("df1", 0L),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.dataFrameAnalyticsTaskId("job-2"),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams("foo-2", MlConfigVersion.CURRENT, true),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             MlTasks.snapshotUpgradeTaskId("job-3", "snapshot-3"),
             MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME,
             new SnapshotUpgradeTaskParams("job-3", "snapshot-3"),
-            new PersistentTasksCustomMetadata.Assignment("node-3", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-3",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         Metadata metadata = Metadata.builder().putCustom(PersistentTasksCustomMetadata.TYPE, tasksBuilder.build()).build();
@@ -145,14 +161,22 @@ public class MlLifeCycleServiceTests extends ESTestCase {
             MlTasks.jobTaskId("job-1"),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams("job-1"),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.updateTaskState(MlTasks.jobTaskId("job-1"), new JobTaskState(JobState.FAILED, 1, "testing", Instant.now()));
         tasksBuilder.addTask(
             MlTasks.dataFrameAnalyticsTaskId("job-2"),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams("foo-2", MlConfigVersion.CURRENT, true),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.updateTaskState(
             MlTasks.dataFrameAnalyticsTaskId("job-2"),
@@ -162,7 +186,11 @@ public class MlLifeCycleServiceTests extends ESTestCase {
             MlTasks.snapshotUpgradeTaskId("job-3", "snapshot-3"),
             MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME,
             new SnapshotUpgradeTaskParams("job-3", "snapshot-3"),
-            new PersistentTasksCustomMetadata.Assignment("node-3", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-3",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.updateTaskState(
             MlTasks.snapshotUpgradeTaskId("job-3", "snapshot-3"),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlMetricsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlMetricsTests.java
@@ -174,7 +174,13 @@ public class MlMetricsTests extends ESTestCase {
             MlTasks.datafeedTaskId(datafeedId),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams(datafeedId, System.currentTimeMillis()),
-            nodeId == null ? AWAITING_LAZY_ASSIGNMENT : new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment")
+            nodeId == null
+                ? AWAITING_LAZY_ASSIGNMENT
+                : new PersistentTasksCustomMetadata.Assignment(
+                    nodeId,
+                    "test assignment",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                )
         );
         if (datafeedState != null) {
             builder.updateTaskState(MlTasks.datafeedTaskId(datafeedId), datafeedState);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportCloseJobActionTests.java
@@ -332,7 +332,7 @@ public class TransportCloseJobActionTests extends ESTestCase {
             MlTasks.datafeedTaskId(datafeedId),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams(datafeedId, startTime),
-            new Assignment(nodeId, "test assignment")
+            new Assignment(nodeId, "test assignment", PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL)
         );
         tasks.updateTaskState(MlTasks.datafeedTaskId(datafeedId), state);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStartDataFrameAnalyticsActionTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -42,7 +43,9 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -64,7 +67,7 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
 
         Assignment assignment = executor.getAssignment(params, clusterState.nodes().getAllNodes(), clusterState);
         assertThat(assignment.getExecutorNode(), is(nullValue()));
-        assertThat(assignment.getExplanation(), is(equalTo("persistent task cannot be assigned while upgrade mode is enabled.")));
+        assertThat(assignment.getExplanation(), containsString("persistent task cannot be assigned while upgrade mode is enabled."));
     }
 
     // Cannot assign the node because there are no existing nodes in the cluster state
@@ -77,6 +80,7 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
 
         Assignment assignment = executor.getAssignment(params, clusterState.nodes().getAllNodes(), clusterState);
         assertThat(assignment.getExecutorNode(), is(nullValue()));
+        assertThat(assignment.getExplanationCodes(), empty());
         assertThat(assignment.getExplanation(), is(emptyString()));
     }
 
@@ -96,6 +100,7 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
 
         Assignment assignment = executor.getAssignment(params, clusterState.nodes().getAllNodes(), clusterState);
         assertThat(assignment.getExecutorNode(), is(nullValue()));
+        assertThat(assignment.getExplanationCodes(), contains(PersistentTasksCustomMetadata.Explanation.NODE_NOT_COMPATIBLE));
         assertThat(
             assignment.getExplanation(),
             allOf(
@@ -118,6 +123,7 @@ public class TransportStartDataFrameAnalyticsActionTests extends ESTestCase {
 
         Assignment assignment = executor.getAssignment(params, clusterState.nodes().getAllNodes(), clusterState);
         assertThat(assignment.getExecutorNode(), is(equalTo("_node_id0")));
+        assertThat(assignment.getExplanationCodes(), contains(PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL));
         assertThat(assignment.getExplanation(), is(emptyString()));
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStopDataFrameAnalyticsActionTests.java
@@ -79,7 +79,11 @@ public class TransportStopDataFrameAnalyticsActionTests extends ESTestCase {
             MlTasks.dataFrameAnalyticsTaskId(analyticsId),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams(analyticsId, MlConfigVersion.CURRENT, allowLazyStart),
-            new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                nodeId,
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         if (state != null) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedActionTests.java
@@ -100,7 +100,11 @@ public class TransportStopDatafeedActionTests extends ESTestCase {
             MlTasks.datafeedTaskId(datafeedId),
             MlTasks.DATAFEED_TASK_NAME,
             new StartDatafeedAction.DatafeedParams(datafeedId, startTime),
-            new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                nodeId,
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         taskBuilder.updateTaskState(MlTasks.datafeedTaskId(datafeedId), state);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
@@ -1347,7 +1347,11 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
                 MlTasks.datafeedTaskId(jobId + "-datafeed"),
                 MlTasks.DATAFEED_TASK_NAME,
                 dfParams,
-                new PersistentTasksCustomMetadata.Assignment(nodeAssignment, "test")
+                new PersistentTasksCustomMetadata.Assignment(
+                    nodeAssignment,
+                    "test",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                )
             );
         }
         for (String analyticsId : analyticsTasks) {
@@ -1409,7 +1413,13 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             MlTasks.dataFrameAnalyticsTaskId(jobId),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams(jobId, MlConfigVersion.CURRENT, true),
-            nodeId == null ? AWAITING_LAZY_ASSIGNMENT : new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment")
+            nodeId == null
+                ? AWAITING_LAZY_ASSIGNMENT
+                : new PersistentTasksCustomMetadata.Assignment(
+                    nodeId,
+                    "test assignment",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                )
         );
         if (jobState != null) {
             builder.updateTaskState(
@@ -1424,7 +1434,13 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             MlTasks.jobTaskId(jobId),
             MlTasks.JOB_TASK_NAME,
             new OpenJobAction.JobParams(jobId),
-            nodeId == null ? AWAITING_LAZY_ASSIGNMENT : new PersistentTasksCustomMetadata.Assignment(nodeId, "test assignment")
+            nodeId == null
+                ? AWAITING_LAZY_ASSIGNMENT
+                : new PersistentTasksCustomMetadata.Assignment(
+                    nodeId,
+                    "test assignment",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                )
         );
         if (jobState != null) {
             builder.updateTaskState(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -1330,7 +1330,11 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
             MlTasks.dataFrameAnalyticsTaskId("dfa-1"),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams("dfa-1", MlConfigVersion.CURRENT, true),
-            new PersistentTasksCustomMetadata.Assignment(mlNodeId, "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                mlNodeId,
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         PersistentTasksCustomMetadata.Builder currentTasksBuilder = PersistentTasksCustomMetadata.builder();
@@ -1401,7 +1405,11 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
             MlTasks.dataFrameAnalyticsTaskId("dfa-1"),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams("dfa-1", MlConfigVersion.CURRENT, true),
-            new PersistentTasksCustomMetadata.Assignment(mlNodeId, "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                mlNodeId,
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         PersistentTasksCustomMetadata.Builder currentTasksBuilder = PersistentTasksCustomMetadata.builder();
@@ -1421,7 +1429,11 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
             MlTasks.dataFrameAnalyticsTaskId("dfa-1"),
             MlTasks.DATA_FRAME_ANALYTICS_TASK_NAME,
             new StartDataFrameAnalyticsAction.TaskParams("dfa-1", MlConfigVersion.CURRENT, true),
-            new PersistentTasksCustomMetadata.Assignment(mlNodeId, "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                mlNodeId,
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         ClusterState previousState = ClusterState.builder(new ClusterName("test_cluster"))

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradePredicateTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/snapshot/upgrader/SnapshotUpgradePredicateTests.java
@@ -27,7 +27,7 @@ public class SnapshotUpgradePredicateTests extends ESTestCase {
             MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME,
             new SnapshotUpgradeTaskParams("job", "snapshot"),
             1,
-            new PersistentTasksCustomMetadata.Assignment("test-node", "")
+            new PersistentTasksCustomMetadata.Assignment("test-node", PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL)
         );
         {
             SnapshotUpgradePredicate snapshotUpgradePredicate = new SnapshotUpgradePredicate(true, logger);
@@ -65,7 +65,7 @@ public class SnapshotUpgradePredicateTests extends ESTestCase {
             MlTasks.JOB_SNAPSHOT_UPGRADE_TASK_NAME,
             new SnapshotUpgradeTaskParams("job", "snapshot"),
             1,
-            new PersistentTasksCustomMetadata.Assignment("test-node", "")
+            new PersistentTasksCustomMetadata.Assignment("test-node", PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL)
         );
         {
             SnapshotUpgradePredicate snapshotUpgradePredicate = new SnapshotUpgradePredicate(false, logger);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/job/RollupJobTaskTests.java
@@ -331,7 +331,11 @@ public class RollupJobTaskTests extends ESTestCase {
                             RollupField.TASK_NAME,
                             job,
                             1,
-                            new PersistentTasksCustomMetadata.Assignment("foo", "foo")
+                            new PersistentTasksCustomMetadata.Assignment(
+                                "foo",
+                                "foo",
+                                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                            )
                         )
                     );
                     counter.incrementAndGet();
@@ -433,7 +437,11 @@ public class RollupJobTaskTests extends ESTestCase {
                         RollupField.TASK_NAME,
                         job,
                         1,
-                        new PersistentTasksCustomMetadata.Assignment("foo", "foo")
+                        new PersistentTasksCustomMetadata.Assignment(
+                            "foo",
+                            "foo",
+                            PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                        )
                     )
                 );
             }
@@ -492,7 +500,11 @@ public class RollupJobTaskTests extends ESTestCase {
                         RollupField.TASK_NAME,
                         job,
                         1,
-                        new PersistentTasksCustomMetadata.Assignment("foo", "foo")
+                        new PersistentTasksCustomMetadata.Assignment(
+                            "foo",
+                            "foo",
+                            PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                        )
                     )
                 );
             }
@@ -554,7 +566,11 @@ public class RollupJobTaskTests extends ESTestCase {
                         RollupField.TASK_NAME,
                         job,
                         1,
-                        new PersistentTasksCustomMetadata.Assignment("foo", "foo")
+                        new PersistentTasksCustomMetadata.Assignment(
+                            "foo",
+                            "foo",
+                            PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                        )
                     )
                 );
             }
@@ -650,7 +666,11 @@ public class RollupJobTaskTests extends ESTestCase {
                             RollupField.TASK_NAME,
                             job,
                             1,
-                            new PersistentTasksCustomMetadata.Assignment("foo", "foo")
+                            new PersistentTasksCustomMetadata.Assignment(
+                                "foo",
+                                "foo",
+                                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                            )
                         )
                     );
                 } else if (counterValue == 1) {
@@ -759,7 +779,11 @@ public class RollupJobTaskTests extends ESTestCase {
                             RollupField.TASK_NAME,
                             job,
                             1,
-                            new PersistentTasksCustomMetadata.Assignment("foo", "foo")
+                            new PersistentTasksCustomMetadata.Assignment(
+                                "foo",
+                                "foo",
+                                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                            )
                         )
                     );
                 } else if (counterValue == 1) {
@@ -870,7 +894,11 @@ public class RollupJobTaskTests extends ESTestCase {
                             RollupField.TASK_NAME,
                             job,
                             1,
-                            new PersistentTasksCustomMetadata.Assignment("foo", "foo")
+                            new PersistentTasksCustomMetadata.Assignment(
+                                "foo",
+                                "foo",
+                                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                            )
                         )
                     );
                 } else if (counterValue == 1) {
@@ -992,7 +1020,11 @@ public class RollupJobTaskTests extends ESTestCase {
                             RollupField.TASK_NAME,
                             job,
                             1,
-                            new PersistentTasksCustomMetadata.Assignment("foo", "foo")
+                            new PersistentTasksCustomMetadata.Assignment(
+                                "foo",
+                                "foo",
+                                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                            )
                         )
                     );
                     counter.incrementAndGet();

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -396,7 +396,7 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                             new TransformStats(
                                 stat.getId(),
                                 TransformStats.State.WAITING,
-                                assignment.getExplanation(),
+                                assignment.getExplanationCodesAndExplanation(),
                                 null,
                                 stat.getTransformStats(),
                                 checkpointingInfo,

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -374,7 +374,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
                 // For some reason, the task is not assigned to a node, but is no longer in the `INITIAL_ASSIGNMENT` state
                 // Consider this a failure.
                 exception = new ElasticsearchStatusException(
-                    "Could not start transform, allocation explanation [" + assignment.getExplanation() + "]",
+                    "Could not start transform, allocation explanation [" + assignment.getExplanationCodesAndExplanation() + "]",
                     RestStatus.TOO_MANY_REQUESTS
                 );
                 return true;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformHealthChecker.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformHealthChecker.java
@@ -63,7 +63,7 @@ public final class TransformHealthChecker {
     ) {
         final Assignment assignment = TransformNodes.getAssignment(transformId, clusterState);
         final List<TransformHealthIssue> issues = new ArrayList<>(2);
-        issues.add(IssueType.ASSIGNMENT_FAILED.newIssue(assignment.getExplanation(), 1, null));
+        issues.add(IssueType.ASSIGNMENT_FAILED.newIssue(assignment.getExplanationCodesAndExplanation(), 1, null));
         if (AuthorizationState.isNullOrGreen(authState) == false) {
             issues.add(IssueType.PRIVILEGES_CHECK_FAILED.newIssue(authState.getLastAuthError(), 1, null));
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransportStopTransformActionTests.java
@@ -76,7 +76,10 @@ public class TransportStopTransformActionTests extends ESTestCase {
                 "non-failed-task",
                 TransformTaskParams.NAME,
                 new TransformTaskParams("transform-task-1", TransformConfigVersion.CURRENT, null, false),
-                new PersistentTasksCustomMetadata.Assignment("current-data-node-with-1-tasks", "")
+                new PersistentTasksCustomMetadata.Assignment(
+                    "current-data-node-with-1-tasks",
+                    PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+                )
             );
         ClusterState.Builder csBuilder = ClusterState.builder(new ClusterName("_name")).metadata(buildMetadata(pTasksBuilder.build()));
 
@@ -96,7 +99,10 @@ public class TransportStopTransformActionTests extends ESTestCase {
             "failed-task",
             TransformTaskParams.NAME,
             new TransformTaskParams("transform-task-1", TransformConfigVersion.CURRENT, null, false),
-            new PersistentTasksCustomMetadata.Assignment("current-data-node-with-1-tasks", "")
+            new PersistentTasksCustomMetadata.Assignment(
+                "current-data-node-with-1-tasks",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         )
             .updateTaskState(
                 "failed-task",
@@ -128,7 +134,10 @@ public class TransportStopTransformActionTests extends ESTestCase {
             "failed-task-2",
             TransformTaskParams.NAME,
             new TransformTaskParams("transform-task-2", TransformConfigVersion.CURRENT, null, false),
-            new PersistentTasksCustomMetadata.Assignment("current-data-node-with-2-tasks", "")
+            new PersistentTasksCustomMetadata.Assignment(
+                "current-data-node-with-2-tasks",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         )
             .updateTaskState(
                 "failed-task-2",

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformNodesTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformNodesTests.java
@@ -56,13 +56,21 @@ public class TransformNodesTests extends ESTestCase {
             transformIdFoo,
             TransformField.TASK_NAME,
             new TransformTaskParams(transformIdFoo, TransformConfigVersion.CURRENT, null, false),
-            new PersistentTasksCustomMetadata.Assignment("node-1", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-1",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             transformIdBar,
             TransformField.TASK_NAME,
             new TransformTaskParams(transformIdBar, TransformConfigVersion.CURRENT, null, false),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask("test-task1", "testTasks", new PersistentTaskParams() {
             @Override
@@ -84,24 +92,42 @@ public class TransformNodesTests extends ESTestCase {
             public XContentBuilder toXContent(XContentBuilder builder, Params params) {
                 return null;
             }
-        }, new PersistentTasksCustomMetadata.Assignment("node-3", "test assignment"));
+        },
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-3",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
+        );
         tasksBuilder.addTask(
             transformIdFailed,
             TransformField.TASK_NAME,
             new TransformTaskParams(transformIdFailed, TransformConfigVersion.CURRENT, null, false),
-            new PersistentTasksCustomMetadata.Assignment(null, "awaiting reassignment after node loss")
+            new PersistentTasksCustomMetadata.Assignment(
+                null,
+                "awaiting reassignment after node loss",
+                PersistentTasksCustomMetadata.Explanation.AWAITING_REASSIGNMENT
+            )
         );
         tasksBuilder.addTask(
             transformIdBaz,
             TransformField.TASK_NAME,
             new TransformTaskParams(transformIdBaz, TransformConfigVersion.CURRENT, null, false),
-            new PersistentTasksCustomMetadata.Assignment("node-2", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-2",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
         tasksBuilder.addTask(
             transformIdOther,
             TransformField.TASK_NAME,
             new TransformTaskParams(transformIdOther, TransformConfigVersion.CURRENT, null, false),
-            new PersistentTasksCustomMetadata.Assignment("node-3", "test assignment")
+            new PersistentTasksCustomMetadata.Assignment(
+                "node-3",
+                "test assignment",
+                PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
+            )
         );
 
         ClusterState cs = ClusterState.builder(new ClusterName("_name"))
@@ -284,7 +310,8 @@ public class TransformNodesTests extends ESTestCase {
         );
         PersistentTasksCustomMetadata.Assignment assignment2 = new PersistentTasksCustomMetadata.Assignment(
             randomAlphaOfLengthBetween(1, 10),
-            randomAlphaOfLengthBetween(1, 10)
+            randomAlphaOfLengthBetween(1, 10),
+            PersistentTasksCustomMetadata.Explanation.ASSIGNMENT_SUCCESSFUL
         );
         ClusterState clusterState = ClusterState.builder(new ClusterName("some-cluster"))
             .metadata(


### PR DESCRIPTION
When a task can not be assigned, the ptask framework is able to message back a reason in form of a string. This feature also started to be used for successful assignments, for example in the task that ads a health node.

Callers might need to interpret an assignment failure to e.g. return a HTTP status code. A string is hard to interpret and therefore not suitable.

Therefore, the Assignment can now take a programmer friendly code. It is still possible to provide a freetext String, as some context dependent information (e.g. nodeId) can not be stored in an Enum. Because some tasks provided multiple reasons for being unable to assign (all concatenated in a string), it is possible to provide multiple codes.

This commit also adapted the serialization and deserialization methods for backwards compatibility.

Closes #53711
