### PR TITLE
Implement lucene pushdown on ST_DISTANCE 

### DIFF
--- a/docs/changelog/110102.yaml
+++ b/docs/changelog/110102.yaml
@@ -1,5 +1,6 @@
 pr: 110102
-summary: Implement lucene pushdown on ST_DISTANCE
-area: "ES|QL, Geo"
+summary: Optimize ST_DISTANCE filtering with Lucene circle intersection query
+area: ES|QL
 type: enhancement
-issues: []
+issues:
+  - 109972

--- a/docs/changelog/110102.yaml
+++ b/docs/changelog/110102.yaml
@@ -2,4 +2,5 @@ pr: 110102
 summary: Implement lucene pushdown on ST_DISTANCE
 area: "ES|QL, Geo"
 type: enhancement
-issues: []
+issues:
+ - 109972

--- a/docs/changelog/110102.yaml
+++ b/docs/changelog/110102.yaml
@@ -1,0 +1,5 @@
+pr: 110102
+summary: Implement lucene pushdown on ST_DISTANCE
+area: "ES|QL, Geo"
+type: enhancement
+issues: []

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -7,7 +7,12 @@
 
 package org.elasticsearch.xpack.esql.optimizer;
 
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.geometry.Circle;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.utils.WellKnownBinary;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.xpack.esql.VerificationException;
@@ -18,6 +23,7 @@ import org.elasticsearch.xpack.esql.core.expression.AttributeMap;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
+import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.MetadataAttribute;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.Order;
@@ -34,6 +40,7 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardLike
 import org.elasticsearch.xpack.esql.core.querydsl.query.Query;
 import org.elasticsearch.xpack.esql.core.rule.ParameterizedRuleExecutor;
 import org.elasticsearch.xpack.esql.core.rule.Rule;
+import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.core.util.Queries;
 import org.elasticsearch.xpack.esql.core.util.Queries.Clause;
@@ -41,8 +48,12 @@ import org.elasticsearch.xpack.esql.core.util.StringUtils;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.ip.CIDRMatch;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialIntersects;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesFunction;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesUtils;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StDistance;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.InsensitiveBinaryComparison;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.NotEquals;
@@ -64,6 +75,7 @@ import org.elasticsearch.xpack.esql.planner.AbstractPhysicalOperationProviders;
 import org.elasticsearch.xpack.esql.planner.EsqlTranslatorHandler;
 import org.elasticsearch.xpack.esql.stats.SearchStats;
 
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -110,6 +122,7 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             esSourceRules.add(new PushLimitToSource());
             esSourceRules.add(new PushFiltersToSource());
             esSourceRules.add(new PushStatsToSource());
+            esSourceRules.add(new EnableSpatialDistancePushdown());
         }
 
         // execute the rules multiple times to improve the chances of things being pushed down
@@ -549,6 +562,116 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
             });
             // Disallow more than one spatial field to be extracted using doc-values (for now)
             return spatialRelatesAttributes.size() < 2;
