### PR TITLE
[8.14] Remove obsolete information about tsdb dimensions limit. (#110047)

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -109,19 +109,6 @@ parameter:
 
 For a flattened field, use the `time_series_dimensions` parameter to configure an array of fields as dimensions. For details refer to <<flattened-params,`flattened`>>.
 
-[[dimension-limits]]
-.Dimension limits
-****
-In a TSDS, {es} uses dimensions to
-generate the document `_id` and <<tsid,`_tsid`>> values. The resulting `_id` is
-always a short encoded hash. To prevent the `_tsid` value from being overly
-large, {es} limits the number of dimensions for an index using the
-<<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
-index setting. While you can increase this limit, the resulting document `_tsid`
-value can't exceed 32KB. Additionally the field name of a dimension cannot be
-longer than 512 bytes and the each dimension value can't exceed 1kb.
-****
-
 [discrete]
 [[time-series-metric]]
 ==== Metrics


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Remove obsolete information about tsdb dimensions limit. (#110047)