### PR TITLE
Improve clarity and user friendliness of ES|QL examples

### DIFF
--- a/docs/reference/esql/esql-examples.asciidoc
+++ b/docs/reference/esql/esql-examples.asciidoc
@@ -7,7 +7,7 @@
 
 
 [discrete]
-=== Aggregating and enriching windows event logs
+=== Aggregate and enrich Windows event logs
 
 [source,esql]
 ----
@@ -21,18 +21,45 @@ FROM logs-*
 | KEEP event_code_count,event.code,host.name,event.description
 ----
 
-* It starts by querying logs from indices that match the pattern "logs-*".
-* Filters events where the "event.code" field is not null.
-* Aggregates the count of events by "event.code" and "host.name."
-* Enriches the events with additional information using the "EVENT_DESCRIPTION" field.
-* Filters out events where "EVENT_DESCRIPTION" or "host.name" is null.
-* Renames "EVENT_DESCRIPTION" as "event.description."
-* Sorts the result by "event_code_count" in descending order.
-* Keeps only selected fields: "event_code_count," "event.code," "host.name," and "event.description."
+.Show example with comments
+[%collapsible]
+====
+[source,esql]
+----
+// Query logs from indices matching logs-*
+FROM logs-*
+// Filter out events where event.code is null
+| WHERE event.code IS NOT NULL
+// Aggregate the count of events by event.code and host.name
+| STATS event_code_count = COUNT(event.code) BY event.code,host.name
+// Enrich events with info from event_description
+| ENRICH win_events ON event.code WITH event_description
+// Filter out events where event_description or host.name is null
+| WHERE event_description IS NOT NULL and host.name IS NOT NULL
+// Rename event_description for consistency
+| RENAME event_description AS event.description
+// Sort results by event_code_count in descending order
+| SORT event_code_count DESC
+// Keep only the specified fields
+| KEEP event_code_count,event.code,host.name,event.description
+----
+====
 
+.Show line-by-line explanation
+[%collapsible%open]
+====
+* Query logs from indices that match the pattern `logs-*`.
+* Filter out events where the `event.code` field is null.
+* Aggregate the count of events by `event.code` and `host.name`.
+* Enrich the events with additional information using the `event_description` field.
+* Filter out events where `event_description` or `host.name` is null.
+* Rename `event_description` to `event.description` to match the field naming convention.
+* Sort the results by `event_code_count` in descending order.
+* Keep only the specified fields: `event_code_count`, `event.code`, `host.name`, and `event.description`.
+====
 
 [discrete]
-=== Summing outbound traffic from a process `curl.exe`
+=== Sum outbound traffic from process `curl.exe`
 
 [source,esql]
 ----
@@ -45,16 +72,42 @@ FROM logs-endpoint
 | KEEP kb,destination.address
 ----
 
-* Queries logs from the "logs-endpoint" source.
-* Filters events where the "process.name" field is "curl.exe."
-* Calculates the sum of bytes sent to destination addresses and converts it to kilobytes (KB).
-* Sorts the results by "kb" (kilobytes) in descending order.
-* Limits the output to the top 10 results.
-* Keeps only the "kb" and "destination.address" fields.
+.Show example with comments
+[%collapsible]
+====
+[source,esql]
+----
+// Query the logs-endpoint source
+FROM logs-endpoint
+// Filter for events with a process.name of curl.exe
+| WHERE process.name == "curl.exe"
+// Calculate the sum of bytes sent to destination addresses
+| STATS bytes = SUM(destination.bytes) BY destination.address
+// Convert the sum to kilobytes (KB)
+| EVAL kb =  bytes/1024
+// Sort results by kb in descending order
+| SORT kb DESC
+// Limit the results to 10
+| LIMIT 10
+// Keep only the specified fields
+| KEEP kb,destination.address
+----
+====
 
+.Show line-by-line explanation
+[%collapsible%open]
+====
+* Query logs from the `logs-endpoint` source.
+* Filter the results for events with a `process.name` of `curl.exe`.
+* Calculate the sum of bytes sent to destination addresses.
+* Convert the sum to kilobytes (KB).
+* Sort the results by `kb` (kilobytes) in descending order.
+* Limit the output to the top 10 results.
+* Keep only the `kb` and `destination.address` fields.
+====
 
 [discrete]
-=== Manipulating DNS logs to find a high number of unique dns queries per registered domain
+=== Analyze DNS logs to find domains with high numbers of unique DNS queries
 
 [source,esql]
 ----
@@ -66,16 +119,39 @@ FROM logs-*
 | RENAME unique_queries AS `Unique Queries`, dns.question.registered_domain AS `Registered Domain`, process.name AS `Process`
 ----
 
-* Queries logs from indices matching "logs-*."
-* Uses the "grok" pattern to extract the registered domain from the "dns.question.name" field.
-* Calculates the count of unique DNS queries per registered domain and process name.
-* Filters results where "unique_queries" are greater than 10.
-* Sorts the results by "unique_queries" in descending order.
-* Renames fields for clarity: "unique_queries" to "Unique Queries," "dns.question.registered_domain" to "Registered Domain," and "process.name" to "Process."
+.Show example with comments
+[%collapsible]
+====
+[source,esql]
+----
+// Query logs from indices matching logs-*
+FROM logs-*
+// Use GROK to extract the registered domain from dns.question.name
+| GROK dns.question.name "%{DATA}\\.%{GREEDYDATA:dns.question.registered_domain:string}"
+// Calculate count of unique DNS queries per registered domain and process name
+| STATS unique_queries = COUNT_DISTINCT(dns.question.name) BY dns.question.registered_domain, process.name
+// Limit to results where unique_queries exceeds 10
+| WHERE unique_queries > 10
+// Sort by unique_queries in descending order
+| SORT unique_queries DESC
+// Rename fields for clarity
+| RENAME unique_queries AS `Unique Queries`, dns.question.registered_domain AS `Registered Domain`, process.name AS `Process`
+----
+====
 
