### PR TITLE
[Profiling] Add protocol field to profiling-hosts index

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
@@ -77,6 +77,9 @@
                   "type": "date",
                   "format": "epoch_millis"
                 },
+                "protocol": {
+                  "type": "keyword"
+                },
                 "config.bpf_log_level": {
                   "type": "long"
                 },

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
@@ -51,7 +51,8 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 8: Changed from disabled _source to synthetic _source for profiling-events-* and profiling-metrics
     // version 9: Changed sort order for profiling-events-*
     // version 10: changed mapping profiling-events @timestamp to 'date_nanos' from 'date'
-    public static final int INDEX_TEMPLATE_VERSION = 10;
+    // version 11: Added 'profiling.agent.protocol' keyword mapping to profiling-hosts
+    public static final int INDEX_TEMPLATE_VERSION = 11;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
     public static final int PROFILING_EVENTS_VERSION = 4;


### PR DESCRIPTION
This PR adds the field `profiling.agent.protocol` to the `profiling-hosts` mapping.
It stores whether a profiling host agent uses the Elastic-specific protocol or the new OTEL protocol.
