### PR TITLE
parseHeapRatioOrDeprecatedByteSizeValue for indices.breaker.total.limit

### DIFF
--- a/docs/changelog/110236.yaml
+++ b/docs/changelog/110236.yaml
@@ -1,0 +1,11 @@
+pr: 110236
+summary: '`ParseHeapRatioOrDeprecatedByteSizeValue` for `indices.breaker.total.limit`'
+area: Infra/Settings
+type: deprecation
+issues: []
+deprecation:
+  title: '`ParseHeapRatioOrDeprecatedByteSizeValue` for `indices.breaker.total.limit`'
+  area: Infra/Settings
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/docs/changelog/110236.yaml
+++ b/docs/changelog/110236.yaml
@@ -5,7 +5,7 @@ type: deprecation
 issues: []
 deprecation:
   title: 'Deprecate absolute size values for `indices.breaker.total.limit` setting'
-  area: Infra/Settings
+  area: Cluster and node setting
   details: Previously, the value of `indices.breaker.total.limit` could be specified as
     an absolute size in bytes. This setting controls the overal amount of
     memory the server is allowed to use before taking remedial actions. Setting

--- a/docs/changelog/110236.yaml
+++ b/docs/changelog/110236.yaml
@@ -4,8 +4,18 @@ area: Infra/Settings
 type: deprecation
 issues: []
 deprecation:
-  title: '`ParseHeapRatioOrDeprecatedByteSizeValue` for `indices.breaker.total.limit`'
+  title: 'Deprecate absolute size values for `indices.breaker.total.limit` setting'
   area: Infra/Settings
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  details: Previously, the value of `indices.breaker.total.limit` could be specified as
+    an absolute size in bytes. This setting controls the overal amount of
+    memory the server is allowed to use before taking remedial actions. Setting
+    this to a specific number of bytes led to strange behaviour when the node
+    maximum heap size changed because the circut breaker limit would remain
+    unchanged. This would either leave the value too low, causing part of the
+    heap to remain unused; or it would leave the value too high, causing the
+    circuit breaker to be ineffective at preventing OOM errors.  The only
+    reasonable behaviour for this setting is that it scales with the size of
+    the heap, and so absolute byte limits are now deprecated.
+  impact: Users must change their configuration to specify a percentage instead of
+    an absolute number of bytes for `indices.breaker.total.limit`, or else
+    accept the default, which is already specified as a percentage.

--- a/server/src/main/java/org/elasticsearch/common/unit/MemorySizeValue.java
+++ b/server/src/main/java/org/elasticsearch/common/unit/MemorySizeValue.java
@@ -9,6 +9,9 @@
 package org.elasticsearch.common.unit;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 
 import java.util.Objects;
@@ -25,18 +28,39 @@ public enum MemorySizeValue {
     public static ByteSizeValue parseBytesSizeValueOrHeapRatio(String sValue, String settingName) {
         settingName = Objects.requireNonNull(settingName);
         if (sValue != null && sValue.endsWith("%")) {
-            final String percentAsString = sValue.substring(0, sValue.length() - 1);
-            try {
-                final double percent = Double.parseDouble(percentAsString);
-                if (percent < 0 || percent > 100) {
-                    throw new ElasticsearchParseException("percentage should be in [0-100], got [{}]", percentAsString);
-                }
-                return ByteSizeValue.ofBytes((long) ((percent / 100) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()));
-            } catch (NumberFormatException e) {
-                throw new ElasticsearchParseException("failed to parse [{}] as a double", e, percentAsString);
-            }
+            return parseHeapRatio(sValue);
         } else {
             return parseBytesSizeValue(sValue, settingName);
         }
     }
+
+    public static ByteSizeValue parseHeapRatioOrDeprecatedByteSizeValue(String sValue, String settingName) {
+        settingName = Objects.requireNonNull(settingName);
+        if (sValue != null && sValue.endsWith("%")) {
+            return parseHeapRatio(sValue);
+        } else {
+            DeprecationLogger.getLogger(BalancedShardsAllocator.class)
+                .critical(
+                    DeprecationCategory.SETTINGS,
+                    "absolute_size_not_supported",
+                    "[{}] should be specified using a percentage of the heap. Absolute size settings will be forbidden in a future release",
+                    settingName
+                );
+            return parseBytesSizeValue(sValue, settingName);
+        }
+    }
+
+    private static ByteSizeValue parseHeapRatio(String sValue) {
+        final String percentAsString = sValue.substring(0, sValue.length() - 1);
+        try {
+            final double percent = Double.parseDouble(percentAsString);
+            if (percent < 0 || percent > 100) {
+                throw new ElasticsearchParseException("percentage should be in [0-100], got [{}]", percentAsString);
+            }
+            return ByteSizeValue.ofBytes((long) ((percent / 100) * JvmInfo.jvmInfo().getMem().getHeapMax().getBytes()));
+        } catch (NumberFormatException e) {
+            throw new ElasticsearchParseException("failed to parse [{}] as a double", e, percentAsString);
+        }
+    }
+
 }

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.MemorySizeValue;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.Booleans;
 import org.elasticsearch.core.SuppressForbidden;
