### PR TITLE
Move yml rest test for query roles

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/10_basic.yml
@@ -87,20 +87,6 @@ teardown:
   - match: { admin_role.indices.0.names.0: "*" }
   - match: { admin_role.indices.0.privileges.0:  "all" }
 
-  # query match_all roles
-  - do:
-      headers:
-        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
-      security.query_role:
-        body: >
-          {
-            "query": { "match_all": {} }, "sort": ["name"]
-          }
-  - match: { total: 2 }
-  - match: { count: 2 }
-  - match: { roles.0.name: "admin_role" }
-  - match: { roles.1.name: "backwards_role" }
-
   - do:
       security.put_role:
         name: "role_with_description"
@@ -118,16 +104,3 @@ teardown:
         name: "role_with_description"
   - match: { role_with_description.cluster.0:  "manage_security" }
   - match: { role_with_description.description:  "Allows all security-related operations such as CRUD operations on users and roles and cache clearing." }
-
-  # query again for this last role
-  - do:
-      headers:
-        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
-      security.query_role:
-        body: >
-          {
-            "query": { "match_all": {} }, "sort": ["name"], "from": 2
-          }
-  - match: { total: 3 }
-  - match: { count: 1 }
-  - match: { roles.0.name: "role_with_description" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml
@@ -82,3 +82,17 @@ teardown:
           }
   - match: { deleted.0: "admin_role" }
   - match: { deleted.1: "role_with_description" }
+
+  # query match_all roles
+  - do:
+      headers:
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
+      security.query_role:
+        body: >
+          {
+            "query": { "match_all": {} }, "sort": ["name"]
+          }
+  - match: { total: 2 }
+  - match: { count: 2 }
+  - match: { roles.0.name: "admin_role" }
+  - match: { roles.1.name: "role_with_description" }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml
@@ -96,3 +96,15 @@ teardown:
           }
   - match: { deleted.0: "admin_role" }
   - match: { deleted.1: "role_with_description" }
+
+  # query match_all roles
+  - do:
+      headers:
+        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
+      security.query_role:
+        body: >
+          {
+            "query": { "match_all": {} }, "sort": ["name"]
+          }
+  - match: { total: 0 }
+  - match: { count: 0 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml
@@ -96,15 +96,3 @@ teardown:
           }
   - match: { deleted.0: "admin_role" }
   - match: { deleted.1: "role_with_description" }
-
-  # query match_all roles
-  - do:
-      headers:
-        Authorization: "Basic am9lOnMza3JpdC1wYXNzd29yZA=="
-      security.query_role:
-        body: >
-          {
-            "query": { "match_all": {} }, "sort": ["name"]
-          }
-  - match: { total: 0 }
-  - match: { count: 0 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/roles/60_bulk_roles.yml
@@ -74,15 +74,6 @@ teardown:
   - match: { role_with_description.cluster.0:  "manage_security" }
   - match: { role_with_description.description:  "Allows all security-related operations such as CRUD operations on users and roles and cache clearing." }
 
-  - do:
-      security.bulk_delete_role:
-        body: >
-          {
-             "names": ["admin_role", "role_with_description"]
-          }
-  - match: { deleted.0: "admin_role" }
-  - match: { deleted.1: "role_with_description" }
-
   # query match_all roles
   - do:
       headers:
@@ -96,3 +87,12 @@ teardown:
   - match: { count: 2 }
   - match: { roles.0.name: "admin_role" }
   - match: { roles.1.name: "role_with_description" }
+
+  - do:
+      security.bulk_delete_role:
+        body: >
+          {
+             "names": ["admin_role", "role_with_description"]
+          }
+  - match: { deleted.0: "admin_role" }
+  - match: { deleted.1: "role_with_description" }


### PR DESCRIPTION
This moves the query roles yml rest test away from the file that's also ran in serverless (where the query-roles endpoint is not available).