### PR TITLE
ESQL: Allow another cancel message in test

### DIFF
--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/EsqlActionTaskIT.java
@@ -323,7 +323,10 @@ public class EsqlActionTaskIT extends AbstractPausableIntegTestCase {
          * or the cancellation chained from another cancellation and has
          * "task cancelled".
          */
-        assertThat(cancelException.getMessage(), either(equalTo("test cancel")).or(equalTo("task cancelled")));
+        assertThat(
+            cancelException.getMessage(),
+            either(equalTo("test cancel")).or(equalTo("task cancelled")).or(equalTo("request cancelled test cancel"))
+        );
         assertBusy(
             () -> assertThat(
                 client().admin()


### PR DESCRIPTION
This causes the ESQL tests to be ok with a different cancellation message in the cancellation tests - this one is just as descriptive as the previous allowed ones though I'm not entirely sure where it comes from. But that's ok - it tells us the request is cancelled.

Closes #109890