@@ -65,7 +66,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
         Property.NodeScope
     );
 
-    public static final Setting<ByteSizeValue> TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING = Setting.memorySizeSetting(
+    public static final Setting<ByteSizeValue> TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING = new Setting<>(
         "indices.breaker.total.limit",
         settings -> {
             if (USE_REAL_MEMORY_USAGE_SETTING.get(settings)) {
@@ -74,6 +75,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                 return "70%";
             }
         },
+        (s) -> MemorySizeValue.parseHeapRatioOrDeprecatedByteSizeValue(s, "indices.breaker.total.limit"),
         Property.Dynamic,
         Property.NodeScope
     );

--- a/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerService.java
@@ -75,7 +75,7 @@ public class HierarchyCircuitBreakerService extends CircuitBreakerService {
                 return "70%";
             }
         },
-        (s) -> MemorySizeValue.parseHeapRatioOrDeprecatedByteSizeValue(s, "indices.breaker.total.limit"),
+        (s) -> MemorySizeValue.parseHeapRatioOrDeprecatedByteSizeValue(s, "indices.breaker.total.limit", 50),
         Property.Dynamic,
         Property.NodeScope
     );

--- a/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
@@ -72,6 +72,7 @@ public class MemorySizeSettingsTests extends ESTestCase {
             ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * defaultTotalPercentage))
         );
         assertWarnings(
+            "[indices.breaker.total.limit] setting of [25%] is below the recommended minimum of 50.0% of the heap",
             "[indices.breaker.total.limit] should be specified using a percentage of the heap. "
                 + "Absolute size settings will be forbidden in a future release"
         );

