### PR TITLE
Enable double rounding when test with more than 1 node

### DIFF
--- a/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java
+++ b/x-pack/plugin/esql/qa/server/single-node/src/javaRestTest/java/org/elasticsearch/xpack/esql/qa/single_node/EsqlSpecIT.java
@@ -28,4 +28,10 @@ public class EsqlSpecIT extends EsqlSpecTestCase {
     public EsqlSpecIT(String fileName, String groupName, String testName, Integer lineNumber, CsvTestCase testCase, Mode mode) {
         super(fileName, groupName, testName, lineNumber, testCase, mode);
     }
+
+    @Override
+    protected boolean enableRoundingDoubleValuesOnAsserting() {
+        // This suite runs with more than one node and three shards in serverless
+        return cluster.getNumNodes() > 1;
+    }
 }


### PR DESCRIPTION
With this change, we will enable rounding for double values in the single-node QA module in serverless tests, while keeping it disabled in stateful tests.