### PR TITLE
Add protection for OOM during aggregations partial reduction

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/TermsReduceBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/TermsReduceBenchmark.java
@@ -71,7 +71,7 @@ public class TermsReduceBenchmark {
     private final SearchPhaseController controller = new SearchPhaseController((task, req) -> new AggregationReduceContext.Builder() {
         @Override
         public AggregationReduceContext forPartialReduction() {
-            return new AggregationReduceContext.ForPartial(null, null, task, builder);
+            return new AggregationReduceContext.ForPartial(null, null, task, builder, b -> {});
         }
 
         @Override

--- a/docs/changelog/110520.yaml
+++ b/docs/changelog/110520.yaml
@@ -1,0 +1,5 @@
+pr: 110520
+summary: Add protection for OOM during aggregations partial reduction
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1840,7 +1840,13 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
         return new AggregationReduceContext.Builder() {
             @Override
             public AggregationReduceContext forPartialReduction() {
-                return new AggregationReduceContext.ForPartial(bigArrays, scriptService, isCanceled, aggs);
+                return new AggregationReduceContext.ForPartial(
+                    bigArrays,
+                    scriptService,
+                    isCanceled,
+                    aggs,
+                    multiBucketConsumerService.createForPartial()
+                );
             }
 
             @Override
@@ -1850,7 +1856,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                     scriptService,
                     isCanceled,
                     aggs,
-                    multiBucketConsumerService.create()
+                    multiBucketConsumerService.createForFinal()
                 );
             }
         };

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -134,8 +134,35 @@ public class MultiBucketConsumerService {
         }
     }
 
