### PR TITLE
[8.15] [DOCS] Adds 8.14.2 release notes to 8.15 (#110471)

### DIFF
--- a/docs/reference/release-notes/8.14.2.asciidoc
+++ b/docs/reference/release-notes/8.14.2.asciidoc
@@ -1,0 +1,38 @@
+[[release-notes-8.14.2]]
+== {es} version 8.14.2
+
+coming[8.14.2]
+
+Also see <<breaking-changes-8.14,Breaking changes in 8.14>>.
+
+[[bug-8.14.2]]
+[float]
+=== Bug fixes
+
+Data streams::
+* Ensure a lazy rollover request will rollover the target data stream once. {es-pull}109636[#109636]
+* [Data streams] Fix the description of the lazy rollover task {es-pull}109629[#109629]
+
+ES|QL::
+* Fix ESQL cancellation for exchange requests {es-pull}109695[#109695]
+* Fix equals and hashcode for `SingleValueQuery.LuceneQuery` {es-pull}110035[#110035]
+* Force execute inactive sink reaper {es-pull}109632[#109632]
+
+Infra/Scripting::
+* Check array size before returning array item in script doc values {es-pull}109824[#109824] (issue: {es-issue}104998[#104998])
+
+Infra/Settings::
+* Guard file settings readiness on file settings support {es-pull}109500[#109500]
+
+Machine Learning::
+* Fix IndexOutOfBoundsException during inference {es-pull}109533[#109533]
+
+Mapping::
+* Re-define `index.mapper.dynamic` setting in 8.x for a better 7.x to 8.x upgrade if this setting is used. {es-pull}109341[#109341]
+
+Ranking::
+* Fix for from parameter when using `sub_searches` and rank {es-pull}106253[#106253] (issue: {es-issue}99011[#99011])
+
+Search::
+* Add hexstring support byte painless scorers {es-pull}109492[#109492]
+* Fix automatic tracking of collapse with `docvalue_fields` {es-pull}110103[#110103]


### PR DESCRIPTION
Backports the following commits to 8.15:
 - [DOCS] Adds 8.14.2 release notes to main. (#110471)