### PR TITLE
[8.14] [Bug] During heavy indexing load it's possible for lazy rollover to trigger multiple rollovers (#109636)

### DIFF
--- a/docs/changelog/109636.yaml
+++ b/docs/changelog/109636.yaml
@@ -1,0 +1,5 @@
+pr: 109636
+summary: "Ensure a lazy rollover request will rollover the target data stream once."
+area: Data streams
+type: bug
+issues: []

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/LazyRolloverDuringDisruptionIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/LazyRolloverDuringDisruptionIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.datastreams;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.admin.indices.rollover.RolloverRequestBuilder;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutComposableIndexTemplateAction;
+import org.elasticsearch.action.datastreams.CreateDataStreamAction;
+import org.elasticsearch.action.datastreams.GetDataStreamAction;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.DataStream;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.disruption.IntermittentLongGCDisruption;
+import org.elasticsearch.test.disruption.SingleNodeDisruption;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0, numClientNodes = 0)
+public class LazyRolloverDuringDisruptionIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(DataStreamsPlugin.class);
+    }
+
+    public void testRolloverIsExecutedOnce() throws ExecutionException, InterruptedException {
+        String masterNode = internalCluster().startMasterOnlyNode();
+        internalCluster().startDataOnlyNodes(3);
+        ensureStableCluster(4);
+
+        String dataStreamName = "my-data-stream";
+        createDataStream(dataStreamName);
+
+        // Mark it to lazy rollover
+        new RolloverRequestBuilder(client()).setRolloverTarget(dataStreamName).lazy(true).execute().get();
+
+        // Verify that the data stream is marked for rollover and that it has currently one index
+        DataStream dataStream = getDataStream(dataStreamName);
+        assertThat(dataStream.rolloverOnWrite(), equalTo(true));
+        assertThat(dataStream.getIndices().size(), equalTo(1));
+
+        // Introduce a disruption to the master node that should delay the rollover execution
+        SingleNodeDisruption masterNodeDisruption = new IntermittentLongGCDisruption(random(), masterNode, 100, 200, 30000, 60000);
+        internalCluster().setDisruptionScheme(masterNodeDisruption);
+        masterNodeDisruption.startDisrupting();
+
+        // Start indexing operations
+        int docs = randomIntBetween(5, 10);
+        CountDownLatch countDownLatch = new CountDownLatch(docs);
+        for (int i = 0; i < docs; i++) {
+            var indexRequest = new IndexRequest(dataStreamName).opType(DocWriteRequest.OpType.CREATE);
+            final String doc = "{ \"@timestamp\": \"2099-05-06T16:21:15.000Z\", \"message\": \"something cool happened\" }";
+            indexRequest.source(doc, XContentType.JSON);
+            client().index(indexRequest, new ActionListener<>() {
+                @Override
+                public void onResponse(DocWriteResponse docWriteResponse) {
+                    countDownLatch.countDown();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail("Indexing request should have succeeded eventually, failed with " + e.getMessage());
+                }
+            });
+        }
+
+        // End the disruption so that all pending tasks will complete
+        masterNodeDisruption.stopDisrupting();
+
+        // Wait for all the indexing requests to be processed successfully
+        countDownLatch.await();
+
+        // Verify that the rollover has happened once
+        dataStream = getDataStream(dataStreamName);
+        assertThat(dataStream.rolloverOnWrite(), equalTo(false));
+        assertThat(dataStream.getIndices().size(), equalTo(2));
+    }
+
+    private DataStream getDataStream(String dataStreamName) {
+        return client().execute(GetDataStreamAction.INSTANCE, new GetDataStreamAction.Request(new String[] { dataStreamName }))
+            .actionGet()
+            .getDataStreams()
+            .get(0)
+            .getDataStream();
+    }
+
+    private void createDataStream(String dataStreamName) throws InterruptedException, ExecutionException {
+        final TransportPutComposableIndexTemplateAction.Request putComposableTemplateRequest =
+            new TransportPutComposableIndexTemplateAction.Request("my-template");
+        putComposableTemplateRequest.indexTemplate(
+            ComposableIndexTemplate.builder()
+                .indexPatterns(List.of(dataStreamName))
+                .dataStreamTemplate(new ComposableIndexTemplate.DataStreamTemplate(false, false))
+                .build()
+        );
+        final AcknowledgedResponse putComposableTemplateResponse = client().execute(
+            TransportPutComposableIndexTemplateAction.TYPE,
+            putComposableTemplateRequest
+        ).actionGet();
+        assertThat(putComposableTemplateResponse.isAcknowledged(), is(true));
+
+        final CreateDataStreamAction.Request createDataStreamRequest = new CreateDataStreamAction.Request(dataStreamName);
+        final AcknowledgedResponse createDataStreamResponse = client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest)
+            .get();
+        assertThat(createDataStreamResponse.isAcknowledged(), is(true));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/LazyRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/LazyRolloverAction.java
@@ -7,18 +7,28 @@
  */
 package org.elasticsearch.action.admin.indices.rollover;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.datastreams.autosharding.DataStreamAutoShardingService;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActiveShardsObserver;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataDataStreamsService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.allocator.AllocationActionMultiListener;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.tasks.CancellableTask;
