### PR TITLE
Fix CoordinatorVotingConfigurationTests.testClusterUUIDLogging

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -1,7 +1,4 @@
 tests:
-- class: "org.elasticsearch.cluster.coordination.CoordinatorVotingConfigurationTests"
-  issue: "https://github.com/elastic/elasticsearch/issues/108729"
-  method: "testClusterUUIDLogging"
 - class: "org.elasticsearch.xpack.textstructure.structurefinder.TimestampFormatFinderTests"
   issue: "https://github.com/elastic/elasticsearch/issues/108855"
   method: "testGuessIsDayFirstFromLocale"


### PR DESCRIPTION
Fix CoordinatorVotingConfigurationTests.testClusterUUIDLogging to add log expectation before creating cluster.

When randomly picking a single node cluster, the cluster is formed before adding the log expectation and the expected log line can't be observed any more.

Caused by the recent changes to MockLog appender (https://github.com/elastic/elasticsearch/pull/108206)

Fixes #108729