### PR TITLE
[ML] Wait for test to finish

### DIFF
--- a/muted-tests.yml
+++ b/muted-tests.yml
@@ -100,9 +100,6 @@ tests:
 - class: org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT
   method: test {p0=search.vectors/41_knn_search_half_byte_quantized/Test create, merge, and search cosine}
   issue: https://github.com/elastic/elasticsearch/issues/109978
-- class: org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentNodeServiceTests
-  method: testLoadQueuedModelsWhenOneFails
-  issue: https://github.com/elastic/elasticsearch/issues/110536
 
 # Examples:
 #

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -184,6 +184,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
 
     void loadQueuedModels(ActionListener<Boolean> rescheduleImmediately) {
         if (stopped) {
+            rescheduleImmediately.onResponse(false);
             return;
         }
         if (latestState != null) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
@@ -11,7 +11,6 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.ShardSearchFailure;
-import org.elasticsearch.action.support.SubscribableListener;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
@@ -50,13 +49,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.xpack.ml.MachineLearning.UTILITY_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentClusterServiceTests.shutdownMetadata;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -125,14 +123,17 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
     private void loadQueuedModels(TrainedModelAssignmentNodeService trainedModelAssignmentNodeService, boolean expectedRunImmediately)
         throws InterruptedException {
         var latch = new CountDownLatch(1);
-        trainedModelAssignmentNodeService.loadQueuedModels(ActionListener.runAfter(ActionListener.wrap(actualRunImmediately -> {
-            assertThat(
-                "We should rerun immediately if there are still model loading tasks to process.",
-                actualRunImmediately,
-                equalTo(expectedRunImmediately)
-            );
-        }, e -> fail("We should never call the onFailure method of this listener.")), latch::countDown));
+        var actual = new AtomicReference<Boolean>(); // AtomicReference for nullable
+        trainedModelAssignmentNodeService.loadQueuedModels(
+            ActionListener.runAfter(ActionListener.wrap(actual::set, e -> {}), latch::countDown)
+        );
         assertTrue("Timed out waiting for loadQueuedModels to finish.", latch.await(10, TimeUnit.SECONDS));
+        assertThat("Test failed to call the onResponse handler.", actual.get(), notNullValue());
+        assertThat(
+            "We should rerun immediately if there are still model loading tasks to process.",
+            actual.get(),
+            equalTo(expectedRunImmediately)
+        );
     }
 
     public void testLoadQueuedModels() throws InterruptedException {
@@ -213,7 +214,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         verifyNoMoreInteractions(deploymentManager, trainedModelAssignmentService);
     }
 
-    public void testLoadQueuedModelsWhenStopped() {
+    public void testLoadQueuedModelsWhenStopped() throws InterruptedException {
         TrainedModelAssignmentNodeService trainedModelAssignmentNodeService = createService();
 
         // When there are no queued models
@@ -223,8 +224,11 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelToLoad, modelToLoad));
         trainedModelAssignmentNodeService.stop();
 
-        trainedModelAssignmentNodeService.loadQueuedModels(
-            ActionListener.running(() -> fail("When stopped, then loadQueuedModels should never run."))
+        var latch = new CountDownLatch(1);
+        trainedModelAssignmentNodeService.loadQueuedModels(ActionListener.running(latch::countDown));
+        assertTrue(
+            "loadQueuedModels should immediately call the listener without forking to another thread.",
+            latch.await(0, TimeUnit.SECONDS)
         );
         verifyNoMoreInteractions(deploymentManager, trainedModelAssignmentService);
     }


### PR DESCRIPTION
The tests can kick off tasks on another thread.  We should wait for
those threads to join back before we begin making assertions.

Fix #110536