### PR TITLE
Fix MapperBuilderContext#isDataStream when used in dynamic mappers

### DIFF
--- a/docs/changelog/110554.yaml
+++ b/docs/changelog/110554.yaml
@@ -1,5 +1,5 @@
 pr: 110554
 summary: Fix `MapperBuilderContext#isDataStream` when used in dynamic mappers
-area: "Mapping, Mapping"
+area: "Mapping"
 type: bug
 issues: []

--- a/docs/changelog/110554.yaml
+++ b/docs/changelog/110554.yaml
@@ -1,0 +1,5 @@
+pr: 110554
+summary: Fix `MapperBuilderContext#isDataStream` when used in dynamic mappers
+area: "Mapping, Mapping"
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParserContext.java
@@ -673,7 +673,7 @@ public abstract class DocumentParserContext {
         return new MapperBuilderContext(
             p,
             mappingLookup.isSourceSynthetic(),
-            false,
+            mappingLookup.isDataStreamTimestampFieldEnabled(),
             containsDimensions,
             dynamic,
             MergeReason.MAPPING_UPDATE,


### PR DESCRIPTION
Noticed this in scope of other work and i see no reason why it should be always `false`. `isDataStreamTimestampFieldEnabled` contains the same logic as logic determining `isDataStream` in `MappingParser`.

https://github.com/elastic/elasticsearch/blob/27b177938f9e78fa341a523bc8ff333e04939222/server/src/main/java/org/elasticsearch/index/mapper/MappingLookup.java#L509

https://github.com/elastic/elasticsearch/blob/27b177938f9e78fa341a523bc8ff333e04939222/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java#L156

