### PR TITLE
Fixing RankFeature tests in SearchServiceTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -596,7 +596,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             // execute fetch phase and perform any validations once we retrieve the response
             // the difference in how we do assertions here is needed because once the transport service sends back the response
             // it decrements the reference to the FetchSearchResult (through the ActionListener#respondAndRelease) and sets hits to null
-            service.executeFetchPhase(fetchRequest, searchTask, new ActionListener<>() {
+            PlainActionFuture<FetchSearchResult> fetchListener = new PlainActionFuture<>() {
                 @Override
                 public void onResponse(FetchSearchResult fetchSearchResult) {
                     assertNotNull(fetchSearchResult);
@@ -610,13 +610,17 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
                         assertNotNull(hit.getFields().get(fetchFieldName));
                         assertEquals(hit.getFields().get(fetchFieldName).getValue(), fetchFieldValue + "_" + hit.docId());
                     }
+                    super.onResponse(fetchSearchResult);
                 }
 
                 @Override
                 public void onFailure(Exception e) {
+                    super.onFailure(e);
                     throw new AssertionError("No failure should have been raised", e);
                 }
-            });
+            };
+            service.executeFetchPhase(fetchRequest, searchTask, fetchListener);
+            fetchListener.get();
         } catch (Exception ex) {
             if (queryResult != null) {
                 if (queryResult.hasReferences()) {


### PR DESCRIPTION
While looking into https://github.com/elastic/elasticsearch/issues/109830, I noticed that there was an issue in `SearchServiceTests#testRankFeaturePhaseSearchPhases`, as the evaluation and assertions of the fetch phase results could take place after the `after` methods for the test cases are invoked. 