### PR TITLE
ESQL: Reenable test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -73,8 +73,6 @@ tests:
 - class: org.elasticsearch.xpack.transform.transforms.TransformIndexerTests
   method: testMaxPageSearchSizeIsResetToConfiguredValue
   issue: https://github.com/elastic/elasticsearch/issues/109844
-- class: org.elasticsearch.xpack.esql.tree.EsqlNodeSubclassTests
-  issue: https://github.com/elastic/elasticsearch/issues/110203
 - class: org.elasticsearch.http.netty4.Netty4ChunkedContinuationsIT
   method: testClientCancellation
   issue: https://github.com/elastic/elasticsearch/issues/109866


### PR DESCRIPTION
Our test muting tools muted this test, but the fix was in flight. It's merged now.

Closes #110203
