### PR TITLE
[Inference API] Fix docs typo in Google AI Studio task type

### DIFF
--- a/docs/reference/inference/put-inference.asciidoc
+++ b/docs/reference/inference/put-inference.asciidoc
@@ -75,7 +75,7 @@ Available services:
 * `cohere`: specify the `completion`, `text_embedding` or the `rerank` task type to use the Cohere service.
 * `elasticsearch`: specify the `text_embedding` task type to use the E5 built-in model or text embedding models uploaded by Eland.
 * `elser`: specify the `sparse_embedding` task type to use the ELSER service.
-* `googleaistudio`: specify the `completion` or `text_embeddig` task to use the Google AI Studio service.
+* `googleaistudio`: specify the `completion` or `text_embedding` task to use the Google AI Studio service.
 * `hugging_face`: specify the `text_embedding` task type to use the Hugging Face service.
 * `mistral`: specify the `text_embedding` task type to use the Mistral service.
 * `openai`: specify the `completion` or `text_embedding` task type to use the OpenAI service.
@@ -261,7 +261,7 @@ The total number of allocations this model is assigned across machine learning n
 
 `num_threads`:::
 (Required, integer)
-Sets the number of threads used by each model allocation during inference. This generally increases the speed per inference request. The inference process is a compute-bound process; `threads_per_allocations` must not exceed the number of available allocated processors per node. 
+Sets the number of threads used by each model allocation during inference. This generally increases the speed per inference request. The inference process is a compute-bound process; `threads_per_allocations` must not exceed the number of available allocated processors per node.
 Must be a power of 2. Max allowed value is 32.
 
 =====
@@ -276,7 +276,7 @@ The total number of allocations this model is assigned across machine learning n
 
 `num_threads`:::
 (Required, integer)
-Sets the number of threads used by each model allocation during inference. This generally increases the speed per inference request. The inference process is a compute-bound process; `threads_per_allocations` must not exceed the number of available allocated processors per node. 
+Sets the number of threads used by each model allocation during inference. This generally increases the speed per inference request. The inference process is a compute-bound process; `threads_per_allocations` must not exceed the number of available allocated processors per node.
 Must be a power of 2. Max allowed value is 32.
 
 =====


### PR DESCRIPTION
Small typo fix `text_embeddig` -> `text_embedding`