### PR TITLE
ES|QL: Fix DISSECT that overwrites input

### DIFF
--- a/docs/changelog/110201.yaml
+++ b/docs/changelog/110201.yaml
@@ -1,0 +1,6 @@
+pr: 110201
+summary: "ES|QL: Fix DISSECT that overwrites input"
+area: ES|QL
+type: bug
+issues:
+ - 110184

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
@@ -175,6 +175,14 @@ Parto Bamford     | Parto          | Bamford
 ;
 
 
+overwriteInputName
+from employees | sort emp_no asc | dissect first_name "%{first_name}o%{rest}" | keep emp_no, first_name, rest | limit 1;
+
+emp_no:integer | first_name:keyword | rest:keyword
+10001          | Ge                 | rgi
+;
+
+
 overwriteNameWhere
 from employees | sort emp_no asc | eval full_name = concat(first_name, " ", last_name) | dissect full_name "%{emp_no} %{b}" | where emp_no == "Bezalel" | keep full_name, emp_no, b | limit 3;
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/dissect.csv-spec
@@ -175,7 +175,10 @@ Parto Bamford     | Parto          | Bamford
 ;
 
 
+// different from shadowingSelf because in this case we dissect an indexed field
+// see https://github.com/elastic/elasticsearch/issues/110184
 overwriteInputName
+required_capability: grok_dissect_masking
 from employees | sort emp_no asc | dissect first_name "%{first_name}o%{rest}" | keep emp_no, first_name, rest | limit 1;
 
 emp_no:integer | first_name:keyword | rest:keyword

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/grok.csv-spec
@@ -229,3 +229,11 @@ emp_no:integer | a:keyword                         | b:keyword                  
 10004          | [Head, Reporting, Support, Tech]  | [Human, Analyst, Engineer, Lead]   | Resources      | [Head Human Resources, Reporting Analyst, Support Engineer, Tech Lead]
 10005          | null                              | null                               | null           | null
 ;
+
+overwriteInputName
+required_capability: grok_dissect_masking
+row text = "123 abc", int = 5 | sort int asc | grok text "%{NUMBER:text:int} %{WORD:description}" | keep text, int, description;
+
+text:integer | int:integer | description:keyword
+123          | 5           | abc
+;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -89,7 +89,13 @@ public class EsqlCapabilities {
         /**
          * Support for function {@code ST_DISTANCE}. Done in #108764.
          */
-        ST_DISTANCE;
+        ST_DISTANCE,
+
+        /**
+         * Fix to GROK and DISSECT that allows extracting attributes with the same name as the input
+         * https://github.com/elastic/elasticsearch/issues/110184
+         */
+        GROK_DISSECT_MASKING;
 
         Cap() {
             snapshotOnly = false;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/session/EsqlSession.java
@@ -235,14 +235,12 @@ public class EsqlSession {
 
         parsed.forEachDown(p -> {// go over each plan top-down
             if (p instanceof RegexExtract re) { // for Grok and Dissect
-                AttributeSet dissectRefs = p.references();
-                // don't add to the list of fields the extracted ones (they are not real fields in mappings)
-                dissectRefs.removeAll(re.extractedFields());
-                references.addAll(dissectRefs);
-                // also remove other down-the-tree references to the extracted fields
+                // remove other down-the-tree references to the extracted fields
                 for (Attribute extracted : re.extractedFields()) {
                     references.removeIf(attr -> matchByName(attr, extracted.qualifiedName(), false));
                 }
+                // but keep the inputs needed by Grok/Dissect
+                references.addAll(re.input().references());
             } else if (p instanceof Enrich) {
                 AttributeSet enrichRefs = p.references();
                 // Enrich adds an EmptyAttribute if no match field is specified

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/session/IndexResolverFieldNamesTests.java
@@ -1212,6 +1212,14 @@ public class IndexResolverFieldNamesTests extends ESTestCase {
         assertThat(fieldNames, equalTo(Set.of("emp_no", "emp_no.*", "language_name", "language_name.*")));
     }
 
+    public void testDissectOverwriteName() {
+        Set<String> fieldNames = EsqlSession.fieldNames(parser.createStatement("""
+            from employees
+            | dissect first_name "%{first_name} %{more}"
+            | keep emp_no, first_name, more"""), Set.of());
+        assertThat(fieldNames, equalTo(Set.of("emp_no", "emp_no.*", "first_name", "first_name.*")));
+    }
+
     public void testEnrichOnDefaultField() {
         Set<String> fieldNames = EsqlSession.fieldNames(parser.createStatement("""
             from employees


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/110184

When a DISSECT command overwrites the input, eg.

```
FROM idx | DISSECT foo "%{foo} %{bar}" | KEEP foo, bar
```

The input field (`foo` in this case) could be excluded from the index resolution (incorrectly masked by the `foo` that is the result of the DISSECT).
This PR makes sure that the input field does not get lost and is correctly passed to the indexResolver.

