### PR TITLE
[8.14] Fix equals and hashcode for SingleValueQuery.LuceneQuery (#110035)

### DIFF
--- a/docs/changelog/110035.yaml
+++ b/docs/changelog/110035.yaml
@@ -1,0 +1,5 @@
+pr: 110035
+summary: Fix equals and hashcode for `SingleValueQuery.LuceneQuery`
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
@@ -239,6 +239,7 @@ public class SingleValueQuery extends Query {
     private static class LuceneQuery extends org.apache.lucene.search.Query {
         final org.apache.lucene.search.Query next;
         private final IndexFieldData<?> fieldData;
+        // mutable object for collecting stats and warnings, not really part of the query
         private final Stats stats;
         private final Warnings warnings;
 
@@ -283,14 +284,12 @@ public class SingleValueQuery extends Query {
                 return false;
             }
             SingleValueQuery.LuceneQuery other = (SingleValueQuery.LuceneQuery) obj;
-            return next.equals(other.next)
-                && fieldData.getFieldName().equals(other.fieldData.getFieldName())
-                && warnings.equals(other.warnings);
+            return next.equals(other.next) && fieldData.getFieldName().equals(other.fieldData.getFieldName());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(classHash(), next, fieldData, warnings);
+            return Objects.hash(classHash(), next, fieldData.getFieldName());
         }
 
         @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQueryTests.java
@@ -230,8 +230,14 @@ public class SingleValueQueryTests extends MapperServiceTestCase {
                 if (rewritesToMatchNone != YesNoSometimes.SOMETIMES) {
                     assertThat(builder.stats().noNextScorer(), equalTo(0));
                 }
+                assertEqualsAndHashcodeStable(query, rewritten.toQuery(ctx));
             }
         }
+    }
+
+    private void assertEqualsAndHashcodeStable(Query query1, Query query2) {
+        assertEquals(query1, query2);
+        assertEquals(query1.hashCode(), query2.hashCode());
     }
 
     private record StandardSetup(String fieldType, boolean multivaluedField, boolean empty, int count) implements Setup {


### PR DESCRIPTION
Fixes the implementation of equals and hashcode so the lucene queries can be cached.

backport #110035