### PR TITLE
Don't run the JVM crash test on windows

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -73,9 +73,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.transforms.TransformIndexerTests
   method: testMaxPageSearchSizeIsResetToConfiguredValue
   issue: https://github.com/elastic/elasticsearch/issues/109844
-- class: "org.elasticsearch.test.jvm_crash.JvmCrashIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/110052"
-  method: "testJvmCrash"
 
 # Examples:
 #

--- a/test/external-modules/jvm-crash/src/javaRestTest/java/org/elasticsearch/test/jvm_crash/JvmCrashIT.java
+++ b/test/external-modules/jvm-crash/src/javaRestTest/java/org/elasticsearch/test/jvm_crash/JvmCrashIT.java
@@ -50,7 +50,7 @@ public class JvmCrashIT extends ESRestTestCase {
 
     @BeforeClass
     public static void dontRunWindows() {
-        assumeFalse("Stdout redirects don't work on windows", OS.current() == OS.WINDOWS);
+        assumeFalse("JVM crash log doesn't go to stdout on windows", OS.current() == OS.WINDOWS);
     }
 
     private static class StdOutCatchingClusterBuilder extends AbstractLocalClusterSpecBuilder<ElasticsearchCluster> {

--- a/test/external-modules/jvm-crash/src/javaRestTest/java/org/elasticsearch/test/jvm_crash/JvmCrashIT.java
+++ b/test/external-modules/jvm-crash/src/javaRestTest/java/org/elasticsearch/test/jvm_crash/JvmCrashIT.java
@@ -22,9 +22,11 @@ import org.elasticsearch.test.cluster.local.distribution.DistributionType;
 import org.elasticsearch.test.cluster.local.distribution.LocalDistributionResolver;
 import org.elasticsearch.test.cluster.local.distribution.ReleasedDistributionResolver;
 import org.elasticsearch.test.cluster.local.distribution.SnapshotDistributionResolver;
+import org.elasticsearch.test.cluster.util.OS;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.hamcrest.Matcher;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
 import java.io.BufferedReader;
@@ -45,6 +47,11 @@ import static org.hamcrest.Matchers.matchesRegex;
 import static org.hamcrest.Matchers.not;
 
 public class JvmCrashIT extends ESRestTestCase {
+
+    @BeforeClass
+    public static void dontRunWindows() {
+        assumeFalse("Stdout redirects don't work on windows", OS.current() == OS.WINDOWS);
+    }
 
     private static class StdOutCatchingClusterBuilder extends AbstractLocalClusterSpecBuilder<ElasticsearchCluster> {
 


### PR DESCRIPTION
Fixes #110052

Don't run the JVM crash test on windows, as stdout/err work differently on windows.