### PR TITLE
Fix `testBatchCloseIndices`

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -75,6 +75,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.MockBigArrays;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
@@ -2290,12 +2291,30 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
     }
 
+    /**
+     * Wait for all tasks currently running or enqueued on the given executor to complete.
+     */
     public static void flushThreadPoolExecutor(ThreadPool threadPool, String executorName) {
         final var maxThreads = threadPool.info(executorName).getMax();
         final var barrier = new CyclicBarrier(maxThreads + 1);
         final var executor = threadPool.executor(executorName);
         for (int i = 0; i < maxThreads; i++) {
-            executor.execute(() -> safeAwait(barrier));
+            executor.execute(new AbstractRunnable() {
+                @Override
+                protected void doRun() {
+                    safeAwait(barrier);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    fail(e, "unexpected");
+                }
+
+                @Override
+                public boolean isForceExecution() {
+                    return true;
+                }
+            });
         }
         safeAwait(barrier);
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2290,6 +2290,16 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
     }
 
+    public static void flushThreadPoolExecutor(ThreadPool threadPool, String executorName) {
+        final var maxThreads = threadPool.info(executorName).getMax();
+        final var barrier = new CyclicBarrier(maxThreads + 1);
+        final var executor = threadPool.executor(executorName);
+        for (int i = 0; i < maxThreads; i++) {
+            executor.execute(() -> safeAwait(barrier));
+        }
+        safeAwait(barrier);
+    }
+
     protected static boolean isTurkishLocale() {
         return Locale.getDefault().getLanguage().equals(new Locale("tr").getLanguage())
             || Locale.getDefault().getLanguage().equals(new Locale("az").getLanguage());


### PR DESCRIPTION
It's not enough to wait for the tasks to appear in the pending tasks
queue, we must also then wait for the submitting threads to become idle
to ensure that the queue size is correct and therefore that the batch is
properly formed.

Closes #109187