### PR TITLE
[ML] Enhancements to `ml.allocated_processors_scale` for increased flexibility in model allocations.

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -601,10 +601,10 @@ public class MachineLearning extends Plugin
      * Increasing this setting above 1 reduces the number of model
      * allocations that can be deployed on a node.
      */
-    public static final Setting<Integer> ALLOCATED_PROCESSORS_SCALE = Setting.intSetting(
+    public static final Setting<Double> ALLOCATED_PROCESSORS_SCALE = Setting.doubleSetting(
         "xpack.ml.allocated_processors_scale",
-        1,
-        1,
+        1.0,
+        0,
         Property.Dynamic,
         Property.NodeScope
     );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingDeciderService.java
@@ -44,7 +44,7 @@ public final class MlAutoscalingDeciderService implements AutoscalingDeciderServ
     private final MlProcessorAutoscalingDecider processorDecider;
 
     private volatile boolean isMaster;
-    private volatile int allocatedProcessorsScale;
+    private volatile double allocatedProcessorsScale;
 
     public MlAutoscalingDeciderService(
         MlMemoryTracker memoryTracker,
@@ -78,7 +78,7 @@ public final class MlAutoscalingDeciderService implements AutoscalingDeciderServ
             .addSettingsUpdateConsumer(MachineLearning.ALLOCATED_PROCESSORS_SCALE, this::setAllocatedProcessorsScale);
     }
 
-    void setAllocatedProcessorsScale(int scale) {
+    void setAllocatedProcessorsScale(double scale) {
         this.allocatedProcessorsScale = scale;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDecider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDecider.java
@@ -125,7 +125,7 @@ class MlMemoryAutoscalingDecider {
         Settings configuration,
         AutoscalingDeciderContext context,
         MlAutoscalingContext mlContext,
-        int allocatedProcessorsScale
+        double allocatedProcessorsScale
     ) {
         final ClusterState clusterState = context.state();
 
@@ -830,7 +830,7 @@ class MlMemoryAutoscalingDecider {
     static boolean modelAssignmentsRequireMoreThanHalfCpu(
         Collection<TrainedModelAssignment> assignments,
         List<DiscoveryNode> mlNodes,
-        int allocatedProcessorsScale
+        double allocatedProcessorsScale
     ) {
         int totalRequiredProcessors = assignments.stream()
             .mapToInt(t -> t.getTaskParams().getNumberOfAllocations() * t.getTaskParams().getThreadsPerAllocation())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlProcessorAutoscalingDecider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlProcessorAutoscalingDecider.java
@@ -45,7 +45,7 @@ class MlProcessorAutoscalingDecider {
         Settings configuration,
         AutoscalingDeciderContext context,
         MlAutoscalingContext mlContext,
-        int allocatedProcessorsScale
+        double allocatedProcessorsScale
     ) {
         TrainedModelAssignmentMetadata trainedModelAssignmentMetadata = TrainedModelAssignmentMetadata.fromState(context.state());
 
@@ -147,7 +147,7 @@ class MlProcessorAutoscalingDecider {
         );
     }
 
-    MlProcessorAutoscalingCapacity computeCurrentCapacity(List<DiscoveryNode> mlNodes, int allocatedProcessorsScale) {
+    MlProcessorAutoscalingCapacity computeCurrentCapacity(List<DiscoveryNode> mlNodes, double allocatedProcessorsScale) {
         Processors maxNodeProcessors = Processors.ZERO;
         Processors tierProcessors = Processors.ZERO;
         for (DiscoveryNode node : mlNodes) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -89,7 +89,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
     private volatile int maxOpenJobs;
     protected volatile int maxLazyMLNodes;
     protected volatile long maxMLNodeSize;
-    protected volatile int allocatedProcessorsScale;
+    protected volatile double allocatedProcessorsScale;
 
     public TrainedModelAssignmentClusterService(
         Settings settings,
@@ -147,7 +147,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         this.maxMLNodeSize = value.getBytes();
     }
 
-    private void setAllocatedProcessorsScale(int scale) {
+    private void setAllocatedProcessorsScale(double scale) {
         this.allocatedProcessorsScale = scale;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancer.java
@@ -51,7 +51,7 @@ class TrainedModelAssignmentRebalancer {
     private final Map<DiscoveryNode, NodeLoad> nodeLoads;
     private final Map<List<String>, Collection<DiscoveryNode>> mlNodesByZone;
     private final Optional<StartTrainedModelDeploymentAction.TaskParams> deploymentToAdd;
-    private final int allocatedProcessorsScale;
+    private final double allocatedProcessorsScale;
 
     private final boolean useNewMemoryFields;
 
@@ -60,7 +60,7 @@ class TrainedModelAssignmentRebalancer {
         Map<DiscoveryNode, NodeLoad> nodeLoads,
         Map<List<String>, Collection<DiscoveryNode>> mlNodesByZone,
         Optional<StartTrainedModelDeploymentAction.TaskParams> deploymentToAdd,
-        int allocatedProcessorsScale,
+        double allocatedProcessorsScale,
         boolean useNewMemoryFields
     ) {
         this.currentMetadata = Objects.requireNonNull(currentMetadata);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/MlProcessors.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/MlProcessors.java
@@ -17,7 +17,7 @@ public final class MlProcessors {
 
     private MlProcessors() {}
 
-    public static Processors get(DiscoveryNode node, Integer allocatedProcessorScale) {
+    public static Processors get(DiscoveryNode node, Double allocatedProcessorScale) {
         // Try getting the most modern setting, and if that's null then instead get the older setting. (If both are null then return zero.)
         String allocatedProcessorsString = node.getAttributes().get(MachineLearning.ALLOCATED_PROCESSORS_NODE_ATTR);
         if (allocatedProcessorsString == null) {
@@ -47,7 +47,7 @@ public final class MlProcessors {
         }
     }
 
-    public static Processors getMaxMlNodeProcessors(DiscoveryNodes nodes, Integer allocatedProcessorScale) {
+    public static Processors getMaxMlNodeProcessors(DiscoveryNodes nodes, Double allocatedProcessorScale) {
         Processors answer = Processors.ZERO;
         for (DiscoveryNode node : nodes) {
             if (node.getRoles().contains(DiscoveryNodeRole.ML_ROLE)) {
@@ -60,7 +60,7 @@ public final class MlProcessors {
         return answer;
     }
 
-    public static Processors getTotalMlNodeProcessors(DiscoveryNodes nodes, Integer allocatedProcessorScale) {
+    public static Processors getTotalMlNodeProcessors(DiscoveryNodes nodes, Double allocatedProcessorScale) {
         int total = 0;
         for (DiscoveryNode node : nodes) {
             if (node.getRoles().contains(DiscoveryNodeRole.ML_ROLE)) {


### PR DESCRIPTION
### Related Issue
https://github.com/elastic/elasticsearch/issues/109001

### Motivation

The current implementation of `ml.allocated_processors_scale` is limited to integer values, primarily used for scaling down processor counts to account for hyper-threading. This proposal aims to extend its functionality to better utilize excess capacity on nodes by allowing the scaling up of processor counts.

### Proposed Changes

1. Modify `ml.allocated_processors_scale` to accept floating-point values for finer granularity in scaling.
2. Allow `ml.allocated_processors_scale` to support values less than 1, enabling an increase in the effective processor count used in model planning.
3. Update documentation to clearly describe the effects of `ml.allocated_processors_scale` on model allocations and thread usage.

These changes will make the setting more adaptable to various resource availability scenarios.