### PR TITLE
Do not trip circuit breaker when getting shutdown status

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -83,6 +83,7 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
     ) {
         super(
             GetShutdownStatusAction.NAME,
+            false,
             transportService,
             clusterService,
             threadPool,


### PR DESCRIPTION
Update TransportGetShutdownStatusAction so that it can not trip circuit breaker.
If circuit breaker is tripped when orchestrator is checking the shutdown status then cluster is shutdown prematurely, leading to availability lose. 