### PR TITLE
Tidy up some geoip code and fix a mistaken test

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -511,4 +511,5 @@ public final class DatabaseNodeService implements GeoIpDatabaseProvider, Closeab
     public CacheStats getCacheStats() {
         return cache.getCacheStats();
     }
+
 }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -64,7 +64,7 @@ import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
 import static org.elasticsearch.core.Strings.format;
-import static org.elasticsearch.persistent.PersistentTasksCustomMetadata.getTaskWithId;
+import static org.elasticsearch.ingest.geoip.GeoIpTaskState.getGeoIpTaskState;
 
 /**
  * A component that is responsible for making the databases maintained by {@link GeoIpDownloader}
@@ -179,11 +179,10 @@ public final class DatabaseNodeService implements GeoIpDatabaseProvider, Closeab
         ClusterState currentState = clusterService.state();
         assert currentState != null;
 
-        PersistentTasksCustomMetadata.PersistentTask<?> task = getTaskWithId(currentState, GeoIpDownloader.GEOIP_DOWNLOADER);
-        if (task == null || task.getState() == null) {
+        GeoIpTaskState state = getGeoIpTaskState(currentState);
+        if (state == null) {
             return true;
         }
-        GeoIpTaskState state = (GeoIpTaskState) task.getState();
         GeoIpTaskState.Metadata metadata = state.getDatabases().get(databaseFile);
         // we never remove metadata from cluster state, if metadata is null we deal with built-in database, which is always valid
         if (metadata == null) {
@@ -270,12 +269,11 @@ public final class DatabaseNodeService implements GeoIpDatabaseProvider, Closeab
             }
         }
 
-        PersistentTasksCustomMetadata.PersistentTask<?> task = PersistentTasksCustomMetadata.getTaskWithId(
-            state,
-            GeoIpDownloader.GEOIP_DOWNLOADER
-        );
-        // Empty state will purge stale entries in databases map.
-        GeoIpTaskState taskState = task == null || task.getState() == null ? GeoIpTaskState.EMPTY : (GeoIpTaskState) task.getState();
+        GeoIpTaskState taskState = getGeoIpTaskState(state);
+        if (taskState == null) {
+            // Note: an empty state will purge stale entries in databases map
+            taskState = GeoIpTaskState.EMPTY;
+        }
 
         taskState.getDatabases().entrySet().stream().filter(e -> e.getValue().isValid(state.getMetadata().settings())).forEach(e -> {
             String name = e.getKey();

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -291,7 +291,7 @@ public final class DatabaseNodeService implements GeoIpDatabaseProvider, Closeab
             try {
                 retrieveAndUpdateDatabase(name, metadata);
             } catch (Exception ex) {
-                logger.error(() -> "attempt to download database [" + name + "] failed", ex);
+                logger.error(() -> "failed to retrieve database [" + name + "]", ex);
             }
         });
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
@@ -111,11 +111,11 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
         Supplier<Boolean> atLeastOneGeoipProcessorSupplier
     ) {
         super(id, type, action, description, parentTask, headers);
-        this.httpClient = httpClient;
         this.client = client;
+        this.httpClient = httpClient;
         this.clusterService = clusterService;
         this.threadPool = threadPool;
-        endpoint = ENDPOINT_SETTING.get(settings);
+        this.endpoint = ENDPOINT_SETTING.get(settings);
         this.pollIntervalSupplier = pollIntervalSupplier;
         this.eagerDownloadSupplier = eagerDownloadSupplier;
         this.atLeastOneGeoipProcessorSupplier = atLeastOneGeoipProcessorSupplier;

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloader.java
@@ -171,7 +171,7 @@ public class GeoIpDownloader extends AllocatedPersistentTask {
         logger.debug("downloading geoip database [{}]", name);
         String url = databaseInfo.get("url").toString();
         if (url.startsWith("http") == false) {
-            // relative url, add it after last slash (i.e resolve sibling) or at the end if there's no slash after http[s]://
+            // relative url, add it after last slash (i.e. resolve sibling) or at the end if there's no slash after http[s]://
             int lastSlash = endpoint.substring(8).lastIndexOf('/');
             url = (lastSlash != -1 ? endpoint.substring(0, lastSlash + 8) : endpoint) + "/" + url;
         }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -105,7 +105,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
         this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.settings = clusterService.getSettings();
-        persistentTasksService = new PersistentTasksService(clusterService, threadPool, client);
+        this.persistentTasksService = new PersistentTasksService(clusterService, threadPool, client);
         this.pollInterval = POLL_INTERVAL_SETTING.get(settings);
         this.eagerDownload = EAGER_DOWNLOAD_SETTING.get(settings);
     }

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -155,7 +155,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
     @Override
     protected void nodeOperation(AllocatedPersistentTask task, GeoIpTaskParams params, PersistentTaskState state) {
         GeoIpDownloader downloader = (GeoIpDownloader) task;
-        GeoIpTaskState geoIpTaskState = state == null ? GeoIpTaskState.EMPTY : (GeoIpTaskState) state;
+        GeoIpTaskState geoIpTaskState = (state == null) ? GeoIpTaskState.EMPTY : (GeoIpTaskState) state;
         downloader.setState(geoIpTaskState);
         currentTask.set(downloader);
         if (ENABLED_SETTING.get(clusterService.state().metadata().settings(), settings)) {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
@@ -277,9 +277,8 @@ public class GeoIpDownloaderTests extends ESTestCase {
             () -> true
         ) {
             @Override
-            void updateTaskState() {
-                assertEquals(0, state.get("test").firstChunk());
-                assertEquals(10, state.get("test").lastChunk());
+            protected void updateTimestamp(String name, GeoIpTaskState.Metadata metadata) {
+                fail();
             }
 
             @Override
@@ -290,8 +289,9 @@ public class GeoIpDownloaderTests extends ESTestCase {
             }
 
             @Override
-            protected void updateTimestamp(String name, GeoIpTaskState.Metadata metadata) {
-                fail();
+            void updateTaskState() {
+                assertEquals(0, state.get("test").firstChunk());
+                assertEquals(10, state.get("test").lastChunk());
             }
 
             @Override
@@ -328,9 +328,8 @@ public class GeoIpDownloaderTests extends ESTestCase {
             () -> true
         ) {
             @Override
-            void updateTaskState() {
-                assertEquals(9, state.get("test.mmdb").firstChunk());
-                assertEquals(10, state.get("test.mmdb").lastChunk());
+            protected void updateTimestamp(String name, GeoIpTaskState.Metadata metadata) {
+                fail();
             }
 
             @Override
@@ -341,8 +340,9 @@ public class GeoIpDownloaderTests extends ESTestCase {
             }
 
             @Override
-            protected void updateTimestamp(String name, GeoIpTaskState.Metadata metadata) {
-                fail();
+            void updateTaskState() {
+                assertEquals(9, state.get("test.mmdb").firstChunk());
+                assertEquals(10, state.get("test.mmdb").lastChunk());
             }
 
             @Override
@@ -381,8 +381,9 @@ public class GeoIpDownloaderTests extends ESTestCase {
             () -> true
         ) {
             @Override
-            void updateTaskState() {
-                fail();
+            protected void updateTimestamp(String name, GeoIpTaskState.Metadata newMetadata) {
+                assertEquals(metadata, newMetadata);
+                assertEquals("test.mmdb", name);
             }
 
             @Override
@@ -392,9 +393,8 @@ public class GeoIpDownloaderTests extends ESTestCase {
             }
 
             @Override
-            protected void updateTimestamp(String name, GeoIpTaskState.Metadata newMetadata) {
-                assertEquals(metadata, newMetadata);
-                assertEquals("test.mmdb", name);
+            void updateTaskState() {
+                fail();
             }
 
             @Override

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.ingest.geoip.stats.GeoIpDownloaderStats;
 import org.elasticsearch.node.Node;
 import org.elasticsearch.persistent.PersistentTaskState;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -302,6 +303,8 @@ public class GeoIpDownloaderTests extends ESTestCase {
 
         geoIpDownloader.setState(GeoIpTaskState.EMPTY);
         geoIpDownloader.processDatabase(Map.of("name", "test.tgz", "url", "http://a.b/t1", "md5_hash", "1"));
+        GeoIpDownloaderStats stats = geoIpDownloader.getStatus();
+        assertEquals(0, stats.getFailedDownloads());
     }
 
     public void testProcessDatabaseUpdate() throws IOException {
@@ -351,6 +354,8 @@ public class GeoIpDownloaderTests extends ESTestCase {
 
         geoIpDownloader.setState(GeoIpTaskState.EMPTY.put("test.mmdb", new GeoIpTaskState.Metadata(0, 5, 8, "0", 0)));
         geoIpDownloader.processDatabase(Map.of("name", "test.tgz", "url", "http://a.b/t1", "md5_hash", "1"));
+        GeoIpDownloaderStats stats = geoIpDownloader.getStatus();
+        assertEquals(0, stats.getFailedDownloads());
     }
 
     public void testProcessDatabaseSame() throws IOException {
@@ -399,6 +404,8 @@ public class GeoIpDownloaderTests extends ESTestCase {
         };
         geoIpDownloader.setState(taskState);
         geoIpDownloader.processDatabase(Map.of("name", "test.tgz", "url", "http://a.b/t1", "md5_hash", "1"));
+        GeoIpDownloaderStats stats = geoIpDownloader.getStatus();
+        assertEquals(0, stats.getFailedDownloads());
     }
 
     @SuppressWarnings("unchecked")

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTests.java
@@ -290,13 +290,13 @@ public class GeoIpDownloaderTests extends ESTestCase {
 
             @Override
             void updateTaskState() {
-                assertEquals(0, state.get("test").firstChunk());
-                assertEquals(10, state.get("test").lastChunk());
+                assertEquals(0, state.get("test.mmdb").firstChunk());
+                assertEquals(10, state.get("test.mmdb").lastChunk());
             }
 
             @Override
             void deleteOldChunks(String name, int firstChunk) {
-                assertEquals("test", name);
+                assertEquals("test.mmdb", name);
                 assertEquals(0, firstChunk);
             }
         };

--- a/server/src/main/java/org/elasticsearch/persistent/NodePersistentTasksExecutor.java
+++ b/server/src/main/java/org/elasticsearch/persistent/NodePersistentTasksExecutor.java
@@ -35,7 +35,6 @@ public class NodePersistentTasksExecutor {
                 } catch (Exception ex) {
                     task.markAsFailed(ex);
                 }
-
             }
         });
     }


### PR DESCRIPTION
A variety of individually pretty trivial cleanups to some of the geoip database code. In the course of reading some of this code I realized that there's a test that looked innocent enough but actually wasn't testing anything like what it thought it was testing, so I've rewritten that here across a few commits.