### PR TITLE
Run terms concurrently when cardinality is only lower than shard size

### DIFF
--- a/docs/changelog/110369.yaml
+++ b/docs/changelog/110369.yaml
@@ -1,0 +1,6 @@
+pr: 110369
+summary: Run terms concurrently when cardinality is only lower than shard size
+area: Aggregations
+type: bug
+issues:
+ - 105505

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -172,7 +172,8 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Term
                 return cardinality <= KEY_ORDER_CONCURRENCY_THRESHOLD;
             }
             BucketCountThresholds adjusted = TermsAggregatorFactory.adjustBucketCountThresholds(bucketCountThresholds, order);
-            return cardinality <= adjusted.getShardSize();
+            // for cardinality equal to shard size, we don't know if there were more terms when merging.
+            return cardinality < adjusted.getShardSize();
         }
         return false;
     }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/TermsTests.java
@@ -211,8 +211,8 @@ public class TermsTests extends BaseAggregationTestCase<TermsAggregationBuilder>
         {
             TermsAggregationBuilder terms = new TermsAggregationBuilder("terms");
             terms.shardSize(10);
-            assertTrue(terms.supportsParallelCollection(field -> randomIntBetween(1, 10)));
-            assertFalse(terms.supportsParallelCollection(field -> randomIntBetween(11, 100)));
+            assertTrue(terms.supportsParallelCollection(field -> randomIntBetween(1, 9)));
+            assertFalse(terms.supportsParallelCollection(field -> randomIntBetween(10, 100)));
         }
         {
             TermsAggregationBuilder terms = new TermsAggregationBuilder("terms");

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilderTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilderTests.java
@@ -161,10 +161,10 @@ public class MultiTermsAggregationBuilderTests extends AbstractXContentSerializi
             List<String> fields = new ArrayList<>();
             assertTrue(builder.supportsParallelCollection(field -> {
                 fields.add(field);
-                return randomIntBetween(0, 10);
+                return randomIntBetween(0, 9);
             }));
             assertEquals(List.of("field1", "field2"), fields);
-            assertFalse(builder.supportsParallelCollection(field -> randomIntBetween(11, 100)));
+            assertFalse(builder.supportsParallelCollection(field -> randomIntBetween(10, 100)));
             terms.terms(
                 List.of(
                     sourceBuilder1.build(),
@@ -183,14 +183,14 @@ public class MultiTermsAggregationBuilderTests extends AbstractXContentSerializi
                 List.of(sourceBuilder1.build(), sourceBuilder2.build())
             );
             terms.shardSize(10);
-            assertTrue(terms.supportsParallelCollection(field -> randomIntBetween(0, 10)));
+            assertTrue(terms.supportsParallelCollection(field -> randomIntBetween(0, 9)));
             terms.subAggregation(new TermsAggregationBuilder("name") {
                 @Override
                 public boolean supportsParallelCollection(ToLongFunction<String> fieldCardinalityResolver) {
                     return false;
                 }
             });
-            assertFalse(terms.supportsParallelCollection(field -> randomIntBetween(0, 10)));
+            assertFalse(terms.supportsParallelCollection(field -> randomIntBetween(0, 9)));
         }
         {
             MultiValuesSourceFieldConfig.Builder sourceBuilder1 = new MultiValuesSourceFieldConfig.Builder();


### PR DESCRIPTION
We currently run terms aggregations concurrently when cardinality is lower or equal to shard size. The issue is that when merging internal aggregations for cardinalities equal to the shard size, we don't know if we have truncate the list of terms, so an error is computed which is not expected.

This is happening here where the condition is `size < terms.getShardSize()`: https://github.com/elastic/elasticsearch/blob/ecacb2effbc48f191c2ac9f61b599626ea6cb4e3/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/AbstractInternalTerms.java#L118

To make sure the results are the same between concurrent and non-concurrent runs, we need to exclude situations where shard size == cardinality. This showed up in a random test.

fixes https://github.com/elastic/elasticsearch/issues/105505