### PR TITLE
fix compile error related to new PARTIAL_AGG data type

### DIFF
--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleAggregatorFunction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class TopDoubleAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("topList", ElementType.DOUBLE)  );
+      new IntermediateStateDesc("top", ElementType.DOUBLE)  );
 
   private final DriverContext driverContext;
 
@@ -35,7 +35,7 @@ public final class TopDoubleAggregatorFunction implements AggregatorFunction {
   private final boolean ascending;
 
   public TopDoubleAggregatorFunction(DriverContext driverContext, List<Integer> channels,
-                                     TopDoubleAggregator.SingleState state, int limit, boolean ascending) {
+      TopDoubleAggregator.SingleState state, int limit, boolean ascending) {
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = state;
@@ -44,7 +44,7 @@ public final class TopDoubleAggregatorFunction implements AggregatorFunction {
   }
 
   public static TopDoubleAggregatorFunction create(DriverContext driverContext,
-                                                   List<Integer> channels, int limit, boolean ascending) {
+      List<Integer> channels, int limit, boolean ascending) {
     return new TopDoubleAggregatorFunction(driverContext, channels, TopDoubleAggregator.initSingle(driverContext.bigArrays(), limit, ascending), limit, ascending);
   }
 
@@ -91,13 +91,13 @@ public final class TopDoubleAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block topListUncast = page.getBlock(channels.get(0));
-    if (topListUncast.areAllValuesNull()) {
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
       return;
     }
-    DoubleBlock topList = (DoubleBlock) topListUncast;
-    assert topList.getPositionCount() == 1;
-    TopDoubleAggregator.combineIntermediate(state, topList);
+    DoubleBlock top = (DoubleBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    TopDoubleAggregator.combineIntermediate(state, top);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleAggregatorFunctionSupplier.java
@@ -21,8 +21,7 @@ public final class TopDoubleAggregatorFunctionSupplier implements AggregatorFunc
 
   private final boolean ascending;
 
-  public TopDoubleAggregatorFunctionSupplier(List<Integer> channels, int limit,
-                                             boolean ascending) {
+  public TopDoubleAggregatorFunctionSupplier(List<Integer> channels, int limit, boolean ascending) {
     this.channels = channels;
     this.limit = limit;
     this.ascending = ascending;

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopDoubleGroupingAggregatorFunction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class TopDoubleGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("topList", ElementType.DOUBLE)  );
+      new IntermediateStateDesc("top", ElementType.DOUBLE)  );
 
   private final TopDoubleAggregator.GroupingState state;
 
@@ -37,8 +37,8 @@ public final class TopDoubleGroupingAggregatorFunction implements GroupingAggreg
   private final boolean ascending;
 
   public TopDoubleGroupingAggregatorFunction(List<Integer> channels,
-                                             TopDoubleAggregator.GroupingState state, DriverContext driverContext, int limit,
-                                             boolean ascending) {
+      TopDoubleAggregator.GroupingState state, DriverContext driverContext, int limit,
+      boolean ascending) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
@@ -47,7 +47,7 @@ public final class TopDoubleGroupingAggregatorFunction implements GroupingAggreg
   }
 
   public static TopDoubleGroupingAggregatorFunction create(List<Integer> channels,
-                                                           DriverContext driverContext, int limit, boolean ascending) {
+      DriverContext driverContext, int limit, boolean ascending) {
     return new TopDoubleGroupingAggregatorFunction(channels, TopDoubleAggregator.initGrouping(driverContext.bigArrays(), limit, ascending), driverContext, limit, ascending);
   }
 
@@ -154,14 +154,14 @@ public final class TopDoubleGroupingAggregatorFunction implements GroupingAggreg
   public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
-    Block topListUncast = page.getBlock(channels.get(0));
-    if (topListUncast.areAllValuesNull()) {
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
       return;
     }
-    DoubleBlock topList = (DoubleBlock) topListUncast;
+    DoubleBlock top = (DoubleBlock) topUncast;
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = Math.toIntExact(groups.getInt(groupPosition));
-      TopDoubleAggregator.combineIntermediate(state, groupId, topList, groupPosition + positionOffset);
+      TopDoubleAggregator.combineIntermediate(state, groupId, top, groupPosition + positionOffset);
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatAggregatorFunction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class TopFloatAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("topList", ElementType.FLOAT)  );
+      new IntermediateStateDesc("top", ElementType.FLOAT)  );
 
   private final DriverContext driverContext;
 
