### PR TITLE
[ML] Increase response size limit for batched requests

### DIFF
--- a/docs/changelog/110112.yaml
+++ b/docs/changelog/110112.yaml
@@ -1,0 +1,5 @@
+pr: 110112
+summary: Increase response size limit for batched requests
+area: Machine Learning
+type: bug
+issues: []

--- a/docs/reference/settings/inference-settings.asciidoc
+++ b/docs/reference/settings/inference-settings.asciidoc
@@ -34,7 +34,7 @@ message can be logged again. Defaults to one hour (`1h`).
 
 `xpack.inference.http.max_response_size`::
 (<<cluster-update-settings,Dynamic>>) Specifies the maximum size in bytes an HTTP response is allowed to have,
-defaults to `10mb`, the maximum configurable value is `50mb`.
+defaults to `50mb`, the maximum configurable value is `100mb`.
 
 `xpack.inference.http.max_total_connections`::
 (<<cluster-update-settings,Dynamic>>) Specifies the maximum number of connections the internal connection pool can

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/SizeLimitInputStream.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/common/SizeLimitInputStream.java
@@ -21,6 +21,13 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public final class SizeLimitInputStream extends FilterInputStream {
 
+    public static class InputStreamTooLargeException extends IOException {
+
+        public InputStreamTooLargeException(String message) {
+            super(message);
+        }
+    }
+
     private final long maxByteSize;
     private final AtomicLong byteCounter = new AtomicLong(0);
 
@@ -73,9 +80,9 @@ public final class SizeLimitInputStream extends FilterInputStream {
         return false;
     }
 
-    private void checkMaximumLengthReached() throws IOException {
+    private void checkMaximumLengthReached() throws InputStreamTooLargeException {
         if (byteCounter.get() > maxByteSize) {
-            throw new IOException("Maximum limit of [" + maxByteSize + "] bytes reached");
+            throw new InputStreamTooLargeException("Maximum limit of [" + maxByteSize + "] bytes reached");
         }
     }
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/HttpSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/HttpSettings.java
@@ -20,9 +20,9 @@ public class HttpSettings {
     // These settings are default scope for testing
     static final Setting<ByteSizeValue> MAX_HTTP_RESPONSE_SIZE = Setting.byteSizeSetting(
         "xpack.inference.http.max_response_size",
-        new ByteSizeValue(10, ByteSizeUnit.MB),   // default
+        new ByteSizeValue(50, ByteSizeUnit.MB),   // default
         ByteSizeValue.ONE, // min
-        new ByteSizeValue(50, ByteSizeUnit.MB),   // max
+        new ByteSizeValue(100, ByteSizeUnit.MB),   // max
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/retry/RetryingHttpSender.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.RetryableAction;
 import org.elasticsearch.inference.InferenceServiceResults;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.inference.common.SizeLimitInputStream;
 import org.elasticsearch.xpack.inference.external.http.HttpClient;
 import org.elasticsearch.xpack.inference.external.http.HttpResult;
 import org.elasticsearch.xpack.inference.external.request.Request;
@@ -26,12 +27,16 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Objects;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.inference.InferencePlugin.UTILITY_THREAD_POOL_NAME;
 
 public class RetryingHttpSender implements RequestSender {
+
+    static final int MAX_RETIES = 3;
+
     private final HttpClient httpClient;
     private final ThrottlerManager throttlerManager;
     private final RetrySettings retrySettings;
@@ -68,6 +73,7 @@ public class RetryingHttpSender implements RequestSender {
         private final Logger logger;
         private final HttpClientContext context;
         private final Supplier<Boolean> hasRequestCompletedFunction;
+        private final AtomicInteger retryCount;
 
         InternalRetrier(
             Logger logger,
@@ -91,10 +97,12 @@ public class RetryingHttpSender implements RequestSender {
             this.context = Objects.requireNonNull(context);
             this.responseHandler = Objects.requireNonNull(responseHandler);
             this.hasRequestCompletedFunction = Objects.requireNonNull(hasRequestCompletedFunction);
+            this.retryCount = new AtomicInteger(0);
         }
 
         @Override
         public void tryAction(ActionListener<InferenceServiceResults> listener) {
+            retryCount.incrementAndGet();
             // A timeout likely occurred so let's stop attempting to execute the request
             if (hasRequestCompletedFunction.get()) {
                 return;
@@ -140,10 +148,10 @@ public class RetryingHttpSender implements RequestSender {
                     RestStatus.BAD_REQUEST,
                     e
                 );
-            }
-
-            if (e instanceof IOException) {
-                exceptionToReturn = new RetryException(true, e);
+            } else if (e instanceof SizeLimitInputStream.InputStreamTooLargeException) {
+                return e;
+            } else if (e instanceof IOException) {
+                return new RetryException(true, e);
             }
 
             return exceptionToReturn;
@@ -164,6 +172,10 @@ public class RetryingHttpSender implements RequestSender {
 
         @Override
         public boolean shouldRetry(Exception e) {
+            if (retryCount.get() >= MAX_RETIES) {
+                return false;
+            }
+
             if (e instanceof Retryable retry) {
                 request = retry.rebuildRequest(request);
                 return retry.shouldRetry();


### PR DESCRIPTION
Testing with semantic_text against the OpenAI service, a batch of 512 requests would return a response slightly over 10MB which was then rejected as too large. This PR increases the response size limit to 50MB. The size limit is a precaution against large memory consuming inputs but perhaps this logic should be revisited. The requests are created in Elasticsearch, the code therefore has control of the number of items in the request and hence to some extent the size of the response. 

I noticed that as the response too large error was an IOException it would be retired which is not appropriate, in fact it would be retired multiple times. This PR also adds logic to address those retires. 