### PR TITLE
Fix assertion error when using passthrough with contradicting fields

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -424,6 +424,89 @@ dynamic templates - conflicting aliases:
   - match: { aggregations.filterA.tsids.buckets.0.doc_count: 2 }
 
 ---
+dynamic templates - conflicting aliases with top-level field:
+  - requires:
+      cluster_features: ["mapper.pass_through_priority"]
+      reason: support for priority in passthrough objects
+  - do:
+      allowed_warnings:
+        - "index template [my-dynamic-template] has index patterns [otel] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-dynamic-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-dynamic-template
+        body:
+          index_patterns: [otel]
+          data_stream: {}
+          template:
+            settings:
+              index:
+                number_of_shards: 1
+                mode: time_series
+                time_series:
+                  start_time: 2023-08-31T13:03:08.138Z
+
+            mappings:
+              properties:
+                body:
+                  type: match_only_text
+                attributes:
+                  type: passthrough
+                  dynamic: true
+                  time_series_dimension: true
+                  priority: 1
+                scope:
+                  properties:
+                    attributes:
+                      type: passthrough
+                      dynamic: true
+                      time_series_dimension: true
+                      priority: 2
+                resource:
+                  properties:
+                    attributes:
+                      type: passthrough
+                      dynamic: true
+                      time_series_dimension: true
+                      priority: 3
+                metrics:
+                  type: passthrough
+                  dynamic: true
+                  priority: 0
+              dynamic_templates:
+                - counter_metric:
+                    mapping:
+                      type: integer
+                      time_series_metric: counter
+                      ignore_malformed: true
+                - strings_as_keyword:
+                    mapping:
+                      type: keyword
+                      ignore_above: 1024
+                      match_mapping_type: string
+                      path_match: "*attributes.*"
+
+  - do:
+      bulk:
+        index: otel
+        refresh: true
+        body:
+          - '{ "create": { "dynamic_templates": { "metrics.data": "counter_metric" } } }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "metrics": {"data": "10"}, "body": "top-level", "attributes": {"body": "attribute"}, "scope": {"attributes": {"body": "scope" }}, "resource": {"attributes": {"body": "resource" }}}'
+  - match: { errors: false }
+
+  - do:
+      search:
+        index: otel
+        body:
+          size: 1
+          fields: ["*"]
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0.fields.body: [ top-level ] }
+  - match: { hits.hits.0.fields.attributes\.body: [ attribute ] }
+  - match: { hits.hits.0.fields.scope\.attributes\.body: [ scope ] }
+  - match: { hits.hits.0.fields.resource\.attributes\.body: [ resource ] }
+
+---
 dynamic templates with nesting:
   - requires:
       cluster_features: ["mapper.pass_through_priority"]

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -106,18 +106,24 @@ final class FieldTypeLookup {
                         if (conflict.priority() > passThroughMapper.priority()) {
                             // Keep the conflicting field if it has higher priority.
                             passThroughFieldAliases.put(name, conflict);
-                            continue;
                         }
                     }