+.Show line-by-line explanation
+[%collapsible%open]
+====
+* Query logs from indices that match the pattern `logs-*`.
+* Use a <<esql-process-data-with-grok,grok>> pattern to extract the registered domain from the `dns.question.name` field.
+* Calculate the count of unique DNS queries per registered domain and process name.
+* Limit to results where the number of `unique_queries` is greater than 10.
+* Sort the results by `unique_queries` in descending order.
+* Rename fields for clarity: `unique_queries` to `Unique Queries`, `dns.question.registered_domain` to `Registered Domain`, and `process.name` to `Process`.
+====
 
 [discrete]
-=== Identifying high-numbers of outbound user connections
+=== Find high volumes of outbound user connections
 
 [source,esql]
 ----
@@ -89,11 +165,39 @@ FROM logs-*
 | KEEP destcount, host.name, user.name, group.name, follow_up
 ----
 
-* Queries logs from indices matching "logs-*."
-* Filters out events where the destination IP address falls within private IP address ranges (e.g., 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16).
-* Calculates the count of unique destination IPs by "user.name" and "host.name."
-* Enriches the "user.name" field with LDAP group information.
-* Filters out results where "group.name" is not null.
-* Uses a "CASE" statement to create a "follow_up" field, setting it to "true" when "destcount" is greater than or equal to 100 and "false" otherwise.
-* Sorts the results by "destcount" in descending order.
-* Keeps selected fields: "destcount," "host.name," "user.name," "group.name," and "follow_up."
+.Show example with comments
+[%collapsible]
+====
+[source,esql]
+----
+// Query logs from indices matching logs-*
+FROM logs-*
+// Exclude destination IPs in private ranges
+| WHERE NOT CIDR_MATCH(destination.ip, "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16")
+// Calculate count of unique destination IPs by user.name and host.name
+| STATS destcount = COUNT(destination.ip) BY user.name, host.name
+// Enrich user.name with LDAP info
+| ENRICH ldap_lookup_new ON user.name
+// Filter out results where group.name is null
+| WHERE group.name IS NOT NULL
+// Create a follow_up field that is true when destcount is greater than or equal to 100
+| EVAL follow_up = CASE(destcount >= 100, "true","false")
+// Sort results by destcount in descending order
+| SORT destcount DESC
+// Keep only the specified fields
+| KEEP destcount, host.name, user.name, group.name, follow_up
+----
+====
+
+.Show line-by-line explanation
+[%collapsible%open]
+====
+* Query logs from indices that match the pattern `logs-*`.
+* Filter out events where the destination IP address falls within private IP address ranges (specifically, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`).
+* Calculate the count of unique destination IPs by `user.name` and `host.name`.
+* Enrich the `user.name` field with LDAP group information.
+* Filter out results where `group.name` is null.
+* Use a `CASE` statement to create a `follow_up` field, setting it to `true` when `destcount` is greater than or equal to 100 and to `false` otherwise.
+* Sort the results by `destcount` in descending order.
+* Keep only the specified fields: `destcount`, `host.name`, `user.name`, `group.name`, and `follow_up`.
+====

--- a/docs/reference/esql/esql-examples.asciidoc
+++ b/docs/reference/esql/esql-examples.asciidoc
@@ -83,7 +83,7 @@ FROM logs-endpoint
 | WHERE process.name == "curl.exe"
 // Calculate the sum of bytes sent to destination addresses
 | STATS bytes = SUM(destination.bytes) BY destination.address
-// Convert the sum to kilobytes (KB)
+// Convert the sum to kilobytes (kb)
 | EVAL kb =  bytes/1024
 // Sort results by kb in descending order
 | SORT kb DESC
@@ -130,7 +130,7 @@ FROM logs-*
 | GROK dns.question.name "%{DATA}\\.%{GREEDYDATA:dns.question.registered_domain:string}"
 // Calculate count of unique DNS queries per registered domain and process name
 | STATS unique_queries = COUNT_DISTINCT(dns.question.name) BY dns.question.registered_domain, process.name
-// Limit to results where unique_queries exceeds 10
+// Limit to results with more than 10 unique_queries
 | WHERE unique_queries > 10
 // Sort by unique_queries in descending order
 | SORT unique_queries DESC
@@ -197,7 +197,7 @@ FROM logs-*
 * Calculate the count of unique destination IPs by `user.name` and `host.name`.
 * Enrich the `user.name` field with LDAP group information.
 * Filter out results where `group.name` is null.
-* Use a `CASE` statement to create a `follow_up` field, setting it to `true` when `destcount` is greater than or equal to 100 and to `false` otherwise.
+* Use a `CASE` statement to create a `follow_up` field, setting it to `true` when `destcount` is greater than or equal to 100. Otherwise, `follow_up` is `false`.
 * Sort the results by `destcount` in descending order.
 * Keep only the specified fields: `destcount`, `host.name`, `user.name`, `group.name`, and `follow_up`.
 ====


### PR DESCRIPTION
Add commented examples in collapsible sections. Spruce up the page generally.
* Collapsed content is largely a matter of taste, and it's arguably less accessible. So this is just a PoC to take or leave.
* Initially I was going to leave both blocks collapsed by default, but that seemed like a skimmability trade-off. But it's an option.

[Preview](https://elasticsearch_bk_110017.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/esql-examples.html) 