### PR TITLE
[8.14] Automatically adjust ignore_malformed only for the @timestamp (#109948)

### DIFF
--- a/docs/changelog/109948.yaml
+++ b/docs/changelog/109948.yaml
@@ -1,0 +1,5 @@
+pr: 109948
+summary: Automatically adjust `ignore_malformed` only for the @timestamp
+area: Mapping
+type: bug
+issues: []

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/mapper/DataStreamTimestampFieldMapperTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/mapper/DataStreamTimestampFieldMapperTests.java
@@ -177,11 +177,29 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
                     b.startObject("@timestamp");
                     b.field("type", "date");
                     b.endObject();
+                    b.startObject("summary");
+                    {
+                        b.startObject("properties");
+                        {
+                            b.startObject("@timestamp");
+                            b.field("type", "date");
+                            b.endObject();
+                        }
+                        b.endObject();
+                    }
+                    b.endObject();
                 })
             );
             assertThat(mapperService, notNullValue());
             assertThat(mapperService.documentMapper().mappers().getMapper("@timestamp"), notNullValue());
             assertThat(((DateFieldMapper) mapperService.documentMapper().mappers().getMapper("@timestamp")).ignoreMalformed(), is(false));
+            DateFieldMapper summaryTimestamp = (DateFieldMapper) (mapperService.documentMapper()
+                .mappers()
+                .objectMappers()
+                .get("summary")
+                .getMapper("@timestamp"));
+            assertThat(summaryTimestamp, notNullValue());
+            assertThat(summaryTimestamp.ignoreMalformed(), is(true));
         }
         {
             MapperService mapperService = createMapperService(
@@ -193,11 +211,22 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
                     b.field("type", "date");
                     b.field("ignore_malformed", false);
                     b.endObject();
+                    b.startObject("summary.@timestamp");
+                    b.field("type", "date");
+                    b.field("ignore_malformed", false);
+                    b.endObject();
                 })
             );
             assertThat(mapperService, notNullValue());
             assertThat(mapperService.documentMapper().mappers().getMapper("@timestamp"), notNullValue());
             assertThat(((DateFieldMapper) mapperService.documentMapper().mappers().getMapper("@timestamp")).ignoreMalformed(), is(false));
+            DateFieldMapper summaryTimestamp = (DateFieldMapper) (mapperService.documentMapper()
+                .mappers()
+                .objectMappers()
+                .get("summary")
+                .getMapper("@timestamp"));
+            assertThat(summaryTimestamp, notNullValue());
+            assertThat(summaryTimestamp.ignoreMalformed(), is(false));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -359,7 +359,7 @@ public final class DateFieldMapper extends FieldMapper {
             );
 
             Long nullTimestamp = parseNullValue(ft);
-            if (name().equals(DataStreamTimestampFieldMapper.DEFAULT_PATH)
+            if (ft.name().equals(DataStreamTimestampFieldMapper.DEFAULT_PATH)
                 && context.isDataStream()
                 && ignoreMalformed.isConfigured() == false) {
                 ignoreMalformed.setValue(false);


### PR DESCRIPTION
Backport of #109948

We introduced automatic disabling ignore_malformed for the @timestamp field with #99346, but the change was applied to any field with name @timestamp under any path, while it should have been applied only to the top-level @timestamp field.

Relates to #107760

