### PR TITLE
Run terms concurrently when cardinality is only lower than shard size

### DIFF
--- a/docs/changelog/110339.yaml
+++ b/docs/changelog/110339.yaml
@@ -1,0 +1,6 @@
+pr: 110339
+summary: Run terms concurrently when cardinality is only lower than shard size
+area: Aggregations
+type: bug
+issues:
+ - 105505

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -172,7 +172,7 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Term
                 return cardinality <= KEY_ORDER_CONCURRENCY_THRESHOLD;
             }
             BucketCountThresholds adjusted = TermsAggregatorFactory.adjustBucketCountThresholds(bucketCountThresholds, order);
-            return cardinality <= adjusted.getShardSize();
+            return cardinality < adjusted.getShardSize();
         }
         return false;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -172,6 +172,7 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Term
                 return cardinality <= KEY_ORDER_CONCURRENCY_THRESHOLD;
             }
             BucketCountThresholds adjusted = TermsAggregatorFactory.adjustBucketCountThresholds(bucketCountThresholds, order);
+            // shard size is not inclusive
             return cardinality < adjusted.getShardSize();
         }
         return false;


### PR DESCRIPTION
We currently run terns concurrently when cardinality is lower or equal to shard size. The issue is shard size is not inclusive so in the rare case that the cardinality is equal to the shard size, we can be adding some error to the result. 

This showed up in a random test.

fixes https://github.com/elastic/elasticsearch/issues/105505