### PR TITLE
[8.14] ESQL docs: Push down needs index and doc_values (#110353)

### DIFF
--- a/docs/reference/esql/functions/binary.asciidoc
+++ b/docs/reference/esql/functions/binary.asciidoc
@@ -7,6 +7,12 @@
 [.text-center]
 image::esql/functions/signature/equals.svg[Embedded,opts=inline]
 
+Check if two fields are equal. If either field is <<esql-multivalued-fields,multivalued>> then
+the result is `null`.
+
+NOTE: This is pushed to the underlying search index if one side of the comparison is constant
+      and the other side is a field in the index that has both an <<mapping-index>> and <<doc-values>>.
+
 Supported types:
 
 include::types/equals.asciidoc[]
@@ -14,6 +20,12 @@ include::types/equals.asciidoc[]
 ==== Inequality `!=`
 [.text-center]
 image::esql/functions/signature/not_equals.svg[Embedded,opts=inline]
+
+Check if two fields are unequal. If either field is <<esql-multivalued-fields,multivalued>> then
+the result is `null`.
+
+NOTE: This is pushed to the underlying search index if one side of the comparison is constant
+      and the other side is a field in the index that has both an <<mapping-index>> and <<doc-values>>.
 
 Supported types:
 
@@ -23,11 +35,27 @@ include::types/not_equals.asciidoc[]
 [.text-center]
 image::esql/functions/signature/less_than.svg[Embedded,opts=inline]
 
+Check if one field is less than another. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
+NOTE: This is pushed to the underlying search index if one side of the comparison is constant
+      and the other side is a field in the index that has both an <<mapping-index>> and <<doc-values>>.
+
+Supported types:
+
 include::types/less_than.asciidoc[]
 
 ==== Less than or equal to `<=`
 [.text-center]
 image::esql/functions/signature/less_than_or_equal.svg[Embedded,opts=inline]
+
+Check if one field is less than or equal to another. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
+NOTE: This is pushed to the underlying search index if one side of the comparison is constant
+      and the other side is a field in the index that has both an <<mapping-index>> and <<doc-values>>.
+
+Supported types:
 
 include::types/less_than_or_equal.asciidoc[]
 
@@ -35,11 +63,27 @@ include::types/less_than_or_equal.asciidoc[]
 [.text-center]
 image::esql/functions/signature/greater_than.svg[Embedded,opts=inline]
 
+Check if one field is greater than another. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
+NOTE: This is pushed to the underlying search index if one side of the comparison is constant
+      and the other side is a field in the index that has both an <<mapping-index>> and <<doc-values>>.
+
+Supported types:
+
 include::types/greater_than.asciidoc[]
 
 ==== Greater than or equal to `>=`
 [.text-center]
 image::esql/functions/signature/greater_than_or_equal.svg[Embedded,opts=inline]
+
+Check if one field is greater than or equal to another. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
+NOTE: This is pushed to the underlying search index if one side of the comparison is constant
+      and the other side is a field in the index that has both an <<mapping-index>> and <<doc-values>>.
+
+Supported types:
 
 include::types/greater_than_or_equal.asciidoc[]
 
@@ -47,11 +91,21 @@ include::types/greater_than_or_equal.asciidoc[]
 [.text-center]
 image::esql/functions/signature/add.svg[Embedded,opts=inline]
 
+Add two numbers together. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
+Supported types:
+
 include::types/add.asciidoc[]
 
 ==== Subtract `-`
 [.text-center]
 image::esql/functions/signature/sub.svg[Embedded,opts=inline]
+
+Subtract one number from another. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
+Supported types:
 
 include::types/sub.asciidoc[]
 
@@ -59,19 +113,34 @@ include::types/sub.asciidoc[]
 [.text-center]
 image::esql/functions/signature/mul.svg[Embedded,opts=inline]
 
+Multiply two numbers together. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
+Supported types:
+
 include::types/mul.asciidoc[]
 
 ==== Divide `/`
 [.text-center]
 image::esql/functions/signature/div.svg[Embedded,opts=inline]
 
+Divide one number by another. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
 NOTE: Division of two integer types will yield an integer result, rounding towards 0.
       If you need floating point division, wrap one of the arguments in <<esql-to_double>>.
+
+Supported types:
 
 include::types/div.asciidoc[]
 
 ==== Modulus `%`
 [.text-center]
 image::esql/functions/signature/mod.svg[Embedded,opts=inline]
+
+Divide one number by another and return the remainder. If either field is <<esql-multivalued-fields,multivalued>>
+then the result is `null`.
+
+Supported types:
 
 include::types/mod.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.14:
 - ESQL docs: Push down needs index and doc_values (#110353)