### PR TITLE
[Profiling] Add field env_https_proxy to profiling-hosts

### DIFF
--- a/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
+++ b/x-pack/plugin/core/template-resources/src/main/resources/profiling/component-template/profiling-hosts.json
@@ -79,6 +79,9 @@
                 "protocol": {
                   "type": "keyword"
                 },
+                "env_https_proxy": {
+                  "type": "keyword"
+                },
                 "config.bpf_log_level": {
                   "type": "long"
                 },

--- a/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiling/src/main/java/org/elasticsearch/xpack/profiling/persistence/ProfilingIndexTemplateRegistry.java
@@ -52,7 +52,8 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
     // version 9: Changed sort order for profiling-events-*
     // version 10: changed mapping profiling-events @timestamp to 'date_nanos' from 'date'
     // version 11: Added 'profiling.agent.protocol' keyword mapping to profiling-hosts
-    public static final int INDEX_TEMPLATE_VERSION = 11;
+    // version 12: Added 'profiling.agent.env_https_proxy' keyword mapping to profiling-hosts
+    public static final int INDEX_TEMPLATE_VERSION = 12;
 
     // history for individual indices / index templates. Only bump these for breaking changes that require to create a new index
     public static final int PROFILING_EVENTS_VERSION = 4;


### PR DESCRIPTION
The profiling host agent already reports this field as part of the host metadata, but the collector currently ignores it since we didn't have a mapping for this field.

This PR adds the mapping to allow the collector writing this field.