### PR TITLE
Include ent search yaml rest specs in rest resources zip

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/build.gradle
+++ b/x-pack/plugin/ent-search/qa/rest/build.gradle
@@ -33,3 +33,7 @@ testClusters.configureEach {
   user username: 'entsearch-user', password: 'entsearch-user-password', role: 'user'
   user username: 'entsearch-unprivileged', password: 'entsearch-unprivileged-password', role: 'unprivileged'
 }
+
+artifacts {
+  restXpackTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
+}

--- a/x-pack/rest-resources-zip/build.gradle
+++ b/x-pack/rest-resources-zip/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   freeCompatTests project(path: ':rest-api-spec', configuration: 'restCompatTests')
   platinumTests project(path: ':x-pack:plugin', configuration: 'restXpackTests')
   platinumTests project(path: ':x-pack:plugin:eql:qa:rest', configuration: 'restXpackTests')
+  platinumTests project(path: ':x-pack:plugin:ent-search:qa:rest', configuration: 'restXpackTests')
   platinumCompatTests project(path: ':x-pack:plugin', configuration: 'restCompatTests')
   platinumCompatTests project(path: ':x-pack:plugin:eql:qa:rest', configuration: 'restCompatTests')
 }


### PR DESCRIPTION
This should allow supporting ent-search api in Elasticsearch specification validation