### PR TITLE
[8.14] Remove obsolete sentence from TSDS docs (#110162)

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -277,11 +277,6 @@ created the initial backing index has:
 
 Only data that falls inside that range can be indexed.
 
-In our <<create-tsds-index-template,TSDS example>>,
-`index.look_ahead_time` is set to three hours, so only documents with a
-`@timestamp` value that is within three hours previous or subsequent to the
-present time are accepted for indexing.
-
 You can use the <<indices-get-data-stream,get data stream API>> to check the
 accepted time range for writing to any TSDS.
 


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Remove obsolete sentence from TSDS docs (#110162)