@@ -35,7 +35,7 @@ public final class TopFloatAggregatorFunction implements AggregatorFunction {
   private final boolean ascending;
 
   public TopFloatAggregatorFunction(DriverContext driverContext, List<Integer> channels,
-                                    TopFloatAggregator.SingleState state, int limit, boolean ascending) {
+      TopFloatAggregator.SingleState state, int limit, boolean ascending) {
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = state;
@@ -44,7 +44,7 @@ public final class TopFloatAggregatorFunction implements AggregatorFunction {
   }
 
   public static TopFloatAggregatorFunction create(DriverContext driverContext,
-                                                  List<Integer> channels, int limit, boolean ascending) {
+      List<Integer> channels, int limit, boolean ascending) {
     return new TopFloatAggregatorFunction(driverContext, channels, TopFloatAggregator.initSingle(driverContext.bigArrays(), limit, ascending), limit, ascending);
   }
 
@@ -91,13 +91,13 @@ public final class TopFloatAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block topListUncast = page.getBlock(channels.get(0));
-    if (topListUncast.areAllValuesNull()) {
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
       return;
     }
-    FloatBlock topList = (FloatBlock) topListUncast;
-    assert topList.getPositionCount() == 1;
-    TopFloatAggregator.combineIntermediate(state, topList);
+    FloatBlock top = (FloatBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    TopFloatAggregator.combineIntermediate(state, top);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatAggregatorFunctionSupplier.java
@@ -21,8 +21,7 @@ public final class TopFloatAggregatorFunctionSupplier implements AggregatorFunct
 
   private final boolean ascending;
 
-  public TopFloatAggregatorFunctionSupplier(List<Integer> channels, int limit,
-                                            boolean ascending) {
+  public TopFloatAggregatorFunctionSupplier(List<Integer> channels, int limit, boolean ascending) {
     this.channels = channels;
     this.limit = limit;
     this.ascending = ascending;

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopFloatGroupingAggregatorFunction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class TopFloatGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("topList", ElementType.FLOAT)  );
+      new IntermediateStateDesc("top", ElementType.FLOAT)  );
 
   private final TopFloatAggregator.GroupingState state;
 
@@ -37,8 +37,8 @@ public final class TopFloatGroupingAggregatorFunction implements GroupingAggrega
   private final boolean ascending;
 
   public TopFloatGroupingAggregatorFunction(List<Integer> channels,
-                                            TopFloatAggregator.GroupingState state, DriverContext driverContext, int limit,
-                                            boolean ascending) {
+      TopFloatAggregator.GroupingState state, DriverContext driverContext, int limit,
+      boolean ascending) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
@@ -47,7 +47,7 @@ public final class TopFloatGroupingAggregatorFunction implements GroupingAggrega
   }
 
   public static TopFloatGroupingAggregatorFunction create(List<Integer> channels,
-                                                          DriverContext driverContext, int limit, boolean ascending) {
+      DriverContext driverContext, int limit, boolean ascending) {
     return new TopFloatGroupingAggregatorFunction(channels, TopFloatAggregator.initGrouping(driverContext.bigArrays(), limit, ascending), driverContext, limit, ascending);
   }
 
@@ -154,14 +154,14 @@ public final class TopFloatGroupingAggregatorFunction implements GroupingAggrega
   public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
-    Block topListUncast = page.getBlock(channels.get(0));
-    if (topListUncast.areAllValuesNull()) {
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
       return;
     }
-    FloatBlock topList = (FloatBlock) topListUncast;
+    FloatBlock top = (FloatBlock) topUncast;
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = Math.toIntExact(groups.getInt(groupPosition));
-      TopFloatAggregator.combineIntermediate(state, groupId, topList, groupPosition + positionOffset);
+      TopFloatAggregator.combineIntermediate(state, groupId, top, groupPosition + positionOffset);
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntAggregatorFunction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class TopIntAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("topList", ElementType.INT)  );
+      new IntermediateStateDesc("top", ElementType.INT)  );
 
   private final DriverContext driverContext;
 
