### PR TITLE
[ML]add InferenceAction request query validation

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
@@ -38,6 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static org.elasticsearch.core.Strings.format;
+
 public class InferenceAction extends ActionType<InferenceAction.Response> {
 
     public static final InferenceAction INSTANCE = new InferenceAction();
@@ -176,12 +178,12 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
             if (taskType.equals(TaskType.RERANK)) {
                 if (query == null) {
                     var e = new ActionRequestValidationException();
-                    e.addValidationError("missing query");
+                    e.addValidationError(format("Field [query] cannot be null for task type [%s]", TaskType.RERANK));
                     return e;
                 }
                 if (query.isEmpty()) {
                     var e = new ActionRequestValidationException();
-                    e.addValidationError("query is empty");
+                    e.addValidationError(format("Field [query] cannot be empty for task type [%s]", TaskType.RERANK));
                     return e;
                 }
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
@@ -173,6 +173,18 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
                 e.addValidationError("input array is empty");
                 return e;
             }
+            if (taskType.equals(TaskType.RERANK)) {
+                if (query == null) {
+                    var e = new ActionRequestValidationException();
+                    e.addValidationError("missing query");
+                    return e;
+                }
+                if (query.isEmpty()) {
+                    var e = new ActionRequestValidationException();
+                    e.addValidationError("query is empty");
+                    return e;
+                }
+            }
             return null;
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
@@ -72,7 +72,35 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         }
     }
 
-    public void testValidation() throws IOException {
+    public void testValidation_TextEmbedding() {
+        InferenceAction.Request request = new InferenceAction.Request(
+            TaskType.TEXT_EMBEDDING,
+            "model",
+            null,
+            List.of("input"),
+            null,
+            null,
+            null
+        );
+        ActionRequestValidationException e = request.validate();
+        assertNull(e);
+    }
+
+    public void testValidation_Rerank() {
+        InferenceAction.Request request = new InferenceAction.Request(
+            TaskType.RERANK,
+            "model",
+            "query",
+            List.of("input"),
+            null,
+            null,
+            null
+        );
+        ActionRequestValidationException e = request.validate();
+        assertNull(e);
+    }
+
+    public void testValidation_TextEmbedding_Null() {
         InferenceAction.Request inputNullRequest = new InferenceAction.Request(
             TaskType.TEXT_EMBEDDING,
             "model",
@@ -85,7 +113,9 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         ActionRequestValidationException inputNullError = inputNullRequest.validate();
         assertNotNull(inputNullError);
         assertThat(inputNullError.getMessage(), is("Validation Failed: 1: missing input;"));
+    }
 
+    public void testValidation_TextEmbedding_Empty() {
         InferenceAction.Request inputEmptyRequest = new InferenceAction.Request(
             TaskType.TEXT_EMBEDDING,
             "model",
@@ -98,7 +128,9 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         ActionRequestValidationException inputEmptyError = inputEmptyRequest.validate();
         assertNotNull(inputEmptyError);
         assertThat(inputEmptyError.getMessage(), is("Validation Failed: 1: input array is empty;"));
+    }
 
+    public void testValidation_Rerank_Null() {
         InferenceAction.Request queryNullRequest = new InferenceAction.Request(
             TaskType.RERANK,
             "model",
@@ -110,8 +142,10 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         );
         ActionRequestValidationException queryNullError = queryNullRequest.validate();
         assertNotNull(queryNullError);
-        assertThat(queryNullError.getMessage(), is("Validation Failed: 1: missing query;"));
+        assertThat(queryNullError.getMessage(), is("Validation Failed: 1: Field [query] cannot be null for task type [rerank];"));
+    }
 
+    public void testValidation_Rerank_Empty() {
         InferenceAction.Request queryEmptyRequest = new InferenceAction.Request(
             TaskType.RERANK,
             "model",
@@ -123,31 +157,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         );
         ActionRequestValidationException queryEmptyError = queryEmptyRequest.validate();
         assertNotNull(queryEmptyError);
-        assertThat(queryEmptyError.getMessage(), is("Validation Failed: 1: query is empty;"));
-
-        InferenceAction.Request request = new InferenceAction.Request(
-            TaskType.TEXT_EMBEDDING,
-            "model",
-            null,
-            List.of("input"),
-            null,
-            null,
-            null
-        );
-        ActionRequestValidationException e = request.validate();
-        assertNull(e);
-
-        InferenceAction.Request rerankRequest = new InferenceAction.Request(
-            TaskType.RERANK,
-            "model",
-            "query",
-            List.of("input"),
-            null,
-            null,
-            null
-        );
-        ActionRequestValidationException rerankError = rerankRequest.validate();
-        assertNull(rerankError);
+        assertThat(queryEmptyError.getMessage(), is("Validation Failed: 1: Field [query] cannot be empty for task type [rerank];"));
     }
 
     public void testParseRequest_DefaultsInputTypeToIngest() throws IOException {


### PR DESCRIPTION
When testing Cohere's rerank function, we discovered that if a query is not provided, cohereRerankRequest will throw a NPE. 
The validate() method of InferenceAction checks the input but does not validate the query, causing cohereRerankRequest to throw a NPE because it requires the query to be non-null.