### PR TITLE
Fix trailing slash in security.put_privileges specification

### DIFF
--- a/docs/changelog/110177.yaml
+++ b/docs/changelog/110177.yaml
@@ -1,0 +1,5 @@
+pr: 110177
+summary: Fix trailing slash in `security.put_privileges` specification
+area: Authorization
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/security.put_privileges.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/security.put_privileges.json
@@ -13,7 +13,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_security/privilege/",
+          "path":"/_security/privilege",
           "methods":[
             "PUT",
             "POST"


### PR DESCRIPTION
Elasticsearch URLs should never have trailing slashes. This is a bug because this is the URL that the Elasticsearch clients use, and the trailing slash fails one of our linting rules. The documentation is also correct in this regard: https://www.elastic.co/guide/en/elasticsearch/reference/master/security-api-put-privileges.html.