### PR TITLE
Add auth and better tests to the ingest geoip http client

### DIFF
--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -64,6 +64,15 @@ tasks.named("internalClusterTest") {
   onlyIf("OS != windows") { OS.current() != OS.WINDOWS }
 }
 
+tasks.named('forbiddenApisTest').configure {
+  //we are using jdk-internal instead of jdk-non-portable to allow for com.sun.net.httpserver.* usage
+  modifyBundledSignatures { bundledSignatures ->
+    bundledSignatures -= 'jdk-non-portable'
+    bundledSignatures += 'jdk-internal'
+    bundledSignatures
+  }
+}
+
 tasks.named("forbiddenPatterns").configure {
   exclude '**/*.mmdb'
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/HttpClient.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/HttpClient.java
@@ -32,11 +32,11 @@ import static java.net.HttpURLConnection.HTTP_SEE_OTHER;
 
 class HttpClient {
 
-    byte[] getBytes(String url) throws IOException {
+    byte[] getBytes(final String url) throws IOException {
         return get(url).readAllBytes();
     }
 
-    InputStream get(String urlToGet) throws IOException {
+    InputStream get(final String urlToGet) throws IOException {
         return doPrivileged(() -> {
             String url = urlToGet;
             HttpURLConnection conn = createConnection(url);
@@ -52,9 +52,11 @@ class HttpClient {
                         if (redirectsCount++ > 50) {
                             throw new IllegalStateException("too many redirects connection to [" + urlToGet + "]");
                         }
-                        String location = conn.getHeaderField("Location");
-                        URL base = new URL(url);
-                        URL next = new URL(base, location);  // Deal with relative URLs
+
+                        // deal with redirections (including relative urls)
+                        final String location = conn.getHeaderField("Location");
+                        final URL base = new URL(url);
+                        final URL next = new URL(base, location);
                         url = next.toExternalForm();
                         conn = createConnection(url);
                         break;
@@ -69,12 +71,12 @@ class HttpClient {
     }
 
     @SuppressForbidden(reason = "we need socket connection to download data from internet")
-    private static InputStream getInputStream(HttpURLConnection conn) throws IOException {
+    private static InputStream getInputStream(final HttpURLConnection conn) throws IOException {
         return conn.getInputStream();
     }
 
-    private static HttpURLConnection createConnection(String url) throws IOException {
-        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+    private static HttpURLConnection createConnection(final String url) throws IOException {
+        final HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
         conn.setConnectTimeout(10000);
         conn.setReadTimeout(10000);
         conn.setDoOutput(false);
@@ -82,7 +84,7 @@ class HttpClient {
         return conn;
     }
 
-    private static <R> R doPrivileged(CheckedSupplier<R, IOException> supplier) throws IOException {
+    private static <R> R doPrivileged(final CheckedSupplier<R, IOException> supplier) throws IOException {
         SpecialPermission.check();
         try {
             return AccessController.doPrivileged((PrivilegedExceptionAction<R>) supplier::get);

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/HttpClient.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/HttpClient.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.rest.RestStatus;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Authenticator;
@@ -70,7 +69,7 @@ class HttpClient {
             while (true) {
                 switch (conn.getResponseCode()) {
                     case HTTP_OK:
-                        return new BufferedInputStream(getInputStream(conn));
+                        return getInputStream(conn);
                     case HTTP_MOVED_PERM:
                     case HTTP_MOVED_TEMP:
                     case HTTP_SEE_OTHER:

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/HttpClient.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/HttpClient.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Objects;
 
 import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
 import static java.net.HttpURLConnection.HTTP_MOVED_TEMP;
@@ -37,6 +38,8 @@ class HttpClient {
     }
 
     InputStream get(final String url) throws IOException {
+        Objects.requireNonNull(url);
+
         return doPrivileged(() -> {
             String innerUrl = url;
             HttpURLConnection conn = createConnection(innerUrl);

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
@@ -108,37 +108,43 @@ public class HttpClientTests extends ESTestCase {
 
     public void testGetBytes() throws Exception {
         HttpClient client = new HttpClient();
-        String response = bytesToString(client.getBytes(url("/hello/")));
+        String u = url("/hello/");
+        String response = bytesToString(client.getBytes(u));
         assertThat(response, equalTo("hello world"));
     }
 
-    public void testGetBytes404() throws Exception {
+    public void testGetBytes404() {
         HttpClient client = new HttpClient();
-        Exception e = expectThrows(ResourceNotFoundException.class, () -> client.getBytes(url("/404/")));
-        assertThat(e.getMessage(), equalTo(url("/404/") + " not found"));
+        String u = url("/404/");
+        Exception e = expectThrows(ResourceNotFoundException.class, () -> client.getBytes(u));
+        assertThat(e.getMessage(), equalTo(u + " not found"));
     }
 
     public void testRedirect() throws Exception {
         HttpClient client = new HttpClient();
-        String response = bytesToString(client.getBytes(url("/redirect/3/hello/")));
+        String u = url("/redirect/3/hello/");
+        String response = bytesToString(client.getBytes(u));
         assertThat(response, equalTo("hello world"));
     }
 
     public void testRelativeRedirect() throws Exception {
         HttpClient client = new HttpClient();
-        String response = bytesToString(client.getBytes(url("/redirect")));
+        String u = url("/redirect");
+        String response = bytesToString(client.getBytes(u));
         assertThat(response, equalTo("hello world"));
     }
 
-    public void testRedirectTo404() throws Exception {
+    public void testRedirectTo404() {
         HttpClient client = new HttpClient();
-        Exception e = expectThrows(ResourceNotFoundException.class, () -> client.getBytes(url("/redirect/5/404/")));
-        assertThat(e.getMessage(), equalTo(url("/redirect/5/404/") + " not found"));
+        String u = url("/redirect/5/404/");
+        Exception e = expectThrows(ResourceNotFoundException.class, () -> client.getBytes(u));
+        assertThat(e.getMessage(), equalTo(u + " not found"));
     }
 
-    public void testTooManyRedirects() throws Exception {
+    public void testTooManyRedirects() {
         HttpClient client = new HttpClient();
-        Exception e = expectThrows(IllegalStateException.class, () -> client.getBytes(url("/redirect/100/hello/")));
-        assertThat(e.getMessage(), equalTo("too many redirects connection to [" + url("/redirect/100/hello/") + "]"));
+        String u = url("/redirect/100/hello/");
+        Exception e = expectThrows(IllegalStateException.class, () -> client.getBytes(u));
+        assertThat(e.getMessage(), equalTo("too many redirects connection to [" + u + "]"));
     }
 }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.ingest.geoip;
 
 import com.sun.net.httpserver.HttpServer;
 
+import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.AfterClass;
@@ -41,6 +42,13 @@ public class HttpClientTests extends ESTestCase {
                 fail(e);
             }
         });
+        server.createContext("/404/", exchange -> {
+            try {
+                exchange.sendResponseHeaders(404, 0);
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
         server.start();
     }
 
@@ -63,5 +71,11 @@ public class HttpClientTests extends ESTestCase {
         HttpClient client = new HttpClient();
         String response = bytesToString(client.getBytes(url("/hello/")));
         assertThat(response, equalTo("hello world"));
+    }
+
+    public void testGetBytes404() throws Exception {
+        HttpClient client = new HttpClient();
+        Exception e = expectThrows(ResourceNotFoundException.class, () -> client.getBytes(url("/404/")));
+        assertThat(e.getMessage(), equalTo(url("/404/") + " not found"));
     }
 }

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.ingest.geoip;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.Matchers.equalTo;
+
+@SuppressForbidden(reason = "uses httpserver by design")
+public class HttpClientTests extends ESTestCase {
+
+    private static HttpServer server;
+
+    @BeforeClass
+    public static void startServer() throws Throwable {
+        server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext("/hello/", exchange -> {
+            try {
+                String response = "hello world";
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes());
+                }
+            } catch (Exception e) {
+                fail(e);
+            }
+        });
+        server.start();
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        server.stop(0);
+    }
+
+    private static String url(final String path) {
+        String hostname = server.getAddress().getHostString();
+        int port = server.getAddress().getPort();
+        return "http://" + hostname + ":" + port + path;
+    }
+
+    private static String bytesToString(final byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+
+    public void testGetBytes() throws Exception {
+        HttpClient client = new HttpClient();
+        String response = bytesToString(client.getBytes(url("/hello/")));
+        assertThat(response, equalTo("hello world"));
+    }
+}

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/HttpClientTests.java
@@ -13,7 +13,6 @@ import com.sun.net.httpserver.HttpServer;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
-import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -26,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.equalTo;
 
-@SuppressForbidden(reason = "uses httpserver by design")
 public class HttpClientTests extends ESTestCase {
 
     private static HttpServer server;
@@ -39,7 +37,7 @@ public class HttpClientTests extends ESTestCase {
                 String response = "hello world";
                 exchange.sendResponseHeaders(200, response.length());
                 try (OutputStream os = exchange.getResponseBody()) {
-                    os.write(response.getBytes());
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
                 }
             } catch (Exception e) {
                 fail(e);
@@ -57,7 +55,7 @@ public class HttpClientTests extends ESTestCase {
                 String response = "super secret hello world";
                 exchange.sendResponseHeaders(200, response.length());
                 try (OutputStream os = exchange.getResponseBody()) {
-                    os.write(response.getBytes());
+                    os.write(response.getBytes(StandardCharsets.UTF_8));
                 }
             } catch (Exception e) {
                 fail(e);


### PR DESCRIPTION
In terms of total lines of code, this is primarily a better tests and code tidying PR. However, it also adds the ability to thread basic auth credentials through the client (and tests for the same).