### PR TITLE
Remove the experimental section from the redact docs

### DIFF
--- a/docs/changelog/110395.yaml
+++ b/docs/changelog/110395.yaml
@@ -1,9 +1,10 @@
 pr: 110395
-summary: Remove the experimental section from the redact docs
+summary: Mark the Redact processor as Generally Available
 area: Ingest Node
 type: feature
 issues: []
 highlight:
-  title: Remove the experimental section from the redact docs
-  body: This removes the `experimental` label from the redact docs page
+  title: The Redact processor is Generally Available
+  body: The Redact processor uses the Grok rules engine to obscure text in the input document matching the given Grok patterns.
+  The Redact processor was initially released as Technical Preview in `8.7.0`, and is now released as Generally Available.
   notable: true

--- a/docs/changelog/110395.yaml
+++ b/docs/changelog/110395.yaml
@@ -5,6 +5,7 @@ type: feature
 issues: []
 highlight:
   title: The Redact processor is Generally Available
-  body: The Redact processor uses the Grok rules engine to obscure text in the input document matching the given Grok patterns.
+  body: |
+  The Redact processor uses the Grok rules engine to obscure text in the input document matching the given Grok patterns.
   The Redact processor was initially released as Technical Preview in `8.7.0`, and is now released as Generally Available.
   notable: true

--- a/docs/changelog/110395.yaml
+++ b/docs/changelog/110395.yaml
@@ -5,7 +5,5 @@ type: feature
 issues: []
 highlight:
   title: The Redact processor is Generally Available
-  body: |
-  The Redact processor uses the Grok rules engine to obscure text in the input document matching the given Grok patterns.
-  The Redact processor was initially released as Technical Preview in `8.7.0`, and is now released as Generally Available.
+  body: The Redact processor uses the Grok rules engine to obscure text in the input document matching the given Grok patterns. The Redact processor was initially released as Technical Preview in `8.7.0`, and is now released as Generally Available.
   notable: true

--- a/docs/changelog/110395.yaml
+++ b/docs/changelog/110395.yaml
@@ -1,0 +1,9 @@
+pr: 110395
+summary: Remove the experimental section from the redact docs
+area: Ingest Node
+type: docs
+issues: []
+highlight:
+  title: Remove the experimental section from the redact docs
+  body: This removes the `experimental` label from the redact docs page
+  notable: true

--- a/docs/changelog/110395.yaml
+++ b/docs/changelog/110395.yaml
@@ -1,7 +1,7 @@
 pr: 110395
 summary: Remove the experimental section from the redact docs
 area: Ingest Node
-type: docs
+type: feature
 issues: []
 highlight:
   title: Remove the experimental section from the redact docs

--- a/docs/reference/ingest/processors/redact.asciidoc
+++ b/docs/reference/ingest/processors/redact.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Redact</titleabbrev>
 ++++
 
-experimental::[]
-
 The Redact processor uses the Grok rules engine to obscure
 text in the input document matching the given Grok patterns. The processor can
 be used to obscure Personal Identifying Information (PII) by configuring it to


### PR DESCRIPTION
This removes the `experimental` label from the redact docs page