### PR TITLE
Clarify cross cluster search support for search applications

### DIFF
--- a/docs/reference/search/search-your-data/search-application-api.asciidoc
+++ b/docs/reference/search/search-your-data/search-application-api.asciidoc
@@ -295,6 +295,12 @@ This may be helpful when experimenting with specific search queries that you wan
 If your search application's name is `my_search_application`, your alias will be `my_search_application`.
 You can search this using the <<search-search,search API>>.
 
+[discrete]
+[[search-application-cross-cluster-search]]
+===== Cross cluster search
+
+Search applications do not currently support {ccs} because it is not possible to add a remote cluster's index or index pattern to an index alias.
+
 [NOTE]
 ====
 You should use the Search Applications management APIs to update your application and _not_ directly use {es} APIs such as the alias API.


### PR DESCRIPTION
Add a subsection about cross cluster search support for search applications.

Please backport for 8.11 and above.

cc: @ioanatia 