### PR TITLE
[Connector API] Update mistake in docs for list sync job API

### DIFF
--- a/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
+++ b/docs/reference/connector/apis/list-connector-sync-jobs-api.asciidoc
@@ -31,7 +31,7 @@ To get started with Connector APIs, check out the {enterprise-search-ref}/connec
 (Optional, integer) The offset from the first result to fetch. Defaults to `0`.
 
 `status`::
-(Optional, job status) A comma-separated list of job statuses to filter the results. Available statuses include: `canceling`, `canceled`, `completed`, `error`, `in_progress`, `pending`, `suspended`.
+(Optional, job status) A job status to filter the results for. Available statuses include: `canceling`, `canceled`, `completed`, `error`, `in_progress`, `pending`, `suspended`.
 
 `connector_id`::
 (Optional, string) The connector id the fetched sync jobs need to have.


### PR DESCRIPTION
### Changes

In list sync job API, `status` is a single string not a list. See [implementation](https://github.com/elastic/elasticsearch/blob/5d791d4e278977bdd9113c58c25aaea54318d869/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/syncjob/ConnectorSyncJobIndexService.java#L382)