### PR TITLE
Pass over Sparse Vector docs for correctness

### DIFF
--- a/docs/reference/ingest/search-nlp-tutorial.asciidoc
+++ b/docs/reference/ingest/search-nlp-tutorial.asciidoc
@@ -256,4 +256,3 @@ In this guide, we covered how to:
 * {ml-docs}/ml-nlp-deploy-models.html[Deploying a model ML guide^]
 * {ml-docs}/ml-nlp-import-model.html#ml-nlp-authentication[Eland Authentication methods^]
 * <<ingest-pipeline-search-inference-add-inference-processors,Adding inference pipelines>>
-// * <<elser-text-expansion,Using ELSER for text expansion>>

--- a/docs/reference/mapping/types/sparse-vector.asciidoc
+++ b/docs/reference/mapping/types/sparse-vector.asciidoc
@@ -94,6 +94,6 @@ Negative values will be rejected.
 NOTE: `sparse_vector` fields do not support querying, sorting or aggregating.
 They may only be used within specialized queries.
 The recommended query to use on these fields are <<query-dsl-sparse-vector-query, `sparse_vector`>> queries.
-They may also be used within <<query-dsl-text-expansion-query,`text_expansion`>> queries.
+They may also be used within legacy <<query-dsl-text-expansion-query,`text_expansion`>> queries.
 
 NOTE: `sparse_vector` fields only preserve 9 significant bits for the precision, which translates to a relative error of about 0.4%.

