### PR TITLE
Fix serialization of to_partial and from_partial

### DIFF
--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FromPartial.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/FromPartial.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 
 import java.io.IOException;
@@ -48,13 +49,13 @@ public class FromPartial extends AggregateFunction implements ToAggregator {
     }
 
     private FromPartial(StreamInput in) throws IOException {
-        super(in);
-        this.function = in.readNamedWriteable(Expression.class);
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(Expression.class), in.readNamedWriteable(Expression.class));
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+        source().writeTo(out);
+        out.writeNamedWriteable(field());
         out.writeNamedWriteable(function);
     }
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ToPartial.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/expression/function/aggregate/ToPartial.java
@@ -24,6 +24,7 @@ import org.elasticsearch.xpack.esql.core.expression.Expression;
 import org.elasticsearch.xpack.esql.core.tree.NodeInfo;
 import org.elasticsearch.xpack.esql.core.tree.Source;
 import org.elasticsearch.xpack.esql.core.type.DataType;
+import org.elasticsearch.xpack.esql.io.stream.PlanStreamInput;
 import org.elasticsearch.xpack.esql.planner.ToAggregator;
 
 import java.io.IOException;
@@ -75,13 +76,13 @@ public class ToPartial extends AggregateFunction implements ToAggregator {
     }
 
     private ToPartial(StreamInput in) throws IOException {
-        super(in);
-        this.function = in.readNamedWriteable(Expression.class);
+        this(Source.readFrom((PlanStreamInput) in), in.readNamedWriteable(Expression.class), in.readNamedWriteable(Expression.class));
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+        source().writeTo(out);
+        out.writeNamedWriteable(field());
         out.writeNamedWriteable(function);
     }
 


### PR DESCRIPTION
#110157 broke the serialization of ToPartial and FromPartial, where the 
parameters weren't properly assigned.

I will look into making these classes more compatible with 
AggregateFunction, but this small change should stabilize the CI.

Relates #110157