### PR TITLE
[Inference API] Use projectId for Google Vertex AI embeddings rate limit grouping

### DIFF
--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/GoogleVertexAiEmbeddingsRequestManager.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/external/http/sender/GoogleVertexAiEmbeddingsRequestManager.java
@@ -46,11 +46,11 @@ public class GoogleVertexAiEmbeddingsRequestManager extends GoogleVertexAiReques
         this.truncator = Objects.requireNonNull(truncator);
     }
 
-    record RateLimitGrouping(int modelIdHash) {
+    record RateLimitGrouping(int projectIdHash) {
         public static RateLimitGrouping of(GoogleVertexAiEmbeddingsModel model) {
             Objects.requireNonNull(model);
 
-            return new RateLimitGrouping(model.rateLimitServiceSettings().modelId().hashCode());
+            return new RateLimitGrouping(model.rateLimitServiceSettings().projectId().hashCode());
         }
     }
 

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsRateLimitServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsRateLimitServiceSettings.java
@@ -11,5 +11,5 @@ import org.elasticsearch.xpack.inference.services.googlevertexai.GoogleVertexAiR
 
 public interface GoogleVertexAiEmbeddingsRateLimitServiceSettings extends GoogleVertexAiRateLimitServiceSettings {
 
-    String modelId();
+    String projectId();
 }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsServiceSettings.java
@@ -155,6 +155,7 @@ public class GoogleVertexAiEmbeddingsServiceSettings extends FilteredXContentObj
         this.rateLimitSettings = new RateLimitSettings(in);
     }
 
+    @Override
     public String projectId() {
         return projectId;
     }

--- a/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsServiceSettings.java
+++ b/x-pack/plugin/inference/src/main/java/org/elasticsearch/xpack/inference/services/googlevertexai/embeddings/GoogleVertexAiEmbeddingsServiceSettings.java
@@ -163,7 +163,6 @@ public class GoogleVertexAiEmbeddingsServiceSettings extends FilteredXContentObj
         return location;
     }
 
-    @Override
     public String modelId() {
         return modelId;
     }


### PR DESCRIPTION
Follow-up for https://github.com/elastic/elasticsearch/pull/110273#discussion_r1660971704