### PR TITLE
Do not cache SingleValueQuery.LuceneQuery

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
@@ -436,7 +436,8 @@ public class SingleValueQuery extends Query {
 
         @Override
         public boolean isCacheable(LeafReaderContext ctx) {
-            return next.isCacheable(ctx);
+            // we cannot cache this query because we loose the ability of emitting warnings
+            return false;
         }
     }
 


### PR DESCRIPTION
If the query gets cached, then it won't be able to emit warnings for multivalue fields. 

fixes https://github.com/elastic/elasticsearch/issues/110076

