### PR TITLE
Dry up Bucket types in o.e.search.aggregations.bucket.histogram

### DIFF
--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/DateDerivativeIT.java
@@ -15,9 +15,9 @@ import org.elasticsearch.common.time.DateFormatters;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.metrics.Sum;
 import org.elasticsearch.search.aggregations.pipeline.SimpleValue;
 import org.elasticsearch.search.aggregations.support.AggregationPath;
@@ -127,7 +127,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
                 assertThat(bucket.getDocCount(), equalTo(1L));
@@ -171,7 +171,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKey(), equalTo(key));
                 assertThat(bucket.getDocCount(), equalTo(1L));
@@ -383,7 +383,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
     }
 
     private static void assertBucket(
-        Histogram.Bucket bucket,
+        Bucket bucket,
         ZonedDateTime expectedKey,
         long expectedDocCount,
         Matcher<Object> derivativeMatcher,
@@ -421,7 +421,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
                 Object[] propertiesCounts = (Object[]) ((InternalAggregation) histo).getProperty("sum.value");
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
                 assertThat(bucket.getDocCount(), equalTo(1L));
@@ -500,7 +500,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(4));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
                 assertThat(bucket.getDocCount(), equalTo(1L));
@@ -574,7 +574,7 @@ public class DateDerivativeIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat((ZonedDateTime) bucket.getKey(), equalTo(key));
                 assertThat(bucket.getDocCount(), equalTo(1L));

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/pipeline/SerialDiffIT.java
@@ -12,8 +12,8 @@ import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.aggregations.AggregationIntegTestCase;
 import org.elasticsearch.common.collect.EvictingQueue;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers;
 import org.elasticsearch.search.aggregations.pipeline.SimpleValue;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
@@ -91,7 +91,7 @@ public class SerialDiffIT extends AggregationIntegTestCase {
         }
     }
 
