### PR TITLE
Fix bit vector tests

### DIFF
--- a/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/146_dense_vector_bit_basic.yml
+++ b/modules/lang-painless/src/yamlRestTest/resources/rest-api-spec/test/painless/146_dense_vector_bit_basic.yml
@@ -8,6 +8,8 @@ setup:
       indices.create:
         index: test-index
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               vector:
@@ -107,7 +109,6 @@ setup:
       headers:
         Content-Type: application/json
       search:
-        rest_total_hits_as_int: true
         body:
           query:
             script_score:
@@ -138,7 +139,6 @@ setup:
       headers:
         Content-Type: application/json
       search:
-        rest_total_hits_as_int: true
         body:
           query:
             script_score:
@@ -152,7 +152,6 @@ setup:
       headers:
         Content-Type: application/json
       search:
-        rest_total_hits_as_int: true
         body:
           query:
             script_score:
@@ -167,7 +166,6 @@ setup:
       headers:
         Content-Type: application/json
       search:
-        rest_total_hits_as_int: true
         body:
           query:
             script_score:

--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -76,12 +76,6 @@ tests:
 - class: org.elasticsearch.compute.lucene.ValueSourceReaderTypeConversionTests
   method: testLoadAll
   issue: https://github.com/elastic/elasticsearch/issues/110244
-- class: org.elasticsearch.painless.LangPainlessClientYamlTestSuiteIT
-  method: test {yaml=painless/146_dense_vector_bit_basic/Cosine Similarity is not supported}
-  issue: https://github.com/elastic/elasticsearch/issues/110290
-- class: org.elasticsearch.painless.LangPainlessClientYamlTestSuiteIT
-  method: test {yaml=painless/146_dense_vector_bit_basic/Dot Product is not supported}
-  issue: https://github.com/elastic/elasticsearch/issues/110291
 - class: org.elasticsearch.action.search.SearchProgressActionListenerIT
   method: testSearchProgressWithQuery
   issue: https://github.com/elastic/elasticsearch/issues/109867


### PR DESCRIPTION
Bit vector tests were failing in cases where an index has more than 1 shards. For error cases when we expected a failure of the whole request, shards with empty documents returned success and the whole request unexpectedly returned 200.

Ensuring that index contains only 1 shard fixes these failures.

Closes #110290, #110291
