### PR TITLE
feat: Add new option omit_zero_term_query to bool query

### DIFF
--- a/docs/changelog/110079.yaml
+++ b/docs/changelog/110079.yaml
@@ -1,0 +1,6 @@
+pr: 110079
+summary: "feat: Add new option omit_zero_term_query to bool query"
+area: Search
+type: feature
+issues:
+ - 110080

--- a/docs/reference/query-dsl/bool-query.asciidoc
+++ b/docs/reference/query-dsl/bool-query.asciidoc
@@ -54,6 +54,7 @@ POST _search
         { "term" : { "tags" : "deployed" } }
       ],
       "minimum_should_match" : 1,
+      "omit_zero_term_query" : false
       "boost" : 1.0
     }
   }
@@ -206,3 +207,9 @@ response. Typically, this adds a small overhead to a request. However, using
 computationally expensive named queries on a large number of hits may add
 significant overhead. For example, named queries in combination with a
 `top_hits` aggregation on many buckets may lead to longer response times.
+
+[[bool-omit-zero-term-query]]
+==== Using `omit_zero_term_query`
+
+(Optional, Boolean) If set to `true`, the query will be omitted if the analyzer
+removes all tokens using a stop filter or similar. Defaults to `false`.

--- a/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/BoolQueryBuilder.java
@@ -231,12 +231,16 @@ public class BoolQueryBuilder extends AbstractQueryBuilder<BoolQueryBuilder> {
     }
 
     /**
-     * @return the setting for the omit_zero_term_query setting in this query
+     * @return the setting for the adjust_pure_negative setting in this query
      */
     public boolean adjustPureNegative() {
         return this.adjustPureNegative;
     }
 
+    /**
+     * Decide whether to omit query to use in case no query terms are available, e.g. after analysis removed them.
+     * The default is <code>true</code>.
+     */
     public BoolQueryBuilder omitZeroTermQuery(boolean omitZeroTermQuery) {
         this.omitZeroTermQuery = omitZeroTermQuery;
         return this;


### PR DESCRIPTION
Add omit_zero_term_query option to the bool query.
By giving this option, I hope bool queries will ignore queries with 0 token.
This behavior is the same as query_string and simple_query_string_query.

close #110080