### PR TITLE
ESQL: Move all remaining Expression serialization

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/UnaryScalarFunction.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/function/scalar/UnaryScalarFunction.java
@@ -33,7 +33,7 @@ public abstract class UnaryScalarFunction extends ScalarFunction {
     }
 
     @Override
-    public final void writeTo(StreamOutput out) throws IOException {
+    public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
         ((PlanStreamOutput) out).writeExpression(field);
     }

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/logical/And.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/logical/And.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.esql.core.expression.predicate.logical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.predicate.Negatable;
 import org.elasticsearch.xpack.esql.core.expression.predicate.Predicates;
@@ -13,10 +15,22 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogi
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
+import java.io.IOException;
+
 public class And extends BinaryLogic implements Negatable<BinaryLogic> {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "And", And::new);
 
     public And(Source source, Expression left, Expression right) {
         super(source, left, right, BinaryLogicOperation.AND);
+    }
+
+    private And(StreamInput in) throws IOException {
+        super(in, BinaryLogicOperation.AND);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/logical/BinaryLogic.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/logical/BinaryLogic.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.esql.core.expression.predicate.logical;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal;
@@ -13,6 +15,10 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.BinaryOperator;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogicProcessor.BinaryLogicOperation;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.PlanStreamInput;
+import org.elasticsearch.xpack.esql.core.util.PlanStreamOutput;
+
+import java.io.IOException;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isBoolean;
 
@@ -20,6 +26,22 @@ public abstract class BinaryLogic extends BinaryOperator<Boolean, Boolean, Boole
 
     protected BinaryLogic(Source source, Expression left, Expression right, BinaryLogicOperation operation) {
         super(source, left, right, operation);
+    }
+
+    protected BinaryLogic(StreamInput in, BinaryLogicOperation op) throws IOException {
+        this(
+            Source.readFrom((StreamInput & PlanStreamInput) in),
+            ((StreamInput & PlanStreamInput) in).readExpression(),
+            ((StreamInput & PlanStreamInput) in).readExpression(),
+            op
+        );
+    }
+
+    @Override
+    public final void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        ((StreamOutput & PlanStreamOutput) out).writeExpression(left());
+        ((StreamOutput & PlanStreamOutput) out).writeExpression(right());
     }
 
     @Override

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/logical/Or.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/predicate/logical/Or.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.esql.core.expression.predicate.logical;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.predicate.Negatable;
 import org.elasticsearch.xpack.esql.core.expression.predicate.Predicates;