--- a/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
@@ -72,8 +72,8 @@ public class MemorySizeSettingsTests extends ESTestCase {
             ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * defaultTotalPercentage))
         );
         assertWarnings(
-            "[indices.breaker.total.limit] should be specified using a percentage of the heap. " +
-                "Absolute size settings will be forbidden in a future release"
+            "[indices.breaker.total.limit] should be specified using a percentage of the heap. "
+                + "Absolute size settings will be forbidden in a future release"
         );
         assertMemorySizeSetting(
             HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING,

--- a/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/MemorySizeSettingsTests.java
@@ -71,6 +71,10 @@ public class MemorySizeSettingsTests extends ESTestCase {
             "indices.breaker.total.limit",
             ByteSizeValue.ofBytes((long) (JvmInfo.jvmInfo().getMem().getHeapMax().getBytes() * defaultTotalPercentage))
         );
+        assertWarnings(
+            "[indices.breaker.total.limit] should be specified using a percentage of the heap. " +
+                "Absolute size settings will be forbidden in a future release"
+        );
         assertMemorySizeSetting(
             HierarchyCircuitBreakerService.FIELDDATA_CIRCUIT_BREAKER_LIMIT_SETTING,
             "indices.breaker.fielddata.limit",

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -254,6 +254,8 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             assertThat(exception.getMessage(), containsString("request=157286400/150mb"));
             assertThat(exception.getDurability(), equalTo(CircuitBreaker.Durability.TRANSIENT));
         }
+
+        assertCircuitBreakerLimitWarning();
     }
 
     public void testParentBreaksOnRealMemoryUsage() {
@@ -325,6 +327,8 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         memoryUsage.set(100);
         requestBreaker.addEstimateBytesAndMaybeBreak(reservationInBytes, "request");
         assertEquals(0, requestBreaker.getTrippedCount());
+
+        assertCircuitBreakerLimitWarning();
     }
 
     /**
@@ -749,6 +753,7 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
                 equalTo(expectedDurability)
             );
         }
+        assertCircuitBreakerLimitWarning();
     }
 
     public void testAllocationBucketsBreaker() {
@@ -785,6 +790,8 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
             assertThat(exception.getMessage(), containsString("[parent] Data too large, data for [allocated_buckets] would be"));
             assertThat(exception.getMessage(), containsString("which is larger than the limit of [100/100b]"));
         }
+
+        assertCircuitBreakerLimitWarning();
     }
 
     public void testRegisterCustomCircuitBreakers_WithDuplicates() {
@@ -971,5 +978,13 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         } finally {
             HierarchyCircuitBreakerService.permitNegativeValues = false;
         }
+    }
+
+    void assertCircuitBreakerLimitWarning() {
+        assertWarnings(
+            "[indices.breaker.total.limit] should be specified using a percentage of the heap. " +
+                "Absolute size settings will be forbidden in a future release"
+        );
+
     }
 }

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -898,13 +898,21 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
                 service.getParentLimit()
             );
 
-            // total.limit defaults to 70% of the JVM heap if use_real_memory set to true
+            // total.limit defaults to 95% of the JVM heap if use_real_memory set to true
             clusterSettings.applySettings(Settings.builder().put(useRealMemoryUsageSetting, true).build());
             assertEquals(
                 MemorySizeValue.parseBytesSizeValueOrHeapRatio("95%", totalCircuitBreakerLimitSetting).getBytes(),
                 service.getParentLimit()
             );
         }
+    }
+
+    public void testSizeBelowMinimumWarning() {
+        ByteSizeValue sizeValue = MemorySizeValue.parseHeapRatioOrDeprecatedByteSizeValue(
+            "19%",
+            HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(),
+            20);
+        assertWarnings("[indices.breaker.total.limit] setting of [19%] is below the recommended minimum of 20.0% of the heap");
     }
 
     public void testBuildParentTripMessage() {

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -911,7 +911,8 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
         ByteSizeValue sizeValue = MemorySizeValue.parseHeapRatioOrDeprecatedByteSizeValue(
             "19%",
             HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(),
-            20);
+            20
+        );
         assertWarnings("[indices.breaker.total.limit] setting of [19%] is below the recommended minimum of 20.0% of the heap");
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/breaker/HierarchyCircuitBreakerServiceTests.java
@@ -982,8 +982,8 @@ public class HierarchyCircuitBreakerServiceTests extends ESTestCase {
 
     void assertCircuitBreakerLimitWarning() {
         assertWarnings(
-            "[indices.breaker.total.limit] should be specified using a percentage of the heap. " +
-                "Absolute size settings will be forbidden in a future release"
+            "[indices.breaker.total.limit] should be specified using a percentage of the heap. "
+                + "Absolute size settings will be forbidden in a future release"
         );
 
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -649,7 +649,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     /**
      * Convenience method to assert warnings for settings deprecations and general deprecation warnings. All warnings passed to this method
      * are assumed to be at WARNING level.
-     * @param expectedWarnings expected general deprecation warnings.
+     * @param expectedWarnings expected general deprecation warning messages.
      */
     protected final void assertWarnings(String... expectedWarnings) {
         assertWarnings(
@@ -663,7 +663,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     /**
      * Convenience method to assert warnings for settings deprecations and general deprecation warnings. All warnings passed to this method
      * are assumed to be at CRITICAL level.
-     * @param expectedWarnings expected general deprecation warnings.
+     * @param expectedWarnings expected general deprecation warning messages.
      */
     protected final void assertCriticalWarnings(String... expectedWarnings) {
         assertWarnings(

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -279,6 +279,7 @@ public class CircuitBreakerTests extends ESTestCase {
             TumblingWindow window = new TumblingWindow(eqlClient, criteria, null, matcher, Collections.emptyList());
             window.execute(wrap(p -> fail(), ex -> assertTrue(ex instanceof CircuitBreakingException)));
         }
+        assertCriticalWarnings("[indices.breaker.total.limit] setting of [0%] is below the recommended minimum of 50.0% of the heap");
     }
 
     private List<BreakerSettings> breakerSettings() {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -245,7 +245,9 @@ public class CircuitBreakerTests extends ESTestCase {
         final int searchRequestsExpectedCount = 2;
 
         // let the parent circuit breaker fail, setting its limit to zero
-        Settings settings = Settings.builder().put(HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), 0).build();
+        Settings settings = Settings.builder()
+            .put(HierarchyCircuitBreakerService.TOTAL_CIRCUIT_BREAKER_LIMIT_SETTING.getKey(), "0%")
+            .build();
 
         try (
             CircuitBreakerService service = new HierarchyCircuitBreakerService(


### PR DESCRIPTION
An idea to make absolute sizes for `indices.breaker.total.limit` critically deprecated.

Supporting https://github.com/elastic/dev/issues/2558