### PR TITLE
Disallow duplicate LTR feature extractors

### DIFF
--- a/docs/changelog/110266.yaml
+++ b/docs/changelog/110266.yaml
@@ -1,0 +1,5 @@
+pr: 110266
+summary: Disallow duplicate LTR feature extractors
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlLearningToRankRescorerIT.java
+++ b/x-pack/plugin/ml/qa/basic-multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlLearningToRankRescorerIT.java
@@ -357,7 +357,7 @@ public class MlLearningToRankRescorerIT extends ESRestTestCase {
                   "feature_extractors": [
                     {
                       "query_extractor": {
-                        "feature_name": "cost",
+                        "feature_name": "cost_feature",
                         "query": {
                           "script_score": {
                             "query": { "match_all": {} },
@@ -372,12 +372,12 @@ public class MlLearningToRankRescorerIT extends ESRestTestCase {
               "definition": {
                 "trained_model": {
                   "ensemble": {
-                    "feature_names": ["cost"],
+                    "feature_names": ["cost_feature"],
                     "target_type": "regression",
                     "trained_models": [
                       {
                         "tree": {
-                          "feature_names": ["cost"],
+                          "feature_names": ["cost_feature"],
                           "tree_structure": [
                             {
                               "node_index": 0,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorer.java
@@ -56,6 +56,12 @@ public class LearningToRankRescorer implements Rescorer {
             throw new IllegalStateException("local model reference is null, missing rewriteAndFetch before rescore phase?");
         }
 
+        // Check for duplicate QueryFeatureExtractor and FieldValueFeatureExtractor
+        // This is a temporary fix to prevent duplicate feature extractors from being created
+        if (ltrRescoreContext.hasDuplicateFeatureExtractors()) {
+            throw new IllegalArgumentException("Duplicate feature extractors found in the LTR model");
+        }
+
         LocalModel definition = ltrRescoreContext.regressionModelDefinition;
 
         // Because scores of the first-pass query and the LTR model are not comparable, there is no way to combine the results.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorer.java
@@ -56,12 +56,6 @@ public class LearningToRankRescorer implements Rescorer {
             throw new IllegalStateException("local model reference is null, missing rewriteAndFetch before rescore phase?");
         }
 
-        // Check for duplicate QueryFeatureExtractor and FieldValueFeatureExtractor
-        // This is a temporary fix to prevent duplicate feature extractors from being created
-        if (ltrRescoreContext.hasDuplicateFeatureExtractors()) {
-            throw new IllegalArgumentException("Duplicate feature extractors found in the LTR model");
-        }
-
         LocalModel definition = ltrRescoreContext.regressionModelDefinition;
 
         // Because scores of the first-pass query and the LTR model are not comparable, there is no way to combine the results.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerContext.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.function.Predicate.not;
+
 public class LearningToRankRescorerContext extends RescoreContext {
 
     final SearchExecutionContext executionContext;
@@ -53,11 +55,6 @@ public class LearningToRankRescorerContext extends RescoreContext {
     List<FeatureExtractor> buildFeatureExtractors(IndexSearcher searcher) throws IOException {
         assert this.regressionModelDefinition != null && this.learningToRankConfig != null;
         List<FeatureExtractor> featureExtractors = new ArrayList<>();
-        if (this.regressionModelDefinition.inputFields().isEmpty() == false) {
-            featureExtractors.add(
-                new FieldValueFeatureExtractor(new ArrayList<>(this.regressionModelDefinition.inputFields()), this.executionContext)
-            );
-        }
         List<Weight> weights = new ArrayList<>();
         List<String> queryFeatureNames = new ArrayList<>();
         for (LearningToRankFeatureExtractorBuilder featureExtractorBuilder : learningToRankConfig.getFeatureExtractorBuilders()) {
@@ -70,6 +67,14 @@ public class LearningToRankRescorerContext extends RescoreContext {
         }
         if (weights.isEmpty() == false) {
             featureExtractors.add(new QueryFeatureExtractor(queryFeatureNames, weights));
+        }
+
+        List<String> fieldValueExtractorFields = this.regressionModelDefinition.inputFields()
+            .stream()
+            .filter(not(queryFeatureNames::contains))
+            .toList();
+        if (fieldValueExtractorFields.isEmpty() == false) {
+            featureExtractors.add(new FieldValueFeatureExtractor(fieldValueExtractorFields, this.executionContext));
         }
 
         return featureExtractors;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerContext.java
@@ -50,16 +50,21 @@ public class LearningToRankRescorerContext extends RescoreContext {
         this.executionContext = executionContext;
         this.regressionModelDefinition = regressionModelDefinition;
         this.learningToRankConfig = learningToRankConfig;
+
+        validateUniqueFeatureExtractors();
     }
 
-    boolean hasDuplicateFeatureExtractors() {
+    // TODO Temporary workaround to the issue of duplicate feature extractors - disallow them for now until we can find a better solution
+    private void validateUniqueFeatureExtractors() {
         Set<String> queryFeatureNames = learningToRankConfig.getFeatureExtractorBuilders()
             .stream()
             .filter(b -> b instanceof QueryExtractorBuilder)
             .map(LearningToRankFeatureExtractorBuilder::featureName)
             .collect(Collectors.toSet());
 
-        return regressionModelDefinition.inputFields().stream().anyMatch(queryFeatureNames::contains);
+        if (regressionModelDefinition.inputFields().stream().anyMatch(queryFeatureNames::contains)) {
+            throw new IllegalArgumentException("Duplicate feature extractors found in the query and the model definition");
+        }
     }
 
     List<FeatureExtractor> buildFeatureExtractors(IndexSearcher searcher) throws IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerContext.java
@@ -62,7 +62,7 @@ public class LearningToRankRescorerContext extends RescoreContext {
             .map(LearningToRankFeatureExtractorBuilder::featureName)
             .collect(Collectors.toSet());
 
-        if (regressionModelDefinition.inputFields().stream().anyMatch(queryFeatureNames::contains)) {
+        if (regressionModelDefinition != null && regressionModelDefinition.inputFields().stream().anyMatch(queryFeatureNames::contains)) {
             throw new IllegalArgumentException("Duplicate feature extractors found in the query and the model definition");
         }
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilderRewriteTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankRescorerBuilderRewriteTests.java
@@ -37,6 +37,7 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.LearningToR
 import static org.elasticsearch.xpack.ml.inference.ltr.LearningToRankServiceTests.BAD_MODEL;
 import static org.elasticsearch.xpack.ml.inference.ltr.LearningToRankServiceTests.GOOD_MODEL;
 import static org.elasticsearch.xpack.ml.inference.ltr.LearningToRankServiceTests.GOOD_MODEL_CONFIG;
+import static org.elasticsearch.xpack.ml.inference.ltr.LearningToRankServiceTests.MODEL_WITH_DUPS_CONFIG;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -220,7 +221,7 @@ public class LearningToRankRescorerBuilderRewriteTests extends AbstractBuilderTe
 
     public void testThatDuplicateFeaturesAreDisallowed() throws Exception {
         LocalModel localModel = mock(LocalModel.class);
-        when(localModel.inputFields()).thenReturn(GOOD_MODEL_CONFIG.getInput().getFieldNames());
+        when(localModel.inputFields()).thenReturn(MODEL_WITH_DUPS_CONFIG.getInput().getFieldNames());
 
         IndexSearcher searcher = mock(IndexSearcher.class);
         doAnswer(invocation -> invocation.getArgument(0)).when(searcher).rewrite(any(Query.class));
@@ -228,7 +229,7 @@ public class LearningToRankRescorerBuilderRewriteTests extends AbstractBuilderTe
 
         LearningToRankRescorerBuilder rescorerBuilder = new LearningToRankRescorerBuilder(
             localModel,
-            (LearningToRankConfig) GOOD_MODEL_CONFIG.getInferenceConfig(),
+            (LearningToRankConfig) MODEL_WITH_DUPS_CONFIG.getInferenceConfig(),
             null,
             mock(LearningToRankService.class)
         );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankServiceTests.java
@@ -54,7 +54,7 @@ public class LearningToRankServiceTests extends ESTestCase {
     public static final String BAD_MODEL = "badModel";
     public static final TrainedModelConfig GOOD_MODEL_CONFIG = TrainedModelConfig.builder()
         .setModelId(GOOD_MODEL)
-        .setInput(new TrainedModelInput(List.of("field1", "field2")))
+        .setInput(new TrainedModelInput(List.of("field1", "field2", "feature_1", "feature_2")))
         .setEstimatedOperations(1)
         .setModelSize(2)
         .setModelType(TrainedModelType.TREE_ENSEMBLE)

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ltr/LearningToRankServiceTests.java
@@ -52,9 +52,11 @@ import static org.mockito.Mockito.verify;
 public class LearningToRankServiceTests extends ESTestCase {
     public static final String GOOD_MODEL = "inferenceEntityId";
     public static final String BAD_MODEL = "badModel";
+    public static final String MODEL_WITH_DUPS = "modelConfigWithDups";
+
     public static final TrainedModelConfig GOOD_MODEL_CONFIG = TrainedModelConfig.builder()
         .setModelId(GOOD_MODEL)
-        .setInput(new TrainedModelInput(List.of("field1", "field2", "feature_1", "feature_2")))
+        .setInput(new TrainedModelInput(List.of("field1", "field2")))
         .setEstimatedOperations(1)
         .setModelSize(2)
         .setModelType(TrainedModelType.TREE_ENSEMBLE)
@@ -76,6 +78,23 @@ public class LearningToRankServiceTests extends ESTestCase {
         .setModelSize(2)
         .setModelType(TrainedModelType.TREE_ENSEMBLE)
         .setInferenceConfig(new RegressionConfig(null, null))
+        .build();
+    public static final TrainedModelConfig MODEL_WITH_DUPS_CONFIG = TrainedModelConfig.builder()
+        .setModelId(MODEL_WITH_DUPS)
+        .setInput(new TrainedModelInput(List.of("field1", "field2", "feature_1", "feature_2")))
+        .setEstimatedOperations(1)
+        .setModelSize(2)
+        .setModelType(TrainedModelType.TREE_ENSEMBLE)
+        .setInferenceConfig(
+            new LearningToRankConfig(
+                2,
+                List.of(
+                    new QueryExtractorBuilder("feature_1", QueryProviderTests.createTestQueryProvider("field_1", "foo")),
+                    new QueryExtractorBuilder("feature_2", QueryProviderTests.createTestQueryProvider("field_2", "bar"))
+                ),
+                Map.of()
+            )
+        )
         .build();
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Replaces https://github.com/elastic/elasticsearch/pull/109437

With the following LTR config cause the feature `quantity` to be extracted twice:

```
    "input": {
        "field_names": [
          "quantity"
        ]
      },
    "inference_config": {
      "learning_to_rank": {
        "num_top_feature_importance_values": 0,
        "feature_extractors": [
            {
              "query_extractor": {
                "feature_name": "quantity",
                "query": {
                  "script_score": {
                    "query": {"exists": { "field": "quantity"} },
                    "script": { "source": "return field('quantity').get(0);" }
                  }
                }
              }
            }
        ]
     }
  }
```

First, it is extracted using the `QueryFeatureExtractor` which is expected.
Then it is extracted using the `FieldValueFeatureExtractor`.

This PR disallows this behavior by throwing an `IllegalArgumentException` in the case of duplicate query feature extractor and field value feature extractor names. 



