### PR TITLE
Fix Semantic Text Test Failures

### DIFF
--- a/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
+++ b/x-pack/plugin/inference/qa/test-service-plugin/src/main/java/org/elasticsearch/xpack/inference/mock/TestDenseInferenceServiceExtension.java
@@ -215,6 +215,12 @@ public class TestDenseInferenceServiceExtension implements InferenceServiceExten
 
         static final String NAME = "test_text_embedding_service_settings";
 
+        public TestServiceSettings {
+            if (elementType == DenseVectorFieldMapper.ElementType.BIT) {
+                throw new IllegalArgumentException("Test dense inference service does not yet support element type BIT");
+            }
+        }
+
         public static TestServiceSettings fromMap(Map<String, Object> map) {
             ValidationException validationException = new ValidationException();
 

--- a/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
+++ b/x-pack/plugin/inference/src/internalClusterTest/java/org/elasticsearch/xpack/inference/action/filter/ShardBulkInferenceActionFilterIT.java
@@ -47,7 +47,8 @@ public class ShardBulkInferenceActionFilterIT extends ESIntegTestCase {
             randomIntBetween(1, 100),
             // dot product means that we need normalized vectors; it's not worth doing that in this test
             randomValueOtherThan(SimilarityMeasure.DOT_PRODUCT, () -> randomFrom(SimilarityMeasure.values())),
-            randomFrom(DenseVectorFieldMapper.ElementType.values())
+            // TODO: Allow element type BIT once TestDenseInferenceServiceExtension supports it
+            randomValueOtherThan(DenseVectorFieldMapper.ElementType.BIT, () -> randomFrom(DenseVectorFieldMapper.ElementType.values()))
         );
     }
 

--- a/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
+++ b/x-pack/plugin/inference/src/test/java/org/elasticsearch/xpack/inference/queries/SemanticQueryBuilderTests.java
@@ -96,7 +96,10 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
         // These are class variables because they are used when initializing additional mappings, which happens once per test suite run in
         // AbstractBuilderTestCase#beforeTest as part of service holder creation.
         inferenceResultType = randomFrom(InferenceResultType.values());
-        denseVectorElementType = randomFrom(DenseVectorFieldMapper.ElementType.values());
+        denseVectorElementType = randomValueOtherThan(
+            DenseVectorFieldMapper.ElementType.BIT,
+            () -> randomFrom(DenseVectorFieldMapper.ElementType.values())
+        ); // TODO: Support bit elements once KNN bit vector queries are available
     }
 
     @Override
@@ -202,6 +205,7 @@ public class SemanticQueryBuilderTests extends AbstractQueryTestCase<SemanticQue
         Class<? extends Query> expectedKnnQueryClass = switch (denseVectorElementType) {
             case FLOAT -> KnnFloatVectorQuery.class;
             case BYTE -> KnnByteVectorQuery.class;
+            default -> throw new IllegalStateException("Unhandled element type [" + denseVectorElementType + "]");
         };
         assertThat(innerQuery, instanceOf(expectedKnnQueryClass));
     }


### PR DESCRIPTION
Fix semantic text test failures caused by the concurrent addition of `DenseVectorFieldMapper.ElementType.BIT` and #110010
