### PR TITLE
ESQL: Add javadocs for some of DataType

### DIFF
--- a/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
+++ b/x-pack/plugin/esql-core/src/main/java/org/elasticsearch/xpack/esql/core/type/DataType.java
@@ -254,18 +254,31 @@ public enum DataType {
         return esType;
     }
 
+    /**
+     * The name we give to types on the response.
+     */
     public String outputType() {
         return esType == null ? "unsupported" : esType;
     }
 
+    /**
+     * Does this data type represent whole numbers? As in, numbers without a decimal point.
+     * Like {@code int} or {@code long}. See {@link #isRational} for numbers with a decimal point.
+     */
     public boolean isInteger() {
         return isInteger;
     }
 
+    /**
+     * Does this data type represent rational numbers (like floating point)?
+     */
     public boolean isRational() {
         return isRational;
     }
 
+    /**
+     * Does this data type represent <strong>any</strong> number?
+     */
     public boolean isNumeric() {
         return isInteger || isRational;
     }


### PR DESCRIPTION
This adds some javadoc to a few of the methods on `DataType`. That's important because `DataType` is pretty central to how ESQL works and is referenced in tons of code. The method `isInteger` especially wants an explanation - it's true for all whole numbers.
