### PR TITLE
Store and update the latest read version for each shard of an index

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersions.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersions.java
@@ -208,6 +208,7 @@ public class TransportVersions {
     public static final TransportVersion TEXT_SIMILARITY_RERANKER_RETRIEVER = def(8_699_00_0);
     public static final TransportVersion ML_INFERENCE_GOOGLE_VERTEX_AI_RERANKING_ADDED = def(8_700_00_0);
     public static final TransportVersion VERSIONED_MASTER_NODE_REQUESTS = def(8_701_00_0);
+    public static final TransportVersion INDEX_SHARD_READ_VERSION = def(8_702_00_0);
 
     /*
      * STOP! READ THIS FIRST! No, really,

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -539,6 +539,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     static final String KEY_ALIASES = "aliases";
     static final String KEY_ROLLOVER_INFOS = "rollover_info";
     static final String KEY_MAPPINGS_UPDATED_VERSION = "mappings_updated_version";
+    static final String KEY_SHARD_READ_VERSION = "shard_read_version";
     static final String KEY_SYSTEM = "system";
     static final String KEY_TIMESTAMP_RANGE = "timestamp_range";
     static final String KEY_EVENT_INGESTED_RANGE = "event_ingested_range";
@@ -601,6 +602,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
     private final IndexVersion indexCreatedVersion;
     private final IndexVersion mappingsUpdatedVersion;
     private final IndexVersion indexCompatibilityVersion;
+    private final Map<Integer, IndexVersion> shardReadVersions;
 
     private final ActiveShardCount waitForActiveShards;
     private final ImmutableOpenMap<String, RolloverInfo> rolloverInfos;
@@ -669,6 +671,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         final DiscoveryNodeFilters excludeFilters,
         final IndexVersion indexCreatedVersion,
         final IndexVersion mappingsUpdatedVersion,
+        final Map<Integer, IndexVersion> shardReadVersions,
         final int routingNumShards,
         final int routingPartitionSize,
         final List<String> routingPaths,
@@ -701,6 +704,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         assert mappingVersion >= 0 : mappingVersion;
         this.mappingVersion = mappingVersion;
         this.mappingsUpdatedVersion = mappingsUpdatedVersion;
+        this.shardReadVersions = shardReadVersions;
         assert settingsVersion >= 0 : settingsVersion;
         this.settingsVersion = settingsVersion;
         assert aliasesVersion >= 0 : aliasesVersion;
@@ -781,6 +785,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.excludeFilters,
             this.indexCreatedVersion,
             this.mappingsUpdatedVersion,
+            this.shardReadVersions,
             this.routingNumShards,
             this.routingPartitionSize,
             this.routingPaths,
@@ -842,6 +847,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.excludeFilters,
             this.indexCreatedVersion,
             this.mappingsUpdatedVersion,
+            this.shardReadVersions,
             this.routingNumShards,
             this.routingPartitionSize,
             this.routingPaths,
@@ -901,6 +907,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.excludeFilters,
             this.indexCreatedVersion,
             this.mappingsUpdatedVersion,
+            this.shardReadVersions,
             this.routingNumShards,
             this.routingPartitionSize,
             this.routingPaths,
@@ -971,6 +978,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.excludeFilters,
             this.indexCreatedVersion,
             this.mappingsUpdatedVersion,
+            this.shardReadVersions,
             this.routingNumShards,
             this.routingPartitionSize,
             this.routingPaths,
@@ -1026,6 +1034,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.excludeFilters,
             this.indexCreatedVersion,
             this.mappingsUpdatedVersion,
+            this.shardReadVersions,
             this.routingNumShards,
             this.routingPartitionSize,
             this.routingPaths,
@@ -1081,6 +1090,10 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     public long getAliasesVersion() {
         return aliasesVersion;
+    }
+
+    public IndexVersion getShardReadVersion(int shardId) {
+        return shardReadVersions.getOrDefault(shardId, IndexVersions.ZERO);
     }
 
     /**
@@ -1517,6 +1530,18 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
     private static final TransportVersion SETTING_DIFF_VERSION = TransportVersions.V_8_5_0;
 
+    private static class IndexVersionDiff extends DiffableUtils.NonDiffableValueSerializer<Integer, IndexVersion> {
+        @Override
+        public void write(IndexVersion value, StreamOutput out) throws IOException {
+            out.writeVInt(value.id());
+        }
+
+        @Override
+        public IndexVersion read(StreamInput in, Integer key) throws IOException {
+            return IndexVersion.fromId(in.readVInt());
+        }
+    }
+
     private static class IndexMetadataDiff implements Diff<IndexMetadata> {
 
         private final String index;
@@ -1540,6 +1565,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private final Diff<Map<Integer, Set<String>>> inSyncAllocationIds;
         private final Diff<ImmutableOpenMap<String, RolloverInfo>> rolloverInfos;
         private final IndexVersion mappingsUpdatedVersion;
+        private final Diff<Map<Integer, IndexVersion>> shardReadVersions;
         private final boolean isSystem;
 
         // range for the @timestamp field for the Index
@@ -1583,6 +1609,12 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             );
             rolloverInfos = DiffableUtils.diff(before.rolloverInfos, after.rolloverInfos, DiffableUtils.getStringKeySerializer());
             mappingsUpdatedVersion = after.mappingsUpdatedVersion;
+            shardReadVersions = DiffableUtils.diff(
+                before.shardReadVersions,
+                after.shardReadVersions,
+                DiffableUtils.getVIntKeySerializer(),
+                new IndexVersionDiff()
+            );
             isSystem = after.isSystem;
             timestampRange = after.timestampRange;
             eventIngestedRange = after.eventIngestedRange;
@@ -1649,6 +1681,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             } else {
                 mappingsUpdatedVersion = IndexVersions.ZERO;
             }
+            if (in.getTransportVersion().onOrAfter(TransportVersions.INDEX_SHARD_READ_VERSION)) {
+                shardReadVersions = DiffableUtils.readJdkMapDiff(in, DiffableUtils.getVIntKeySerializer(), new IndexVersionDiff());
+            } else {
+                shardReadVersions = DiffableUtils.emptyDiff();
+            }
             if (in.getTransportVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
                 isSystem = in.readBoolean();
             } else {
@@ -1701,6 +1738,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             if (out.getTransportVersion().onOrAfter(TransportVersions.INDEX_METADATA_MAPPINGS_UPDATED_VERSION)) {
                 IndexVersion.writeVersion(mappingsUpdatedVersion, out);
             }
+            if (out.getTransportVersion().onOrAfter(TransportVersions.INDEX_SHARD_READ_VERSION)) {
+                shardReadVersions.writeTo(out);
+            }
             if (out.getTransportVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
                 out.writeBoolean(isSystem);
             }
@@ -1737,6 +1777,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 ImmutableOpenMap.<String, MappingMetadata>builder(1).fPut(MapperService.SINGLE_MAPPING_NAME, part.mapping).build()
             ).get(MapperService.SINGLE_MAPPING_NAME);
             builder.mappingsUpdatedVersion = mappingsUpdatedVersion;
+            builder.shardReadVersions.putAll(shardReadVersions.apply(part.shardReadVersions));
             builder.inferenceFields.putAllFromMap(inferenceFields.apply(part.inferenceFields));
             builder.aliases.putAllFromMap(aliases.apply(part.aliases));
             builder.customMetadata.putAllFromMap(customData.apply(part.customData));
@@ -1812,6 +1853,14 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (in.getTransportVersion().onOrAfter(TransportVersions.INDEX_METADATA_MAPPINGS_UPDATED_VERSION)) {
             builder.mappingsUpdatedVersion(IndexVersion.readVersion(in));
         }
+        if (in.getTransportVersion().onOrAfter(TransportVersions.INDEX_SHARD_READ_VERSION)) {
+            int shardVersionsSize = in.readVInt();
+            for (int i = 0; i < shardVersionsSize; i++) {
+                int key = in.readVInt();
+                IndexVersion value = IndexVersion.fromId(in.readVInt());
+                builder.putShardReadVersion(key, value);
+            }
+        }
         if (in.getTransportVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
             builder.system(in.readBoolean());
         }
@@ -1870,6 +1919,9 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         if (out.getTransportVersion().onOrAfter(TransportVersions.INDEX_METADATA_MAPPINGS_UPDATED_VERSION)) {
             IndexVersion.writeVersion(mappingsUpdatedVersion, out);
         }
+        if (out.getTransportVersion().onOrAfter(TransportVersions.INDEX_SHARD_READ_VERSION)) {
+            out.writeMap(shardReadVersions, StreamOutput::writeVInt, (o, v) -> o.writeVInt(v.id()));
+        }
         if (out.getTransportVersion().onOrAfter(SYSTEM_INDEX_FLAG_ADDED)) {
             out.writeBoolean(isSystem);
         }
@@ -1924,6 +1976,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
         private Settings settings = Settings.EMPTY;
         private MappingMetadata mapping;
         private IndexVersion mappingsUpdatedVersion = IndexVersion.current();
+        private final Map<Integer, IndexVersion> shardReadVersions;
         private final ImmutableOpenMap.Builder<String, InferenceFieldMetadata> inferenceFields;
         private final ImmutableOpenMap.Builder<String, AliasMetadata> aliases;
         private final ImmutableOpenMap.Builder<String, DiffableStringMap> customMetadata;
@@ -1940,6 +1993,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
         public Builder(String index) {
             this.index = index;
+            this.shardReadVersions = new HashMap<>();
             this.inferenceFields = ImmutableOpenMap.builder();
             this.aliases = ImmutableOpenMap.builder();
             this.customMetadata = ImmutableOpenMap.builder();
@@ -1964,6 +2018,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             this.routingNumShards = indexMetadata.routingNumShards;
             this.inSyncAllocationIds = new HashMap<>(indexMetadata.inSyncAllocationIds);
             this.mappingsUpdatedVersion = indexMetadata.mappingsUpdatedVersion;
+            this.shardReadVersions = new HashMap<>(indexMetadata.shardReadVersions);
             this.rolloverInfos = ImmutableOpenMap.builder(indexMetadata.rolloverInfos);
             this.isSystem = indexMetadata.isSystem;
             this.timestampRange = indexMetadata.timestampRange;
@@ -2058,6 +2113,15 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
         public Builder mappingsUpdatedVersion(IndexVersion indexVersion) {
             this.mappingsUpdatedVersion = indexVersion;
+            return this;
+        }
+
+        public IndexVersion getShardReadVersion(int shardId) {
+            return shardReadVersions.get(shardId);
+        }
+
+        public Builder putShardReadVersion(int shardId, IndexVersion indexVersion) {
+            shardReadVersions.put(shardId, indexVersion);
             return this;
         }
 
@@ -2413,6 +2477,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 excludeFilters,
                 indexCreatedVersion,
                 mappingsUpdatedVersion,
+                Map.copyOf(shardReadVersions),
                 getRoutingNumShards(),
                 routingPartitionSize,
                 routingPaths,
@@ -2546,6 +2611,11 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
             builder.endObject();
 
             builder.field(KEY_MAPPINGS_UPDATED_VERSION, indexMetadata.mappingsUpdatedVersion);
+            builder.startObject(KEY_SHARD_READ_VERSION);
+            for (Map.Entry<Integer, IndexVersion> v : indexMetadata.shardReadVersions.entrySet()) {
+                builder.field(String.valueOf(v.getKey()), v.getValue().id());
+            }
+            builder.endObject();
             builder.field(KEY_SYSTEM, indexMetadata.isSystem);
 
             builder.startObject(KEY_TIMESTAMP_RANGE);
@@ -2662,6 +2732,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                         case KEY_INFERENCE_FIELDS:
                             while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
                                 builder.putInferenceField(InferenceFieldMetadata.fromXContent(parser));
+                            }
+                            break;
+                        case KEY_SHARD_READ_VERSION:
+                            while ((currentFieldName = parser.nextFieldName()) != null) {
+                                token = parser.nextToken();
+                                XContentParserUtils.ensureExpectedToken(XContentParser.Token.VALUE_NUMBER, token, parser);
+                                builder.putShardReadVersion(Integer.parseInt(currentFieldName), IndexVersion.fromId(parser.intValue()));
                             }
                             break;
                         default:

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -25,7 +25,6 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
 import org.elasticsearch.cluster.coordination.PublicationTransportHandler;
 import org.elasticsearch.cluster.metadata.IndexAbstraction.ConcreteIndex;
-import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -522,7 +521,7 @@ public class Metadata implements Iterable<IndexMetadata>, Diffable<Metadata>, Ch
     /**
      * Creates a copy of this instance updated with the given {@link IndexMetadata} that must only contain changes to primary terms
      * and in-sync allocation ids relative to the existing entries. This method is only used by
-     * {@link org.elasticsearch.cluster.routing.allocation.IndexMetadataUpdater#applyChanges(Metadata, RoutingTable, TransportVersion)}.
+     * {@link org.elasticsearch.cluster.routing.allocation.IndexMetadataUpdater#applyChanges}.
      * @param updates map of index name to {@link IndexMetadata}.
      * @return updated metadata instance
      */

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetadataUpdater.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/IndexMetadataUpdater.java
@@ -23,6 +23,7 @@ import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexVersion;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.Comparator;
@@ -139,9 +140,8 @@ public class IndexMetadataUpdater implements RoutingChangesObserver {
                 );
 
                 // TODO: primaries? or replicas too?
-                IndexVersion allocatedNodeIndexVersion = getNodeIndexVersion.apply(
-                    newRoutingTable.shardRoutingTable(shardId).primaryShard().currentNodeId()
-                );
+                String nodeId = newRoutingTable.shardRoutingTable(shardId).primaryShard().currentNodeId();
+                IndexVersion allocatedNodeIndexVersion = nodeId != null ? getNodeIndexVersion.apply(nodeId) : IndexVersions.ZERO;
                 updatedIndexMetadata = updatedIndexMetadata.updateForAllocation(
                     shardId.id(),
                     updates.increaseTerm,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.index.IndexVersions;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.RestoreService.RestoreInProgressUpdater;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
@@ -343,7 +344,10 @@ public class RoutingAllocation {
         Metadata metadata = indexMetadataUpdater.applyChanges(
             metadata(),
             newRoutingTable,
-            n -> nodes.get(n).getMaxIndexVersion(),
+            n -> {
+                var node = nodes.get(n);
+                return node != null ? node.getMaxIndexVersion() : IndexVersions.ZERO;
+            },
             clusterState.getMinTransportVersion()
         );
         return resizeSourceIndexUpdater.applyChanges(metadata, newRoutingTable);

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -339,7 +339,13 @@ public class RoutingAllocation {
      * Returns updated {@link Metadata} based on the changes that were made to the routing nodes
      */
     public Metadata updateMetadataWithRoutingChanges(RoutingTable newRoutingTable) {
-        Metadata metadata = indexMetadataUpdater.applyChanges(metadata(), newRoutingTable, clusterState.getMinTransportVersion());
+        DiscoveryNodes nodes = clusterState.nodes();
+        Metadata metadata = indexMetadataUpdater.applyChanges(
+            metadata(),
+            newRoutingTable,
+            n -> nodes.get(n).getMaxIndexVersion(),
+            clusterState.getMinTransportVersion()
+        );
         return resizeSourceIndexUpdater.applyChanges(metadata, newRoutingTable);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -341,15 +341,10 @@ public class RoutingAllocation {
      */
     public Metadata updateMetadataWithRoutingChanges(RoutingTable newRoutingTable) {
         DiscoveryNodes nodes = clusterState.nodes();
-        Metadata metadata = indexMetadataUpdater.applyChanges(
-            metadata(),
-            newRoutingTable,
-            n -> {
-                var node = nodes.get(n);
-                return node != null ? node.getMaxIndexVersion() : IndexVersions.ZERO;
-            },
-            clusterState.getMinTransportVersion()
-        );
+        Metadata metadata = indexMetadataUpdater.applyChanges(metadata(), newRoutingTable, n -> {
+            var node = nodes.get(n);
+            return node != null ? node.getMaxIndexVersion() : IndexVersions.ZERO;
+        }, clusterState.getMinTransportVersion());
         return resizeSourceIndexUpdater.applyChanges(metadata, newRoutingTable);
     }
 


### PR DESCRIPTION
Add a `Map<Integer, IndexVersion>` to `IndexMetadata` and update it when shards are allocated to a node, indicating the maximum read version that has read a shard primary. The index version will be used to inform allocations in https://github.com/elastic/elasticsearch/pull/102708