### PR TITLE
Don't detect PlainActionFuture deadlock on concurrent complete

### DIFF
--- a/docs/changelog/110361.yaml
+++ b/docs/changelog/110361.yaml
@@ -1,0 +1,7 @@
+pr: 110361
+summary: Don't detect `PlainActionFuture` deadlock on concurrent complete
+area: Distributed
+type: bug
+issues:
+ - 110181
+ - 110360

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -379,7 +379,11 @@ public class PlainActionFuture<T> implements ActionFuture<T>, ActionListener<T> 
             } else if (getState() == COMPLETING) {
                 // If some other thread is currently completing the future, block until
                 // they are done so we can guarantee completion.
-                acquireShared(-1);
+                // Don't use acquire here, to prevent false-positive deadlock detection
+                // when multiple threads from the same pool are completing the future
+                while (isDone() == false) {
+                    Thread.onSpinWait();
+                }
             }
             return doCompletion;
         }

--- a/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
@@ -150,7 +150,7 @@ public class PlainActionFutureTests extends ESTestCase {
         assertPropagatesInterrupt(() -> future.actionGet(10, TimeUnit.SECONDS));
     }
 
-    public void testAssertCompleteAllowedAllowsConcurrentCompletes() throws InterruptedException {
+    public void testAssertCompleteAllowedAllowsConcurrentCompletesFromSamePool() throws InterruptedException {
         assumeTrue("Assertions need to be enabled for assertCompleteAllowed to be invoked", Assertions.ENABLED);
         try (TestThreadPool threadPool = new TestThreadPool(getTestName())) {
             final AtomicReference<PlainActionFuture<?>> futureReference = new AtomicReference<>(new PlainActionFuture<>());

--- a/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
@@ -164,7 +164,7 @@ public class PlainActionFutureTests extends ESTestCase {
             }
             startBarrier.countDown();
             safeAwait(startBarrier);
-            cs.poll(500, TimeUnit.MILLISECONDS);
+            cs.poll(250, TimeUnit.MILLISECONDS);
             running.set(false);
             futures.forEach(ESTestCase::safeGet);
         }
@@ -175,7 +175,6 @@ public class PlainActionFutureTests extends ESTestCase {
         private final AtomicReference<PlainActionFuture<?>> future;
         private final AtomicBoolean running;
         private final CountDownLatch startBarrier;
-        private volatile boolean failed = false;
 
         private FutureCompleter(
             int number,
@@ -201,10 +200,7 @@ public class PlainActionFutureTests extends ESTestCase {
                     future.get().onResponse(null);
                 }
             } finally {
-                if (running.get()) {
-                    // We failed
-                    failed = true;
-                }
+                // In the event we failed, stop all the other FutureCompleter instances
                 running.set(false);
             }
         }

--- a/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
@@ -164,7 +164,7 @@ public class PlainActionFutureTests extends ESTestCase {
             }
             startBarrier.countDown();
             safeAwait(startBarrier);
-            cs.poll(250, TimeUnit.MILLISECONDS);
+            cs.poll(20, TimeUnit.MILLISECONDS);
             running.set(false);
             futures.forEach(ESTestCase::safeGet);
         }

--- a/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/PlainActionFutureTests.java
@@ -146,7 +146,6 @@ public class PlainActionFutureTests extends ESTestCase {
     }
 
     public void testAssertCompleteAllowedAllowsConcurrentCompletesFromSamePool() {
-        assumeTrue("Assertions need to be enabled for assertCompleteAllowed to be invoked", Assertions.ENABLED);
         final AtomicReference<PlainActionFuture<?>> futureReference = new AtomicReference<>(new PlainActionFuture<>());
         final var executorName = randomFrom(ThreadPool.Names.GENERIC, ThreadPool.Names.MANAGEMENT);
         final var running = new AtomicBoolean(true);


### PR DESCRIPTION
Closes #110360
Closes #110181 

I don't love the test for this, but it does reproduce the issue reliably. Any suggestions for making it less verbose are appreciated.