-    public MultiBucketConsumer create() {
+    /**
+     * Similar to {@link MultiBucketConsumer} but it only checks the parent circuit breaker every 1024 calls.
+     * It provides protection for OOM during partial reductions.
+     */
+    private static class MultiBucketConsumerPartialReduction implements IntConsumer {
+        private final CircuitBreaker breaker;
+
+        // aggregations execute in a single thread so no atomic here
+        private int callCount = 0;
+
+        private MultiBucketConsumerPartialReduction(CircuitBreaker breaker) {
+            this.breaker = breaker;
+        }
+
+        @Override
+        public void accept(int value) {
+            // check parent circuit breaker every 1024 calls
+            if ((++callCount & 0x3FF) == 0) {
+                breaker.addEstimateBytesAndMaybeBreak(0, "allocated_buckets");
+            }
+        }
+    }
+
+    public IntConsumer createForFinal() {
         return new MultiBucketConsumer(maxBucket, breaker);
+    }
+
+    public IntConsumer createForPartial() {
+        return new MultiBucketConsumerPartialReduction(breaker);
     }
 
     public int getLimit() {

--- a/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
@@ -53,7 +53,13 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
         searchPhaseController = new SearchPhaseController((t, s) -> new AggregationReduceContext.Builder() {
             @Override
             public AggregationReduceContext forPartialReduction() {
-                return new AggregationReduceContext.ForPartial(BigArrays.NON_RECYCLING_INSTANCE, null, t, mock(AggregationBuilder.class));
+                return new AggregationReduceContext.ForPartial(
+                    BigArrays.NON_RECYCLING_INSTANCE,
+                    null,
+                    t,
+                    mock(AggregationBuilder.class),
+                    b -> {}
+                );
             }
 
             public AggregationReduceContext forFinalReduction() {

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -122,7 +122,7 @@ public class SearchPhaseControllerTests extends ESTestCase {
             @Override
             public AggregationReduceContext forPartialReduction() {
                 reductions.add(false);
-                return new AggregationReduceContext.ForPartial(BigArrays.NON_RECYCLING_INSTANCE, null, t, agg);
+                return new AggregationReduceContext.ForPartial(BigArrays.NON_RECYCLING_INSTANCE, null, t, agg, b -> {});
             }
 
             public AggregationReduceContext forFinalReduction() {

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -47,7 +47,10 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -151,6 +154,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.IntConsumer;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyList;
@@ -1982,6 +1986,38 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         {
             AggregationReduceContext reduceContext = reduceContextBuilder.forPartialReduction();
             reduceContext.consumeBucketsAndMaybeBreak(MultiBucketConsumerService.DEFAULT_MAX_BUCKETS + 1);
+        }
+    }
+
+    public void testMultiBucketConsumerServiceCB() {
+        MultiBucketConsumerService service = new MultiBucketConsumerService(
+            getInstanceFromNode(ClusterService.class),
+            Settings.EMPTY,
+            new NoopCircuitBreaker("test") {
+
+                @Override
+                public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+                    throw new CircuitBreakingException("tripped", getDurability());
+                }
+            }
+        );
+        // for partial
+        {
+            IntConsumer consumer = service.createForPartial();
+            for (int i = 0; i < 1023; i++) {
+                consumer.accept(0);
+            }
+            CircuitBreakingException ex = expectThrows(CircuitBreakingException.class, () -> consumer.accept(0));
+            assertThat(ex.getMessage(), equalTo("tripped"));
+        }
+        // for final
+        {
+            IntConsumer consumer = service.createForFinal();
+            for (int i = 0; i < 1023; i++) {
+                consumer.accept(0);
+            }
+            CircuitBreakingException ex = expectThrows(CircuitBreakingException.class, () -> consumer.accept(0));
+            assertThat(ex.getMessage(), equalTo("tripped"));
         }
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -644,7 +644,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
                         bigArraysForReduction,
                         getMockScriptService(),
                         () -> false,
-                        builder
+                        builder,
+                        b -> {}
                     );
                     AggregatorCollectorManager aggregatorCollectorManager = new AggregatorCollectorManager(
                         aggregatorSupplier,
@@ -669,7 +670,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     bigArraysForReduction,
                     getMockScriptService(),
                     () -> false,
-                    builder
+                    builder,
+                    b -> {}
                 );
                 internalAggs = new ArrayList<>(internalAggs.subList(r, toReduceSize));
                 internalAggs.add(InternalAggregations.topLevelReduce(toReduce, reduceContext));

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalAggregationTestCase.java
@@ -77,7 +77,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         return new AggregationReduceContext.Builder() {
             @Override
             public AggregationReduceContext forPartialReduction() {
-                return new AggregationReduceContext.ForPartial(BigArrays.NON_RECYCLING_INSTANCE, null, () -> false, aggs);
+                return new AggregationReduceContext.ForPartial(BigArrays.NON_RECYCLING_INSTANCE, null, () -> false, aggs, b -> {});
             }
 
             @Override
@@ -95,7 +95,7 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
         return new AggregationReduceContext.Builder() {
             @Override
             public AggregationReduceContext forPartialReduction() {
-                return new AggregationReduceContext.ForPartial(BigArrays.NON_RECYCLING_INSTANCE, null, () -> false, agg);
+                return new AggregationReduceContext.ForPartial(BigArrays.NON_RECYCLING_INSTANCE, null, () -> false, agg, b -> {});
             }
 
             @Override
@@ -244,7 +244,8 @@ public abstract class InternalAggregationTestCase<T extends InternalAggregation>
                 bigArrays,
                 mockScriptService,
                 () -> false,
-                inputs.builder()
+                inputs.builder(),
+                b -> {}
             );
             @SuppressWarnings("unchecked")
             T reduced = (T) reduce(toPartialReduce, context);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportRollupSearchAction.java
@@ -128,7 +128,8 @@ public class TransportRollupSearchAction extends TransportAction<SearchRequest, 
                         bigArrays,
                         scriptService,
                         ((CancellableTask) task)::isCancelled,
-                        request.source().aggregations()
+                        request.source().aggregations(),
+                        b -> {}
                     );
                 }
 


### PR DESCRIPTION
During aggregations final reduction we have two protections against using too much memory. First we limit the number of buckets we can generate and second, we call the parent circuit breaker every 1024 calls. In the other hand, during partial reduction we have no protection whatsoever.

during partial reduction, some aggregations expect to be able to create as many buckets as they need so we cannot break on that but still we can check the parent circuit breaker to provide some protection.

This commit proposes to check the parent circuit breaker every 1024 call to the buckets consumer during aggregations partial reduction.

