### PR TITLE
[ESQL] Replace explicit type list with filtered stream

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -14,6 +14,7 @@ import org.elasticsearch.index.mapper.SourceFieldMapper;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -124,37 +125,8 @@ public enum DataType {
         this.counter = builder.counter;
     }
 
-    private static final Collection<DataType> TYPES = Stream.of(
-        UNSUPPORTED,
-        NULL,
-        BOOLEAN,
-        BYTE,
-        SHORT,
-        INTEGER,
-        LONG,
-        UNSIGNED_LONG,
-        DOUBLE,
-        FLOAT,
-        HALF_FLOAT,
-        SCALED_FLOAT,
-        KEYWORD,
-        TEXT,
-        DATETIME,
-        IP,
-        VERSION,
-        OBJECT,
-        NESTED,
-        SOURCE,
-        DATE_PERIOD,
-        TIME_DURATION,
-        GEO_POINT,
-        CARTESIAN_POINT,
-        CARTESIAN_SHAPE,
-        GEO_SHAPE,
-        COUNTER_LONG,
-        COUNTER_INTEGER,
-        COUNTER_DOUBLE
-    ).sorted(Comparator.comparing(DataType::typeName)).toList();
+    private static final Collection<DataType> TYPES = Arrays.stream(values()).filter(d -> d != DOC_DATA_TYPE && d != TSID_DATA_TYPE)
+    .sorted(Comparator.comparing(DataType::typeName)).toList();
 
     private static final Map<String, DataType> NAME_TO_TYPE = TYPES.stream().collect(toUnmodifiableMap(DataType::typeName, t -> t));
 

--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -22,7 +22,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toUnmodifiableMap;
@@ -125,8 +124,10 @@ public enum DataType {
         this.counter = builder.counter;
     }
 
-    private static final Collection<DataType> TYPES = Arrays.stream(values()).filter(d -> d != DOC_DATA_TYPE && d != TSID_DATA_TYPE)
-    .sorted(Comparator.comparing(DataType::typeName)).toList();
+    private static final Collection<DataType> TYPES = Arrays.stream(values())
+        .filter(d -> d != DOC_DATA_TYPE && d != TSID_DATA_TYPE)
+        .sorted(Comparator.comparing(DataType::typeName))
+        .toList();
 
     private static final Map<String, DataType> NAME_TO_TYPE = TYPES.stream().collect(toUnmodifiableMap(DataType::typeName, t -> t));
 


### PR DESCRIPTION
Follow up to https://github.com/elastic/elasticsearch/pull/109227.  As discussed there, this makes it clear what is being excluded from the type list. It also makes adding new types easier, as implementers do not need to remember to add the type to the list.

I do not know why these two data types (`DOC_DATA_TYPE` and `TSID_DATA_TYPE`) are excluded from this list.  It was like that when I found it.