### PR TITLE
Clarify when file realm configuration is necessary

### DIFF
--- a/docs/reference/security/authentication/configuring-file-realm.asciidoc
+++ b/docs/reference/security/authentication/configuring-file-realm.asciidoc
@@ -1,31 +1,37 @@
-You don't need to explicitly configure a `file` realm. The `file` and `native`
+The `file` and `native`
 realms are added to the realm chain by default. Unless configured otherwise, the
 `file` realm is added first, followed by the `native` realm.
+
+If you configure the realm chain manually,
+you must include the `file` realm for it to be used.
 
 IMPORTANT: While it is possible to define multiple instances of some other
 realms, you can define only _one_ `file` realm per node.
 
-All the data about the users for the `file` realm is stored in two files on each 
-node in the cluster: `users` and `users_roles`. Both files are located in 
+All the data about the users for the `file` realm is stored in two files on each
+node in the cluster: `users` and `users_roles`. Both files are located in
 `ES_PATH_CONF` and are read on startup.
 
 [IMPORTANT]
 ==============================
-The `users` and `users_roles` files are managed locally by the node and are 
-**not** managed globally by the cluster. This means that with a typical 
-multi-node cluster, the exact same changes need to be applied on each and every 
+The `users` and `users_roles` files are managed locally by the node and are
+**not** managed globally by the cluster. This means that with a typical
+multi-node cluster, the exact same changes need to be applied on each and every
 node in the cluster.
 
-A safer approach would be to apply the change on one of the nodes and have the 
-files distributed or copied to all other nodes in the cluster (either manually 
+A safer approach would be to apply the change on one of the nodes and have the
+files distributed or copied to all other nodes in the cluster (either manually
 or using a configuration management system such as Puppet or Chef).
 ==============================
 
-. (Optional) Add a realm configuration to `elasticsearch.yml` under the
-`xpack.security.authc.realms.file` namespace. At a minimum, you must set 
+. This step is _optional_ if you haven't manually configured the realm chain.
++
+Add a realm configuration to `elasticsearch.yml` under the
+`xpack.security.authc.realms.file` namespace. At a minimum, you must set
 the realm's `order` attribute.
 +
 --
+
 //See <<ref-users-settings>> for all of the options you can set for a `file` realm.
 
 For example, the following snippet shows a `file` realm configuration that sets
@@ -47,11 +53,11 @@ NOTE: You can configure only one file realm on {es} nodes.
 
 . Restart {es}.
 
-. Add user information to the `ES_PATH_CONF/users` file on each node in the 
-cluster. 
+. Add user information to the `ES_PATH_CONF/users` file on each node in the
+cluster.
 +
 --
-The `users` file stores all the users and their passwords. Each line in the file 
+The `users` file stores all the users and their passwords. Each line in the file
 represents a single user entry consisting of the username and **hashed** and **salted** password.
 
 [source,bash]
@@ -69,18 +75,18 @@ version of passwords is stored on disk salted and hashed with the `bcrypt`
 hash algorithm. To use different hash algorithms, see <<hashing-settings>>.
 
 While it is possible to modify the `users` files directly using any standard text
-editor, we strongly recommend using the <<users-command>> tool to apply the 
+editor, we strongly recommend using the <<users-command>> tool to apply the
 required changes.
 
 IMPORTANT:  As the administrator of the cluster, it is your responsibility to
             ensure the same users are defined on every node in the cluster.
             The {es} {security-features} do not deliver any mechanisms to
             guarantee this.
-            
+
 --
 
-. Add role information to the `ES_PATH_CONF/users_roles` file on each node 
-in the cluster. 
+. Add role information to the `ES_PATH_CONF/users_roles` file on each node
+in the cluster.
 +
 --
 The `users_roles` file stores the roles associated with the users. For example:
@@ -95,15 +101,15 @@ user:jacknich
 Each row maps a role to a comma-separated list of all the users that are
 associated with that role.
 
-You can use the <<users-command>> tool to update this file. You must ensure that 
-the same changes are made on every node in the cluster. 
+You can use the <<users-command>> tool to update this file. You must ensure that
+the same changes are made on every node in the cluster.
 --
 
-. (Optional) Change how often the `users` and `users_roles` files are checked. 
+. (Optional) Change how often the `users` and `users_roles` files are checked.
 +
 --
 By default, {es} checks these files for changes every 5 seconds. You can
-change this default behavior by changing the `resource.reload.interval.high` 
+change this default behavior by changing the `resource.reload.interval.high`
 setting in the `elasticsearch.yml` file (as this is a common setting in {es},
 changing its value may effect other schedules in the system).
 --

--- a/docs/reference/security/authentication/configuring-file-realm.asciidoc
+++ b/docs/reference/security/authentication/configuring-file-realm.asciidoc
@@ -24,14 +24,13 @@ files distributed or copied to all other nodes in the cluster (either manually
 or using a configuration management system such as Puppet or Chef).
 ==============================
 
-. This step is _optional_ if you haven't manually configured the realm chain.
+. This step is required if you have manually configured the realm chain, optional otherwise.
 +
 Add a realm configuration to `elasticsearch.yml` under the
 `xpack.security.authc.realms.file` namespace. At a minimum, you must set
 the realm's `order` attribute.
 +
 --
-
 //See <<ref-users-settings>> for all of the options you can set for a `file` realm.
 
 For example, the following snippet shows a `file` realm configuration that sets


### PR DESCRIPTION
This PR clarifies when file realm configuration is necessary and when it's optional. This may be somewhat redundant w.r.t. our realm chain docs, however this is a page users may land on "in case of emergency" so I prefer to disambiguate as much as possible. 

Relates: ES-8757