### PR TITLE
Remove InternalAggregations#asMap and InternalAggregations#getAsMap methods

### DIFF
--- a/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregatorTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/aggregations/ChildrenToParentAggregatorTests.java
@@ -68,7 +68,7 @@ public class ChildrenToParentAggregatorTests extends AggregatorTestCase {
             assertEquals(0, childrenToParent.getDocCount());
             Aggregation parentAggregation = childrenToParent.getAggregations().get("in_parent");
             assertEquals(0, childrenToParent.getDocCount());
-            assertNotNull("Aggregations: " + childrenToParent.getAggregations().asMap(), parentAggregation);
+            assertNotNull("Aggregations: " + childrenToParent.getAggregations().asList(), parentAggregation);
             assertEquals(Double.POSITIVE_INFINITY, ((Min) parentAggregation).value(), Double.MIN_VALUE);
             assertFalse(JoinAggregationInspectionHelper.hasValue(childrenToParent));
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SignificantTermsSignificanceScoreIT.java
@@ -20,7 +20,6 @@ import org.elasticsearch.script.MockScriptPlugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.filter.InternalFilter;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTerms;
@@ -136,8 +135,8 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
             StringTerms classes = response.getAggregations().get("class");
             assertThat(classes.getBuckets().size(), equalTo(2));
             for (Terms.Bucket classBucket : classes.getBuckets()) {
-                Map<String, InternalAggregation> aggs = classBucket.getAggregations().asMap();
-                assertTrue(aggs.containsKey("sig_terms"));
+                InternalAggregations aggs = classBucket.getAggregations();
+                assertNotNull(aggs.get("sig_terms"));
                 SignificantTerms agg = (SignificantTerms) aggs.get("sig_terms");
                 assertThat(agg.getBuckets().size(), equalTo(1));
                 String term = agg.iterator().next().getKeyAsString();
@@ -323,21 +322,21 @@ public class SignificantTermsSignificanceScoreIT extends ESIntegTestCase {
         assertNoFailuresAndResponse(request1, response1 -> assertNoFailuresAndResponse(request2, response2 -> {
             StringTerms classes = response1.getAggregations().get("class");
 
-            SignificantTerms sigTerms0 = ((SignificantTerms) (classes.getBucketByKey("0").getAggregations().asMap().get("sig_terms")));
+            SignificantTerms sigTerms0 = classes.getBucketByKey("0").getAggregations().get("sig_terms");
             assertThat(sigTerms0.getBuckets().size(), equalTo(2));
             double score00Background = sigTerms0.getBucketByKey("0").getSignificanceScore();
             double score01Background = sigTerms0.getBucketByKey("1").getSignificanceScore();
-            SignificantTerms sigTerms1 = ((SignificantTerms) (classes.getBucketByKey("1").getAggregations().asMap().get("sig_terms")));
+            SignificantTerms sigTerms1 = classes.getBucketByKey("1").getAggregations().get("sig_terms");
             double score10Background = sigTerms1.getBucketByKey("0").getSignificanceScore();
             double score11Background = sigTerms1.getBucketByKey("1").getSignificanceScore();
 
             InternalAggregations aggs = response2.getAggregations();
 
-            sigTerms0 = (SignificantTerms) ((InternalFilter) aggs.get("0")).getAggregations().getAsMap().get("sig_terms");
+            sigTerms0 = ((InternalFilter) aggs.get("0")).getAggregations().get("sig_terms");
             double score00SeparateSets = sigTerms0.getBucketByKey("0").getSignificanceScore();
             double score01SeparateSets = sigTerms0.getBucketByKey("1").getSignificanceScore();
 
-            sigTerms1 = (SignificantTerms) ((InternalFilter) aggs.get("1")).getAggregations().getAsMap().get("sig_terms");
+            sigTerms1 = ((InternalFilter) aggs.get("1")).getAggregations().get("sig_terms");
             double score10SeparateSets = sigTerms1.getBucketByKey("0").getSignificanceScore();
             double score11SeparateSets = sigTerms1.getBucketByKey("1").getSignificanceScore();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsIT.java
@@ -290,7 +290,7 @@ public class ExtendedStatsIT extends AbstractNumericTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(10L));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 ExtendedStats stats = global.getAggregations().get("stats");
                 assertThat(stats, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksIT.java
@@ -222,7 +222,7 @@ public class HDRPercentileRanksIT extends AbstractNumericTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(10L));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 PercentileRanks values = global.getAggregations().get("percentile_ranks");
                 assertThat(values, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesIT.java
@@ -199,7 +199,7 @@ public class HDRPercentilesIT extends AbstractNumericTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(10L));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 Percentiles percentiles = global.getAggregations().get("percentiles");
                 assertThat(percentiles, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationIT.java
@@ -185,7 +185,7 @@ public class MedianAbsoluteDeviationIT extends AbstractNumericTestCase {
                 assertThat(global.getName(), is("global"));
                 assertThat(global.getDocCount(), is((long) NUMBER_OF_DOCS));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().entrySet(), hasSize(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 final MedianAbsoluteDeviation mad = global.getAggregations().get("mad");
                 assertThat(mad, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -722,7 +722,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(numDocs));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 ScriptedMetric scriptedMetricAggregation = global.getAggregations().get("scripted");
                 assertThat(scriptedMetricAggregation, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/StatsIT.java
@@ -127,7 +127,7 @@ public class StatsIT extends AbstractNumericTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(10L));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 Stats stats = global.getAggregations().get("stats");
                 assertThat(stats, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/SumIT.java
@@ -140,7 +140,7 @@ public class SumIT extends AbstractNumericTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(10L));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 Sum sum = global.getAggregations().get("sum");
                 assertThat(sum, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksIT.java
@@ -190,7 +190,7 @@ public class TDigestPercentileRanksIT extends AbstractNumericTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(10L));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 PercentileRanks values = global.getAggregations().get("percentile_ranks");
                 assertThat(values, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesIT.java
@@ -176,7 +176,7 @@ public class TDigestPercentilesIT extends AbstractNumericTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(10L));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 Percentiles percentiles = global.getAggregations().get("percentiles");
                 assertThat(percentiles, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -461,7 +461,7 @@ public class TopHitsIT extends ESIntegTestCase {
                 assertThat(global, notNullValue());
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 TopHits topHits = global.getAggregations().get("hits");
                 assertThat(topHits, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ValueCountIT.java
@@ -99,7 +99,7 @@ public class ValueCountIT extends ESIntegTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo(10L));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 ValueCount valueCount = global.getAggregations().get("count");
                 assertThat(valueCount, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/FunctionScoreIT.java
@@ -116,11 +116,8 @@ public class FunctionScoreIT extends ESIntegTestCase {
             ),
             response -> {
                 assertThat(response.getHits().getAt(0).getScore(), equalTo(1.0f));
-                assertThat(
-                    ((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getKeyAsString(),
-                    equalTo("1.0")
-                );
-                assertThat(((Terms) response.getAggregations().asMap().get("score_agg")).getBuckets().get(0).getDocCount(), is(1L));
+                assertThat(((Terms) response.getAggregations().get("score_agg")).getBuckets().get(0).getKeyAsString(), equalTo("1.0"));
+                assertThat(((Terms) response.getAggregations().get("score_agg")).getBuckets().get(0).getDocCount(), is(1L));
             }
         );
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalAggregations.java
@@ -73,17 +73,7 @@ public final class InternalAggregations implements Iterable<InternalAggregation>
         return aggregations;
     }
 
-    /**
-     * Returns the {@link InternalAggregation}s keyed by aggregation name.
-     */
-    public Map<String, InternalAggregation> asMap() {
-        return getAsMap();
-    }
-
-    /**
-     * Returns the {@link InternalAggregation}s keyed by aggregation name.
-     */
-    public Map<String, InternalAggregation> getAsMap() {
+    private Map<String, InternalAggregation> asMap() {
         if (aggregationsAsMap == null) {
             Map<String, InternalAggregation> newAggregationsAsMap = Maps.newMapWithExpectedSize(aggregations.size());
             for (InternalAggregation aggregation : aggregations) {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregatorTests.java
@@ -766,8 +766,8 @@ public class NestedAggregatorTests extends AggregatorTestCase {
                 assertNotNull(terms);
 
                 for (LongTerms.Bucket bucket : terms.getBuckets()) {
-                    Max max = (Max) bucket.getAggregations().asMap().get(MAX_AGG_NAME);
-                    InternalSimpleValue bucketScript = (InternalSimpleValue) bucket.getAggregations().asMap().get("bucketscript");
+                    Max max = (Max) bucket.getAggregations().get(MAX_AGG_NAME);
+                    InternalSimpleValue bucketScript = (InternalSimpleValue) bucket.getAggregations().get("bucketscript");
                     assertNotNull(max);
                     assertNotNull(bucketScript);
                     assertEquals(max.value(), -bucketScript.getValue(), Double.MIN_VALUE);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorTests.java
@@ -768,7 +768,7 @@ public class CardinalityAggregatorTests extends AggregatorTestCase {
             assertEquals("global", global.getName());
             assertEquals(numDocs * 2, global.getDocCount());
             assertNotNull(global.getAggregations());
-            assertEquals(1, global.getAggregations().asMap().size());
+            assertEquals(1, global.getAggregations().asList().size());
 
             final Cardinality cardinality = global.getAggregations().get("cardinality");
             assertNotNull(cardinality);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
@@ -440,7 +440,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         assertEquals("global", global.getName());
         assertEquals(10L, global.getDocCount());
         assertNotNull(global.getAggregations());
-        assertEquals(1, global.getAggregations().asMap().size());
+        assertEquals(1, global.getAggregations().asList().size());
 
         Max max = global.getAggregations().get("max");
         assertNotNull(max);
@@ -651,7 +651,7 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         assertEquals("global", global.getName());
         assertEquals(0L, global.getDocCount());
         assertNotNull(global.getAggregations());
-        assertEquals(1, global.getAggregations().asMap().size());
+        assertEquals(1, global.getAggregations().asList().size());
 
         Max max = global.getAggregations().get("max");
         assertNotNull(max);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
@@ -297,18 +297,18 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<InternalHistogram>) histo -> {
             assertThat(histo.getBuckets().size(), equalTo(3));
 
-            assertNotNull(histo.getBuckets().get(0).getAggregations().asMap().get("min"));
-            Min min = (Min) histo.getBuckets().get(0).getAggregations().asMap().get("min");
+            assertNotNull(histo.getBuckets().get(0).getAggregations().get("min"));
+            Min min = (Min) histo.getBuckets().get(0).getAggregations().get("min");
             assertEquals(1.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
 
-            assertNotNull(histo.getBuckets().get(1).getAggregations().asMap().get("min"));
-            min = (Min) histo.getBuckets().get(1).getAggregations().asMap().get("min");
+            assertNotNull(histo.getBuckets().get(1).getAggregations().get("min"));
+            min = (Min) histo.getBuckets().get(1).getAggregations().get("min");
             assertEquals(Double.POSITIVE_INFINITY, min.value(), 0);
             assertFalse(AggregationInspectionHelper.hasValue(min));
 
-            assertNotNull(histo.getBuckets().get(2).getAggregations().asMap().get("min"));
-            min = (Min) histo.getBuckets().get(2).getAggregations().asMap().get("min");
+            assertNotNull(histo.getBuckets().get(2).getAggregations().get("min"));
+            min = (Min) histo.getBuckets().get(2).getAggregations().get("min");
             assertEquals(3.0, min.value(), 0);
             assertTrue(AggregationInspectionHelper.hasValue(min));
 
@@ -343,9 +343,9 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, (Consumer<InternalGlobal>) global -> {
             assertEquals(2, global.getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(global));
-            assertNotNull(global.getAggregations().asMap().get("min"));
+            assertNotNull(global.getAggregations().get("min"));
 
-            Min min = (Min) global.getAggregations().asMap().get("min");
+            Min min = (Min) global.getAggregations().get("min");
             assertEquals(1.0, min.value(), 0);
             assertThat(global.getProperty("min"), equalTo(min));
             assertThat(global.getProperty("min.value"), equalTo(1.0));

--- a/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
+++ b/server/src/test/java/org/elasticsearch/test/search/aggregations/bucket/SharedSignificantTermsTestMethods.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.test.search.aggregations.bucket;
 
 import org.elasticsearch.action.index.IndexRequestBuilder;
-import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.terms.SignificantTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
@@ -20,7 +20,6 @@ import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.search.aggregations.AggregationBuilders.significantTerms;
@@ -55,9 +54,9 @@ public class SharedSignificantTermsTestMethods {
                 StringTerms classes = response.getAggregations().get("class");
                 Assert.assertThat(classes.getBuckets().size(), equalTo(2));
                 for (Terms.Bucket classBucket : classes.getBuckets()) {
-                    Map<String, InternalAggregation> aggs = classBucket.getAggregations().asMap();
-                    Assert.assertTrue(aggs.containsKey("sig_terms"));
-                    SignificantTerms agg = (SignificantTerms) aggs.get("sig_terms");
+                    InternalAggregations aggs = classBucket.getAggregations();
+                    Assert.assertNotNull(aggs.get("sig_terms"));
+                    SignificantTerms agg = aggs.get("sig_terms");
                     Assert.assertThat(agg.getBuckets().size(), equalTo(1));
                     SignificantTerms.Bucket sigBucket = agg.iterator().next();
                     String term = sigBucket.getKeyAsString();

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/CentroidAggregationTestBase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/CentroidAggregationTestBase.java
@@ -102,7 +102,7 @@ public abstract class CentroidAggregationTestBase extends AbstractGeoTestCase {
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo((long) numDocs));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 CentroidAggregation geoCentroid = global.getAggregations().get(aggName());
                 InternalAggregation agg = (InternalAggregation) global;

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/SpatialBoundsAggregationTestBase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/SpatialBoundsAggregationTestBase.java
@@ -67,7 +67,7 @@ public abstract class SpatialBoundsAggregationTestBase<T extends SpatialPoint> e
                 assertThat(global.getName(), equalTo("global"));
                 assertThat(global.getDocCount(), equalTo((long) numDocs));
                 assertThat(global.getAggregations(), notNullValue());
-                assertThat(global.getAggregations().asMap().size(), equalTo(1));
+                assertThat(global.getAggregations().asList().size(), equalTo(1));
 
                 SpatialBounds<T> geobounds = global.getAggregations().get(aggName());
                 assertThat(geobounds, notNullValue());

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorTests.java
@@ -270,24 +270,24 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
         }, (Consumer<InternalHistogram>) histo -> {
             assertThat(histo.getBuckets().size(), equalTo(3));
 
-            assertNotNull(histo.getBuckets().get(0).getAggregations().asMap().get("boxplot"));
-            InternalBoxplot boxplot = (InternalBoxplot) histo.getBuckets().get(0).getAggregations().asMap().get("boxplot");
+            assertNotNull(histo.getBuckets().get(0).getAggregations().get("boxplot"));
+            InternalBoxplot boxplot = histo.getBuckets().get(0).getAggregations().get("boxplot");
             assertEquals(1, boxplot.getMin(), 0);
             assertEquals(3, boxplot.getMax(), 0);
             assertEquals(1.5, boxplot.getQ1(), 0);
             assertEquals(2, boxplot.getQ2(), 0);
             assertEquals(2.5, boxplot.getQ3(), 0);
 
-            assertNotNull(histo.getBuckets().get(1).getAggregations().asMap().get("boxplot"));
-            boxplot = (InternalBoxplot) histo.getBuckets().get(1).getAggregations().asMap().get("boxplot");
+            assertNotNull(histo.getBuckets().get(1).getAggregations().get("boxplot"));
+            boxplot = histo.getBuckets().get(1).getAggregations().get("boxplot");
             assertEquals(Double.POSITIVE_INFINITY, boxplot.getMin(), 0);
             assertEquals(Double.NEGATIVE_INFINITY, boxplot.getMax(), 0);
             assertEquals(Double.NaN, boxplot.getQ1(), 0);
             assertEquals(Double.NaN, boxplot.getQ2(), 0);
             assertEquals(Double.NaN, boxplot.getQ3(), 0);
 
-            assertNotNull(histo.getBuckets().get(2).getAggregations().asMap().get("boxplot"));
-            boxplot = (InternalBoxplot) histo.getBuckets().get(2).getAggregations().asMap().get("boxplot");
+            assertNotNull(histo.getBuckets().get(2).getAggregations().get("boxplot"));
+            boxplot = histo.getBuckets().get(2).getAggregations().get("boxplot");
             assertEquals(21, boxplot.getMin(), 0);
             assertEquals(23, boxplot.getMax(), 0);
             assertEquals(21.5, boxplot.getQ1(), 0);
@@ -337,8 +337,8 @@ public class BoxplotAggregatorTests extends AggregatorTestCase {
         }, (Consumer<InternalGlobal>) global -> {
             assertEquals(5, global.getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(global));
-            assertNotNull(global.getAggregations().asMap().get("boxplot"));
-            InternalBoxplot boxplot = (InternalBoxplot) global.getAggregations().asMap().get("boxplot");
+            assertNotNull(global.getAggregations().get("boxplot"));
+            InternalBoxplot boxplot = global.getAggregations().get("boxplot");
             assertThat(global.getProperty("boxplot"), equalTo(boxplot));
             assertThat(global.getProperty("boxplot.min"), equalTo(1.0));
             assertThat(global.getProperty("boxplot.max"), equalTo(5.0));

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/ttest/TTestAggregatorTests.java
@@ -410,20 +410,20 @@ public class TTestAggregatorTests extends AggregatorTestCase {
             );
         }, (Consumer<InternalHistogram>) histo -> {
             assertEquals(3, histo.getBuckets().size());
-            assertNotNull(histo.getBuckets().get(0).getAggregations().asMap().get("t_test"));
-            InternalTTest tTest = (InternalTTest) histo.getBuckets().get(0).getAggregations().asMap().get("t_test");
+            assertNotNull(histo.getBuckets().get(0).getAggregations().get("t_test"));
+            InternalTTest tTest = histo.getBuckets().get(0).getAggregations().get("t_test");
             assertEquals(
                 tTestType == TTestType.PAIRED ? 0.1939778614 : tTestType == TTestType.HOMOSCEDASTIC ? 0.05878871029 : 0.07529006595,
                 tTest.getValue(),
                 0.000001
             );
 
-            assertNotNull(histo.getBuckets().get(1).getAggregations().asMap().get("t_test"));
-            tTest = (InternalTTest) histo.getBuckets().get(1).getAggregations().asMap().get("t_test");
+            assertNotNull(histo.getBuckets().get(1).getAggregations().get("t_test"));
+            tTest = histo.getBuckets().get(1).getAggregations().get("t_test");
             assertEquals(Double.NaN, tTest.getValue(), 0.000001);
 
-            assertNotNull(histo.getBuckets().get(2).getAggregations().asMap().get("t_test"));
-            tTest = (InternalTTest) histo.getBuckets().get(2).getAggregations().asMap().get("t_test");
+            assertNotNull(histo.getBuckets().get(2).getAggregations().get("t_test"));
+            tTest = histo.getBuckets().get(2).getAggregations().get("t_test");
             assertEquals(
                 tTestType == TTestType.PAIRED ? 0.6666666667 : tTestType == TTestType.HOMOSCEDASTIC ? 0.8593081179 : 0.8594865044,
                 tTest.getValue(),
@@ -475,8 +475,8 @@ public class TTestAggregatorTests extends AggregatorTestCase {
         }, (Consumer<InternalGlobal>) global -> {
             assertEquals(3, global.getDocCount());
             assertTrue(AggregationInspectionHelper.hasValue(global));
-            assertNotNull(global.getAggregations().asMap().get("t_test"));
-            InternalTTest tTest = (InternalTTest) global.getAggregations().asMap().get("t_test");
+            assertNotNull(global.getAggregations().get("t_test"));
+            InternalTTest tTest = global.getAggregations().get("t_test");
             assertEquals(tTest, global.getProperty("t_test"));
             assertEquals(0.1939778614, (Double) global.getProperty("t_test.value"), 0.000001);
         }, new AggTestConfig(globalBuilder, fieldType1, fieldType2));

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -1321,7 +1321,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
                     .stream()
                     .filter(agg -> agg.getType().equals("top_hits"))
                     .toList();
-                assertEquals(topHitsDownsampleAggregations.size(), topHitsDownsampleAggregations.size());
+                assertEquals(topHitsOriginalAggregations.size(), topHitsDownsampleAggregations.size());
 
                 for (int j = 0; j < topHitsDownsampleAggregations.size(); ++j) {
                     InternalTopHits originalTopHits = (InternalTopHits) topHitsOriginalAggregations.get(j);

--- a/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/downsample/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -1270,12 +1270,15 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         Map<String, String> labelFields
     ) {
         final AggregationBuilder aggregations = buildAggregations(config, metricFields, labelFields, config.getTimestampField());
-        InternalAggregations origResp = aggregate(sourceIndex, aggregations);
-        InternalAggregations downsampleResp = aggregate(downsampleIndex, aggregations);
-        assertEquals(origResp.asMap().keySet(), downsampleResp.asMap().keySet());
+        List<InternalAggregation> origList = aggregate(sourceIndex, aggregations).asList();
+        List<InternalAggregation> downsampleList = aggregate(downsampleIndex, aggregations).asList();
+        assertEquals(origList.size(), downsampleList.size());
+        for (int i = 0; i < origList.size(); i++) {
+            assertEquals(origList.get(i).getName(), downsampleList.get(i).getName());
+        }
 
-        StringTerms originalTsIdTermsAggregation = (StringTerms) origResp.getAsMap().values().stream().toList().get(0);
-        StringTerms downsampleTsIdTermsAggregation = (StringTerms) downsampleResp.getAsMap().values().stream().toList().get(0);
+        StringTerms originalTsIdTermsAggregation = (StringTerms) origList.get(0);
+        StringTerms downsampleTsIdTermsAggregation = (StringTerms) downsampleList.get(0);
         originalTsIdTermsAggregation.getBuckets().forEach(originalBucket -> {
 
             StringTerms.Bucket downsampleBucket = downsampleTsIdTermsAggregation.getBucketByKey(originalBucket.getKeyAsString());

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -198,7 +198,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
                 + ", docCount="
                 + serializableCategory.getNumMatches()
                 + ", aggregations="
-                + aggregations.asMap()
+                + aggregations.asList()
                 + "}\n";
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -74,7 +74,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
 import org.elasticsearch.search.aggregations.bucket.filter.Filters;
 import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator;
-import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStats;
 import org.elasticsearch.search.aggregations.metrics.Stats;
 import org.elasticsearch.search.aggregations.metrics.TopHits;
@@ -1816,20 +1815,13 @@ public class JobResultsProvider {
                     handler.accept(new ForecastStats());
                     return;
                 }
-                Map<String, InternalAggregation> aggregationsAsMap = aggregations.asMap();
-                StatsAccumulator memoryStats = StatsAccumulator.fromStatsAggregation(
-                    (Stats) aggregationsAsMap.get(ForecastStats.Fields.MEMORY)
-                );
-                Stats aggRecordsStats = (Stats) aggregationsAsMap.get(ForecastStats.Fields.RECORDS);
+                StatsAccumulator memoryStats = StatsAccumulator.fromStatsAggregation(aggregations.get(ForecastStats.Fields.MEMORY));
+                Stats aggRecordsStats = aggregations.get(ForecastStats.Fields.RECORDS);
                 // Stats already gives us all the counts and every doc as a "records" field.
                 long totalHits = aggRecordsStats.getCount();
                 StatsAccumulator recordStats = StatsAccumulator.fromStatsAggregation(aggRecordsStats);
-                StatsAccumulator runtimeStats = StatsAccumulator.fromStatsAggregation(
-                    (Stats) aggregationsAsMap.get(ForecastStats.Fields.RUNTIME)
-                );
-                CountAccumulator statusCount = CountAccumulator.fromTermsAggregation(
-                    (StringTerms) aggregationsAsMap.get(ForecastStats.Fields.STATUSES)
-                );
+                StatsAccumulator runtimeStats = StatsAccumulator.fromStatsAggregation(aggregations.get(ForecastStats.Fields.RUNTIME));
+                CountAccumulator statusCount = CountAccumulator.fromTermsAggregation(aggregations.get(ForecastStats.Fields.STATUSES));
 
                 ForecastStats forecastStats = new ForecastStats(totalHits, memoryStats, recordStats, runtimeStats, statusCount);
                 handler.accept(forecastStats);


### PR DESCRIPTION
This methods are not needed as we have InternalAggregations#get to find aggregations by name.