-                    if (fullNameToFieldType.containsKey(name)) {
-                        // There's an existing field or alias for the same field.
-                        continue;
-                    }
-                    MappedFieldType fieldType = fieldMapper.fieldType();
-                    fullNameToFieldType.put(name, fieldType);
-                    if (fieldType instanceof DynamicFieldType) {
-                        dynamicFieldTypes.put(name, (DynamicFieldType) fieldType);
-                    }
+                }
+            }
+        }
+
+        for (Map.Entry<String, PassThroughObjectMapper> entry : passThroughFieldAliases.entrySet()) {
+            String name = entry.getKey();
+            if (fullNameToFieldType.containsKey(name)) {
+                // There's an existing field or alias for the same field.
+                continue;
+            }
+            Mapper mapper = entry.getValue().getMapper(name);
+            if (mapper instanceof FieldMapper fieldMapper) {
+                MappedFieldType fieldType = fieldMapper.fieldType();
+                fullNameToFieldType.put(name, fieldType);
+                if (fieldType instanceof DynamicFieldType) {
+                    dynamicFieldTypes.put(name, (DynamicFieldType) fieldType);
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldTypeLookup.java
@@ -108,7 +108,8 @@ final class FieldTypeLookup {
                             passThroughFieldAliases.put(name, conflict);
                             continue;
                         }
-                    } else if (fullNameToFieldType.containsKey(name)) {
+                    }
+                    if (fullNameToFieldType.containsKey(name)) {
                         // There's an existing field or alias for the same field.
                         continue;
                     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -503,10 +503,18 @@ public class FieldTypeLookupTests extends ESTestCase {
 
     public void testNoRootAliasForPassThroughFieldOnConflictingField() {
         MockFieldMapper attributeFoo = new MockFieldMapper("attributes.foo");
+        MockFieldMapper resourceAttributeFoo = new MockFieldMapper("resource.attributes.foo");
         MockFieldMapper foo = new MockFieldMapper("foo");
         PassThroughObjectMapper attributes = createPassThroughMapper("attributes", Map.of("foo", attributeFoo), 0);
+        PassThroughObjectMapper resourceAttributes = createPassThroughMapper("resource.attributes", Map.of("foo", resourceAttributeFoo), 1);
 
-        FieldTypeLookup lookup = new FieldTypeLookup(List.of(foo, attributeFoo), List.of(), List.of(attributes), List.of());
+        FieldTypeLookup lookup = new FieldTypeLookup(
+            List.of(foo, attributeFoo, resourceAttributeFoo),
+            List.of(),
+            List.of(attributes, resourceAttributes),
+            List.of()
+        );
+
         assertEquals(foo.fieldType(), lookup.get("foo"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -520,6 +520,7 @@ public class FieldTypeLookupTests extends ESTestCase {
     }
 
     @SafeVarargs
+    @SuppressWarnings("varargs")
     static <T> List<T> randomizedList(T... values) {
         ArrayList<T> list = new ArrayList<>(Arrays.asList(values));
         Collections.shuffle(list, random());

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.index.mapper.flattened.FlattenedFieldMapper;
 import org.elasticsearch.test.ESTestCase;
 import org.hamcrest.Matchers;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -493,9 +494,9 @@ public class FieldTypeLookupTests extends ESTestCase {
         );
 
         FieldTypeLookup lookup = new FieldTypeLookup(
-            List.of(attributeField, resourceAttributeField),
+            randomizedList(attributeField, resourceAttributeField),
             List.of(),
-            List.of(attributes, resourceAttributes),
+            randomizedList(attributes, resourceAttributes),
             List.of()
         );
         assertEquals(attributeField.fieldType(), lookup.get("foo"));
@@ -509,12 +510,18 @@ public class FieldTypeLookupTests extends ESTestCase {
         PassThroughObjectMapper resourceAttributes = createPassThroughMapper("resource.attributes", Map.of("foo", resourceAttributeFoo), 1);
 
         FieldTypeLookup lookup = new FieldTypeLookup(
-            List.of(foo, attributeFoo, resourceAttributeFoo),
+            randomizedList(foo, attributeFoo, resourceAttributeFoo),
             List.of(),
-            List.of(attributes, resourceAttributes),
+            randomizedList(attributes, resourceAttributes),
             List.of()
         );
 
         assertEquals(foo.fieldType(), lookup.get("foo"));
+    }
+
+    static <T> List<T> randomizedList(T... values) {
+        ArrayList<T> list = new ArrayList<>(Arrays.asList(values));
+        Collections.shuffle(list, random());
+        return list;
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldTypeLookupTests.java
@@ -519,6 +519,7 @@ public class FieldTypeLookupTests extends ESTestCase {
         assertEquals(foo.fieldType(), lookup.get("foo"));
     }
 
+    @SafeVarargs
     static <T> List<T> randomizedList(T... values) {
         ArrayList<T> list = new ArrayList<>(Arrays.asList(values));
         Collections.shuffle(list, random());


### PR DESCRIPTION
I've added a yml rest test that reproduces an assertion error when using the `passthrough` field type with conflicts on multiple levels with a top-level `match_only_text` field. 

```
[2024-07-01T03:48:58,737][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [test-cluster-1] fatal error in thread [elasticsearch[test-cluster-1][write][T#5]], exiting java.lang.AssertionError: Field body should not have docvalues
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.FieldNamesFieldMapper.addFieldNames(FieldNamesFieldMapper.java:177)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.DocumentParserContext.addToFieldNames(DocumentParserContext.java:292)
	at org.elasticsearch.mapper.extras@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.extras.MatchOnlyTextFieldMapper.parseCreateField(MatchOnlyTextFieldMapper.java:421)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.FieldMapper.parse(FieldMapper.java:185)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:450)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.DocumentParser.parseValue(DocumentParser.java:775)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.DocumentParser.innerParseObject(DocumentParser.java:368)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.DocumentParser.parseObjectOrNested(DocumentParser.java:319)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.DocumentParser.internalParseDocument(DocumentParser.java:143)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.DocumentParser.parseDocument(DocumentParser.java:88)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.mapper.DocumentMapper.parse(DocumentMapper.java:112)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.shard.IndexShard.prepareIndex(IndexShard.java:1038)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.shard.IndexShard.applyIndexOperation(IndexShard.java:979)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.index.shard.IndexShard.applyIndexOperationOnPrimary(IndexShard.java:923)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.action.bulk.TransportShardBulkAction.executeBulkItemRequest(TransportShardBulkAction.java:376)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.action.bulk.TransportShardBulkAction$2.doRun(TransportShardBulkAction.java:234)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.TimedRunnable.doRun(TimedRunnable.java:33)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:984)
	at org.elasticsearch.server@8.15.0-SNAPSHOT/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1570)
```

When changing the top-level field to a different field type, for example, `keyword` or `text`, the assertion error disappears, but the ordering is not quite right. Note that sometimes the tests pass and sometimes they fail with the following message: `Expected a list containing 0: expected "top-level" but was "resource"`. Seems like in certain cases, the passthrough field type overrides the top-level field. I'm not sure if the two issues are related or separate.

This is a dump of the search:

```json
[{
  "stash" : {
    "body" : {
      "took" : 35,
      "timed_out" : false,
      "_shards" : {
        "total" : 1,
        "successful" : 1,
        "skipped" : 0,
        "failed" : 0
      },
      "hits" : {
        "total" : {
          "value" : 1,
          "relation" : "eq"
        },
        "max_score" : 1.0,
        "hits" : [
          {
            "_index" : ".ds-otel-2024.07.01-000001",
            "_id" : "IHWS-EudCPGf0ayGAAABilDXF2o",
            "_score" : 1.0,
            "_source" : {
              "@timestamp" : "2023-09-01T13:03:08.138Z",
              "attributes" : {
                "body" : "attribute"
              },
              "body" : "top-level",
              "metrics" : {
                "data" : 10
              },
              "resource" : {
                "attributes" : {
                  "body" : "resource"
                }
              },
              "scope" : {
                "attributes" : {
                  "body" : "scope"
                }
              }
            },
            "fields" : {
              "metrics.data" : [
                10
              ],
              "@timestamp" : [
                "2023-09-01T13:03:08.138Z"
              ],
              "data" : [
                10
              ],
              "scope.attributes.body" : [
                "scope"
              ],
              "attributes.body" : [
                "attribute"
              ],
              "resource.attributes.body" : [
                "resource"
              ],
              "body" : [
                "resource"
              ]
            }
          }
        ]
      }
    }
  }
}]
```