### PR TITLE
Don't sample calls to ReduceContext#consumeBucketsAndMaybeBreak in InternalDateHistogram and InternalHistogram during reduction

### DIFF
--- a/docs/changelog/110186.yaml
+++ b/docs/changelog/110186.yaml
@@ -1,0 +1,6 @@
+pr: 110186
+summary: Don't sample calls to `ReduceContext#consumeBucketsAndMaybeBreak` ins `InternalDateHistogram`
+  and `InternalHistogram` during reduction
+area: Aggregations
+type: bug
+issues: []


### PR DESCRIPTION
 We are only calling the method every 10K buckets, so for deeply nested aggregations might never call the method although the final number of buckets can be enormous. 

The call is not so expensive, and the expensive parts are already sample inside the MultiBucketsConsumer so lets call the method for every new bucket.

(we are calling this method for each bucket in DelayedBucket, therefore should not be too bad)