@@ -26,13 +36,20 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * API that lazily rolls over a data stream that has the flag {@link DataStream#rolloverOnWrite()} enabled. These requests always
  * originate from requests that write into the data stream.
  */
 public final class LazyRolloverAction extends ActionType<RolloverResponse> {
+
+    private static final Logger logger = LogManager.getLogger(LazyRolloverAction.class);
 
     public static final NodeFeature DATA_STREAM_LAZY_ROLLOVER = new NodeFeature("data_stream.rollover.lazy");
 
@@ -49,6 +66,8 @@ public final class LazyRolloverAction extends ActionType<RolloverResponse> {
     }
 
     public static final class TransportLazyRolloverAction extends TransportRolloverAction {
+
+        private final MasterServiceTaskQueue<LazyRolloverTask> lazyRolloverTaskQueue;
 
         @Inject
         public TransportLazyRolloverAction(
@@ -76,6 +95,11 @@ public final class LazyRolloverAction extends ActionType<RolloverResponse> {
                 metadataDataStreamsService,
                 dataStreamAutoShardingService
             );
+            this.lazyRolloverTaskQueue = clusterService.createTaskQueue(
+                "lazy-rollover",
+                Priority.NORMAL,
+                new LazyRolloverExecutor(clusterService, allocationService, rolloverService, threadPool)
+            );
         }
 
         @Override
@@ -93,6 +117,12 @@ public final class LazyRolloverAction extends ActionType<RolloverResponse> {
                 : "The auto rollover action does not expect any other parameters in the request apart from the data stream name";
 
             Metadata metadata = clusterState.metadata();
+            DataStream dataStream = metadata.dataStreams().get(rolloverRequest.getRolloverTarget());
+            // Skip submitting the task if we detect that the lazy rollover has been already executed.
+            if (dataStream.rolloverOnWrite() == false) {
+                listener.onResponse(noopLazyRolloverResponse(dataStream));
+                return;
+            }
             // We evaluate the names of the source index as well as what our newly created index would be.
             final MetadataRolloverService.NameResolution trialRolloverNames = MetadataRolloverService.resolveRolloverNames(
                 clusterState,
@@ -107,28 +137,164 @@ public final class LazyRolloverAction extends ActionType<RolloverResponse> {
 
             assert metadata.dataStreams().containsKey(rolloverRequest.getRolloverTarget()) : "Auto-rollover applies only to data streams";
 
-            final RolloverResponse trialRolloverResponse = new RolloverResponse(
-                trialSourceIndexName,
-                trialRolloverIndexName,
-                Map.of(),
-                false,
-                false,
-                false,
-                false,
-                false
-            );
-
             String source = "lazy_rollover source [" + trialSourceIndexName + "] to target [" + trialRolloverIndexName + "]";
             // We create a new rollover request to ensure that it doesn't contain any other parameters apart from the data stream name
             // This will provide a more resilient user experience
-            RolloverTask rolloverTask = new RolloverTask(
-                new RolloverRequest(rolloverRequest.getRolloverTarget(), null),
-                null,
-                trialRolloverResponse,
-                null,
-                listener
-            );
-            submitRolloverTask(rolloverRequest, source, rolloverTask);
+            var newRolloverRequest = new RolloverRequest(rolloverRequest.getRolloverTarget(), null);
+            newRolloverRequest.setIndicesOptions(rolloverRequest.indicesOptions());
+            LazyRolloverTask rolloverTask = new LazyRolloverTask(newRolloverRequest, listener);
+            lazyRolloverTaskQueue.submitTask(source, rolloverTask, rolloverRequest.masterNodeTimeout());
         }
+    }
+
+    /**
+     * A lazy rollover task holds the rollover request and the listener.
+     */
+    record LazyRolloverTask(RolloverRequest rolloverRequest, ActionListener<RolloverResponse> listener)
+        implements
+            ClusterStateTaskListener {
+
+        @Override
+        public void onFailure(Exception e) {
+            listener.onFailure(e);
+        }
+    }
+
+    /**
+     * Performs a lazy rollover when required and notifies the listener. Due to the nature of the lazy rollover we are able
+     * to perform certain optimisations like identifying duplicate requests and executing them once. This is an optimisation
+     * that can work since we do not take into consideration any stats or auto-sharding conditions here.
+     */
+    record LazyRolloverExecutor(
+        ClusterService clusterService,
+        AllocationService allocationService,
+        MetadataRolloverService rolloverService,
+        ThreadPool threadPool
+    ) implements ClusterStateTaskExecutor<LazyRolloverTask> {
+
+        @Override
+        public ClusterState execute(BatchExecutionContext<LazyRolloverTask> batchExecutionContext) {
+            final var listener = new AllocationActionMultiListener<RolloverResponse>(threadPool.getThreadContext());
+            final var results = new ArrayList<MetadataRolloverService.RolloverResult>(batchExecutionContext.taskContexts().size());
+            var state = batchExecutionContext.initialState();
+            Map<RolloverRequest, List<TaskContext<LazyRolloverTask>>> groupedRequests = new HashMap<>();
+            for (final var taskContext : batchExecutionContext.taskContexts()) {
+                groupedRequests.computeIfAbsent(taskContext.getTask().rolloverRequest(), ignored -> new ArrayList<>()).add(taskContext);
+            }
+            for (final var entry : groupedRequests.entrySet()) {
+                List<TaskContext<LazyRolloverTask>> rolloverTaskContexts = entry.getValue();
+                try {
+                    RolloverRequest rolloverRequest = entry.getKey();
+                    state = executeTask(state, rolloverRequest, results, rolloverTaskContexts, listener);
+                } catch (Exception e) {
+                    rolloverTaskContexts.forEach(taskContext -> taskContext.onFailure(e));
+                } finally {
+                    rolloverTaskContexts.forEach(taskContext -> taskContext.captureResponseHeaders().close());
+                }
+            }
+
+            if (state != batchExecutionContext.initialState()) {
+                var reason = new StringBuilder();
+                Strings.collectionToDelimitedStringWithLimit(
+                    (Iterable<String>) () -> Iterators.map(results.iterator(), t -> t.sourceIndexName() + "->" + t.rolloverIndexName()),
+                    ",",
+                    "lazy bulk rollover [",
+                    "]",
+                    1024,
+                    reason
+                );
+                try (var ignored = batchExecutionContext.dropHeadersContext()) {
+                    state = allocationService.reroute(state, reason.toString(), listener.reroute());
+                }
+            } else {
+                listener.noRerouteNeeded();
+            }
+            return state;
+        }
+
+        public ClusterState executeTask(
+            ClusterState currentState,
+            RolloverRequest rolloverRequest,
+            List<MetadataRolloverService.RolloverResult> results,
+            List<TaskContext<LazyRolloverTask>> rolloverTaskContexts,
+            AllocationActionMultiListener<RolloverResponse> allocationActionMultiListener
+        ) throws Exception {
+
+            // If the data stream has been rolled over since it was marked for lazy rollover, this operation is a noop
+            final DataStream dataStream = currentState.metadata().dataStreams().get(rolloverRequest.getRolloverTarget());
+            assert dataStream != null;
+
+            if (dataStream.rolloverOnWrite() == false) {
+                var noopResponse = noopLazyRolloverResponse(dataStream);
+                notifyAllListeners(rolloverTaskContexts, context -> context.getTask().listener.onResponse(noopResponse));
+                return currentState;
+            }
+
+            // Perform the actual rollover
+            final var rolloverResult = rolloverService.rolloverClusterState(
+                currentState,
+                rolloverRequest.getRolloverTarget(),
+                rolloverRequest.getNewIndexName(),
+                rolloverRequest.getCreateIndexRequest(),
+                List.of(),
+                Instant.now(),
+                false,
+                false,
+                null,
+                null,
+                rolloverRequest.targetsFailureStore()
+            );
+            results.add(rolloverResult);
+            logger.trace("lazy rollover result [{}]", rolloverResult);
+
+            final var rolloverIndexName = rolloverResult.rolloverIndexName();
+            final var sourceIndexName = rolloverResult.sourceIndexName();
+
+            final var waitForActiveShardsTimeout = rolloverRequest.masterNodeTimeout().millis() < 0
+                ? null
+                : rolloverRequest.masterNodeTimeout();
+
+            notifyAllListeners(rolloverTaskContexts, context -> {
+                // Now assuming we have a new state and the name of the rolled over index, we need to wait for the configured number of
+                // active shards, as well as return the names of the indices that were rolled/created
+                ActiveShardsObserver.waitForActiveShards(
+                    clusterService,
+                    new String[] { rolloverIndexName },
+                    rolloverRequest.getCreateIndexRequest().waitForActiveShards(),
+                    waitForActiveShardsTimeout,
+                    allocationActionMultiListener.delay(context.getTask().listener())
+                        .map(
+                            isShardsAcknowledged -> new RolloverResponse(
+                                // Note that we use the actual rollover result for these, because even though we're single threaded,
+                                // it's possible for the rollover names generated before the actual rollover to be different due to
+                                // things like date resolution
+                                sourceIndexName,
+                                rolloverIndexName,
+                                Map.of(),
+                                false,
+                                true,
+                                true,
+                                isShardsAcknowledged,
+                                false
+                            )
+                        )
+                );
+            });
+
+            // Return the new rollover cluster state, which includes the changes that create the new index
+            return rolloverResult.clusterState();
+        }
+    }
+
+    private static void notifyAllListeners(
+        List<ClusterStateTaskExecutor.TaskContext<LazyRolloverTask>> taskContexts,
+        Consumer<ClusterStateTaskExecutor.TaskContext<LazyRolloverTask>> onPublicationSuccess
+    ) {
+        taskContexts.forEach(context -> context.success(() -> onPublicationSuccess.accept(context)));
+    }
+
+    private static RolloverResponse noopLazyRolloverResponse(DataStream dataStream) {
+        String latestWriteIndex = dataStream.getWriteIndex().getName();
+        return new RolloverResponse(latestWriteIndex, latestWriteIndex, Map.of(), false, false, true, true, false);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/RolloverRequest.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.support.ActiveShardCount;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.RestApiVersion;
@@ -181,6 +182,13 @@ public class RolloverRequest extends AcknowledgedRequest<RolloverRequest> implem
     @Override
     public IndicesOptions indicesOptions() {
         return indicesOptions;
+    }
+
+    /**
+     * @return true of the rollover request targets the failure store, false otherwise.
+     */
+    public boolean targetsFailureStore() {
+        return DataStream.isFailureStoreFeatureFlagEnabled() && indicesOptions.failureStoreOptions().includeFailureIndices();
     }
 
     public void setIndicesOptions(IndicesOptions indicesOptions) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverAction.java
@@ -364,7 +364,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                 .flatMap(Arrays::stream)
                 .filter(shard -> shard.getShardRouting().primary())
                 .map(ShardStats::getStats)
-                .mapToLong(shard -> shard.docs.getTotalSizeInBytes())
+                .mapToLong(shard -> shard.docs == null ? 0L : shard.docs.getTotalSizeInBytes())
                 .max()
                 .orElse(0);
 
@@ -374,7 +374,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                 .flatMap(Arrays::stream)
                 .filter(shard -> shard.getShardRouting().primary())
                 .map(ShardStats::getStats)
-                .mapToLong(shard -> shard.docs.getCount())
+                .mapToLong(shard -> shard.docs == null ? 0L : shard.docs.getCount())
                 .max()
                 .orElse(0);
 
@@ -455,7 +455,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                 rolloverRequest.getRolloverTarget(),
                 rolloverRequest.getNewIndexName(),
                 rolloverRequest.getCreateIndexRequest(),
-                rolloverRequest.indicesOptions().failureStoreOptions().includeFailureIndices()
+                rolloverRequest.targetsFailureStore()
             );
 
             // Re-evaluate the conditions, now with our final source index name
@@ -506,7 +506,7 @@ public class TransportRolloverAction extends TransportMasterNodeAction<RolloverR
                     false,
                     sourceIndexStats,
                     rolloverTask.autoShardingResult(),
-                    rolloverRequest.indicesOptions().failureStoreOptions().includeFailureIndices()
+                    rolloverRequest.targetsFailureStore()
                 );
                 results.add(rolloverResult);
                 logger.trace("rollover result [{}]", rolloverResult);

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -452,12 +452,12 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
 
                     @Override
                     public void onResponse(RolloverResponse result) {
-                        // A successful response has rolled_over false when in the following cases:
-                        // - A request had the parameter lazy or dry_run enabled
-                        // - A request had conditions that were not met
-                        // Since none of the above apply, getting a response with rolled_over false is considered a bug
-                        // that should be caught here and inform the developer.
-                        assert result.isRolledOver() : "An successful lazy rollover should always result in a rolled over data stream";
+                        logger.debug(
+                            "Data stream {} has {} over, the latest index is {}",
+                            dataStream,
+                            result.isRolledOver() ? "been successfully rolled" : "skipped rolling",
+                            result.getNewIndex()
+                        );
                     }
 
                     @Override


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [[Bug] During heavy indexing load it's possible for lazy rollover to trigger multiple rollovers (#109636)](https://github.com/elastic/elasticsearch/pull/109636)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)