### PR TITLE
[Test improvement] Verify template creation in data stream lifecycle test 

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/dlm/10_usage.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/dlm/10_usage.yml
@@ -31,6 +31,7 @@
             lifecycle:
               data_retention: 10d
           data_stream: {}
+  - is_true: acknowledged
 
   - do:
       indices.create_data_stream:


### PR DESCRIPTION
We would like to verify that the template has been created to ensure a problem here will not crash the test.
