### PR TITLE
Update geo-bounding-box-query accepted formats: Lat lon as string to WKT

### DIFF
--- a/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
+++ b/docs/reference/query-dsl/geo-bounding-box-query.asciidoc
@@ -238,9 +238,9 @@ GET my_locations/_search
 --------------------------------------------------
 
 [discrete]
-===== Lat lon as string
+===== Lat lon as WKT string
 
-Format in `lat,lon`.
+Format in https://docs.opengeospatial.org/is/12-063r5/12-063r5.html[Well-Known Text].
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
##  Documentation Changes Made:

### Accepted Format Update:
* From: `Lat lon as string`
* To: `Lat lon as WKT string`

### Corresponding Description Update:
* From: `Format in lat,lon`
* To: `Format in Well-Known Text`

## Reason:
The previous description was ambiguous and caused confusion about how to properly format the coordinates. The snippet `lat,lon` was not sufficiently clear due to the reversed longitude and latitude, leading to `failed to parse [geo_bounding_box] query. [Invalid WKT format]` Bad Request errors.
