### PR TITLE
Avoid possible flaky builds

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -158,6 +158,10 @@ TaskProvider<Test> indexSettingsOverrideTest = tasks.register("indexSettingsOver
   testClassesDirs = sourceSets.test.output.classesDirs
 }
 
+tasks.named("check").configure {
+  dependsOn(indexSettingsOverrideTest)
+}
+
 tasks.named("thirdPartyAudit").configure {
     ignoreMissingClasses(
             // from com.fasterxml.jackson.dataformat.yaml.YAMLMapper (jackson-dataformat-yaml)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -148,6 +148,14 @@ if (BuildParams.isSnapshotBuild() == false) {
 
 tasks.named("test").configure {
   systemProperty 'es.insecure_network_trace_enabled', 'true'
+  excludes << '**/IndexSettingsOverrideTests.class'
+}
+
+TaskProvider<Test> indexSettingsOverrideTest = tasks.register("indexSettingsOverrideTest", Test) {
+  include '**/IndexSettingsOverrideTests.class'
+  systemProperty 'es.stateless.allow.index.refresh_interval.override', 'true'
+  classpath = sourceSets.test.runtimeClasspath
+  testClassesDirs = sourceSets.test.output.classesDirs
 }
 
 tasks.named("thirdPartyAudit").configure {

--- a/server/src/main/java/org/elasticsearch/index/IndexSettings.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexSettings.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.ingest.IngestService;
@@ -297,9 +296,8 @@ public final class IndexSettings {
     static class RefreshIntervalValidator implements Setting.Validator<TimeValue> {
 
         static final String STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE = "es.stateless.allow.index.refresh_interval.override";
-
-        private LazyInitializable<Boolean, RuntimeException> isOverrideAllowed = new LazyInitializable<>(
-            () -> Boolean.parseBoolean(System.getProperty(STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false"))
+        private static final boolean IS_OVERRIDE_ALLOWED = Boolean.parseBoolean(
+            System.getProperty(STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false")
         );
 
         @Override
@@ -317,7 +315,7 @@ public final class IndexSettings {
                 && value.compareTo(STATELESS_MIN_NON_FAST_REFRESH_INTERVAL) < 0
                 && indexVersion.after(IndexVersions.V_8_10_0)) {
 
-                if (isOverrideAllowed.getOrCompute() == false) {
+                if (IS_OVERRIDE_ALLOWED == false) {
                     throw new IllegalArgumentException(
                         "index setting ["
                             + IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey()

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
@@ -10,17 +10,12 @@ package org.elasticsearch.index;
 
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 
 import static org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_INDEX_VERSION_CREATED;
 import static org.elasticsearch.cluster.routing.allocation.ExistingShardsAllocator.EXISTING_SHARDS_ALLOCATOR_SETTING;
 
-@ESTestCase.WithoutSecurityManager
-@SuppressForbidden(reason = "manipulates system properties for testing")
 public class IndexSettingsOverrideTests extends ESTestCase {
 
     public static IndexMetadata newIndexMeta(String name, Settings indexSettings) {
@@ -29,12 +24,12 @@ public class IndexSettingsOverrideTests extends ESTestCase {
             .build();
     }
 
-    @BeforeClass
-    public static void setSystemProperty() {
-        System.setProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "true");
-    }
-
     public void testStatelessMinRefreshIntervalOverride() {
+        assumeTrue("This test depends on system property",
+            Boolean.parseBoolean(
+                System.getProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false")
+            )
+        );
         IndexMetadata metadata = newIndexMeta(
             "index",
             Settings.builder()
@@ -46,10 +41,5 @@ public class IndexSettingsOverrideTests extends ESTestCase {
         );
         IndexSettings settings = new IndexSettings(metadata, Settings.EMPTY);
         assertEquals(TimeValue.timeValueSeconds(1), settings.getRefreshInterval());
-    }
-
-    @AfterClass
-    public static void clearSystemProperty() {
-        System.clearProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE);
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
@@ -25,7 +25,8 @@ public class IndexSettingsOverrideTests extends ESTestCase {
     }
 
     public void testStatelessMinRefreshIntervalOverride() {
-        assumeTrue("This test depends on system property",
+        assumeTrue(
+            "This test depends on system property",
             Boolean.parseBoolean(
                 System.getProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false")
             )

--- a/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexSettingsOverrideTests.java
@@ -26,7 +26,7 @@ public class IndexSettingsOverrideTests extends ESTestCase {
 
     public void testStatelessMinRefreshIntervalOverride() {
         assumeTrue(
-            "This test depends on system property",
+            "This test depends on system property configured in build.gradle",
             Boolean.parseBoolean(
                 System.getProperty(IndexSettings.RefreshIntervalValidator.STATELESS_ALLOW_INDEX_REFRESH_INTERVAL_OVERRIDE, "false")
             )


### PR DESCRIPTION
As @ywangd pointed out [here](https://github.com/elastic/elasticsearch/pull/110172#discussion_r1658065797) there is a risk of CI flakiness. It hasn't happened yet, but I agree that it might happen if the tests got allocated to the same forked jvm and run in parallel. 