+        }
+    }
+
+    /**
+     * When a spatial distance predicate can be pushed down to lucene, this is done by capturing the distance within the same function.
+     * In principle this is like re-writing the predicate:
+     * <pre>WHERE ST_DISTANCE(field, TO_GEOPOINT("POINT(0 0)")) &lt;= 10000</pre>
+     * as:
+     * <pre>WHERE ST_INTERSECTS(field, TO_GEOSHAPE("CIRCLE(0,0,10000)"))</pre>
+     */
+    public static class EnableSpatialDistancePushdown extends PhysicalOptimizerRules.ParameterizedOptimizerRule<
+        FilterExec,
+        LocalPhysicalOptimizerContext> {
+
+        @Override
+        protected PhysicalPlan rule(FilterExec filterExec, LocalPhysicalOptimizerContext ctx) {
+            PhysicalPlan plan = filterExec;
+            if (filterExec.child() instanceof EsQueryExec) {
+                if (filterExec.condition() instanceof EsqlBinaryComparison comparison) {
+                    ComparisonType comparisonType = ComparisonType.from(comparison.getFunctionType());
+                    if (comparison.left() instanceof StDistance dist && comparison.right().foldable()) {
+                        plan = rewriteComparison(filterExec, dist, comparison.right(), comparisonType);
+                    } else if (comparison.right() instanceof StDistance dist && comparison.left().foldable()) {
+                        plan = rewriteComparison(filterExec, dist, comparison.right(), ComparisonType.invert(comparisonType));
+                    }
+                }
+            }
+
+            return plan;
+        }
+
+        private FilterExec rewriteComparison(FilterExec filterExec, StDistance dist, Expression literal, ComparisonType comparisonType) {
+            // We currently only support spatial distance within a minimum range
+            if (comparisonType.lt) {
+                Object value = literal.fold();
+                if (value instanceof Number number) {
+                    if (dist.right().foldable()) {
+                        return rewriteDistanceFilter(filterExec, dist.source(), dist.left(), dist.right(), number, comparisonType.eq);
+                    } else if (dist.left().foldable()) {
+                        return rewriteDistanceFilter(filterExec, dist.source(), dist.right(), dist.left(), number, comparisonType.eq);
+                    }
+                }
+            }
+            return filterExec;
+        }
+
+        private FilterExec rewriteDistanceFilter(
+            FilterExec filterExec,
+            Source source,
+            Expression spatialExpression,
+            Expression literalExpression,
+            Number number,
+            boolean inclusive
+        ) {
+            Geometry geometry = SpatialRelatesUtils.makeGeometryFromLiteral(literalExpression);
+            if (geometry instanceof Point point) {
+                double distance = number.doubleValue();
+                if (inclusive == false) {
+                    distance = Math.nextDown(distance);
+                }
+                var circle = new Circle(point.getX(), point.getY(), distance);
+                var wkb = WellKnownBinary.toWKB(circle, ByteOrder.LITTLE_ENDIAN);
+                var cExp = new Literal(literalExpression.source(), new BytesRef(wkb), DataType.GEO_SHAPE);
+                return new FilterExec(filterExec.source(), filterExec.child(), new SpatialIntersects(source, spatialExpression, cExp));
+            }
+            return filterExec;
+        }
+
+        /**
+         * This enum captures the key differences between various inequalities as perceived from the spatial distance function.
+         * In particular, we need to know which direction the inequality points, with lt=true meaning the left is expected to be smaller
+         * than the right. And eq=true meaning we expect euality as well. We currently don't support Equals and NotEquals, so the third
+         * field disables those.
+         */
+        enum ComparisonType {
+            LTE(true, true, true),
+            LT(true, false, true),
+            GTE(false, true, true),
+            GT(false, false, true),
+            UNSUPPORTED(false, false, false);
+
+            private final boolean lt;
+            private final boolean eq;
+            private final boolean supported;
+
+            ComparisonType(boolean lt, boolean eq, boolean supported) {
+                this.lt = lt;
+                this.eq = eq;
+                this.supported = supported;
+            }
+
+            static ComparisonType from(EsqlBinaryComparison.BinaryComparisonOperation op) {
+                return switch (op) {
+                    case LT -> LT;
+                    case LTE -> LTE;
+                    case GT -> GT;
+                    case GTE -> GTE;
+                    default -> UNSUPPORTED;
+                };
+            }
+
+            static ComparisonType invert(ComparisonType comparisonType) {
+                return switch (comparisonType) {
+                    case LT -> GT;
+                    case LTE -> GTE;
+                    case GT -> LT;
+                    case GTE -> LTE;
+                    default -> UNSUPPORTED;
+                };
+            }
         }
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.geometry.Circle;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.ShapeType;
 import org.elasticsearch.index.IndexMode;
@@ -63,7 +64,9 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialDi
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialIntersects;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialRelatesFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialWithin;
+import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StDistance;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.Equals;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThan;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.GreaterThanOrEqual;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.LessThan;
@@ -3472,6 +3475,55 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             var polygon = as(condition.shape(), Polygon.class);
             assertThat("Polygon shell length", polygon.getPolygon().length(), equalTo(5));
             assertThat("Polygon holes", polygon.getNumberOfHoles(), equalTo(0));
+        }
+    }
+
+    public void testPushSpatialDistanceToSource() {
+        for (String distanceFunction : new String[] {
+            "ST_DISTANCE(location, TO_GEOPOINT(\"POINT(12.565 55.673)\"))",
+            "ST_DISTANCE(TO_GEOPOINT(\"POINT(12.565 55.673)\"), location)" }) {
+
+            for (String op : new String[] { "<", "<=", ">", ">=" }) {
+                var eq = op.contains("=");
+                var lt = op.contains("<");
+                var predicate = lt ? distanceFunction + " " + op + " 600000" : "600000 " + op + " " + distanceFunction;
+                var query = "FROM airports | WHERE " + predicate + " AND scalerank > 1";
+                var plan = this.physicalPlan(query, airports);
+                var limit = as(plan, LimitExec.class);
+                var exchange = as(limit.child(), ExchangeExec.class);
+                var fragment = as(exchange.child(), FragmentExec.class);
+                var limit2 = as(fragment.fragment(), Limit.class);
+                var filter = as(limit2.child(), Filter.class);
+                var and = as(filter.condition(), And.class);
+                var comp = as(and.left(), EsqlBinaryComparison.class);
+                var expectedComp = eq ? LessThanOrEqual.class : LessThan.class;  // normalized to less than
+                assertThat("filter contains expected binary comparison for " + predicate, comp, instanceOf(expectedComp));
+                assertThat("filter contains ST_DISTANCE", comp.left(), instanceOf(StDistance.class));
+
+                var optimized = optimizedPlan(plan);
+                var topLimit = as(optimized, LimitExec.class);
+                exchange = as(topLimit.child(), ExchangeExec.class);
+                var project = as(exchange.child(), ProjectExec.class);
+                var fieldExtract = as(project.child(), FieldExtractExec.class);
+                var source = source(fieldExtract.child());
+                // TODO: bring back SingleValueQuery once it can handle LeafShapeFieldData
+                // var condition = as(sv(source.query(), "location"), AbstractGeometryQueryBuilder.class);
+                var bool = as(source.query(), BoolQueryBuilder.class);
+                var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
+                assertThat("Expected one range query builder", rangeQueryBuilders.size(), equalTo(1));
+                assertThat(((SingleValueQuery.Builder) rangeQueryBuilders.get(0)).field(), equalTo("scalerank"));
+                var shapeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+                assertThat("Expected one shape query builder", shapeQueryBuilders.size(), equalTo(1));
+                var condition = as(shapeQueryBuilders.get(0), SpatialRelatesQuery.ShapeQueryBuilder.class);
+                assertThat("Geometry field name", condition.fieldName(), equalTo("location"));
+                assertThat("Spatial relationship", condition.relation(), equalTo(ShapeRelation.INTERSECTS));
+                assertThat("Geometry is Circle", condition.shape().type(), equalTo(ShapeType.CIRCLE));
+                var circle = as(condition.shape(), Circle.class);
+                assertThat("Circle center-x", circle.getX(), equalTo(12.565));
+                assertThat("Circle center-y", circle.getY(), equalTo(55.673));
+                var expected = eq ? 600000.0 : Math.nextDown(600000.0);
+                assertThat("Circle radius", circle.getRadiusMeters(), equalTo(expected));
+            }
         }
     }
 


### PR DESCRIPTION
#108764 created the distance function, but without lucene pushdown to `geo_distance`, this will be slow.

This PR implemented this in a similar way to `geo_distance`. That code uses the GeoDistanceQueryBuilder to create a lucene query for spatial intersection with a Circle geometry. This PR does a similar thing, but by creating an instance of the `SpatialIntersects` function, which itself is optimized down to lucene using a similar spatial intersection.

Benchmark results for 90th percentile latency:

| branch | task | value | unit |
| -- | -- | -- | -- |
| main |          distanceFilter |     9.06487     |     ms |
| main |     distanceFilter-esql |    33.0614      |     ms |
| st_distance_pushdown |          distanceFilter |     8.97413     |     ms |
| st_distance_pushdown |     distanceFilter-esql |     5.55073     |     ms |

Fixes #109972