### PR TITLE
Synonyms API - Fix #110212

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -68,9 +68,6 @@ tests:
 - class: org.elasticsearch.index.store.FsDirectoryFactoryTests
   method: testPreload
   issue: https://github.com/elastic/elasticsearch/issues/110211
-- class: org.elasticsearch.synonyms.SynonymsManagementAPIServiceIT
-  method: testUpdateRuleWithMaxSynonyms
-  issue: https://github.com/elastic/elasticsearch/issues/110212
 - class: "org.elasticsearch.rest.RestControllerIT"
   issue: "https://github.com/elastic/elasticsearch/issues/110225"
 - class: "org.elasticsearch.xpack.security.authz.store.NativePrivilegeStoreCacheTests"

--- a/server/src/internalClusterTest/java/org/elasticsearch/synonyms/SynonymsManagementAPIServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/synonyms/SynonymsManagementAPIServiceIT.java
@@ -194,7 +194,7 @@ public class SynonymsManagementAPIServiceIT extends ESIntegTestCase {
                 // Updating a rule fails
                 synonymsManagementAPIService.putSynonymRule(
                     synonymSetId,
-                    synonymsSet[randomIntBetween(0, maxSynonymSets)],
+                    synonymsSet[randomIntBetween(0, maxSynonymSets - 1)],
                     new ActionListener<>() {
                         @Override
                         public void onResponse(SynonymsManagementAPIService.SynonymsReloadResult synonymsReloadResult) {


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/110212

Fixes ArrayOutOfBounds when choosing a random element from the created synonyms.