--- a/docs/reference/query-dsl/sparse-vector-query.asciidoc
+++ b/docs/reference/query-dsl/sparse-vector-query.asciidoc
@@ -21,6 +21,30 @@ For example, a stored vector `{"feature_0": 0.12, "feature_1": 1.2, "feature_2":
 [[sparse-vector-query-ex-request]]
 === Example request using an {nlp} model
 
+////
+[source, console]
+--------------------------------------------------
+PUT index1
+{
+  "mappings": {
+    "properties": {
+      "image-vector": {
+        "type": "dense_vector",
+        "dims": 3
+      }
+    }
+  }
+}
+--------------------------------------------------
+// TESTSETUP
+
+[source,console]
+--------------------------------------------------
+DELETE index1
+--------------------------------------------------
+// TEARDOWN
+////
+
 [source,console]
 ----
 GET _search
@@ -57,33 +81,33 @@ GET _search
 [[sparse-vector-field-params]]
 === Top level parameters for `sparse_vector`
 
-`<field>`:::
-(Required, object) The name of the field that contains the token-weight pairs to be searched against.
+`field`::
+(Required, string) The name of the field that contains the token-weight pairs to be searched against.
 
-`inference_id`::::
+`inference_id`::
 (Optional, string) The <<inference-apis,inference ID>> to use to convert the query text into token-weight pairs.
 It must be the same inference ID that was used to create the tokens from the input text.
 Only one of `inference_id` and `query_vector` is allowed.
 If `inference_id` is specified, `query` must also be specified.
 
-`query`::::
+`query`::
 (Optional, string) The query text you want to use for search.
 If `inference_id` is specified, `query` must also be specified.
 If `query_vector` is specified, `query` must not be specified.
 
-`query_vector`::::
+`query_vector`::
 (Optional, dictionary) A dictionary of token-weight pairs representing the precomputed query vector to search.
 Searching using this query vector will bypass additional inference.
 Only one of `inference_id` and `query_vector` is allowed.
 
-`prune` ::::
+`prune` ::
 (Optional, boolean)
 preview:[]
 Whether to perform pruning, omitting the non-significant tokens from the query to improve query performance.
 If `prune` is true but the `pruning_config` is not specified, pruning will occur but default values will be used.
 Default: false.
 
-`pruning_config` ::::
+`pruning_config` ::
 (Optional, object)
 preview:[]
 Optional pruning configuration.
@@ -92,7 +116,7 @@ This is only used if `prune` is set to `true`.
 If `prune` is set to `true` but `pruning_config` is not specified, default values will be used.
 +
 --
-Parameters for `<pruning_config>` are:
+Parameters for `pruning_config` are:
 
 `tokens_freq_ratio_threshold`::
 (Optional, integer)
@@ -139,24 +163,6 @@ GET my-index/_search
 }
 ----
 // TEST[skip: Requires inference]
-
-[[sparse-vector-query-with-query-vectors-example]]
-=== Example sparse_vector query using query vectors
-
-An alternate way to search is with precomputed query vectors to search without performing inference at search time, for example:
-
-[source,console]
-----
-GET my-index/_search
-{
-   "query":{
-      "sparse_vector": {
-         "field": "ml.tokens",
-         "query_vector": { "token1": 0.5, "token2": 0.3, "token3": 0.2 }
-      }
-   }
-}
-----
 
 Multiple `sparse_vector` queries can be combined with each other or other query types.
 This can be achieved by wrapping them in <<query-dsl-bool-query, boolean query clauses>> and using linear boosting:

--- a/docs/reference/query-dsl/sparse-vector-query.asciidoc
+++ b/docs/reference/query-dsl/sparse-vector-query.asciidoc
@@ -69,6 +69,12 @@ If `inference_id` is specified, `query` must also be specified.
 `query`::::
 (Optional, string) The query text you want to use for search.
 If `inference_id` is specified, `query` must also be specified.
+If `query_vector` is specified, `query` must not be specified.
+
+`query_vector`::::
+(Optional, dictionary) A dictionary of token-weight pairs representing the precomputed query vector to search.
+Searching using this query vector will bypass additional inference.
+Only one of `inference_id` and `query_vector` is allowed.
 
 `prune` ::::
 (Optional, boolean)
@@ -133,6 +139,24 @@ GET my-index/_search
 }
 ----
 // TEST[skip: Requires inference]
+
+[[sparse-vector-query-with-query-vectors-example]]
+=== Example sparse_vector query using query vectors
+
+An alternate way to search is with precomputed query vectors to search without performing inference at search time, for example:
+
+[source,console]
+----
+GET my-index/_search
+{
+   "query":{
+      "sparse_vector": {
+         "field": "ml.tokens",
+         "query_vector": { "token1": 0.5, "token2": 0.3, "token3": 0.2 }
+      }
+   }
+}
+----
 
 Multiple `sparse_vector` queries can be combined with each other or other query types.
 This can be achieved by wrapping them in <<query-dsl-bool-query, boolean query clauses>> and using linear boosting:
@@ -285,3 +309,5 @@ GET my-index/_search
 //TEST[skip: Requires inference]
 
 NOTE: When performing <<modules-cross-cluster-search, cross-cluster search>>, inference is performed on the local cluster.
+
+

--- a/docs/reference/query-dsl/sparse-vector-query.asciidoc
+++ b/docs/reference/query-dsl/sparse-vector-query.asciidoc
@@ -21,30 +21,6 @@ For example, a stored vector `{"feature_0": 0.12, "feature_1": 1.2, "feature_2":
 [[sparse-vector-query-ex-request]]
 === Example request using an {nlp} model
 
-////
-[source, console]
---------------------------------------------------
-PUT index1
-{
-  "mappings": {
-    "properties": {
-      "image-vector": {
-        "type": "dense_vector",
-        "dims": 3
-      }
-    }
-  }
-}
---------------------------------------------------
-// TESTSETUP
-
-[source,console]
---------------------------------------------------
-DELETE index1
---------------------------------------------------
-// TEARDOWN
-////
-
 [source,console]
 ----
 GET _search

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -325,7 +325,7 @@ PUT my-index
 
 [NOTE]
 ====
-Depending on your data, the text expansion query may be faster with `track_total_hits: false`.
+Depending on your data, the `sparse_vector` query may be faster with `track_total_hits: false`.
 ====
 
 [discrete]

--- a/docs/reference/search/search-your-data/semantic-search.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search.asciidoc
@@ -1,13 +1,12 @@
 [[semantic-search]]
 == Semantic search
 
-Semantic search is a search method that helps you find data based on the intent and contextual meaning of a search query, instead of a match on query terms
-(lexical search).
+Semantic search is a search method that helps you find data based on the intent and contextual meaning of a search query, instead of a match on query terms (lexical search).
 
 {es} provides various semantic search capabilities using {ml-docs}/ml-nlp.html[natural language processing (NLP)] and vector search.
 Using an NLP model enables you to extract text embeddings out of text.
 Embeddings are vectors that provide a numeric representation of a text.
-Pieces of content with similar meaning have similar representations. 
+Pieces of content with similar meaning have similar representations.
 NLP models can be used in the {stack} various ways, you can:
 
 * deploy models in {es}
@@ -29,44 +28,32 @@ IMPORTANT: For the easiest way to perform semantic search in the {stack}, refer 
 [[semantic-search-select-nlp-model]]
 === Select an NLP model
 
-{es} offers the usage of a 
-{ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[wide range of NLP models], 
-including both dense and sparse vector models. Your choice of the language model 
-is critical for implementing semantic search successfully.
+{es} offers the usage of a
+{ml-docs}/ml-nlp-model-ref.html#ml-nlp-model-ref-text-embedding[wide range of NLP models], including both dense and sparse vector models.
+Your choice of the language model is critical for implementing semantic search successfully.
 
-While it is possible to bring your own text embedding model, achieving good 
-search results through model tuning is challenging. Selecting an appropriate 
-model from our third-party model list is the first step. Training the model on 
-your own data is essential to ensure better search results than using only BM25. 
-However, the model training process requires a team of data scientists and ML 
-experts, making it expensive and time-consuming.
+While it is possible to bring your own text embedding model, achieving good search results through model tuning is challenging.
+Selecting an appropriate model from our third-party model list is the first step.
+Training the model on your own data is essential to ensure better search results than using only BM25.
+However, the model training process requires a team of data scientists and ML experts, making it expensive and time-consuming.
 
-To address this issue, Elastic provides a pre-trained representational model 
-called {ml-docs}/ml-nlp-elser.html[Elastic Learned Sparse EncodeR (ELSER)]. 
-ELSER, currently available only for English, is an out-of-domain sparse vector 
-model that does not require fine-tuning. This adaptability makes it suitable for 
-various NLP use cases out of the box. Unless you have a team of ML specialists, 
-it is highly recommended to use the ELSER model.
+To address this issue, Elastic provides a pre-trained representational model called {ml-docs}/ml-nlp-elser.html[Elastic Learned Sparse EncodeR (ELSER)].
+ELSER, currently available only for English, is an out-of-domain sparse vector model that does not require fine-tuning.
+This adaptability makes it suitable for various NLP use cases out of the box.
+Unless you have a team of ML specialists, it is highly recommended to use the ELSER model.
 
-In the case of sparse vector representation, the vectors mostly consist of zero 
-values, with only a small subset containing non-zero values. This representation 
-is commonly used for textual data. In the case of ELSER, each document in an 
-index and the query text itself are represented by high-dimensional sparse 
-vectors. Each non-zero element of the vector corresponds to a term in the model 
-vocabulary. The ELSER vocabulary contains around 30000 terms, so the sparse 
-vectors created by ELSER contain about 30000 values, the majority of which are 
-zero. Effectively the ELSER model is replacing the terms in the original query 
-with other terms that have been learnt to exist in the documents that best match 
-the original search terms in a training dataset, and weights to control how 
-important each is.
-
+In the case of sparse vector representation, the vectors mostly consist of zero values, with only a small subset containing non-zero values.
+This representation is commonly used for textual data.
+In the case of ELSER, each document in an index and the query text itself are represented by high-dimensional sparse vectors.
+Each non-zero element of the vector corresponds to a term in the model vocabulary.
+The ELSER vocabulary contains around 30000 terms, so the sparse vectors created by ELSER contain about 30000 values, the majority of which are zero.
+Effectively the ELSER model is replacing the terms in the original query with other terms that have been learnt to exist in the documents that best match the original search terms in a training dataset, and weights to control how important each is.
 
 [discrete]
 [[semantic-search-deploy-nlp-model]]
 === Deploy the model
 
-After you decide which model you want to use for implementing semantic search, 
-you need to deploy the model in {es}.
+After you decide which model you want to use for implementing semantic search, you need to deploy the model in {es}.
 
 include::{es-ref-dir}/tab-widgets/semantic-search/deploy-nlp-model-widget.asciidoc[]
 
@@ -74,9 +61,8 @@ include::{es-ref-dir}/tab-widgets/semantic-search/deploy-nlp-model-widget.asciid
 [[semantic-search-field-mappings]]
 === Map a field for the text embeddings
 
-Before you start using the deployed model to generate embeddings based on your 
-input text, you need to prepare your index mapping first. The mapping of the 
-index depends on the type of model.
+Before you start using the deployed model to generate embeddings based on your input text, you need to prepare your index mapping first.
+The mapping of the index depends on the type of model.
 
 include::{es-ref-dir}/tab-widgets/semantic-search/field-mappings-widget.asciidoc[]
 
@@ -84,14 +70,12 @@ include::{es-ref-dir}/tab-widgets/semantic-search/field-mappings-widget.asciidoc
 [[semantic-search-generate-embeddings]]
 === Generate text embeddings
 
-Once you have created the mappings for the index, you can generate text 
-embeddings from your input text. This can be done by using an 
-<<ingest,ingest pipeline>> with an <<inference-processor,inference processor>>. 
-The ingest pipeline processes the input data and indexes it into the destination 
-index. At index time, the inference ingest processor uses the trained model to 
-infer against the data ingested through the pipeline. After you created the 
-ingest pipeline with the inference processor, you can ingest your data through 
-it to generate the model output.
+Once you have created the mappings for the index, you can generate text embeddings from your input text.
+This can be done by using an
+<<ingest,ingest pipeline>> with an <<inference-processor,inference processor>>.
+The ingest pipeline processes the input data and indexes it into the destination index.
+At index time, the inference ingest processor uses the trained model to infer against the data ingested through the pipeline.
+After you created the ingest pipeline with the inference processor, you can ingest your data through it to generate the model output.
 
 include::{es-ref-dir}/tab-widgets/semantic-search/generate-embeddings-widget.asciidoc[]
 
@@ -101,8 +85,7 @@ Now it is time to perform semantic search!
 [[semantic-search-search]]
 === Search the data
 
-Depending on the type of model you have deployed, you can query rank features 
-with a text expansion query, or dense vectors with a kNN search.
+Depending on the type of model you have deployed, you can query rank features with a <<query-dsl-sparse-vector-query, sparse vector>> query, or dense vectors with a kNN search.
 
 include::{es-ref-dir}/tab-widgets/semantic-search/search-widget.asciidoc[]
 
@@ -110,13 +93,12 @@ include::{es-ref-dir}/tab-widgets/semantic-search/search-widget.asciidoc[]
 [[semantic-search-hybrid-search]]
 === Beyond semantic search with hybrid search
 
-In some situations, lexical search may perform better than semantic search. For
-example, when searching for single words or IDs, like product numbers.
+In some situations, lexical search may perform better than semantic search.
+For example, when searching for single words or IDs, like product numbers.
 
 Combining semantic and lexical search into one hybrid search request using
-<<rrf,reciprocal rank fusion>> provides the best of both worlds. Not only that,
-but hybrid search using reciprocal rank fusion {blog-ref}improving-information-retrieval-elastic-stack-hybrid[has been shown to perform better
-in general].
+<<rrf,reciprocal rank fusion>> provides the best of both worlds.
+Not only that, but hybrid search using reciprocal rank fusion {blog-ref}improving-information-retrieval-elastic-stack-hybrid[has been shown to perform better in general].
 
 include::{es-ref-dir}/tab-widgets/semantic-search/hybrid-search-widget.asciidoc[]
 


### PR DESCRIPTION
Docs PR for `sparse_vector` query: 

- Adds a missing param, `query_vector` 
- Fixes some formatting errors
- Removes any remaining legacy pointers to `text_expansion` query that don't list it as legacy or deprecated.
