### PR TITLE
(Doc+) Error "number of documents in the index can't exceed"

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -548,8 +548,6 @@ PUT _cluster/settings
 [discrete]
 ==== Number of documents in the index shard cannot exceed [2147483519]
 
-NOTE: Historically, this error reported `Number of documents in the index shard cannot exceed [2147483519]` where 
-`index` was referencing a Lucene index which correlates to an <<glossary-shard,Elasticsearch shard>>. 
 
 Elasticsearch shards reflect Lucene's underlying https://github.com/apache/lucene/issues/5176[index 
 `MAX_DOC` hard limit] of 2,147,483,519 (`(2^31)-129`) docs. This figure calulates 
@@ -559,7 +557,7 @@ will cause error
 
 [source, txt]
 ----
-Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the index shard cannot exceed [2147483519]]
+Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the shard cannot exceed [2147483519]]
 ----
 
 or this error's sister stack trace will appear 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -554,7 +554,7 @@ Elasticsearch shards reflect Lucene's underlying https://github.com/apache/lucen
 the sum of `docs.count` plus `docs.deleted` as reported by the <<indices-stats,Index stats API>> 
 per shard. Exceeding this limit will result in errors like the following:
 
-[source]
+[source,txt]
 ----
 Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the shard cannot exceed [2147483519]]
 ----

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -546,14 +546,13 @@ PUT _cluster/settings
 ----
 
 [discrete]
-==== Number of documents in the index shard cannot exceed [2147483519]
+==== Number of documents in the shard cannot exceed [2147483519]
 
 
 Elasticsearch shards reflect Lucene's underlying https://github.com/apache/lucene/issues/5176[index 
-`MAX_DOC` hard limit] of 2,147,483,519 (`(2^31)-129`) docs. This figure calulates 
-from the sum of `docs.count` plus `docs.deleted` as reported by <<indices-stats,Index Stats>> 
-per shard. Attempting to surpass this limit, e.g. via ingestion's <<index-modules-translog,translog>>, 
-will cause error 
+`MAX_DOC` hard limit] of 2,147,483,519 (`(2^31)-129`) docs. This figure is
+the sum of `docs.count` plus `docs.deleted` as reported by the <<indices-stats,Index stats API>> 
+per shard. Exceeding this limit will result in errors like the following:
 
 [source, txt]
 ----
@@ -567,17 +566,14 @@ or this error's sister stack trace will appear
 Caused by: java.lang.IllegalArgumentException: number of documents in the index cannot exceed 2147483519
 ----
 
-TIP: This calculation works off all docs within the shard, including nested docs. 
+TIP: This calculation includes nested documents.
+This may differ from the results of the <<search-count,Count API>>.
 Therefore, it's results are not guaranteed to line up to the <<search-count,Count API>> 
 which masks nested docs. 
 
-Encountering this error usually suggests an issue with sharding strategy being 
-out of compliance with the above recommendations on this page, specifically at least 
-<<shard-size-recommendation,aiming for shards of up to 200M documents>>. 
 
-Frequently, the `docs.deleted` for the index will be elevated that 
-<<indices-forcemerge,expunging deleted docs>> can work as a short-term stop gap to regain
-ability to admin the index, e.g. for `my-index-000001` this command would appear 
+Try using the <<indices-forcemerge,Force merge API>> to free up space and recover the
+ability to admin the index. For example:
 
 [source,console]
 ----

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -559,22 +559,20 @@ per shard. Exceeding this limit will result in errors like the following:
 Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the shard cannot exceed [2147483519]]
 ----
 
-TIP: This calculation includes nested documents.
-This may differ from the results of the <<search-count,Count API>>.
-Therefore, it's results are not guaranteed to line up to the <<search-count,Count API>> 
-which masks nested docs. 
+TIP: This calculation may differ from the <<search-count,Count API's>> calculation, because the Count API does not include nested documents.
 
 
-Try using the <<indices-forcemerge,Force merge API>> to free up space and recover the
-ability to admin the index. For example:
+Try using the <<indices-forcemerge,Force Merge API>> to clear deleted docs. For example:
 
 [source,console]
 ----
 POST my-index-000001/_forcemerge?only_expunge_deletes=true
 ----
 
-This will kick off an asynchronous task which can be monitored via the <<tasks,Task Management API>>. 
+This will launch an asynchronous task which can be monitored via the <<tasks,Task Management API>>. 
 
-Longer-term, this error can usually be resolved by <<docs-delete-by-query,removing unneeded docs>> 
-from the index or by <<indices-split-index,Splitting>> or <<docs-reindex,Reindexing>> the index with 
-corrected shard strategy settings. 
+For a long-term solution try:
+
+* <<docs-delete-by-query,deleting unneeded documents>> 
+* aligning the index to recommendations on this page by either 
+<<indices-split-index,Splitting>> or <<docs-reindex,Reindexing>> the index 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -544,3 +544,50 @@ PUT _cluster/settings
   }
 }
 ----
