### PR TITLE
Support mixed aggregates in METRICS

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -68,7 +68,8 @@ public enum DataType {
     GEO_SHAPE(builder().esType("geo_shape").unknownSize().docValues()),
 
     DOC_DATA_TYPE(builder().esType("_doc").size(Integer.BYTES * 3)),
-    TSID_DATA_TYPE(builder().esType("_tsid").unknownSize().docValues());
+    TSID_DATA_TYPE(builder().esType("_tsid").unknownSize().docValues()),
+    PARTIAL_AGG(builder().esType("partial_agg").unknownSize());
 
     private final String typeName;
 

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialAggregatorFunction.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.CompositeBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+
+import java.util.List;
+
+public class FromPartialAggregatorFunction implements AggregatorFunction {
+    private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+        new IntermediateStateDesc("partial", ElementType.COMPOSITE, "partial_agg")
+    );
+
+    public static List<IntermediateStateDesc> intermediateStateDesc() {
+        return INTERMEDIATE_STATE_DESC;
+    }
+
+    private final DriverContext driverContext;
+    private final GroupingAggregatorFunction groupingAggregator;
+    private final int inputChannel;
+    private boolean receivedInput = false;
+
+    public FromPartialAggregatorFunction(DriverContext driverContext, GroupingAggregatorFunction groupingAggregator, int inputChannel) {
+        this.driverContext = driverContext;
+        this.groupingAggregator = groupingAggregator;
+        this.inputChannel = inputChannel;
+    }
+
+    @Override
+    public void addRawInput(Page page) {
+        addIntermediateInput(page);
+    }
+
+    @Override
+    public void addIntermediateInput(Page page) {
+        try (IntVector groupIds = driverContext.blockFactory().newConstantIntVector(0, page.getPositionCount())) {
+            if (page.getPositionCount() > 0) {
+                receivedInput = true;
+            }
+            final CompositeBlock inputBlock = page.getBlock(inputChannel);
+            groupingAggregator.addIntermediateInput(0, groupIds, inputBlock.asPage());
+        }
+    }
+
+    private IntVector outputPositions() {
+        return driverContext.blockFactory().newConstantIntVector(0, receivedInput ? 1 : 0);
+    }
+
+    @Override
+    public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        final Block[] partialBlocks = new Block[groupingAggregator.intermediateBlockCount()];
+        boolean success = false;
+        try (IntVector selected = outputPositions()) {
+            groupingAggregator.evaluateIntermediate(partialBlocks, 0, selected);
+            blocks[offset] = new CompositeBlock(partialBlocks);
+            success = true;
+        } finally {
+            if (success == false) {
+                Releasables.close(blocks);
+            }
+        }
+    }
+
+    @Override
+    public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+        try (IntVector selected = outputPositions()) {
+            groupingAggregator.evaluateFinal(blocks, offset, selected, driverContext);
+        }
+    }
+
+    @Override
+    public int intermediateBlockCount() {
+        return INTERMEDIATE_STATE_DESC.size();
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(groupingAggregator);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialAggregatorFunction.java
@@ -17,6 +17,9 @@ import org.elasticsearch.core.Releasables;
 
 import java.util.List;
 
+/**
+ * @see ToPartialGroupingAggregatorFunction
+ */
 public class FromPartialAggregatorFunction implements AggregatorFunction {
     private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
         new IntermediateStateDesc("partial", ElementType.COMPOSITE, "partial_agg")
@@ -87,5 +90,10 @@ public class FromPartialAggregatorFunction implements AggregatorFunction {
     @Override
     public void close() {
         Releasables.close(groupingAggregator);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[" + "channel=" + inputChannel + ",delegate=" + groupingAggregator + "]";
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialAggregatorFunction.java
@@ -70,7 +70,7 @@ public class FromPartialAggregatorFunction implements AggregatorFunction {
             success = true;
         } finally {
             if (success == false) {
-                Releasables.close(blocks);
+                Releasables.close(partialBlocks);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialGroupingAggregatorFunction.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.CompositeBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntBlock;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+
+import java.util.List;
+
+public class FromPartialGroupingAggregatorFunction implements GroupingAggregatorFunction {
+    private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+        new IntermediateStateDesc("partial", ElementType.COMPOSITE, "partial_agg")
+    );
+
+    public static List<IntermediateStateDesc> intermediateStateDesc() {
+        return INTERMEDIATE_STATE_DESC;
+    }
+
+    private final GroupingAggregatorFunction delegate;
+    private final int inputChannel;
+
+    public FromPartialGroupingAggregatorFunction(GroupingAggregatorFunction delegate, int inputChannel) {
+        this.delegate = delegate;
+        this.inputChannel = inputChannel;
+    }
+
+    @Override
+    public AddInput prepareProcessPage(SeenGroupIds seenGroupIds, Page page) {
+        return new AddInput() {
+            @Override
+            public void add(int positionOffset, IntBlock groupIds) {
+                assert false : "Intermediate group id must not have nulls";
+                throw new IllegalStateException("Intermediate group id must not have nulls");
+            }
+
+            @Override
+            public void add(int positionOffset, IntVector groupIds) {
+                addIntermediateInput(positionOffset, groupIds, page);
+            }
+        };
+    }
+
+    @Override
+    public void addIntermediateInput(int positionOffset, IntVector groupIdVector, Page page) {
+        final CompositeBlock inputBlock = page.getBlock(inputChannel);
+        delegate.addIntermediateInput(positionOffset, groupIdVector, inputBlock.asPage());
+    }
+
+    @Override
+    public void addIntermediateRowInput(int groupId, GroupingAggregatorFunction input, int position) {
+        if (input instanceof FromPartialGroupingAggregatorFunction toPartial) {
+            input = toPartial.delegate;
+        }
+        delegate.addIntermediateRowInput(groupId, input, position);
+    }
+
+    @Override
+    public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+        Block[] partialBlocks = new Block[delegate.intermediateBlockCount()];
+        boolean success = false;
+        try {
+            delegate.evaluateIntermediate(partialBlocks, 0, selected);
+            blocks[offset] = new CompositeBlock(partialBlocks);
+            success = true;
+        } finally {
+            if (success == false) {
+                Releasables.close(blocks);
+            }
+        }
+    }
+
+    @Override
+    public void evaluateFinal(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        delegate.evaluateFinal(blocks, offset, selected, driverContext);
+    }
+
+    @Override
+    public int intermediateBlockCount() {
+        return INTERMEDIATE_STATE_DESC.size();
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(delegate);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialGroupingAggregatorFunction.java
@@ -18,6 +18,9 @@ import org.elasticsearch.core.Releasables;
 
 import java.util.List;
 
+/**
+ * @see ToPartialGroupingAggregatorFunction
+ */
 public class FromPartialGroupingAggregatorFunction implements GroupingAggregatorFunction {
     private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
         new IntermediateStateDesc("partial", ElementType.COMPOSITE, "partial_agg")
@@ -93,5 +96,10 @@ public class FromPartialGroupingAggregatorFunction implements GroupingAggregator
     @Override
     public void close() {
         Releasables.close(delegate);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[" + "channel=" + inputChannel + ",delegate=" + delegate + "]";
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/FromPartialGroupingAggregatorFunction.java
@@ -78,7 +78,7 @@ public class FromPartialGroupingAggregatorFunction implements GroupingAggregator
             success = true;
         } finally {
             if (success == false) {
-                Releasables.close(blocks);
+                Releasables.close(partialBlocks);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/IntermediateStateDesc.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/IntermediateStateDesc.java
@@ -10,4 +10,8 @@ package org.elasticsearch.compute.aggregation;
 import org.elasticsearch.compute.data.ElementType;
 
 /** Intermediate aggregation state descriptor. Intermediate state is a list of these. */
-public record IntermediateStateDesc(String name, ElementType type) {}
+public record IntermediateStateDesc(String name, ElementType type, String dataType) {
+    public IntermediateStateDesc(String name, ElementType type) {
+        this(name, type, "");
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialAggregatorFunction.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.CompositeBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+
+import java.util.List;
+
+public class ToPartialAggregatorFunction implements AggregatorFunction {
+    private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+        new IntermediateStateDesc("partial", ElementType.COMPOSITE, "partial_agg")
+    );
+
+    public static List<IntermediateStateDesc> intermediateStateDesc() {
+        return INTERMEDIATE_STATE_DESC;
+    }
+
+    private final AggregatorFunction delegate;
+    private final List<Integer> channels;
+
+    public ToPartialAggregatorFunction(AggregatorFunction delegate, List<Integer> channels) {
+        this.delegate = delegate;
+        this.channels = channels;
+    }
+
+    @Override
+    public void addRawInput(Page page) {
+        delegate.addRawInput(page);
+    }
+
+    @Override
+    public void addIntermediateInput(Page page) {
+        final CompositeBlock inputBlock = page.getBlock(channels.get(0));
+        delegate.addIntermediateInput(inputBlock.asPage());
+    }
+
+    @Override
+    public void evaluateIntermediate(Block[] blocks, int offset, DriverContext driverContext) {
+        final Block[] partialBlocks = new Block[delegate.intermediateBlockCount()];
+        boolean success = false;
+        try {
+            delegate.evaluateIntermediate(partialBlocks, 0, driverContext);
+            blocks[offset] = new CompositeBlock(partialBlocks);
+            success = true;
+        } finally {
+            if (success == false) {
+                Releasables.close(blocks);
+            }
+        }
+    }
+
+    @Override
+    public void evaluateFinal(Block[] blocks, int offset, DriverContext driverContext) {
+        evaluateIntermediate(blocks, offset, driverContext);
+    }
+
+    @Override
+    public int intermediateBlockCount() {
+        return INTERMEDIATE_STATE_DESC.size();
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(delegate);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialAggregatorFunction.java
@@ -57,7 +57,7 @@ public class ToPartialAggregatorFunction implements AggregatorFunction {
             success = true;
         } finally {
             if (success == false) {
-                Releasables.close(blocks);
+                Releasables.close(partialBlocks);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialAggregatorFunction.java
@@ -16,6 +16,9 @@ import org.elasticsearch.core.Releasables;
 
 import java.util.List;
 
+/**
+ * @see ToPartialGroupingAggregatorFunction
+ */
 public class ToPartialAggregatorFunction implements AggregatorFunction {
     private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
         new IntermediateStateDesc("partial", ElementType.COMPOSITE, "partial_agg")
@@ -72,5 +75,10 @@ public class ToPartialAggregatorFunction implements AggregatorFunction {
     @Override
     public void close() {
         Releasables.close(delegate);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[" + "channels=" + channels + ",delegate=" + delegate + "]";
     }
 }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialGroupingAggregatorFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.aggregation;
+
+import org.elasticsearch.compute.data.Block;
+import org.elasticsearch.compute.data.CompositeBlock;
+import org.elasticsearch.compute.data.ElementType;
+import org.elasticsearch.compute.data.IntVector;
+import org.elasticsearch.compute.data.Page;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.core.Releasables;
+
+import java.util.List;
+
+public class ToPartialGroupingAggregatorFunction implements GroupingAggregatorFunction {
+    private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
+        new IntermediateStateDesc("partial", ElementType.COMPOSITE, "partial_agg")
+    );
+
+    public static List<IntermediateStateDesc> intermediateStateDesc() {
+        return INTERMEDIATE_STATE_DESC;
+    }
+
+    private final GroupingAggregatorFunction delegate;
+    private final List<Integer> channels;
+
+    public ToPartialGroupingAggregatorFunction(GroupingAggregatorFunction delegate, List<Integer> channels) {
+        this.delegate = delegate;
+        this.channels = channels;
+    }
+
+    @Override
+    public AddInput prepareProcessPage(SeenGroupIds seenGroupIds, Page page) {
+        return delegate.prepareProcessPage(seenGroupIds, page);
+    }
+
+    @Override
+    public void addIntermediateInput(int positionOffset, IntVector groupIdVector, Page page) {
+        final CompositeBlock inputBlock = page.getBlock(channels.get(0));
+        delegate.addIntermediateInput(positionOffset, groupIdVector, inputBlock.asPage());
+    }
+
+    @Override
+    public void addIntermediateRowInput(int groupId, GroupingAggregatorFunction input, int position) {
+        if (input instanceof ToPartialGroupingAggregatorFunction toPartial) {
+            input = toPartial.delegate;
+        }
+        delegate.addIntermediateRowInput(groupId, input, position);
+    }
+
+    @Override
+    public void evaluateIntermediate(Block[] blocks, int offset, IntVector selected) {
+        final Block[] partialBlocks = new Block[delegate.intermediateBlockCount()];
+        boolean success = false;
+        try {
+            delegate.evaluateIntermediate(partialBlocks, 0, selected);
+            blocks[offset] = new CompositeBlock(partialBlocks);
+            success = true;
+        } finally {
+            if (success == false) {
+                Releasables.close(blocks);
+            }
+        }
+    }
+
+    @Override
+    public void evaluateFinal(Block[] blocks, int offset, IntVector selected, DriverContext driverContext) {
+        evaluateIntermediate(blocks, offset, selected);
+    }
+
+    @Override
+    public int intermediateBlockCount() {
+        return INTERMEDIATE_STATE_DESC.size();
+    }
+
+    @Override
+    public void close() {
+        Releasables.close(delegate);
+    }
+}

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/aggregation/ToPartialGroupingAggregatorFunction.java
@@ -84,7 +84,7 @@ public class ToPartialGroupingAggregatorFunction implements GroupingAggregatorFu
             success = true;
         } finally {
             if (success == false) {
-                Releasables.close(blocks);
+                Releasables.close(partialBlocks);
             }
         }
     }

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/CompositeBlock.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/data/CompositeBlock.java
@@ -58,6 +58,10 @@ public final class CompositeBlock extends AbstractNonThreadSafeRefCounted implem
         return block;
     }
 
+    public Page asPage() {
+        return new Page(positionCount, blocks);
+    }
+
     /**
      * Returns the number of blocks in this composite block.
      */

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
@@ -262,6 +262,7 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
             intermediateOperators.add(ValuesSourceReaderOperatorTests.factory(reader, groupingField, ElementType.BYTES_REF).get(ctx));
         }
         // _doc, tsid, timestamp, bucket, requests, grouping1, grouping2
+
         Operator intialAgg = new TimeSeriesAggregationOperatorFactories.Initial(
             1,
             3,

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/TimeSeriesAggregationOperatorTests.java
@@ -262,7 +262,6 @@ public class TimeSeriesAggregationOperatorTests extends ComputeTestCase {
             intermediateOperators.add(ValuesSourceReaderOperatorTests.factory(reader, groupingField, ElementType.BYTES_REF).get(ctx));
         }
         // _doc, tsid, timestamp, bucket, requests, grouping1, grouping2
-
         Operator intialAgg = new TimeSeriesAggregationOperatorFactories.Initial(
             1,
             3,

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-metrics.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/k8s-metrics.csv-spec
@@ -36,6 +36,30 @@ max_cost: double
 0.16151685393258428
 ;
 
+maxRateAndBytes
+required_capability: metrics_syntax
+METRICS k8s max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in);
+
+max(rate(network.total_bytes_in, 1minute)): double | max(network.bytes_in): long
+790.4235090751945                                  | 1021
+;
+
+`maxRateAndMarkupBytes`
+required_capability: metrics_syntax
+METRICS k8s max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in * 1.05);
+
+max(rate(network.total_bytes_in, 1minute)): double | max(network.bytes_in * 1.05): double
+790.4235090751945                                  | 1072.05
+;
+
+maxRateAndBytesAndCost
+required_capability: metrics_syntax
+METRICS k8s max(rate(network.total_bytes_in, 1minute)), max(network.bytes_in), max(rate(network.total_cost));
+
+max(rate(network.total_bytes_in, 1minute)): double| max(network.bytes_in): long| max(rate(network.total_cost)): double
+790.4235090751945                                 | 1021                       | 0.16151685393258428
+;
+
 sumRate
 required_capability: metrics_syntax
 METRICS k8s bytes=sum(rate(network.total_bytes_in)), sum(rate(network.total_cost)) BY cluster | SORT cluster;
@@ -77,6 +101,19 @@ max(rate(network.total_bytes_in)): double | time_bucket:date          | cluster:
 15.913978494623656                        | 2024-05-10T00:15:00.000Z  | prod
 23.702205882352942                        | 2024-05-10T00:15:00.000Z  | qa
 9.823232323232324                         | 2024-05-10T00:15:00.000Z  | staging
+;
+
+BytesAndCostByBucketAndCluster
+required_capability: metrics_syntax
+METRICS k8s max(rate(network.total_bytes_in)), max(network.cost) BY time_bucket = bucket(@timestamp,5minute), cluster | SORT time_bucket DESC, cluster | LIMIT 6;
+
+max(rate(network.total_bytes_in)): double | max(network.cost): double | time_bucket:date         | cluster: keyword
+10.594594594594595                        | 10.75                     | 2024-05-10T00:20:00.000Z | prod
+5.586206896551724                         | 11.875                    | 2024-05-10T00:20:00.000Z | qa
+5.37037037037037                          | 9.5                       | 2024-05-10T00:20:00.000Z | staging
+15.913978494623656                        | 12.375                    | 2024-05-10T00:15:00.000Z | prod
+23.702205882352942                        | 12.125                    | 2024-05-10T00:15:00.000Z | qa
+9.823232323232324                         | 11.5                      | 2024-05-10T00:15:00.000Z | staging
 ;
 
 oneRateWithBucketAndClusterThenFilter

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/AggregateFunction.java
@@ -43,7 +43,10 @@ public abstract class AggregateFunction extends Function {
             Sum.ENTRY,
             TopList.ENTRY,
             Values.ENTRY,
-            Rate.ENTRY
+            Rate.ENTRY,
+            // internal functions
+            ToPartial.ENTRY,
+            FromPartial.ENTRY
         );
     }
 
@@ -76,6 +79,14 @@ public abstract class AggregateFunction extends Function {
 
     public List<? extends Expression> parameters() {
         return parameters;
+    }
+
+    /**
+     * Returns the input expressions used in aggregation.
+     * Defaults to a list containing the only the input field.
+     */
+    public List<Expression> inputExpressions() {
+        return List.of(field);
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FromPartial.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FromPartial.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.aggregation.Aggregator;
+import org.elasticsearch.compute.aggregation.AggregatorFunction;
+import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.aggregation.FromPartialAggregatorFunction;
+import org.elasticsearch.compute.aggregation.FromPartialGroupingAggregatorFunction;
+import org.elasticsearch.compute.aggregation.GroupingAggregator;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.xpack.esql.core.expression.AttributeSet;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
+import org.elasticsearch.xpack.esql.planner.ToAggregator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Internal aggregate function that accepts partial input from {@link ToPartial} aggregation.
+ */
+public class FromPartial extends AggregateFunction implements ToAggregator {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "FromPartial",
+        FromPartial::new
+    );
+
+    private final Expression function;
+
+    public FromPartial(Source source, Expression field, Expression function) {
+        super(source, field, List.of(function));
+        this.function = function;
+    }
+
+    private FromPartial(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), ((PlanStreamInput) in).readExpression());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        PlanStreamOutput planOut = (PlanStreamOutput) out;
+        planOut.writeExpression(function);
+    }
+
+    public Expression function() {
+        return function;
+    }
+
+    @Override
+    public DataType dataType() {
+        return function.dataType();
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        return TypeResolution.TYPE_RESOLVED;
+    }
+
+    @Override
+    public AttributeSet references() {
+        return field().references(); // exclude the function and its argument
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new FromPartial(source(), newChildren.get(0), newChildren.get(1));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, FromPartial::new, field(), function);
+    }
+
+    @Override
+    public AggregatorFunctionSupplier supplier(List<Integer> inputChannels) {
+        final ToAggregator toAggregator = (ToAggregator) function;
+        if (inputChannels.size() != 1) {
+            assert false : "from_partial aggregation requires exactly one input channel; got " + inputChannels;
+            throw new IllegalArgumentException("from_partial aggregation requires exactly one input channel; got " + inputChannels);
+        }
+        final int inputChannel = inputChannels.get(0);
+        return new AggregatorFunctionSupplier() {
+            @Override
+            public AggregatorFunction aggregator(DriverContext driverContext) {
+                assert false : "aggregatorFactory() is override";
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public GroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+                assert false : "groupingAggregatorFactory() is override";
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Aggregator.Factory aggregatorFactory(AggregatorMode mode) {
+                final AggregatorFunctionSupplier supplier;
+                try (var dummy = toAggregator.supplier(inputChannels).aggregator(DriverContext.getLocalDriver())) {
+                    var intermediateChannels = IntStream.range(0, dummy.intermediateBlockCount()).boxed().toList();
+                    supplier = toAggregator.supplier(intermediateChannels);
+                }
+                return new Aggregator.Factory() {
+                    @Override
+                    public Aggregator apply(DriverContext driverContext) {
+                        // use groupingAggregator since we can receive intermediate output from a grouping aggregate
+                        final var groupingAggregator = supplier.groupingAggregator(driverContext);
+                        return new Aggregator(new FromPartialAggregatorFunction(driverContext, groupingAggregator, inputChannel), mode);
+                    }
+
+                    @Override
+                    public String describe() {
+                        return "from_partial(" + supplier.describe() + ")";
+                    }
+                };
+            }
+
+            @Override
+            public GroupingAggregator.Factory groupingAggregatorFactory(AggregatorMode mode) {
+                final AggregatorFunctionSupplier supplier;
+                try (var dummy = toAggregator.supplier(inputChannels).aggregator(DriverContext.getLocalDriver())) {
+                    var intermediateChannels = IntStream.range(0, dummy.intermediateBlockCount()).boxed().toList();
+                    supplier = toAggregator.supplier(intermediateChannels);
+                }
+                return new GroupingAggregator.Factory() {
+                    @Override
+                    public GroupingAggregator apply(DriverContext driverContext) {
+                        final GroupingAggregatorFunction aggregator = supplier.groupingAggregator(driverContext);
+                        return new GroupingAggregator(new FromPartialGroupingAggregatorFunction(aggregator, inputChannel), mode);
+                    }
+
+                    @Override
+                    public String describe() {
+                        return "from_partial(" + supplier.describe() + ")";
+                    }
+                };
+            }
+
+            @Override
+            public String describe() {
+                return "from_partial";
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FromPartial.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FromPartial.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 /**
- * Internal aggregate function that accepts partial input from {@link ToPartial} aggregation.
+ * @see ToPartial
  */
 public class FromPartial extends AggregateFunction implements ToAggregator {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Rate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Rate.java
@@ -148,6 +148,11 @@ public class Rate extends AggregateFunction implements OptionalArgument, ToAggre
     }
 
     @Override
+    public List<Expression> inputExpressions() {
+        return List.of(field(), timestamp);
+    }
+
+    @Override
     public AggregatorFunctionSupplier supplier(List<Integer> inputChannels) {
         if (inputChannels.size() != 2 && inputChannels.size() != 3) {
             throw new IllegalArgumentException("rate requires two for raw input or three channels for partial input; got " + inputChannels);

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ToPartial.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ToPartial.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.expression.function.aggregate;
+
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.compute.aggregation.Aggregator;
+import org.elasticsearch.compute.aggregation.AggregatorFunction;
+import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
+import org.elasticsearch.compute.aggregation.AggregatorMode;
+import org.elasticsearch.compute.aggregation.GroupingAggregator;
+import org.elasticsearch.compute.aggregation.GroupingAggregatorFunction;
+import org.elasticsearch.compute.aggregation.ToPartialAggregatorFunction;
+import org.elasticsearch.compute.aggregation.ToPartialGroupingAggregatorFunction;
+import org.elasticsearch.compute.operator.DriverContext;
+import org.elasticsearch.xpack.esql.core.expression.Expression;
+import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
+import org.elasticsearch.xpack.esql.core.tree.Source;
+import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamOutput;
+import org.elasticsearch.xpack.esql.planner.ToAggregator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * An internal aggregate function that always emits intermediate output.
+ * The intermediate output should be consumed by {@link ToPartial}.
+ * `STATS af(x)` is equivalent to `STATS y=to_partial(af(x)) | STATS af(x)=from_partial(y)`
+ *
+ * @see org.elasticsearch.xpack.esql.optimizer.rules.TranslateMetricsAggregate
+ */
+public class ToPartial extends AggregateFunction implements ToAggregator {
+    public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
+        Expression.class,
+        "ToPartial",
+        ToPartial::new
+    );
+
+    private final Expression function;
+
+    public ToPartial(Source source, AggregateFunction function) {
+        super(source, function.field(), List.of(function));
+        this.function = function;
+    }
+
+    private ToPartial(Source source, Expression field, Expression function) {
+        super(source, field, List.of(function));
+        this.function = function;
+    }
+
+    private ToPartial(StreamInput in) throws IOException {
+        this(Source.readFrom((PlanStreamInput) in), ((PlanStreamInput) in).readExpression(), ((PlanStreamInput) in).readExpression());
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        PlanStreamOutput planOut = (PlanStreamOutput) out;
+        planOut.writeExpression(function);
+    }
+
+    public Expression function() {
+        return function;
+    }
+
+    @Override
+    public DataType dataType() {
+        return DataType.PARTIAL_AGG;
+    }
+
+    @Override
+    protected TypeResolution resolveType() {
+        return function.typeResolved();
+    }
+
+    @Override
+    public Expression replaceChildren(List<Expression> newChildren) {
+        return new ToPartial(source(), newChildren.get(0), newChildren.get(1));
+    }
+
+    @Override
+    protected NodeInfo<? extends Expression> info() {
+        return NodeInfo.create(this, ToPartial::new, field(), function);
+    }
+
+    @Override
+    public AggregatorFunctionSupplier supplier(List<Integer> inputChannels) {
+        final ToAggregator toAggregator = (ToAggregator) function;
+        return new AggregatorFunctionSupplier() {
+            @Override
+            public AggregatorFunction aggregator(DriverContext driverContext) {
+                assert false : "aggregatorFactory() is override";
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public GroupingAggregatorFunction groupingAggregator(DriverContext driverContext) {
+                assert false : "groupingAggregatorFactory() is override";
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Aggregator.Factory aggregatorFactory(AggregatorMode mode) {
+                final AggregatorFunctionSupplier supplier;
+                if (mode.isInputPartial()) {
+                    try (var dummy = toAggregator.supplier(inputChannels).aggregator(DriverContext.getLocalDriver())) {
+                        var intermediateChannels = IntStream.range(0, dummy.intermediateBlockCount()).boxed().toList();
+                        supplier = toAggregator.supplier(intermediateChannels);
+                    }
+                } else {
+                    supplier = toAggregator.supplier(inputChannels);
+                }
+                return new Aggregator.Factory() {
+                    @Override
+                    public Aggregator apply(DriverContext driverContext) {
+                        final AggregatorFunction aggregatorFunction = supplier.aggregator(driverContext);
+                        return new Aggregator(new ToPartialAggregatorFunction(aggregatorFunction, inputChannels), mode);
+                    }
+
+                    @Override
+                    public String describe() {
+                        return "to_partial(" + supplier.describe() + ")";
+                    }
+                };
+            }
+
+            @Override
+            public GroupingAggregator.Factory groupingAggregatorFactory(AggregatorMode mode) {
+                final AggregatorFunctionSupplier supplier;
+                if (mode.isInputPartial()) {
+                    try (var dummy = toAggregator.supplier(inputChannels).aggregator(DriverContext.getLocalDriver())) {
+                        var intermediateChannels = IntStream.range(0, dummy.intermediateBlockCount()).boxed().toList();
+                        supplier = toAggregator.supplier(intermediateChannels);
+                    }
+                } else {
+                    supplier = toAggregator.supplier(inputChannels);
+                }
+                return new GroupingAggregator.Factory() {
+                    @Override
+                    public GroupingAggregator apply(DriverContext driverContext) {
+                        final GroupingAggregatorFunction aggregatorFunction = supplier.groupingAggregator(driverContext);
+                        return new GroupingAggregator(new ToPartialGroupingAggregatorFunction(aggregatorFunction, inputChannels), mode);
+                    }
+
+                    @Override
+                    public String describe() {
+                        return "to_partial(" + supplier.describe() + ")";
+                    }
+                };
+            }
+
+            @Override
+            public String describe() {
+                return "to_partial";
+            }
+        };
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/TranslateMetricsAggregate.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/rules/TranslateMetricsAggregate.java
@@ -20,7 +20,9 @@ import org.elasticsearch.xpack.esql.core.optimizer.OptimizerRules;
 import org.elasticsearch.xpack.esql.core.plan.logical.LogicalPlan;
 import org.elasticsearch.xpack.esql.core.util.Holder;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.FromPartial;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.ToPartial;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
 import org.elasticsearch.xpack.esql.expression.function.grouping.Bucket;
 import org.elasticsearch.xpack.esql.plan.logical.Aggregate;
@@ -80,7 +82,39 @@ import java.util.stream.Stream;
  * | EVAL `avg(rate(request))` = `sum(rate(request))` / `count(rate(request))`
  * | KEEP `avg(rate(request))`, host, `bucket(@timestamp, 1minute)`
  * </pre>
- * Mixing between rate and non-rate aggregates will be supported later.
+ *
+ * Non-rate aggregates will be rewritten as a pair of to_partial and from_partial aggregates, where the `to_partial`
+ * aggregates will be executed in the first pass and always produce an intermediate output regardless of the aggregate
+ * mode. The `from_partial` aggregates will be executed on the second pass and always receive intermediate output
+ * produced by `to_partial`. Examples:
+ *
+ * <pre>
+ * METRICS k8s max(rate(request)), max(memory_used) becomes:
+ *
+ * METRICS k8s
+ * | STATS rate(request), $p1=to_partial(max(memory_used)) BY _tsid
+ * | STATS max(`rate(request)`), `max(memory_used)` = from_partial($p1, max($_))
+ *
+ * METRICS k8s max(rate(request)) avg(memory_used) BY host
+ *
+ * becomes
+ *
+ * METRICS k8s
+ * | STATS rate(request), $p1=to_partial(sum(memory_used)), $p2=to_partial(count(memory_used)), VALUES(host) BY _tsid
+ * | STATS max(`rate(request)`), $sum=from_partial($p1, sum($_)), $count=from_partial($p2, count($_)) BY host=`VALUES(host)`
+ * | EVAL `avg(memory_used)` = $sum / $count
+ * | KEEP `max(rate(request))`, `avg(memory_used)`, host
+ *
+ * METRICS k8s min(memory_used) sum(rate(request)) BY pod, bucket(@timestamp, 5m)
+ *
+ * becomes
+ *
+ * METRICS k8s
+ * | EVAL `bucket(@timestamp, 5m)` = datetrunc(@timestamp, '5m')
+ * | STATS rate(request), $p1=to_partial(min(memory_used)), VALUES(pod) BY _tsid, `bucket(@timestamp, 5m)`
+ * | STATS sum(`rate(request)`), `min(memory_used)` = from_partial($p1, min($)) BY pod=`VALUES(pod)`, `bucket(@timestamp, 5m)`
+ * | KEEP `min(memory_used)`, `sum(rate(request))`, pod, `bucket(@timestamp, 5m)`
+ * </pre>
  */
 public final class TranslateMetricsAggregate extends OptimizerRules.OptimizerRule<Aggregate> {
 
@@ -98,33 +132,33 @@ public final class TranslateMetricsAggregate extends OptimizerRules.OptimizerRul
     }
 
     LogicalPlan translate(Aggregate metrics) {
-        Map<Rate, Alias> rateAggs = new HashMap<>(); // TODO
-        List<NamedExpression> nonRateAggs = new ArrayList<>();
-        List<Alias> outerRateAggs = new ArrayList<>();
+        Map<Rate, Alias> rateAggs = new HashMap<>();
+        List<NamedExpression> firstPassAggs = new ArrayList<>();
+        List<NamedExpression> secondPassAggs = new ArrayList<>();
         for (NamedExpression agg : metrics.aggregates()) {
-            if (agg instanceof Alias alias) {
-                // METRICS af(rate(counter)) becomes STATS $rate_1=rate(counter) | STATS `af(rate(counter))`=af($rate_1)
-                if (alias.child() instanceof AggregateFunction outerRate) {
-                    Holder<Boolean> changed = new Holder<>(Boolean.FALSE);
-                    Expression outerAgg = outerRate.transformDown(Rate.class, rate -> {
-                        changed.set(Boolean.TRUE);
-                        Alias rateAgg = rateAggs.computeIfAbsent(rate, k -> new Alias(rate.source(), agg.name(), rate));
-                        return rateAgg.toAttribute();
+            if (agg instanceof Alias alias && alias.child() instanceof AggregateFunction af) {
+                Holder<Boolean> changed = new Holder<>(Boolean.FALSE);
+                Expression outerAgg = af.transformDown(Rate.class, rate -> {
+                    changed.set(Boolean.TRUE);
+                    Alias rateAgg = rateAggs.computeIfAbsent(rate, k -> {
+                        Alias newRateAgg = new Alias(rate.source(), agg.name(), rate);
+                        firstPassAggs.add(newRateAgg);
+                        return newRateAgg;
                     });
-                    if (changed.get()) {
-                        outerRateAggs.add(new Alias(alias.source(), alias.name(), null, outerAgg, agg.id()));
-                    }
+                    return rateAgg.toAttribute();
+                });
+                if (changed.get()) {
+                    secondPassAggs.add(new Alias(alias.source(), alias.name(), null, outerAgg, agg.id()));
                 } else {
-                    nonRateAggs.add(agg);
+                    var toPartial = new Alias(agg.source(), alias.name(), new ToPartial(agg.source(), af));
+                    var fromPartial = new FromPartial(agg.source(), toPartial.toAttribute(), af);
+                    firstPassAggs.add(toPartial);
+                    secondPassAggs.add(new Alias(alias.source(), alias.name(), null, fromPartial, alias.id()));
                 }
             }
         }
         if (rateAggs.isEmpty()) {
             return toStandardAggregate(metrics);
-        }
-        if (nonRateAggs.isEmpty() == false) {
-            // TODO: support this
-            throw new IllegalArgumentException("regular aggregates with rate aggregates are not supported yet");
         }
         Holder<Attribute> tsid = new Holder<>();
         Holder<Attribute> timestamp = new Holder<>();
@@ -142,9 +176,9 @@ public final class TranslateMetricsAggregate extends OptimizerRules.OptimizerRul
             throw new IllegalArgumentException("_tsid or @timestamp field are missing from the metrics source");
         }
         // metrics aggregates must be grouped by _tsid (and time-bucket) first and re-group by users key
-        List<Expression> initialGroupings = new ArrayList<>();
-        initialGroupings.add(tsid.get());
-        List<Expression> finalGroupings = new ArrayList<>();
+        List<Expression> firstPassGroupings = new ArrayList<>();
+        firstPassGroupings.add(tsid.get());
+        List<Expression> secondPassGroupings = new ArrayList<>();
         Holder<NamedExpression> timeBucketRef = new Holder<>();
         metrics.child().forEachExpressionUp(NamedExpression.class, e -> {
             for (Expression child : e.children()) {
@@ -157,7 +191,6 @@ public final class TranslateMetricsAggregate extends OptimizerRules.OptimizerRul
             }
         });
         NamedExpression timeBucket = timeBucketRef.get();
-        List<NamedExpression> initialAggs = new ArrayList<>(rateAggs.values());
         for (Expression group : metrics.groupings()) {
             if (group instanceof Attribute == false) {
                 throw new EsqlIllegalArgumentException("expected named expression for grouping; got " + group);
@@ -166,19 +199,18 @@ public final class TranslateMetricsAggregate extends OptimizerRules.OptimizerRul
             final NamedExpression newFinalGroup;
             if (timeBucket != null && g.id().equals(timeBucket.id())) {
                 newFinalGroup = timeBucket.toAttribute();
-                initialGroupings.add(newFinalGroup);
+                firstPassGroupings.add(newFinalGroup);
             } else {
                 newFinalGroup = new Alias(g.source(), g.name(), null, new Values(g.source(), g), g.id());
-                initialAggs.add(newFinalGroup);
+                firstPassAggs.add(newFinalGroup);
             }
-            finalGroupings.add(new Alias(g.source(), g.name(), null, newFinalGroup.toAttribute(), g.id()));
+            secondPassGroupings.add(new Alias(g.source(), g.name(), null, newFinalGroup.toAttribute(), g.id()));
         }
-        var finalAggregates = Stream.concat(outerRateAggs.stream(), nonRateAggs.stream()).toList();
         return newAggregate(
-            newAggregate(metrics.child(), Aggregate.AggregateType.METRICS, initialAggs, initialGroupings),
+            newAggregate(metrics.child(), Aggregate.AggregateType.METRICS, firstPassAggs, firstPassGroupings),
             Aggregate.AggregateType.STANDARD,
-            finalAggregates,
-            finalGroupings
+            secondPassAggs,
+            secondPassGroupings
         );
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plan/physical/EstimatesRowSize.java
@@ -119,7 +119,7 @@ public interface EstimatesRowSize {
             case LONG -> Long.BYTES;
             case NULL -> 0;
             // TODO: provide a specific estimate for aggregated_metrics_double
-            case COMPOSITE -> throw new EsqlIllegalArgumentException("can't estimate size for composite blocks");
+            case COMPOSITE -> 50;
             case UNKNOWN -> throw new EsqlIllegalArgumentException("[unknown] can't be the result of field extraction");
         };
     }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AbstractPhysicalOperationProviders.java
@@ -257,16 +257,7 @@ public abstract class AbstractPhysicalOperationProviders implements PhysicalOper
                                 );
                             }
                         } else {
-                            List<Expression> inputExpressions = new ArrayList<>();
-                            inputExpressions.add(field);
-                            for (Expression param : aggregateFunction.parameters()) {
-                                if (param.foldable() == false) {
-                                    inputExpressions.add(param);
-                                } else {
-                                    Object ignored = param.fold();
-                                }
-                            }
-                            sourceAttr = inputExpressions.stream().map(e -> {
+                            sourceAttr = aggregateFunction.inputExpressions().stream().map(e -> {
                                 Attribute attr = Expressions.attribute(e);
                                 if (attr == null) {
                                     throw new EsqlIllegalArgumentException(

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/AggregateMapper.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.esql.planner;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.compute.aggregation.IntermediateStateDesc;
 import org.elasticsearch.compute.data.ElementType;
 import org.elasticsearch.core.Tuple;
@@ -24,6 +25,7 @@ import org.elasticsearch.xpack.esql.core.type.DataType;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.AggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Count;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.CountDistinct;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.FromPartial;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Max;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.MedianAbsoluteDeviation;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Min;
@@ -33,6 +35,7 @@ import org.elasticsearch.xpack.esql.expression.function.aggregate.Rate;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialAggregateFunction;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.SpatialCentroid;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Sum;
+import org.elasticsearch.xpack.esql.expression.function.aggregate.ToPartial;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.TopList;
 import org.elasticsearch.xpack.esql.expression.function.aggregate.Values;
 
@@ -65,7 +68,11 @@ final class AggregateMapper {
         Sum.class,
         Values.class,
         TopList.class,
-        Rate.class
+        Rate.class,
+
+        // internal function
+        FromPartial.class,
+        ToPartial.class
     );
 
     /** Record of agg Class, type, and grouping (or non-grouping). */
@@ -151,9 +158,13 @@ final class AggregateMapper {
             types = List.of("Int", "Long", "Double");
         } else if (Rate.class.isAssignableFrom(clazz)) {
             types = List.of("Int", "Long", "Double");
-        } else {
-            assert clazz == CountDistinct.class : "Expected CountDistinct, got: " + clazz;
+        } else if (FromPartial.class.isAssignableFrom(clazz) || ToPartial.class.isAssignableFrom(clazz)) {
+            types = List.of(""); // no type
+        } else if (CountDistinct.class.isAssignableFrom(clazz)) {
             types = Stream.concat(NUMERIC.stream(), Stream.of("Boolean", "BytesRef")).toList();
+        } else {
+            assert false : "unknown aggregate type " + clazz;
+            throw new IllegalArgumentException("unknown aggregate type " + clazz);
         }
         return combinations(types, extraConfigs).map(combo -> new Tuple<>(clazz, combo));
     }
@@ -233,7 +244,15 @@ final class AggregateMapper {
 
     /** Maps intermediate state description to named expressions.  */
     private static Stream<NamedExpression> isToNE(List<IntermediateStateDesc> intermediateStateDescs) {
-        return intermediateStateDescs.stream().map(is -> new ReferenceAttribute(Source.EMPTY, is.name(), toDataType(is.type())));
+        return intermediateStateDescs.stream().map(is -> {
+            final DataType dataType;
+            if (Strings.isEmpty(is.dataType())) {
+                dataType = toDataType(is.type());
+            } else {
+                dataType = DataType.fromEs(is.dataType());
+            }
+            return new ReferenceAttribute(Source.EMPTY, is.name(), dataType);
+        });
     }
 
     /** Returns the data type for the engines element type. */
@@ -253,6 +272,9 @@ final class AggregateMapper {
     private static String dataTypeToString(DataType type, Class<?> aggClass) {
         if (aggClass == Count.class) {
             return "";  // no type distinction
+        }
+        if (aggClass == ToPartial.class || aggClass == FromPartial.class) {
+            return "";
         }
         if (type.equals(DataType.BOOLEAN)) {
             return "Boolean";

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/LocalExecutionPlanner.java
@@ -354,7 +354,7 @@ public class LocalExecutionPlanner {
                 case GEO_POINT, CARTESIAN_POINT, GEO_SHAPE, CARTESIAN_SHAPE, COUNTER_LONG, COUNTER_INTEGER, COUNTER_DOUBLE ->
                     TopNEncoder.DEFAULT_UNSORTABLE;
                 // unsupported fields are encoded as BytesRef, we'll use the same encoder; all values should be null at this point
-                case UNSUPPORTED -> TopNEncoder.UNSUPPORTED;
+                case PARTIAL_AGG, UNSUPPORTED -> TopNEncoder.UNSUPPORTED;
                 case SOURCE -> throw new EsqlIllegalArgumentException("No TopN sorting encoder for type " + inverse.get(channel).type());
             };
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/PlannerUtils.java
@@ -253,6 +253,7 @@ public class PlannerUtils {
             case TSID_DATA_TYPE -> ElementType.BYTES_REF;
             case GEO_POINT, CARTESIAN_POINT -> fieldExtractPreference == DOC_VALUES ? ElementType.LONG : ElementType.BYTES_REF;
             case GEO_SHAPE, CARTESIAN_SHAPE -> ElementType.BYTES_REF;
+            case PARTIAL_AGG -> ElementType.COMPOSITE;
             case SHORT, BYTE, DATE_PERIOD, TIME_DURATION, OBJECT, NESTED, FLOAT, HALF_FLOAT, SCALED_FLOAT ->
                 throw EsqlIllegalArgumentException.illegalDataType(dataType);
         };

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/type/EsqlDataTypes.java
@@ -18,6 +18,7 @@ import static org.elasticsearch.xpack.esql.core.type.DataType.KEYWORD;
 import static org.elasticsearch.xpack.esql.core.type.DataType.NESTED;
 import static org.elasticsearch.xpack.esql.core.type.DataType.NULL;
 import static org.elasticsearch.xpack.esql.core.type.DataType.OBJECT;
+import static org.elasticsearch.xpack.esql.core.type.DataType.PARTIAL_AGG;
 import static org.elasticsearch.xpack.esql.core.type.DataType.SCALED_FLOAT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.SHORT;
 import static org.elasticsearch.xpack.esql.core.type.DataType.SOURCE;
@@ -89,6 +90,7 @@ public final class EsqlDataTypes {
             && t != SCALED_FLOAT
             && t != SOURCE
             && t != HALF_FLOAT
+            && t != PARTIAL_AGG
             && t.isCounter() == false;
     }
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/action/EsqlQueryResponseTests.java
@@ -123,7 +123,7 @@ public class EsqlQueryResponseTests extends AbstractChunkedSerializingTestCase<E
 
     private ColumnInfo randomColumnInfo() {
         DataType type = randomValueOtherThanMany(
-            t -> false == DataType.isPrimitive(t) || t == DataType.DATE_PERIOD || t == DataType.TIME_DURATION,
+            t -> false == DataType.isPrimitive(t) || t == DataType.DATE_PERIOD || t == DataType.TIME_DURATION || t == DataType.PARTIAL_AGG,
             () -> randomFrom(DataType.types())
         ).widenSmallNumeric();
         return new ColumnInfo(randomAlphaOfLength(10), type.esType());


### PR DESCRIPTION
This pull request supports mixed aggregates in the METRICS command. Non-rate aggregates will be rewritten as a pair of `to_partial` and `from_partial` aggregates:

- The `to_partial` aggregates will be executed in the first pass and always produce an intermediate output regardless of the aggregate mode.
- The `from_partial` aggregates will be executed in the second pass and always receive the intermediate output produced by `to_partial`.

Example:
 
**METRICS k8s max(rate(request)), max(memory_used)** becomes:

```
METRICS k8s
| STATS rate(request), $p1=to_partial(max(memory_used)) BY _tsid
| STATS max(`rate(request)`), `max(memory_used)` = from_partial($p1, max($_))
```

**METRICS k8s max(rate(request)), avg(memory_used) BY host** becomes:

```
METRICS k8s
| STATS rate(request), 
    $p1=to_partial(sum(memory_used)), 
    $p2=to_partial(count(memory_used)), 
    values(host) BY _tsid
| STATS max(`rate(request)`), 
    $sum=from_partial($p1, sum($_)),
    $count=from_partial($p2, count($_)) BY host=`values(host)`
| EVAL `avg(memory_used)` = $sum / $count
| KEEP `max(rate(request))`, `avg(memory_used)`, host
```

**METRICS k8s min(memory_used), sum(rate(request)) BY pod, bucket(@timestamp, 5m)** becomes:

```
METRICS k8s
| EVAL `bucket(@timestamp, 5m)` = datetrunc(@timestamp, '5m')
| STATS rate(request), 
    $p1=to_partial(min(memory_used)),
    VALUES(pod) BY _tsid, `bucket(@timestamp, 5m)`
| STATS sum(`rate(request)`),
    `min(memory_used)` = from_partial($p1, min($)) BY pod=`VALUES(pod)`, `bucket(@timestamp, 5m)`
| KEEP `min(memory_used)`, `sum(rate(request))`, pod, `bucket(@timestamp, 5m)`
```

----
I also took a different approach for this. The alternative is to extend the runtime to support scatter/gather via exchange. We could have two pipelines: one aggregate grouped by _tsid (and time bucket), and another grouped by the user-specified keys. These pipelines expand to fill necessary blocks so that they have the same output. However, this requires replicating most of the aggregate rules for dual aggregates.

Hence, I opted for the approach in this PR, which doesn't change anything with non-metrics, making it safer. However, the dual aggregates should have better performance and use less memory than the approach in this PR.

Relates #109979