### PR TITLE
[CI] Add gradle cache validation buildkite script

### DIFF
--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -24,10 +24,12 @@ investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$
 #echo "PERF OUTPUT $perfOutput"
 #echo "INVESTIGATION OUTPUT $investigationOutput"
 
+# End of the HTML file
+echo "</ul>" >> "$output_file"
+
+
 cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --style "info"
-```term
     $perfOutput
-```
 EOF
 
 

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -12,7 +12,7 @@ curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scrip
 tmpOutputFile=$(mktemp)
 trap "rm $tmpOutputFile" EXIT
 
-gradle-enterprise-gradle-build-validation./03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t licenseHeaders --fail-if-not-fully-cacheable | tee $tmpOutputFile
+gradle-enterprise-gradle-build-validation/03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t licenseHeaders --fail-if-not-fully-cacheable | tee $tmpOutputFile
 
 # Capture the return value
 retval=$?

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -12,7 +12,7 @@ curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scrip
 tmpOutputFile=$(mktemp)
 trap "rm $tmpOutputFile" EXIT
 
-gradle-enterprise-gradle-build-validation/03-validate-local-build-caching-different-locations.sh -r . -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t licenseHeaders --fail-if-not-fully-cacheable | tee $tmpOutputFile
+gradle-enterprise-gradle-build-validation./03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t licenseHeaders --fail-if-not-fully-cacheable | tee $tmpOutputFile
 
 # Capture the return value
 retval=$?

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -31,14 +31,29 @@ cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --sty
 <summary>Performance Characteristics</summary>
 EOF
 
-cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --append --style "info"
-    "<code>$perfOutput</code>"
-EOF
+# Initialize HTML output variable
+perfHtml="<ul>"
+
+# Process each line of the string
+while IFS=: read -r label value; do
+    if [[ -n "$label" && -n "$value" ]]; then
+        # Trim whitespace from label and value
+        trimmed_label=$(echo "$label" | xargs)
+        trimmed_value=$(echo "$value" | xargs)
+
+        # Append to HTML output variable
+        perfHtml+="<li><strong>$trimmed_label:</strong> $trimmed_value</li>"
+    fi
+done <<< "$perfOutput"
+
+# End of the HTML content
+perfHtml+="</ul>"
+
+echo $perfHtml | buildkite-agent annotate --context "ctx-perf-characteristics" --append --style "info"
 
 
 # generate html for links
-html_output="<h3>Investigation Quick Links</h3>"
-html_output+="<ul>"
+linkHtml="<ul>"
 
 # Process each line of the string
 while IFS= read -r line; do
@@ -48,12 +63,12 @@ while IFS= read -r line; do
         description=$(echo "$line" | sed -e "s/:.*//")
 
         # Append to HTML output variable
-        html_output+="    <li><a href=\"$url\">$description</a></li>"
+        linkHtml+="    <li><a href=\"$url\">$description</a></li>"
     fi
 done <<< "$investigationOutput"
 
 # End of the HTML content
-html_output+="</ul>"
+linkHtml+="</ul>"
 
 cat << EOF | buildkite-agent annotate --context "ctx-investigation-links" --style "info"
 <details>
@@ -61,7 +76,7 @@ cat << EOF | buildkite-agent annotate --context "ctx-investigation-links" --styl
 <summary>Investigation Links</summary>
 EOF
 # Print the output to standard output or use it as needed
-echo $html_output | buildkite-agent annotate --context "ctx-investigation-links" --append --style "info" 
+echo $linkHtml | buildkite-agent annotate --context "ctx-investigation-links" --append --style "info" 
 
 
 # Check if the command was successful

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -18,7 +18,7 @@ gradle-enterprise-gradle-build-validation/03-validate-local-build-caching-differ
 retval=$?
 
 # Now read the content from the temporary file into a variable
