### PR TITLE
[8.14] Do not cache SingleValueQuery.LuceneQuery (#110082)

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SingleValueQuery.java
@@ -452,7 +452,8 @@ public class SingleValueQuery extends Query {
 
         @Override
         public boolean isCacheable(LeafReaderContext ctx) {
-            return next.isCacheable(ctx);
+            // we cannot cache this query because we loose the ability of emitting warnings
+            return false;
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Do not cache SingleValueQuery.LuceneQuery (#110082)