### PR TITLE
Update the recorded index version when an index is opened

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexStateService.java
@@ -1132,6 +1132,7 @@ public class MetadataIndexStateService {
                         .state(IndexMetadata.State.OPEN)
                         .settingsVersion(indexMetadata.getSettingsVersion() + 1)
                         .settings(updatedSettings)
+                        .indexVersionWatermark(IndexVersion.current())
                         .timestampRange(IndexLongFieldRange.NO_SHARDS)
                         .eventIngestedRange(IndexLongFieldRange.NO_SHARDS, currentState.getMinTransportVersion())
                         .build();

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -201,7 +201,7 @@ public class MetadataMappingService {
                 }
                 if (updatedMapping) {
                     indexMetadataBuilder.mappingVersion(1 + indexMetadataBuilder.mappingVersion())
-                        .mappingsUpdatedVersion(IndexVersion.current());
+                        .indexVersionWatermark(IndexVersion.current());
                 }
                 /*
                  * This implicitly increments the index metadata version and builds the index metadata. This means that we need to have

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
@@ -247,7 +247,7 @@ public class MetadataMigrateToDataStreamService {
         imb.settings(settingsUpdate.build())
             .settingsVersion(im.getSettingsVersion() + 1)
             .mappingVersion(im.getMappingVersion() + 1)
-            .mappingsUpdatedVersion(IndexVersion.current())
+            .indexVersionWatermark(IndexVersion.current())
             .putMapping(new MappingMetadata(mapper));
         b.put(imb);
     }

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -1757,7 +1757,7 @@ public final class RestoreService implements ClusterStateApplier {
             .state(IndexMetadata.State.OPEN)
             .version(Math.max(snapshotIndexMetadata.getVersion(), 1 + currentIndexMetadata.getVersion()))
             .mappingVersion(Math.max(snapshotIndexMetadata.getMappingVersion(), 1 + currentIndexMetadata.getMappingVersion()))
-            .mappingsUpdatedVersion(snapshotIndexMetadata.getMappingsUpdatedVersion())
+            .indexVersionWatermark(snapshotIndexMetadata.getIndexVersionWatermark())
             .settingsVersion(Math.max(snapshotIndexMetadata.getSettingsVersion(), 1 + currentIndexMetadata.getSettingsVersion()))
             .aliasesVersion(Math.max(snapshotIndexMetadata.getAliasesVersion(), 1 + currentIndexMetadata.getAliasesVersion()))
             .timestampRange(IndexLongFieldRange.NO_SHARDS)

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -188,7 +188,7 @@ public class ClusterRerouteResponseTests extends ESTestCase {
                                 "0": []
                               },
                               "rollover_info": {},
-                              "mappings_updated_version" : %s,
+                              "index_version_watermark" : %s,
                               "system": false,
                               "timestamp_range": {
                                 "shards": []
@@ -272,7 +272,7 @@ public class ClusterRerouteResponseTests extends ESTestCase {
                             "0" : [ ]
                           },
                           "rollover_info" : { },
-                          "mappings_updated_version" : %s,
+                          "index_version_watermark" : %s,
                           "system" : false,
                           "timestamp_range" : {
                             "shards" : [ ]

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -310,7 +310,7 @@ public class ClusterStateTests extends ESTestCase {
                                     "time": 1
                                   }
                                 },
-                                "mappings_updated_version" : %s,
+                                "index_version_watermark" : %s,
                                 "system": false,
                                 "timestamp_range": {
                                   "shards": []
@@ -578,7 +578,7 @@ public class ClusterStateTests extends ESTestCase {
                                 "time" : 1
                               }
                             },
-                            "mappings_updated_version" : %s,
+                            "index_version_watermark" : %s,
                             "system" : false,
                             "timestamp_range" : {
                               "shards" : [ ]
@@ -856,7 +856,7 @@ public class ClusterStateTests extends ESTestCase {
                                 "time" : 1
                               }
                             },
-                            "mappings_updated_version" : %s,
+                            "index_version_watermark" : %s,
                             "system" : false,
                             "timestamp_range" : {
                               "shards" : [ ]
@@ -1030,7 +1030,7 @@ public class ClusterStateTests extends ESTestCase {
                       "0" : [ ]
                     },
                     "rollover_info" : { },
-                    "mappings_updated_version" : %s,
+                    "index_version_watermark" : %s,
                     "system" : false,
                     "timestamp_range" : {
                       "shards" : [ ]

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataTests.java
@@ -115,7 +115,7 @@ public class IndexMetadataTests extends ESTestCase {
                     randomNonNegativeLong()
                 )
             )
-            .mappingsUpdatedVersion(mappingsUpdatedVersion)
+            .indexVersionWatermark(mappingsUpdatedVersion)
             .stats(indexStats)
             .indexWriteLoadForecast(indexWriteLoadForecast)
             .shardSizeInBytesForecast(shardSizeInBytesForecast)
@@ -155,7 +155,7 @@ public class IndexMetadataTests extends ESTestCase {
         assertEquals(metadata.getCreationDate(), fromXContentMeta.getCreationDate());
         assertEquals(metadata.getRoutingFactor(), fromXContentMeta.getRoutingFactor());
         assertEquals(metadata.primaryTerm(0), fromXContentMeta.primaryTerm(0));
-        assertEquals(metadata.getMappingsUpdatedVersion(), fromXContentMeta.getMappingsUpdatedVersion());
+        assertEquals(metadata.getIndexVersionWatermark(), fromXContentMeta.getIndexVersionWatermark());
         assertEquals(metadata.isSystem(), fromXContentMeta.isSystem());
         Map<String, DiffableStringMap> expectedCustom = Map.of("my_custom", new DiffableStringMap(customMap));
         assertEquals(metadata.getCustomData(), expectedCustom);
@@ -183,7 +183,7 @@ public class IndexMetadataTests extends ESTestCase {
             assertEquals(metadata.getRolloverInfos(), deserialized.getRolloverInfos());
             assertEquals(deserialized.getCustomData(), expectedCustom);
             assertEquals(metadata.getCustomData(), deserialized.getCustomData());
-            assertEquals(metadata.getMappingsUpdatedVersion(), deserialized.getMappingsUpdatedVersion());
+            assertEquals(metadata.getIndexVersionWatermark(), deserialized.getIndexVersionWatermark());
             assertEquals(metadata.isSystem(), deserialized.isSystem());
             assertEquals(metadata.getStats(), deserialized.getStats());
             assertEquals(metadata.getForecastedWriteLoad(), deserialized.getForecastedWriteLoad());

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
@@ -95,7 +95,7 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
             singleTask(request)
         );
         assertThat(resultingState.metadata().index("test").getMappingVersion(), equalTo(1 + previousVersion));
-        assertThat(resultingState.metadata().index("test").getMappingsUpdatedVersion(), equalTo(IndexVersion.current()));
+        assertThat(resultingState.metadata().index("test").getIndexVersionWatermark(), equalTo(IndexVersion.current()));
     }
 
     public void testMappingVersionUnchanged() throws Exception {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
@@ -349,7 +349,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
                       "0" : [ ]
                     },
                     "rollover_info" : { },
-                    "mappings_updated_version" : %s,
+                    "index_version_watermark" : %s,
                     "system" : false,
                     "timestamp_range" : {
                       "shards" : [ ]
@@ -523,7 +523,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
                         "time" : 1
                       }
                     },
-                    "mappings_updated_version" : %s,
+                    "index_version_watermark" : %s,
                     "system" : false,
                     "timestamp_range" : {
                       "shards" : [ ]
@@ -637,7 +637,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
                         "time" : 1
                       }
                     },
-                    "mappings_updated_version" : %s,
+                    "index_version_watermark" : %s,
                     "system" : false,
                     "timestamp_range" : {
                       "shards" : [ ]
@@ -777,7 +777,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
                         "time" : 1
                       }
                     },
-                    "mappings_updated_version" : %s,
+                    "index_version_watermark" : %s,
                     "system" : false,
                     "timestamp_range" : {
                       "shards" : [ ]


### PR DESCRIPTION
This is for #102708

Update the recorded highest index version when an index is opened, not just when mappings are updated. This is to ensure that once an index has been opened by a node with a particular index version, it is then only allocated (by the index version allocator in #102708) to nodes with that index version or above