### PR TITLE
Handle malformed date when objects are supplied

### DIFF
--- a/docs/changelog/110049.yaml
+++ b/docs/changelog/110049.yaml
@@ -1,0 +1,6 @@
+pr: 110049
+summary: Handle malformed date when objects are supplied
+area: Logs
+type: bug
+issues:
+ - 109539

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/530_date_ignore_malformed.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/530_date_ignore_malformed.yml
@@ -1,0 +1,115 @@
+---
+"date with ignore_malformed in synthetic source":
+  - do:
+      indices.create:
+        index: test
+        body:
+          mappings:
+            _source:
+              mode: synthetic
+            properties:
+              date_ignored:
+                type: date
+                ignore_malformed: true
+              date_not_ignored:
+                type: date
+                ignore_malformed: false
+              date_nanos_ignored:
+                type: date_nanos
+                ignore_malformed: true
+              date_nanos_not_ignored:
+                type: date_nanos
+                ignore_malformed: false
+
+  - do:
+      index:
+        refresh: true
+        index: test
+        id: "1"
+        body: { "date_ignored": "2024-02-03T10:12:43.123Z", "date_not_ignored": "2024-02-03T10:12:43.123Z", date_nanos_ignored: "2024-02-03T10:12:43.123456789Z", "date_nanos_not_ignored": "2024-02-03T10:12:43.123456789Z" }
+
+  - do:
+      catch: bad_request
+      index:
+        refresh: true
+        index: test
+        id: "2"
+        body: { "date_ignored": "2024-02-03T10:12:43.123Z", "date_not_ignored": { "key": "a", "value": 10 }, date_nanos_ignored: "2024-02-03T10:12:43.123456789Z", "date_nanos_not_ignored": "2024-02-03T10:12:43.123456789Z" }
+
+  - match: { error.root_cause.0.type: "document_parsing_exception" }
+
+  - do:
+      catch: bad_request
+      index:
+        refresh: true
+        index: test
+        id: "3"
+        body: { "date_ignored": "2024-02-03T10:12:43.123Z", "date_not_ignored": "2024-02-03T10:12:43.123Z", date_nanos_ignored: "2024-02-03T10:12:43.123456789Z", "date_nanos_not_ignored": { "key": "b", "value": 20 } }
+
+  - match: { error.root_cause.0.type: "document_parsing_exception" }
+
+  - do:
+      index:
+        refresh: true
+        index: test
+        id: "1"
+        body: { "date_ignored": { "key": "a", "value": 10 }, "date_not_ignored": "2024-02-03T10:12:43.123Z", date_nanos_ignored: { "key": "b", "value": 20 }, "date_nanos_not_ignored": "2024-02-03T10:12:43.123456789Z" }
+
+  - do:
+      index:
+        refresh: true
+        index: test
+        id: "2"
+        body: { "date_ignored": [ 1, 2, 3 ], "date_not_ignored": "2024-02-03T10:12:43.123Z", date_nanos_ignored: [ 10, 20, 30 ], "date_nanos_not_ignored": "2024-02-03T10:12:43.123456789Z" }
+
+  - do:
+      index:
+        refresh: true
+        index: test
+        id: "3"
+        body: { "date_ignored": [ { "key": "a", "value": 10 }, { "key": "c", "value": 100 } ], "date_not_ignored": "2024-02-03T10:12:43.123Z", date_nanos_ignored: [ { "key": "b", "value": 20 }, { "key": "d", "value": 40 } ], "date_nanos_not_ignored": "2024-02-03T10:12:43.123456789Z" }
+
+  - do:
+      index:
+        refresh: true
+        index: test
+        id: "4"
+        body: { "date_ignored": [ "foo", "bar", "baz" ], "date_not_ignored": "2024-02-03T10:12:43.123Z", date_nanos_ignored: [ -10, -20, -30 ], "date_nanos_not_ignored": "2024-02-03T10:12:43.123456789Z" }
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            match_all: { }
+
+  - match: { hits.total.value: 4 }
+
+  - match: { hits.hits.0._source.date_ignored.key: "a" }
+  - match: { hits.hits.0._source.date_ignored.value: 10 }
+  - match: { hits.hits.0._source.date_not_ignored: "2024-02-03T10:12:43.123Z" }
+  - match: { hits.hits.0._source.date_nanos_ignored.key: "b" }
+  - match: { hits.hits.0._source.date_nanos_ignored.value: 20 }
+  - match: { hits.hits.0._source.date_nanos_not_ignored: "2024-02-03T10:12:43.123456789Z" }
+
+  # NOTE: this is interesting...numeric values translate to millis since epoch
+  - match: { hits.hits.1._source.date_ignored: [ "1970-01-01T00:00:00.001Z", "1970-01-01T00:00:00.002Z", "1970-01-01T00:00:00.003Z" ] }
+  - match: { hits.hits.1._source.date_not_ignored: "2024-02-03T10:12:43.123Z" }
+  - match: { hits.hits.1._source.date_nanos_ignored: [ "1970-01-01T00:00:00.010Z", "1970-01-01T00:00:00.020Z", "1970-01-01T00:00:00.030Z" ] }
+  - match: { hits.hits.1._source.date_nanos_not_ignored: "2024-02-03T10:12:43.123456789Z" }
+
+  - match: { hits.hits.2._source.date_ignored.0.key: "a" }
+  - match: { hits.hits.2._source.date_ignored.0.value: 10 }
+  - match: { hits.hits.2._source.date_ignored.1.key: "c" }
+  - match: { hits.hits.2._source.date_ignored.1.value: 100 }
+  - match: { hits.hits.2._source.date_not_ignored: "2024-02-03T10:12:43.123Z" }
+  - match: { hits.hits.2._source.date_nanos_ignored.0.key: "b" }
+  - match: { hits.hits.2._source.date_nanos_ignored.0.value: 20 }
+  - match: { hits.hits.2._source.date_nanos_ignored.1.key: "d" }
+  - match: { hits.hits.2._source.date_nanos_ignored.1.value: 40 }
+  - match: { hits.hits.2._source.date_nanos_not_ignored: "2024-02-03T10:12:43.123456789Z" }
+
+  - match: { hits.hits.3._source.date_ignored: [ "foo", "bar", "baz" ] }
+  - match: { hits.hits.3._source.date_not_ignored: "2024-02-03T10:12:43.123Z" }
+  - match: { hits.hits.3._source.date_nanos_ignored: [ -10, -20, -30 ] }
+  - match: { hits.hits.3._source.date_nanos_not_ignored: "2024-02-03T10:12:43.123456789Z" }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -55,6 +55,7 @@ import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.LongScriptFieldDistanceFeatureQuery;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.text.NumberFormat;
@@ -913,7 +914,7 @@ public final class DateFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
-        if (context.parser().currentToken().isValue() == false) {
+        if (context.parser().currentToken() == XContentParser.Token.START_OBJECT) {
             if (ignoreMalformed) {
                 context.addIgnoredField(mappedFieldType.name());
                 if (isSourceSynthetic) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -55,6 +55,7 @@ import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.LongScriptFieldDistanceFeatureQuery;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.text.NumberFormat;
@@ -913,6 +914,17 @@ public final class DateFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
+        if (context.parser().currentToken() == XContentParser.Token.START_OBJECT) {
+            if (ignoreMalformed) {
+                context.addIgnoredField(mappedFieldType.name());
+                if (isSourceSynthetic) {
+                    context.doc().add(IgnoreMalformedStoredValues.storedField(name(), context.parser()));
+                }
+                return;
+            } else {
+                throw new IllegalArgumentException("Unable to parse object as a " + mappedFieldType.name() + " field");
+            }
+        }
         String dateAsString = context.parser().textOrNull();
 
         long timestamp;

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -55,7 +55,6 @@ import org.elasticsearch.search.lookup.FieldValues;
 import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.runtime.LongScriptFieldDistanceFeatureQuery;
 import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.text.NumberFormat;
@@ -914,7 +913,7 @@ public final class DateFieldMapper extends FieldMapper {
 
     @Override
     protected void parseCreateField(DocumentParserContext context) throws IOException {
-        if (context.parser().currentToken() == XContentParser.Token.START_OBJECT) {
+        if (context.parser().currentToken().isValue() == false) {
             if (ignoreMalformed) {
                 context.addIgnoredField(mappedFieldType.name());
                 if (isSourceSynthetic) {


### PR DESCRIPTION
When an `object` is supplied as a value for a field whose type is `date` or `date_nanos` we need
to trigger handling of the field value using our ignore malformed handling strategy.

Resolves #109539 