### PR TITLE
Make Ccs old version remote cluster setup lazy

### DIFF
--- a/qa/ccs-old-version-remote-cluster/build.gradle
+++ b/qa/ccs-old-version-remote-cluster/build.gradle
@@ -23,30 +23,29 @@ for (Version bwcVersion : BuildParams.bwcVersions.wireCompatible) {
   String baseName = "v${bwcVersion}"
   String bwcVersionStr = "${bwcVersion}"
 
-  testClusters {
-    "${baseName}-local" {
+  def localCluster = testClusters.register("${baseName}-local") {
       numberOfNodes = 2
       versions = [project.version]
       setting 'cluster.remote.node.attr', 'gateway'
       setting 'xpack.security.enabled', 'false'
-    }
-    "${baseName}-remote" {
-      numberOfNodes = 2 
+  }
+
+  def remoteCluster = testClusters.register("${baseName}-remote") {
+      numberOfNodes = 2
       versions = [bwcVersionStr]
       firstNode.setting 'node.attr.gateway', 'true'
       lastNode.setting 'node.attr.gateway', 'true'
       setting 'xpack.security.enabled', 'false'
-    }
   }
 
   tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
-    useCluster testClusters."${baseName}-local"
-    useCluster testClusters."${baseName}-remote"
+    useCluster localCluster
+    useCluster remoteCluster
     systemProperty 'tests.upgrade_from_version', bwcVersionStr.replace('-SNAPSHOT', '')
 
     doFirst {
-      nonInputProperties.systemProperty('tests.rest.cluster', "${-> testClusters."${baseName}-local".allHttpSocketURI.join(",")}")
-      nonInputProperties.systemProperty('tests.rest.remote_cluster', "${-> testClusters."${baseName}-remote".allHttpSocketURI.join(",")}")
+      nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))
+      nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteCluster.map(c -> c.allHttpSocketURI.join(",")))
     }
   }
 

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -27,13 +27,13 @@ BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
    * - Only node-0 and node-2 of the remote cluster can accept remote connections. This can creates a test
    *   scenario where a query request and fetch request are sent via **proxy nodes** that have different version.
    */
-  def localCluster = testClusters.register("${baseName}-local") {
+  def localClusterProvider = testClusters.register("${baseName}-local") {
     numberOfNodes = 2
     versions = [bwcVersion.toString(), project.version]
     setting 'cluster.remote.node.attr', 'gateway'
     setting 'xpack.security.enabled', 'false'
   }
-  def remoteCluster = testClusters.register("${baseName}-remote") {
+  def remoteClusterProvider = testClusters.register("${baseName}-remote") {
     numberOfNodes = 3
     versions = [bwcVersion.toString(), project.version]
     firstNode.setting 'node.attr.gateway', 'true'
@@ -43,13 +43,13 @@ BuildParams.bwcVersions.withWireCompatiple { bwcVersion, baseName ->
 
 
   tasks.withType(StandaloneRestIntegTestTask).matching { it.name.startsWith("${baseName}#") }.configureEach {
-    useCluster localCluster
-    useCluster remoteCluster
+    useCluster localClusterProvider
+    useCluster remoteClusterProvider
     systemProperty 'tests.upgrade_from_version', bwcVersion.toString().replace('-SNAPSHOT', '')
 
     doFirst {
-      nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))
-      nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteCluster.map(c -> c.allHttpSocketURI.join(",")))
+      nonInputProperties.systemProperty('tests.rest.cluster', localClusterProvider.map(c -> c.allHttpSocketURI.join(",")))
+      nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteClusterProvider.map(c -> c.allHttpSocketURI.join(",")))
     }
   }
 


### PR DESCRIPTION
This should also solve eagerly resolving all kind of old elasticsearch distributions as part of our ci image baking.