### PR TITLE
Rename Mapper#simpleName to Mapper#leafName

### DIFF
--- a/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
+++ b/modules/legacy-geo/src/main/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapper.java
@@ -610,7 +610,7 @@ public class LegacyGeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<
     @Override
     public FieldMapper.Builder getMergeBuilder() {
         return new Builder(
-            simpleName(),
+            leafName(),
             indexCreatedVersion,
             builder.ignoreMalformed.getDefaultValue().value(),
             builder.coerce.getDefaultValue().value()

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapper.java
@@ -405,7 +405,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), indexCreatedVersion, indexAnalyzers).init(this);
+        return new Builder(leafName(), indexCreatedVersion, indexAnalyzers).init(this);
     }
 
     @Override
@@ -447,7 +447,7 @@ public class MatchOnlyTextFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new StringStoredFieldFieldLoader(fieldType().storedFieldNameForSyntheticSource(), simpleName(), null) {
+        return new StringStoredFieldFieldLoader(fieldType().storedFieldNameForSyntheticSource(), leafName(), null) {
             @Override
             protected void write(XContentBuilder b, Object value) throws IOException {
                 b.value((String) value);

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
@@ -233,6 +233,6 @@ public class RankFeatureFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 }

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapper.java
@@ -137,7 +137,7 @@ public class RankFeaturesFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     @Override

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -511,7 +511,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), ignoreMalformedByDefault, coerceByDefault, indexMode).metric(metricType).init(this);
+        return new Builder(leafName(), ignoreMalformedByDefault, coerceByDefault, indexMode).metric(metricType).init(this);
     }
 
     @Override
@@ -729,7 +729,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new SortedNumericDocValuesSyntheticFieldLoader(name(), simpleName(), ignoreMalformed.value()) {
+        return new SortedNumericDocValuesSyntheticFieldLoader(name(), leafName(), ignoreMalformed.value()) {
             @Override
             protected void writeValue(XContentBuilder b, long value) throws IOException {
                 b.value(decodeForSyntheticSource(value, scalingFactor));

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapper.java
@@ -721,7 +721,7 @@ public class SearchAsYouTypeFieldMapper extends FieldMapper {
     }
 
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), builder.indexCreatedVersion, builder.analyzers.indexAnalyzers).init(this);
+        return new Builder(leafName(), builder.indexCreatedVersion, builder.analyzers.indexAnalyzers).init(this);
     }
 
     public static String getShingleFieldName(String parentField, int shingleSize) {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -213,6 +213,6 @@ public class TokenCountFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 }