-    private void assertBucketContents(Histogram.Bucket actual, Double expectedCount, Double expectedValue) {
+    private void assertBucketContents(Bucket actual, Double expectedCount, Double expectedValue) {
         // This is a gap bucket
         SimpleValue countDiff = actual.getAggregations().get("diff_counts");
         if (expectedCount == null) {
@@ -239,7 +239,7 @@ public class SerialDiffIT extends AggregationIntegTestCase {
                 List<Double> expectedCounts = testValues.get(MetricTarget.COUNT.toString());
                 List<Double> expectedValues = testValues.get(MetricTarget.VALUE.toString());
 
-                Iterator<? extends Histogram.Bucket> actualIter = buckets.iterator();
+                Iterator<? extends Bucket> actualIter = buckets.iterator();
                 Iterator<PipelineAggregationHelperTests.MockBucket> expectedBucketIter = mockHisto.iterator();
                 Iterator<Double> expectedCountsIter = expectedCounts.iterator();
                 Iterator<Double> expectedValuesIter = expectedValues.iterator();
@@ -247,7 +247,7 @@ public class SerialDiffIT extends AggregationIntegTestCase {
                 while (actualIter.hasNext()) {
                     assertValidIterators(expectedBucketIter, expectedCountsIter, expectedValuesIter);
 
-                    Histogram.Bucket actual = actualIter.next();
+                    Bucket actual = actualIter.next();
                     PipelineAggregationHelperTests.MockBucket expected = expectedBucketIter.next();
                     Double expectedCount = expectedCountsIter.next();
                     Double expectedValue = expectedValuesIter.next();

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogramTests.java
@@ -501,7 +501,7 @@ public class InternalAutoDateHistogramTests extends AggregationMultiBucketAggreg
             assertEquals(1, deserialized.getBuckets().size());
             InternalAutoDateHistogram.Bucket bucket = deserialized.getBuckets().iterator().next();
             assertEquals(10, bucket.key);
-            assertEquals(100, bucket.docCount);
+            assertEquals(100, bucket.getDocCount());
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
@@ -16,10 +16,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.index.cache.request.RequestCacheStats;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -24,9 +24,9 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.InternalDateHistogram;
 import org.elasticsearch.search.aggregations.bucket.histogram.LongBounds;
 import org.elasticsearch.search.aggregations.metrics.Avg;
@@ -241,7 +241,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -283,7 +283,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(6));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 23, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -354,7 +354,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 expectedKeys.add(ZonedDateTime.of(2012, 3, 22, 23, 0, 0, 0, ZoneOffset.UTC));
 
                 Iterator<ZonedDateTime> keyIterator = expectedKeys.iterator();
-                for (Histogram.Bucket bucket : buckets) {
+                for (Bucket bucket : buckets) {
                     assertThat(bucket, notNullValue());
                     ZonedDateTime expectedKey = keyIterator.next();
                     String bucketKey = bucket.getKeyAsString();
@@ -380,7 +380,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 int i = 0;
-                for (Histogram.Bucket bucket : buckets) {
+                for (Bucket bucket : buckets) {
                     assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
                     i++;
                 }
@@ -400,7 +400,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(3));
 
                 int i = 2;
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                for (Bucket bucket : histo.getBuckets()) {
                     assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
                     i--;
                 }
@@ -420,7 +420,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(3));
 
                 int i = 0;
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                for (Bucket bucket : histo.getBuckets()) {
                     assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
                     i++;
                 }
@@ -440,7 +440,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(3));
 
                 int i = 2;
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                for (Bucket bucket : histo.getBuckets()) {
                     assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
                     i--;
                 }
@@ -465,7 +465,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 Object[] propertiesCounts = (Object[]) ((InternalAggregation) histo).getProperty("sum.value");
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -521,7 +521,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(3));
 
                 int i = 0;
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                for (Bucket bucket : histo.getBuckets()) {
                     assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
                     i++;
                 }
@@ -544,7 +544,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(3));
 
                 int i = 2;
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                for (Bucket bucket : histo.getBuckets()) {
                     assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
                     i--;
                 }
@@ -567,7 +567,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(3));
 
                 int i = 2;
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                for (Bucket bucket : histo.getBuckets()) {
                     assertThat(((ZonedDateTime) bucket.getKey()), equalTo(ZonedDateTime.of(2012, i + 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)));
                     i--;
                 }
@@ -590,7 +590,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(3));
 
                 int i = 1;
-                for (Histogram.Bucket bucket : histo.getBuckets()) {
+                for (Bucket bucket : histo.getBuckets()) {
                     assertThat(bucket.getKey(), equalTo(date(i, 1)));
                     i++;
                 }
@@ -645,7 +645,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -688,7 +688,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(4));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -729,9 +729,9 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histo.getName(), equalTo("histo"));
                 assertThat(histo.getBuckets().size(), equalTo(4));
 
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
 
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKey(), equalTo(date(3, 1)));
                 assertThat(bucket.getDocCount(), equalTo(5L));
@@ -781,7 +781,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(4));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -835,7 +835,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -874,7 +874,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(4));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -940,7 +940,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 ZonedDateTime key = ZonedDateTime.of(2012, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -976,10 +976,10 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(response.getHits().getTotalHits().value, equalTo(2L));
                 Histogram histo = response.getAggregations().get("histo");
                 assertThat(histo, Matchers.notNullValue());
-                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                List<? extends Bucket> buckets = histo.getBuckets();
                 assertThat(buckets.size(), equalTo(3));
 
-                Histogram.Bucket bucket = buckets.get(1);
+                Bucket bucket = buckets.get(1);
                 assertThat(bucket, Matchers.notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo("1.0"));
 
@@ -1013,10 +1013,10 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(response.getHits().getTotalHits().value, equalTo(5L));
 
                 Histogram histo = response.getAggregations().get("date_histo");
-                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                List<? extends Bucket> buckets = histo.getBuckets();
                 assertThat(buckets.size(), equalTo(2));
 
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo("2014-03-10:00-00-00-02:00"));
                 assertThat(bucket.getDocCount(), equalTo(2L));
