### PR TITLE
Ignore unknown shards in the prevalidate shard path API

### DIFF
--- a/docs/changelog/110129.yaml
+++ b/docs/changelog/110129.yaml
@@ -2,4 +2,5 @@ pr: 110129
 summary: Ignore unknown shards in the prevalidate shard path API
 area: Allocation
 type: bug
-issues: []
+issues:
+ - 104807

--- a/docs/changelog/110129.yaml
+++ b/docs/changelog/110129.yaml
@@ -1,0 +1,5 @@
+pr: 110129
+summary: Ignore unknown shards in the prevalidate shard path API
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportPrevalidateShardPathAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/shutdown/TransportPrevalidateShardPathAction.java
@@ -108,6 +108,7 @@ public class TransportPrevalidateShardPathAction extends TransportNodesAction<
                 } else {
                     // The index is not known to this node. This shouldn't happen, but it can be safely ignored for this operation.
                     logger.warn("node doesn't have metadata for the index [{}]", shardId.getIndex());
+                    continue;
                 }
                 shardPath = ShardPath.loadShardPath(logger, nodeEnv, shardId, customDataPath);
                 if (shardPath != null) {


### PR DESCRIPTION
If the node doesn't have metadata about a shard's index, we can't make any assumptions whether the shard is actually located on it.

I believe this should actually fix #104807. In all cases where that test fails, the shard is actually relocated from the `node_2`, but if send a `PrevalidateShardPathRequest` to the node_2, it keeps claiming that the shard is still located on it despite that the node doesn't even know about the index in the metadata.

Resolves #104807
