### PR TITLE
Add more logging for FsDirectoryFactoryTests#testStoreDirectory

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -50,8 +50,6 @@ tests:
 - class: "org.elasticsearch.xpack.rollup.job.RollupIndexerStateTests"
   issue: "https://github.com/elastic/elasticsearch/issues/109627"
   method: "testMultipleJobTriggering"
-- class: "org.elasticsearch.index.store.FsDirectoryFactoryTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/109681"
 - class: "org.elasticsearch.xpack.test.rest.XPackRestIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109687"
   method: "test {p0=sql/translate/Translate SQL}"

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -166,7 +166,7 @@ public class FsDirectoryFactoryTests extends ESTestCase {
                     assertTrue(type + " " + directory.toString(), directory instanceof NIOFSDirectory);
                     break;
                 case MMAPFS:
-                    assertTrue(type + " " + directory.toString(), directory instanceof MMapDirectory);
+                    assertTrue(type + " " + directory.getClass().getName() + " " + directory, directory instanceof MMapDirectory);
                     break;
                 case FS:
                     if (Constants.JRE_IS_64BIT && MMapDirectory.UNMAP_SUPPORTED) {


### PR DESCRIPTION
Test failed on verifying the type of the Lucene directory for the type `MMAPFS`. But in the logs you can see that the instance being checked is a `MMapDirectory`. It seems that impossible to fail the `instanceof` check.

Unnmute the test (which doesn't seem muted, because I can test runs on CI) and log the full class name of the directory class being checked.

See #109681