@@ -1118,7 +1118,7 @@ public class DateHistogramIT extends ESIntegTestCase {
 
                     ZonedDateTime key = baseKey.isBefore(boundsMinKey) ? baseKey : boundsMinKey;
                     for (int i = 0; i < bucketsCount; i++) {
-                        Histogram.Bucket bucket = buckets.get(i);
+                        Bucket bucket = buckets.get(i);
                         assertThat(bucket, notNullValue());
                         assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
                         assertThat(bucket.getKeyAsString(), equalTo(format(key, pattern)));
@@ -1185,7 +1185,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(24));
 
                 for (int i = 0; i < buckets.size(); i++) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     ZonedDateTime zonedDateTime = timeZoneStartToday.plus(i * 60 * 60 * 1000, ChronoUnit.MILLIS);
                     assertThat("InternalBucket " + i + " had wrong key", (ZonedDateTime) bucket.getKey(), equalTo(zonedDateTime));
@@ -1283,11 +1283,11 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertSearchHits(response, "0", "1", "2", "3", "4");
 
                 Histogram histo = response.getAggregations().get("date_histo");
-                List<? extends Histogram.Bucket> buckets = histo.getBuckets();
+                List<? extends Bucket> buckets = histo.getBuckets();
                 assertThat(buckets.size(), equalTo(1));
 
                 ZonedDateTime key = ZonedDateTime.of(2014, 3, 10, 0, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -1315,7 +1315,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(3));
 
                 ZonedDateTime key = ZonedDateTime.of(2011, 12, 31, 23, 0, 0, 0, ZoneOffset.UTC);
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(bucket.getKeyAsString(), equalTo(getBucketKeyAsString(key, tz)));
                 assertThat(((ZonedDateTime) bucket.getKey()), equalTo(key));
@@ -1683,7 +1683,7 @@ public class DateHistogramIT extends ESIntegTestCase {
                 assertThat(histogram.getBuckets().size(), equalTo(expectedKeys.length));
 
                 int i = 0;
-                for (Histogram.Bucket bucket : histogram.getBuckets()) {
+                for (Bucket bucket : histogram.getBuckets()) {
                     assertThat(bucket, notNullValue());
                     assertThat(key(bucket), equalTo(expectedKeys[i]));
                     assertThat(bucket.getDocCount(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("_count")));
@@ -1699,7 +1699,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         );
     }
 
-    private ZonedDateTime key(Histogram.Bucket bucket) {
+    private ZonedDateTime key(Bucket bucket) {
         return (ZonedDateTime) bucket.getKey();
     }
 
@@ -1753,7 +1753,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             ),
             response -> {
                 InternalDateHistogram histogram = response.getAggregations().get("histo");
-                List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();
+                List<? extends Bucket> buckets = histogram.getBuckets();
                 assertThat(buckets.get(0).getKeyAsString(), equalTo("2012-01-01T00:00:00.000-07:00"));
                 assertThat(buckets.get(1).getKeyAsString(), equalTo("2012-02-01T00:00:00.000-07:00"));
                 assertThat(buckets.get(2).getKeyAsString(), equalTo("2012-03-01T00:00:00.000-07:00"));
@@ -1770,7 +1770,7 @@ public class DateHistogramIT extends ESIntegTestCase {
             ),
             response -> {
                 InternalDateHistogram histogram = response.getAggregations().get("histo");
-                List<InternalDateHistogram.Bucket> buckets = histogram.getBuckets();
+                List<? extends Bucket> buckets = histogram.getBuckets();
                 assertThat(buckets.size(), equalTo(30));
                 assertThat(buckets.get(1).getKeyAsString(), equalTo("2012-02-03T00:00:00.000Z"));
                 assertThat(buckets.get(29).getKeyAsString(), equalTo("2012-03-02T00:00:00.000Z"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
@@ -19,10 +19,10 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
 import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.histogram.DoubleBounds;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.metrics.Avg;
 import org.elasticsearch.search.aggregations.metrics.Max;
 import org.elasticsearch.search.aggregations.metrics.Stats;
@@ -252,7 +252,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(numValueBuckets));
 
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
@@ -276,7 +276,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(expectedNumberOfBuckets));
 
                 // first bucket should start at -5, contain 4 documents
-                Histogram.Bucket bucket = histo.getBuckets().get(0);
+                Bucket bucket = histo.getBuckets().get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(((Number) bucket.getKey()).longValue(), equalTo(-5L));
                 assertThat(bucket.getDocCount(), equalTo(4L));
@@ -310,7 +310,7 @@ public class HistogramIT extends ESIntegTestCase {
 
                 long docsCounted = 0;
                 for (int i = 0; i < expectedNumberOfBuckets; ++i) {
-                    Histogram.Bucket bucket = histo.getBuckets().get(i);
+                    Bucket bucket = histo.getBuckets().get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) ((i - 1) * interval + offset)));
                     if (i == 0) {
@@ -340,9 +340,9 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(histo.getName(), equalTo("histo"));
                 assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
@@ -362,9 +362,9 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(histo.getName(), equalTo("histo"));
                 assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(numValueBuckets - i - 1);
+                    Bucket bucket = buckets.get(numValueBuckets - i - 1);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
@@ -385,10 +385,10 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
                 Set<Long> buckets = new HashSet<>();
-                List<Histogram.Bucket> histoBuckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> histoBuckets = new ArrayList<>(histo.getBuckets());
                 long previousCount = Long.MIN_VALUE;
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = histoBuckets.get(i);
+                    Bucket bucket = histoBuckets.get(i);
                     assertThat(bucket, notNullValue());
                     long key = ((Number) bucket.getKey()).longValue();
                     assertEquals(0, key % interval);
@@ -413,10 +413,10 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
                 Set<Long> buckets = new HashSet<>();
-                List<Histogram.Bucket> histoBuckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> histoBuckets = new ArrayList<>(histo.getBuckets());
                 long previousCount = Long.MAX_VALUE;
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = histoBuckets.get(i);
+                    Bucket bucket = histoBuckets.get(i);
                     assertThat(bucket, notNullValue());
                     long key = ((Number) bucket.getKey()).longValue();
                     assertEquals(0, key % interval);
@@ -446,9 +446,9 @@ public class HistogramIT extends ESIntegTestCase {
                 Object[] propertiesDocCounts = (Object[]) ((InternalAggregation) histo).getProperty("_count");
                 Object[] propertiesCounts = (Object[]) ((InternalAggregation) histo).getProperty("sum.value");
 
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
@@ -486,9 +486,9 @@ public class HistogramIT extends ESIntegTestCase {
 
                 Set<Long> visited = new HashSet<>();
                 double previousSum = Double.NEGATIVE_INFINITY;
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     long key = ((Number) bucket.getKey()).longValue();
                     assertTrue(visited.add(key));
@@ -527,9 +527,9 @@ public class HistogramIT extends ESIntegTestCase {
 
                 Set<Long> visited = new HashSet<>();
                 double previousSum = Double.POSITIVE_INFINITY;
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     long key = ((Number) bucket.getKey()).longValue();
                     assertTrue(visited.add(key));
@@ -569,9 +569,9 @@ public class HistogramIT extends ESIntegTestCase {
                 Set<Long> visited = new HashSet<>();
                 double previousSum = Double.POSITIVE_INFINITY;
 
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     long key = ((Number) bucket.getKey()).longValue();
                     assertTrue(visited.add(key));
@@ -611,9 +611,9 @@ public class HistogramIT extends ESIntegTestCase {
 
                 Set<Long> visited = new HashSet<>();
                 double prevMax = asc ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     long key = ((Number) bucket.getKey()).longValue();
                     assertTrue(visited.add(key));
@@ -646,9 +646,9 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(histo.getName(), equalTo("histo"));
                 assertThat(histo.getBuckets().size(), equalTo(numValueBuckets));
 
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
@@ -705,7 +705,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(numBuckets));
 
                 for (int i = 0; i < numBuckets; i++) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     int key = ((2 / interval) + i) * interval;
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) key));
@@ -726,7 +726,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(numValuesBuckets));
 
                 for (int i = 0; i < numValuesBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valuesCounts[i]));
@@ -746,9 +746,9 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(histo.getName(), equalTo("histo"));
                 assertThat(histo.getBuckets().size(), equalTo(numValuesBuckets));
 
-                List<Histogram.Bucket> buckets = new ArrayList<>(histo.getBuckets());
+                List<Bucket> buckets = new ArrayList<>(histo.getBuckets());
                 for (int i = 0; i < numValuesBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(numValuesBuckets - i - 1);
+                    Bucket bucket = buckets.get(numValuesBuckets - i - 1);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valuesCounts[i]));
@@ -783,7 +783,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(numBuckets));
 
                 for (int i = 0; i < numBuckets; i++) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     int key = ((2 / interval) + i) * interval;
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) key));
@@ -807,7 +807,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(numValueBuckets));
 
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
@@ -830,7 +830,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(numValuesBuckets));
 
                 for (int i = 0; i < numValuesBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valuesCounts[i]));