@@ -35,7 +35,7 @@ public final class TopIntAggregatorFunction implements AggregatorFunction {
   private final boolean ascending;
 
   public TopIntAggregatorFunction(DriverContext driverContext, List<Integer> channels,
-                                  TopIntAggregator.SingleState state, int limit, boolean ascending) {
+      TopIntAggregator.SingleState state, int limit, boolean ascending) {
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = state;
@@ -43,8 +43,8 @@ public final class TopIntAggregatorFunction implements AggregatorFunction {
     this.ascending = ascending;
   }
 
-  public static TopIntAggregatorFunction create(DriverContext driverContext,
-                                                List<Integer> channels, int limit, boolean ascending) {
+  public static TopIntAggregatorFunction create(DriverContext driverContext, List<Integer> channels,
+      int limit, boolean ascending) {
     return new TopIntAggregatorFunction(driverContext, channels, TopIntAggregator.initSingle(driverContext.bigArrays(), limit, ascending), limit, ascending);
   }
 
@@ -91,13 +91,13 @@ public final class TopIntAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block topListUncast = page.getBlock(channels.get(0));
-    if (topListUncast.areAllValuesNull()) {
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
       return;
     }
-    IntBlock topList = (IntBlock) topListUncast;
-    assert topList.getPositionCount() == 1;
-    TopIntAggregator.combineIntermediate(state, topList);
+    IntBlock top = (IntBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    TopIntAggregator.combineIntermediate(state, top);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntAggregatorFunctionSupplier.java
@@ -21,8 +21,7 @@ public final class TopIntAggregatorFunctionSupplier implements AggregatorFunctio
 
   private final boolean ascending;
 
-  public TopIntAggregatorFunctionSupplier(List<Integer> channels, int limit,
-                                          boolean ascending) {
+  public TopIntAggregatorFunctionSupplier(List<Integer> channels, int limit, boolean ascending) {
     this.channels = channels;
     this.limit = limit;
     this.ascending = ascending;

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopIntGroupingAggregatorFunction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class TopIntGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("topList", ElementType.INT)  );
+      new IntermediateStateDesc("top", ElementType.INT)  );
 
   private final TopIntAggregator.GroupingState state;
 
@@ -35,8 +35,8 @@ public final class TopIntGroupingAggregatorFunction implements GroupingAggregato
   private final boolean ascending;
 
   public TopIntGroupingAggregatorFunction(List<Integer> channels,
-                                          TopIntAggregator.GroupingState state, DriverContext driverContext, int limit,
-                                          boolean ascending) {
+      TopIntAggregator.GroupingState state, DriverContext driverContext, int limit,
+      boolean ascending) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
@@ -45,7 +45,7 @@ public final class TopIntGroupingAggregatorFunction implements GroupingAggregato
   }
 
   public static TopIntGroupingAggregatorFunction create(List<Integer> channels,
-                                                        DriverContext driverContext, int limit, boolean ascending) {
+      DriverContext driverContext, int limit, boolean ascending) {
     return new TopIntGroupingAggregatorFunction(channels, TopIntAggregator.initGrouping(driverContext.bigArrays(), limit, ascending), driverContext, limit, ascending);
   }
 
@@ -152,14 +152,14 @@ public final class TopIntGroupingAggregatorFunction implements GroupingAggregato
   public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
-    Block topListUncast = page.getBlock(channels.get(0));
-    if (topListUncast.areAllValuesNull()) {
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
       return;
     }
-    IntBlock topList = (IntBlock) topListUncast;
+    IntBlock top = (IntBlock) topUncast;
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = Math.toIntExact(groups.getInt(groupPosition));
-      TopIntAggregator.combineIntermediate(state, groupId, topList, groupPosition + positionOffset);
+      TopIntAggregator.combineIntermediate(state, groupId, top, groupPosition + positionOffset);
     }
   }
 

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongAggregatorFunction.java
@@ -22,7 +22,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class TopLongAggregatorFunction implements AggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("topList", ElementType.LONG)  );
+      new IntermediateStateDesc("top", ElementType.LONG)  );
 
   private final DriverContext driverContext;
 
