### PR TITLE
[DOCS] Fix tab widgets in semantic search with the inference API tutorial

### DIFF
--- a/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-ingest-pipeline-widget.asciidoc
@@ -8,7 +8,7 @@
       Cohere
     </button>
     <button role="tab"
-            aria-selected="true"
+            aria-selected="false"
             aria-controls="infer-api-ingest-hf-tab"
             id="infer-api-ingest-hf">
       HuggingFace

--- a/docs/reference/tab-widgets/inference-api/infer-api-mapping-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-mapping-widget.asciidoc
@@ -39,7 +39,8 @@ include::infer-api-mapping.asciidoc[tag=cohere]
   <div tabindex="0"
        role="tabpanel"
        id="infer-api-mapping-hf-tab"
-       aria-labelledby="infer-api-mapping-hf">
+       aria-labelledby="infer-api-mapping-hf"
+       hidden="">
 ++++
 
 include::infer-api-mapping.asciidoc[tag=hugging-face]

--- a/docs/reference/tab-widgets/inference-api/infer-api-reindex-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-reindex-widget.asciidoc
@@ -8,7 +8,7 @@
       Cohere
     </button>
     <button role="tab"
-            aria-selected="true"
+            aria-selected="false"
             aria-controls="infer-api-reindex-hf-tab"
             id="infer-api-reindex-hf">
       HuggingFace
@@ -57,7 +57,6 @@ include::infer-api-reindex.asciidoc[tag=hugging-face]
 include::infer-api-reindex.asciidoc[tag=openai]
 
 ++++
-  </div>
   </div>
   <div tabindex="0"
        role="tabpanel"

--- a/docs/reference/tab-widgets/inference-api/infer-api-search-widget.asciidoc
+++ b/docs/reference/tab-widgets/inference-api/infer-api-search-widget.asciidoc
@@ -8,7 +8,7 @@
       Cohere
     </button>
     <button role="tab"
-            aria-selected="true"
+            aria-selected="false"
             aria-controls="infer-api-search-hf-tab"
             id="infer-api-search-hf">
       HuggingFace


### PR DESCRIPTION
Fixes several issues with the tab widgets in the current (8.14) version of [Tutorial: semantic search with the inference API](https://www.elastic.co/guide/en/elasticsearch/reference/current/semantic-search-inference.html) that are currently causing the page to render incorrectly: 

<img width="1482" alt="Screenshot 2024-06-21 at 3 38 32 PM" src="https://github.com/elastic/elasticsearch/assets/10479155/ce6b1634-8f4f-440a-be5f-92c2a3f9e689">


Note: This PR targets `8.14` because this is already [fixed in `main`](https://www.elastic.co/guide/en/elasticsearch/reference/master/semantic-search-inference.html).

h/t @woodywalton for reporting this issue