### PR TITLE
[ML] Use documented weighted_tokens format in YAML tests

### DIFF
--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/40_text_expansion.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/40_text_expansion.yml
@@ -282,7 +282,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -307,7 +307,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -329,7 +329,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -353,7 +353,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "octopus": 1.0 }, { "comforter": 1.0 }, { "is": 1.0 }, { "the": 1.0 }, { "best": 1.0 }, { "of": 1.0 }, { "the": 1.0 }, { "bunch": 1.0 } ]
+                tokens: {"the": 1.0, "octopus": 1.0, "comforter": 1.0, "is": 1.0, "the": 1.0, "best": 1.0, "of": 1.0, "the": 1.0, "bunch": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4

--- a/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/40_text_expansion.yml
+++ b/x-pack/plugin/ml/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/remote_cluster/40_text_expansion.yml
@@ -282,7 +282,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -307,7 +307,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -329,7 +329,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -353,7 +353,7 @@ teardown:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "octopus": 1.0 }, { "comforter": 1.0 }, { "is": 1.0 }, { "the": 1.0 }, { "best": 1.0 }, { "of": 1.0 }, { "the": 1.0 }, { "bunch": 1.0 } ]
+                tokens: {"the": 1.0, "octopus": 1.0, "comforter": 1.0, "is": 1.0, "the": 1.0, "best": 1.0, "of": 1.0, "the": 1.0, "bunch": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
@@ -247,7 +247,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 1
                   tokens_weight_threshold: 0.4
@@ -272,7 +272,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config: { }
       allowed_warnings:
         - "weighted_tokens is deprecated and will be removed. Use sparse_vector instead."
@@ -294,7 +294,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "comforter": 1.0 }, { "smells": 1.0 }, { "bad": 1.0 } ]
+                tokens: {"the": 1.0, "comforter": 1.0, "smells": 1.0, "bad": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 4
                   tokens_weight_threshold: 0.4
@@ -318,7 +318,7 @@ setup:
           query:
             weighted_tokens:
               ml.tokens:
-                tokens: [ { "the": 1.0 }, { "octopus": 1.0 }, { "comforter": 1.0 }, { "is": 1.0 }, { "the": 1.0 }, { "best": 1.0 }, { "of": 1.0 }, { "the": 1.0 }, { "bunch": 1.0 } ]
+                tokens: {"the": 1.0, "octopus": 1.0, "comforter": 1.0, "is": 1.0, "the": 1.0, "best": 1.0, "of": 1.0, "the": 1.0, "bunch": 1.0}
                 pruning_config:
                   tokens_freq_ratio_threshold: 3
                   tokens_weight_threshold: 0.4


### PR DESCRIPTION
The weighted_tokens query is documented to accept "a list of pairs" but the example code documents a dictionary. It's useful to only use a single form to make it clear to clients what they can use. The YAML tests are used for validation of the specification too.

This is currently not assigned to a team while I'm experimenting.