### PR TITLE
[8.15] Always write empty role descriptor fields to index (#110424)

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -109,12 +109,6 @@ tests:
 - class: "org.elasticsearch.xpack.searchablesnapshots.FrozenSearchableSnapshotsIntegTests"
   issue: "https://github.com/elastic/elasticsearch/issues/110408"
   method: "testCreateAndRestorePartialSearchableSnapshot"
-- class: "org.elasticsearch.xpack.security.role.RoleWithDescriptionRestIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/110416"
-  method: "testCreateOrUpdateRoleWithDescription"
-- class: "org.elasticsearch.xpack.security.role.RoleWithDescriptionRestIT"
-  issue: "https://github.com/elastic/elasticsearch/issues/110417"
-  method: "testCreateOrUpdateRoleWithDescription"
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_half_byte_quantized/Test create, merge, and search cosine}
   issue: https://github.com/elastic/elasticsearch/issues/109978

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/QueryRoleResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/role/QueryRoleResponse.java
@@ -86,7 +86,7 @@ public final class QueryRoleResponse extends ActionResponse implements ToXConten
             // other details of the role descriptor (in the same object).
             assert Strings.isNullOrEmpty(roleDescriptor.getName()) == false;
             builder.field("name", roleDescriptor.getName());
-            roleDescriptor.innerToXContent(builder, params, false, false);
+            roleDescriptor.innerToXContent(builder, params, false);
             if (sortValues != null && sortValues.length > 0) {
                 builder.array("_sort", sortValues);
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/RoleDescriptor.java
@@ -417,13 +417,8 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
     }
 
     public XContentBuilder toXContent(XContentBuilder builder, Params params, boolean docCreation) throws IOException {
-        return toXContent(builder, params, docCreation, false);
-    }
-
-    public XContentBuilder toXContent(XContentBuilder builder, Params params, boolean docCreation, boolean includeMetadataFlattened)
-        throws IOException {
         builder.startObject();
-        innerToXContent(builder, params, docCreation, includeMetadataFlattened);
+        innerToXContent(builder, params, docCreation);
         return builder.endObject();
     }
 
@@ -435,12 +430,10 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
      * @param docCreation {@code true} if the x-content is being generated for creating a document
      *                    in the security index, {@code false} if the x-content being generated
      *                    is for API display purposes
-     * @param includeMetadataFlattened {@code true} if the metadataFlattened field should be included in doc
      * @return x-content builder
      * @throws IOException if there was an error writing the x-content to the builder
      */
-    public XContentBuilder innerToXContent(XContentBuilder builder, Params params, boolean docCreation, boolean includeMetadataFlattened)
-        throws IOException {
+    public XContentBuilder innerToXContent(XContentBuilder builder, Params params, boolean docCreation) throws IOException {
         builder.array(Fields.CLUSTER.getPreferredName(), clusterPrivileges);
         if (configurableClusterPrivileges.length != 0) {
             builder.field(Fields.GLOBAL.getPreferredName());
@@ -452,9 +445,7 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
             builder.array(Fields.RUN_AS.getPreferredName(), runAs);
         }
         builder.field(Fields.METADATA.getPreferredName(), metadata);
-        if (includeMetadataFlattened) {
-            builder.field(Fields.METADATA_FLATTENED.getPreferredName(), metadata);
-        }
+
         if (docCreation) {
             builder.field(Fields.TYPE.getPreferredName(), ROLE_TYPE);
         } else {
@@ -1196,7 +1187,7 @@ public class RoleDescriptor implements ToXContentObject, Writeable {
 
     public static final class RemoteIndicesPrivileges implements Writeable, ToXContentObject {
 
-        private static final RemoteIndicesPrivileges[] NONE = new RemoteIndicesPrivileges[0];
+        public static final RemoteIndicesPrivileges[] NONE = new RemoteIndicesPrivileges[0];
 
         private final IndicesPrivileges indicesPrivileges;
         private final String[] remoteClusters;


### PR DESCRIPTION
Backports the following commit to 8.15:
- Always write empty role descriptor fields to index (#110424)