### PR TITLE
Fix trailing slash in two rollup specifications

### DIFF
--- a/docs/changelog/110176.yaml
+++ b/docs/changelog/110176.yaml
@@ -1,0 +1,5 @@
+pr: 110176
+summary: Fix trailing slash in two rollup specifications
+area: Rollup
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_jobs.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_jobs.json
@@ -24,7 +24,7 @@
           }
         },
         {
-          "path":"/_rollup/job/",
+          "path":"/_rollup/job",
           "methods":[
             "GET"
           ]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_caps.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/rollup.get_rollup_caps.json
@@ -24,7 +24,7 @@
           }
         },
         {
-          "path":"/_rollup/data/",
+          "path":"/_rollup/data",
           "methods":[
             "GET"
           ]


### PR DESCRIPTION
Elasticsearch URLs should never have trailing slashes. This is a bug because this is the URL that the Elasticsearch clients use, and the trailing slash fails one of our linting rules. That said, the documentation suggests getting all rollups should be done with `/_all` and I'm not seeing any documentation for `/_rollup/data` or `/_rollup/job`.