### PR TITLE
Fix ClassCastException with MV_EXPAND on missing field

### DIFF
--- a/docs/changelog/110096.yaml
+++ b/docs/changelog/110096.yaml
@@ -1,0 +1,6 @@
+pr: 110096
+summary: Fix `ClassCastException` with MV_EXPAND on missing field
+area: ES|QL
+type: bug
+issues:
+ - 109974

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -168,10 +168,7 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
                 // https://github.com/elastic/elasticsearch/issues/109974
                 // Unfortunately we cannot remove the MvExpand right away, or we'll lose the output field (layout problems)
                 // TODO but this could be a follow-up optimization
-                plan = plan.transformExpressionsOnlyUp(
-                    FieldAttribute.class,
-                    f -> stats.exists(f.qualifiedName()) ? f : new Alias(f.source(), f.name(), null, Literal.of(f, null), f.id())
-                );
+                return plan;
             }
             // otherwise transform fields in place
             else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizer.java
@@ -38,6 +38,7 @@ import org.elasticsearch.xpack.esql.optimizer.rules.PropagateEmptyRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
 import org.elasticsearch.xpack.esql.plan.logical.TopN;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
@@ -162,6 +163,15 @@ public class LocalLogicalPlanOptimizer extends ParameterizedRuleExecutor<Logical
                     plan = new Eval(project.source(), project.child(), new ArrayList<>(nullLiteral.values()));
                     plan = new Project(project.source(), plan, newProjections);
                 }
+            } else if (plan instanceof MvExpand) {
+                // We cannot replace the target (NamedExpression) with a Literal
+                // https://github.com/elastic/elasticsearch/issues/109974
+                // Unfortunately we cannot remove the MvExpand right away, or we'll lose the output field (layout problems)
+                // TODO but this could be a follow-up optimization
+                plan = plan.transformExpressionsOnlyUp(
+                    FieldAttribute.class,
+                    f -> stats.exists(f.qualifiedName()) ? f : new Alias(f.source(), f.name(), null, Literal.of(f, null), f.id())
+                );
             }
             // otherwise transform fields in place
             else {

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -195,7 +195,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
         var plan = plan("""
               from test
             | mv_expand last_name
-            | keep first_name
+            | keep first_name, last_name
             """);
 
         var testStats = statsForMissingField("last_name");
@@ -203,7 +203,7 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
 
         var project = as(localPlan, EsqlProject.class);
         var projections = project.projections();
-        assertThat(Expressions.names(projections), contains("first_name"));
+        assertThat(Expressions.names(projections), contains("first_name", "last_name"));
 
         var limit = as(project.child(), Limit.class);
         // MvExpand cannot be optimized (yet) because the target NamedExpression cannot be replaced with a NULL literal

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/LocalLogicalPlanOptimizerTests.java
@@ -34,7 +34,9 @@ import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add
 import org.elasticsearch.xpack.esql.parser.EsqlParser;
 import org.elasticsearch.xpack.esql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.esql.plan.logical.Eval;
+import org.elasticsearch.xpack.esql.plan.logical.MvExpand;
 import org.elasticsearch.xpack.esql.plan.logical.Project;
+import org.elasticsearch.xpack.esql.plan.logical.local.EsqlProject;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalRelation;
 import org.elasticsearch.xpack.esql.plan.logical.local.LocalSupplier;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
@@ -179,6 +181,37 @@ public class LocalLogicalPlanOptimizerTests extends ESTestCase {
 
         var limit = as(project.child(), Limit.class);
         var source = as(limit.child(), EsRelation.class);
+    }
+
+    /**
+     * Expects
+     * EsqlProject[[first_name{f}#6]]
+     * \_Limit[1000[INTEGER]]
+     *   \_MvExpand[last_name{f}#9,last_name{r}#15]
+     *     \_Limit[1000[INTEGER]]
+     *       \_EsRelation[test][_meta_field{f}#11, emp_no{f}#5, first_name{f}#6, ge..]
+     */
+    public void testMissingFieldInMvExpand() {
+        var plan = plan("""
+              from test
+            | mv_expand last_name
+            | keep first_name
+            """);
+
+        var testStats = statsForMissingField("last_name");
+        var localPlan = localPlan(plan, testStats);
+
+        var project = as(localPlan, EsqlProject.class);
+        var projections = project.projections();
+        assertThat(Expressions.names(projections), contains("first_name"));
+
+        var limit = as(project.child(), Limit.class);
+        // MvExpand cannot be optimized (yet) because the target NamedExpression cannot be replaced with a NULL literal
+        // https://github.com/elastic/elasticsearch/issues/109974
+        // See LocalLogicalPlanOptimizer.ReplaceMissingFieldWithNull
+        var mvExpand = as(limit.child(), MvExpand.class);
+        var limit2 = as(mvExpand.child(), Limit.class);
+        as(limit2.child(), EsRelation.class);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/109974

`LocalLogicalPlanOptimizer.ReplaceMissingFieldWithNull` tries to replace missing fields (ie. fields that are not present on the mappings of local node) with a NULL literal.
This is not possible for MvExpand, because the target is a `NamedExpression` (and `Literal` is not). This caused `ClassCastException`.

This PR fixes the problem using a null `Alias` in this specific case.