+
+[discrete]
+==== Number of documents in the index can't exceed [2147483519]
+
+Elasticsearch shards reflect Lucene's underlying https://github.com/apache/lucene/issues/5176[index 
+`MAX_DOC` hard limit] of 2,147,483,519 (`(2^31)-1`) docs. This figure calulates 
+from the sum of `docs.count` plus `docs.deleted` as reported by <<indices-stats,Index Stats>> 
+per shard. Attempting to surpass this limit, e.g. via ingestion's <<index-modules-translog,translog>>, 
+will cause error 
+
+[source, txt]
+----
+Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the index can't exceed [2147483519]]
+----
+
+or this error's sister stack trace will appear 
+
+[source, txt]
+----
+Caused by: java.lang.IllegalArgumentException: number of documents in the index cannot exceed 2147483519
+----
+
+Noting that in this error message, `index` is referencing a Lucene index which correlates to an 
+<<glossary-shard,Elasticsearch shard>>. 
+
+TIP: This calculation works off all docs within the shard, including nested docs. 
+Therefore, it's results are not guaranteed to line up to the <<search-count,Count API>> 
+which masks nested docs. 
+
+Encountering this error usually suggests an issue with sharding strategy being 
+out of compliance with the above recommendations on this page, specifically at least 
+<<shard-size-recommendation,aiming for shards of up to 200M documents>>. 
+
+Frequently, the `docs.deleted` for the index will be elevated that 
+<<indices-forcemerge,expunging deleted docs>> can work as a short-term stop gap to regain
+ability to admin the index, e.g. for `my-index-000001` this command would appear 
+
+[source,console]
+----
+POST my-index-000001/_forcemerge?only_expunge_deletes=true
+----
+
+This will kick off an asynchronous task which can be monitored via the <<tasks,Task Management API>>. 
+
+Longer-term, this error can usually be resolved by <<docs-delete-by-query,removing unneeded docs>> 
+from the index or by <<indices-split-index,Splitting>> or <<docs-reindex,Reindexing>> the index with 
+corrected shard strategy settings. 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -568,6 +568,7 @@ Try using the <<indices-forcemerge,Force Merge API>> to clear deleted docs. For 
 ----
 POST my-index-000001/_forcemerge?only_expunge_deletes=true
 ----
+// TEST[setup:my_index]
 
 This will launch an asynchronous task which can be monitored via the <<tasks,Task Management API>>. 
 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -559,13 +559,6 @@ per shard. Exceeding this limit will result in errors like the following:
 Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the shard cannot exceed [2147483519]]
 ----
 
-or this error's sister stack trace will appear 
-
-[source, txt]
-----
-Caused by: java.lang.IllegalArgumentException: number of documents in the index cannot exceed 2147483519
-----
-
 TIP: This calculation includes nested documents.
 This may differ from the results of the <<search-count,Count API>>.
 Therefore, it's results are not guaranteed to line up to the <<search-count,Count API>> 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -554,7 +554,7 @@ Elasticsearch shards reflect Lucene's underlying https://github.com/apache/lucen
 the sum of `docs.count` plus `docs.deleted` as reported by the <<indices-stats,Index stats API>> 
 per shard. Exceeding this limit will result in errors like the following:
 
-[source, txt]
+[source]
 ----
 Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the shard cannot exceed [2147483519]]
 ----

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -546,17 +546,20 @@ PUT _cluster/settings
 ----
 
 [discrete]
-==== Number of documents in the index can't exceed [2147483519]
+==== Number of documents in the index shard cannot exceed [2147483519]
+
+NOTE: Historically, this error reported `Number of documents in the index shard cannot exceed [2147483519]` where 
+`index` was referencing a Lucene index which correlates to an <<glossary-shard,Elasticsearch shard>>. 
 
 Elasticsearch shards reflect Lucene's underlying https://github.com/apache/lucene/issues/5176[index 
-`MAX_DOC` hard limit] of 2,147,483,519 (`(2^31)-1`) docs. This figure calulates 
+`MAX_DOC` hard limit] of 2,147,483,519 (`(2^31)-129`) docs. This figure calulates 
 from the sum of `docs.count` plus `docs.deleted` as reported by <<indices-stats,Index Stats>> 
 per shard. Attempting to surpass this limit, e.g. via ingestion's <<index-modules-translog,translog>>, 
 will cause error 
 
 [source, txt]
 ----
-Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the index can't exceed [2147483519]]
+Elasticsearch exception [type=illegal_argument_exception, reason=Number of documents in the index shard cannot exceed [2147483519]]
 ----
 
 or this error's sister stack trace will appear 
@@ -565,9 +568,6 @@ or this error's sister stack trace will appear
 ----
 Caused by: java.lang.IllegalArgumentException: number of documents in the index cannot exceed 2147483519
 ----
-
-Noting that in this error message, `index` is referencing a Lucene index which correlates to an 
-<<glossary-shard,Elasticsearch shard>>. 
 
 TIP: This calculation works off all docs within the shard, including nested docs. 
 Therefore, it's results are not guaranteed to line up to the <<search-count,Count API>> 


### PR DESCRIPTION
👋 howdy, team!  This adds resolution outline for error under [Troubleshooting shard-related errors](https://www.elastic.co/guide/en/elasticsearch/reference/current/size-your-shards.html#troubleshoot-shard-related-errors) ... which induces ongoing, lowkey support
```
Number of documents in the index can't exceed [2147483519]
```
Kindly correct resolution steps as needed 🙂 . 