-perfOutput=$(cat $tmpOutputFile | sed -n '/Performance Characteristics/,/See https:\/\/gradle.com\/bvs\/main\/Gradle.md#performance-characteristics for details./p' | sed 's/\x1b\[[0-9;]*m//g')
+perfOutput=$(cat $tmpOutputFile | sed -n '/Performance Characteristics/,/See https:\/\/gradle.com\/bvs\/main\/Gradle.md#performance-characteristics for details./p' | sed '$d' | sed 's/\x1b\[[0-9;]*m//g')
 investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$p' | sed 's/\x1b\[[0-9;]*m//g')
 
 #echo "PERF OUTPUT $perfOutput"

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -9,4 +9,23 @@ export GRADLE_ENTERPRISE_ACCESS_KEY
 curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/v$VALIDATION_SCRIPTS_VERSION/gradle-enterprise-gradle-build-validation-$VALIDATION_SCRIPTS_VERSION.zip && unzip -q -o gradle-enterprise-gradle-build-validation-$VALIDATION_SCRIPTS_VERSION.zip
 cd gradle-enterprise-gradle-build-validation
 
-./03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t licenseHeaders -t precommit
+./03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t licenseHeaders -t precommit --fail-if-not-fully-cacheable
+
+# Capture the return value
+retval=$?
+
+# Check if the command was successful
+if [ $retval -eq 0 ]; then
+    echo "Experiment completed successfully"
+elif [ $retval -eq 1 ]; then
+    echo "An invalid input was provided while attempting to run the experiment"
+elif [ $retval -eq 2 ]; then
+    echo "One of the builds that is part of the experiment failed"
+elif [ $retval -eq 3 ]; then
+    echo "The build was not fully cacheable for the given task graph"
+elif [ $retval -eq 3 ]; then
+    echo "An unclassified, fatal error happened while running the experiment"
+fi
+
+exit retval
+

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -22,7 +22,8 @@ perfOutput=$(cat $tmpOutputFile | sed -n '/Performance Characteristics/,/See htt
 investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$p' | sed 's/\x1b\[[0-9;]*m//g')
 
 # Initialize HTML output variable
-perfHtml="<ul>"
+summaryHtml="<h2>Performance Characteristics</h2>"
+summaryHtml+="<ul>"
 
 # Process each line of the string
 while IFS=: read -r label value; do
@@ -32,22 +33,15 @@ while IFS=: read -r label value; do
         trimmed_value=$(echo "$value" | xargs)
 
         # Append to HTML output variable
-        perfHtml+="<li><strong>$trimmed_label:</strong> $trimmed_value</li>"
+        summaryHtml+="<li><strong>$trimmed_label:</strong> $trimmed_value</li>"
     fi
 done <<< "$perfOutput"
 
-# End of the HTML content
-perfHtml+="</ul>"
-
-cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --style "info"
-<details>
-
-<summary>Performance Characteristics</summary>
-$perfHtml
-EOF
+summaryHtml+="</ul>"
 
 # generate html for links
-linkHtml="<ul>"
+summaryHtml="<h2>Investigation Links</h2>"
+summaryHtml+="<ul>"
 
 # Process each line of the string
 while IFS= read -r line; do
@@ -57,18 +51,15 @@ while IFS= read -r line; do
         description=$(echo "$line" | sed -e "s/:.*//")
 
         # Append to HTML output variable
-        linkHtml+="    <li><a href=\"$url\">$description</a></li>"
+        summaryHtml+="    <li><a href=\"$url\">$description</a></li>"
     fi
 done <<< "$investigationOutput"
 
 # End of the HTML content
-linkHtml+="</ul>"
+summaryHtml+="</ul>"
 
-cat << EOF | buildkite-agent annotate --context "ctx-investigation-links" --style "info"
-<details>
-
-<summary>Investigation Links</summary>
-$linkHtml
+cat << EOF | buildkite-agent annotate --context "ctx-validation-summary" --style "info"
+$summaryHtml
 EOF
 
 # Check if the command was successful

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -26,7 +26,13 @@ investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$
 
 
 cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --style "info"
-    $perfOutput
+<details>
+
+<summary>Performance Characteristics</summary>
+EOF
+
+cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --append --style "info"
+    "<code>$perfOutput</code>"
 EOF
 
 
@@ -49,10 +55,13 @@ done <<< "$investigationOutput"
 # End of the HTML content
 html_output+="</ul>"
 
-# Print the output to standard output or use it as needed
 cat << EOF | buildkite-agent annotate --context "ctx-investigation-links" --style "info"
-    $html_output
+<details>
+
+<summary>Investigation Links</summary>
 EOF
+# Print the output to standard output or use it as needed
+echo $html_output | buildkite-agent annotate --context "ctx-investigation-links" --append --style "info" 
 
 
 # Check if the command was successful

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/v2.5.1/gradle-enterprise-gradle-build-validation-2.5.1.zip && unzip -q -o gradle-enterprise-gradle-build-validation-2.5.1.zip
+cd gradle-enterprise-gradle-build-validation
+
+./03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t tasks

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -12,7 +12,7 @@ curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scrip
 tmpOutputFile=$(mktemp)
 trap "rm $tmpOutputFile" EXIT
 
-gradle-enterprise-gradle-build-validation/03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t licenseHeaders --fail-if-not-fully-cacheable | tee $tmpOutputFile
+gradle-enterprise-gradle-build-validation/03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t precommit --fail-if-not-fully-cacheable | tee $tmpOutputFile
 
 # Capture the return value
 retval=$?
@@ -22,7 +22,7 @@ perfOutput=$(cat $tmpOutputFile | sed -n '/Performance Characteristics/,/See htt
 investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$p' | sed 's/\x1b\[[0-9;]*m//g')
 
 # Initialize HTML output variable
-summaryHtml="<h2>Performance Characteristics</h2>"
+summaryHtml="<h3>Performance Characteristics</h3>"
 summaryHtml+="<ul>"
 
 # Process each line of the string
@@ -40,7 +40,7 @@ done <<< "$perfOutput"
 summaryHtml+="</ul>"
 
 # generate html for links
-summaryHtml+="<h2>Investigation Links</h2>"
+summaryHtml+="<h3>Investigation Links</h3>"
 summaryHtml+="<ul>"
 
 # Process each line of the string

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -27,5 +27,5 @@ elif [ $retval -eq 3 ]; then
     echo "An unclassified, fatal error happened while running the experiment"
 fi
 
-exit retval
+exit $retval
 

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -22,7 +22,7 @@ perfOutput=$(cat $tmpOutputFile | sed -n '/Performance Characteristics/,/See htt
 investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$p' | sed 's/\x1b\[[0-9;]*m//g')
 
 # Initialize HTML output variable
-summaryHtml="<h3>Performance Characteristics</h3>"
+summaryHtml="<h4>Performance Characteristics</h4>"
 summaryHtml+="<ul>"
 
 # Process each line of the string
@@ -40,7 +40,7 @@ done <<< "$perfOutput"
 summaryHtml+="</ul>"
 
 # generate html for links
-summaryHtml+="<h3>Investigation Links</h3>"
+summaryHtml+="<h4>Investigation Links</h4>"
 summaryHtml+="<ul>"
 
 # Process each line of the string

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -21,16 +21,6 @@ retval=$?
 perfOutput=$(cat $tmpOutputFile | sed -n '/Performance Characteristics/,/See https:\/\/gradle.com\/bvs\/main\/Gradle.md#performance-characteristics for details./p' | sed '$d' | sed 's/\x1b\[[0-9;]*m//g')
 investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$p' | sed 's/\x1b\[[0-9;]*m//g')
 
-#echo "PERF OUTPUT $perfOutput"
-#echo "INVESTIGATION OUTPUT $investigationOutput"
-
-
-cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --style "info"
-<details>
-
-<summary>Performance Characteristics</summary>
-EOF
-
 # Initialize HTML output variable
 perfHtml="<ul>"
 
@@ -49,8 +39,12 @@ done <<< "$perfOutput"
 # End of the HTML content
 perfHtml+="</ul>"
 
-echo $perfHtml | buildkite-agent annotate --context "ctx-perf-characteristics" --append --style "info"
+cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --style "info"
+<details>
 
+<summary>Performance Characteristics</summary>
+$perfHtml
+EOF
 
 # generate html for links
 linkHtml="<ul>"
@@ -74,10 +68,8 @@ cat << EOF | buildkite-agent annotate --context "ctx-investigation-links" --styl
 <details>
 
 <summary>Investigation Links</summary>
+$linkHtml
 EOF
-# Print the output to standard output or use it as needed
-echo $linkHtml | buildkite-agent annotate --context "ctx-investigation-links" --append --style "info" 
-
 
 # Check if the command was successful
 if [ $retval -eq 0 ]; then

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -2,7 +2,11 @@
 
 set -euo pipefail
 
-curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/v2.5.1/gradle-enterprise-gradle-build-validation-2.5.1.zip && unzip -q -o gradle-enterprise-gradle-build-validation-2.5.1.zip
+VALIDATION_SCRIPTS_VERSION=2.5.1
+GRADLE_ENTERPRISE_ACCESS_KEY=$(vault kv get -field=value secret/ci/elastic-elasticsearch/gradle-enterprise-api-key)
+export GRADLE_ENTERPRISE_ACCESS_KEY
+
+curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/v$VALIDATION_SCRIPTS_VERSION/gradle-enterprise-gradle-build-validation-$VALIDATION_SCRIPTS_VERSION.zip && unzip -q -o gradle-enterprise-gradle-build-validation-$VALIDATION_SCRIPTS_VERSION.zip
 cd gradle-enterprise-gradle-build-validation
 
-./03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t tasks
+./03-validate-local-build-caching-different-locations.sh -r https://github.com/elastic/elasticsearch.git -b $BUILDKITE_BRANCH --gradle-enterprise-server https://gradle-enterprise.elastic.co -t licenseHeaders -t precommit

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -40,7 +40,7 @@ done <<< "$perfOutput"
 summaryHtml+="</ul>"
 
 # generate html for links
-summaryHtml="<h2>Investigation Links</h2>"
+summaryHtml+="<h2>Investigation Links</h2>"
 summaryHtml+="<ul>"
 
 # Process each line of the string

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -24,9 +24,6 @@ investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$
 #echo "PERF OUTPUT $perfOutput"
 #echo "INVESTIGATION OUTPUT $investigationOutput"
 
-# End of the HTML file
-echo "</ul>" >> "$output_file"
-
 
 cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --style "info"
     $perfOutput

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -18,8 +18,8 @@ gradle-enterprise-gradle-build-validation/03-validate-local-build-caching-differ
 retval=$?
 
 # Now read the content from the temporary file into a variable
-perfOutput=$(cat $tmpOutputFile | sed -n '/Performance Characteristics/,/See https:\/\/gradle.com\/bvs\/main\/Gradle.md#performance-characteristics for details./p')
-investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$p')
+perfOutput=$(cat $tmpOutputFile | sed -n '/Performance Characteristics/,/See https:\/\/gradle.com\/bvs\/main\/Gradle.md#performance-characteristics for details./p' | sed 's/\x1b\[[0-9;]*m//g')
+investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$p' | sed 's/\x1b\[[0-9;]*m//g')
 
 #echo "PERF OUTPUT $perfOutput"
 #echo "INVESTIGATION OUTPUT $investigationOutput"

--- a/.buildkite/scripts/gradle-cache-validation.sh
+++ b/.buildkite/scripts/gradle-cache-validation.sh
@@ -24,14 +24,6 @@ investigationOutput=$(cat $tmpOutputFile | sed -n '/Investigation Quick Links/,$
 #echo "PERF OUTPUT $perfOutput"
 #echo "INVESTIGATION OUTPUT $investigationOutput"
 
-# End of the HTML file
-echo "</ul>" >> "$output_file"
-
-# Inform user of completion
-echo "HTML file created: $output_file"
-
-echo $(cat $output_file)
-
 cat << EOF | buildkite-agent annotate --context "ctx-perf-characteristics" --style "info"
 ```term
     $perfOutput


### PR DESCRIPTION
Validating the Gradle caching utilisation should allow us to detect regressions in that area earlier.
This adds an initial check that gradle build tasks caching works also across different folders.

We probably want to run more experiments as part of this pipeline. 

Example buildkite pipeline run: https://buildkite.com/elastic/elasticsearch-gradle-cache-validation/builds/19#019053f9-9995-4433-b42a-24ea1d2cca95