### PR TITLE
ESQL: Fix running tests in intellij

### DIFF
--- a/x-pack/plugin/esql/src/main/plugin-metadata/plugin-security.codebases
+++ b/x-pack/plugin/esql/src/main/plugin-metadata/plugin-security.codebases
@@ -1,0 +1,1 @@
+arrow: org.elasticsearch.xpack.esql.arrow.AllocationManagerShim


### PR DESCRIPTION
When we added arrow support we needed to add a security permission to hack around their initialization code. That confused intellij running tests. This removes the confusion by manually resolving the location.
