### PR TITLE
[Connector API] Update status when setting/resetting connector error

### DIFF
--- a/docs/reference/connector/apis/update-connector-error-api.asciidoc
+++ b/docs/reference/connector/apis/update-connector-error-api.asciidoc
@@ -21,6 +21,11 @@ To get started with Connector APIs, check out the {enterprise-search-ref}/connec
 * To sync data using self-managed connectors, you need to deploy the {enterprise-search-ref}/build-connector.html[Elastic connector service] on your own infrastructure. This service runs automatically on Elastic Cloud for native connectors.
 * The `connector_id` parameter should reference an existing connector.
 
+[[update-connector-error-api-desc]]
+==== {api-description-title}
+
+Sets the `error` field for the specified connector. If the `error` provided in the request body is non-null, the connector's status is updated to `error`. Otherwise, if the `error` is reset to null, the connector status is updated to `connected`.
+
 [[update-connector-error-api-path-params]]
 ==== {api-path-parms-title}
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/100_connector_update_error.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/connector/100_connector_update_error.yml
@@ -29,6 +29,7 @@ setup:
         connector_id: test-connector
 
   - match: { error: "some error" }
+  - match: { status: error }
 
 
 ---
@@ -59,6 +60,7 @@ setup:
         connector_id: test-connector
 
   - match: { error: null }
+  - match: { status: connected }
 
 ---
 "Update Connector Error - 404 when connector doesn't exist":

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -467,7 +467,8 @@ public class ConnectorIndexService {
     }
 
     /**
-     * Updates the error property of a {@link Connector}.
+     * Updates the error property of a {@link Connector}. If error is non-null the resulting {@link ConnectorStatus}
+     * is 'error', otherwise it's 'connected'.
      *
      * @param connectorId The ID of the {@link Connector} to be updated.
      * @param error       An instance of error property of {@link Connector}, can be reset to [null].
@@ -475,6 +476,9 @@ public class ConnectorIndexService {
      */
     public void updateConnectorError(String connectorId, String error, ActionListener<UpdateResponse> listener) {
         try {
+
+            ConnectorStatus connectorStatus = Strings.isNullOrEmpty(error) ? ConnectorStatus.CONNECTED : ConnectorStatus.ERROR;
+
             final UpdateRequest updateRequest = new UpdateRequest(CONNECTOR_INDEX_NAME, connectorId).doc(
                 new IndexRequest(CONNECTOR_INDEX_NAME).opType(DocWriteRequest.OpType.INDEX)
                     .id(connectorId)
@@ -482,6 +486,7 @@ public class ConnectorIndexService {
                     .source(new HashMap<>() {
                         {
                             put(Connector.ERROR_FIELD.getPreferredName(), error);
+                            put(Connector.STATUS_FIELD.getPreferredName(), connectorStatus.toString());
                         }
                     })
             );


### PR DESCRIPTION
### Changes

Adapt the logic of tech-preview [update connector error api endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/update-connector-error-api.html). If the `error` provided in the request body is non-null, the connector's status is updated to `error`. Otherwise, if the `error` is reset to null, the connector status is updated to `connected`.

We don't need to consider any other cases than:
- beginning of a sync when error is "unset" and status is connected
- on error, then we should set the error and resulting status to error

See discussion in: https://github.com/elastic/connectors/pull/2641#discussion_r1652662274

Endpoint docs got updated.

### Validation
- e2e tests 
- unit tests

