### PR TITLE
[8.14] Tolerate floating point precision in multi node tests (#110238)

### DIFF
--- a/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/mixed-cluster/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/mixed/MixedClusterEsqlSpecIT.java
@@ -73,4 +73,9 @@ public class MixedClusterEsqlSpecIT extends EsqlSpecTestCase {
     protected boolean supportsAsync() {
         return oldClusterHasFeature(ASYNC_QUERY_FEATURE_ID);
     }
+
+    @Override
+    protected boolean enableRoundingDoubleValuesOnAsserting() {
+        return true;
+    }
 }

--- a/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-clusters/src/javaRestTest/java/org/elasticsearch/xpack/esql/ccq/MultiClusterSpecIT.java
@@ -231,4 +231,9 @@ public class MultiClusterSpecIT extends EsqlSpecTestCase {
         }
         return false;
     }
+
+    @Override
+    protected boolean enableRoundingDoubleValuesOnAsserting() {
+        return true;
+    }
 }

--- a/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/multi_node/EsqlSpecIT.java
@@ -24,4 +24,9 @@ public class EsqlSpecIT extends EsqlSpecTestCase {
     public EsqlSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, Mode mode) {
         super(fileName, groupName, testName, lineNumber, testCase, mode);
     }
+
+    @Override
+    protected boolean enableRoundingDoubleValuesOnAsserting() {
+        return true;
+    }
 }

--- a/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
+++ b/x-pack/plugin/esql/qa/server/src/main/java/org/elasticsearch/xpack/esql/qa/rest/EsqlSpecTestCase.java
@@ -30,6 +30,9 @@ import org.junit.AfterClass;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -187,10 +190,10 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
         Logger logger
     ) {
         assertMetadata(expected, actualColumns, logger);
-        assertData(expected, actualValues, testCase.ignoreOrder, logger, EsqlSpecTestCase::valueMapper);
+        assertData(expected, actualValues, testCase.ignoreOrder, logger, this::valueMapper);
     }
 
-    private static Object valueMapper(CsvTestUtils.Type type, Object value) {
+    private Object valueMapper(CsvTestUtils.Type type, Object value) {
         if (value == null) {
             return "null";
         }
@@ -205,7 +208,28 @@ public abstract class EsqlSpecTestCase extends ESRestTestCase {
                 } catch (Throwable ignored) {}
             }
         }
+        if (type == CsvTestUtils.Type.DOUBLE && enableRoundingDoubleValuesOnAsserting()) {
+            if (value instanceof List<?> vs) {
+                List<Object> values = new ArrayList<>();
+                for (Object v : vs) {
+                    values.add(valueMapper(type, v));
+                }
+                return values;
+            } else if (value instanceof Double d) {
+                return new BigDecimal(d).round(new MathContext(10, RoundingMode.DOWN)).doubleValue();
+            } else if (value instanceof String s) {
+                return new BigDecimal(s).round(new MathContext(10, RoundingMode.DOWN)).doubleValue();
+            }
+        }
         return value.toString();
+    }
+
+    /**
+     * Rounds double values when asserting double values returned in queries.
+     * By default, no rounding is performed.
+     */
+    protected boolean enableRoundingDoubleValuesOnAsserting() {
+        return false;
     }
 
     private static String normalizedPoint(CsvTestUtils.Type type, double x, double y) {


### PR DESCRIPTION
Backports the following commits to 8.14:
 - Tolerate floating point precision in multi node tests (#110238)