### PR TITLE
Consider node name as well as executor name in allowedExecutors

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -405,6 +405,15 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
         return fut.actionGet(timeout, unit);
     }
 
+    /**
+     * Are there any threads waiting on the result, see {@link AbstractQueuedSynchronizer#hasQueuedThreads()}
+     *
+     * @return true if one or more threads are waiting on the result of this future, false otherwise
+     */
+    public boolean hasQueuedThreads() {
+        return sync.hasQueuedThreads();
+    }
+
     private boolean assertCompleteAllowed() {
         Thread waiter = sync.getFirstQueuedThread();
         assert waiter == null || allowedExecutors(waiter, Thread.currentThread())

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -422,8 +422,8 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
         // this should only be used to validate thread interactions, like not waiting for a future completed on the same
         // executor, hence calling it with the same thread indicates a bug in the assertion using this.
         assert thread1 != thread2 : "only call this for different threads";
-        String thread1Name = EsExecutors.executorName(thread1);
-        String thread2Name = EsExecutors.executorName(thread2);
+        String thread1Name = EsExecutors.esThreadExecutorInfo(thread1);
+        String thread2Name = EsExecutors.esThreadExecutorInfo(thread2);
         return thread1Name == null || thread2Name == null || thread1Name.equals(thread2Name) == false;
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
@@ -194,10 +194,8 @@ public class PlainActionFutureTests extends ESTestCase {
                     }
                     result.set(Result.SUCCESS);
                 } catch (AssertionError e) {
-                    logger.error(e);
                     result.set(Result.FAILURE);
                 } catch (Exception e) {
-                    logger.error(e);
                     fail(e);
                 }
             });


### PR DESCRIPTION
Closes #109792

Might be overkill, but it did seem safe enough to pattern match the thread-name here. A less hacky approach might be to create `EsThread extends Thread` which keeps a reference to the actual executor it belongs to so we could be more precise with these checks. But that seems like an impactful change that would require a lot more discussion.
