### PR TITLE
Implement lucene pushdown on ST_DISTANCE for GT and GTE

### DIFF
--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/spatial.csv-spec
@@ -966,6 +966,29 @@ ARN      | Arlanda                 | POINT(17.9307299016916 59.6511203397372) | 
 SVG      | Stavanger Sola          | POINT (5.6298103297218 58.8821564842185) | Norway    | Sandnes         | POINT (5.7361 58.8517)  | 548.26     | 541.35
 ;
 
+airportsWithinDistanceBandFromCopenhagenTrainStation
+required_capability: st_distance
+
+FROM airports
+| WHERE ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")) < 600000
+    AND ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")) > 400000
+| EVAL distance = ROUND(ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)"))/1000,2)
+| EVAL city_distance = ROUND(ST_DISTANCE(city_location, TO_GEOPOINT("POINT(12.565 55.673)"))/1000,2)
+| KEEP abbrev, name, location, country, city, city_location, distance, city_distance
+| SORT distance ASC
+;
+
+abbrev:k | name:text               | location:geo_point                       | country:k | city:k          | city_location:geo_point | distance:d | city_distance:d    
+GDN      | Gdansk Lech Walesa      | POINT(18.4684422165911 54.3807025352925) | Poland    | Gdańsk          | POINT(18.6453 54.3475)  | 402.61     | 414.59
+NYO      | Stockholm-Skavsta       | POINT(16.9216055584254 58.7851041303448) | Sweden    | Nyköping        | POINT(17.0086 58.7531)  | 433.99     | 434.43
+OSL      | Oslo Gardermoen         | POINT(11.0991032762581 60.1935783171386) | Norway    | Oslo            | POINT(10.7389 59.9133)  | 510.03     | 483.71
+DRS      | Dresden                 | POINT(13.7649671440047 51.1250912428871) | Germany   | Dresden         | POINT(13.74 51.05)      | 511.9      | 519.91
+BMA      | Bromma                  | POINT(17.9456175406145 59.3555902065112) | Sweden    | Stockholm       | POINT(18.0686 59.3294)  | 520.18     | 522.54
+PLQ      | Palanga Int'l           | POINT(21.0974463986251 55.9713426235358) | Lithuania | Klaipėda        | POINT(21.1667 55.75)    | 533.67     | 538.56
+ARN      | Arlanda                 | POINT(17.9307299016916 59.6511203397372) | Sweden    | Stockholm       | POINT(18.0686 59.3294)  | 545.09     | 522.54
+SVG      | Stavanger Sola          | POINT (5.6298103297218 58.8821564842185) | Norway    | Sandnes         | POINT (5.7361 58.8517)  | 548.26     | 541.35
+;
+
 airportsWithinDistanceCopenhagenTrainStationCount
 required_capability: st_distance
 
@@ -979,6 +1002,24 @@ count:long | country:k
 3          | Germany
 3          | Sweden
 1          | Denmark
