### PR TITLE
[ESQL] remove duplicate datatype functions

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -166,7 +166,6 @@ public enum DataType {
         // ES calls this 'point', but ESQL calls it 'cartesian_point'
         map.put("point", DataType.CARTESIAN_POINT);
         map.put("shape", DataType.CARTESIAN_SHAPE);
-        map.put("date_nanos", DATETIME);
         ES_TO_TYPE = Collections.unmodifiableMap(map);
     }
 

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -162,6 +162,10 @@ public enum DataType {
 
     static {
         Map<String, DataType> map = TYPES.stream().filter(e -> e.esType() != null).collect(toMap(DataType::esType, t -> t));
+        // TODO: Why don't we use the names ES uses as the esType field for these?
+        // ES calls this 'point', but ESQL calls it 'cartesian_point'
+        map.put("point", DataType.CARTESIAN_POINT);
+        map.put("shape", DataType.CARTESIAN_SHAPE);
         map.put("date_nanos", DATETIME);
         ES_TO_TYPE = Collections.unmodifiableMap(map);
     }

--- a/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/type/TypesTests.java
+++ b/x-pack/plugin/esql-core/src/test/java/org/elasticsearch/xpack/esql/core/type/TypesTests.java
@@ -103,16 +103,6 @@ public class TypesTests extends ESTestCase {
         assertThat(field, is(instanceOf(DateEsField.class)));
     }
 
-    public void testDateNanosField() {
-        Map<String, EsField> mapping = loadMapping("mapping-date_nanos.json");
-
-        assertThat(mapping.size(), is(1));
-        EsField field = mapping.get("date_nanos");
-        assertThat(field.getDataType(), is(DATETIME));
-        assertThat(field.isAggregatable(), is(true));
-        assertThat(field, is(instanceOf(DateEsField.class)));
-    }
-
     public void testDocValueField() {
         Map<String, EsField> mapping = loadMapping("mapping-docvalues.json");
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
@@ -39,7 +39,7 @@ public final class EsqlDataTypes {
     private EsqlDataTypes() {}
 
     public static DataType fromTypeName(String name) {
-        return NAME_TO_TYPE.get(name.toLowerCase(Locale.ROOT));
+        return DataType.fromTypeName(name.toLowerCase(Locale.ROOT));
     }
 
     public static DataType fromName(String name) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
@@ -8,12 +8,8 @@ package org.elasticsearch.xpack.esql.type;
 
 import org.elasticsearch.xpack.esql.core.type.DataType;
 
-import java.util.Collections;
 import java.util.Locale;
-import java.util.Map;
 
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toUnmodifiableMap;
 import static org.elasticsearch.xpack.esql.core.type.DataType.BYTE;
 import static org.elasticsearch.xpack.esql.core.type.DataType.DATE_PERIOD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.FLOAT;
@@ -31,10 +27,6 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.UNSUPPORTED;
 import static org.elasticsearch.xpack.esql.core.type.DataType.isNull;
 
 public final class EsqlDataTypes {
-
-    private static final Map<String, DataType> NAME_TO_TYPE = DataType.types()
-        .stream()
-        .collect(toUnmodifiableMap(DataType::typeName, t -> t));
 
     private EsqlDataTypes() {}
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
@@ -36,16 +36,6 @@ public final class EsqlDataTypes {
         .stream()
         .collect(toUnmodifiableMap(DataType::typeName, t -> t));
 
-    private static final Map<String, DataType> ES_TO_TYPE;
-
-    static {
-        Map<String, DataType> map = DataType.types().stream().filter(e -> e.esType() != null).collect(toMap(DataType::esType, t -> t));
-        // ES calls this 'point', but ESQL calls it 'cartesian_point'
-        map.put("point", DataType.CARTESIAN_POINT);
-        map.put("shape", DataType.CARTESIAN_SHAPE);
-        ES_TO_TYPE = Collections.unmodifiableMap(map);
-    }
-
     private EsqlDataTypes() {}
 
     public static DataType fromTypeName(String name) {
@@ -53,8 +43,7 @@ public final class EsqlDataTypes {
     }
 
     public static DataType fromName(String name) {
-        DataType type = ES_TO_TYPE.get(name);
-        return type != null ? type : UNSUPPORTED;
+        return DataType.fromEs(name);
     }
 
     public static boolean isUnsupported(DataType type) {


### PR DESCRIPTION
We had two, slightly different, mappings from ES types to ES|QL types, in `EsqlDataTypes` and `DataType`.  This merges them, and removes other redundant duplicate data structures.