### PR TITLE
[ESQL] Refactor Element Type selection to use a switch

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -60,6 +60,7 @@ import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.DOC_VALUES;
+import static org.elasticsearch.index.mapper.MappedFieldType.FieldExtractPreference.NONE;
 import static org.elasticsearch.xpack.esql.core.util.Queries.Clause.FILTER;
 import static org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer.PushFiltersToSource.canPushToSource;
 import static org.elasticsearch.xpack.esql.optimizer.LocalPhysicalPlanOptimizer.TRANSLATOR_HANDLER;
@@ -230,7 +231,7 @@ public class PlannerUtils {
      * Map QL's {@link DataType} to the compute engine's {@link ElementType}.
      */
     public static ElementType toElementType(DataType dataType) {
-        return toElementType(dataType, MappedFieldType.FieldExtractPreference.NONE);
+        return toElementType(dataType, NONE);
     }
 
     /**
@@ -272,6 +273,6 @@ public class PlannerUtils {
      * Returns DOC_VALUES if the given boolean is set.
      */
     public static MappedFieldType.FieldExtractPreference extractPreference(boolean hasPreference) {
-        return hasPreference ? DOC_VALUES : MappedFieldType.FieldExtractPreference.NONE;
+        return hasPreference ? DOC_VALUES : NONE;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -239,47 +239,23 @@ public class PlannerUtils {
      * For example, spatial types can be extracted into doc-values under specific conditions, otherwise they extract as BytesRef.
      */
     public static ElementType toElementType(DataType dataType, MappedFieldType.FieldExtractPreference fieldExtractPreference) {
-        if (dataType == DataType.LONG
-            || dataType == DataType.DATETIME
-            || dataType == DataType.UNSIGNED_LONG
-            || dataType == DataType.COUNTER_LONG) {
-            return ElementType.LONG;
-        }
-        if (dataType == DataType.INTEGER || dataType == DataType.COUNTER_INTEGER) {
-            return ElementType.INT;
-        }
-        if (dataType == DataType.DOUBLE || dataType == DataType.COUNTER_DOUBLE) {
-            return ElementType.DOUBLE;
-        }
-        // unsupported fields are passed through as a BytesRef
-        if (dataType == DataType.KEYWORD
-            || dataType == DataType.TEXT
-            || dataType == DataType.IP
-            || dataType == DataType.SOURCE
-            || dataType == DataType.VERSION
-            || dataType == DataType.UNSUPPORTED) {
-            return ElementType.BYTES_REF;
-        }
-        if (dataType == DataType.NULL) {
-            return ElementType.NULL;
-        }
-        if (dataType == DataType.BOOLEAN) {
-            return ElementType.BOOLEAN;
-        }
-        if (dataType == DataType.DOC_DATA_TYPE) {
-            return ElementType.DOC;
-        }
-        if (dataType == DataType.TSID_DATA_TYPE) {
-            return ElementType.BYTES_REF;
-        }
-        if (EsqlDataTypes.isSpatialPoint(dataType)) {
-            return fieldExtractPreference == DOC_VALUES ? ElementType.LONG : ElementType.BYTES_REF;
-        }
-        if (EsqlDataTypes.isSpatial(dataType)) {
+
+        return switch (dataType) {
+            case LONG, DATETIME, UNSIGNED_LONG, COUNTER_LONG -> ElementType.LONG;
+            case INTEGER, COUNTER_INTEGER -> ElementType.INT;
+            case DOUBLE, COUNTER_DOUBLE -> ElementType.DOUBLE;
+            // unsupported fields are passed through as a BytesRef
+            case KEYWORD, TEXT, IP, SOURCE, VERSION, UNSUPPORTED -> ElementType.BYTES_REF;
+            case NULL -> ElementType.NULL;
+            case BOOLEAN -> ElementType.BOOLEAN;
+            case DOC_DATA_TYPE -> ElementType.DOC;
+            case TSID_DATA_TYPE -> ElementType.BYTES_REF;
+            case GEO_POINT, CARTESIAN_POINT -> fieldExtractPreference == DOC_VALUES ? ElementType.LONG : ElementType.BYTES_REF;
             // TODO: support forStats for shape aggregations, like st_centroid
-            return ElementType.BYTES_REF;
-        }
-        throw EsqlIllegalArgumentException.illegalDataType(dataType);
+            case GEO_SHAPE, CARTESIAN_SHAPE -> ElementType.BYTES_REF;
+            case SHORT, BYTE, DATE_PERIOD, TIME_DURATION, OBJECT, NESTED, FLOAT, HALF_FLOAT, SCALED_FLOAT ->
+                throw EsqlIllegalArgumentException.illegalDataType(dataType);
+        };
     }
 
     /**
@@ -296,6 +272,6 @@ public class PlannerUtils {
      * Returns DOC_VALUES if the given boolean is set.
      */
     public static MappedFieldType.FieldExtractPreference extractPreference(boolean hasPreference) {
-        return hasPreference ? MappedFieldType.FieldExtractPreference.DOC_VALUES : MappedFieldType.FieldExtractPreference.NONE;
+        return hasPreference ? DOC_VALUES : MappedFieldType.FieldExtractPreference.NONE;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -252,7 +252,6 @@ public class PlannerUtils {
             case DOC_DATA_TYPE -> ElementType.DOC;
             case TSID_DATA_TYPE -> ElementType.BYTES_REF;
             case GEO_POINT, CARTESIAN_POINT -> fieldExtractPreference == DOC_VALUES ? ElementType.LONG : ElementType.BYTES_REF;
-            // TODO: support forStats for shape aggregations, like st_centroid
             case GEO_SHAPE, CARTESIAN_SHAPE -> ElementType.BYTES_REF;
             case SHORT, BYTE, DATE_PERIOD, TIME_DURATION, OBJECT, NESTED, FLOAT, HALF_FLOAT, SCALED_FLOAT ->
                 throw EsqlIllegalArgumentException.illegalDataType(dataType);


### PR DESCRIPTION
Similar to https://github.com/elastic/elasticsearch/pull/110036, this creates the opportunity for the compiler to flag this as a place which needs to be changed when we add a data type.  It's also fewer lines of code, and makes it explicit which types are not supported.

Ideally, this would also become a property on DataType, but that can't happen until we pull it out of core.