@@ -35,7 +35,7 @@ public final class TopLongAggregatorFunction implements AggregatorFunction {
   private final boolean ascending;
 
   public TopLongAggregatorFunction(DriverContext driverContext, List<Integer> channels,
-                                   TopLongAggregator.SingleState state, int limit, boolean ascending) {
+      TopLongAggregator.SingleState state, int limit, boolean ascending) {
     this.driverContext = driverContext;
     this.channels = channels;
     this.state = state;
@@ -44,7 +44,7 @@ public final class TopLongAggregatorFunction implements AggregatorFunction {
   }
 
   public static TopLongAggregatorFunction create(DriverContext driverContext,
-                                                 List<Integer> channels, int limit, boolean ascending) {
+      List<Integer> channels, int limit, boolean ascending) {
     return new TopLongAggregatorFunction(driverContext, channels, TopLongAggregator.initSingle(driverContext.bigArrays(), limit, ascending), limit, ascending);
   }
 
@@ -91,13 +91,13 @@ public final class TopLongAggregatorFunction implements AggregatorFunction {
   public void addIntermediateInput(Page page) {
     assert channels.size() == intermediateBlockCount();
     assert page.getBlockCount() >= channels.get(0) + intermediateStateDesc().size();
-    Block topListUncast = page.getBlock(channels.get(0));
-    if (topListUncast.areAllValuesNull()) {
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
       return;
     }
-    LongBlock topList = (LongBlock) topListUncast;
-    assert topList.getPositionCount() == 1;
-    TopLongAggregator.combineIntermediate(state, topList);
+    LongBlock top = (LongBlock) topUncast;
+    assert top.getPositionCount() == 1;
+    TopLongAggregator.combineIntermediate(state, top);
   }
 
   @Override

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongAggregatorFunctionSupplier.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongAggregatorFunctionSupplier.java
@@ -21,8 +21,7 @@ public final class TopLongAggregatorFunctionSupplier implements AggregatorFuncti
 
   private final boolean ascending;
 
-  public TopLongAggregatorFunctionSupplier(List<Integer> channels, int limit,
-                                           boolean ascending) {
+  public TopLongAggregatorFunctionSupplier(List<Integer> channels, int limit, boolean ascending) {
     this.channels = channels;
     this.limit = limit;
     this.ascending = ascending;

--- a/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongGroupingAggregatorFunction.java
+++ b/x-pack/plugin/esql/compute/src/main/generated/org/elasticsearch/compute/aggregation/TopLongGroupingAggregatorFunction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.compute.operator.DriverContext;
  */
 public final class TopLongGroupingAggregatorFunction implements GroupingAggregatorFunction {
   private static final List<IntermediateStateDesc> INTERMEDIATE_STATE_DESC = List.of(
-      new IntermediateStateDesc("topList", ElementType.LONG)  );
+      new IntermediateStateDesc("top", ElementType.LONG)  );
 
   private final TopLongAggregator.GroupingState state;
 
@@ -37,8 +37,8 @@ public final class TopLongGroupingAggregatorFunction implements GroupingAggregat
   private final boolean ascending;
 
   public TopLongGroupingAggregatorFunction(List<Integer> channels,
-                                           TopLongAggregator.GroupingState state, DriverContext driverContext, int limit,
-                                           boolean ascending) {
+      TopLongAggregator.GroupingState state, DriverContext driverContext, int limit,
+      boolean ascending) {
     this.channels = channels;
     this.state = state;
     this.driverContext = driverContext;
@@ -47,7 +47,7 @@ public final class TopLongGroupingAggregatorFunction implements GroupingAggregat
   }
 
   public static TopLongGroupingAggregatorFunction create(List<Integer> channels,
-                                                         DriverContext driverContext, int limit, boolean ascending) {
+      DriverContext driverContext, int limit, boolean ascending) {
     return new TopLongGroupingAggregatorFunction(channels, TopLongAggregator.initGrouping(driverContext.bigArrays(), limit, ascending), driverContext, limit, ascending);
   }
 
@@ -154,14 +154,14 @@ public final class TopLongGroupingAggregatorFunction implements GroupingAggregat
   public void addIntermediateInput(int positionOffset, IntVector groups, Page page) {
     state.enableGroupIdTracking(new SeenGroupIds.Empty());
     assert channels.size() == intermediateBlockCount();
-    Block topListUncast = page.getBlock(channels.get(0));
-    if (topListUncast.areAllValuesNull()) {
+    Block topUncast = page.getBlock(channels.get(0));
+    if (topUncast.areAllValuesNull()) {
       return;
     }
-    LongBlock topList = (LongBlock) topListUncast;
+    LongBlock top = (LongBlock) topUncast;
     for (int groupPosition = 0; groupPosition < groups.getPositionCount(); groupPosition++) {
       int groupId = Math.toIntExact(groups.getInt(groupPosition));
-      TopLongAggregator.combineIntermediate(state, groupId, topList, groupPosition + positionOffset);
+      TopLongAggregator.combineIntermediate(state, groupId, top, groupPosition + positionOffset);
     }
   }
 

--- a/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
+++ b/x-pack/plugin/esql/src/internalClusterTest/java/org/elasticsearch/xpack/esql/action/TimeSeriesIT.java
@@ -258,10 +258,10 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
                 resp.columns(),
                 equalTo(
                     List.of(
-                        new ColumnInfo("max(rate(request_count))", "double"),
-                        new ColumnInfo("min(rate(request_count))", "double"),
-                        new ColumnInfo("min(cpu)", "double"),
-                        new ColumnInfo("max(cpu)", "double")
+                        new ColumnInfoImpl("max(rate(request_count))", "double"),
+                        new ColumnInfoImpl("min(rate(request_count))", "double"),
+                        new ColumnInfoImpl("min(cpu)", "double"),
+                        new ColumnInfoImpl("max(cpu)", "double")
                     )
                 )
             );
@@ -629,10 +629,10 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
                 resp.columns(),
                 equalTo(
                     List.of(
-                        new ColumnInfo("sum(rate(request_count))", "double"),
-                        new ColumnInfo("max(cpu)", "double"),
-                        new ColumnInfo("ts", "date"),
-                        new ColumnInfo("cluster", "keyword")
+                        new ColumnInfoImpl("sum(rate(request_count))", "double"),
+                        new ColumnInfoImpl("max(cpu)", "double"),
+                        new ColumnInfoImpl("ts", "date"),
+                        new ColumnInfoImpl("cluster", "keyword")
                     )
                 )
             );
@@ -666,10 +666,10 @@ public class TimeSeriesIT extends AbstractEsqlIntegTestCase {
                 resp.columns(),
                 equalTo(
                     List.of(
-                        new ColumnInfo("sum(rate(request_count))", "double"),
-                        new ColumnInfo("avg(cpu)", "double"),
-                        new ColumnInfo("ts", "date"),
-                        new ColumnInfo("cluster", "keyword")
+                        new ColumnInfoImpl("sum(rate(request_count))", "double"),
+                        new ColumnInfoImpl("avg(cpu)", "double"),
+                        new ColumnInfoImpl("ts", "date"),
+                        new ColumnInfoImpl("cluster", "keyword")
                     )
                 )
             );

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/PositionToXContent.java
@@ -165,8 +165,8 @@ abstract class PositionToXContent {
                     }
                 }
             };
-            case DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE, SHORT, BYTE, OBJECT, NESTED, FLOAT, HALF_FLOAT, SCALED_FLOAT ->
-                throw new IllegalArgumentException("can't convert values of type [" + columnInfo.type() + "]");
+            case DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE, SHORT, BYTE, OBJECT, NESTED, FLOAT, HALF_FLOAT, SCALED_FLOAT,
+                PARTIAL_AGG -> throw new IllegalArgumentException("can't convert values of type [" + columnInfo.type() + "]");
         };
     }
 }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/ResponseValueUtils.java
@@ -152,7 +152,7 @@ public final class ResponseValueUtils {
                 }
             }
             case SHORT, BYTE, FLOAT, HALF_FLOAT, SCALED_FLOAT, OBJECT, NESTED, DATE_PERIOD, TIME_DURATION, DOC_DATA_TYPE, TSID_DATA_TYPE,
-                NULL -> throw EsqlIllegalArgumentException.illegalDataType(dataType);
+                NULL, PARTIAL_AGG -> throw EsqlIllegalArgumentException.illegalDataType(dataType);
         };
     }
 


### PR DESCRIPTION
Reconcile changes from https://github.com/elastic/elasticsearch/pull/110288 and https://github.com/elastic/elasticsearch/pull/110206.  The new data type added in the later caused a compilation failure.