### PR TITLE
Add an explicit fsync option to empty translog

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -1870,7 +1870,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         ChannelFactory channelFactory,
         long primaryTerm
     ) throws IOException {
-        return createEmptyTranslog(location, shardId, initialGlobalCheckpoint, primaryTerm, null, channelFactory);
+        return createEmptyTranslog(location, shardId, initialGlobalCheckpoint, primaryTerm, null, channelFactory, true);
     }
 
     /**
@@ -1887,6 +1887,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * @param primaryTerm             the shard's primary term to initialize the translog with
      * @param translogUUID            the unique identifier to initialize the translog with
      * @param factory                 a {@link ChannelFactory} used to open translog files
+     * @param fsync                   allows using fsync file api
      * @return the translog's unique identifier
      * @throws IOException if something went wrong during translog creation
      */
@@ -1896,7 +1897,8 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         final long initialGlobalCheckpoint,
         final long primaryTerm,
         @Nullable final String translogUUID,
-        @Nullable final ChannelFactory factory
+        @Nullable final ChannelFactory factory,
+        final boolean fsync
     ) throws IOException {
         IOUtils.rm(location);
         Files.createDirectories(location);
@@ -1931,7 +1933,7 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
             BigArrays.NON_RECYCLING_INSTANCE,
             DiskIoBufferPool.INSTANCE,
             TranslogConfig.NOOP_OPERATION_LISTENER,
-            true
+            fsync
         );
         writer.close();
         return uuid;


### PR DESCRIPTION
Add an explicit fsync option to empty translog. It is follow up for #108242, [comment about empty translog](https://github.com/elastic/elasticsearch/pull/108242#discussion_r1588972387). `createEmptyTranslog` with explicit fsync is not used anywhere other than single place mentioned in this PR. 

This change should not have an impact.

Related to: ES-8430