### PR TITLE
Add system property to allow `index.refresh_interval` be less than 5s

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -7,7 +7,6 @@
  */
 package org.elasticsearch.index;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.lucene.index.MergePolicy;
@@ -296,7 +295,10 @@ public final class IndexSettings {
 
     static class RefreshIntervalValidator implements Setting.Validator<TimeValue> {
 
-        public static final String STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE = "stateless.allow.index.refresh_interval.override";
+        static final String STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE = "es.stateless.allow.index.refresh_interval.override";
+        // conditional flag to facilitate property check in unit testing
+        private static boolean INIT_OVERRIDE_CHECK;
+        private static boolean ALLOW_OVERRIDE;
 
         @Override
         public void validate(TimeValue value) {}
@@ -307,9 +309,12 @@ public final class IndexSettings {
             final Boolean fastRefresh = (Boolean) settings.get(INDEX_FAST_REFRESH_SETTING);
             final IndexVersion indexVersion = (IndexVersion) settings.get(SETTING_INDEX_VERSION_CREATED);
 
-            final boolean allowOverride = Boolean.parseBoolean(
-                System.getProperty(STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false")
-            );
+            if (INIT_OVERRIDE_CHECK == false) {
+                synchronized (RefreshIntervalValidator.class) {
+                    INIT_OVERRIDE_CHECK = true;
+                    ALLOW_OVERRIDE = Boolean.parseBoolean(System.getProperty(STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false"));
+                }
+            }
 
             if (existingShardsAllocator.equals("stateless")
                 && fastRefresh == false
@@ -317,23 +322,19 @@ public final class IndexSettings {
                 && value.compareTo(STATELESS_MIN_NON_FAST_REFRESH_INTERVAL) < 0
                 && indexVersion.after(IndexVersions.V_8_10_0)) {
 
-                if (allowOverride) {
-                    final Logger logger = LogManager.getLogger(RefreshIntervalValidator.class);
-                    logger.warn("Overriding `index.refresh_interval` setting to {}", value);
-                    // allow `index.refresh_interval` setting be in a range (0 .. `STATELESS_MIN_NON_FAST_REFRESH_INTERVAL`)
-                    return;
+                // ALLOW_OVERRIDE lets `index.refresh_interval` setting be in a range (0 .. `STATELESS_MIN_NON_FAST_REFRESH_INTERVAL`)
+                if (ALLOW_OVERRIDE == false) {
+                    throw new IllegalArgumentException(
+                        "index setting ["
+                            + IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey()
+                            + "="
+                            + value
+                            + "] should be either "
+                            + TimeValue.MINUS_ONE
+                            + " or equal to or greater than "
+                            + STATELESS_MIN_NON_FAST_REFRESH_INTERVAL
+                    );
                 }
-
-                throw new IllegalArgumentException(
-                    "index setting ["
-                        + IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey()
-                        + "="
-                        + value
-                        + "] should be either "
-                        + TimeValue.MINUS_ONE
-                        + " or equal to or greater than "
-                        + STATELESS_MIN_NON_FAST_REFRESH_INTERVAL
-                );
             }
         }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -296,11 +296,13 @@ public final class IndexSettings {
     static class RefreshIntervalValidator implements Setting.Validator<TimeValue> {
 
         static final String STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE = "es.stateless.allow.index.refresh_interval.override";
+
         private static class AllowOverrideLazyHolder {
             private static final boolean ALLOW_OVERRIDE = Boolean.parseBoolean(
                 System.getProperty(STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false")
             );
         }
+
         private static boolean isOverrideAllowed() {
             return AllowOverrideLazyHolder.ALLOW_OVERRIDE;
         }

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -298,7 +298,7 @@ public final class IndexSettings {
         static final String STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE = "es.stateless.allow.index.refresh_interval.override";
         // conditional flag to facilitate property check in unit testing
         private static boolean INIT_OVERRIDE_CHECK;
-        private static boolean ALLOW_OVERRIDE;
+        private static volatile boolean ALLOW_OVERRIDE;
 
         @Override
         public void validate(TimeValue value) {}
@@ -322,7 +322,7 @@ public final class IndexSettings {
                 && value.compareTo(STATELESS_MIN_NON_FAST_REFRESH_INTERVAL) < 0
                 && indexVersion.after(IndexVersions.V_8_10_0)) {
 
-                // ALLOW_OVERRIDE lets `index.refresh_interval` setting be in a range (0 .. `STATELESS_MIN_NON_FAST_REFRESH_INTERVAL`)
+                // ALLOW_OVERRIDE=true lets `index.refresh_interval` setting be in a range (0 .. `STATELESS_MIN_NON_FAST_REFRESH_INTERVAL`)
                 if (ALLOW_OVERRIDE == false) {
                     throw new IllegalArgumentException(
                         "index setting ["

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.ingest.IngestService;
@@ -297,15 +298,9 @@ public final class IndexSettings {
 
         static final String STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE = "es.stateless.allow.index.refresh_interval.override";
 
-        private static class AllowOverrideLazyHolder {
-            private static final boolean ALLOW_OVERRIDE = Boolean.parseBoolean(
-                System.getProperty(STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false")
-            );
-        }
-
-        private static boolean isOverrideAllowed() {
-            return AllowOverrideLazyHolder.ALLOW_OVERRIDE;
-        }
+        private LazyInitializable<Boolean, RuntimeException> isOverrideAllowed = new LazyInitializable<>(
+            () -> Boolean.parseBoolean(System.getProperty(STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false"))
+        );
 
         @Override
         public void validate(TimeValue value) {}
@@ -322,7 +317,7 @@ public final class IndexSettings {
                 && value.compareTo(STATELESS_MIN_NON_FAST_REFRESH_INTERVAL) < 0
                 && indexVersion.after(IndexVersions.V_8_10_0)) {
 
-                if (isOverrideAllowed() == false) {
+                if (isOverrideAllowed.getOrCompute() == false) {
                     throw new IllegalArgumentException(
                         "index setting ["
                             + IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey()

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
@@ -8,18 +8,19 @@
 
 package org.elasticsearch.index;
 
-import org.apache.logging.log4j.Level;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.MockLog;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
 import static org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING;
 
 @ESTestCase.WithoutSecurityManager
+@SuppressForbidden(reason = "manipulates system properties for testing")
 public class IndexSettingsOverrideTests extends ESTestCase {
 
     public static IndexMetadata newIndexMeta(String name, Settings indexSettings) {
@@ -28,32 +29,27 @@ public class IndexSettingsOverrideTests extends ESTestCase {
             .build();
     }
 
-    @SuppressForbidden(reason = "manipulates system properties for testing")
-    public void testStatelessMinRefreshIntervalOverride() {
+    @BeforeClass
+    public static void setSystemProperty() {
         System.setProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "true");
-        try (var mockLog = MockLog.capture(IndexSettings.RefreshIntervalValidator.class)) {
-            mockLog.addExpectation(
-                new MockLog.SeenEventExpectation(
-                    "warnings",
-                    IndexSettings.RefreshIntervalValidator.class.getCanonicalName(),
-                    Level.WARN,
-                    "Overriding `index.refresh_interval` setting to 2s"
-                )
-            );
-            IndexMetadata metadata = newIndexMeta(
-                "index",
-                Settings.builder()
-                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
-                    .put(EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(), "stateless")
-                    .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "2s")
-                    .put(SETTING_INDEX_VERSION_CREATED.getKey(), IndexVersions.V_8_10_0.id() + 1)
-                    .build()
-            );
-            IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
-            assertEquals(TimeValue.timeValueSeconds(2), settings.getRefreshInterval());
-            mockLog.assertAllExpectationsMatched();
-        } finally {
-            System.clearProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE);
-        }
+    }
+
+    public void testStatelessMinRefreshIntervalOverride() {
+        IndexMetadata metadata = newIndexMeta(
+            "index",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                .put(EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(), "stateless")
+                .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "1s")
+                .put(SETTING_INDEX_VERSION_CREATED.getKey(), IndexVersions.V_8_10_0.id() + 1)
+                .build()
+        );
+        IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
+        assertEquals(TimeValue.timeValueSeconds(1), settings.getRefreshInterval());
+    }
+
+    @AfterClass
+    public static void clearSystemProperty() {
+        System.clearProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index;
 import org.apache.logging.log4j.Level;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLog;
@@ -27,6 +28,7 @@ public class IndexSettingsOverrideTests extends ESTestCase {
             .build();
     }
 
+    @SuppressForbidden(reason = "manipulates system properties for testing")
     public void testStatelessMinRefreshIntervalOverride() {
         System.setProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "true");
         try (var mockLog = MockLog.capture(IndexSettings.RefreshIntervalValidator.class)) {

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index;
+
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLog;
+
+import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
+import static org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING;
+
+@ESTestCase.WithoutSecurityManager
+public class IndexSettingsOverrideTests extends ESTestCase {
+
+    public static IndexMetadata newIndexMeta(String name, Settings indexSettings) {
+        return IndexMetadata.builder(name)
+            .settings(indexSettings(IndexVersion.current(), randomIntBetween(1, 3), randomIntBetween(1, 3)).put(indexSettings))
+            .build();
+    }
+
+    public void testStatelessMinRefreshIntervalOverride() {
+        System.setProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "true");
+        try (var mockLog = MockLog.capture(IndexSettings.RefreshIntervalValidator.class)) {
+            mockLog.addExpectation(
+                new MockLog.SeenEventExpectation(
+                    "warnings",
+                    IndexSettings.RefreshIntervalValidator.class.getCanonicalName(),
+                    Level.WARN,
+                    "Overriding `index.refresh_interval` setting to 2s"
+                )
+            );
+            IndexMetadata metadata = newIndexMeta(
+                "index",
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, IndexVersion.current())
+                    .put(EXISTING_SHARDS_ALLOCATOR_SETTING.getKey(), "stateless")
+                    .put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "2s")
+                    .put(SETTING_INDEX_VERSION_CREATED.getKey(), IndexVersions.V_8_10_0.id() + 1)
+                    .build()
+            );
+            IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
+            assertEquals(TimeValue.timeValueSeconds(2), settings.getRefreshInterval());
+            mockLog.assertAllExpectationsMatched();
+        } finally {
+            System.clearProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE);
+        }
+    }
+}


### PR DESCRIPTION
Introducing system property (temporarily for testing and experiments) to allow lower refresh interval in rally

ES-8785