### PR TITLE
Fix condition that check for new security index

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -249,14 +249,11 @@ public class SecurityIndexManager implements ClusterStateListener {
     /**
      * Check if the index was created on the latest index version available in the cluster
      */
-    private static boolean isCreatedOnLatestVersion(IndexMetadata indexMetadata, ClusterState clusterState) {
+    private static boolean isCreatedOnLatestVersion(IndexMetadata indexMetadata) {
         final IndexVersion indexVersionCreated = indexMetadata != null
             ? SETTING_INDEX_VERSION_CREATED.get(indexMetadata.getSettings())
             : null;
-        return indexVersionCreated != null
-            && indexVersionCreated.onOrAfter(
-                IndexVersion.min(IndexVersion.current(), clusterState.nodes().getMaxDataNodeCompatibleIndexVersion())
-            );
+        return indexVersionCreated != null && indexVersionCreated.onOrAfter(IndexVersion.current());
     }
 
     @Override
@@ -269,7 +266,7 @@ public class SecurityIndexManager implements ClusterStateListener {
         }
         final State previousState = state;
         final IndexMetadata indexMetadata = resolveConcreteIndex(systemIndexDescriptor.getAliasName(), event.state().metadata());
-        final boolean createdOnLatestVersion = isCreatedOnLatestVersion(indexMetadata, event.state());
+        final boolean createdOnLatestVersion = isCreatedOnLatestVersion(indexMetadata);
         final Instant creationTime = indexMetadata != null ? Instant.ofEpochMilli(indexMetadata.getCreationDate()) : null;
         final boolean isIndexUpToDate = indexMetadata == null
             || INDEX_FORMAT_SETTING.get(indexMetadata.getSettings()) == systemIndexDescriptor.getIndexFormat();


### PR DESCRIPTION
When we create a new index, we create it using the version from `IndexVersion.min(IndexVersion.current(), clusterState.nodes().getMaxDataNodeCompatibleIndexVersion())`, this means that the created index version will be compatible with all nodes in the cluster. 

When we want to check if an index was created on the latest version we don't want to include `getMaxDataNodeCompatibleIndexVersion` since we need to make sure that the index contains the latest migration, if it doesn't, we want to run the migration. 

In the BWC tests, the `getMaxDataNodeCompatibleIndexVersion` will return the index version form `7.X` as the "latest" version (which is wrong) and therefore it will skip the migration, instead it should only skip on the very latest version. 