--- a/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
+++ b/modules/parent-join/src/main/java/org/elasticsearch/join/mapper/ParentJoinFieldMapper.java
@@ -249,7 +249,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
     @Override
     public void parse(DocumentParserContext context) throws IOException {
-        context.path().add(simpleName());
+        context.path().add(leafName());
         XContentParser.Token token = context.parser().currentToken();
         String name = null;
         String parent = null;
@@ -329,7 +329,7 @@ public final class ParentJoinFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     @Override

--- a/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
+++ b/modules/percolator/src/main/java/org/elasticsearch/percolator/PercolatorFieldMapper.java
@@ -100,8 +100,9 @@ public class PercolatorFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), searchExecutionContext, mapUnmappedFieldsAsText, indexCreatedVersion, clusterTransportVersion)
-            .init(this);
+        return new Builder(leafName(), searchExecutionContext, mapUnmappedFieldsAsText, indexCreatedVersion, clusterTransportVersion).init(
+            this
+        );
     }
 
     static class Builder extends FieldMapper.Builder {

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapper.java
@@ -508,7 +508,7 @@ public class ICUCollationKeywordFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     @Override

--- a/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
+++ b/plugins/mapper-annotated-text/src/main/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapper.java
@@ -564,7 +564,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
     @Override
     public FieldMapper.Builder getMergeBuilder() {
         return new Builder(
-            simpleName(),
+            leafName(),
             builder.indexCreatedVersion,
             builder.analyzers.indexAnalyzers,
             builder.isSyntheticSourceEnabledViaIndexMode
@@ -584,7 +584,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
             );
         }
         if (fieldType.stored()) {
-            return new StringStoredFieldFieldLoader(name(), simpleName(), null) {
+            return new StringStoredFieldFieldLoader(name(), leafName(), null) {
                 @Override
                 protected void write(XContentBuilder b, Object value) throws IOException {
                     b.value((String) value);
@@ -594,7 +594,7 @@ public class AnnotatedTextFieldMapper extends FieldMapper {
 
         var kwd = TextFieldMapper.SyntheticSourceHelper.getKeywordFieldMapperForSyntheticSource(this);
         if (kwd != null) {
-            return kwd.syntheticFieldLoader(simpleName());
+            return kwd.syntheticFieldLoader(leafName());
         }
 
         throw new IllegalArgumentException(

--- a/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
+++ b/plugins/mapper-murmur3/src/main/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapper.java
@@ -100,7 +100,7 @@ public class Murmur3FieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -859,7 +859,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
 
         @Override
         public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-            return new StringStoredFieldFieldLoader(name(), simpleName(), null) {
+            return new StringStoredFieldFieldLoader(name(), leafName(), null) {
                 @Override
                 protected void write(XContentBuilder b, Object value) throws IOException {
                     BytesRef ref = (BytesRef) value;

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryFieldMapper.java
@@ -192,7 +192,7 @@ public class BinaryFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new BinaryFieldMapper.Builder(simpleName(), isSyntheticSourceEnabledViaIndexMode).init(this);
+        return new BinaryFieldMapper.Builder(leafName(), isSyntheticSourceEnabledViaIndexMode).init(this);
     }
 
     @Override
@@ -229,10 +229,10 @@ public class BinaryFieldMapper extends FieldMapper {
                     case 0:
                         return;
                     case 1:
-                        b.field(simpleName());
+                        b.field(leafName());
                         break;
                     default:
-                        b.startArray(simpleName());
+                        b.startArray(leafName());
                 }
 
                 for (int i = 0; i < count; i++) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -480,7 +480,7 @@ public class BooleanFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), scriptCompiler, ignoreMalformedByDefault, indexCreatedVersion).init(this);
+        return new Builder(leafName(), scriptCompiler, ignoreMalformedByDefault, indexCreatedVersion).init(this);
     }
 
     @Override
@@ -513,7 +513,7 @@ public class BooleanFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new SortedNumericDocValuesSyntheticFieldLoader(name(), simpleName(), ignoreMalformed.value()) {
+        return new SortedNumericDocValuesSyntheticFieldLoader(name(), leafName(), ignoreMalformed.value()) {
             @Override
             protected void writeValue(XContentBuilder b, long value) throws IOException {
                 b.value(value == 1);

--- a/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/CompletionFieldMapper.java
@@ -82,7 +82,7 @@ public class CompletionFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), builder.defaultAnalyzer, builder.indexVersionCreated).init(this);
+        return new Builder(leafName(), builder.defaultAnalyzer, builder.indexVersionCreated).init(this);
     }
 
     public static class Defaults {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -898,7 +898,7 @@ public final class DateFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), resolution, null, scriptCompiler, ignoreMalformedByDefault, indexCreatedVersion).init(this);
+        return new Builder(leafName(), resolution, null, scriptCompiler, ignoreMalformedByDefault, indexCreatedVersion).init(this);
     }
 
     @Override
@@ -997,7 +997,7 @@ public final class DateFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new SortedNumericDocValuesSyntheticFieldLoader(name(), simpleName(), ignoreMalformed) {
+        return new SortedNumericDocValuesSyntheticFieldLoader(name(), leafName(), ignoreMalformed) {
             @Override
             protected void writeValue(XContentBuilder b, long value) throws IOException {
                 b.value(fieldType().format(value, fieldType().dateTimeFormatter()));

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -295,7 +295,7 @@ public final class DocumentParser {
                 context.addIgnoredField(
                     new IgnoredSourceFieldMapper.NameValue(
                         context.parent().name(),
-                        context.parent().fullPath().indexOf(context.parent().simpleName()),
+                        context.parent().fullPath().indexOf(context.parent().leafName()),
                         XContentDataHelper.encodeXContentBuilder(tuple.v2()),
                         context.doc()
                     )
@@ -429,7 +429,7 @@ public final class DocumentParser {
         } else if (mapper instanceof FieldMapper fieldMapper) {
             if (shouldFlattenObject(context, fieldMapper)) {
                 // we pass the mapper's simpleName as parentName to the new DocumentParserContext
-                String currentFieldName = fieldMapper.simpleName();
+                String currentFieldName = fieldMapper.leafName();
                 context.path().remove();
                 parseObjectOrNested(context.createFlattenContext(currentFieldName));
                 context.path().add(currentFieldName);
@@ -562,7 +562,7 @@ public final class DocumentParser {
                     throw new DocumentParsingException(
                         context.parser().getTokenLocation(),
                         "Tried to add nested object ["
-                            + dynamicObjectMapper.simpleName()
+                            + dynamicObjectMapper.leafName()
                             + "] to object ["
                             + context.parent().name()
                             + "] which does not support subobjects"

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldAliasMapper.java
@@ -71,7 +71,7 @@ public final class FieldAliasMapper extends Mapper {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        return builder.startObject(simpleName()).field("type", CONTENT_TYPE).field(Names.PATH, path).endObject();
+        return builder.startObject(leafName()).field("type", CONTENT_TYPE).field(Names.PATH, path).endObject();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -194,7 +194,7 @@ public abstract class FieldMapper extends Mapper {
     }
 
     private void doParseMultiFields(DocumentParserContext context) throws IOException {
-        context.path().add(simpleName());
+        context.path().add(leafName());
         for (FieldMapper mapper : multiFields.mappers) {
             mapper.parse(context);
         }
@@ -416,7 +416,7 @@ public abstract class FieldMapper extends Mapper {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(simpleName());
+        builder.startObject(leafName());
         doXContentBody(builder, params);
         return builder.endObject();
     }
@@ -526,7 +526,7 @@ public abstract class FieldMapper extends Mapper {
             }
 
             private void add(FieldMapper mapper) {
-                mapperBuilders.put(mapper.simpleName(), context -> mapper);
+                mapperBuilders.put(mapper.leafName(), context -> mapper);
 
                 if (mapper instanceof KeywordFieldMapper kwd) {
                     if (kwd.hasNormalizer() == false && (kwd.fieldType().hasDocValues() || kwd.fieldType().isStored())) {
@@ -536,12 +536,12 @@ public abstract class FieldMapper extends Mapper {
             }
 
             private void update(FieldMapper toMerge, MapperMergeContext context) {
-                if (mapperBuilders.containsKey(toMerge.simpleName()) == false) {
+                if (mapperBuilders.containsKey(toMerge.leafName()) == false) {
                     if (context.decrementFieldBudgetIfPossible(toMerge.getTotalFieldsCount())) {
                         add(toMerge);
                     }
                 } else {
-                    FieldMapper existing = mapperBuilders.get(toMerge.simpleName()).apply(context.getMapperBuilderContext());
+                    FieldMapper existing = mapperBuilders.get(toMerge.leafName()).apply(context.getMapperBuilderContext());
                     add(existing.merge(toMerge, context));
                 }
             }
@@ -584,7 +584,7 @@ public abstract class FieldMapper extends Mapper {
             if (mappers.length == 0) {
                 return;
             }
-            context.path().add(mainField.simpleName());
+            context.path().add(mainField.leafName());
             for (FieldMapper mapper : mappers) {
                 mapper.parse(multiFieldContextSupplier.get());
             }
@@ -1314,7 +1314,7 @@ public abstract class FieldMapper extends Mapper {
             for (Parameter<?> param : getParameters()) {
                 param.merge(in, conflicts);
             }
-            MapperMergeContext childContext = mapperMergeContext.createChildContext(in.simpleName(), null);
+            MapperMergeContext childContext = mapperMergeContext.createChildContext(in.leafName(), null);
             for (FieldMapper newSubField : in.multiFields.mappers) {
                 multiFieldsBuilder.update(newSubField, childContext);
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -99,7 +99,7 @@ final class FieldTypeLookup {
         for (PassThroughObjectMapper passThroughMapper : passThroughMappers) {
             for (Mapper subfield : passThroughMapper.mappers.values()) {
                 if (subfield instanceof FieldMapper fieldMapper) {
-                    String name = fieldMapper.simpleName();
+                    String name = fieldMapper.leafName();
                     // Check for conflict between PassThroughObjectMapper subfields.
                     PassThroughObjectMapper conflict = passThroughFieldAliases.put(name, passThroughMapper);
                     if (conflict != null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -284,7 +284,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
     @Override
     public FieldMapper.Builder getMergeBuilder() {
         return new Builder(
-            simpleName(),
+            leafName(),
             builder.scriptCompiler,
             builder.ignoreMalformed.getDefaultValue().value(),
             indexCreatedVersion,
@@ -636,7 +636,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new SortedNumericDocValuesSyntheticFieldLoader(name(), simpleName(), ignoreMalformed()) {
+        return new SortedNumericDocValuesSyntheticFieldLoader(name(), leafName(), ignoreMalformed()) {
             final GeoPoint point = new GeoPoint();
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoShapeFieldMapper.java
@@ -184,7 +184,7 @@ public class GeoShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geomet
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), builder.ignoreMalformed.getDefaultValue().value(), builder.coerce.getDefaultValue().value()).init(
+        return new Builder(leafName(), builder.ignoreMalformed.getDefaultValue().value(), builder.coerce.getDefaultValue().value()).init(
             this
         );
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpFieldMapper.java
@@ -589,7 +589,7 @@ public class IpFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), scriptCompiler, ignoreMalformedByDefault, indexCreatedVersion).dimension(dimension).init(this);
+        return new Builder(leafName(), scriptCompiler, ignoreMalformedByDefault, indexCreatedVersion).dimension(dimension).init(this);
     }
 
     @Override
@@ -621,7 +621,7 @@ public class IpFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new SortedSetDocValuesSyntheticFieldLoader(name(), simpleName(), null, ignoreMalformed) {
+        return new SortedSetDocValuesSyntheticFieldLoader(name(), leafName(), null, ignoreMalformed) {
             @Override
             protected BytesRef convert(BytesRef value) {
                 byte[] bytes = Arrays.copyOfRange(value.bytes, value.offset, value.offset + value.length);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -995,8 +995,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), indexAnalyzers, scriptCompiler, indexCreatedVersion).dimension(fieldType().isDimension())
-            .init(this);
+        return new Builder(leafName(), indexAnalyzers, scriptCompiler, indexCreatedVersion).dimension(fieldType().isDimension()).init(this);
     }
 
     @Override
@@ -1028,7 +1027,7 @@ public final class KeywordFieldMapper extends FieldMapper {
 
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-        return syntheticFieldLoader(simpleName());
+        return syntheticFieldLoader(leafName());
     }
 
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader(String simpleName) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/Mapper.java
@@ -53,18 +53,15 @@ public abstract class Mapper implements ToXContentFragment, Iterable<Mapper> {
         }
     }
 
-    private final String simpleName;
+    private final String leafName;
 
-    public Mapper(String simpleName) {
-        Objects.requireNonNull(simpleName);
-        this.simpleName = internFieldName(simpleName);
+    public Mapper(String leafName) {
+        Objects.requireNonNull(leafName);
+        this.leafName = internFieldName(leafName);
     }
 
-    /** Returns the simple name, which identifies this mapper against other mappers at the same level in the mappers hierarchy
-     * TODO: make this protected once Mapper and FieldMapper are merged together */
-    // TODO rename this to leafName?
-    public final String simpleName() {
-        return simpleName;
+    public final String leafName() {
+        return leafName;
     }
 
     /** Returns the canonical name which uniquely identifies the mapper against other mappers in a type. */

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java
@@ -226,7 +226,7 @@ public final class MappingLookup {
     private static void assertNamesInterned(String name, Mapper mapper) {
         assert name == name.intern();
         assert mapper.name() == mapper.name().intern();
-        assert mapper.simpleName() == mapper.simpleName().intern();
+        assert mapper.leafName() == mapper.leafName().intern();
         if (mapper instanceof ObjectMapper) {
             ((ObjectMapper) mapper).mappers.forEach(MappingLookup::assertNamesInterned);
         }
@@ -362,7 +362,7 @@ public final class MappingLookup {
 
     private static void validateMapperNameIn(Collection<? extends Mapper> mappers, long limit) {
         for (Mapper mapper : mappers) {
-            String name = mapper.simpleName();
+            String name = mapper.leafName();
             if (name.length() > limit) {
                 throw new IllegalArgumentException("Field name [" + name + "] is longer than the limit of [" + limit + "] characters");
             }

--- a/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MetadataFieldMapper.java
@@ -188,7 +188,7 @@ public abstract class MetadataFieldMapper extends FieldMapper {
         if (mergeBuilder == null || mergeBuilder.isConfigured() == false) {
             return builder;
         }
-        builder.startObject(simpleName());
+        builder.startObject(leafName());
         getMergeBuilder().toXContent(builder, params);
         return builder.endObject();
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -244,7 +244,7 @@ public class NestedObjectMapper extends ObjectMapper {
 
     @Override
     public ObjectMapper.Builder newBuilder(IndexVersion indexVersionCreated) {
-        NestedObjectMapper.Builder builder = new NestedObjectMapper.Builder(simpleName(), indexVersionCreated, bitsetProducer);
+        NestedObjectMapper.Builder builder = new NestedObjectMapper.Builder(leafName(), indexVersionCreated, bitsetProducer);
         builder.enabled = enabled;
         builder.dynamic = dynamic;
         builder.includeInRoot = includeInRoot;
@@ -255,7 +255,7 @@ public class NestedObjectMapper extends ObjectMapper {
     @Override
     NestedObjectMapper withoutMappers() {
         return new NestedObjectMapper(
-            simpleName(),
+            leafName(),
             fullPath(),
             Map.of(),
             enabled,
@@ -272,7 +272,7 @@ public class NestedObjectMapper extends ObjectMapper {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(simpleName());
+        builder.startObject(leafName());
         builder.field("type", CONTENT_TYPE);
         if (includeInParent.explicit() && includeInParent.value()) {
             builder.field("include_in_parent", includeInParent.value());
@@ -330,7 +330,7 @@ public class NestedObjectMapper extends ObjectMapper {
             }
         }
         return new NestedObjectMapper(
-            simpleName(),
+            leafName(),
             fullPath(),
             mergeResult.mappers(),
             mergeResult.enabled(),
@@ -451,12 +451,12 @@ public class NestedObjectMapper extends ObjectMapper {
         public void write(XContentBuilder b) throws IOException {
             assert (children != null && children.size() > 0);
             if (children.size() == 1) {
-                b.startObject(simpleName());
+                b.startObject(leafName());
                 leafStoredFieldLoader.advanceTo(children.get(0));
                 leafSourceLoader.write(leafStoredFieldLoader, children.get(0), b);
                 b.endObject();
             } else {
-                b.startArray(simpleName());
+                b.startArray(leafName());
                 for (int childId : children) {
                     b.startObject();
                     leafStoredFieldLoader.advanceTo(childId);

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1970,7 +1970,7 @@ public class NumberFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), type, scriptCompiler, ignoreMalformedByDefault, coerceByDefault, indexCreatedVersion, indexMode)
+        return new Builder(leafName(), type, scriptCompiler, ignoreMalformedByDefault, coerceByDefault, indexCreatedVersion, indexMode)
             .dimension(dimension)
             .metric(metricType)
             .allowMultipleValues(allowMultipleValues)
@@ -2006,7 +2006,7 @@ public class NumberFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return type.syntheticFieldLoader(name(), simpleName(), ignoreMalformed.value());
+        return type.syntheticFieldLoader(name(), leafName(), ignoreMalformed.value());
     }
 
     // For testing only:

--- a/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -166,7 +166,7 @@ public class ObjectMapper extends Mapper {
             Map<String, Mapper> mappers = new HashMap<>();
             for (Mapper.Builder builder : mappersBuilders) {
                 Mapper mapper = builder.build(mapperBuilderContext);
-                Mapper existing = mappers.get(mapper.simpleName());
+                Mapper existing = mappers.get(mapper.leafName());
                 if (existing != null) {
                     // The same mappings or document may hold the same field twice, either because duplicated JSON keys are allowed or
                     // the same field is provided using the object notation as well as the dot notation at the same time.
@@ -177,9 +177,9 @@ public class ObjectMapper extends Mapper {
                 }
                 if (subobjects.value() == false && mapper instanceof ObjectMapper objectMapper) {
                     // We're parsing a mapping that has set `subobjects: false` but has defined sub-objects
-                    objectMapper.asFlattenedFieldMappers(mapperBuilderContext).forEach(m -> mappers.put(m.simpleName(), m));
+                    objectMapper.asFlattenedFieldMappers(mapperBuilderContext).forEach(m -> mappers.put(m.leafName(), m));
                 } else {
-                    mappers.put(mapper.simpleName(), mapper);
+                    mappers.put(mapper.leafName(), mapper);
                 }
             }
             return mappers;
@@ -418,7 +418,7 @@ public class ObjectMapper extends Mapper {
      * @return a Builder that will produce an empty ObjectMapper with the same configuration as this one
      */
     public ObjectMapper.Builder newBuilder(IndexVersion indexVersionCreated) {
-        ObjectMapper.Builder builder = new ObjectMapper.Builder(simpleName(), subobjects);
+        ObjectMapper.Builder builder = new ObjectMapper.Builder(leafName(), subobjects);
         builder.enabled = this.enabled;
         builder.dynamic = this.dynamic;
         return builder;
@@ -429,7 +429,7 @@ public class ObjectMapper extends Mapper {
      * This is typically used in the context of a mapper merge when there's not enough budget to add the entire object.
      */
     ObjectMapper withoutMappers() {
-        return new ObjectMapper(simpleName(), fullPath, enabled, subobjects, storeArraySource, dynamic, Map.of());
+        return new ObjectMapper(leafName(), fullPath, enabled, subobjects, storeArraySource, dynamic, Map.of());
     }
 
     @Override
@@ -500,7 +500,7 @@ public class ObjectMapper extends Mapper {
         }
         var mergeResult = MergeResult.build(this, (ObjectMapper) mergeWith, parentMergeContext);
         return new ObjectMapper(
-            simpleName(),
+            leafName(),
             fullPath,
             mergeResult.enabled,
             mergeResult.subObjects,
@@ -559,7 +559,7 @@ public class ObjectMapper extends Mapper {
             } else {
                 trackArraySource = existing.storeArraySource;
             }
-            MapperMergeContext objectMergeContext = existing.createChildContext(parentMergeContext, existing.simpleName());
+            MapperMergeContext objectMergeContext = existing.createChildContext(parentMergeContext, existing.leafName());
             Map<String, Mapper> mergedMappers = buildMergedMappers(existing, mergeWithObject, objectMergeContext, subObjects.value());
             return new MergeResult(
                 enabled,
@@ -581,13 +581,13 @@ public class ObjectMapper extends Mapper {
                 if (subobjects == false && childOfExistingMapper instanceof ObjectMapper objectMapper) {
                     // An existing mapping with sub-objects is merged with a mapping that has set `subobjects: false`
                     objectMapper.asFlattenedFieldMappers(objectMergeContext.getMapperBuilderContext())
-                        .forEach(m -> mergedMappers.put(m.simpleName(), m));
+                        .forEach(m -> mergedMappers.put(m.leafName(), m));
                 } else {
                     putMergedMapper(mergedMappers, childOfExistingMapper);
                 }
             }
             for (Mapper mergeWithMapper : mergeWithObject) {
-                Mapper mergeIntoMapper = mergedMappers.get(mergeWithMapper.simpleName());
+                Mapper mergeIntoMapper = mergedMappers.get(mergeWithMapper.leafName());
                 if (mergeIntoMapper == null) {
                     if (subobjects == false && mergeWithMapper instanceof ObjectMapper objectMapper) {
                         // An existing mapping that has set `subobjects: false` is merged with a mapping with sub-objects
@@ -625,7 +625,7 @@ public class ObjectMapper extends Mapper {
 
         private static void putMergedMapper(Map<String, Mapper> mergedMappers, @Nullable Mapper merged) {
             if (merged != null) {
-                mergedMappers.put(merged.simpleName(), merged);
+                mergedMappers.put(merged.leafName(), merged);
             }
         }
 
@@ -656,11 +656,11 @@ public class ObjectMapper extends Mapper {
 
     private void asFlattenedFieldMappers(MapperBuilderContext context, List<FieldMapper> flattenedMappers, ContentPath path) {
         ensureFlattenable(context, path);
-        path.add(simpleName());
+        path.add(leafName());
         for (Mapper mapper : mappers.values()) {
             if (mapper instanceof FieldMapper fieldMapper) {
                 FieldMapper.Builder fieldBuilder = fieldMapper.getMergeBuilder();
-                fieldBuilder.setLeafName(path.pathAsText(mapper.simpleName()));
+                fieldBuilder.setLeafName(path.pathAsText(mapper.leafName()));
                 flattenedMappers.add(fieldBuilder.build(context));
             } else if (mapper instanceof ObjectMapper objectMapper) {
                 objectMapper.asFlattenedFieldMappers(context, flattenedMappers, path);
@@ -691,10 +691,10 @@ public class ObjectMapper extends Mapper {
     private void throwAutoFlatteningException(ContentPath path, String reason) {
         throw new IllegalArgumentException(
             "Object mapper ["
-                + path.pathAsText(simpleName())
+                + path.pathAsText(leafName())
                 + "] was found in a context where subobjects is set to false. "
                 + "Auto-flattening ["
-                + path.pathAsText(simpleName())
+                + path.pathAsText(leafName())
                 + "] failed because "
                 + reason
         );
@@ -707,7 +707,7 @@ public class ObjectMapper extends Mapper {
     }
 
     void toXContent(XContentBuilder builder, Params params, ToXContent custom) throws IOException {
-        builder.startObject(simpleName());
+        builder.startObject(leafName());
         if (mappers.isEmpty() && custom == null) {
             // only write the object content type if there are no properties, otherwise, it is automatically detected
             builder.field("type", CONTENT_TYPE);
@@ -849,7 +849,7 @@ public class ObjectMapper extends Mapper {
                 if (isRoot()) {
                     b.startObject();
                 } else {
-                    b.startObject(simpleName());
+                    b.startObject(leafName());
                 }
             }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/PassThroughObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/PassThroughObjectMapper.java
@@ -113,7 +113,7 @@ public class PassThroughObjectMapper extends ObjectMapper {
 
     @Override
     PassThroughObjectMapper withoutMappers() {
-        return new PassThroughObjectMapper(simpleName(), fullPath(), enabled, dynamic, Map.of(), timeSeriesDimensionSubFields, priority);
+        return new PassThroughObjectMapper(leafName(), fullPath(), enabled, dynamic, Map.of(), timeSeriesDimensionSubFields, priority);
     }
 
     @Override
@@ -131,7 +131,7 @@ public class PassThroughObjectMapper extends ObjectMapper {
 
     @Override
     public PassThroughObjectMapper.Builder newBuilder(IndexVersion indexVersionCreated) {
-        PassThroughObjectMapper.Builder builder = new PassThroughObjectMapper.Builder(simpleName());
+        PassThroughObjectMapper.Builder builder = new PassThroughObjectMapper.Builder(leafName());
         builder.enabled = enabled;
         builder.dynamic = dynamic;
         builder.timeSeriesDimensionSubFields = timeSeriesDimensionSubFields;
@@ -153,7 +153,7 @@ public class PassThroughObjectMapper extends ObjectMapper {
             : this.timeSeriesDimensionSubFields;
 
         return new PassThroughObjectMapper(
-            simpleName(),
+            leafName(),
             fullPath(),
             mergeResult.enabled(),
             mergeResult.dynamic(),
@@ -165,7 +165,7 @@ public class PassThroughObjectMapper extends ObjectMapper {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(simpleName());
+        builder.startObject(leafName());
         builder.field("type", CONTENT_TYPE);
         if (timeSeriesDimensionSubFields.explicit()) {
             builder.field(TimeSeriesParams.TIME_SERIES_DIMENSION_PARAM, timeSeriesDimensionSubFields.value());

--- a/server/src/main/java/org/elasticsearch/index/mapper/PlaceHolderFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/PlaceHolderFieldMapper.java
@@ -277,7 +277,7 @@ public class PlaceHolderFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new PlaceHolderFieldMapper.Builder(simpleName(), typeName()).init(this);
+        return new PlaceHolderFieldMapper.Builder(leafName(), typeName()).init(this);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -364,7 +364,7 @@ public class RangeFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), type, coerceByDefault).init(this);
+        return new Builder(leafName(), type, coerceByDefault).init(this);
     }
 
     @Override
@@ -488,11 +488,11 @@ public class RangeFieldMapper extends FieldMapper {
                     case 0:
                         return;
                     case 1:
-                        b.field(simpleName());
+                        b.field(leafName());
                         ranges.get(0).toXContent(b, fieldType().dateTimeFormatter);
                         break;
                     default:
-                        b.startArray(simpleName());
+                        b.startArray(leafName());
                         for (var range : ranges) {
                             range.toXContent(b, fieldType().dateTimeFormatter);
                         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RootObjectMapper.java
@@ -161,7 +161,7 @@ public class RootObjectMapper extends ObjectMapper {
     @Override
     RootObjectMapper withoutMappers() {
         return new RootObjectMapper(
-            simpleName(),
+            leafName(),
             enabled,
             subobjects,
             storeArraySource,
@@ -277,7 +277,7 @@ public class RootObjectMapper extends ObjectMapper {
         }
 
         return new RootObjectMapper(
-            simpleName(),
+            leafName(),
             mergeResult.enabled(),
             mergeResult.subObjects(),
             mergeResult.trackArraySource(),

--- a/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TextFieldMapper.java
@@ -1265,7 +1265,7 @@ public final class TextFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), indexCreatedVersion, indexAnalyzers, isSyntheticSourceEnabledViaIndexMode).init(this);
+        return new Builder(leafName(), indexCreatedVersion, indexAnalyzers, isSyntheticSourceEnabledViaIndexMode).init(this);
     }
 
     @Override
@@ -1459,7 +1459,7 @@ public final class TextFieldMapper extends FieldMapper {
             );
         }
         if (store) {
-            return new StringStoredFieldFieldLoader(name(), simpleName(), null) {
+            return new StringStoredFieldFieldLoader(name(), leafName(), null) {
                 @Override
                 protected void write(XContentBuilder b, Object value) throws IOException {
                     b.value((String) value);
@@ -1469,7 +1469,7 @@ public final class TextFieldMapper extends FieldMapper {
 
         var kwd = SyntheticSourceHelper.getKeywordFieldMapperForSyntheticSource(this);
         if (kwd != null) {
-            return kwd.syntheticFieldLoader(simpleName());
+            return kwd.syntheticFieldLoader(leafName());
         }
 
         throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapper.java
@@ -801,7 +801,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     @Override
@@ -815,7 +815,7 @@ public final class FlattenedFieldMapper extends FieldMapper {
             return SourceLoader.SyntheticFieldLoader.NOTHING;
         }
         if (fieldType().hasDocValues()) {
-            return new FlattenedSortedSetDocValuesSyntheticFieldLoader(name() + "._keyed", simpleName());
+            return new FlattenedSortedSetDocValuesSyntheticFieldLoader(name() + "._keyed", leafName());
         }
 
         throw new IllegalArgumentException(

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -1666,7 +1666,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
                 fieldType().meta()
             );
             Mapper update = new DenseVectorFieldMapper(
-                simpleName(),
+                leafName(),
                 updatedDenseVectorFieldType,
                 indexOptions,
                 indexCreatedVersion,
@@ -1757,7 +1757,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), indexCreatedVersion).init(this);
+        return new Builder(leafName(), indexCreatedVersion).init(this);
     }
 
     private static IndexOptions parseIndexOptions(String fieldName, Object propNode) {
@@ -1883,7 +1883,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             if (hasMagnitude) {
                 magnitude = Float.intBitsToFloat((int) magnitudeReader.longValue());
             }
-            b.startArray(simpleName());
+            b.startArray(leafName());
             if (values != null) {
                 for (float v : values.vectorValue()) {
                     if (hasMagnitude) {
@@ -1943,7 +1943,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
             if (false == hasValue) {
                 return;
             }
-            b.startArray(simpleName());
+            b.startArray(leafName());
             BytesRef ref = values.binaryValue();
             ByteBuffer byteBuffer = ByteBuffer.wrap(ref.bytes, ref.offset, ref.length);
             if (indexCreatedVersion.onOrAfter(LITTLE_ENDIAN_FLOAT_STORED_INDEX_VERSION)) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapper.java
@@ -142,7 +142,7 @@ public class SparseVectorFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentParserTests.java
@@ -2606,7 +2606,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
         Mapper baz = ((ObjectMapper) barMapper).getMapper("baz");
         assertNotNull(baz);
         assertEquals("foo.bar.baz", baz.name());
-        assertEquals("baz", baz.simpleName());
+        assertEquals("baz", baz.leafName());
         List<IndexableField> fields = doc.rootDoc().getFields("foo.bar.baz");
         assertEquals(2, fields.size());
         String[] fieldStrings = fields.stream().map(Object::toString).toArray(String[]::new);
@@ -3245,7 +3245,7 @@ public class DocumentParserTests extends MapperServiceTestCase {
 
             @Override
             public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
-                return new StringStoredFieldFieldLoader(name(), simpleName(), null) {
+                return new StringStoredFieldFieldLoader(name(), leafName(), null) {
                     @Override
                     protected void write(XContentBuilder b, Object value) throws IOException {
                         BytesRef ref = (BytesRef) value;

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -273,7 +273,7 @@ public class MapperServiceTests extends MapperServiceTestCase {
 
         DocumentMapper documentMapper = mapperService.merge("_doc", mapping, MergeReason.MAPPING_RECOVERY);
 
-        assertEquals(testString, documentMapper.mappers().getMapper(testString).simpleName());
+        assertEquals(testString, documentMapper.mappers().getMapper(testString).leafName());
     }
 
     public void testIsMetadataField() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupInferenceFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingLookupInferenceFieldMapperTests.java
@@ -114,7 +114,7 @@ public class MappingLookupInferenceFieldMapperTests extends MapperServiceTestCas
 
         @Override
         public Builder getMergeBuilder() {
-            return new Builder(simpleName());
+            return new Builder(leafName());
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MappingParserTests.java
@@ -206,19 +206,19 @@ public class MappingParserTests extends MapperServiceTestCase {
         assertEquals(1, mapping.getRoot().mappers.size());
         Mapper object = mapping.getRoot().getMapper("obj");
         assertThat(object, CoreMatchers.instanceOf(ObjectMapper.class));
-        assertEquals("obj", object.simpleName());
+        assertEquals("obj", object.leafName());
         assertEquals("obj", object.name());
         ObjectMapper objectMapper = (ObjectMapper) object;
         assertEquals(1, objectMapper.mappers.size());
         object = objectMapper.getMapper("source");
         assertThat(object, CoreMatchers.instanceOf(ObjectMapper.class));
-        assertEquals("source", object.simpleName());
+        assertEquals("source", object.leafName());
         assertEquals("obj.source", object.name());
         objectMapper = (ObjectMapper) object;
         assertEquals(1, objectMapper.mappers.size());
         object = objectMapper.getMapper("geo");
         assertThat(object, CoreMatchers.instanceOf(ObjectMapper.class));
-        assertEquals("geo", object.simpleName());
+        assertEquals("geo", object.leafName());
         assertEquals("obj.source.geo", object.name());
         objectMapper = (ObjectMapper) object;
         assertEquals(1, objectMapper.mappers.size());
@@ -226,7 +226,7 @@ public class MappingParserTests extends MapperServiceTestCase {
         assertThat(location, CoreMatchers.instanceOf(GeoPointFieldMapper.class));
         GeoPointFieldMapper geoPointFieldMapper = (GeoPointFieldMapper) location;
         assertEquals("obj.source.geo.location", geoPointFieldMapper.name());
-        assertEquals("location", geoPointFieldMapper.simpleName());
+        assertEquals("location", geoPointFieldMapper.leafName());
         assertEquals("obj.source.geo.location", geoPointFieldMapper.mappedFieldType.name());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NonDynamicFieldMapperTests.java
@@ -82,7 +82,7 @@ public class NonDynamicFieldMapperTests extends NonDynamicFieldMapperTestCase {
 
         @Override
         public FieldMapper.Builder getMergeBuilder() {
-            return new Builder(simpleName()).init(this);
+            return new Builder(leafName()).init(this);
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ObjectMapperMergeTests.java
@@ -53,10 +53,10 @@ public final class ObjectMapperMergeTests extends ESTestCase {
         final ObjectMapper mergedFoo = (ObjectMapper) merged.getMapper("foo");
         {
             Mapper bar = mergedFoo.getMapper("bar");
-            assertEquals("bar", bar.simpleName());
+            assertEquals("bar", bar.leafName());
             assertEquals("foo.bar", bar.name());
             Mapper baz = mergedFoo.getMapper("baz");
-            assertEquals("baz", baz.simpleName());
+            assertEquals("baz", baz.leafName());
             assertEquals("foo.baz", baz.name());
         }
     }
@@ -140,7 +140,7 @@ public final class ObjectMapperMergeTests extends ESTestCase {
 
         final KeywordFieldMapper keywordFieldMapper = (KeywordFieldMapper) merged.getMapper("host.name");
         assertEquals("host.name", keywordFieldMapper.name());
-        assertEquals("host.name", keywordFieldMapper.simpleName());
+        assertEquals("host.name", keywordFieldMapper.leafName());
     }
 
     public void testMergedFieldNamesFieldWithDotsSubobjectsFalse() {
@@ -157,7 +157,7 @@ public final class ObjectMapperMergeTests extends ESTestCase {
         ObjectMapper metrics = (ObjectMapper) foo.getMapper("metrics");
         final KeywordFieldMapper keywordFieldMapper = (KeywordFieldMapper) metrics.getMapper("host.name");
         assertEquals("foo.metrics.host.name", keywordFieldMapper.name());
-        assertEquals("host.name", keywordFieldMapper.simpleName());
+        assertEquals("host.name", keywordFieldMapper.leafName());
     }
 
     public void testMergedFieldNamesMultiFields() {
@@ -170,10 +170,10 @@ public final class ObjectMapperMergeTests extends ESTestCase {
 
         TextFieldMapper text = (TextFieldMapper) merged.getMapper("text");
         assertEquals("text", text.name());
-        assertEquals("text", text.simpleName());
+        assertEquals("text", text.leafName());
         KeywordFieldMapper keyword = (KeywordFieldMapper) text.multiFields().iterator().next();
         assertEquals("text.keyword", keyword.name());
-        assertEquals("keyword", keyword.simpleName());
+        assertEquals("keyword", keyword.leafName());
     }
 
     public void testMergedFieldNamesMultiFieldsWithinSubobjectsFalse() {
@@ -190,10 +190,10 @@ public final class ObjectMapperMergeTests extends ESTestCase {
         ObjectMapper metrics = (ObjectMapper) foo.getMapper("metrics");
         final TextFieldMapper textFieldMapper = (TextFieldMapper) metrics.getMapper("host.name");
         assertEquals("foo.metrics.host.name", textFieldMapper.name());
-        assertEquals("host.name", textFieldMapper.simpleName());
+        assertEquals("host.name", textFieldMapper.leafName());
         FieldMapper fieldMapper = textFieldMapper.multiFields.iterator().next();
         assertEquals("foo.metrics.host.name.keyword", fieldMapper.name());
-        assertEquals("keyword", fieldMapper.simpleName());
+        assertEquals("keyword", fieldMapper.leafName());
     }
 
     public void testMergeWithLimit() {
@@ -324,7 +324,7 @@ public final class ObjectMapperMergeTests extends ESTestCase {
     private static RootObjectMapper createRootSubobjectFalseLeafWithDots() {
         FieldMapper.Builder fieldBuilder = new KeywordFieldMapper.Builder("host.name", IndexVersion.current());
         FieldMapper fieldMapper = fieldBuilder.build(MapperBuilderContext.root(false, false));
-        assertEquals("host.name", fieldMapper.simpleName());
+        assertEquals("host.name", fieldMapper.leafName());
         assertEquals("host.name", fieldMapper.name());
         return new RootObjectMapper.Builder("_doc", Explicit.EXPLICIT_FALSE).add(fieldBuilder)
             .build(MapperBuilderContext.root(false, false));
@@ -342,7 +342,7 @@ public final class ObjectMapperMergeTests extends ESTestCase {
                 MapperService.MergeReason.MAPPING_UPDATE
             )
         );
-        assertEquals("host.name", fieldMapper.simpleName());
+        assertEquals("host.name", fieldMapper.leafName());
         assertEquals("foo.metrics.host.name", fieldMapper.name());
         return new ObjectMapper.Builder("foo", ObjectMapper.Defaults.SUBOBJECTS).add(
             new ObjectMapper.Builder("metrics", Explicit.EXPLICIT_FALSE).add(fieldBuilder)
@@ -361,10 +361,10 @@ public final class ObjectMapperMergeTests extends ESTestCase {
                 MapperService.MergeReason.MAPPING_UPDATE
             )
         );
-        assertEquals("host.name", textKeywordMultiField.simpleName());
+        assertEquals("host.name", textKeywordMultiField.leafName());
         assertEquals("foo.metrics.host.name", textKeywordMultiField.name());
         FieldMapper fieldMapper = textKeywordMultiField.multiFields.iterator().next();
-        assertEquals("keyword", fieldMapper.simpleName());
+        assertEquals("keyword", fieldMapper.leafName());
         assertEquals("foo.metrics.host.name.keyword", fieldMapper.name());
         return new ObjectMapper.Builder("foo", ObjectMapper.Defaults.SUBOBJECTS).add(
             new ObjectMapper.Builder("metrics", Explicit.EXPLICIT_FALSE).add(fieldBuilder)

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -228,7 +228,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
 
         @Override
         public Builder getMergeBuilder() {
-            return new ParametrizedMapperTests.Builder(simpleName()).init(this);
+            return new ParametrizedMapperTests.Builder(leafName()).init(this);
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MockFieldMapper.java
@@ -34,7 +34,7 @@ public class MockFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName());
+        return new Builder(leafName());
     }
 
     static String findSimpleName(String fullName) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/mapper/HistogramFieldMapper.java
@@ -138,7 +138,7 @@ public class HistogramFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), ignoreMalformedByDefault).init(this);
+        return new Builder(leafName(), ignoreMalformedByDefault).init(this);
     }
 
     @Override
@@ -289,7 +289,7 @@ public class HistogramFieldMapper extends FieldMapper {
 
     @Override
     public void parse(DocumentParserContext context) throws IOException {
-        context.path().add(simpleName());
+        context.path().add(leafName());
 
         boolean shouldStoreMalformedDataForSyntheticSource = context.mappingLookup().isSourceSynthetic() && ignoreMalformed();
         XContentParser.Token token;
@@ -521,7 +521,7 @@ public class HistogramFieldMapper extends FieldMapper {
         }
 
         return new CompositeSyntheticFieldLoader(
-            simpleName(),
+            leafName(),
             name(),
             new HistogramSyntheticFieldLoader(),
             new CompositeSyntheticFieldLoader.MalformedValuesLayer(name())

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -137,7 +137,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
             super.merge(mergeWith, conflicts, mapperMergeContext);
             conflicts.check();
             var semanticMergeWith = (SemanticTextFieldMapper) mergeWith;
-            var context = mapperMergeContext.createChildContext(mergeWith.simpleName(), ObjectMapper.Dynamic.FALSE);
+            var context = mapperMergeContext.createChildContext(mergeWith.leafName(), ObjectMapper.Dynamic.FALSE);
             var inferenceField = inferenceFieldBuilder.apply(context.getMapperBuilderContext());
             var mergedInferenceField = inferenceField.merge(semanticMergeWith.fieldType().getInferenceField(), context);
             inferenceFieldBuilder = c -> mergedInferenceField;
@@ -182,7 +182,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), fieldType().indexVersionCreated, fieldType().getChunksField().bitsetProducer()).init(this);
+        return new Builder(leafName(), fieldType().indexVersionCreated, fieldType().getChunksField().bitsetProducer()).init(this);
     }
 
     @Override
@@ -221,7 +221,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
         if (fieldType().getModelSettings() == null) {
             context.path().remove();
             Builder builder = (Builder) new Builder(
-                simpleName(),
+                leafName(),
                 fieldType().indexVersionCreated,
                 fieldType().getChunksField().bitsetProducer()
             ).init(this);
@@ -231,7 +231,7 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                     .build(context.createDynamicMapperBuilderContext());
                 context.addDynamicMapper(mapper);
             } finally {
-                context.path().add(simpleName());
+                context.path().add(leafName());
             }
         } else {
             Conflicts conflicts = new Conflicts(fullFieldName);

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/mapper/AggregateDoubleMetricFieldMapper.java
@@ -588,7 +588,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
-        context.path().add(simpleName());
+        context.path().add(leafName());
         XContentParser.Token token;
         XContentSubParser subParser = null;
         EnumMap<Metric, Number> metricsParsed = new EnumMap<>(Metric.class);
@@ -707,7 +707,7 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), ignoreMalformedByDefault, indexCreatedVersion, indexMode).metric(metricType).init(this);
+        return new Builder(leafName(), ignoreMalformedByDefault, indexCreatedVersion, indexMode).metric(metricType).init(this);
     }
 
     @Override
@@ -718,9 +718,9 @@ public class AggregateDoubleMetricFieldMapper extends FieldMapper {
     @Override
     public SourceLoader.SyntheticFieldLoader syntheticFieldLoader() {
         return new CompositeSyntheticFieldLoader(
-            simpleName(),
+            leafName(),
             name(),
-            new AggregateMetricSyntheticFieldLoader(name(), simpleName(), metrics),
+            new AggregateMetricSyntheticFieldLoader(name(), leafName(), metrics),
             new CompositeSyntheticFieldLoader.MalformedValuesLayer(name())
         );
     }

--- a/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/main/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapper.java
@@ -74,7 +74,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     public static class Builder extends FieldMapper.Builder {
@@ -321,7 +321,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
 
         if (fieldType().value == null) {
             ConstantKeywordFieldType newFieldType = new ConstantKeywordFieldType(fieldType().name(), value, fieldType().meta());
-            Mapper update = new ConstantKeywordFieldMapper(simpleName(), newFieldType);
+            Mapper update = new ConstantKeywordFieldMapper(leafName(), newFieldType);
             boolean dynamicMapperAdded = context.addDynamicMapper(update);
             // the mapper is already part of the mapping, we're just updating it with the new value
             assert dynamicMapperAdded;
@@ -374,7 +374,7 @@ public class ConstantKeywordFieldMapper extends FieldMapper {
             @Override
             public void write(XContentBuilder b) throws IOException {
                 if (fieldType().value != null) {
-                    b.field(simpleName(), fieldType().value);
+                    b.field(leafName(), fieldType().value);
                 }
             }
 

--- a/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapper.java
+++ b/x-pack/plugin/mapper-counted-keyword/src/main/java/org/elasticsearch/xpack/countedkeyword/CountedKeywordFieldMapper.java
@@ -401,7 +401,7 @@ public class CountedKeywordFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     @Override

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -679,7 +679,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), ignoreMalformedByDefault, indexMode).dimension(dimension).metric(metricType).init(this);
+        return new Builder(leafName(), ignoreMalformedByDefault, indexMode).dimension(dimension).metric(metricType).init(this);
     }
 
     /**
@@ -777,7 +777,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new SortedNumericDocValuesSyntheticFieldLoader(name(), simpleName(), ignoreMalformed()) {
+        return new SortedNumericDocValuesSyntheticFieldLoader(name(), leafName(), ignoreMalformed()) {
             @Override
             protected void writeValue(XContentBuilder b, long value) throws IOException {
                 b.value(DocValueFormat.UNSIGNED_LONG_SHIFTED.format(value));

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapper.java
@@ -442,7 +442,7 @@ public class VersionStringFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName()).init(this);
+        return new Builder(leafName()).init(this);
     }
 
     @Override
@@ -457,7 +457,7 @@ public class VersionStringFieldMapper extends FieldMapper {
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
             );
         }
-        return new SortedSetDocValuesSyntheticFieldLoader(name(), simpleName(), null, false) {
+        return new SortedSetDocValuesSyntheticFieldLoader(name(), leafName(), null, false) {
             @Override
             protected BytesRef convert(BytesRef value) {
                 return VersionEncoder.decodeVersion(value);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapper.java
@@ -458,7 +458,7 @@ public class GeoShapeWithDocValuesFieldMapper extends AbstractShapeGeometryField
     @Override
     public FieldMapper.Builder getMergeBuilder() {
         return new Builder(
-            simpleName(),
+            leafName(),
             builder.version,
             builder.scriptCompiler,
             builder.ignoreMalformed.getDefaultValue().value(),

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -177,7 +177,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), builder.ignoreMalformed.getDefaultValue().value()).init(this);
+        return new Builder(leafName(), builder.ignoreMalformed.getDefaultValue().value()).init(this);
     }
 
     public static class PointFieldType extends AbstractPointFieldType<CartesianPoint> implements ShapeQueryable {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapper.java
@@ -237,7 +237,7 @@ public class ShapeFieldMapper extends AbstractShapeGeometryFieldMapper<Geometry>
     @Override
     public FieldMapper.Builder getMergeBuilder() {
         return new Builder(
-            simpleName(),
+            leafName(),
             builder.version,
             builder.ignoreMalformed.getDefaultValue().value(),
             builder.coerce.getDefaultValue().value()

--- a/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
+++ b/x-pack/plugin/wildcard/src/main/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapper.java
@@ -988,7 +988,7 @@ public class WildcardFieldMapper extends FieldMapper {
 
     @Override
     public FieldMapper.Builder getMergeBuilder() {
-        return new Builder(simpleName(), indexVersionCreated).init(this);
+        return new Builder(leafName(), indexVersionCreated).init(this);
     }
 
     @Override
@@ -1053,10 +1053,10 @@ public class WildcardFieldMapper extends FieldMapper {
                 case 0:
                     return;
                 case 1:
-                    b.field(simpleName());
+                    b.field(leafName());
                     break;
                 default:
-                    b.startArray(simpleName());
+                    b.startArray(leafName());
             }
             for (int i = 0; i < docValueCount; i++) {
                 int length = docValuesStream.readVInt();


### PR DESCRIPTION
This addresses a long standing TODO that caused quite a few bugs over time, in that the mapper name does not include its full path, while the MappedFieldType name does. We have method called simpleName to signal that, but leafName signals that more clearly and aligns with the name we have recently introduced in Mapper.Builder (renamed from name to leafName).

Note that this will require adjustments for plugin developers that implement custom mappers. They will need to switch from using `simpleName()` to `leafName()` in their code.

Relates to #109971