@@ -13,10 +15,22 @@ import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogi
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 
+import java.io.IOException;
+
 public class Or extends BinaryLogic implements Negatable<BinaryLogic> {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Or", Or::new);
 
     public Or(Source source, Expression left, Expression right) {
         super(source, left, right, BinaryLogicOperation.OR);
+    }
+
+    private Or(StreamInput in) throws IOException {
+        super(in, BinaryLogicOperation.OR);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/EsqlScalarFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/EsqlScalarFunction.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
+import org.elasticsearch.xpack.esql.core.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
@@ -22,10 +24,29 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateFormat;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateParse;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.DateTrunc;
 import org.elasticsearch.xpack.esql.expression.function.scalar.date.Now;
+import org.elasticsearch.xpack.esql.expression.function.scalar.ip.CIDRMatch;
+import org.elasticsearch.xpack.esql.expression.function.scalar.ip.IpPrefix;
+import org.elasticsearch.xpack.esql.expression.function.scalar.math.Atan2;
+import org.elasticsearch.xpack.esql.expression.function.scalar.math.E;
+import org.elasticsearch.xpack.esql.expression.function.scalar.math.Log;
+import org.elasticsearch.xpack.esql.expression.function.scalar.math.Pi;
+import org.elasticsearch.xpack.esql.expression.function.scalar.math.Pow;
+import org.elasticsearch.xpack.esql.expression.function.scalar.math.Round;
+import org.elasticsearch.xpack.esql.expression.function.scalar.math.Tau;
 import org.elasticsearch.xpack.esql.expression.function.scalar.nulls.Coalesce;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Concat;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Left;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Locate;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Repeat;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Replace;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Right;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Split;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.Substring;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.ToLower;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.ToUpper;
+import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.InsensitiveEquals;
 
 import java.util.List;
@@ -43,19 +64,40 @@ import java.util.List;
 public abstract class EsqlScalarFunction extends ScalarFunction implements EvaluatorMapper {
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
         return List.of(
+            And.ENTRY,
+            Atan2.ENTRY,
             Bucket.ENTRY,
             Case.ENTRY,
+            CIDRMatch.ENTRY,
             Coalesce.ENTRY,
             Concat.ENTRY,
+            E.ENTRY,
+            EndsWith.ENTRY,
             Greatest.ENTRY,
+            In.ENTRY,
             InsensitiveEquals.ENTRY,
             DateExtract.ENTRY,
             DateDiff.ENTRY,
             DateFormat.ENTRY,
             DateParse.ENTRY,
             DateTrunc.ENTRY,
+            IpPrefix.ENTRY,
             Least.ENTRY,
+            Left.ENTRY,
+            Locate.ENTRY,
+            Log.ENTRY,
             Now.ENTRY,
+            Or.ENTRY,
+            Pi.ENTRY,
+            Pow.ENTRY,
+            Right.ENTRY,
+            Repeat.ENTRY,
+            Replace.ENTRY,
+            Round.ENTRY,
+            Split.ENTRY,
+            Substring.ENTRY,
+            StartsWith.ENTRY,
+            Tau.ENTRY,
             ToLower.ENTRY,
             ToUpper.ENTRY
         );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/UnaryScalarFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/UnaryScalarFunction.java
@@ -54,8 +54,10 @@ import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StX;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StY;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.LTrim;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Length;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.RLike;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.RTrim;
 import org.elasticsearch.xpack.esql.expression.function.scalar.string.Trim;
+import org.elasticsearch.xpack.esql.expression.function.scalar.string.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Neg;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
@@ -86,6 +88,7 @@ public abstract class UnaryScalarFunction extends EsqlScalarFunction {
             LTrim.ENTRY,
             Neg.ENTRY,
             Not.ENTRY,
+            RLike.ENTRY,
             RTrim.ENTRY,
             Signum.ENTRY,
             Sin.ENTRY,
@@ -111,7 +114,8 @@ public abstract class UnaryScalarFunction extends EsqlScalarFunction {
             ToString.ENTRY,
             ToUnsignedLong.ENTRY,
             ToVersion.ENTRY,
-            Trim.ENTRY
+            Trim.ENTRY,
+            WildcardLike.ENTRY
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatch.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatch.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.ip;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.network.CIDRUtils;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator;
@@ -22,7 +25,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -32,6 +38,8 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.fromIndex;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isIPAndExact;
 import static org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions.isStringAndExact;
+import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanReader.readerFromPlanReader;
+import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.PlanWriter.writerFromPlanWriter;
 
 /**
  * This function takes a first parameter of type IP, followed by one or more parameters evaluated to a CIDR specification:
@@ -45,6 +53,11 @@ import static org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions.isStri
  * Example: `| eval cidr="10.0.0.0/8" | where cidr_match(ip_field, "127.0.0.1/30", cidr)`
  */
 public class CIDRMatch extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "CIDRMatch",
+        CIDRMatch::new
+    );
 
     private final Expression ipField;
     private final List<Expression> matches;
@@ -66,6 +79,27 @@ public class CIDRMatch extends EsqlScalarFunction {
         super(source, CollectionUtils.combine(singletonList(ipField), matches));
         this.ipField = ipField;
         this.matches = matches;
+    }
+
+    private CIDRMatch(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            ((PlanStreamInput) in).readExpression(),
+            in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readExpression))
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        assert children().size() > 1;
+        ((PlanStreamOutput) out).writeExpression(children().get(0));
+        out.writeCollection(children().subList(1, children().size()), writerFromPlanWriter(PlanStreamOutput::writeExpression));
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     public Expression ipField() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefix.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefix.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.ip;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
@@ -40,6 +43,8 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
  * Truncates an IP value to a given prefix length.
  */
 public class IpPrefix extends EsqlScalarFunction implements OptionalArgument {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "IpPrefix", IpPrefix::new);
+
     // Borrowed from Lucene, rfc4291 prefix
     private static final byte[] IPV4_PREFIX = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1 };
 
@@ -76,17 +81,28 @@ public class IpPrefix extends EsqlScalarFunction implements OptionalArgument {
         this.prefixLengthV6Field = prefixLengthV6Field;
     }
 
-    public static IpPrefix readFrom(PlanStreamInput in) throws IOException {
-        return new IpPrefix(Source.readFrom(in), in.readExpression(), in.readExpression(), in.readExpression());
+    private IpPrefix(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            ((PlanStreamInput) in).readExpression(),
+            ((PlanStreamInput) in).readExpression(),
+            ((PlanStreamInput) in).readExpression()
+        );
     }
 
-    public void writeTo(PlanStreamOutput out) throws IOException {
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
         source().writeTo(out);
         List<Expression> fields = children();
         assert fields.size() == 3;
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-        out.writeExpression(fields.get(2));
+        ((PlanStreamOutput) out).writeExpression(fields.get(0));
+        ((PlanStreamOutput) out).writeExpression(fields.get(1));
+        ((PlanStreamOutput) out).writeExpression(fields.get(2));
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     public Expression ipField() {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -19,7 +22,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
 
@@ -29,6 +35,8 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isNum
  * Inverse cosine trigonometric function.
  */
 public class Atan2 extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Atan2", Atan2::new);
+
     private final Expression y;
     private final Expression x;
 
@@ -54,6 +62,22 @@ public class Atan2 extends EsqlScalarFunction {
         super(source, List.of(y, x));
         this.y = y;
         this.x = x;
+    }
+
+    private Atan2(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), ((PlanStreamInput) in).readExpression());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(y());
+        ((PlanStreamOutput) out).writeExpression(x());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/E.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/E.java
@@ -7,17 +7,24 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
  * Function that emits Euler's number.
  */
 public class E extends DoubleConstantFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "E", E::new);
+
     @FunctionInfo(
         returnType = "double",
         description = "Returns {wikipedia}/E_(mathematical_constant)[Euler's number].",
@@ -25,6 +32,20 @@ public class E extends DoubleConstantFunction {
     )
     public E(Source source) {
         super(source);
+    }
+
+    private E(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Log.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -18,7 +21,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -28,6 +34,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isNumeric;
 
 public class Log extends EsqlScalarFunction implements OptionalArgument {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Log", Log::new);
 
     private final Expression base;
     private final Expression value;
@@ -58,6 +65,27 @@ public class Log extends EsqlScalarFunction implements OptionalArgument {
         super(source, value != null ? Arrays.asList(base, value) : Arrays.asList(base));
         this.value = value != null ? value : base;
         this.base = value != null ? base : null;
+    }
+
+    private Log(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            ((PlanStreamInput) in).readExpression(),
+            ((PlanStreamInput) in).readOptionalNamed(Expression.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        assert children().size() == 1 || children().size() == 2;
+        ((PlanStreamOutput) out).writeExpression(children().get(0));
+        out.writeOptionalWriteable(children().size() == 2 ? o -> ((PlanStreamOutput) o).writeExpression(children().get(1)) : null);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override
@@ -125,5 +153,13 @@ public class Log extends EsqlScalarFunction implements OptionalArgument {
             return new LogEvaluator.Factory(source(), baseEval, valueEval);
         }
         return new LogConstantEvaluator.Factory(source(), valueEval);
+    }
+
+    Expression value() {
+        return value;
+    }
+
+    Expression base() {
+        return base;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Pi.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Pi.java
@@ -7,17 +7,23 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
  * Function that emits pi.
  */
 public class Pi extends DoubleConstantFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Pi", Pi::new);
 
     @FunctionInfo(
         returnType = "double",
@@ -26,6 +32,20 @@ public class Pi extends DoubleConstantFunction {
     )
     public Pi(Source source) {
         super(source);
+    }
+
+    private Pi(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Pow.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Pow.java
@@ -7,6 +7,9 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -18,7 +21,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -28,6 +34,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isNumeric;
 
 public class Pow extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Pow", Pow::new);
 
     private final Expression base;
     private final Expression exponent;
@@ -56,6 +63,22 @@ public class Pow extends EsqlScalarFunction {
         super(source, Arrays.asList(base, exponent));
         this.base = base;
         this.exponent = exponent;
+    }
+
+    private Pow(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), ((PlanStreamInput) in).readExpression());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(base);
+        ((PlanStreamOutput) out).writeExpression(exponent);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Tau.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Tau.java
@@ -7,17 +7,24 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.math;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
  * Function that emits tau, also known as 2 * pi.
  */
 public class Tau extends DoubleConstantFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Tau", Tau::new);
+
     public static final double TAU = Math.PI * 2;
 
     @FunctionInfo(
@@ -27,6 +34,20 @@ public class Tau extends DoubleConstantFunction {
     )
     public Tau(Source source) {
         super(source);
+    }
+
+    private Tau(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
@@ -65,7 +65,7 @@ public abstract class BinarySpatialFunction extends BinaryScalarFunction impleme
 
     protected BinarySpatialFunction(StreamInput in, boolean leftDocValues, boolean rightDocValues, boolean pointsOnly) throws IOException {
         this(
-            Source.readFrom((StreamInput & PlanStreamInput) in),
+            Source.EMPTY,
             ((PlanStreamInput) in).readExpression(),
             ((PlanStreamInput) in).readExpression(),
             leftDocValues,
@@ -76,7 +76,6 @@ public abstract class BinarySpatialFunction extends BinaryScalarFunction impleme
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        Source.EMPTY.writeTo(out);
         ((PlanStreamOutput) out).writeExpression(left());
         ((PlanStreamOutput) out).writeExpression(right());
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/BinarySpatialFunction.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.lucene.spatial.CoordinateEncoder;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -15,11 +18,14 @@ import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 import org.elasticsearch.xpack.esql.core.expression.function.scalar.BinaryScalarFunction;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.core.util.PlanStreamInput;
+import org.elasticsearch.xpack.esql.core.util.PlanStreamOutput;
 import org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes;
 import org.elasticsearch.xpack.esql.expression.EsqlTypeResolutions;
 import org.elasticsearch.xpack.esql.type.EsqlDataTypes;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
@@ -34,6 +40,10 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.isNull;
  * and of compatible CRS. For example geo_point and geo_shape can be compared, but not geo_point and cartesian_point.
  */
 public abstract class BinarySpatialFunction extends BinaryScalarFunction implements SpatialEvaluatorFactory.SpatialSourceResolution {
+    public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return List.of(SpatialContains.ENTRY, SpatialDisjoint.ENTRY, SpatialIntersects.ENTRY, SpatialWithin.ENTRY, StDistance.ENTRY);
+    }
+
     private final SpatialTypeResolver spatialTypeResolver;
     protected SpatialCrsType crsType;
     protected final boolean leftDocValues;
@@ -51,6 +61,24 @@ public abstract class BinarySpatialFunction extends BinaryScalarFunction impleme
         this.leftDocValues = leftDocValues;
         this.rightDocValues = rightDocValues;
         this.spatialTypeResolver = new SpatialTypeResolver(this, pointsOnly);
+    }
+
+    protected BinarySpatialFunction(StreamInput in, boolean leftDocValues, boolean rightDocValues, boolean pointsOnly) throws IOException {
+        this(
+            Source.readFrom((StreamInput & PlanStreamInput) in),
+            ((PlanStreamInput) in).readExpression(),
+            ((PlanStreamInput) in).readExpression(),
+            leftDocValues,
+            rightDocValues,
+            pointsOnly
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Source.EMPTY.writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(left());
+        ((PlanStreamOutput) out).writeExpression(right());
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContains.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContains.java
@@ -11,6 +11,8 @@ import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.geometry.Geometry;
@@ -51,6 +53,12 @@ import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.Sp
  * Here we simply wire the rules together specific to ST_CONTAINS and QueryRelation.CONTAINS.
  */
 public class SpatialContains extends SpatialRelatesFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "SpatialContains",
+        SpatialContains::new
+    );
+
     // public for test access with reflection
     public static final SpatialRelationsContains GEO = new SpatialRelationsContains(
         SpatialCoordinateTypes.GEO,
@@ -132,6 +140,15 @@ public class SpatialContains extends SpatialRelatesFunction {
 
     SpatialContains(Source source, Expression left, Expression right, boolean leftDocValues, boolean rightDocValues) {
         super(source, left, right, leftDocValues, rightDocValues);
+    }
+
+    private SpatialContains(StreamInput in) throws IOException {
+        super(in, false, false);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjoint.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjoint.java
@@ -11,6 +11,8 @@ import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.geometry.Geometry;
@@ -48,6 +50,12 @@ import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.Sp
  * Here we simply wire the rules together specific to ST_DISJOINT and QueryRelation.DISJOINT.
  */
 public class SpatialDisjoint extends SpatialRelatesFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "SpatialDisjoint",
+        SpatialDisjoint::new
+    );
+
     // public for test access with reflection
     public static final SpatialRelations GEO = new SpatialRelations(
         ShapeField.QueryRelation.DISJOINT,
@@ -87,6 +95,15 @@ public class SpatialDisjoint extends SpatialRelatesFunction {
 
     private SpatialDisjoint(Source source, Expression left, Expression right, boolean leftDocValues, boolean rightDocValues) {
         super(source, left, right, leftDocValues, rightDocValues);
+    }
+
+    private SpatialDisjoint(StreamInput in) throws IOException {
+        super(in, false, false);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersects.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersects.java
@@ -11,6 +11,8 @@ import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.geometry.Geometry;
@@ -48,6 +50,12 @@ import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.Sp
  * Here we simply wire the rules together specific to ST_INTERSECTS and QueryRelation.INTERSECTS.
  */
 public class SpatialIntersects extends SpatialRelatesFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "SpatialIntersects",
+        SpatialIntersects::new
+    );
+
     // public for test access with reflection
     public static final SpatialRelations GEO = new SpatialRelations(
         ShapeField.QueryRelation.INTERSECTS,
@@ -85,6 +93,15 @@ public class SpatialIntersects extends SpatialRelatesFunction {
 
     private SpatialIntersects(Source source, Expression left, Expression right, boolean leftDocValues, boolean rightDocValues) {
         super(source, left, right, leftDocValues, rightDocValues);
+    }
+
+    private SpatialIntersects(StreamInput in) throws IOException {
+        super(in, false, false);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialRelatesFunction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
 import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
@@ -44,6 +45,10 @@ public abstract class SpatialRelatesFunction extends BinarySpatialFunction
 
     protected SpatialRelatesFunction(Source source, Expression left, Expression right, boolean leftDocValues, boolean rightDocValues) {
         super(source, left, right, leftDocValues, rightDocValues, false);
+    }
+
+    protected SpatialRelatesFunction(StreamInput in, boolean leftDocValues, boolean rightDocValues) throws IOException {
+        super(in, leftDocValues, rightDocValues, false);
     }
 
     public abstract ShapeField.QueryRelation queryRelation();

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithin.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithin.java
@@ -11,6 +11,8 @@ import org.apache.lucene.document.ShapeField;
 import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.geo.Orientation;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.geometry.Geometry;
@@ -49,6 +51,12 @@ import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.Sp
  * Here we simply wire the rules together specific to ST_WITHIN and QueryRelation.WITHIN.
  */
 public class SpatialWithin extends SpatialRelatesFunction implements SurrogateExpression {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "SpatialWithin",
+        SpatialWithin::new
+    );
+
     // public for test access with reflection
     public static final SpatialRelations GEO = new SpatialRelations(
         ShapeField.QueryRelation.WITHIN,
@@ -87,6 +95,15 @@ public class SpatialWithin extends SpatialRelatesFunction implements SurrogateEx
 
     SpatialWithin(Source source, Expression left, Expression right, boolean leftDocValues, boolean rightDocValues) {
         super(source, left, right, leftDocValues, rightDocValues);
+    }
+
+    private SpatialWithin(StreamInput in) throws IOException {
+        super(in, false, false);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistance.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistance.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.SloppyMath;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator;
@@ -40,6 +42,12 @@ import static org.elasticsearch.xpack.esql.expression.function.scalar.spatial.Sp
  * Alternatively it is described in PostGIS documentation at <a href="https://postgis.net/docs/ST_Distance.html">PostGIS:ST_Distance</a>.
  */
 public class StDistance extends BinarySpatialFunction implements EvaluatorMapper {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "StDistance",
+        StDistance::new
+    );
+
     // public for test access with reflection
     public static final DistanceCalculator GEO = new GeoDistanceCalculator();
     // public for test access with reflection
@@ -130,6 +138,15 @@ public class StDistance extends BinarySpatialFunction implements EvaluatorMapper
 
     protected StDistance(Source source, Expression left, Expression right, boolean leftDocValues, boolean rightDocValues) {
         super(source, left, right, leftDocValues, rightDocValues, true);
+    }
+
+    private StDistance(StreamInput in) throws IOException {
+        super(in, false, false, true);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWith.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -18,7 +21,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -28,6 +34,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 
 public class EndsWith extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "EndsWith", EndsWith::new);
 
     private final Expression str;
     private final Expression suffix;
@@ -53,6 +60,22 @@ public class EndsWith extends EsqlScalarFunction {
         super(source, Arrays.asList(str, suffix));
         this.str = str;
         this.suffix = suffix;
+    }
+
+    private EndsWith(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), ((PlanStreamInput) in).readExpression());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(str);
+        ((PlanStreamOutput) out).writeExpression(suffix);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override
@@ -106,5 +129,13 @@ public class EndsWith extends EsqlScalarFunction {
     @Override
     public ExpressionEvaluator.Factory toEvaluator(Function<Expression, ExpressionEvaluator.Factory> toEvaluator) {
         return new EndsWithEvaluator.Factory(source(), toEvaluator.apply(str), toEvaluator.apply(suffix));
+    }
+
+    Expression str() {
+        return str;
+    }
+
+    Expression suffix() {
+        return suffix;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Left.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Left.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
@@ -21,7 +24,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -35,6 +41,8 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
  * {code left(foo, len)} is an alias to {code substring(foo, 0, len)}
  */
 public class Left extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Left", Left::new);
+
     private final Expression str;
     private final Expression length;
 
@@ -51,6 +59,22 @@ public class Left extends EsqlScalarFunction {
         super(source, Arrays.asList(str, length));
         this.str = str;
         this.length = length;
+    }
+
+    private Left(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), ((PlanStreamInput) in).readExpression());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(str);
+        ((PlanStreamOutput) out).writeExpression(length);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Evaluator
@@ -119,5 +143,13 @@ public class Left extends EsqlScalarFunction {
     @Override
     public boolean foldable() {
         return str.foldable() && length.foldable();
+    }
+
+    Expression str() {
+        return str;
+    }
+
+    Expression length() {
+        return length;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Locate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Locate.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -20,7 +23,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -35,6 +41,7 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isTyp
  * Locate function, given a string 'a' and a substring 'b', it returns the index of the first occurrence of the substring 'b' in 'a'.
  */
 public class Locate extends EsqlScalarFunction implements OptionalArgument {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Locate", Locate::new);
 
     private final Expression str;
     private final Expression substr;
@@ -59,6 +66,28 @@ public class Locate extends EsqlScalarFunction implements OptionalArgument {
         this.str = str;
         this.substr = substr;
         this.start = start;
+    }
+
+    private Locate(StreamInput in) throws IOException {
+        this(
+            Source.readFrom((PlanStreamInput) in),
+            ((PlanStreamInput) in).readExpression(),
+            ((PlanStreamInput) in).readExpression(),
+            ((PlanStreamInput) in).readOptionalNamed(Expression.class)
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(str);
+        ((PlanStreamOutput) out).writeExpression(substr);
+        ((PlanStreamOutput) out).writeOptionalExpression(start);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override
@@ -141,5 +170,17 @@ public class Locate extends EsqlScalarFunction implements OptionalArgument {
             return new LocateNoStartEvaluator.Factory(source(), strExpr, substrExpr);
         }
         return new LocateEvaluator.Factory(source(), strExpr, substrExpr, toEvaluator.apply(start));
+    }
+
+    Expression str() {
+        return str;
+    }
+
+    Expression substr() {
+        return substr;
+    }
+
+    Expression start() {
+        return start;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RLike.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RLike.java
@@ -7,25 +7,49 @@
 
 package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePattern;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.function.Function;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 
 public class RLike extends org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLike implements EvaluatorMapper {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "RLike", RLike::new);
+
     public RLike(Source source, Expression value, RLikePattern pattern) {
         super(source, value, pattern);
     }
 
     public RLike(Source source, Expression field, RLikePattern rLikePattern, boolean caseInsensitive) {
         super(source, field, rLikePattern, caseInsensitive);
+    }
+
+    private RLike(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), new RLikePattern(in.readString()));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(field());
+        out.writeString(pattern().asJavaRegex());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Replace.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Replace.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
@@ -19,7 +22,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -32,10 +38,11 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 
 public class Replace extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Replace", Replace::new);
 
     private final Expression str;
-    private final Expression newStr;
     private final Expression regex;
+    private final Expression newStr;
 
     @FunctionInfo(
         returnType = "keyword",
@@ -58,6 +65,27 @@ public class Replace extends EsqlScalarFunction {
         this.str = str;
         this.regex = regex;
         this.newStr = newStr;
+    }
+
+    private Replace(StreamInput in) throws IOException {
+        this(
+            Source.EMPTY,
+            ((PlanStreamInput) in).readExpression(),
+            ((PlanStreamInput) in).readExpression(),
+            ((PlanStreamInput) in).readExpression()
+        );
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        ((PlanStreamOutput) out).writeExpression(str);
+        ((PlanStreamOutput) out).writeExpression(regex);
+        ((PlanStreamOutput) out).writeExpression(newStr);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override
@@ -139,5 +167,17 @@ public class Replace extends EsqlScalarFunction {
 
         var regexEval = toEvaluator.apply(regex);
         return new ReplaceEvaluator.Factory(source(), strEval, regexEval, newStrEval);
+    }
+
+    Expression str() {
+        return str;
+    }
+
+    Expression regex() {
+        return regex;
+    }
+
+    Expression newStr() {
+        return newStr;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Right.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/Right.java
@@ -9,6 +9,9 @@ package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.ann.Fixed;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
@@ -21,7 +24,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -35,6 +41,8 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.INTEGER;
  * {code right(foo, len)} is an alias to {code substring(foo, foo.length-len, len)}
  */
 public class Right extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(Expression.class, "Right", Right::new);
+
     private final Expression str;
     private final Expression length;
 
@@ -51,6 +59,22 @@ public class Right extends EsqlScalarFunction {
         super(source, Arrays.asList(str, length));
         this.str = str;
         this.length = length;
+    }
+
+    private Right(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), ((PlanStreamInput) in).readExpression());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(str);
+        ((PlanStreamOutput) out).writeExpression(length);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Evaluator
@@ -124,5 +148,13 @@ public class Right extends EsqlScalarFunction {
     @Override
     public boolean foldable() {
         return str.foldable() && length.foldable();
+    }
+
+    Expression str() {
+        return str;
+    }
+
+    Expression length() {
+        return length;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWith.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.ann.Evaluator;
 import org.elasticsearch.compute.operator.EvalOperator.ExpressionEvaluator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
@@ -18,7 +21,10 @@ import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
@@ -28,6 +34,11 @@ import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.Param
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 
 public class StartsWith extends EsqlScalarFunction {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "StartsWith",
+        StartsWith::new
+    );
 
     private final Expression str;
     private final Expression prefix;
@@ -53,6 +64,22 @@ public class StartsWith extends EsqlScalarFunction {
         super(source, Arrays.asList(str, prefix));
         this.str = str;
         this.prefix = prefix;
+    }
+
+    private StartsWith(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), ((PlanStreamInput) in).readExpression());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(str);
+        ((PlanStreamOutput) out).writeExpression(prefix);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override
@@ -99,5 +126,13 @@ public class StartsWith extends EsqlScalarFunction {
     @Override
     public ExpressionEvaluator.Factory toEvaluator(Function<Expression, ExpressionEvaluator.Factory> toEvaluator) {
         return new StartsWithEvaluator.Factory(source(), toEvaluator.apply(str), toEvaluator.apply(prefix));
+    }
+
+    Expression str() {
+        return str;
+    }
+
+    Expression prefix() {
+        return prefix;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLike.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLike.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.esql.expression.function.scalar.string;
 
 import org.apache.lucene.util.automaton.Automata;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.compute.operator.EvalOperator;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
@@ -17,13 +20,22 @@ import org.elasticsearch.xpack.esql.evaluator.mapper.EvaluatorMapper;
 import org.elasticsearch.xpack.esql.expression.function.Example;
 import org.elasticsearch.xpack.esql.expression.function.FunctionInfo;
 import org.elasticsearch.xpack.esql.expression.function.Param;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
 
+import java.io.IOException;
 import java.util.function.Function;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isString;
 
 public class WildcardLike extends org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardLike implements EvaluatorMapper {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "WildcardLike",
+        WildcardLike::new
+    );
+
     @FunctionInfo(returnType = "boolean", description = """
         Use `LIKE` to filter data based on string patterns using wildcards. `LIKE`
         usually acts on a field placed on the left-hand side of the operator, but it can
@@ -40,6 +52,22 @@ public class WildcardLike extends org.elasticsearch.xpack.esql.core.expression.p
         @Param(name = "pattern", type = { "keyword", "text" }) WildcardPattern pattern
     ) {
         super(source, left, pattern, false);
+    }
+
+    private WildcardLike(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), new WildcardPattern(in.readString()));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        source().writeTo(out);
+        ((PlanStreamOutput) out).writeExpression(field());
+        out.writeString(pattern().pattern());
+    }
+
+    @Override
+    public String getWriteableName() {
+        return ENTRY.name;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypes.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.esql.io.stream;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.TransportVersions;
-import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,17 +27,10 @@ import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NamedExpression;
 import org.elasticsearch.xpack.esql.core.expression.Order;
-import org.elasticsearch.xpack.esql.core.expression.function.scalar.ScalarFunction;
 import org.elasticsearch.xpack.esql.core.expression.predicate.fulltext.FullTextPredicate;
-import org.elasticsearch.xpack.esql.core.expression.predicate.logical.And;
-import org.elasticsearch.xpack.esql.core.expression.predicate.logical.BinaryLogic;
 import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Not;
-import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
 import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNotNull;
 import org.elasticsearch.xpack.esql.core.expression.predicate.nulls.IsNull;
-import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePattern;
-import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RegexMatch;
-import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.esql.core.index.EsIndex;
 import org.elasticsearch.xpack.esql.core.plan.logical.Filter;
 import org.elasticsearch.xpack.esql.core.plan.logical.Limit;
@@ -50,36 +42,10 @@ import org.elasticsearch.xpack.esql.expression.function.UnsupportedAttribute;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
-import org.elasticsearch.xpack.esql.expression.function.scalar.ip.CIDRMatch;
-import org.elasticsearch.xpack.esql.expression.function.scalar.ip.IpPrefix;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.Atan2;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.E;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.Log;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.Pi;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.Pow;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.Round;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.Tau;
 import org.elasticsearch.xpack.esql.expression.function.scalar.multivalue.AbstractMultivalueFunction;
 import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.BinarySpatialFunction;
-import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialContains;
-import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialDisjoint;
-import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialIntersects;
-import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.SpatialWithin;
-import org.elasticsearch.xpack.esql.expression.function.scalar.spatial.StDistance;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.EndsWith;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.Left;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.Locate;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.RLike;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.Repeat;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.Replace;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.Right;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.Split;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.Substring;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.WildcardLike;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.EsqlArithmeticOperation;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.EsqlBinaryComparison;
-import org.elasticsearch.xpack.esql.expression.predicate.operator.comparison.In;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
 import org.elasticsearch.xpack.esql.plan.logical.Dissect;
 import org.elasticsearch.xpack.esql.plan.logical.Dissect.Parser;
@@ -124,7 +90,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import static java.util.Map.entry;
 import static org.elasticsearch.xpack.esql.io.stream.PlanNameRegistry.Entry.of;
@@ -155,11 +120,6 @@ public final class PlanNamedTypes {
     public static String name(Class<?> cls) {
         return cls.getSimpleName();
     }
-
-    static final Class<org.elasticsearch.xpack.esql.core.expression.function.scalar.UnaryScalarFunction> QL_UNARY_SCLR_CLS =
-        org.elasticsearch.xpack.esql.core.expression.function.scalar.UnaryScalarFunction.class;
-
-    static final Class<UnaryScalarFunction> ESQL_UNARY_SCLR_CLS = UnaryScalarFunction.class;
 
     /**
      * List of named type entries that link concrete names to stream reader and writer implementations.
@@ -211,39 +171,7 @@ public final class PlanNamedTypes {
             of(LogicalPlan.class, MvExpand.class, PlanNamedTypes::writeMvExpand, PlanNamedTypes::readMvExpand),
             of(LogicalPlan.class, OrderBy.class, PlanNamedTypes::writeOrderBy, PlanNamedTypes::readOrderBy),
             of(LogicalPlan.class, Project.class, PlanNamedTypes::writeProject, PlanNamedTypes::readProject),
-            of(LogicalPlan.class, TopN.class, PlanNamedTypes::writeTopN, PlanNamedTypes::readTopN),
-            // InComparison
-            of(ScalarFunction.class, In.class, PlanNamedTypes::writeInComparison, PlanNamedTypes::readInComparison),
-            // RegexMatch
-            of(RegexMatch.class, WildcardLike.class, PlanNamedTypes::writeWildcardLike, PlanNamedTypes::readWildcardLike),
-            of(RegexMatch.class, RLike.class, PlanNamedTypes::writeRLike, PlanNamedTypes::readRLike),
-            // BinaryLogic
-            of(BinaryLogic.class, And.class, PlanNamedTypes::writeBinaryLogic, PlanNamedTypes::readBinaryLogic),
-            of(BinaryLogic.class, Or.class, PlanNamedTypes::writeBinaryLogic, PlanNamedTypes::readBinaryLogic),
-            // ScalarFunction
-            of(ScalarFunction.class, Atan2.class, PlanNamedTypes::writeAtan2, PlanNamedTypes::readAtan2),
-            of(ScalarFunction.class, CIDRMatch.class, PlanNamedTypes::writeCIDRMatch, PlanNamedTypes::readCIDRMatch),
-            of(ScalarFunction.class, E.class, PlanNamedTypes::writeNoArgScalar, PlanNamedTypes::readNoArgScalar),
-            of(ScalarFunction.class, IpPrefix.class, (out, prefix) -> prefix.writeTo(out), IpPrefix::readFrom),
-            of(ScalarFunction.class, Log.class, PlanNamedTypes::writeLog, PlanNamedTypes::readLog),
-            of(ScalarFunction.class, Pi.class, PlanNamedTypes::writeNoArgScalar, PlanNamedTypes::readNoArgScalar),
-            of(ScalarFunction.class, Round.class, PlanNamedTypes::writeRound, PlanNamedTypes::readRound),
-            of(ScalarFunction.class, Pow.class, PlanNamedTypes::writePow, PlanNamedTypes::readPow),
-            of(ScalarFunction.class, StartsWith.class, PlanNamedTypes::writeStartsWith, PlanNamedTypes::readStartsWith),
-            of(ScalarFunction.class, EndsWith.class, PlanNamedTypes::writeEndsWith, PlanNamedTypes::readEndsWith),
-            of(ScalarFunction.class, SpatialIntersects.class, PlanNamedTypes::writeBinarySpatialFunction, PlanNamedTypes::readIntersects),
-            of(ScalarFunction.class, SpatialDisjoint.class, PlanNamedTypes::writeBinarySpatialFunction, PlanNamedTypes::readDisjoint),
-            of(ScalarFunction.class, SpatialContains.class, PlanNamedTypes::writeBinarySpatialFunction, PlanNamedTypes::readContains),
-            of(ScalarFunction.class, SpatialWithin.class, PlanNamedTypes::writeBinarySpatialFunction, PlanNamedTypes::readWithin),
-            of(ScalarFunction.class, StDistance.class, PlanNamedTypes::writeBinarySpatialFunction, PlanNamedTypes::readDistance),
-            of(ScalarFunction.class, Substring.class, PlanNamedTypes::writeSubstring, PlanNamedTypes::readSubstring),
-            of(ScalarFunction.class, Locate.class, PlanNamedTypes::writeLocate, PlanNamedTypes::readLocate),
-            of(ScalarFunction.class, Left.class, PlanNamedTypes::writeLeft, PlanNamedTypes::readLeft),
-            of(ScalarFunction.class, Repeat.class, PlanNamedTypes::writeRepeat, PlanNamedTypes::readRepeat),
-            of(ScalarFunction.class, Right.class, PlanNamedTypes::writeRight, PlanNamedTypes::readRight),
-            of(ScalarFunction.class, Split.class, PlanNamedTypes::writeSplit, PlanNamedTypes::readSplit),
-            of(ScalarFunction.class, Tau.class, PlanNamedTypes::writeNoArgScalar, PlanNamedTypes::readNoArgScalar),
-            of(ScalarFunction.class, Replace.class, PlanNamedTypes::writeReplace, PlanNamedTypes::readReplace)
+            of(LogicalPlan.class, TopN.class, PlanNamedTypes::writeTopN, PlanNamedTypes::readTopN)
         );
         List<PlanNameRegistry.Entry> entries = new ArrayList<>(declared);
 
@@ -251,6 +179,7 @@ public final class PlanNamedTypes {
         for (List<NamedWriteableRegistry.Entry> ee : List.of(
             AbstractMultivalueFunction.getNamedWriteables(),
             AggregateFunction.getNamedWriteables(),
+            BinarySpatialFunction.getNamedWriteables(),
             EsqlArithmeticOperation.getNamedWriteables(),
             EsqlBinaryComparison.getNamedWriteables(),
             EsqlScalarFunction.getNamedWriteables(),
@@ -890,82 +819,6 @@ public final class PlanNamedTypes {
         out.writeExpression(topN.limit());
     }
 
-    // -- InComparison
-
-    static In readInComparison(PlanStreamInput in) throws IOException {
-        return new In(
-            Source.readFrom(in),
-            in.readExpression(),
-            in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readExpression))
-        );
-    }
-
-    static void writeInComparison(PlanStreamOutput out, In in) throws IOException {
-        in.source().writeTo(out);
-        out.writeExpression(in.value());
-        out.writeCollection(in.list(), writerFromPlanWriter(PlanStreamOutput::writeExpression));
-    }
-
-    // -- RegexMatch
-
-    static WildcardLike readWildcardLike(PlanStreamInput in, String name) throws IOException {
-        return new WildcardLike(Source.readFrom(in), in.readExpression(), new WildcardPattern(in.readString()));
-    }
-
-    static void writeWildcardLike(PlanStreamOutput out, WildcardLike like) throws IOException {
-        like.source().writeTo(out);
-        out.writeExpression(like.field());
-        out.writeString(like.pattern().pattern());
-    }
-
-    static RLike readRLike(PlanStreamInput in, String name) throws IOException {
-        return new RLike(Source.readFrom(in), in.readExpression(), new RLikePattern(in.readString()));
-    }
-
-    static void writeRLike(PlanStreamOutput out, RLike like) throws IOException {
-        like.source().writeTo(out);
-        out.writeExpression(like.field());
-        out.writeString(like.pattern().asJavaRegex());
-    }
-
-    // -- BinaryLogic
-
-    static final Map<String, TriFunction<Source, Expression, Expression, BinaryLogic>> BINARY_LOGIC_CTRS = Map.ofEntries(
-        entry(name(And.class), And::new),
-        entry(name(Or.class), Or::new)
-    );
-
-    static BinaryLogic readBinaryLogic(PlanStreamInput in, String name) throws IOException {
-        var source = Source.readFrom(in);
-        var left = in.readExpression();
-        var right = in.readExpression();
-        return BINARY_LOGIC_CTRS.get(name).apply(source, left, right);
-    }
-
-    static void writeBinaryLogic(PlanStreamOutput out, BinaryLogic binaryLogic) throws IOException {
-        Source.EMPTY.writeTo(out);
-        out.writeExpression(binaryLogic.left());
-        out.writeExpression(binaryLogic.right());
-    }
-
-    static final Map<String, Function<Source, ScalarFunction>> NO_ARG_SCALAR_CTRS = Map.ofEntries(
-        entry(name(E.class), E::new),
-        entry(name(Pi.class), Pi::new),
-        entry(name(Tau.class), Tau::new)
-    );
-
-    static ScalarFunction readNoArgScalar(PlanStreamInput in, String name) throws IOException {
-        var ctr = NO_ARG_SCALAR_CTRS.get(name);
-        if (ctr == null) {
-            throw new IOException("Constructor not found:" + name);
-        }
-        return ctr.apply(Source.readFrom(in));
-    }
-
-    static void writeNoArgScalar(PlanStreamOutput out, ScalarFunction function) throws IOException {
-        Source.EMPTY.writeTo(out);
-    }
-
     static final Map<
         String,
         BiFunction<
@@ -994,187 +847,6 @@ public final class PlanNamedTypes {
     ) throws IOException {
         function.source().writeTo(out);
         out.writeExpression(function.field());
-    }
-
-    // -- ScalarFunction
-
-    static Atan2 readAtan2(PlanStreamInput in) throws IOException {
-        return new Atan2(Source.readFrom(in), in.readExpression(), in.readExpression());
-    }
-
-    static void writeAtan2(PlanStreamOutput out, Atan2 atan2) throws IOException {
-        atan2.source().writeTo(out);
-        out.writeExpression(atan2.y());
-        out.writeExpression(atan2.x());
-    }
-
-    static SpatialIntersects readIntersects(PlanStreamInput in) throws IOException {
-        return new SpatialIntersects(Source.EMPTY, in.readExpression(), in.readExpression());
-    }
-
-    static SpatialDisjoint readDisjoint(PlanStreamInput in) throws IOException {
-        return new SpatialDisjoint(Source.EMPTY, in.readExpression(), in.readExpression());
-    }
-
-    static SpatialContains readContains(PlanStreamInput in) throws IOException {
-        return new SpatialContains(Source.EMPTY, in.readExpression(), in.readExpression());
-    }
-
-    static SpatialWithin readWithin(PlanStreamInput in) throws IOException {
-        return new SpatialWithin(Source.EMPTY, in.readExpression(), in.readExpression());
-    }
-
-    static StDistance readDistance(PlanStreamInput in) throws IOException {
-        return new StDistance(Source.EMPTY, in.readExpression(), in.readExpression());
-    }
-
-    static void writeBinarySpatialFunction(PlanStreamOutput out, BinarySpatialFunction binarySpatialFunction) throws IOException {
-        out.writeExpression(binarySpatialFunction.left());
-        out.writeExpression(binarySpatialFunction.right());
-    }
-
-    static Round readRound(PlanStreamInput in) throws IOException {
-        return new Round(Source.readFrom(in), in.readExpression(), in.readOptionalNamed(Expression.class));
-    }
-
-    static void writeRound(PlanStreamOutput out, Round round) throws IOException {
-        round.source().writeTo(out);
-        out.writeExpression(round.field());
-        out.writeOptionalExpression(round.decimals());
-    }
-
-    static Pow readPow(PlanStreamInput in) throws IOException {
-        return new Pow(Source.readFrom(in), in.readExpression(), in.readExpression());
-    }
-
-    static void writePow(PlanStreamOutput out, Pow pow) throws IOException {
-        pow.source().writeTo(out);
-        out.writeExpression(pow.base());
-        out.writeExpression(pow.exponent());
-    }
-
-    static StartsWith readStartsWith(PlanStreamInput in) throws IOException {
-        return new StartsWith(Source.readFrom(in), in.readExpression(), in.readExpression());
-    }
-
-    static void writeStartsWith(PlanStreamOutput out, StartsWith startsWith) throws IOException {
-        startsWith.source().writeTo(out);
-        List<Expression> fields = startsWith.children();
-        assert fields.size() == 2;
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-    }
-
-    static EndsWith readEndsWith(PlanStreamInput in) throws IOException {
-        return new EndsWith(Source.readFrom(in), in.readExpression(), in.readExpression());
-    }
-
-    static void writeEndsWith(PlanStreamOutput out, EndsWith endsWith) throws IOException {
-        List<Expression> fields = endsWith.children();
-        assert fields.size() == 2;
-        Source.EMPTY.writeTo(out);
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-    }
-
-    static Substring readSubstring(PlanStreamInput in) throws IOException {
-        return new Substring(Source.readFrom(in), in.readExpression(), in.readExpression(), in.readOptionalNamed(Expression.class));
-    }
-
-    static void writeSubstring(PlanStreamOutput out, Substring substring) throws IOException {
-        substring.source().writeTo(out);
-        List<Expression> fields = substring.children();
-        assert fields.size() == 2 || fields.size() == 3;
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-        out.writeOptionalWriteable(fields.size() == 3 ? o -> out.writeExpression(fields.get(2)) : null);
-    }
-
-    static Locate readLocate(PlanStreamInput in) throws IOException {
-        return new Locate(Source.readFrom(in), in.readExpression(), in.readExpression(), in.readOptionalNamed(Expression.class));
-    }
-
-    static void writeLocate(PlanStreamOutput out, Locate locate) throws IOException {
-        locate.source().writeTo(out);
-        List<Expression> fields = locate.children();
-        assert fields.size() == 2 || fields.size() == 3;
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-        out.writeOptionalWriteable(fields.size() == 3 ? o -> out.writeExpression(fields.get(2)) : null);
-    }
-
-    static Replace readReplace(PlanStreamInput in) throws IOException {
-        return new Replace(Source.EMPTY, in.readExpression(), in.readExpression(), in.readExpression());
-    }
-
-    static void writeReplace(PlanStreamOutput out, Replace replace) throws IOException {
-        List<Expression> fields = replace.children();
-        assert fields.size() == 3;
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-        out.writeExpression(fields.get(2));
-    }
-
-    static Left readLeft(PlanStreamInput in) throws IOException {
-        return new Left(Source.readFrom(in), in.readExpression(), in.readExpression());
-    }
-
-    static void writeLeft(PlanStreamOutput out, Left left) throws IOException {
-        left.source().writeTo(out);
-        List<Expression> fields = left.children();
-        assert fields.size() == 2;
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-    }
-
-    static Repeat readRepeat(PlanStreamInput in) throws IOException {
-        return new Repeat(Source.readFrom(in), in.readExpression(), in.readExpression());
-    }
-
-    static void writeRepeat(PlanStreamOutput out, Repeat repeat) throws IOException {
-        repeat.source().writeTo(out);
-        List<Expression> fields = repeat.children();
-        assert fields.size() == 2;
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-    }
-
-    static Right readRight(PlanStreamInput in) throws IOException {
-        return new Right(Source.readFrom(in), in.readExpression(), in.readExpression());
-    }
-
-    static void writeRight(PlanStreamOutput out, Right right) throws IOException {
-        right.source().writeTo(out);
-        List<Expression> fields = right.children();
-        assert fields.size() == 2;
-        out.writeExpression(fields.get(0));
-        out.writeExpression(fields.get(1));
-    }
-
-    static Split readSplit(PlanStreamInput in) throws IOException {
-        return new Split(Source.readFrom(in), in.readExpression(), in.readExpression());
-    }
-
-    static void writeSplit(PlanStreamOutput out, Split split) throws IOException {
-        split.source().writeTo(out);
-        out.writeExpression(split.left());
-        out.writeExpression(split.right());
-    }
-
-    static CIDRMatch readCIDRMatch(PlanStreamInput in) throws IOException {
-        return new CIDRMatch(
-            Source.readFrom(in),
-            in.readExpression(),
-            in.readCollectionAsList(readerFromPlanReader(PlanStreamInput::readExpression))
-        );
-    }
-
-    static void writeCIDRMatch(PlanStreamOutput out, CIDRMatch cidrMatch) throws IOException {
-        cidrMatch.source().writeTo(out);
-        List<Expression> children = cidrMatch.children();
-        assert children.size() > 1;
-        out.writeExpression(children.get(0));
-        out.writeCollection(children.subList(1, children.size()), writerFromPlanWriter(PlanStreamOutput::writeExpression));
     }
 
     // -- ancillary supporting classes of plan nodes, etc
@@ -1217,17 +889,5 @@ public final class PlanNamedTypes {
     static void writeDissectParser(PlanStreamOutput out, Parser dissectParser) throws IOException {
         out.writeString(dissectParser.pattern());
         out.writeString(dissectParser.appendSeparator());
-    }
-
-    static Log readLog(PlanStreamInput in) throws IOException {
-        return new Log(Source.readFrom(in), in.readExpression(), in.readOptionalNamed(Expression.class));
-    }
-
-    static void writeLog(PlanStreamOutput out, Log log) throws IOException {
-        log.source().writeTo(out);
-        List<Expression> fields = log.children();
-        assert fields.size() == 1 || fields.size() == 2;
-        out.writeExpression(fields.get(0));
-        out.writeOptionalWriteable(fields.size() == 2 ? o -> out.writeExpression(fields.get(1)) : null);
     }
 }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/AndSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/AndSerializationTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.predicate.logical.And;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class AndSerializationTests extends AbstractExpressionSerializationTests<And> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected And createTestInstance() {
+        Source source = randomSource();
+        Expression left = randomChild();
+        Expression right = randomChild();
+        return new And(source, left, right);
+    }
+
+    @Override
+    protected And mutateInstance(And instance) throws IOException {
+        Source source = instance.source();
+        Expression left = instance.left();
+        Expression right = instance.right();
+        if (randomBoolean()) {
+            left = randomValueOtherThan(left, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            right = randomValueOtherThan(right, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new And(source, left, right);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/OrSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/OrSerializationTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.predicate.logical.Or;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public class OrSerializationTests extends AbstractExpressionSerializationTests<Or> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Or createTestInstance() {
+        Source source = randomSource();
+        Expression left = randomChild();
+        Expression right = randomChild();
+        return new Or(source, left, right);
+    }
+
+    @Override
+    protected Or mutateInstance(Or instance) throws IOException {
+        Source source = instance.source();
+        Expression left = instance.left();
+        Expression right = instance.right();
+        if (randomBoolean()) {
+            left = randomValueOtherThan(left, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            right = randomValueOtherThan(right, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Or(source, left, right);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatchSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/CIDRMatchSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.ip;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class CIDRMatchSerializationTests extends AbstractExpressionSerializationTests<CIDRMatch> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected CIDRMatch createTestInstance() {
+        Source source = randomSource();
+        Expression ipField = randomChild();
+        List<Expression> matches = randomList(1, 10, AbstractExpressionSerializationTests::randomChild);
+        return new CIDRMatch(source, ipField, matches);
+    }
+
+    @Override
+    protected CIDRMatch mutateInstance(CIDRMatch instance) throws IOException {
+        Source source = instance.source();
+        Expression ipField = instance.ipField();
+        List<Expression> matches = instance.matches();
+        if (randomBoolean()) {
+            ipField = randomValueOtherThan(ipField, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            matches = randomValueOtherThan(matches, () -> randomList(1, 10, AbstractExpressionSerializationTests::randomChild));
+        }
+        return new CIDRMatch(source, ipField, matches);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefixSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/ip/IpPrefixSerializationTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.ip;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class IpPrefixSerializationTests extends AbstractExpressionSerializationTests<IpPrefix> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected IpPrefix createTestInstance() {
+        Source source = randomSource();
+        Expression ipField = randomChild();
+        Expression prefixLengthV4Field = randomChild();
+        Expression prefixLengthV6Field = randomChild();
+        return new IpPrefix(source, ipField, prefixLengthV4Field, prefixLengthV6Field);
+    }
+
+    @Override
+    protected IpPrefix mutateInstance(IpPrefix instance) throws IOException {
+        Source source = instance.source();
+        Expression ipField = instance.ipField();
+        Expression prefixLengthV4Field = instance.prefixLengthV4Field();
+        Expression prefixLengthV6Field = instance.prefixLengthV6Field();
+        switch (between(0, 2)) {
+            case 0 -> ipField = randomValueOtherThan(ipField, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> prefixLengthV4Field = randomValueOtherThan(prefixLengthV4Field, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> prefixLengthV6Field = randomValueOtherThan(prefixLengthV6Field, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new IpPrefix(source, ipField, prefixLengthV4Field, prefixLengthV6Field);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2SerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/Atan2SerializationTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class Atan2SerializationTests extends AbstractExpressionSerializationTests<Atan2> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Atan2 createTestInstance() {
+        Source source = randomSource();
+        Expression y = randomChild();
+        Expression x = randomChild();
+        return new Atan2(source, y, x);
+    }
+
+    @Override
+    protected Atan2 mutateInstance(Atan2 instance) throws IOException {
+        Source source = instance.source();
+        Expression y = instance.y();
+        Expression x = instance.x();
+        if (randomBoolean()) {
+            y = randomValueOtherThan(y, AbstractUnaryScalarSerializationTests::randomChild);
+        } else {
+            x = randomValueOtherThan(x, AbstractUnaryScalarSerializationTests::randomChild);
+        }
+        return new Atan2(source, y, x);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/ESerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/ESerializationTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ESerializationTests extends AbstractExpressionSerializationTests<E> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected E createTestInstance() {
+        return new E(randomSource());
+    }
+
+    @Override
+    protected E mutateInstance(E instance) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/LogSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/LogSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class LogSerializationTests extends AbstractExpressionSerializationTests<Log> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Log createTestInstance() {
+        Source source = randomSource();
+        Expression value = randomChild();
+        Expression base = randomBoolean() ? null : randomChild();
+        return new Log(source, value, base);
+    }
+
+    @Override
+    protected Log mutateInstance(Log instance) throws IOException {
+        Source source = instance.source();
+        Expression value = instance.value();
+        Expression base = instance.base();
+        if (randomBoolean()) {
+            value = randomValueOtherThan(value, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            base = randomValueOtherThan(base, () -> randomBoolean() ? null : randomChild());
+        }
+        return new Log(source, value, base);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/PiSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/PiSerializationTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class PiSerializationTests extends AbstractExpressionSerializationTests<Pi> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Pi createTestInstance() {
+        return new Pi(randomSource());
+    }
+
+    @Override
+    protected Pi mutateInstance(Pi instance) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/PowSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/PowSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class PowSerializationTests extends AbstractExpressionSerializationTests<Pow> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Pow createTestInstance() {
+        Source source = randomSource();
+        Expression base = randomChild();
+        Expression exponent = randomChild();
+        return new Pow(source, base, exponent);
+    }
+
+    @Override
+    protected Pow mutateInstance(Pow instance) throws IOException {
+        Source source = instance.source();
+        Expression base = instance.base();
+        Expression exponent = instance.exponent();
+        if (randomBoolean()) {
+            base = randomValueOtherThan(base, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            exponent = randomValueOtherThan(exponent, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Pow(source, base, exponent);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/RoundSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RoundSerializationTests extends AbstractExpressionSerializationTests<Round> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Round createTestInstance() {
+        Source source = randomSource();
+        Expression field = randomChild();
+        Expression decimals = randomBoolean() ? null : randomChild();
+        return new Round(source, field, decimals);
+    }
+
+    @Override
+    protected Round mutateInstance(Round instance) throws IOException {
+        Source source = instance.source();
+        Expression field = instance.field();
+        Expression decimals = instance.decimals();
+        if (randomBoolean()) {
+            field = randomValueOtherThan(field, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            decimals = randomValueOtherThan(decimals, () -> randomBoolean() ? null : randomChild());
+        }
+        return new Round(source, field, decimals);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SignumSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/SignumSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class SignumSerializationTests extends AbstractUnaryScalarSerializationTests<Signum> {
+    @Override
+    protected Signum create(Source source, Expression child) {
+        return new Signum(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TauSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/math/TauSerializationTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.math;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class TauSerializationTests extends AbstractExpressionSerializationTests<Tau> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Tau createTestInstance() {
+        return new Tau(randomSource());
+    }
+
+    @Override
+    protected Tau mutateInstance(Tau instance) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/AbstractBinarySpatialFunctionSerializationTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/AbstractBinarySpatialFunctionSerializationTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+
+import java.io.IOException;
+import java.util.List;
+
+public abstract class AbstractBinarySpatialFunctionSerializationTestCase<T extends BinarySpatialFunction> extends
+    AbstractExpressionSerializationTests<T> {
+
+    protected abstract T build(Source source, Expression left, Expression right);
+
+    @Override
+    protected final List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return BinarySpatialFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected final T createTestInstance() {
+        Source source = randomSource();
+        Expression left = randomChild();
+        Expression right = randomChild();
+        return build(source, left, right);
+    }
+
+    @Override
+    protected final T mutateInstance(T instance) throws IOException {
+        Source source = instance.source();
+        Expression left = instance.left();
+        Expression right = instance.right();
+        if (randomBoolean()) {
+            left = randomValueOtherThan(left, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            right = randomValueOtherThan(right, AbstractExpressionSerializationTests::randomChild);
+        }
+        return build(source, left, right);
+    }
+
+    @Override
+    protected final boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContainsSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialContainsSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class SpatialContainsSerializationTests extends AbstractBinarySpatialFunctionSerializationTestCase<SpatialContains> {
+    @Override
+    protected SpatialContains build(Source source, Expression left, Expression right) {
+        return new SpatialContains(source, left, right);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjointSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialDisjointSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class SpatialDisjointSerializationTests extends AbstractBinarySpatialFunctionSerializationTestCase<SpatialDisjoint> {
+    @Override
+    protected SpatialDisjoint build(Source source, Expression left, Expression right) {
+        return new SpatialDisjoint(source, left, right);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersectsSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialIntersectsSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class SpatialIntersectsSerializationTests extends AbstractBinarySpatialFunctionSerializationTestCase<SpatialIntersects> {
+    @Override
+    protected SpatialIntersects build(Source source, Expression left, Expression right) {
+        return new SpatialIntersects(source, left, right);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithinSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/SpatialWithinSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class SpatialWithinSerializationTests extends AbstractBinarySpatialFunctionSerializationTestCase<SpatialWithin> {
+    @Override
+    protected SpatialWithin build(Source source, Expression left, Expression right) {
+        return new SpatialWithin(source, left, right);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistanceSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StDistanceSerializationTests.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+
+public class StDistanceSerializationTests extends AbstractBinarySpatialFunctionSerializationTestCase<StDistance> {
+    @Override
+    protected StDistance build(Source source, Expression left, Expression right) {
+        return new StDistance(source, left, right);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StXSerializationTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class StXSerializationTests extends AbstractExpressionSerializationTests<StX> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return UnaryScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected StX createTestInstance() {
+        return new StX(randomSource(), randomChild());
+    }
+
+    @Override
+    protected StX mutateInstance(StX instance) throws IOException {
+        return new StX(instance.source(), randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/spatial/StYSerializationTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.spatial;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class StYSerializationTests extends AbstractExpressionSerializationTests<StY> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return UnaryScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected StY createTestInstance() {
+        return new StY(randomSource(), randomChild());
+    }
+
+    @Override
+    protected StY mutateInstance(StY instance) throws IOException {
+        return new StY(instance.source(), randomValueOtherThan(instance.field(), AbstractExpressionSerializationTests::randomChild));
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/EndsWithSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class EndsWithSerializationTests extends AbstractExpressionSerializationTests<EndsWith> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected EndsWith createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression suffix = randomChild();
+        return new EndsWith(source, str, suffix);
+    }
+
+    @Override
+    protected EndsWith mutateInstance(EndsWith instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression suffix = instance.suffix();
+        if (randomBoolean()) {
+            str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            suffix = randomValueOtherThan(suffix, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new EndsWith(source, str, suffix);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LTrimSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LTrimSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class LTrimSerializationTests extends AbstractUnaryScalarSerializationTests<LTrim> {
+    @Override
+    protected LTrim create(Source source, Expression child) {
+        return new LTrim(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LeftSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LeftSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class LeftSerializationTests extends AbstractExpressionSerializationTests<Left> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Left createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression length = randomChild();
+        return new Left(source, str, length);
+    }
+
+    @Override
+    protected Left mutateInstance(Left instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression length = instance.length();
+        if (randomBoolean()) {
+            str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            length = randomValueOtherThan(length, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Left(source, str, length);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LengthSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LengthSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class LengthSerializationTests extends AbstractUnaryScalarSerializationTests<Length> {
+    @Override
+    protected Length create(Source source, Expression child) {
+        return new Length(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LocateSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/LocateSerializationTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class LocateSerializationTests extends AbstractExpressionSerializationTests<Locate> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Locate createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression substr = randomChild();
+        Expression start = randomChild();
+        return new Locate(source, str, substr, start);
+    }
+
+    @Override
+    protected Locate mutateInstance(Locate instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression substr = instance.substr();
+        Expression start = instance.start();
+        switch (between(0, 2)) {
+            case 0 -> str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> substr = randomValueOtherThan(substr, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> start = randomValueOtherThan(start, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Locate(source, str, substr, start);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RLikeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RLikeSerializationTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.RLikePattern;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RLikeSerializationTests extends AbstractExpressionSerializationTests<RLike> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return UnaryScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected RLike createTestInstance() {
+        Source source = randomSource();
+        Expression child = randomChild();
+        RLikePattern pattern = new RLikePattern(randomAlphaOfLength(4));
+        return new RLike(source, child, pattern);
+    }
+
+    @Override
+    protected RLike mutateInstance(RLike instance) throws IOException {
+        Source source = instance.source();
+        Expression child = instance.field();
+        RLikePattern pattern = instance.pattern();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            pattern = randomValueOtherThan(pattern, () -> new RLikePattern(randomAlphaOfLength(4)));
+        }
+        return new RLike(source, child, pattern);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RTrimSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RTrimSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class RTrimSerializationTests extends AbstractUnaryScalarSerializationTests<RTrim> {
+    @Override
+    protected RTrim create(Source source, Expression child) {
+        return new RTrim(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RepeatSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RepeatSerializationTests extends AbstractExpressionSerializationTests<Repeat> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Repeat createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression number = randomChild();
+        return new Repeat(source, str, number);
+    }
+
+    @Override
+    protected Repeat mutateInstance(Repeat instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression number = instance.number();
+        if (randomBoolean()) {
+            str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            number = randomValueOtherThan(number, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Repeat(source, str, number);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/ReplaceSerializationTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class ReplaceSerializationTests extends AbstractExpressionSerializationTests<Replace> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Replace createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression regex = randomChild();
+        Expression newStr = randomChild();
+        return new Replace(source, str, regex, newStr);
+    }
+
+    @Override
+    protected Replace mutateInstance(Replace instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression regex = instance.regex();
+        Expression newStr = instance.newStr();
+        switch (between(0, 2)) {
+            case 0 -> str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> regex = randomValueOtherThan(regex, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> newStr = randomValueOtherThan(newStr, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Replace(source, str, regex, newStr);
+    }
+
+    @Override
+    protected boolean alwaysEmptySource() {
+        return true;
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RightSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/RightSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RightSerializationTests extends AbstractExpressionSerializationTests<Right> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Right createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression length = randomChild();
+        return new Right(source, str, length);
+    }
+
+    @Override
+    protected Right mutateInstance(Right instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression length = instance.length();
+        if (randomBoolean()) {
+            str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            length = randomValueOtherThan(length, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Right(source, str, length);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SplitSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class SplitSerializationTests extends AbstractExpressionSerializationTests<Split> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Split createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression delim = randomChild();
+        return new Split(source, str, delim);
+    }
+
+    @Override
+    protected Split mutateInstance(Split instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression delim = instance.delim();
+        if (randomBoolean()) {
+            str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            delim = randomValueOtherThan(delim, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Split(source, str, delim);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/StartsWithSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class StartsWithSerializationTests extends AbstractExpressionSerializationTests<StartsWith> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected StartsWith createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression prefix = randomChild();
+        return new StartsWith(source, str, prefix);
+    }
+
+    @Override
+    protected StartsWith mutateInstance(StartsWith instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression prefix = instance.prefix();
+        if (randomBoolean()) {
+            str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            prefix = randomValueOtherThan(prefix, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new StartsWith(source, str, prefix);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SubstringSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/SubstringSerializationTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class SubstringSerializationTests extends AbstractExpressionSerializationTests<Substring> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected Substring createTestInstance() {
+        Source source = randomSource();
+        Expression str = randomChild();
+        Expression start = randomChild();
+        Expression length = randomChild();
+        return new Substring(source, str, start, length);
+    }
+
+    @Override
+    protected Substring mutateInstance(Substring instance) throws IOException {
+        Source source = instance.source();
+        Expression str = instance.str();
+        Expression start = instance.start();
+        Expression length = instance.length();
+        switch (between(0, 2)) {
+            case 0 -> str = randomValueOtherThan(str, AbstractExpressionSerializationTests::randomChild);
+            case 1 -> start = randomValueOtherThan(start, AbstractExpressionSerializationTests::randomChild);
+            case 2 -> length = randomValueOtherThan(length, AbstractExpressionSerializationTests::randomChild);
+        }
+        return new Substring(source, str, start, length);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TrimSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/TrimSerializationTests.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractUnaryScalarSerializationTests;
+
+public class TrimSerializationTests extends AbstractUnaryScalarSerializationTests<Trim> {
+    @Override
+    protected Trim create(Source source, Expression child) {
+        return new Trim(source, child);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLikeSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/scalar/string/WildcardLikeSerializationTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.scalar.string;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.expression.predicate.regex.WildcardPattern;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.UnaryScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class WildcardLikeSerializationTests extends AbstractExpressionSerializationTests<WildcardLike> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return UnaryScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected WildcardLike createTestInstance() {
+        Source source = randomSource();
+        Expression child = randomChild();
+        WildcardPattern pattern = new WildcardPattern(randomAlphaOfLength(4));
+        return new WildcardLike(source, child, pattern);
+    }
+
+    @Override
+    protected WildcardLike mutateInstance(WildcardLike instance) throws IOException {
+        Source source = instance.source();
+        Expression child = instance.field();
+        WildcardPattern pattern = instance.pattern();
+        if (randomBoolean()) {
+            child = randomValueOtherThan(child, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            pattern = randomValueOtherThan(pattern, () -> new WildcardPattern(randomAlphaOfLength(4)));
+        }
+        return new WildcardLike(source, child, pattern);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InSerializationTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/predicate/operator/comparison/InSerializationTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.predicate.operator.comparison;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.expression.AbstractExpressionSerializationTests;
+import org.elasticsearch.xpack.esql.expression.function.scalar.EsqlScalarFunction;
+
+import java.io.IOException;
+import java.util.List;
+
+public class InSerializationTests extends AbstractExpressionSerializationTests<In> {
+    @Override
+    protected List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return EsqlScalarFunction.getNamedWriteables();
+    }
+
+    @Override
+    protected In createTestInstance() {
+        Source source = randomSource();
+        Expression value = randomChild();
+        List<Expression> list = randomList(10, AbstractExpressionSerializationTests::randomChild);
+        return new In(source, value, list);
+    }
+
+    @Override
+    protected In mutateInstance(In instance) throws IOException {
+        Source source = instance.source();
+        Expression value = instance.value();
+        List<Expression> list = instance.list();
+        if (randomBoolean()) {
+            value = randomValueOtherThan(value, AbstractExpressionSerializationTests::randomChild);
+        } else {
+            list = randomValueOtherThan(list, () -> randomList(10, AbstractExpressionSerializationTests::randomChild));
+        }
+        return new In(source, value, list);
+    }
+}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/io/stream/PlanNamedTypesTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xpack.esql.SerializationTestUtils;
 import org.elasticsearch.xpack.esql.core.expression.Alias;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
-import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.NameId;
 import org.elasticsearch.xpack.esql.core.expression.Nullability;
 import org.elasticsearch.xpack.esql.core.expression.predicate.operator.arithmetic.ArithmeticOperation;
@@ -36,10 +35,6 @@ import org.elasticsearch.xpack.esql.core.type.EsField;
 import org.elasticsearch.xpack.esql.core.type.KeywordEsField;
 import org.elasticsearch.xpack.esql.expression.Order;
 import org.elasticsearch.xpack.esql.expression.function.EsqlFunctionRegistry;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.Pow;
-import org.elasticsearch.xpack.esql.expression.function.scalar.math.Round;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.StartsWith;
-import org.elasticsearch.xpack.esql.expression.function.scalar.string.Substring;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Add;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Div;
 import org.elasticsearch.xpack.esql.expression.predicate.operator.arithmetic.Mod;
@@ -239,42 +234,6 @@ public class PlanNamedTypesTests extends ESTestCase {
 
     public void testArithmeticOperation() {
         Stream.generate(PlanNamedTypesTests::randomArithmeticOperation).limit(100).forEach(obj -> assertNamedType(Expression.class, obj));
-    }
-
-    public void testSubStringSimple() throws IOException {
-        var orig = new Substring(Source.EMPTY, field("foo", DataType.KEYWORD), new Literal(Source.EMPTY, 1, DataType.INTEGER), null);
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeSubstring(out, orig);
-        var deser = PlanNamedTypes.readSubstring(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    public void testStartsWithSimple() throws IOException {
-        var orig = new StartsWith(Source.EMPTY, field("foo", DataType.KEYWORD), new Literal(Source.EMPTY, "fo", DataType.KEYWORD));
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeStartsWith(out, orig);
-        var deser = PlanNamedTypes.readStartsWith(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    public void testRoundSimple() throws IOException {
-        var orig = new Round(Source.EMPTY, field("value", DataType.DOUBLE), new Literal(Source.EMPTY, 1, DataType.INTEGER));
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writeRound(out, orig);
-        var deser = PlanNamedTypes.readRound(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
-    }
-
-    public void testPowSimple() throws IOException {
-        var orig = new Pow(Source.EMPTY, field("value", DataType.DOUBLE), new Literal(Source.EMPTY, 1, DataType.INTEGER));
-        BytesStreamOutput bso = new BytesStreamOutput();
-        PlanStreamOutput out = new PlanStreamOutput(bso, planNameRegistry, null);
-        PlanNamedTypes.writePow(out, orig);
-        var deser = PlanNamedTypes.readPow(planStreamInput(bso));
-        EqualsHashCodeTestUtils.checkEqualsAndHashCode(orig, unused -> deser);
     }
 
     public void testFieldSortSimple() throws IOException {


### PR DESCRIPTION
To line it up with the rest of Elasticsearch.
