### PR TITLE
ESQL: extend Validatable support

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/TypeResolutions.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/expression/TypeResolutions.java
@@ -117,58 +117,6 @@ public final class TypeResolutions {
         return isExact(e, operationName, paramOrd);
     }
 
-    public static TypeResolution isFoldable(Expression e, String operationName, ParamOrdinal paramOrd) {
-        if (e.foldable() == false) {
-            return new TypeResolution(
-                format(
-                    null,
-                    "{}argument of [{}] must be a constant, received [{}]",
-                    paramOrd == null || paramOrd == DEFAULT ? "" : paramOrd.name().toLowerCase(Locale.ROOT) + " ",
-                    operationName,
-                    Expressions.name(e)
-                )
-            );
-        }
-        return TypeResolution.TYPE_RESOLVED;
-    }
-
-    public static TypeResolution isNotNullAndFoldable(Expression e, String operationName, ParamOrdinal paramOrd) {
-        TypeResolution resolution = isFoldable(e, operationName, paramOrd);
-
-        if (resolution.unresolved()) {
-            return resolution;
-        }
-
-        if (e.dataType() == DataType.NULL || e.fold() == null) {
-            resolution = new TypeResolution(
-                format(
-                    null,
-                    "{}argument of [{}] cannot be null, received [{}]",
-                    paramOrd == null || paramOrd == DEFAULT ? "" : paramOrd.name().toLowerCase(Locale.ROOT) + " ",
-                    operationName,
-                    Expressions.name(e)
-                )
-            );
-        }
-
-        return resolution;
-    }
-
-    public static TypeResolution isNotFoldable(Expression e, String operationName, ParamOrdinal paramOrd) {
-        if (e.foldable()) {
-            return new TypeResolution(
-                format(
-                    null,
-                    "{}argument of [{}] must be a table column, found constant [{}]",
-                    paramOrd == null || paramOrd == DEFAULT ? "" : paramOrd.name().toLowerCase(Locale.ROOT) + " ",
-                    operationName,
-                    Expressions.name(e)
-                )
-            );
-        }
-        return TypeResolution.TYPE_RESOLVED;
-    }
-
     public static TypeResolution isType(
         Expression e,
         Predicate<DataType> predicate,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/Validatable.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/capabilities/Validatable.java
@@ -19,5 +19,5 @@ public interface Validatable {
      * Validates the implementing expression - discovered failures are reported to the given
      * {@link Failures} class.
      */
-    default void validate(Failures failures) {}
+    void validate(Failures failures);
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Validations.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Validations.java
@@ -66,14 +66,20 @@ public final class Validations {
         var failure = isFoldable(e, operationName, paramOrd);
 
         if (failure == null) {
-            failure = validateFolded.apply(e.fold(), message -> Failure.fail(e, format(
-                null,
-                "{}argument of [{}] {}, received [{}]",
-                paramOrd == null || paramOrd == DEFAULT ? "" : paramOrd.name().toLowerCase(Locale.ROOT) + " ",
-                operationName,
-                message,
-                Expressions.name(e)
-            )));
+            failure = validateFolded.apply(
+                e.fold(),
+                message -> Failure.fail(
+                    e,
+                    format(
+                        null,
+                        "{}argument of [{}] {}, received [{}]",
+                        paramOrd == null || paramOrd == DEFAULT ? "" : paramOrd.name().toLowerCase(Locale.ROOT) + " ",
+                        operationName,
+                        message,
+                        Expressions.name(e)
+                    )
+                )
+            );
         }
 
         return failure;

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Validations.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/Validations.java
@@ -9,9 +9,19 @@ package org.elasticsearch.xpack.esql.expression;
 
 import org.elasticsearch.xpack.esql.core.common.Failure;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
-import org.elasticsearch.xpack.esql.core.expression.Expression.TypeResolution;
+import org.elasticsearch.xpack.esql.core.expression.Expressions;
 import org.elasticsearch.xpack.esql.core.expression.TypeResolutions;
 
+import java.util.Locale;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
+import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
+
+/**
+ * Common validations to be used in {@link org.elasticsearch.xpack.esql.capabilities.Validatable} implementations.
+ */
 public final class Validations {
 
     private Validations() {}
@@ -20,7 +30,52 @@ public final class Validations {
      * Validates if the given expression is foldable - if not returns a Failure.
      */
     public static Failure isFoldable(Expression e, String operationName, TypeResolutions.ParamOrdinal paramOrd) {
-        TypeResolution resolution = TypeResolutions.isFoldable(e, operationName, paramOrd);
-        return resolution.unresolved() ? Failure.fail(e, resolution.message()) : null;
+        if (e.foldable() == false) {
+            return Failure.fail(
+                e,
+                format(
+                    null,
+                    "{}argument of [{}] must be a constant, received [{}]",
+                    paramOrd == null || paramOrd == DEFAULT ? "" : paramOrd.name().toLowerCase(Locale.ROOT) + " ",
+                    operationName,
+                    Expressions.name(e)
+                )
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Validates if the given expression is foldable - if not returns a Failure.
+     * If it is foldable, it calls the given validateFolded function with the folded value and a failure builder, to validate it.
+     *
+     * @param e the expression to validate
+     * @param operationName the name of the operation
+     * @param paramOrd the ordinal of the parameter
+     * @param validateFolded the function to validate the folded value.
+     *                       It receives the folded valua, and a function to generate the Failer based on a message.
+     *                       It must return a Failure, or null if none
+     */
+    public static Failure isFoldableAnd(
+        Expression e,
+        String operationName,
+        TypeResolutions.ParamOrdinal paramOrd,
+        BiFunction<Object, Function<String, Failure>, Failure> validateFolded
+    ) {
+        var failure = isFoldable(e, operationName, paramOrd);
+
+        if (failure == null) {
+            failure = validateFolded.apply(e.fold(), message -> Failure.fail(e, format(
+                null,
+                "{}argument of [{}] {}, received [{}]",
+                paramOrd == null || paramOrd == DEFAULT ? "" : paramOrd.name().toLowerCase(Locale.ROOT) + " ",
+                operationName,
+                message,
+                Expressions.name(e)
+            )));
+        }
+
+        return failure;
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/CountDistinct.java
@@ -17,6 +17,8 @@ import org.elasticsearch.compute.aggregation.CountDistinctDoubleAggregatorFuncti
 import org.elasticsearch.compute.aggregation.CountDistinctIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.CountDistinctLongAggregatorFunctionSupplier;
 import org.elasticsearch.xpack.esql.EsqlIllegalArgumentException;
+import org.elasticsearch.xpack.esql.capabilities.Validatable;
+import org.elasticsearch.xpack.esql.core.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.Literal;
 import org.elasticsearch.xpack.esql.core.expression.function.OptionalArgument;
@@ -40,11 +42,11 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
-import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isFoldable;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isInteger;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+import static org.elasticsearch.xpack.esql.expression.Validations.isFoldable;
 
-public class CountDistinct extends AggregateFunction implements OptionalArgument, ToAggregator, SurrogateExpression {
+public class CountDistinct extends AggregateFunction implements OptionalArgument, ToAggregator, SurrogateExpression, Validatable {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         Expression.class,
         "CountDistinct",
@@ -125,7 +127,12 @@ public class CountDistinct extends AggregateFunction implements OptionalArgument
         if (resolution.unresolved() || precision == null) {
             return resolution;
         }
-        return isInteger(precision, sourceText(), SECOND).and(isFoldable(precision, sourceText(), SECOND));
+        return isInteger(precision, sourceText(), SECOND);
+    }
+
+    @Override
+    public void validate(Failures failures) {
+        failures.add(precision == null ? null : isFoldable(precision, sourceText(), SECOND));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Percentile.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/Percentile.java
@@ -14,6 +14,8 @@ import org.elasticsearch.compute.aggregation.AggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.PercentileDoubleAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.PercentileIntAggregatorFunctionSupplier;
 import org.elasticsearch.compute.aggregation.PercentileLongAggregatorFunctionSupplier;
+import org.elasticsearch.xpack.esql.capabilities.Validatable;
+import org.elasticsearch.xpack.esql.core.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
@@ -28,11 +30,11 @@ import java.util.List;
 
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.FIRST;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.ParamOrdinal.SECOND;
-import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isFoldable;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isNumeric;
 import static org.elasticsearch.xpack.esql.core.expression.TypeResolutions.isType;
+import static org.elasticsearch.xpack.esql.expression.Validations.isFoldable;
 
-public class Percentile extends NumericAggregate {
+public class Percentile extends NumericAggregate implements Validatable {
     public static final NamedWriteableRegistry.Entry ENTRY = new NamedWriteableRegistry.Entry(
         Expression.class,
         "Percentile",
@@ -102,7 +104,12 @@ public class Percentile extends NumericAggregate {
             return resolution;
         }
 
-        return isNumeric(percentile, sourceText(), SECOND).and(isFoldable(percentile, sourceText(), SECOND));
+        return isNumeric(percentile, sourceText(), SECOND);
+    }
+
+    @Override
+    public void validate(Failures failures) {
+        failures.add(isFoldable(percentile, sourceText(), SECOND));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopList.java
@@ -132,31 +132,29 @@ public class TopList extends AggregateFunction implements ToAggregator, Surrogat
 
     @Override
     public void validate(Failures failures) {
-        failures
-            .add(isFoldableAnd(limitField(), sourceText(), SECOND, (limitValue, formatFailure) -> {
-                if (limitValue == null) {
-                    return formatFailure.apply("cannot be null");
-                }
+        failures.add(isFoldableAnd(limitField(), sourceText(), SECOND, (limitValue, formatFailure) -> {
+            if (limitValue == null) {
+                return formatFailure.apply("cannot be null");
+            }
 
-                if ((int) limitValue <= 0) {
-                    return formatFailure.apply("must be greater than 0");
-                }
+            if ((int) limitValue <= 0) {
+                return formatFailure.apply("must be greater than 0");
+            }
 
-                return null;
-            }))
-            .add(isFoldableAnd(orderField(), sourceText(), THIRD, (orderValue, formatFailure) -> {
-                if (orderValue == null) {
-                    return formatFailure.apply("cannot be null");
-                }
+            return null;
+        })).add(isFoldableAnd(orderField(), sourceText(), THIRD, (orderValue, formatFailure) -> {
+            if (orderValue == null) {
+                return formatFailure.apply("cannot be null");
+            }
 
-                String order = BytesRefs.toString(orderValue);
+            String order = BytesRefs.toString(orderValue);
 
-                if (order.equalsIgnoreCase(ORDER_ASC) == false && order.equalsIgnoreCase(ORDER_DESC) == false) {
-                    return formatFailure.apply("must be either '" + ORDER_ASC + "' or '" + ORDER_DESC + "'");
-                }
+            if (order.equalsIgnoreCase(ORDER_ASC) == false && order.equalsIgnoreCase(ORDER_DESC) == false) {
+                return formatFailure.apply("must be either '" + ORDER_ASC + "' or '" + ORDER_DESC + "'");
+            }
 
-                return null;
-            }));
+            return null;
+        }));
     }
 
     @Override

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopList.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopList.java
@@ -102,8 +102,8 @@ public class TopList extends AggregateFunction implements ToAggregator, Surrogat
         return parameters().get(1);
     }
 
-    private int limitValue() {
-        return (int) limitField().fold();
+    private Integer limitValue() {
+        return (Integer) limitField().fold();
     }
 
     private String orderRawValue() {
@@ -191,7 +191,7 @@ public class TopList extends AggregateFunction implements ToAggregator, Surrogat
     public Expression surrogate() {
         var s = source();
 
-        if (limitValue() == 1) {
+        if (limitField().foldable() && orderField().foldable() && Integer.valueOf(1).equals(limitValue())) {
             if (orderValue()) {
                 return new Min(s, field());
             } else {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/package-info.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/package-info.java
@@ -50,6 +50,31 @@
  *         </ul>
  *     </li>
  *     <li>
+ *         Your function may also implement some of those interfaces:
+ *         <ul>
+ *             <li>
+ *                 {@link org.elasticsearch.xpack.esql.core.expression.function.OptionalArgument}:
+ *                 Required if the last argument of your function is optional
+ *             </li>
+ *             <li>
+ *                 {@link org.elasticsearch.xpack.esql.core.expression.function.TwoOptionalArguments}:
+ *                 Required if the last 2 arguments of your function are optional
+ *             </li>
+ *             <li>
+ *                 {@link org.elasticsearch.xpack.esql.capabilities.Validatable}:
+ *                 If it needs validation post-optimization. Useful to validate foldable parameters
+ *             </li>
+ *             <li>
+ *                 {@link org.elasticsearch.xpack.esql.planner.ToAggregator}: (More information about aggregators below)
+ *             </li>
+ *             <li>
+ *                 {@link org.elasticsearch.xpack.esql.expression.SurrogateExpression}:
+ *                 Lets the aggregation be transformed to another aggregation or evaluable function.
+ *                 This could be used to reuse code, improve performance based on foldable parameters, or fold the function.
+ *             </li>
+ *         </ul>
+ *     </li>
+ *     <li>
  *         Fill the required methods in your new function. Check their JavaDoc for more information.
  *         Here are some of the important ones:
  *         <ul>
@@ -67,17 +92,6 @@
  *             <li>
  *                 {@code dataType}: This will return the datatype of your function.
  *                 May be based on its current parameters.
- *             </li>
- *         </ul>
- *
- *         Finally, you may want to implement some interfaces.
- *         Check their JavaDocs to see if they are suitable for your function:
- *         <ul>
- *             <li>
- *                 {@link org.elasticsearch.xpack.esql.planner.ToAggregator}: (More information about aggregators below)
- *             </li>
- *             <li>
- *                 {@link org.elasticsearch.xpack.esql.expression.SurrogateExpression}
  *             </li>
  *         </ul>
  *     </li>

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/grouping/Bucket.java
@@ -382,11 +382,23 @@ public class Bucket extends GroupingFunction implements Validatable, TwoOptional
 
     @Override
     public void validate(Failures failures) {
+        var fieldType = field.dataType();
+        var bucketsType = buckets.dataType();
+
+        if (fieldType == DataType.NULL || bucketsType == DataType.NULL || bucketsType.isInteger() == false) {
+            return;
+        }
+
         String operation = sourceText();
 
-        failures.add(isFoldable(buckets, operation, SECOND))
-            .add(from != null ? isFoldable(from, operation, THIRD) : null)
-            .add(to != null ? isFoldable(to, operation, FOURTH) : null);
+        failures.add(isFoldable(buckets, operation, SECOND));
+
+        // Any null return null; no need to validate
+        if (from == null || from.dataType() == DataType.NULL || to == null || to.dataType() == DataType.NULL) {
+            return;
+        }
+
+        failures.add(isFoldable(from, operation, THIRD)).add(isFoldable(to, operation, FOURTH));
     }
 
     private long foldToLong(Expression e) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/package-info.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/scalar/package-info.java
@@ -69,6 +69,23 @@
  *         </ul>
  *     </li>
  *     <li>
+ *         Your function may also implement some of those interfaces:
+ *         <ul>
+ *             <li>
+ *                 {@link org.elasticsearch.xpack.esql.core.expression.function.OptionalArgument}:
+ *                 Required if the last argument of your function is optional
+ *             </li>
+ *             <li>
+ *                 {@link org.elasticsearch.xpack.esql.core.expression.function.TwoOptionalArguments}:
+ *                 Required if the last 2 arguments of your function are optional
+ *             </li>
+ *             <li>
+ *                 {@link org.elasticsearch.xpack.esql.capabilities.Validatable}:
+ *                 If it needs validation post-optimization. Useful to validate foldable parameters
+ *             </li>
+ *         </ul>
+ *     </li>
+ *     <li>
  *         There are also methods annotated with {@link org.elasticsearch.compute.ann.Evaluator}
  *         that contain the actual inner implementation of the function. They are usually named
  *         "process" or "processInts" or "processBar". Modify those to look right and run the {@code CsvTests}

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/analysis/VerifierTests.java
@@ -83,14 +83,6 @@ public class VerifierTests extends ESTestCase {
                 + " found value [first_name] type [keyword]",
             error("from test | stats count(avg(first_name)) by first_name")
         );
-        assertEquals(
-            "1:23: second argument of [percentile(languages, languages)] must be a constant, received [languages]",
-            error("from test | stats x = percentile(languages, languages) by emp_no")
-        );
-        assertEquals(
-            "1:23: second argument of [count_distinct(languages, languages)] must be a constant, received [languages]",
-            error("from test | stats x = count_distinct(languages, languages) by emp_no")
-        );
         // no agg function
         assertEquals("1:19: expected an aggregate function but found [5]", error("from test | stats 5 by emp_no"));
 

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
@@ -133,26 +133,14 @@ public abstract class AbstractAggregationTestCase extends AbstractFunctionTestCa
             "Test Values: " + testCase.getData().stream().map(TestCaseSupplier.TypedData::toString).collect(Collectors.joining(","))
         );
 
-        if (testCase.getExpectedTypeError() != null) {
-            assertTypeResolutionFailure(expression);
+        if (checkExpectedErrors(expression)) {
             return;
-        }
-        if (testCase.getExpectedValidationFailures() != null) {
-            assertValidationFailures(expression);
-            return;
-        }
-
-        var failures = validate(expression);
-        if (failures.hasFailures()) {
-            throw new AssertionError("unexpected validation failures: " + failures);
         }
 
         expression = resolveSurrogates(expression);
 
-        Expression.TypeResolution resolution = expression.typeResolved();
-        if (resolution.unresolved()) {
-            throw new AssertionError("expected resolved " + resolution.message());
-        }
+        // No expected errors, but we want to check that the surrogate is ok
+        checkExpectedErrors(expression);
 
         expression = new FoldNull().rule(expression);
         assertThat(expression.dataType(), equalTo(testCase.expectedType()));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractAggregationTestCase.java
@@ -132,10 +132,21 @@ public abstract class AbstractAggregationTestCase extends AbstractFunctionTestCa
         logger.info(
             "Test Values: " + testCase.getData().stream().map(TestCaseSupplier.TypedData::toString).collect(Collectors.joining(","))
         );
+
         if (testCase.getExpectedTypeError() != null) {
             assertTypeResolutionFailure(expression);
             return;
         }
+        if (testCase.getExpectedValidationFailures() != null) {
+            assertValidationFailures(expression);
+            return;
+        }
+
+        var failures = validate(expression);
+        if (failures.hasFailures()) {
+            throw new AssertionError("unexpected validation failures: " + failures);
+        }
+
         expression = resolveSurrogates(expression);
 
         Expression.TypeResolution resolution = expression.typeResolved();

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -36,6 +36,9 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.esql.TestBlockFactory;
+import org.elasticsearch.xpack.esql.capabilities.Validatable;
+import org.elasticsearch.xpack.esql.core.common.Failure;
+import org.elasticsearch.xpack.esql.core.common.Failures;
 import org.elasticsearch.xpack.esql.core.expression.Attribute;
 import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.expression.FieldAttribute;
@@ -80,6 +83,7 @@ import static org.elasticsearch.compute.data.BlockUtils.toJavaObject;
 import static org.elasticsearch.xpack.esql.SerializationTestUtils.assertSerialization;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.CARTESIAN;
 import static org.elasticsearch.xpack.esql.core.util.SpatialCoordinateTypes.GEO;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -295,6 +299,7 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
                 testCase.getMatcher(),
                 testCase.getExpectedWarnings(),
                 testCase.getExpectedTypeError(),
+                testCase.getExpectedValidationFailures(),
                 testCase.foldingExceptionClass(),
                 testCase.foldingExceptionMessage()
             );
@@ -354,6 +359,26 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
     protected final void assertTypeResolutionFailure(Expression expression) {
         assertTrue("expected unresolved", expression.typeResolved().unresolved());
         assertThat(expression.typeResolved().message(), equalTo(testCase.getExpectedTypeError()));
+    }
+
+    protected final void assertValidationFailures(Expression expression) {
+        var failures = validate(expression);
+        var failureMessages = failures.failures().stream().map(Failure::message).toList();
+
+        assertThat(failureMessages, containsInAnyOrder(testCase.getExpectedValidationFailures()));
+    }
+
+    /**
+     * Validates a possible {@link Validatable} expression.
+     */
+    protected Failures validate(Expression expression) {
+        Failures failures = new Failures();
+
+        if (expression instanceof Validatable v) {
+            v.validate(failures);
+        }
+
+        return failures;
     }
 
     @AfterClass

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractFunctionTestCase.java
@@ -356,6 +356,36 @@ public abstract class AbstractFunctionTestCase extends ESTestCase {
         assertEquals(returnFromSignature, returnTypes);
     }
 
+    /**
+     * Checks expected errors, and returns true if an error was expected.
+     * <p>
+     *     This method also checks that there are not errors if they weren't expected.
+     * </p>
+     */
+    protected boolean checkExpectedErrors(Expression expression) {
+        if (testCase.getExpectedTypeError() != null) {
+            assertTypeResolutionFailure(expression);
+            return true;
+        }
+
+        if (testCase.getExpectedValidationFailures() != null) {
+            assertValidationFailures(expression);
+            return true;
+        }
+
+        var resolution = expression.typeResolved();
+        if (resolution.unresolved()) {
+            throw new AssertionError("expected resolved types: " + resolution.message());
+        }
+
+        var failures = validate(expression);
+        if (failures.hasFailures()) {
+            throw new AssertionError("unexpected validation failures: " + failures);
+        }
+
+        return false;
+    }
+
     protected final void assertTypeResolutionFailure(Expression expression) {
         assertTrue("expected unresolved", expression.typeResolved().unresolved());
         assertThat(expression.typeResolved().message(), equalTo(testCase.getExpectedTypeError()));

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
@@ -85,18 +85,13 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
         assumeTrue("Can't build evaluator", testCase.canBuildEvaluator());
         boolean readFloating = randomBoolean();
         Expression expression = readFloating ? buildDeepCopyOfFieldExpression(testCase) : buildFieldExpression(testCase);
-        if (testCase.getExpectedTypeError() != null) {
-            assertTypeResolutionFailure(expression);
+        if (checkExpectedErrors(expression)) {
             return;
         }
         assumeTrue("Expected type must be representable to build an evaluator", EsqlDataTypes.isRepresentable(testCase.expectedType()));
         logger.info(
             "Test Values: " + testCase.getData().stream().map(TestCaseSupplier.TypedData::toString).collect(Collectors.joining(","))
         );
-        Expression.TypeResolution resolution = expression.typeResolved();
-        if (resolution.unresolved()) {
-            throw new AssertionError("expected resolved " + resolution.message());
-        }
         expression = new FoldNull().rule(expression);
         assertThat(expression.dataType(), equalTo(testCase.expectedType()));
         logger.info("Result type: " + expression.dataType());
@@ -185,8 +180,7 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
 
     private void testEvaluateBlock(BlockFactory inputBlockFactory, DriverContext context, boolean insertNulls) {
         Expression expression = randomBoolean() ? buildDeepCopyOfFieldExpression(testCase) : buildFieldExpression(testCase);
-        if (testCase.getExpectedTypeError() != null) {
-            assertTypeResolutionFailure(expression);
+        if (checkExpectedErrors(expression)) {
             return;
         }
         assumeTrue("Can't build evaluator", testCase.canBuildEvaluator());
@@ -247,8 +241,7 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
 
     public void testSimpleWithNulls() { // TODO replace this with nulls inserted into the test case like anyNullIsNull
         Expression expression = buildFieldExpression(testCase);
-        if (testCase.getExpectedTypeError() != null) {
-            assertTypeResolutionFailure(expression);
+        if (checkExpectedErrors(expression)) {
             return;
         }
         assumeTrue("Can't build evaluator", testCase.canBuildEvaluator());
@@ -288,8 +281,7 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
 
     public final void testEvaluateInManyThreads() throws ExecutionException, InterruptedException {
         Expression expression = buildFieldExpression(testCase);
-        if (testCase.getExpectedTypeError() != null) {
-            assertTypeResolutionFailure(expression);
+        if (checkExpectedErrors(expression)) {
             return;
         }
         assumeTrue("Can't build evaluator", testCase.canBuildEvaluator());
@@ -324,8 +316,7 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
 
     public final void testEvaluatorToString() {
         Expression expression = buildFieldExpression(testCase);
-        if (testCase.getExpectedTypeError() != null) {
-            assertTypeResolutionFailure(expression);
+        if (checkExpectedErrors(expression)) {
             return;
         }
         assumeTrue("Can't build evaluator", testCase.canBuildEvaluator());
@@ -337,8 +328,7 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
 
     public final void testFactoryToString() {
         Expression expression = buildFieldExpression(testCase);
-        if (testCase.getExpectedTypeError() != null) {
-            assertTypeResolutionFailure(expression);
+        if (checkExpectedErrors(expression)) {
             return;
         }
         assumeTrue("Can't build evaluator", testCase.canBuildEvaluator());
@@ -348,11 +338,9 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
 
     public final void testFold() {
         Expression expression = buildLiteralExpression(testCase);
-        if (testCase.getExpectedTypeError() != null) {
-            assertTypeResolutionFailure(expression);
+        if (checkExpectedErrors(expression)) {
             return;
         }
-        assertFalse(expression.typeResolved().unresolved());
         Expression nullOptimized = new FoldNull().rule(expression);
         assertThat(nullOptimized.dataType(), equalTo(testCase.expectedType()));
         assertTrue(nullOptimized.foldable());

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/AbstractScalarFunctionTestCase.java
@@ -441,6 +441,7 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
                         null,
                         oc.getExpectedTypeError(),
                         null,
+                        null,
                         null
                     );
                 }));
@@ -463,6 +464,7 @@ public abstract class AbstractScalarFunctionTestCase extends AbstractFunctionTes
                                 nullValue(),
                                 null,
                                 oc.getExpectedTypeError(),
+                                null,
                                 null,
                                 null
                             );

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopListTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/expression/function/aggregate/TopListTests.java
@@ -192,32 +192,32 @@ public class TopListTests extends AbstractAggregationTestCase {
                 )
             ),
 
-            // Resolution errors
+            // Validation errors
             new TestCaseSupplier(
                 List.of(DataType.LONG, DataType.INTEGER, DataType.KEYWORD),
-                () -> TestCaseSupplier.TestCase.typeError(
+                () -> TestCaseSupplier.TestCase.validationFailure(
                     List.of(
                         TestCaseSupplier.TypedData.multiRow(List.of(5L, 8L, 2L, 0L, 200L), DataType.LONG, "field"),
                         new TestCaseSupplier.TypedData(0, DataType.INTEGER, "limit").forceLiteral(),
                         new TestCaseSupplier.TypedData(new BytesRef("desc"), DataType.KEYWORD, "order").forceLiteral()
                     ),
-                    "Limit must be greater than 0 in [], found [0]"
+                    "second argument of [] must be greater than 0, received [limit]"
                 )
             ),
             new TestCaseSupplier(
                 List.of(DataType.LONG, DataType.INTEGER, DataType.KEYWORD),
-                () -> TestCaseSupplier.TestCase.typeError(
+                () -> TestCaseSupplier.TestCase.validationFailure(
                     List.of(
                         TestCaseSupplier.TypedData.multiRow(List.of(5L, 8L, 2L, 0L, 200L), DataType.LONG, "field"),
                         new TestCaseSupplier.TypedData(2, DataType.INTEGER, "limit").forceLiteral(),
                         new TestCaseSupplier.TypedData(new BytesRef("wrong-order"), DataType.KEYWORD, "order").forceLiteral()
                     ),
-                    "Invalid order value in [], expected [ASC, DESC] but got [wrong-order]"
+                    "third argument of [] must be either 'ASC' or 'DESC', received [order]"
                 )
             ),
             new TestCaseSupplier(
                 List.of(DataType.LONG, DataType.INTEGER, DataType.KEYWORD),
-                () -> TestCaseSupplier.TestCase.typeError(
+                () -> TestCaseSupplier.TestCase.validationFailure(
                     List.of(
                         TestCaseSupplier.TypedData.multiRow(List.of(5L, 8L, 2L, 0L, 200L), DataType.LONG, "field"),
                         new TestCaseSupplier.TypedData(null, DataType.INTEGER, "limit").forceLiteral(),
@@ -228,7 +228,7 @@ public class TopListTests extends AbstractAggregationTestCase {
             ),
             new TestCaseSupplier(
                 List.of(DataType.LONG, DataType.INTEGER, DataType.KEYWORD),
-                () -> TestCaseSupplier.TestCase.typeError(
+                () -> TestCaseSupplier.TestCase.validationFailure(
                     List.of(
                         TestCaseSupplier.TypedData.multiRow(List.of(5L, 8L, 2L, 0L, 200L), DataType.LONG, "field"),
                         new TestCaseSupplier.TypedData(1, DataType.INTEGER, "limit").forceLiteral(),


### PR DESCRIPTION
- Moved `TopList` agg foldable validations to `Validatable`. Same for other functions doing the same.
- Add `Validatable` support in function tests
- Add `Validatable` to functions documentation
- Fixed `Bucket` `Validatable` implementation to not fail test cases with `null` parameters

## Do not merge
Waiting for https://github.com/elastic/elasticsearch/issues/100634