### PR TITLE
Avoid bucket-(list) copies in more Aggregations

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/adjacency/InternalAdjacencyMatrix.java
@@ -152,7 +152,7 @@ public class InternalAdjacencyMatrix extends InternalMultiBucketAggregation<Inte
     }
 
     @Override
-    public InternalAdjacencyMatrix create(List<InternalBucket> buckets) {
+    protected InternalAdjacencyMatrix doCreate(List<InternalBucket> buckets) {
         return new InternalAdjacencyMatrix(this.name, buckets, this.metadata);
     }
 

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -264,7 +264,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
 
     @Override
     public List<InternalAutoDateHistogram.Bucket> getBuckets() {
-        return Collections.unmodifiableList(buckets);
+        return buckets;
     }
 
     DocValueFormat getFormatter() {
@@ -280,7 +280,7 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
     }
 
     @Override
-    public InternalAutoDateHistogram create(List<Bucket> buckets) {
+    protected InternalAutoDateHistogram doCreate(List<Bucket> buckets) {
         return new InternalAutoDateHistogram(name, buckets, targetBuckets, bucketInfo, format, metadata, bucketInnerInterval);
     }
 

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
@@ -245,7 +245,7 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
     }
 
     @Override
-    public InternalTimeSeries create(List<InternalBucket> buckets) {
+    protected InternalTimeSeries doCreate(List<InternalBucket> buckets) {
         return new InternalTimeSeries(name, buckets, keyed, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/InternalMultiBucketAggregation.java
@@ -52,13 +52,30 @@ public abstract class InternalMultiBucketAggregation<
 
     /**
      * Create a new copy of this {@link Aggregation} with the same settings as
+     * this {@link Aggregation} and that contains the provided buckets. If the provided buckets are equal
+     * to the buckets in this instance, no copy will be created and this instance will be returned.
+     *
+     * @param buckets
+     *            the buckets to use in the new {@link Aggregation}
+     * @return the new {@link Aggregation}
+     */
+    @SuppressWarnings("unchecked")
+    public final A create(List<B> buckets) {
+        if (buckets.equals(getBuckets())) {
+            return (A) this;
+        }
+        return doCreate(buckets);
+    }
+
+    /**
+     * Create a new copy of this {@link Aggregation} with the same settings as
      * this {@link Aggregation} and contains the provided buckets.
      *
      * @param buckets
      *            the buckets to use in the new {@link Aggregation}
      * @return the new {@link Aggregation}
      */
-    public abstract A create(List<B> buckets);
+    protected abstract A doCreate(List<B> buckets);
 
     /**
      * Create a new {@link InternalBucket} using the provided prototype bucket

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -132,7 +132,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
     }
 
     @Override
-    public InternalComposite create(List<InternalBucket> newBuckets) {
+    protected InternalComposite doCreate(List<InternalBucket> newBuckets) {
         /**
          * This is used by pipeline aggregations to filter/remove buckets so we
          * keep the <code>afterKey</code> of the original aggregation in order

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/filter/InternalFilters.java
@@ -175,7 +175,7 @@ public class InternalFilters extends InternalMultiBucketAggregation<InternalFilt
     }
 
     @Override
-    public InternalFilters create(List<InternalBucket> buckets) {
+    protected InternalFilters doCreate(List<InternalBucket> buckets) {
         return new InternalFilters(name, buckets, keyed, keyedBucket, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoGrid.java
@@ -27,8 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.Collections.unmodifiableList;
-
 /**
  * Represents a grid of cells where each cell's location is determined by a specific geo hashing algorithm.
  * All geo-grid hash-encoding in a grid are of the same precision and held internally as a single long
@@ -74,7 +72,7 @@ public abstract class InternalGeoGrid<B extends InternalGeoGridBucket> extends I
 
     @Override
     public List<InternalGeoGridBucket> getBuckets() {
-        return unmodifiableList(buckets);
+        return buckets;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoHashGrid.java
@@ -30,7 +30,7 @@ public class InternalGeoHashGrid extends InternalGeoGrid<InternalGeoHashGridBuck
     }
 
     @Override
-    public InternalGeoGrid<InternalGeoHashGridBucket> create(List<InternalGeoGridBucket> buckets) {
+    protected InternalGeoGrid<InternalGeoHashGridBucket> doCreate(List<InternalGeoGridBucket> buckets) {
         return new InternalGeoHashGrid(name, requiredSize, buckets, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoTileGrid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/InternalGeoTileGrid.java
@@ -30,7 +30,7 @@ public class InternalGeoTileGrid extends InternalGeoGrid<InternalGeoTileGridBuck
     }
 
     @Override
-    public InternalGeoGrid<InternalGeoTileGridBucket> create(List<InternalGeoGridBucket> buckets) {
+    protected InternalGeoGrid<InternalGeoTileGridBucket> doCreate(List<InternalGeoGridBucket> buckets) {
         return new InternalGeoTileGrid(name, requiredSize, buckets, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -290,7 +290,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
 
     @Override
     public List<InternalDateHistogram.Bucket> getBuckets() {
-        return Collections.unmodifiableList(buckets);
+        return buckets;
     }
 
     long getMinDocCount() {
@@ -306,7 +306,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
     }
 
     @Override
-    public InternalDateHistogram create(List<Bucket> buckets) {
+    protected InternalDateHistogram doCreate(List<Bucket> buckets) {
         return new InternalDateHistogram(
             name,
             buckets,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -269,7 +269,7 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
 
     @Override
     public List<InternalHistogram.Bucket> getBuckets() {
-        return Collections.unmodifiableList(buckets);
+        return buckets;
     }
 
     long getMinDocCount() {
@@ -281,10 +281,7 @@ public class InternalHistogram extends InternalMultiBucketAggregation<InternalHi
     }
 
     @Override
-    public InternalHistogram create(List<Bucket> buckets) {
-        if (this.buckets.equals(buckets)) {
-            return this;
-        }
+    protected InternalHistogram doCreate(List<Bucket> buckets) {
         return new InternalHistogram(name, buckets, order, minDocCount, emptyBucketInfo, format, keyed, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
@@ -282,7 +282,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
 
     @Override
     public List<Bucket> getBuckets() {
-        return Collections.unmodifiableList(buckets);
+        return buckets;
     }
 
     public int getTargetBuckets() {
@@ -294,7 +294,7 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
     }
 
     @Override
-    public InternalVariableWidthHistogram create(List<Bucket> buckets) {
+    protected InternalVariableWidthHistogram doCreate(List<Bucket> buckets) {
         return new InternalVariableWidthHistogram(name, buckets, emptyBucketInfo, targetNumBuckets, format, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefix.java
@@ -25,7 +25,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -308,7 +307,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
     }
 
     @Override
-    public InternalIpPrefix create(List<Bucket> buckets) {
+    protected InternalIpPrefix doCreate(List<Bucket> buckets) {
         return new InternalIpPrefix(name, format, keyed, minDocCount, buckets, metadata);
     }
 
@@ -351,7 +350,7 @@ public class InternalIpPrefix extends InternalMultiBucketAggregation<InternalIpP
 
     @Override
     public List<Bucket> getBuckets() {
-        return Collections.unmodifiableList(buckets);
+        return buckets;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRange.java
@@ -28,8 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static java.util.Collections.unmodifiableList;
-
 /** A range aggregation for data that is encoded in doc values using a binary representation. */
 public final class InternalBinaryRange extends InternalMultiBucketAggregation<InternalBinaryRange, InternalBinaryRange.Bucket>
     implements
@@ -230,11 +228,11 @@ public final class InternalBinaryRange extends InternalMultiBucketAggregation<In
 
     @Override
     public List<InternalBinaryRange.Bucket> getBuckets() {
-        return unmodifiableList(buckets);
+        return buckets;
     }
 
     @Override
-    public InternalBinaryRange create(List<Bucket> buckets) {
+    protected InternalBinaryRange doCreate(List<Bucket> buckets) {
         return new InternalBinaryRange(name, format, keyed, buckets, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/InternalRange.java
@@ -313,7 +313,7 @@ public class InternalRange<B extends InternalRange.Bucket, R extends InternalRan
 
     @SuppressWarnings("unchecked")
     @Override
-    public R create(List<B> buckets) {
+    protected R doCreate(List<B> buckets) {
         return getFactory().create(buckets, (R) this);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/DoubleTerms.java
@@ -140,7 +140,7 @@ public class DoubleTerms extends InternalMappedTerms<DoubleTerms, DoubleTerms.Bu
     }
 
     @Override
-    public DoubleTerms create(List<Bucket> buckets) {
+    protected DoubleTerms doCreate(List<Bucket> buckets) {
         return new DoubleTerms(
             name,
             reduceOrder,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/InternalMappedSignificantTerms.java
@@ -72,7 +72,7 @@ public abstract class InternalMappedSignificantTerms<
 
     @Override
     public Iterator<SignificantTerms.Bucket> iterator() {
-        return buckets.stream().map(bucket -> (SignificantTerms.Bucket) bucket).toList().iterator();
+        return buckets.stream().map(bucket -> (SignificantTerms.Bucket) bucket).iterator();
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongRareTerms.java
@@ -107,7 +107,7 @@ public class LongRareTerms extends InternalMappedRareTerms<LongRareTerms, LongRa
     }
 
     @Override
-    public LongRareTerms create(List<LongRareTerms.Bucket> buckets) {
+    protected LongRareTerms doCreate(List<LongRareTerms.Bucket> buckets) {
         return new LongRareTerms(name, order, metadata, format, buckets, maxDocCount, filter);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/LongTerms.java
@@ -154,7 +154,7 @@ public class LongTerms extends InternalMappedTerms<LongTerms, LongTerms.Bucket> 
     }
 
     @Override
-    public LongTerms create(List<Bucket> buckets) {
+    protected LongTerms doCreate(List<Bucket> buckets) {
         return new LongTerms(
             name,
             reduceOrder,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantLongTerms.java
@@ -119,7 +119,7 @@ public class SignificantLongTerms extends InternalMappedSignificantTerms<Signifi
     }
 
     @Override
-    public SignificantLongTerms create(List<SignificantLongTerms.Bucket> buckets) {
+    protected SignificantLongTerms doCreate(List<SignificantLongTerms.Bucket> buckets) {
         return new SignificantLongTerms(
             name,
             requiredSize,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/SignificantStringTerms.java
@@ -123,7 +123,7 @@ public class SignificantStringTerms extends InternalMappedSignificantTerms<Signi
     }
 
     @Override
-    public SignificantStringTerms create(List<SignificantStringTerms.Bucket> buckets) {
+    protected SignificantStringTerms doCreate(List<SignificantStringTerms.Bucket> buckets) {
         return new SignificantStringTerms(
             name,
             requiredSize,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringRareTerms.java
@@ -101,7 +101,7 @@ public class StringRareTerms extends InternalMappedRareTerms<StringRareTerms, St
     }
 
     @Override
-    public StringRareTerms create(List<StringRareTerms.Bucket> buckets) {
+    protected StringRareTerms doCreate(List<StringRareTerms.Bucket> buckets) {
         return new StringRareTerms(name, order, metadata, format, buckets, maxDocCount, filter);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/StringTerms.java
@@ -160,7 +160,7 @@ public class StringTerms extends InternalMappedTerms<StringTerms, StringTerms.Bu
     }
 
     @Override
-    public StringTerms create(List<Bucket> buckets) {
+    protected StringTerms doCreate(List<Bucket> buckets) {
         return new StringTerms(
             name,
             reduceOrder,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedRareTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedRareTerms.java
@@ -69,8 +69,8 @@ public class UnmappedRareTerms extends InternalRareTerms<UnmappedRareTerms, Unma
     }
 
     @Override
-    public UnmappedRareTerms create(List<UnmappedRareTerms.Bucket> buckets) {
-        return new UnmappedRareTerms(name, metadata);
+    protected UnmappedRareTerms doCreate(List<UnmappedRareTerms.Bucket> buckets) {
+        throw new UnsupportedOperationException("not supported for UnmappedRareTerms");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedSignificantTerms.java
@@ -79,8 +79,8 @@ public class UnmappedSignificantTerms extends InternalSignificantTerms<UnmappedS
     }
 
     @Override
-    public UnmappedSignificantTerms create(List<Bucket> buckets) {
-        return new UnmappedSignificantTerms(name, requiredSize, minDocCount, metadata);
+    protected UnmappedSignificantTerms doCreate(List<Bucket> buckets) {
+        throw new UnsupportedOperationException("not supported for UnmappedSignificantTerms");
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/UnmappedTerms.java
@@ -74,8 +74,8 @@ public class UnmappedTerms extends InternalTerms<UnmappedTerms, UnmappedTerms.Bu
     }
 
     @Override
-    public UnmappedTerms create(List<Bucket> buckets) {
-        return new UnmappedTerms(name, order, requiredSize, minDocCount, metadata);
+    protected UnmappedTerms doCreate(List<Bucket> buckets) {
+        throw new UnsupportedOperationException("not supported for UnmappedTerms");
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/InternalMultiTerms.java
@@ -421,7 +421,7 @@ public class InternalMultiTerms extends AbstractInternalTerms<InternalMultiTerms
 
     @Override
     @SuppressWarnings("HiddenField")
-    public InternalMultiTerms create(List<Bucket> buckets) {
+    protected InternalMultiTerms doCreate(List<Bucket> buckets) {
         return new InternalMultiTerms(
             name,
             reduceOrder,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/InternalCategorizationAggregation.java
@@ -287,7 +287,7 @@ public class InternalCategorizationAggregation extends InternalMultiBucketAggreg
     }
 
     @Override
-    public InternalCategorizationAggregation create(List<Bucket> buckets) {
+    protected InternalCategorizationAggregation doCreate(List<Bucket> buckets) {
         return new InternalCategorizationAggregation(name, requiredSize, minDocCount, similarityThreshold, super.metadata, buckets);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/UnmappedCategorizationAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/categorization/UnmappedCategorizationAggregation.java
@@ -28,8 +28,8 @@ class UnmappedCategorizationAggregation extends InternalCategorizationAggregatio
     }
 
     @Override
-    public InternalCategorizationAggregation create(List<Bucket> buckets) {
-        return new UnmappedCategorizationAggregation(name, getRequiredSize(), getMinDocCount(), getSimilarityThreshold(), super.metadata);
+    protected InternalCategorizationAggregation doCreate(List<Bucket> buckets) {
+        throw new UnsupportedOperationException("not supported for UnmappedCategorizationAggregation");
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/InternalGeoHexGrid.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/InternalGeoHexGrid.java
@@ -31,7 +31,7 @@ public class InternalGeoHexGrid extends InternalGeoGrid<InternalGeoHexGridBucket
     }
 
     @Override
-    public InternalGeoGrid<InternalGeoHexGridBucket> create(List<InternalGeoGridBucket> buckets) {
+    protected InternalGeoGrid<InternalGeoHexGridBucket> doCreate(List<InternalGeoGridBucket> buckets) {
         return new InternalGeoHexGrid(name, requiredSize, buckets, metadata);
     }
 


### PR DESCRIPTION
Same as #110261 but more globally applied. Removed copying of aggregation instances as well as needlessly wrapping bucket list (to make this equals freeish in most cases).
