### PR TITLE
ESQL: Reenable test

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -50,9 +50,6 @@ tests:
 - class: "org.elasticsearch.xpack.test.rest.XPackRestIT"
   issue: "https://github.com/elastic/elasticsearch/issues/109687"
   method: "test {p0=sql/translate/Translate SQL}"
-- class: "org.elasticsearch.xpack.esql.EsqlAsyncSecurityIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/109806"
-  method: "testInsufficientPrivilege"
 - class: org.elasticsearch.action.search.SearchProgressActionListenerIT
   method: testSearchProgressWithHits
   issue: https://github.com/elastic/elasticsearch/issues/109830

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlAsyncSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlAsyncSecurityIT.java
@@ -7,11 +7,13 @@
 
 package org.elasticsearch.xpack.esql;
 
+import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.http.HttpUtils;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -119,8 +121,10 @@ public class EsqlAsyncSecurityIT extends EsqlSecurityIT {
                 logResponse(response);
                 return response;
             } catch (ResponseException e) {
-                if (e.getResponse().getStatusLine().getStatusCode() == 404) {
-                    logger.warn("404 fetching task status", e);
+                if (e.getResponse().getStatusLine().getStatusCode() == 404
+                    && EntityUtils.toString(e.getResponse().getEntity()).contains("no such index [.async-search]")) {
+
+                    logger.warn("async-search index does not exist", e);
                     try {
                         Thread.sleep(1000);
                     } catch (InterruptedException ex) {

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlAsyncSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlAsyncSecurityIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.http.HttpUtils;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -123,7 +122,10 @@ public class EsqlAsyncSecurityIT extends EsqlSecurityIT {
             } catch (ResponseException e) {
                 if (e.getResponse().getStatusLine().getStatusCode() == 404
                     && EntityUtils.toString(e.getResponse().getEntity()).contains("no such index [.async-search]")) {
-
+                    /*
+                     * Work around https://github.com/elastic/elasticsearch/issues/110304 - the .async-search
+                     * index may not exist when we try the fetch, but it should exist on next attempt.
+                     */
                     logger.warn("async-search index does not exist", e);
                     try {
                         Thread.sleep(1000);

--- a/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
+++ b/x-pack/plugin/esql/qa/security/src/javaRestTest/java/org/elasticsearch/xpack/esql/EsqlSecurityIT.java
@@ -142,6 +142,7 @@ public class EsqlSecurityIT extends ESRestTestCase {
             Exception.class,
             () -> runESQLCommand("metadata1_read2", "FROM index-user1,index-user2 | STATS sum=sum(value)")
         );
+        logger.info("error", error);
         assertThat(
             error.getMessage(),
             containsString(


### PR DESCRIPTION
We have a security test that fails one every thousand or so runs because it runs an async esql action and *sometimes* it requests the async result and the index does not yet exist. This retries. I think there's probably a better solution, but for now I'm going to fix the test and open an issue to track that.

Closes #109806
