### PR TITLE
Fix bug in union-types with type-casting in grouping key of STATS

### DIFF
--- a/docs/changelog/110476.yaml
+++ b/docs/changelog/110476.yaml
@@ -1,0 +1,6 @@
+pr: 110476
+summary: Fix bug in union-types with type-casting in grouping key of STATS
+area: ES|QL
+type: bug
+issues:
+ - 109922

--- a/docs/changelog/110476.yaml
+++ b/docs/changelog/110476.yaml
@@ -4,3 +4,4 @@ area: ES|QL
 type: bug
 issues:
  - 109922
+ - 110477

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/java/org/elasticsearch/xpack/esql/CsvTestUtils.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.esql;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateFormatters;
@@ -332,15 +331,15 @@ public final class CsvTestUtils {
             columnTypes = new ArrayList<>(header.length);
 
             for (String c : header) {
-                String[] nameWithType = Strings.split(c, ":");
-                if (nameWithType == null || nameWithType.length != 2) {
+                String[] nameWithType = escapeTypecast(c).split(":");
+                if (nameWithType.length != 2) {
                     throw new IllegalArgumentException("Invalid CSV header " + c);
                 }
-                String typeName = nameWithType[1].trim();
-                if (typeName.length() == 0) {
-                    throw new IllegalArgumentException("A type is always expected in the csv file; found " + nameWithType);
+                String typeName = unescapeTypecast(nameWithType[1]).trim();
+                if (typeName.isEmpty()) {
+                    throw new IllegalArgumentException("A type is always expected in the csv file; found " + Arrays.toString(nameWithType));
                 }
-                String name = nameWithType[0].trim();
+                String name = unescapeTypecast(nameWithType[0]).trim();
                 columnNames.add(name);
                 Type type = Type.asType(typeName);
                 if (type == null) {
@@ -396,6 +395,16 @@ public final class CsvTestUtils {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static final String TYPECAST_SPACER = "__TYPECAST__";
+
+    private static String escapeTypecast(String typecast) {
+        return typecast.replace("::", TYPECAST_SPACER);
+    }
+
+    private static String unescapeTypecast(String typecast) {
+        return typecast.replace(TYPECAST_SPACER, "::");
     }
 
     public enum Type {

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -263,6 +263,24 @@ count:long  |  host_ip:keyword
 2           |  172.21.2.162
 ;
 
+multiIndexIpStringStatsDrop
+required_capability: union_types
+required_capability: union_types_agg_cast
+required_capability: casting_operator
+
+FROM sample_data, sample_data_str
+| STATS count=count(*) BY client_ip::ip
+| KEEP count
+| SORT count DESC
+;
+
+count:long
+8
+2
+2
+2
+;
+
 multiIndexIpStringStatsInline
 required_capability: union_types
 required_capability: union_types_inline_fix
@@ -439,6 +457,26 @@ FROM sample_data, sample_data_ts_long
 count:long  |  @timestamp:date
 10          |  2023-10-23T13:00:00.000Z
 4           |  2023-10-23T12:00:00.000Z
+;
+
+multiIndexTsLongStatsDrop
+required_capability: union_types
+required_capability: union_types_agg_cast
+required_capability: casting_operator
+
+FROM sample_data, sample_data_ts_long
+| STATS count=count(*) BY @timestamp::datetime
+| KEEP count
+;
+
+count:long
+2
+2
+2
+2
+2
+2
+2
 ;
 
 multiIndexTsLongStatsInline2

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -304,8 +304,6 @@ required_capability: casting_operator
 
 FROM sample_data, sample_data_str
 | STATS count=count(*) BY client_ip::ip
-| SORT count DESC, `client_ip::ip` ASC
-| LIMIT 10
 | STATS mc=count(count) BY count
 | SORT mc DESC, count ASC
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -46,7 +46,7 @@ FROM sample_data_ts_long
 
 singleIndexIpStats
 FROM sample_data
-| EVAL client_ip = TO_IP(client_ip)
+| EVAL client_ip = client_ip::ip
 | STATS count=count(*) BY client_ip
 | SORT count DESC, client_ip ASC
 | KEEP count, client_ip
@@ -61,7 +61,7 @@ count:long  |  client_ip:ip
 
 singleIndexIpStringStats
 FROM sample_data_str
-| EVAL client_ip = TO_IP(client_ip)
+| EVAL client_ip = client_ip::ip
 | STATS count=count(*) BY client_ip
 | SORT count DESC, client_ip ASC
 | KEEP count, client_ip
@@ -74,12 +74,25 @@ count:long  |  client_ip:ip
 1           |  172.21.2.162
 ;
 
+singleIndexIpStringStatsInline
+FROM sample_data_str
+| STATS count=count(*) BY client_ip::ip
+| STATS mc=count(count) BY count
+| SORT mc DESC, count ASC
+| KEEP mc, count
+;
+
+mc:l | count:l
+3    | 1
+1    | 4
+;
+
 multiIndexIpString
 required_capability: union_types
 required_capability: metadata_fields
 
 FROM sample_data, sample_data_str METADATA _index
-| EVAL client_ip = TO_IP(client_ip)
+| EVAL client_ip = client_ip::ip
 | KEEP _index, @timestamp, client_ip, event_duration, message
 | SORT _index ASC, @timestamp DESC
 ;
@@ -106,7 +119,7 @@ required_capability: union_types
 required_capability: metadata_fields
 
 FROM sample_data, sample_data_str METADATA _index
-| EVAL host_ip = TO_IP(client_ip)
+| EVAL host_ip = client_ip::ip
 | KEEP _index, @timestamp, host_ip, event_duration, message
 | SORT _index ASC, @timestamp DESC
 ;
@@ -193,7 +206,7 @@ multiIndexIpStringStats
 required_capability: union_types
 
 FROM sample_data, sample_data_str
-| EVAL client_ip = TO_IP(client_ip)
+| EVAL client_ip = client_ip::ip
 | STATS count=count(*) BY client_ip
 | SORT count DESC, client_ip ASC
 | KEEP count, client_ip
@@ -210,7 +223,7 @@ multiIndexIpStringRenameStats
 required_capability: union_types
 
 FROM sample_data, sample_data_str
-| EVAL host_ip = TO_IP(client_ip)
+| EVAL host_ip = client_ip::ip
 | STATS count=count(*) BY host_ip
 | SORT count DESC, host_ip ASC
 | KEEP count, host_ip
@@ -255,6 +268,37 @@ count:long  |  client_ip:ip
 2           |  172.21.0.5
 2           |  172.21.2.113
 2           |  172.21.2.162
+;
+
+multiIndexIpStringStatsInline2
+required_capability: union_types
+
+FROM sample_data, sample_data_str
+| STATS count=count(*) BY client_ip::ip
+| SORT count DESC, `client_ip::ip` ASC
+;
+
+count:long  |  client_ip::ip:ip
+8           |  172.21.3.15
+2           |  172.21.0.5
+2           |  172.21.2.113
+2           |  172.21.2.162
+;
+
+multiIndexIpStringStatsInline3
+required_capability: union_types
+
+FROM sample_data, sample_data_str
+| STATS count=count(*) BY client_ip::ip
+| SORT count DESC, `client_ip::ip` ASC
+| LIMIT 10
+| STATS mc=count(count) BY count
+| SORT mc DESC, count ASC
+;
+
+mc:l | count:l
+3    | 2
+1    | 8
 ;
 
 multiIndexWhereIpStringStats
@@ -716,4 +760,38 @@ FROM sample_data* METADATA _index
 null            | null           |  8268153            | Connection error | sample_data         | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15
 null            | null           |  8268153            | Connection error | sample_data_str     | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15
 null            | null           |  8268153            | Connection error | sample_data_ts_long | 2023-10-23T13:52:55.015Z  | 1698069175015             | 1698069175015  |  172.21.3.15   |  172.21.3.15
+;
+
+multiIndexMultiColumnTypesRenameAndKeep
+required_capability: union_types
+required_capability: metadata_fields
+
+FROM sample_data* METADATA _index
+| WHERE event_duration > 8000000
+| EVAL ts = TO_DATETIME(@timestamp), ts_str = TO_STRING(@timestamp), ts_l = TO_LONG(@timestamp), ip = TO_IP(client_ip), ip_str = TO_STRING(client_ip) 
+| KEEP _index, ts, ts_str, ts_l, ip, ip_str, event_duration
+| SORT _index ASC, ts DESC
+;
+
+_index:keyword      | ts:date                   | ts_str:keyword            | ts_l:long      |  ip:ip         |  ip_str:k      |  event_duration:long
+sample_data         | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15   |  8268153
+sample_data_str     | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15   |  8268153
+sample_data_ts_long | 2023-10-23T13:52:55.015Z  | 1698069175015             | 1698069175015  |  172.21.3.15   |  172.21.3.15   |  8268153
+;
+
+multiIndexMultiColumnTypesRenameAndDrop
+required_capability: union_types
+required_capability: metadata_fields
+
+FROM sample_data* METADATA _index
+| WHERE event_duration > 8000000
+| EVAL ts = TO_DATETIME(@timestamp), ts_str = TO_STRING(@timestamp), ts_l = TO_LONG(@timestamp), ip = TO_IP(client_ip), ip_str = TO_STRING(client_ip) 
+| DROP @timestamp, client_ip, message
+| SORT _index ASC, ts DESC
+;
+
+event_duration:long | _index:keyword      | ts:date                   | ts_str:keyword            | ts_l:long      |  ip:ip         |  ip_str:k  
+8268153             | sample_data         | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15
+8268153             | sample_data_str     | 2023-10-23T13:52:55.015Z  | 2023-10-23T13:52:55.015Z  | 1698069175015  |  172.21.3.15   |  172.21.3.15
+8268153             | sample_data_ts_long | 2023-10-23T13:52:55.015Z  | 1698069175015             | 1698069175015  |  172.21.3.15   |  172.21.3.15
 ;

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -441,6 +441,39 @@ count:long  |  @timestamp:date
 4           |  2023-10-23T12:00:00.000Z
 ;
 
+multiIndexTsLongStatsInline2
+required_capability: union_types
+required_capability: casting_operator
+
+FROM sample_data, sample_data_ts_long
+| STATS count=count(*) BY @timestamp::datetime
+| SORT count DESC, `@timestamp::datetime` DESC
+;
+
+count:long  |  @timestamp::datetime:datetime
+2           |  2023-10-23T13:55:01.543Z
+2           |  2023-10-23T13:53:55.832Z
+2           |  2023-10-23T13:52:55.015Z
+2           |  2023-10-23T13:51:54.732Z
+2           |  2023-10-23T13:33:34.937Z
+2           |  2023-10-23T12:27:28.948Z
+2           |  2023-10-23T12:15:03.360Z
+;
+
+multiIndexTsLongStatsInline3
+required_capability: union_types
+required_capability: casting_operator
+
+FROM sample_data, sample_data_ts_long
+| STATS count=count(*) BY @timestamp::datetime
+| STATS mc=count(count) BY count
+| SORT mc DESC, count ASC
+;
+
+mc:l | count:l
+7    | 2
+;
+
 multiIndexTsLongRenameStats
 required_capability: union_types
 

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -282,6 +282,7 @@ count:long  |  client_ip:ip
 
 multiIndexIpStringStatsInline2
 required_capability: union_types
+required_capability: union_types_agg_cast
 required_capability: casting_operator
 
 FROM sample_data, sample_data_str
@@ -298,6 +299,7 @@ count:long  |  client_ip::ip:ip
 
 multiIndexIpStringStatsInline3
 required_capability: union_types
+required_capability: union_types_agg_cast
 required_capability: casting_operator
 
 FROM sample_data, sample_data_str
@@ -443,6 +445,7 @@ count:long  |  @timestamp:date
 
 multiIndexTsLongStatsInline2
 required_capability: union_types
+required_capability: union_types_agg_cast
 required_capability: casting_operator
 
 FROM sample_data, sample_data_ts_long
@@ -462,6 +465,7 @@ count:long  |  @timestamp::datetime:datetime
 
 multiIndexTsLongStatsInline3
 required_capability: union_types
+required_capability: union_types_agg_cast
 required_capability: casting_operator
 
 FROM sample_data, sample_data_ts_long

--- a/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
+++ b/x-pack/plugin/esql/qa/testFixtures/src/main/resources/union_types.csv-spec
@@ -45,6 +45,8 @@ FROM sample_data_ts_long
 ;
 
 singleIndexIpStats
+required_capability: casting_operator
+
 FROM sample_data
 | EVAL client_ip = client_ip::ip
 | STATS count=count(*) BY client_ip
@@ -60,6 +62,8 @@ count:long  |  client_ip:ip
 ;
 
 singleIndexIpStringStats
+required_capability: casting_operator
+
 FROM sample_data_str
 | EVAL client_ip = client_ip::ip
 | STATS count=count(*) BY client_ip
@@ -75,6 +79,8 @@ count:long  |  client_ip:ip
 ;
 
 singleIndexIpStringStatsInline
+required_capability: casting_operator
+
 FROM sample_data_str
 | STATS count=count(*) BY client_ip::ip
 | STATS mc=count(count) BY count
@@ -90,6 +96,7 @@ mc:l | count:l
 multiIndexIpString
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str METADATA _index
 | EVAL client_ip = client_ip::ip
@@ -117,6 +124,7 @@ sample_data_str | 2023-10-23T12:15:03.360Z  |  172.21.2.162  |  3450233         
 multiIndexIpStringRename
 required_capability: union_types
 required_capability: metadata_fields
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str METADATA _index
 | EVAL host_ip = client_ip::ip
@@ -204,6 +212,7 @@ sample_data_str | 2023-10-23T12:15:03.360Z  |  3450233              |  Connected
 
 multiIndexIpStringStats
 required_capability: union_types
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str
 | EVAL client_ip = client_ip::ip
@@ -221,6 +230,7 @@ count:long  |  client_ip:ip
 
 multiIndexIpStringRenameStats
 required_capability: union_types
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str
 | EVAL host_ip = client_ip::ip
@@ -272,6 +282,7 @@ count:long  |  client_ip:ip
 
 multiIndexIpStringStatsInline2
 required_capability: union_types
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str
 | STATS count=count(*) BY client_ip::ip
@@ -287,6 +298,7 @@ count:long  |  client_ip::ip:ip
 
 multiIndexIpStringStatsInline3
 required_capability: union_types
+required_capability: casting_operator
 
 FROM sample_data, sample_data_str
 | STATS count=count(*) BY client_ip::ip

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/action/EsqlCapabilities.java
@@ -106,7 +106,12 @@ public class EsqlCapabilities {
         /**
          * Support for WEIGHTED_AVG function.
          */
-        AGG_WEIGHTED_AVG;
+        AGG_WEIGHTED_AVG,
+
+        /**
+         * Fix for union-types when aggregating over an inline conversion with casting operator. Done in #110476.
+         */
+        UNION_TYPES_AGG_CAST;
 
         private final boolean snapshotOnly;
 

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1127,7 +1127,7 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
             var named = resolveAgainstList(ua, resolved.keySet());
             return switch (named.size()) {
                 case 0 -> ua;
-                case 1 -> resolved.get(named.get(0));
+                case 1 -> named.get(0).equals(ua) ? ua : resolved.get(named.get(0));
                 default -> ua.withUnresolvedMessage("Resolved [" + ua + "] unexpectedly to multiple attributes " + named);
             };
         }

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/analysis/Analyzer.java
@@ -1087,6 +1087,20 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 return plan;
             }
 
+            // In ResolveRefs the aggregates are resolved from the groupings, which might have an unresolved MultiTypeEsField.
+            // Now that we have resolved those, we need to re-resolve the aggregates.
+            if (plan instanceof EsqlAggregate agg && agg.expressionsResolved() == false) {
+                AttributeMap<Expression> resolved = new AttributeMap<>();
+                for (Expression e : agg.groupings()) {
+                    Attribute attr = Expressions.attribute(e);
+                    if (attr != null && attr.resolved()) {
+                        resolved.put(attr, attr);
+                    }
+                }
+                List<Attribute> resolvedList = NamedExpressions.mergeOutputAttributes(new ArrayList<>(resolved.keySet()), List.of());
+                plan = agg.transformExpressionsOnly(UnresolvedAttribute.class, ua -> resolveAttribute(ua, resolvedList));
+            }
+
             // Otherwise drop the converted attributes after the alias function, as they are only needed for this function, and
             // the original version of the attribute should still be seen as unconverted.
             plan = dropConvertedAttributes(plan, unionFieldAttributes);
@@ -1108,6 +1122,15 @@ public class Analyzer extends ParameterizedRuleExecutor<LogicalPlan, AnalyzerCon
                 return esr;
             });
             return plan;
+        }
+
+        private Attribute resolveAttribute(UnresolvedAttribute ua, List<Attribute> resolvedList) {
+            var named = resolveAgainstList(ua, resolvedList);
+            return switch (named.size()) {
+                case 0 -> ua;
+                case 1 -> named.get(0);
+                default -> ua.withUnresolvedMessage("Resolved [" + ua + "] unexpectedly to multiple attributes " + named);
+            };
         }
 
         private LogicalPlan dropConvertedAttributes(LogicalPlan plan, List<FieldAttribute> unionFieldAttributes) {

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/optimizer/LocalPhysicalPlanOptimizer.java
@@ -196,8 +196,8 @@ public class LocalPhysicalPlanOptimizer extends ParameterizedRuleExecutor<Physic
                  */
                 if (p instanceof AggregateExec agg
                     && agg.groupings().size() == 1
-                    // Union types rely on field extraction.
-                    && (isMultiTypeFieldAttribute(agg.groupings().get(0)) == false)) {
+                    && (isMultiTypeFieldAttribute(agg.groupings().get(0)) == false) // Union types rely on field extraction.
+                ) {
                     var leaves = new LinkedList<>();
                     // TODO: this seems out of place
                     agg.aggregates()

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -233,9 +233,8 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         // The grouping-by values are ready, let's group on them directly.
         // Costin: why are they ready and not already exposed in the layout?
         boolean isUnsupported = attrSource.dataType() == DataType.UNSUPPORTED;
-        var unionTypes = findUnionTypes(attrSource);
         return new OrdinalsGroupingOperator.OrdinalsGroupingOperatorFactory(
-            shardIdx -> getBlockLoaderFor(shardIdx, attrSource.name(), isUnsupported, NONE, unionTypes),
+            shardIdx -> shardContexts.get(shardIdx).blockLoader(attrSource.name(), isUnsupported, NONE),
             vsShardContexts,
             groupElementType,
             docChannel,

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/planner/EsPhysicalOperationProviders.java
@@ -233,8 +233,9 @@ public class EsPhysicalOperationProviders extends AbstractPhysicalOperationProvi
         // The grouping-by values are ready, let's group on them directly.
         // Costin: why are they ready and not already exposed in the layout?
         boolean isUnsupported = attrSource.dataType() == DataType.UNSUPPORTED;
+        var unionTypes = findUnionTypes(attrSource);
         return new OrdinalsGroupingOperator.OrdinalsGroupingOperatorFactory(
-            shardIdx -> shardContexts.get(shardIdx).blockLoader(attrSource.name(), isUnsupported, NONE),
+            shardIdx -> getBlockLoaderFor(shardIdx, attrSource.name(), isUnsupported, NONE, unionTypes),
             vsShardContexts,
             groupElementType,
             docChannel,

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
@@ -204,6 +204,13 @@ load single index keyword_keyword:
 
 ---
 load single index ip_long and aggregate by client_ip:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator]
+      reason: "Casting operator and introduced in 8.15.0"
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
@@ -227,6 +234,13 @@ load single index ip_long and aggregate by client_ip:
 
 ---
 load single index ip_long and aggregate client_ip my message:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator]
+      reason: "Casting operator and introduced in 8.15.0"
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
@@ -252,6 +266,13 @@ load single index ip_long and aggregate client_ip my message:
 
 ---
 load single index ip_long stats invalid grouping:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator]
+      reason: "Casting operator and introduced in 8.15.0"
   - do:
       catch: '/Unknown column \[x\]/'
       esql.query:
@@ -570,6 +591,13 @@ load two indices, convert, rename but not drop ambiguous field client_ip:
 
 ---
 load two indexes and group by converted client_ip:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator, union_types_agg_cast]
+      reason: "Casting operator and Union types introduced in 8.15.0"
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
@@ -593,6 +621,13 @@ load two indexes and group by converted client_ip:
 
 ---
 load two indexes and aggregate converted client_ip:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator, union_types_agg_cast]
+      reason: "Casting operator and Union types introduced in 8.15.0"
   - do:
       allowed_warnings_regex:
         - "No limit defined, adding default limit of \\[.*\\]"
@@ -618,6 +653,13 @@ load two indexes and aggregate converted client_ip:
 
 ---
 load two indexes, convert client_ip and group by something invalid:
+  - requires:
+      capabilities:
+        - method: POST
+          path: /_query
+          parameters: [method, path, parameters, capabilities]
+          capabilities: [casting_operator, union_types_agg_cast]
+      reason: "Casting operator and Union types introduced in 8.15.0"
   - do:
       catch: '/Unknown column \[x\]/'
       esql.query:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/esql/160_union_types.yml
@@ -147,6 +147,9 @@ setup:
           - '{"index": {}}'
           - '{"@timestamp": "2023-10-23T12:15:03.360Z", "client_ip": "172.21.2.162", "event_duration": "3450233", "message": "Connected to 10.1.0.3"}'
 
+############################################################################################################
+# Test a single index as a control of the expected results
+
 ---
 load single index ip_long:
   - do:
@@ -173,9 +176,6 @@ load single index ip_long:
   - match: { values.0.3: 1756467 }
   - match: { values.0.4: "Connected to 10.1.0.1" }
 
-############################################################################################################
-# Test a single index as a control of the expected results
-
 ---
 load single index keyword_keyword:
   - do:
@@ -201,6 +201,62 @@ load single index keyword_keyword:
   - match: { values.0.2: "172.21.3.15" }
   - match: { values.0.3: "1756467" }
   - match: { values.0.4: "Connected to 10.1.0.1" }
+
+---
+load single index ip_long and aggregate by client_ip:
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'FROM events_ip_long | STATS count = COUNT(*) BY client_ip::ip | SORT count DESC, `client_ip::ip` ASC'
+
+  - match: { columns.0.name: "count" }
+  - match: { columns.0.type: "long" }
+  - match: { columns.1.name: "client_ip::ip" }
+  - match: { columns.1.type: "ip" }
+  - length: { values: 4 }
+  - match: { values.0.0: 4 }
+  - match: { values.0.1: "172.21.3.15" }
+  - match: { values.1.0: 1 }
+  - match: { values.1.1: "172.21.0.5" }
+  - match: { values.2.0: 1 }
+  - match: { values.2.1: "172.21.2.113" }
+  - match: { values.3.0: 1 }
+  - match: { values.3.1: "172.21.2.162" }
+
+---
+load single index ip_long and aggregate client_ip my message:
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'FROM events_ip_long | STATS count = COUNT(client_ip::ip) BY message | SORT count DESC, message ASC'
+
+  - match: { columns.0.name: "count" }
+  - match: { columns.0.type: "long" }
+  - match: { columns.1.name: "message" }
+  - match: { columns.1.type: "keyword" }
+  - length: { values: 5 }
+  - match: { values.0.0: 3 }
+  - match: { values.0.1: "Connection error" }
+  - match: { values.1.0: 1 }
+  - match: { values.1.1: "Connected to 10.1.0.1" }
+  - match: { values.2.0: 1 }
+  - match: { values.2.1: "Connected to 10.1.0.2" }
+  - match: { values.3.0: 1 }
+  - match: { values.3.1: "Connected to 10.1.0.3" }
+  - match: { values.4.0: 1 }
+  - match: { values.4.1: "Disconnected" }
+
+---
+load single index ip_long stats invalid grouping:
+  - do:
+      catch: '/Unknown column \[x\]/'
+      esql.query:
+        body:
+          query: 'FROM events_ip_long | STATS count = COUNT(client_ip::ip) BY x'
 
 ############################################################################################################
 # Test two indices where the event_duration is mapped as a LONG and as a KEYWORD
@@ -511,6 +567,62 @@ load two indices, convert, rename but not drop ambiguous field client_ip:
   - match: { values.1.4: "172.21.3.15" }
   - match: { values.1.5: "172.21.3.15" }
   - match: { values.1.6: "172.21.3.15" }
+
+---
+load two indexes and group by converted client_ip:
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'FROM events_*_long | STATS count = COUNT(*) BY client_ip::ip | SORT count DESC, `client_ip::ip` ASC'
+
+  - match: { columns.0.name: "count" }
+  - match: { columns.0.type: "long" }
+  - match: { columns.1.name: "client_ip::ip" }
+  - match: { columns.1.type: "ip" }
+  - length: { values: 4 }
+  - match: { values.0.0: 8 }
+  - match: { values.0.1: "172.21.3.15" }
+  - match: { values.1.0: 2 }
+  - match: { values.1.1: "172.21.0.5" }
+  - match: { values.2.0: 2 }
+  - match: { values.2.1: "172.21.2.113" }
+  - match: { values.3.0: 2 }
+  - match: { values.3.1: "172.21.2.162" }
+
+---
+load two indexes and aggregate converted client_ip:
+  - do:
+      allowed_warnings_regex:
+        - "No limit defined, adding default limit of \\[.*\\]"
+      esql.query:
+        body:
+          query: 'FROM events_*_long | STATS count = COUNT(client_ip::ip) BY message | SORT count DESC, message ASC'
+
+  - match: { columns.0.name: "count" }
+  - match: { columns.0.type: "long" }
+  - match: { columns.1.name: "message" }
+  - match: { columns.1.type: "keyword" }
+  - length: { values: 5 }
+  - match: { values.0.0: 6 }
+  - match: { values.0.1: "Connection error" }
+  - match: { values.1.0: 2 }
+  - match: { values.1.1: "Connected to 10.1.0.1" }
+  - match: { values.2.0: 2 }
+  - match: { values.2.1: "Connected to 10.1.0.2" }
+  - match: { values.3.0: 2 }
+  - match: { values.3.1: "Connected to 10.1.0.3" }
+  - match: { values.4.0: 2 }
+  - match: { values.4.1: "Disconnected" }
+
+---
+load two indexes, convert client_ip and group by something invalid:
+  - do:
+      catch: '/Unknown column \[x\]/'
+      esql.query:
+        body:
+          query: 'FROM events_*_long | STATS count = COUNT(client_ip::ip) BY x'
 
 ############################################################################################################
 # Test four indices with both the client_IP (IP and KEYWORD) and event_duration (LONG and KEYWORD) mappings


### PR DESCRIPTION
It was reported in https://github.com/elastic/elasticsearch/issues/109922, that when the grouping key of an aggregation is the type conversion function, then the union-types is not resolved.

It turns out that the ResolveRefs code resolves the grouping key and aggregation attributes differently than all other refs. This necessitated the `ResolveUnionTypes` taking an extra action, using a much simplified version of the same logic used in ResolveRefs. In essence that logic looks for already resolved references in the groupings, and resolves the matching attributes in the aggregations.

Fixes #109922
Fixes #110477
