### PR TITLE
Avoid semantic_text to be defined as part of a nested field

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperBuilderContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperBuilderContext.java
@@ -134,4 +134,8 @@ public class MapperBuilderContext {
     public MergeReason getMergeReason() {
         return mergeReason;
     }
+
+    public boolean isNested() {
+        return false;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NestedObjectMapper.java
@@ -173,6 +173,11 @@ public class NestedObjectMapper extends ObjectMapper {
                 getMergeReason()
             );
         }
+
+        @Override
+        public boolean isNested() {
+            return true;
+        }
     }
 
     private final Explicit<Boolean> includeInRoot;

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/mapper/SemanticTextFieldMapper.java
@@ -152,6 +152,9 @@ public class SemanticTextFieldMapper extends FieldMapper implements InferenceFie
                 throw new IllegalArgumentException(CONTENT_TYPE + " field [" + leafName() + "] does not support multi-fields");
             }
             final String fullName = context.buildFullName(leafName());
+            if (context.isNested()) {
+                throw new IllegalArgumentException(CONTENT_TYPE + " field [" + fullName + "] cannot be nested");
+            }
             var childContext = context.createChildContext(leafName(), ObjectMapper.Dynamic.FALSE);
             final ObjectMapper inferenceField = inferenceFieldBuilder.apply(childContext);
             return new SemanticTextFieldMapper(

--- a/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
+++ b/x-pack/plugin/inference/src/yamlRestTest/resources/rest-api-spec/test/inference/10_semantic_text_field_mapping.yml
@@ -156,11 +156,12 @@ setup:
                   type: keyword
 
 ---
-"Can be used as a nested field":
+"Cannot be used as a nested field":
 
     - do:
+        catch: /semantic_text field \[nested.semantic\] cannot be nested/
         indices.create:
-          index: test-copy_to-index
+          index: test-nested-index
           body:
             mappings:
               properties:


### PR DESCRIPTION
Until we make it work correctly, let's disable semantic_text to be used in nested fields.