### PR TITLE
[8.14] Fix automatic tracking of collapse with docvalue_fields (#110103)

### DIFF
--- a/docs/changelog/110103.yaml
+++ b/docs/changelog/110103.yaml
@@ -1,0 +1,5 @@
+pr: 110103
+summary: Fix automatic tracking of collapse with `docvalue_fields`
+area: Search
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/CollapseSearchResultsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/CollapseSearchResultsIT.java
@@ -39,4 +39,26 @@ public class CollapseSearchResultsIT extends ESIntegTestCase {
             }
         );
     }
+
+    public void testCollapseWithDocValueFields() {
+        final String indexName = "test_collapse";
+        createIndex(indexName);
+        final String collapseField = "collapse_field";
+        final String otherField = "other_field";
+        assertAcked(indicesAdmin().preparePutMapping(indexName).setSource(collapseField, "type=keyword", otherField, "type=keyword"));
+        index(indexName, "id_1_0", Map.of(collapseField, "value1", otherField, "other_value1"));
+        index(indexName, "id_1_1", Map.of(collapseField, "value1", otherField, "other_value2"));
+        index(indexName, "id_2_0", Map.of(collapseField, "value2", otherField, "other_value3"));
+        refresh(indexName);
+
+        assertNoFailuresAndResponse(
+            prepareSearch(indexName).setQuery(new MatchAllQueryBuilder())
+                .addDocValueField(otherField)
+                .setCollapse(new CollapseBuilder(collapseField).setInnerHits(new InnerHitBuilder("ih").setSize(2))),
+            searchResponse -> {
+                assertEquals(collapseField, searchResponse.getHits().getCollapseField());
+                assertEquals(Set.of(new BytesRef("value1"), new BytesRef("value2")), Set.of(searchResponse.getHits().getCollapseValues()));
+            }
+        );
+    }
 }

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
@@ -175,7 +175,7 @@ public class FetchContext {
                     searchContext.getSearchExecutionContext(),
                     Collections.singletonList(new FieldAndFormat(name, null))
                 );
-            } else if (searchContext.docValuesContext().fields().stream().map(ff -> ff.field).anyMatch(name::equals) == false) {
+            } else if (searchContext.docValuesContext().fields().stream().map(ff -> ff.field).noneMatch(name::equals)) {
                 dvContext.fields().add(new FieldAndFormat(name, null));
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesContext.java
@@ -10,6 +10,7 @@ package org.elasticsearch.search.fetch.subphase;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -24,7 +25,7 @@ import java.util.Map;
  */
 public class FetchDocValuesContext {
 
-    private final Collection<FieldAndFormat> fields;
+    private final List<FieldAndFormat> fields;
 
     /**
      * Create a new FetchDocValuesContext using the provided input list.
@@ -40,7 +41,7 @@ public class FetchDocValuesContext {
                 fieldToFormats.put(fieldName, new FieldAndFormat(fieldName, field.format, field.includeUnmapped));
             }
         }
-        this.fields = fieldToFormats.values();
+        this.fields = new ArrayList<>(fieldToFormats.values());
         int maxAllowedDocvalueFields = searchExecutionContext.getIndexSettings().getMaxDocvalueFields();
         if (fields.size() > maxAllowedDocvalueFields) {
             throw new IllegalArgumentException(
@@ -58,7 +59,7 @@ public class FetchDocValuesContext {
     /**
      * Returns the required docvalue fields.
      */
-    public Collection<FieldAndFormat> fields() {
+    public List<FieldAndFormat> fields() {
         return this.fields;
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Fix automatic tracking of collapse with docvalue_fields (#110103)