### PR TITLE
Support ignore_above on keyword dimensions

### DIFF
--- a/docs/changelog/110337.yaml
+++ b/docs/changelog/110337.yaml
@@ -1,0 +1,5 @@
+pr: 110337
+summary: Support `ignore_above` on keyword dimensions
+area: TSDB
+type: enhancement
+issues: []

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -923,20 +923,38 @@ dimensions with ignore_malformed and ignore_above:
         refresh: true
         body:
           - '{ "create": { } }'
-          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": "10", "attributes.keyword_dim": "foo", "attributes.keyword_dim_ignored": "ignored", "attributes.long_dim_ignored": "ignored" }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": 10, "attributes.keyword_dim": "foo", "attributes.keyword_dim_ignored": "ignored", "attributes.long_dim_ignored": "ignored" }'
           - '{ "create": { } }'
-          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": "20", "attributes.keyword_dim": "foo", "attributes.keyword_dim_ignored": "ignored too", "attributes.long_dim_ignored": "ignored" }'
-  - match: { errors: false }
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": 20, "attributes.keyword_dim": "foo", "attributes.keyword_dim_ignored": "ignored too", "attributes.long_dim_ignored": "ignored" }'
+          - '{ "create": { } }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": 30, "attributes.keyword_dim_ignored": "ignored 3" }'
+          - '{ "create": { } }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": 40, "attributes.keyword_dim_ignored": "ignored 4" }'
+          - '{ "create": { } }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": 50, "attributes.keyword_dim_ignored": "duplicate" }'
+          - '{ "create": { } }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": 60, "attributes.keyword_dim_ignored": "duplicate" }'
+  - match: { errors: true }
+  - match: { items.0.create.result: created }
+  - match: { items.1.create.result: created }
+  - match: { items.2.create.result: created }
+  - match: { items.3.create.result: created }
+  - match: { items.4.create.result: created }
+  - match: { items.5.create.error.type: version_conflict_engine_exception }
 
   - do:
       search:
         index: k9s
         body:
-          size: 2
+          sort:
+            - data: asc
 
-  - match: { hits.total.value: 2 }
+  - match: { hits.total.value: 5 }
   - match: { hits.hits.0._ignored: ["attributes.keyword_dim_ignored", "attributes.long_dim_ignored"]}
   - match: { hits.hits.1._ignored: ["attributes.keyword_dim_ignored", "attributes.long_dim_ignored"]}
+  - match: { hits.hits.2._ignored: ["attributes.keyword_dim_ignored"]}
+  - match: { hits.hits.3._ignored: ["attributes.keyword_dim_ignored"]}
+  - match: { hits.hits.4._ignored: ["attributes.keyword_dim_ignored"]}
 
   - do:
       search:

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/150_tsdb.yml
@@ -875,3 +875,79 @@ passthrough objects with duplicate priority:
                 resource.attributes:
                   type: passthrough
                   priority: 1