+1          | Poland
+;
+
+airportsWithinDistanceBandCopenhagenTrainStationCount
+required_capability: st_distance
+
+FROM airports
+| WHERE ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")) < 600000
+    AND ST_DISTANCE(location, TO_GEOPOINT("POINT(12.565 55.673)")) > 400000
+| STATS count=COUNT() BY country
+| SORT count DESC, country ASC
+;
+
+count:long | country:k
+3          | Sweden
+2          | Norway
+1          | Germany
+1          | Lithuania
 1          | Poland
 ;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -625,12 +625,15 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
         }
 
         private boolean rewriteComparison(List<Expression> rewritten, StDistance dist, Expression literal, ComparisonType comparisonType) {
-            Object value = literal.fold();
-            if (value instanceof Number number) {
-                if (dist.right().foldable()) {
-                    return rewriteDistanceFilter(rewritten, dist.source(), dist.left(), dist.right(), number, comparisonType);
-                } else if (dist.left().foldable()) {
-                    return rewriteDistanceFilter(rewritten, dist.source(), dist.right(), dist.left(), number, comparisonType);
+            // Currently we do not support Equals
+            if (comparisonType.lt || comparisonType.gt) {
+                Object value = literal.fold();
+                if (value instanceof Number number) {
+                    if (dist.right().foldable()) {
+                        return rewriteDistanceFilter(rewritten, dist.source(), dist.left(), dist.right(), number, comparisonType);
+                    } else if (dist.left().foldable()) {
+                        return rewriteDistanceFilter(rewritten, dist.source(), dist.right(), dist.left(), number, comparisonType);
+                    }
                 }
             }
             return false;
@@ -639,33 +642,28 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
         private boolean rewriteDistanceFilter(
             List<Expression> rewritten,
             Source source,
-            Expression spatialExp,
-            Expression literalExp,
+            Expression spatialExpression,
+            Expression literalExpression,
             Number number,
             ComparisonType comparisonType
         ) {
-            Geometry geometry = SpatialRelatesUtils.makeGeometryFromLiteral(literalExp);
+            Geometry geometry = SpatialRelatesUtils.makeGeometryFromLiteral(literalExpression);
             if (geometry instanceof Point point) {
                 double distance = number.doubleValue();
-                if (comparisonType.lt) {
-                    distance = comparisonType.eq ? distance : Math.nextDown(distance);
-                    rewritten.add(new SpatialIntersects(source, spatialExp, makeCircleLiteral(point, distance, literalExp)));
-                } else if (comparisonType.gt) {
-                    distance = comparisonType.eq ? distance : Math.nextUp(distance);
-                    rewritten.add(new SpatialDisjoint(source, spatialExp, makeCircleLiteral(point, distance, literalExp)));
-                } else if (comparisonType.eq) {
-                    rewritten.add(new SpatialIntersects(source, spatialExp, makeCircleLiteral(point, distance, literalExp)));
-                    rewritten.add(new SpatialDisjoint(source, spatialExp, makeCircleLiteral(point, Math.nextDown(distance), literalExp)));
+                if (comparisonType.eq == false) {
+                    distance = comparisonType.lt ? Math.nextDown(distance) : Math.nextUp(distance);
                 }
+                var circle = new Circle(point.getX(), point.getY(), distance);
+                var wkb = WellKnownBinary.toWKB(circle, ByteOrder.LITTLE_ENDIAN);
+                var cExp = new Literal(literalExpression.source(), new BytesRef(wkb), DataType.GEO_SHAPE);
+                rewritten.add(
+                    comparisonType.lt
+                        ? new SpatialIntersects(source, spatialExpression, cExp)
+                        : new SpatialDisjoint(source, spatialExpression, cExp)
+                );
                 return true;
             }
             return false;
-        }
-
-        private Literal makeCircleLiteral(Point point, double distance, Expression literalExpression) {
-            var circle = new Circle(point.getX(), point.getY(), distance);
-            var wkb = WellKnownBinary.toWKB(circle, ByteOrder.LITTLE_ENDIAN);
-            return new Literal(literalExpression.source(), new BytesRef(wkb), DataType.GEO_SHAPE);
         }
 
         /**

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SpatialRelatesQuery.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/querydsl/query/SpatialRelatesQuery.java
@@ -63,7 +63,7 @@ public class SpatialRelatesQuery extends Query {
 
     @Override
     protected String innerToString() {
-        throw new IllegalArgumentException("SpatialRelatesQuery.innerToString() not implemented");
+        return "field:" + field + ", dataType:" + dataType + ", queryRelation:" + queryRelation + ", shape:" + shape;
     }
 
     @Override

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/optimizer/PhysicalPlanOptimizerTests.java
@@ -3486,7 +3486,7 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             "ST_DISTANCE(TO_GEOPOINT(\"POINT(12.565 55.673)\"), location)" }) {
 
             for (boolean reverse : new Boolean[] { false, true }) {
-                for (String op : new String[] { "<", "<=", ">", ">=" }) {
+                for (String op : new String[] { "<", "<=", ">", ">=", "==" }) {
                     var expected = ExpectedComparison.from(op, reverse, 600000.0);
                     var predicate = reverse ? "600000 " + op + " " + distanceFunction : distanceFunction + " " + op + " 600000";
                     var query = "FROM airports | WHERE " + predicate + " AND scalerank > 1";
@@ -3511,19 +3511,30 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
                     var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
                     assertThat("Expected one range query builder", rangeQueryBuilders.size(), equalTo(1));
                     assertThat(((SingleValueQuery.Builder) rangeQueryBuilders.get(0)).field(), equalTo("scalerank"));
-                    var shapeQueryBuilders = bool.filter()
-                        .stream()
-                        .filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder)
-                        .toList();
-                    assertThat("Expected one shape query builder", shapeQueryBuilders.size(), equalTo(1));
-                    var condition = as(shapeQueryBuilders.get(0), SpatialRelatesQuery.ShapeQueryBuilder.class);
-                    assertThat("Geometry field name", condition.fieldName(), equalTo("location"));
-                    assertThat("Spatial relationship", condition.relation(), equalTo(expected.shapeRelation()));
-                    assertThat("Geometry is Circle", condition.shape().type(), equalTo(ShapeType.CIRCLE));
-                    var circle = as(condition.shape(), Circle.class);
-                    assertThat("Circle center-x", circle.getX(), equalTo(12.565));
-                    assertThat("Circle center-y", circle.getY(), equalTo(55.673));
-                    assertThat("Circle radius for predicate " + predicate, circle.getRadiusMeters(), equalTo(expected.value));
+                    if (op.equals("==")) {
+                        var boolQueryBuilders = bool.filter().stream().filter(p -> p instanceof BoolQueryBuilder).toList();
+                        assertThat("Expected one sub-bool query builder", boolQueryBuilders.size(), equalTo(1));
+                        var bool2 = as(boolQueryBuilders.get(0), BoolQueryBuilder.class);
+                        var shapeQueryBuilders = bool2.must()
+                            .stream()
+                            .filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder)
+                            .toList();
+                        assertShapeQueryRange(shapeQueryBuilders, Math.nextDown(expected.value), expected.value);
+                    } else {
+                        var shapeQueryBuilders = bool.filter()
+                            .stream()
+                            .filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder)
+                            .toList();
+                        assertThat("Expected one shape query builder", shapeQueryBuilders.size(), equalTo(1));
+                        var condition = as(shapeQueryBuilders.get(0), SpatialRelatesQuery.ShapeQueryBuilder.class);
+                        assertThat("Geometry field name", condition.fieldName(), equalTo("location"));
+                        assertThat("Spatial relationship", condition.relation(), equalTo(expected.shapeRelation()));
+                        assertThat("Geometry is Circle", condition.shape().type(), equalTo(ShapeType.CIRCLE));
+                        var circle = as(condition.shape(), Circle.class);
+                        assertThat("Circle center-x", circle.getX(), equalTo(12.565));
+                        assertThat("Circle center-y", circle.getY(), equalTo(55.673));
+                        assertThat("Circle radius for predicate " + predicate, circle.getRadiusMeters(), equalTo(expected.value));
+                    }
                 }
             }
         }
@@ -3559,11 +3570,15 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
         var rangeQueryBuilders = bool.filter().stream().filter(p -> p instanceof SingleValueQuery.Builder).toList();
         assertThat("Expected zero range query builder", rangeQueryBuilders.size(), equalTo(0));
         var shapeQueryBuilders = bool.must().stream().filter(p -> p instanceof SpatialRelatesQuery.ShapeQueryBuilder).toList();
+        assertShapeQueryRange(shapeQueryBuilders, 400000.0, 600000.0);
+    }
+
+    private void assertShapeQueryRange(List<QueryBuilder> shapeQueryBuilders, double min, double max) {
         assertThat("Expected two shape query builders", shapeQueryBuilders.size(), equalTo(2));
         var relationStats = new HashMap<ShapeRelation, Integer>();
         for (var builder : shapeQueryBuilders) {
             var condition = as(builder, SpatialRelatesQuery.ShapeQueryBuilder.class);
-            var expected = condition.relation() == ShapeRelation.INTERSECTS ? 600000.0 : 400000.0;
+            var expected = condition.relation() == ShapeRelation.INTERSECTS ? max : min;
             relationStats.compute(condition.relation(), (r, c) -> c == null ? 1 : c + 1);
             assertThat("Geometry field name", condition.fieldName(), equalTo("location"));
             assertThat("Geometry is Circle", condition.shape().type(), equalTo(ShapeType.CIRCLE));
@@ -3572,6 +3587,9 @@ public class PhysicalPlanOptimizerTests extends ESTestCase {
             assertThat("Circle center-y", circle.getY(), equalTo(55.673));
             assertThat("Circle radius for shape relation " + condition.relation(), circle.getRadiusMeters(), equalTo(expected));
         }
+        assertThat("Expected one INTERSECTS and one DISJOINT", relationStats.size(), equalTo(2));
+        assertThat("Expected one INTERSECTS", relationStats.get(ShapeRelation.INTERSECTS), equalTo(1));
+        assertThat("Expected one DISJOINT", relationStats.get(ShapeRelation.DISJOINT), equalTo(1));
     }
 
     private record ExpectedComparison(Class<? extends EsqlBinaryComparison> comp, double value) {


### PR DESCRIPTION
#108764 created the distance function, but without lucene pushdown to `geo_distance`, this will be slow. In #110102 we implemented Lucene pushdown for the primary use case of `ST_DISTANCE < threshold` (and `<= `), but did not support `>` or `>=`.

Now we do the following:

* Convert LessThan and LessThanOrEquals to `ST_INTERSECTS(circle)`
* Convert GreaterThan and GreaterThanOrEquals to `ST_DISJOINT(circle)`
* Support multiple ST_DISTANCE in the same predicate (eg. querying a band of values)

## Benchmarks

| task | limit\|count | search | ES\|QL count(*) (pushdown) | ES\|QL count(location) (pushdown) | ES\|QL (no pushdown) |
| -- | -- | -- | -- | -- | -- |
| distance <= 400km                  | limit 10   |     7.8     |          5.4           ||  32.5 |
| distance >= 400km                  | limit 10   |     4.9     |          7.3           ||  31.6 |
| distance >= 400km                  | limit 10k |  141.9    |      298.8           ||  51.6 |
| distance <= 100km                   | count      |     3.1     |    4.6   |   17.8    |  11791.8 |
| 100km <= distance <= 200km |  count    |     9.4     |    6.1    | 604.3  |  12344.7 |
| distance <= 200km                   | count      |    6.1     |     6.8   |  636.3  |  11949.6 |
| 200km <= distance <= 300km |  count    |   34.6    |     9.2   | 2023.2 |  12043.0 |
| distance <= 300km                   | count      |    14.8    |    6.8   |  2707.7 | 12772.1 |
| 300km <= distance <= 400km |  count    |    46.5    |   10.4  | 4573.9  | 12539.8 |

It is clear from the benchmarks:

* The pushdown improves performance a lot, often faster than `_search`
* Stats performance depends a lot on whether the `location` field is mentioned in the count function:
  * If the count does not reference the location field, the stats performance is very good, usually faster than `_search`
  * But when we use `count(location)`, it is still much slower than _search, although quite a bit faster than with no pushdown at all

What is interesting with this `count(location)` versus `count(*)` question is that the `_search` API equivalent does mention the location field, while still remaining fast:

```
"aggs": {
  "count": {
    "value_count": {
      "field": "location"
    }
  }
}
```

It would be interesting for a followup investigation to understand how this is, and if we can benefit similarly with ES|QL. Perhaps it is to use doc-values?