### PR TITLE
Removing check for index existence from IndicesService::withTempIndexService

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -471,6 +471,8 @@ public class MetadataCreateIndexService {
         final ActionListener<Void> rerouteListener
     ) throws Exception {
         // create the index here (on the master) to validate it can be created, as well as adding the mapping
+        assert indicesService.hasIndex(temporaryIndexMeta.getIndex()) == false
+            : Strings.format("Index [%s] already exists", temporaryIndexMeta.getIndex().getName());
         return indicesService.<ClusterState, Exception>withTempIndexService(temporaryIndexMeta, indexService -> {
             try {
                 updateIndexMappingsAndBuildSortOrder(indexService, request, mappings, sourceMetadata);

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -683,9 +683,6 @@ public class IndicesService extends AbstractLifecycleComponent
         CheckedFunction<IndexService, T, E> indexServiceConsumer
     ) throws IOException, E {
         final Index index = indexMetadata.getIndex();
-        if (hasIndex(index)) {
-            throw new ResourceAlreadyExistsException(index);
-        }
         List<IndexEventListener> finalListeners = List.of(
             // double check that shard is not created.
             new IndexEventListener() {


### PR DESCRIPTION
The check for the existence of an index is required by some clients of withTempIndexService, but is not required by withTempIndexService iteself. This change removes the check from withTempIndexService. Of the three non-test uses of withTempIndexService (TransportSimulateIndexTemplateAction, MetadataCreateIndexService, and MetadataIndexTemplateService) only MetadataCreateIndexService needs to ensure that the index does not exist. I believe that that class is already checking that the index does not already exist, but to be extra careful I have moved the check into that class as an assertion.