### PR TITLE
Make empty aggregation instances a little cheaper

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/AdjacencyMatrixAggregator.java
@@ -239,8 +239,7 @@ public class AdjacencyMatrixAggregator extends BucketsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        List<InternalAdjacencyMatrix.InternalBucket> buckets = new ArrayList<>(0);
-        return new InternalAdjacencyMatrix(name, buckets, metadata());
+        return new InternalAdjacencyMatrix(name, List.of(), metadata());
     }
 
     final long bucketOrd(long owningBucketOrdinal, int filterOrd) {

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
@@ -105,7 +105,7 @@ public class TimeSeriesAggregator extends BucketsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalTimeSeries(name, new ArrayList<>(), false, metadata());
+        return new InternalTimeSeries(name, List.of(), false, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -316,7 +316,10 @@ public abstract class AggregatorBase extends Aggregator {
     protected void doPostCollection() throws IOException {}
 
     protected final InternalAggregations buildEmptySubAggregations() {
-        List<InternalAggregation> aggs = new ArrayList<>();
+        if (subAggregators.length == 0) {
+            return InternalAggregations.EMPTY;
+        }
+        List<InternalAggregation> aggs = new ArrayList<>(subAggregators.length);
         for (Aggregator aggregator : subAggregators) {
             aggs.add(aggregator.buildEmptyAggregation());
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricAggregator.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
@@ -146,9 +147,11 @@ class ScriptedMetricAggregator extends MetricsAggregator {
         return state;
     }
 
+    private static final List<Object> NULL_ITEM_LIST = singletonList(null);
+
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalScriptedMetric(name, singletonList(null), reduceScript, metadata());
+        return new InternalScriptedMetric(name, NULL_ITEM_LIST, reduceScript, metadata());
     }
 
     @Override


### PR DESCRIPTION
For sub-aggregations we were not properly sizing the array. Also we can use singleton lists in a couple spots to save a little more memory.

