### PR TITLE
Fix semantic_text doc page

### DIFF
--- a/docs/reference/mapping/types/semantic-text.asciidoc
+++ b/docs/reference/mapping/types/semantic-text.asciidoc
@@ -5,4 +5,4 @@
 <titleabbrev>Semantic text</titleabbrev>
 ++++
 
-INFO: The `semantic_text` field type is coming in `8.15`
+NOTE: The `semantic_text` field type is coming in `8.15`


### PR DESCRIPTION
Current semantic_text page for 8.14 is not rendered correclty:

![image](https://github.com/elastic/elasticsearch/assets/6339205/74a7bd3c-8b87-429d-854e-27c20ed579df)

Use a `NOTE` instead.