@@ -862,7 +862,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(buckets.size(), equalTo(numValueBuckets));
 
                 for (int i = 0; i < numValueBuckets; ++i) {
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat(bucket, notNullValue());
                     assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) i * interval));
                     assertThat(bucket.getDocCount(), equalTo(valueCounts[i]));
@@ -885,7 +885,7 @@ public class HistogramIT extends ESIntegTestCase {
                 List<? extends Bucket> buckets = histo.getBuckets();
                 assertThat(buckets.size(), equalTo(numValueBuckets + 3));
 
-                Histogram.Bucket bucket = buckets.get(0);
+                Bucket bucket = buckets.get(0);
                 assertThat(bucket, notNullValue());
                 assertThat(((Number) bucket.getKey()).longValue(), equalTo((long) -1 * 2 * interval));
                 assertThat(bucket.getDocCount(), equalTo(0L));
@@ -919,7 +919,7 @@ public class HistogramIT extends ESIntegTestCase {
                 Histogram histo = response.getAggregations().get("histo");
                 assertThat(histo, Matchers.notNullValue());
                 List<? extends Bucket> buckets = histo.getBuckets();
-                Histogram.Bucket bucket = buckets.get(1);
+                Bucket bucket = buckets.get(1);
                 assertThat(bucket, Matchers.notNullValue());
 
                 histo = bucket.getAggregations().get("sub_histo");
@@ -984,7 +984,7 @@ public class HistogramIT extends ESIntegTestCase {
 
                     long key = startKey;
                     for (int i = 0; i < bucketsCount; i++) {
-                        Histogram.Bucket bucket = buckets.get(i);
+                        Bucket bucket = buckets.get(i);
                         assertThat(bucket, notNullValue());
                         assertThat(((Number) bucket.getKey()).longValue(), equalTo(key));
                         assertThat(bucket.getDocCount(), equalTo(extendedValueCounts[i]));
@@ -1058,7 +1058,7 @@ public class HistogramIT extends ESIntegTestCase {
 
                     long key = startKey;
                     for (int i = 0; i < bucketsCount; i++) {
-                        Histogram.Bucket bucket = buckets.get(i);
+                        Bucket bucket = buckets.get(i);
                         assertThat(bucket, notNullValue());
                         assertThat(((Number) bucket.getKey()).longValue(), equalTo(key));
                         assertThat(bucket.getDocCount(), equalTo(0L));
@@ -1302,7 +1302,7 @@ public class HistogramIT extends ESIntegTestCase {
                 assertThat(histogram.getBuckets().size(), equalTo(expectedKeys.length));
 
                 int i = 0;
-                for (Histogram.Bucket bucket : histogram.getBuckets()) {
+                for (Bucket bucket : histogram.getBuckets()) {
                     assertThat(bucket, notNullValue());
                     assertThat(key(bucket), equalTo(expectedKeys[i]));
                     assertThat(bucket.getDocCount(), equalTo(expectedMultiSortBuckets.get(expectedKeys[i]).get("_count")));
@@ -1318,7 +1318,7 @@ public class HistogramIT extends ESIntegTestCase {
         );
     }
 
-    private long key(Histogram.Bucket bucket) {
+    private long key(Bucket bucket) {
         return ((Number) bucket.getKey()).longValue();
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -21,9 +21,9 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.aggregations.Aggregation;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.global.Global;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.ESIntegTestCase.ClusterScope;
 import org.elasticsearch.test.ESIntegTestCase.Scope;
@@ -1103,7 +1103,7 @@ public class ScriptedMetricIT extends ESIntegTestCase {
                 assertThat(response.getHits().getTotalHits().value, equalTo(2L));
                 Histogram histo = response.getAggregations().get("histo");
                 assertThat(histo, notNullValue());
-                Histogram.Bucket bucket = histo.getBuckets().get(1);
+                Bucket bucket = histo.getBuckets().get(1);
                 assertThat(bucket, notNullValue());
 
                 ScriptedMetric scriptedMetric = bucket.getAggregations().get("scripted");

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/ExtendedStatsBucketIT.java
@@ -12,8 +12,8 @@ import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram.Bucket;
 import org.elasticsearch.search.aggregations.metrics.ExtendedStats.Bounds;
 
 import java.util.ArrayList;
@@ -119,7 +119,7 @@ public class ExtendedStatsBucketIT extends BucketMetricsPipeLineAggregationTestC
                     } else {
                         expectedDocCount = 1;
                     }
-                    Histogram.Bucket bucket = buckets.get(i);
+                    Bucket bucket = buckets.get(i);
                     assertThat("i: " + i, bucket, notNullValue());
                     assertThat("i: " + i, ((Number) bucket.getKey()).longValue(), equalTo((long) i));
                     assertThat("i: " + i, bucket.getDocCount(), equalTo(expectedDocCount));

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramBucket.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/AbstractHistogramBucket.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.histogram;
+
+import org.elasticsearch.search.DocValueFormat;
+import org.elasticsearch.search.aggregations.InternalAggregations;
+import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
+
+/**
+ * A bucket in the histogram where documents fall in
+ */
+public abstract class AbstractHistogramBucket extends InternalMultiBucketAggregation.InternalBucket {
+
+    protected final long docCount;
+    protected final InternalAggregations aggregations;
+    protected final transient DocValueFormat format;
+
+    protected AbstractHistogramBucket(long docCount, InternalAggregations aggregations, DocValueFormat format) {
+        this.docCount = docCount;
+        this.aggregations = aggregations;
+        this.format = format;
+    }
+
+    @Override
+    public final long getDocCount() {
+        return docCount;
+    }
+
+    @Override
+    public final InternalAggregations getAggregations() {
+        return aggregations;
+    }
+
+    public final DocValueFormat getFormatter() {
+        return format;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/Histogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/Histogram.java
@@ -10,8 +10,6 @@ package org.elasticsearch.search.aggregations.bucket.histogram;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation;
 import org.elasticsearch.xcontent.ParseField;
 
-import java.util.List;
-
 /**
  * A {@code histogram} aggregation. Defines multiple buckets, each representing an interval in a histogram.
  */
@@ -24,18 +22,5 @@ public interface Histogram extends MultiBucketsAggregation {
     ParseField MIN_DOC_COUNT_FIELD = new ParseField("min_doc_count");
     ParseField EXTENDED_BOUNDS_FIELD = new ParseField("extended_bounds");
     ParseField HARD_BOUNDS_FIELD = new ParseField("hard_bounds");
-
-    /**
-     * A bucket in the histogram where documents fall in
-     */
-    interface Bucket extends MultiBucketsAggregation.Bucket {
-
-    }
-
-    /**
-     * @return  The buckets of this histogram (each bucket representing an interval in the histogram)
-     */
-    @Override
-    List<? extends Bucket> getBuckets();
 
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -49,31 +49,22 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         Histogram,
         HistogramFactory {
 
-    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Histogram.Bucket, KeyComparable<Bucket> {
+    public static class Bucket extends AbstractHistogramBucket implements KeyComparable<Bucket> {
 
         final long key;
-        final long docCount;
-        final InternalAggregations aggregations;
         private final transient boolean keyed;
-        protected final transient DocValueFormat format;
 
         public Bucket(long key, long docCount, boolean keyed, DocValueFormat format, InternalAggregations aggregations) {
-            this.format = format;
+            super(docCount, aggregations, format);
             this.keyed = keyed;
             this.key = key;
-            this.docCount = docCount;
-            this.aggregations = aggregations;
         }
 
         /**
          * Read from a stream.
          */
-        public Bucket(StreamInput in, boolean keyed, DocValueFormat format) throws IOException {
-            this.format = format;
-            this.keyed = keyed;
-            key = in.readLong();
-            docCount = in.readVLong();
-            aggregations = InternalAggregations.readFrom(in);
+        public static Bucket readFrom(StreamInput in, boolean keyed, DocValueFormat format) throws IOException {
+            return new Bucket(in.readLong(), in.readVLong(), keyed, format, InternalAggregations.readFrom(in));
         }
 
         @Override
@@ -110,16 +101,6 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         }
 
         @Override
-        public long getDocCount() {
-            return docCount;
-        }
-
-        @Override
-        public InternalAggregations getAggregations() {
-            return aggregations;
-        }
-
-        @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             String keyAsString = format.format(key).toString();
             if (keyed) {
@@ -140,10 +121,6 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         @Override
         public int compareKey(Bucket other) {
             return Long.compare(key, other.key);
-        }
-
-        public DocValueFormat getFormatter() {
-            return format;
         }
 
         public boolean getKeyed() {
@@ -259,7 +236,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         } else {
             downsampledResultsOffset = false;
         }
-        buckets = in.readCollectionAsList(stream -> new Bucket(stream, keyed, format));
+        buckets = in.readCollectionAsList(stream -> Bucket.readFrom(stream, keyed, format));
         // we changed the order format in 8.13 for partial reduce, therefore we need to order them to perform merge sort
         if (in.getTransportVersion().between(TransportVersions.V_8_13_0, TransportVersions.HISTOGRAM_AGGS_KEY_SORTED)) {
             // list is mutable by #readCollectionAsList contract

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -44,31 +44,22 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
     implements
         Histogram,
         HistogramFactory {
-    public static class Bucket extends InternalMultiBucketAggregation.InternalBucket implements Histogram.Bucket, KeyComparable<Bucket> {
+    public static class Bucket extends AbstractHistogramBucket implements KeyComparable<Bucket> {
 
         final double key;
-        final long docCount;
-        final InternalAggregations aggregations;
         private final transient boolean keyed;
-        protected final transient DocValueFormat format;
 
         public Bucket(double key, long docCount, boolean keyed, DocValueFormat format, InternalAggregations aggregations) {
-            this.format = format;
+            super(docCount, aggregations, format);
             this.keyed = keyed;
             this.key = key;
-            this.docCount = docCount;
-            this.aggregations = aggregations;
         }
 
         /**
          * Read from a stream.
          */
-        public Bucket(StreamInput in, boolean keyed, DocValueFormat format) throws IOException {
-            this.format = format;
-            this.keyed = keyed;
-            key = in.readDouble();
-            docCount = in.readVLong();
-            aggregations = InternalAggregations.readFrom(in);
+        public static Bucket readFrom(StreamInput in, boolean keyed, DocValueFormat format) throws IOException {
+            return new Bucket(in.readDouble(), in.readVLong(), keyed, format, InternalAggregations.readFrom(in));
         }
 
         @Override
@@ -105,16 +96,6 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
         }
 
         @Override
-        public long getDocCount() {
-            return docCount;
-        }
-
-        @Override
-        public InternalAggregations getAggregations() {
-            return aggregations;
-        }
-
-        @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             String keyAsString = format.format(key).toString();
             if (keyed) {
@@ -135,10 +116,6 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
         @Override
         public int compareKey(Bucket other) {
             return Double.compare(key, other.key);
-        }
-
-        public DocValueFormat getFormatter() {
-            return format;
         }
 
         public boolean getKeyed() {
@@ -242,7 +219,7 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
         }
         format = in.readNamedWriteable(DocValueFormat.class);
         keyed = in.readBoolean();
-        buckets = in.readCollectionAsList(stream -> new Bucket(stream, keyed, format));
+        buckets = in.readCollectionAsList(stream -> Bucket.readFrom(stream, keyed, format));
         // we changed the order format in 8.13 for partial reduce, therefore we need to order them to perform merge sort
         if (in.getTransportVersion().between(TransportVersions.V_8_13_0, TransportVersions.HISTOGRAM_AGGS_KEY_SORTED)) {
             // list is mutable by #readCollectionAsList contract

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationTestUtils.java
@@ -36,12 +36,7 @@ public final class AggregationTestUtils {
     private AggregationTestUtils() {}
 
     static InternalHistogram.Bucket createHistogramBucket(long timestamp, long docCount, List<InternalAggregation> subAggregations) {
-        InternalHistogram.Bucket bucket = mock(InternalHistogram.Bucket.class);
-        when(bucket.getKey()).thenReturn(timestamp);
-        when(bucket.getDocCount()).thenReturn(docCount);
-        InternalAggregations aggs = createAggs(subAggregations);
-        when(bucket.getAggregations()).thenReturn(aggs);
-        return bucket;
+        return new InternalHistogram.Bucket(timestamp, docCount, false, DocValueFormat.RAW, createAggs(subAggregations));
     }
 
     static InternalComposite.InternalBucket createCompositeBucket(

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/aggregation/AggregationToJsonProcessorTests.java
@@ -414,11 +414,13 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenUnsupportedAggregationUnderHistogram() {
-        InternalHistogram.Bucket histogramBucket = createHistogramBucket(1000L, 2);
         InternalAggregation anotherHistogram = mock(InternalAggregation.class);
         when(anotherHistogram.getName()).thenReturn("nested-agg");
-        InternalAggregations subAggs = createAggs(Arrays.asList(createMax("time", 1000), anotherHistogram));
-        when(histogramBucket.getAggregations()).thenReturn(subAggs);
+        InternalHistogram.Bucket histogramBucket = createHistogramBucket(
+            1000L,
+            2,
+            Arrays.asList(createMax("time", 1000), anotherHistogram)
+        );
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
@@ -428,13 +430,11 @@ public class AggregationToJsonProcessorTests extends ESTestCase {
     }
 
     public void testProcessGivenMultipleBucketAggregations() {
-        InternalHistogram.Bucket histogramBucket = createHistogramBucket(1000L, 2);
         StringTerms terms1 = mock(StringTerms.class);
         when(terms1.getName()).thenReturn("terms_1");
         StringTerms terms2 = mock(StringTerms.class);
         when(terms2.getName()).thenReturn("terms_2");
-        InternalAggregations subAggs = createAggs(Arrays.asList(createMax("time", 1000), terms1, terms2));
-        when(histogramBucket.getAggregations()).thenReturn(subAggs);
+        InternalHistogram.Bucket histogramBucket = createHistogramBucket(1000L, 2, Arrays.asList(createMax("time", 1000), terms1, terms2));
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,


### PR DESCRIPTION
It's in the title, lots of duplication here that deserves cleanup in isolation. Also, bucket instances are a perpetual source of memory consuption in aggs. There are lots of possible improvements we can make to reduce their footprint, drying up this code enables cleaner PRs for thse improvements.
