### PR TITLE
ESQL: Merge more of EsqlDataTypes into DataType

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -27,9 +27,9 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toUnmodifiableMap;
 
 public enum DataType {
-    UNSUPPORTED(builder(null).typeName("UNSUPPORTED")),
-    NULL(builder("null")),
-    BOOLEAN(builder("boolean").size(1)),
+    UNSUPPORTED(builder().typeName("UNSUPPORTED")),
+    NULL(builder().esType("null")),
+    BOOLEAN(builder().esType("boolean").size(1)),
 
     /**
      * These are numeric fields labeled as metric counters in time-series indices. Although stored
@@ -38,37 +38,37 @@ public enum DataType {
      * These fields are strictly for use in retrieval from indices, rate aggregation, and casting to their
      * parent numeric type.
      */
-    COUNTER_LONG(builder("counter_long").size(Long.BYTES).docValues().counter()),
-    COUNTER_INTEGER(builder("counter_integer").size(Integer.BYTES).docValues().counter()),
-    COUNTER_DOUBLE(builder("counter_double").size(Double.BYTES).docValues().counter()),
+    COUNTER_LONG(builder().esType("counter_long").size(Long.BYTES).docValues().counter()),
+    COUNTER_INTEGER(builder().esType("counter_integer").size(Integer.BYTES).docValues().counter()),
+    COUNTER_DOUBLE(builder().esType("counter_double").size(Double.BYTES).docValues().counter()),
 
-    LONG(builder("long").size(Long.BYTES).integer().docValues().counter(COUNTER_LONG)),
-    INTEGER(builder("integer").size(Integer.BYTES).integer().docValues().counter(COUNTER_INTEGER)),
-    SHORT(builder("short").size(Short.BYTES).integer().docValues().widenSmallNumeric(INTEGER)),
-    BYTE(builder("byte").size(Byte.BYTES).integer().docValues().widenSmallNumeric(INTEGER)),
-    UNSIGNED_LONG(builder("unsigned_long").size(Long.BYTES).integer().docValues()),
-    DOUBLE(builder("double").size(Double.BYTES).rational().docValues().counter(COUNTER_DOUBLE)),
-    FLOAT(builder("float").size(Float.BYTES).rational().docValues().widenSmallNumeric(DOUBLE)),
-    HALF_FLOAT(builder("half_float").size(Float.BYTES).rational().docValues().widenSmallNumeric(DOUBLE)),
-    SCALED_FLOAT(builder("scaled_float").size(Long.BYTES).rational().docValues().widenSmallNumeric(DOUBLE)),
+    LONG(builder().esType("long").size(Long.BYTES).integer().docValues().counter(COUNTER_LONG)),
+    INTEGER(builder().esType("integer").size(Integer.BYTES).integer().docValues().counter(COUNTER_INTEGER)),
+    SHORT(builder().esType("short").size(Short.BYTES).integer().docValues().widenSmallNumeric(INTEGER)),
+    BYTE(builder().esType("byte").size(Byte.BYTES).integer().docValues().widenSmallNumeric(INTEGER)),
+    UNSIGNED_LONG(builder().esType("unsigned_long").size(Long.BYTES).integer().docValues()),
+    DOUBLE(builder().esType("double").size(Double.BYTES).rational().docValues().counter(COUNTER_DOUBLE)),
+    FLOAT(builder().esType("float").size(Float.BYTES).rational().docValues().widenSmallNumeric(DOUBLE)),
+    HALF_FLOAT(builder().esType("half_float").size(Float.BYTES).rational().docValues().widenSmallNumeric(DOUBLE)),
+    SCALED_FLOAT(builder().esType("scaled_float").size(Long.BYTES).rational().docValues().widenSmallNumeric(DOUBLE)),
 
-    KEYWORD(builder("keyword").unknownSize().docValues()),
-    TEXT(builder("text").unknownSize()),
-    DATETIME(builder("date").typeName("DATETIME").size(Long.BYTES).docValues()),
-    IP(builder("ip").size(45).docValues()),
-    VERSION(builder("version").unknownSize().docValues()),
-    OBJECT(builder("object")),
-    NESTED(builder("nested")),
-    SOURCE(builder(SourceFieldMapper.NAME).unknownSize()),
-    DATE_PERIOD(builder(null).typeName("DATE_PERIOD").size(3 * Integer.BYTES)),
-    TIME_DURATION(builder(null).typeName("TIME_DURATION").size(Integer.BYTES + Long.BYTES)),
-    GEO_POINT(builder("geo_point").size(Double.BYTES * 2).docValues()),
-    CARTESIAN_POINT(builder("cartesian_point").size(Double.BYTES * 2).docValues()),
-    CARTESIAN_SHAPE(builder("cartesian_shape").unknownSize().docValues()),
-    GEO_SHAPE(builder("geo_shape").unknownSize().docValues()),
+    KEYWORD(builder().esType("keyword").unknownSize().docValues()),
+    TEXT(builder().esType("text").unknownSize()),
+    DATETIME(builder().esType("date").typeName("DATETIME").size(Long.BYTES).docValues()),
+    IP(builder().esType("ip").size(45).docValues()),
+    VERSION(builder().esType("version").unknownSize().docValues()),
+    OBJECT(builder().esType("object")),
+    NESTED(builder().esType("nested")),
+    SOURCE(builder().esType(SourceFieldMapper.NAME).unknownSize()),
+    DATE_PERIOD(builder().typeName("DATE_PERIOD").size(3 * Integer.BYTES)),
+    TIME_DURATION(builder().typeName("TIME_DURATION").size(Integer.BYTES + Long.BYTES)),
+    GEO_POINT(builder().esType("geo_point").size(Double.BYTES * 2).docValues()),
+    CARTESIAN_POINT(builder().esType("cartesian_point").size(Double.BYTES * 2).docValues()),
+    CARTESIAN_SHAPE(builder().esType("cartesian_shape").unknownSize().docValues()),
+    GEO_SHAPE(builder().esType("geo_shape").unknownSize().docValues()),
 
-    DOC_DATA_TYPE(builder("_doc").size(Integer.BYTES * 3)),
-    TSID_DATA_TYPE(builder("_tsid").unknownSize().docValues());
+    DOC_DATA_TYPE(builder().esType("_doc").size(Integer.BYTES * 3)),
+    TSID_DATA_TYPE(builder().esType("_tsid").unknownSize().docValues());
 
     private final String typeName;
 
@@ -280,6 +280,10 @@ public enum DataType {
         return esType;
     }
 
+    public String outputType() {
+        return esType == null ? "unsupported" : esType;
+    }
+
     public boolean isInteger() {
         return isInteger;
     }
@@ -349,8 +353,8 @@ public enum DataType {
         return type != null ? type : UNSUPPORTED;
     }
 
-    static Builder builder(String esType) {
-        return new Builder(esType);
+    static Builder builder() {
+        return new Builder();
     }
 
     /**
@@ -358,7 +362,7 @@ public enum DataType {
      * a builder in java....
      */
     private static class Builder {
-        private final String esType;
+        private String esType;
 
         private String typeName;
 
@@ -396,8 +400,11 @@ public enum DataType {
          */
         private DataType counter;
 
-        Builder(String esType) {
+        Builder() {}
+
+        Builder esType(String esType) {
             this.esType = esType;
+            return this;
         }
 
         Builder typeName(String typeName) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
@@ -27,8 +27,8 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -163,7 +163,7 @@ public final class ResponseValueUtils {
     static Page valuesToPage(BlockFactory blockFactory, List<ColumnInfo> columns, List<List<Object>> values) {
         List<String> dataTypes = columns.stream().map(ColumnInfo::type).toList();
         List<Block.Builder> results = dataTypes.stream()
-            .map(c -> PlannerUtils.toElementType(EsqlDataTypes.fromName(c)).newBlockBuilder(values.size(), blockFactory))
+            .map(c -> PlannerUtils.toElementType(DataType.fromEs(c)).newBlockBuilder(values.size(), blockFactory))
             .toList();
 
         for (List<Object> row : values) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/enrich/EnrichLookupService.java
@@ -299,7 +299,7 @@ public class EnrichLookupService {
                 );
                 BlockLoader loader = ctx.blockLoader(
                     extractField instanceof Alias a ? ((NamedExpression) a.child()).name() : extractField.name(),
-                    EsqlDataTypes.isUnsupported(extractField.dataType()),
+                    extractField.dataType() == DataType.UNSUPPORTED,
                     MappedFieldType.FieldExtractPreference.NONE
                 );
                 fields.add(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -59,7 +59,6 @@ import org.elasticsearch.xpack.esql.plan.physical.FieldExtractExec;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.DriverParallelism;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.LocalExecutionPlannerContext;
 import org.elasticsearch.xpack.esql.planner.LocalExecutionPlanner.PhysicalOperation;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.esql.type.MultiTypeEsField;
 
 import java.io.IOException;
@@ -118,7 +117,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             MappedFieldType.FieldExtractPreference fieldExtractPreference = PlannerUtils.extractPreference(docValuesAttrs.contains(attr));
             ElementType elementType = PlannerUtils.toElementType(dataType, fieldExtractPreference);
             String fieldName = attr.name();
-            boolean isUnsupported = EsqlDataTypes.isUnsupported(dataType);
+            boolean isUnsupported = dataType == DataType.UNSUPPORTED;
             IntFunction<BlockLoader> loader = s -> getBlockLoaderFor(s, fieldName, isUnsupported, fieldExtractPreference, unionTypes);
             fields.add(new ValuesSourceReaderOperator.FieldInfo(fieldName, elementType, loader));
         }
@@ -233,7 +232,7 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
             .toList();
         // The grouping-by values are ready, let's group on them directly.
         // Costin: why are they ready and not already exposed in the layout?
-        boolean isUnsupported = EsqlDataTypes.isUnsupported(attrSource.dataType());
+        boolean isUnsupported = attrSource.dataType() == DataType.UNSUPPORTED;
         return new OrdinalsGroupingOperator.OrdinalsGroupingOperatorFactory(
             shardIdx -> shardContexts.get(shardIdx).blockLoader(attrSource.name(), isUnsupported, NONE),
             vsShardContexts,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/TransportEsqlQueryAction.java
@@ -38,7 +38,6 @@ import org.elasticsearch.xpack.esql.enrich.EnrichLookupService;
 import org.elasticsearch.xpack.esql.enrich.EnrichPolicyResolver;
 import org.elasticsearch.xpack.esql.execution.PlanExecutor;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -172,7 +171,7 @@ public class TransportEsqlQueryAction extends HandledTransportAction<EsqlQueryRe
                     delegate.map(result -> {
                         List<ColumnInfo> columns = physicalPlan.output()
                             .stream()
-                            .map(c -> new ColumnInfo(c.qualifiedName(), EsqlDataTypes.outputType(c.dataType())))
+                            .map(c -> new ColumnInfo(c.qualifiedName(), c.dataType().outputType()))
                             .toList();
                         EsqlQueryResponse.Profile profile = configuration.profile()
                             ? new EsqlQueryResponse.Profile(result.profiles())

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypeRegistry.java
@@ -35,7 +35,13 @@ public class EsqlDataTypeRegistry implements DataTypeRegistry {
 
     @Override
     public DataType fromEs(String typeName, TimeSeriesParams.MetricType metricType) {
-        DataType type = EsqlDataTypes.fromName(typeName);
+        DataType type = DataType.fromEs(typeName);
+        /*
+         * If we're handling a time series COUNTER type field then convert it
+         * into it's counter. But *first* we have to widen it because we only
+         * have time series counters for `double`, `long` and `int`, not `float`
+         * and `half_float`, etc.
+         */
         return metricType == TimeSeriesParams.MetricType.COUNTER ? type.widenSmallNumeric().counter() : type;
     }
 
@@ -46,7 +52,7 @@ public class EsqlDataTypeRegistry implements DataTypeRegistry {
 
     @Override
     public boolean isUnsupported(DataType type) {
-        return EsqlDataTypes.isUnsupported(type);
+        return type == DataType.UNSUPPORTED;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
@@ -34,21 +34,6 @@ public final class EsqlDataTypes {
         return DataType.fromTypeName(name.toLowerCase(Locale.ROOT));
     }
 
-    public static DataType fromName(String name) {
-        return DataType.fromEs(name);
-    }
-
-    public static boolean isUnsupported(DataType type) {
-        return DataType.isUnsupported(type);
-    }
-
-    public static String outputType(DataType type) {
-        if (type != null && type.esType() != null) {
-            return type.esType();
-        }
-        return "unsupported";
-    }
-
     public static boolean isString(DataType t) {
         return t == KEYWORD || t == TEXT;
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/CsvTests.java
@@ -86,7 +86,6 @@ import org.elasticsearch.xpack.esql.plugin.EsqlFeatures;
 import org.elasticsearch.xpack.esql.plugin.QueryPragmas;
 import org.elasticsearch.xpack.esql.session.EsqlConfiguration;
 import org.elasticsearch.xpack.esql.stats.DisabledSearchStats;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.junit.After;
 import org.junit.Before;
 import org.mockito.Mockito;
@@ -417,7 +416,7 @@ public class CsvTests extends ESTestCase {
         List<String> dataTypes = new ArrayList<>(columnNames.size());
         List<Type> columnTypes = coordinatorPlan.output()
             .stream()
-            .peek(o -> dataTypes.add(EsqlDataTypes.outputType(o.dataType())))
+            .peek(o -> dataTypes.add(o.dataType().outputType()))
             .map(o -> Type.asType(o.dataType().nameUpper()))
             .toList();
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -48,7 +48,6 @@ import org.elasticsearch.xpack.core.esql.action.ColumnInfo;
 import org.elasticsearch.xpack.esql.TestBlockFactory;
 import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.planner.PlannerUtils;
-import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 import org.elasticsearch.xpack.versionfield.Version;
 import org.junit.After;
 import org.junit.Before;
@@ -139,7 +138,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
 
     private Page randomPage(List<ColumnInfo> columns) {
         return new Page(columns.stream().map(c -> {
-            Block.Builder builder = PlannerUtils.toElementType(EsqlDataTypes.fromName(c.type())).newBlockBuilder(1, blockFactory);
+            Block.Builder builder = PlannerUtils.toElementType(DataType.fromEs(c.type())).newBlockBuilder(1, blockFactory);
             switch (c.type()) {
                 case "unsigned_long", "long", "counter_long" -> ((LongBlock.Builder) builder).appendLong(randomLong());
                 case "integer", "counter_integer" -> ((IntBlock.Builder) builder).appendInt(randomInt());


### PR DESCRIPTION
This moves a few more methods from `EsqlDataTypes` into `DataType` and makes some of the followup changes recommended in #109921.
