### PR TITLE
Wait for the logs templates to be initialised 5 sec longer

### DIFF
--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/AbstractDataStreamIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/AbstractDataStreamIT.java
@@ -25,6 +25,7 @@ import org.junit.ClassRule;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This base class provides the boilerplate to simplify the development of integration tests.
@@ -53,7 +54,7 @@ public abstract class AbstractDataStreamIT extends ESRestTestCase {
             } catch (ResponseException e) {
                 fail(e.getMessage());
             }
-        });
+        }, 15, TimeUnit.SECONDS);
     }
 
     static void createDataStream(RestClient client, String name) throws IOException {

--- a/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/DataStreamUpgradeRestIT.java
+++ b/modules/data-streams/src/javaRestTest/java/org/elasticsearch/datastreams/DataStreamUpgradeRestIT.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.rest.action.search.RestSearchAction.TOTAL_HITS_AS_INT_PARAM;
@@ -306,6 +307,6 @@ public class DataStreamUpgradeRestIT extends DisabledSecurityDataStreamTestCase 
                 // Throw the exception, if it was an error we did not anticipate
                 throw responseException;
             }
-        });
+        }, 15, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
We have witnessed some test failures in `DataStreamUpgradeRestIT`, `EcsLogsDataStreamIT` and `LogsDataStreamIT` during which the `logs` related index or component template gets initialised right after the 10 seconds have passed. We increase the timeout to make the test more resilient to this scenario.