### PR TITLE
Fix testShutdownReadinessService: increase timeouts

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -61,9 +61,6 @@ tests:
 - class: org.elasticsearch.action.search.SearchProgressActionListenerIT
   method: testSearchProgressWithHits
   issue: https://github.com/elastic/elasticsearch/issues/109830
-- class: "org.elasticsearch.xpack.shutdown.NodeShutdownReadinessIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/109838"
-  method: "testShutdownReadinessService"
 - class: "org.elasticsearch.xpack.security.ScrollHelperIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/109905"
   method: "testFetchAllEntities"

--- a/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
+++ b/test/framework/src/main/java/org/elasticsearch/readiness/MockReadinessService.java
@@ -29,9 +29,9 @@ public class MockReadinessService extends ReadinessService {
      */
     public static class TestPlugin extends Plugin {}
 
-    private static final int RETRIES = 3;
+    private static final int RETRIES = 30;
 
-    private static final int RETRY_DELAY_IN_MILLIS = 10;
+    private static final int RETRY_DELAY_IN_MILLIS = 100;
 
     private static final String METHOD_NOT_MOCKED = "This method has not been mocked";
 


### PR DESCRIPTION
Test failure linked in https://github.com/elastic/elasticsearch/issues/109838 are due to timing issues: when we revised readiness to include files settings application, we introduced a delay and we did not update the values here (that were pretty aggressive, since they worked on mocked sockets).

This commit fixes the delay/retries to allow for more room and weed out any false positive

Closes https://github.com/elastic/elasticsearch/issues/109838