+
+---
+dimensions with ignore_malformed and ignore_above:
+  - requires:
+      cluster_features: ["mapper.keyword_dimension_ignore_above"]
+      reason: support for ignore_above on keyword dimensions
+  - do:
+      allowed_warnings:
+        - "index template [my-dynamic-template] has index patterns [k9s*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-dynamic-template] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-dynamic-template
+        body:
+          index_patterns: [k9s*]
+          data_stream: {}
+          template:
+            settings:
+              index:
+                number_of_shards: 1
+                mode: time_series
+                time_series:
+                  start_time: 2023-08-31T13:03:08.138Z
+
+            mappings:
+              properties:
+                attributes:
+                  type: passthrough
+                  time_series_dimension: true
+                  priority: 0
+                  properties:
+                    keyword_dim:
+                      type: keyword
+                    keyword_dim_ignored:
+                      type: keyword
+                      ignore_above: 2
+                    long_dim_ignored:
+                      type: long
+                      ignore_malformed: true
+                data:
+                  type: long
+                  time_series_metric: gauge
+                  ignore_malformed: true
+
+  - do:
+      bulk:
+        index: k9s
+        refresh: true
+        body:
+          - '{ "create": { } }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": "10", "attributes.keyword_dim": "foo", "attributes.keyword_dim_ignored": "ignored", "attributes.long_dim_ignored": "ignored" }'
+          - '{ "create": { } }'
+          - '{ "@timestamp": "2023-09-01T13:03:08.138Z", "data": "20", "attributes.keyword_dim": "foo", "attributes.keyword_dim_ignored": "ignored too", "attributes.long_dim_ignored": "ignored" }'
+  - match: { errors: false }
+
+  - do:
+      search:
+        index: k9s
+        body:
+          size: 2
+
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._ignored: ["attributes.keyword_dim_ignored", "attributes.long_dim_ignored"]}
+  - match: { hits.hits.1._ignored: ["attributes.keyword_dim_ignored", "attributes.long_dim_ignored"]}
+
+  - do:
+      search:
+        index: k9s
+        body:
+          size: 0
+          aggs:
+            keyword_dims:
+              terms:
+                field: keyword_dim
+
+  - length: { aggregations.keyword_dims.buckets: 1 }
+  - match: { aggregations.keyword_dims.buckets.0.key: "foo" }
+  - match: { aggregations.keyword_dims.buckets.0.doc_count: 2 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.search.AutomatonQueries;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.features.NodeFeature;
 import org.elasticsearch.index.IndexVersion;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
 import org.elasticsearch.index.analysis.NamedAnalyzer;
@@ -85,6 +86,8 @@ public final class KeywordFieldMapper extends FieldMapper {
     private static final Logger logger = LogManager.getLogger(KeywordFieldMapper.class);
 
     public static final String CONTENT_TYPE = "keyword";
+
+    static final NodeFeature KEYWORD_DIMENSION_IGNORE_ABOVE = new NodeFeature("mapper.keyword_dimension_ignore_above");
 
     public static class Defaults {
         public static final FieldType FIELD_TYPE;
@@ -210,7 +213,7 @@ public final class KeywordFieldMapper extends FieldMapper {
                             + "] are true"
                     );
                 }
-            }).precludesParameters(normalizer, ignoreAbove);
+            }).precludesParameters(normalizer);
         }
 
         public Builder(String name, IndexVersion indexCreatedVersion) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MapperFeatures.java
@@ -27,7 +27,8 @@ public class MapperFeatures implements FeatureSpecification {
             SourceFieldMapper.SYNTHETIC_SOURCE_FALLBACK,
             DenseVectorFieldMapper.INT4_QUANTIZATION,
             DenseVectorFieldMapper.BIT_VECTORS,
-            DocumentMapper.INDEX_SORTING_ON_NESTED
+            DocumentMapper.INDEX_SORTING_ON_NESTED,
+            KeywordFieldMapper.KEYWORD_DIMENSION_IGNORE_ABOVE
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -320,15 +320,13 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         assertDimension(false, KeywordFieldMapper.KeywordFieldType::isDimension);
     }
 
-    public void testDimensionAndIgnoreAbove() {
-        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+    public void testDimensionAndIgnoreAbove() throws IOException {
+        DocumentMapper documentMapper = createDocumentMapper(fieldMapping(b -> {
             minimalMapping(b);
             b.field("time_series_dimension", true).field("ignore_above", 2048);
-        })));
-        assertThat(
-            e.getCause().getMessage(),
-            containsString("Field [ignore_above] cannot be set in conjunction with field [time_series_dimension]")
-        );
+        }));
+        KeywordFieldMapper field = (KeywordFieldMapper) documentMapper.mappers().getMapper("field");
+        assertEquals(2048, field.fieldType().ignoreAbove());
     }
 
     public void testDimensionAndNormalizer() {


### PR DESCRIPTION
At the moment, it's not possible to set `ignore_above` on `keyword` dimension fields. This flag is used a lot in our integrations and in ECS. It helps to reduce the number of logs/metrics we need to reject.

This is also somewhat inconsistent as it's possible to set `ignore_malformed` on numeric dimension fields. Both options end up adding malformed values to `_ignored` and don't add doc_values and postings.

I'd like to propose adding support for `ignore_above` to be consistent with allowing `ignore_malformed` on numeric fields. The other option would be to take away the support for `ignore_malformed` but that seems to be a breaking change.

I've added a test that verifies that ignoring those dimensions is safe in the sense that it doesn't lead to document rejections due to duplicate detection if the only dimensions that differ are ignored.