### PR TITLE
Introduce utility for concurrent execution of arbitrary Runnable in tests

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -832,7 +832,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertAcked(client().execute(TransportPutComposableIndexTemplateAction.TYPE, putTemplateRequest).actionGet());
 
         final CyclicBarrier barrier = new CyclicBarrier(numOfThreads);
-        runInParallel(numOfThreads, i -> () -> {
+        runInParallel(numOfThreads, i -> {
             var aliasName = "test-" + i;
             assertAcked(prepareCreate(aliasName + "-000001").addAlias(new Alias(aliasName).writeIndex(true)).get());
             for (int j = 1; j <= numberOfRolloversPerThread; j++) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -832,30 +832,22 @@ public class RolloverIT extends ESIntegTestCase {
         assertAcked(client().execute(TransportPutComposableIndexTemplateAction.TYPE, putTemplateRequest).actionGet());
 
         final CyclicBarrier barrier = new CyclicBarrier(numOfThreads);
-        final Thread[] threads = new Thread[numOfThreads];
-        for (int i = 0; i < numOfThreads; i++) {
+        runInParallel(numOfThreads, i -> () -> {
             var aliasName = "test-" + i;
-            threads[i] = new Thread(() -> {
-                assertAcked(prepareCreate(aliasName + "-000001").addAlias(new Alias(aliasName).writeIndex(true)).get());
-                for (int j = 1; j <= numberOfRolloversPerThread; j++) {
-                    try {
-                        barrier.await();
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                    var response = indicesAdmin().prepareRolloverIndex(aliasName).waitForActiveShards(ActiveShardCount.NONE).get();
-                    assertThat(response.getOldIndex(), equalTo(aliasName + Strings.format("-%06d", j)));
-                    assertThat(response.getNewIndex(), equalTo(aliasName + Strings.format("-%06d", j + 1)));
-                    assertThat(response.isDryRun(), equalTo(false));
-                    assertThat(response.isRolledOver(), equalTo(true));
+            assertAcked(prepareCreate(aliasName + "-000001").addAlias(new Alias(aliasName).writeIndex(true)).get());
+            for (int j = 1; j <= numberOfRolloversPerThread; j++) {
+                try {
+                    barrier.await();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
                 }
-            });
-            threads[i].start();
-        }
-
-        for (Thread thread : threads) {
-            thread.join();
-        }
+                var response = indicesAdmin().prepareRolloverIndex(aliasName).waitForActiveShards(ActiveShardCount.NONE).get();
+                assertThat(response.getOldIndex(), equalTo(aliasName + Strings.format("-%06d", j)));
+                assertThat(response.getNewIndex(), equalTo(aliasName + Strings.format("-%06d", j + 1)));
+                assertThat(response.isDryRun(), equalTo(false));
+                assertThat(response.isRolledOver(), equalTo(true));
+            }
+        });
 
         for (int i = 0; i < numOfThreads; i++) {
             var aliasName = "test-" + i;

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -519,33 +519,22 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         indexDoc("test", "1", "field", "1");
         final BulkResponse[] responses = new BulkResponse[30];
         final CyclicBarrier cyclicBarrier = new CyclicBarrier(responses.length);
-        Thread[] threads = new Thread[responses.length];
 
-        for (int i = 0; i < responses.length; i++) {
-            final int threadID = i;
-            threads[threadID] = new Thread(() -> {
-                try {
-                    cyclicBarrier.await();
-                } catch (Exception e) {
-                    return;
-                }
-                BulkRequestBuilder requestBuilder = client().prepareBulk();
-                requestBuilder.add(
-                    client().prepareUpdate("test", "1")
-                        .setIfSeqNo(0L)
-                        .setIfPrimaryTerm(1)
-                        .setDoc(Requests.INDEX_CONTENT_TYPE, "field", threadID)
-                );
-                responses[threadID] = requestBuilder.get();
-
-            });
-            threads[threadID].start();
-
-        }
-
-        for (int i = 0; i < threads.length; i++) {
-            threads[i].join();
-        }
+        runInParallel(responses.length, threadID -> () -> {
+            try {
+                cyclicBarrier.await();
+            } catch (Exception e) {
+                return;
+            }
+            BulkRequestBuilder requestBuilder = client().prepareBulk();
+            requestBuilder.add(
+                client().prepareUpdate("test", "1")
+                    .setIfSeqNo(0L)
+                    .setIfPrimaryTerm(1)
+                    .setDoc(Requests.INDEX_CONTENT_TYPE, "field", threadID)
+            );
+            responses[threadID] = requestBuilder.get();
+        });
 
         int successes = 0;
         for (BulkResponse response : responses) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -520,7 +520,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         final BulkResponse[] responses = new BulkResponse[30];
         final CyclicBarrier cyclicBarrier = new CyclicBarrier(responses.length);
 
-        runInParallel(responses.length, threadID -> () -> {
+        runInParallel(responses.length, threadID -> {
             try {
                 cyclicBarrier.await();
             } catch (Exception e) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
@@ -329,7 +329,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
         final int threadCount = randomIntBetween(2, 5);
         final CyclicBarrier barrier = new CyclicBarrier(threadCount);
         try {
-            runInParallel(threadCount, i -> () -> {
+            runInParallel(threadCount, i -> {
                 safeAwait(barrier);
                 try {
                     indicesAdmin().prepareAddBlock(block, indexName).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
@@ -310,7 +312,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
         }
     }
 
-    public void testConcurrentAddBlock() throws InterruptedException {
+    public void testConcurrentAddBlock() throws InterruptedException, ExecutionException {
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         createIndex(indexName);
 
@@ -322,31 +324,21 @@ public class SimpleBlocksIT extends ESIntegTestCase {
             IntStream.range(0, nbDocs).mapToObj(i -> prepareIndex(indexName).setId(String.valueOf(i)).setSource("num", i)).collect(toList())
         );
         ensureYellowAndNoInitializingShards(indexName);
-
-        final CountDownLatch startClosing = new CountDownLatch(1);
-        final Thread[] threads = new Thread[randomIntBetween(2, 5)];
-
         final APIBlock block = randomAddableBlock();
 
+        final int threadCount = randomIntBetween(2, 5);
+        final CyclicBarrier barrier = new CyclicBarrier(threadCount);
         try {
-            for (int i = 0; i < threads.length; i++) {
-                threads[i] = new Thread(() -> {
-                    safeAwait(startClosing);
-                    try {
-                        indicesAdmin().prepareAddBlock(block, indexName).get();
-                        assertIndexHasBlock(block, indexName);
-                    } catch (final ClusterBlockException e) {
-                        assertThat(e.blocks(), hasSize(1));
-                        assertTrue(e.blocks().stream().allMatch(b -> b.id() == block.getBlock().id()));
-                    }
-                });
-                threads[i].start();
-            }
-
-            startClosing.countDown();
-            for (Thread thread : threads) {
-                thread.join();
-            }
+            runInParallel(threadCount, i -> () -> {
+                safeAwait(barrier);
+                try {
+                    indicesAdmin().prepareAddBlock(block, indexName).get();
+                    assertIndexHasBlock(block, indexName);
+                } catch (final ClusterBlockException e) {
+                    assertThat(e.blocks(), hasSize(1));
+                    assertTrue(e.blocks().stream().allMatch(b -> b.id() == block.getBlock().id()));
+                }
+            });
             assertIndexHasBlock(block, indexName);
         } finally {
             disableIndexBlock(indexName, block);

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -156,7 +156,7 @@ public class MaxDocsLimitIT extends ESIntegTestCase {
         final AtomicInteger numSuccess = new AtomicInteger();
         final AtomicInteger numFailure = new AtomicInteger();
         Phaser phaser = new Phaser(numThreads);
-        runInParallel(numThreads, i -> () -> {
+        runInParallel(numThreads, i -> {
             phaser.arriveAndAwaitAdvance();
             while (completedRequests.incrementAndGet() <= numRequests) {
                 try {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -155,27 +155,20 @@ public class MaxDocsLimitIT extends ESIntegTestCase {
         final AtomicInteger completedRequests = new AtomicInteger();
         final AtomicInteger numSuccess = new AtomicInteger();
         final AtomicInteger numFailure = new AtomicInteger();
-        Thread[] indexers = new Thread[numThreads];
-        Phaser phaser = new Phaser(indexers.length);
-        for (int i = 0; i < indexers.length; i++) {
-            indexers[i] = new Thread(() -> {
-                phaser.arriveAndAwaitAdvance();
-                while (completedRequests.incrementAndGet() <= numRequests) {
-                    try {
-                        final DocWriteResponse resp = prepareIndex("test").setSource("{}", XContentType.JSON).get();
-                        numSuccess.incrementAndGet();
-                        assertThat(resp.status(), equalTo(RestStatus.CREATED));
-                    } catch (IllegalArgumentException e) {
-                        numFailure.incrementAndGet();
-                        assertThat(e.getMessage(), containsString("Number of documents in the index can't exceed [" + maxDocs.get() + "]"));
-                    }
+        Phaser phaser = new Phaser(numThreads);
+        runInParallel(numThreads, i -> () -> {
+            phaser.arriveAndAwaitAdvance();
+            while (completedRequests.incrementAndGet() <= numRequests) {
+                try {
+                    final DocWriteResponse resp = prepareIndex("test").setSource("{}", XContentType.JSON).get();
+                    numSuccess.incrementAndGet();
+                    assertThat(resp.status(), equalTo(RestStatus.CREATED));
+                } catch (IllegalArgumentException e) {
+                    numFailure.incrementAndGet();
+                    assertThat(e.getMessage(), containsString("Number of documents in the index can't exceed [" + maxDocs.get() + "]"));
                 }
-            });
-            indexers[i].start();
-        }
-        for (Thread indexer : indexers) {
-            indexer.join();
-        }
+            }
+        });
         internalCluster().assertNoInFlightDocsInEngine();
         return new IndexingResult(numSuccess.get(), numFailure.get());
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -161,31 +162,20 @@ public class DynamicMappingIT extends ESIntegTestCase {
     private Map<String, Object> indexConcurrently(int numberOfFieldsToCreate, Settings.Builder settings) throws Throwable {
         indicesAdmin().prepareCreate("index").setSettings(settings).get();
         ensureGreen("index");
-        final Thread[] indexThreads = new Thread[numberOfFieldsToCreate];
-        final CountDownLatch startLatch = new CountDownLatch(1);
+        final CyclicBarrier barrier = new CyclicBarrier(numberOfFieldsToCreate);
         final AtomicReference<Throwable> error = new AtomicReference<>();
-        for (int i = 0; i < indexThreads.length; ++i) {
+        runInParallel(numberOfFieldsToCreate, i -> () -> {
             final String id = Integer.toString(i);
-            indexThreads[i] = new Thread(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        startLatch.await();
-                        assertEquals(
-                            DocWriteResponse.Result.CREATED,
-                            prepareIndex("index").setId(id).setSource("field" + id, "bar").get().getResult()
-                        );
-                    } catch (Exception e) {
-                        error.compareAndSet(null, e);
-                    }
-                }
-            });
-            indexThreads[i].start();
-        }
-        startLatch.countDown();
-        for (Thread thread : indexThreads) {
-            thread.join();
-        }
+            try {
+                barrier.await();
+                assertEquals(
+                    DocWriteResponse.Result.CREATED,
+                    prepareIndex("index").setId(id).setSource("field" + id, "bar").get().getResult()
+                );
+            } catch (Exception e) {
+                error.compareAndSet(null, e);
+            }
+        });
         if (error.get() != null) {
             throw error.get();
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/DynamicMappingIT.java
@@ -164,7 +164,7 @@ public class DynamicMappingIT extends ESIntegTestCase {
         ensureGreen("index");
         final CyclicBarrier barrier = new CyclicBarrier(numberOfFieldsToCreate);
         final AtomicReference<Throwable> error = new AtomicReference<>();
-        runInParallel(numberOfFieldsToCreate, i -> () -> {
+        runInParallel(numberOfFieldsToCreate, i -> {
             final String id = Integer.toString(i);
             try {
                 barrier.await();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -144,7 +144,7 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
         final CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
 
         // start concurrent indexing threads
-        runInParallel(numberOfThreads, index -> () -> {
+        runInParallel(numberOfThreads, index -> {
             try {
                 barrier.await();
             } catch (BrokenBarrierException | InterruptedException e) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -25,9 +25,7 @@ import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.xcontent.XContentType;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
@@ -143,37 +141,20 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
         final int numberOfDocuments = randomIntBetween(0, 256);
 
         final int numberOfThreads = randomIntBetween(1, 4);
-        final CyclicBarrier barrier = new CyclicBarrier(1 + numberOfThreads);
+        final CyclicBarrier barrier = new CyclicBarrier(numberOfThreads);
 
         // start concurrent indexing threads
-        final List<Thread> threads = new ArrayList<>(numberOfThreads);
-        for (int i = 0; i < numberOfThreads; i++) {
-            final int index = i;
-            final Thread thread = new Thread(() -> {
-                try {
-                    barrier.await();
-                } catch (BrokenBarrierException | InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                for (int j = 0; j < numberOfDocuments; j++) {
-                    final String id = Integer.toString(index * numberOfDocuments + j);
-                    prepareIndex("test").setId(id).setSource("{\"foo\": " + id + "}", XContentType.JSON).get();
-                }
-                try {
-                    barrier.await();
-                } catch (BrokenBarrierException | InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            threads.add(thread);
-            thread.start();
-        }
-
-        // synchronize the start of the threads
-        barrier.await();
-
-        // wait for the threads to finish
-        barrier.await();
+        runInParallel(numberOfThreads, index -> () -> {
+            try {
+                barrier.await();
+            } catch (BrokenBarrierException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            for (int j = 0; j < numberOfDocuments; j++) {
+                final String id = Integer.toString(index * numberOfDocuments + j);
+                prepareIndex("test").setId(id).setSource("{\"foo\": " + id + "}", XContentType.JSON).get();
+            }
+        });
 
         afterIndexing.accept(client());
 
@@ -203,9 +184,6 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
             }
         }, 60, TimeUnit.SECONDS);
         ensureGreen("test");
-        for (final Thread thread : threads) {
-            thread.join();
-        }
     }
 
     public void testPersistGlobalCheckpoint() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -38,12 +38,12 @@ import org.elasticsearch.test.BackgroundIndexer;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.InternalTestCluster;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -170,7 +170,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         assertIndexIsClosed(indexName);
     }
 
-    public void testConcurrentClose() throws InterruptedException {
+    public void testConcurrentClose() throws InterruptedException, ExecutionException {
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         createIndex(indexName);
 
@@ -196,25 +196,16 @@ public class CloseIndexIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getIndices().get(indexName).getStatus().value(), lessThanOrEqualTo(ClusterHealthStatus.YELLOW.value()));
 
-        final CountDownLatch startClosing = new CountDownLatch(1);
-        final Thread[] threads = new Thread[randomIntBetween(2, 5)];
-
-        for (int i = 0; i < threads.length; i++) {
-            threads[i] = new Thread(() -> {
-                safeAwait(startClosing);
-                try {
-                    indicesAdmin().prepareClose(indexName).get();
-                } catch (final Exception e) {
-                    assertException(e, indexName);
-                }
-            });
-            threads[i].start();
-        }
-
-        startClosing.countDown();
-        for (Thread thread : threads) {
-            thread.join();
-        }
+        final int tasks = randomIntBetween(2, 5);
+        final CyclicBarrier barrier = new CyclicBarrier(tasks);
+        runInParallel(tasks, i -> () -> {
+            safeAwait(barrier);
+            try {
+                indicesAdmin().prepareClose(indexName).get();
+            } catch (final Exception e) {
+                assertException(e, indexName);
+            }
+        });
         assertIndexIsClosed(indexName);
     }
 
@@ -256,37 +247,20 @@ public class CloseIndexIT extends ESIntegTestCase {
         }
         assertThat(clusterAdmin().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
 
-        final List<Thread> threads = new ArrayList<>();
-        final CountDownLatch latch = new CountDownLatch(1);
-
-        for (final String indexToDelete : indices) {
-            threads.add(new Thread(() -> {
-                safeAwait(latch);
-                try {
-                    assertAcked(indicesAdmin().prepareDelete(indexToDelete));
-                } catch (final Exception e) {
-                    assertException(e, indexToDelete);
+        final CyclicBarrier barrier = new CyclicBarrier(indices.length * 2);
+        runInParallel(indices.length * 2, i -> () -> {
+            safeAwait(barrier);
+            final String index = indices[i % indices.length];
+            try {
+                if (i < indices.length) {
+                    assertAcked(indicesAdmin().prepareDelete(index));
+                } else {
+                    indicesAdmin().prepareClose(index).get();
                 }
-            }));
-        }
-        for (final String indexToClose : indices) {
-            threads.add(new Thread(() -> {
-                safeAwait(latch);
-                try {
-                    indicesAdmin().prepareClose(indexToClose).get();
-                } catch (final Exception e) {
-                    assertException(e, indexToClose);
-                }
-            }));
-        }
-
-        for (Thread thread : threads) {
-            thread.start();
-        }
-        latch.countDown();
-        for (Thread thread : threads) {
-            thread.join();
-        }
+            } catch (final Exception e) {
+                assertException(e, index);
+            }
+        });
     }
 
     public void testConcurrentClosesAndOpens() throws Exception {
@@ -297,37 +271,22 @@ public class CloseIndexIT extends ESIntegTestCase {
         indexer.setFailureAssertion(e -> {});
         waitForDocs(1, indexer);
 
-        final CountDownLatch latch = new CountDownLatch(1);
+        final int closes = randomIntBetween(1, 3);
+        final int opens = randomIntBetween(1, 3);
+        final CyclicBarrier barrier = new CyclicBarrier(opens + closes);
 
-        final List<Thread> threads = new ArrayList<>();
-        for (int i = 0; i < randomIntBetween(1, 3); i++) {
-            threads.add(new Thread(() -> {
-                try {
-                    safeAwait(latch);
+        runInParallel(opens + closes, i -> () -> {
+            try {
+                safeAwait(barrier);
+                if (i < closes) {
                     indicesAdmin().prepareClose(indexName).get();
-                } catch (final Exception e) {
-                    throw new AssertionError(e);
-                }
-            }));
-        }
-        for (int i = 0; i < randomIntBetween(1, 3); i++) {
-            threads.add(new Thread(() -> {
-                try {
-                    safeAwait(latch);
+                } else {
                     assertAcked(indicesAdmin().prepareOpen(indexName).get());
-                } catch (final Exception e) {
-                    throw new AssertionError(e);
                 }
-            }));
-        }
-
-        for (Thread thread : threads) {
-            thread.start();
-        }
-        latch.countDown();
-        for (Thread thread : threads) {
-            thread.join();
-        }
+            } catch (final Exception e) {
+                throw new AssertionError(e);
+            }
+        });
 
         indexer.stopAndAwaitStopped();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -198,7 +198,7 @@ public class CloseIndexIT extends ESIntegTestCase {
 
         final int tasks = randomIntBetween(2, 5);
         final CyclicBarrier barrier = new CyclicBarrier(tasks);
-        runInParallel(tasks, i -> () -> {
+        runInParallel(tasks, i -> {
             safeAwait(barrier);
             try {
                 indicesAdmin().prepareClose(indexName).get();
@@ -248,7 +248,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         assertThat(clusterAdmin().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
 
         final CyclicBarrier barrier = new CyclicBarrier(indices.length * 2);
-        runInParallel(indices.length * 2, i -> () -> {
+        runInParallel(indices.length * 2, i -> {
             safeAwait(barrier);
             final String index = indices[i % indices.length];
             try {
@@ -275,7 +275,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         final int opens = randomIntBetween(1, 3);
         final CyclicBarrier barrier = new CyclicBarrier(opens + closes);
 
-        runInParallel(opens + closes, i -> () -> {
+        runInParallel(opens + closes, i -> {
             try {
                 safeAwait(barrier);
                 if (i < closes) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
@@ -35,10 +35,10 @@ import org.elasticsearch.test.transport.StubbableTransport;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -187,30 +187,22 @@ public class CloseWhileRelocatingShardsIT extends ESIntegTestCase {
             ClusterRerouteUtils.reroute(client(), commands.toArray(AllocationCommand[]::new));
 
             // start index closing threads
-            final List<Thread> threads = new ArrayList<>();
-            for (final String indexToClose : indices) {
-                final Thread thread = new Thread(() -> {
-                    try {
-                        safeAwait(latch);
-                    } finally {
-                        release.countDown();
-                    }
-                    // Closing is not always acknowledged when shards are relocating: this is the case when the target shard is initializing
-                    // or is catching up operations. In these cases the TransportVerifyShardBeforeCloseAction will detect that the global
-                    // and max sequence number don't match and will not ack the close.
-                    AcknowledgedResponse closeResponse = indicesAdmin().prepareClose(indexToClose).get();
-                    if (closeResponse.isAcknowledged()) {
-                        assertTrue("Index closing should not be acknowledged twice", acknowledgedCloses.add(indexToClose));
-                    }
-                });
-                threads.add(thread);
-                thread.start();
-            }
-
-            latch.countDown();
-            for (Thread thread : threads) {
-                thread.join();
-            }
+            final CyclicBarrier barrier = new CyclicBarrier(indices.length);
+            runInParallel(indices.length, i -> () -> {
+                try {
+                    safeAwait(barrier);
+                } finally {
+                    release.countDown();
+                }
+                // Closing is not always acknowledged when shards are relocating: this is the case when the target shard is initializing
+                // or is catching up operations. In these cases the TransportVerifyShardBeforeCloseAction will detect that the global
+                // and max sequence number don't match and will not ack the close.
+                final String indexToClose = indices[i];
+                AcknowledgedResponse closeResponse = indicesAdmin().prepareClose(indexToClose).get();
+                if (closeResponse.isAcknowledged()) {
+                    assertTrue("Index closing should not be acknowledged twice", acknowledgedCloses.add(indexToClose));
+                }
+            });
 
             // stop indexers first without waiting for stop to not redundantly index on some while waiting for another one to stop
             for (BackgroundIndexer indexer : indexers.values()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
@@ -188,7 +188,7 @@ public class CloseWhileRelocatingShardsIT extends ESIntegTestCase {
 
             // start index closing threads
             final CyclicBarrier barrier = new CyclicBarrier(indices.length);
-            runInParallel(indices.length, i -> () -> {
+            runInParallel(indices.length, i -> {
                 try {
                     safeAwait(barrier);
                 } finally {

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -186,6 +186,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -2438,11 +2439,12 @@ public abstract class ESTestCase extends LuceneTestCase {
      * @param numberOfTasks number of tasks to run in parallel
      * @param taskFactory task factory
      */
-    public static void runInParallel(int numberOfTasks, IntFunction<Runnable> taskFactory) throws InterruptedException, ExecutionException {
+    public static void runInParallel(int numberOfTasks, IntConsumer taskFactory) throws InterruptedException, ExecutionException {
         final ArrayList<Future<?>> futures = new ArrayList<>(numberOfTasks);
         final Thread[] threads = new Thread[numberOfTasks - 1];
         for (int i = 0; i < numberOfTasks; i++) {
-            var future = new FutureTask<Void>(taskFactory.apply(i), null);
+            final int index = i;
+            var future = new FutureTask<Void>(() -> taskFactory.accept(index), null);
             futures.add(future);
             if (i == numberOfTasks - 1) {
                 future.run();

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2440,7 +2440,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * @param numberOfTasks number of tasks to run in parallel
      * @param taskFactory task factory
      */
-    public static void runInParallel(int numberOfTasks, IntConsumer taskFactory) throws InterruptedException, ExecutionException {
+    public static void runInParallel(int numberOfTasks, IntConsumer taskFactory) throws InterruptedException {
         final ArrayList<Future<?>> futures = new ArrayList<>(numberOfTasks);
         final Thread[] threads = new Thread[numberOfTasks - 1];
         for (int i = 0; i < numberOfTasks; i++) {
@@ -2451,6 +2451,7 @@ public abstract class ESTestCase extends LuceneTestCase {
                 future.run();
             } else {
                 threads[i] = new Thread(future);
+                threads[i].setName("runInParallel-T#" + i);
                 threads[i].start();
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -38,6 +38,7 @@ import org.apache.lucene.tests.util.TestRuleMarkFailure;
 import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.tests.util.TimeUnits;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.RequestBuilder;
@@ -2456,8 +2457,16 @@ public abstract class ESTestCase extends LuceneTestCase {
         for (Thread thread : threads) {
             thread.join();
         }
+        Exception e = null;
         for (Future<?> future : futures) {
-            future.get();
+            try {
+                future.get();
+            } catch (Exception ex) {
+                e = ExceptionsHelper.useOrSuppress(e, ex);
+            }
+        }
+        if (e != null) {
+            throw new AssertionError(e);
         }
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -62,7 +62,6 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Predicates;
@@ -126,8 +125,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -148,6 +145,7 @@ import static org.elasticsearch.discovery.FileBasedSeedHostsProvider.UNICAST_HOS
 import static org.elasticsearch.node.Node.INITIAL_STATE_TIMEOUT_SETTING;
 import static org.elasticsearch.test.ESTestCase.assertBusy;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
+import static org.elasticsearch.test.ESTestCase.runInParallel;
 import static org.elasticsearch.test.ESTestCase.safeAwait;
 import static org.elasticsearch.test.NodeRoles.dataOnlyNode;
 import static org.elasticsearch.test.NodeRoles.masterOnlyNode;
@@ -245,8 +243,6 @@ public final class InternalTestCluster extends TestCluster {
     private final int numSharedCoordOnlyNodes;
 
     private final NodeConfigurationSource nodeConfigurationSource;
-
-    private final ExecutorService executor;
 
     private final boolean autoManageMasterNodes;
 
@@ -452,16 +448,6 @@ public final class InternalTestCluster extends TestCluster {
         builder.put(NoMasterBlockService.NO_MASTER_BLOCK_SETTING.getKey(), randomFrom(random, "write", "metadata_write"));
         builder.put(DestructiveOperations.REQUIRES_NAME_SETTING.getKey(), false);
         defaultSettings = builder.build();
-        executor = EsExecutors.newScaling(
-            "internal_test_cluster_executor",
-            0,
-            Integer.MAX_VALUE,
-            0,
-            TimeUnit.SECONDS,
-            true,
-            EsExecutors.daemonThreadFactory("test_" + clusterName),
-            new ThreadContext(Settings.EMPTY)
-        );
     }
 
     /**
@@ -931,7 +917,6 @@ public final class InternalTestCluster extends TestCluster {
             } finally {
                 nodes = Collections.emptyNavigableMap();
                 Loggers.setLevel(nodeConnectionLogger, initialLogLevel);
-                executor.shutdownNow();
             }
         }
     }
@@ -1760,12 +1745,8 @@ public final class InternalTestCluster extends TestCluster {
                 .filter(nac -> nodes.containsKey(nac.name) == false) // filter out old masters
                 .count();
             rebuildUnicastHostFiles(nodeAndClients); // ensure that new nodes can find the existing nodes when they start
-            List<Future<?>> futures = nodeAndClients.stream().map(node -> executor.submit(node::startNode)).collect(Collectors.toList());
-
             try {
-                for (Future<?> future : futures) {
-                    future.get();
-                }
+                runInParallel(nodeAndClients.size(), i -> nodeAndClients.get(i)::startNode);
             } catch (InterruptedException e) {
                 throw new AssertionError("interrupted while starting nodes", e);
             } catch (ExecutionException e) {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -1746,7 +1746,7 @@ public final class InternalTestCluster extends TestCluster {
                 .count();
             rebuildUnicastHostFiles(nodeAndClients); // ensure that new nodes can find the existing nodes when they start
             try {
-                runInParallel(nodeAndClients.size(), i -> nodeAndClients.get(i)::startNode);
+                runInParallel(nodeAndClients.size(), i -> nodeAndClients.get(i).startNode());
             } catch (InterruptedException e) {
                 throw new AssertionError("interrupted while starting nodes", e);
             } catch (ExecutionException e) {

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -61,7 +61,6 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
-import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Predicates;
@@ -1749,10 +1748,6 @@ public final class InternalTestCluster extends TestCluster {
                 runInParallel(nodeAndClients.size(), i -> nodeAndClients.get(i).startNode());
             } catch (InterruptedException e) {
                 throw new AssertionError("interrupted while starting nodes", e);
-            } catch (ExecutionException e) {
-                RuntimeException re = FutureUtils.rethrowExecutionException(e);
-                re.addSuppressed(new RuntimeException("failed to start nodes"));
-                throw re;
             }
             nodeAndClients.forEach(this::publishNode);
 


### PR DESCRIPTION
We have the same pattern in a bunch of places, I dried up a few here. We want to run N tasks so we create N threads in a loop, start them and join them right away. The node starting logic refactored here is essentially the same since the threads have idle lifetime 0.
This can be dried up a little and made more efficient. Might as well always use `N-1` tasks and run one of them on the calling thread. This saves quite a few threads when running tests and speeds things up a little, especially when running many concurrent Gradle workers and CPU is at 100% already (mostly coming from the speedup on starting nodes this brings and the reduction in test thread sleeps).

No functional changes to the tests otherwise, except for some replacing of `CountDownLatch` with `CyclicalBarrier` to make things work with the new API. 