### PR TITLE
[Inference API] Make error messages consistent in InferenceAction

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/inference/action/InferenceAction.java
@@ -167,14 +167,16 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
         public ActionRequestValidationException validate() {
             if (input == null) {
                 var e = new ActionRequestValidationException();
-                e.addValidationError("missing input");
+                e.addValidationError("Field [input] cannot be null");
                 return e;
             }
+
             if (input.isEmpty()) {
                 var e = new ActionRequestValidationException();
-                e.addValidationError("input array is empty");
+                e.addValidationError("Field [input] cannot be an empty array");
                 return e;
             }
+
             if (taskType.equals(TaskType.RERANK)) {
                 if (query == null) {
                     var e = new ActionRequestValidationException();
@@ -187,6 +189,7 @@ public class InferenceAction extends ActionType<InferenceAction.Response> {
                     return e;
                 }
             }
+
             return null;
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/inference/action/InferenceActionRequestTests.java
@@ -112,7 +112,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         );
         ActionRequestValidationException inputNullError = inputNullRequest.validate();
         assertNotNull(inputNullError);
-        assertThat(inputNullError.getMessage(), is("Validation Failed: 1: missing input;"));
+        assertThat(inputNullError.getMessage(), is("Validation Failed: 1: Field [input] cannot be null;"));
     }
 
     public void testValidation_TextEmbedding_Empty() {
@@ -127,7 +127,7 @@ public class InferenceActionRequestTests extends AbstractBWCWireSerializationTes
         );
         ActionRequestValidationException inputEmptyError = inputEmptyRequest.validate();
         assertNotNull(inputEmptyError);
-        assertThat(inputEmptyError.getMessage(), is("Validation Failed: 1: input array is empty;"));
+        assertThat(inputEmptyError.getMessage(), is("Validation Failed: 1: Field [input] cannot be an empty array;"));
     }
 
     public void testValidation_Rerank_Null() {


### PR DESCRIPTION
Looking at the error messages in https://github.com/elastic/elasticsearch/pull/110147 we can be a bit more consistent with the ones for the `input` field IMO.