### PR TITLE
Adjust Dense Vector Unit Vector Epsilon

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -96,7 +96,7 @@ import static org.elasticsearch.index.IndexVersions.DEFAULT_DENSE_VECTOR_TO_INT8
  */
 public class DenseVectorFieldMapper extends FieldMapper {
     public static final String COSINE_MAGNITUDE_FIELD_SUFFIX = "._magnitude";
-    private static final float EPS = 1e-4f;
+    private static final float EPS = 1e-3f;
 
     static boolean isNotUnitVector(float magnitude) {
         return Math.abs(magnitude - 1.0f) > EPS;


### PR DESCRIPTION
Change dense vector unit vector epsilon to `1e-3`. This is required because Cohere sometimes generates unit vectors with magnitude slightly outside our current epsilon. For example, we have observed Cohere unit vectors with magnitude 1.0001829.