### PR TITLE
Fix trailing slash in ml.get_categories specification

### DIFF
--- a/docs/changelog/110146.yaml
+++ b/docs/changelog/110146.yaml
@@ -1,0 +1,5 @@
+pr: 110146
+summary: Fix trailing slash in `ml.get_categories` specification
+area: Machine Learning
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_categories.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.get_categories.json
@@ -30,7 +30,7 @@
           }
         },
         {
-          "path":"/_ml/anomaly_detectors/{job_id}/results/categories/",
+          "path":"/_ml/anomaly_detectors/{job_id}/results/categories",
           "methods":[
             "GET",
             "POST"

--- a/x-pack/qa/xpack-prefix-rest-compat/src/yamlRestTestV7Compat/resources/rest-api-spec/api/xpack-ml.get_categories.json
+++ b/x-pack/qa/xpack-prefix-rest-compat/src/yamlRestTestV7Compat/resources/rest-api-spec/api/xpack-ml.get_categories.json
@@ -34,7 +34,7 @@
           }
         },
         {
-          "path":"/_xpack/ml/anomaly_detectors/{job_id}/results/categories/",
+          "path":"/_xpack/ml/anomaly_detectors/{job_id}/results/categories",
           "methods":[
             "GET",
             "POST"


### PR DESCRIPTION
Elasticsearch URLs should never have trailing slashes, and the documentation is correct in this regard: https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-get-category.html. This is a bug because this is the URL that the Elasticsearch clients use.

I have no idea if I should be touching `yamlRestTestV7Compat` as well.