### PR TITLE
Introduce compute listener (#110400)

### DIFF
--- a/docs/changelog/110400.yaml
+++ b/docs/changelog/110400.yaml
@@ -1,0 +1,5 @@
+pr: 110400
+summary: Introduce compute listener
+area: ES|QL
+type: bug
+issues: []

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/AsyncOperator.java
@@ -21,13 +21,11 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.seqno.LocalCheckpointTracker;
 import org.elasticsearch.index.seqno.SequenceNumbers;
-import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
 /**
@@ -40,7 +38,7 @@ public abstract class AsyncOperator implements Operator {
     private volatile SubscribableListener<Void> blockedFuture;
 
     private final Map<Long, Page> buffers = ConcurrentCollections.newConcurrentMap();
-    private final AtomicReference<Exception> failure = new AtomicReference<>();
+    private final FailureCollector failureCollector = new FailureCollector();
     private final DriverContext driverContext;
 
     private final int maxOutstandingRequests;
@@ -77,7 +75,7 @@ public abstract class AsyncOperator implements Operator {
 
     @Override
     public void addInput(Page input) {
-        if (failure.get() != null) {
+        if (failureCollector.hasFailure()) {
             input.releaseBlocks();
             return;
         }
@@ -90,7 +88,7 @@ public abstract class AsyncOperator implements Operator {
                 onSeqNoCompleted(seqNo);
             }, e -> {
                 releasePageOnAnyThread(input);
-                onFailure(e);
+                failureCollector.unwrapAndCollect(e);
                 onSeqNoCompleted(seqNo);
             });
             final long startNanos = System.nanoTime();
@@ -121,31 +119,12 @@ public abstract class AsyncOperator implements Operator {
 
     protected abstract void doClose();
 
-    private void onFailure(Exception e) {
-        failure.getAndUpdate(first -> {
-            if (first == null) {
-                return e;
-            }
-            // ignore subsequent TaskCancelledException exceptions as they don't provide useful info.
-            if (ExceptionsHelper.unwrap(e, TaskCancelledException.class) != null) {
-                return first;
-            }
-            if (ExceptionsHelper.unwrap(first, TaskCancelledException.class) != null) {
-                return e;
-            }
-            if (ExceptionsHelper.unwrapCause(first) != ExceptionsHelper.unwrapCause(e)) {
-                first.addSuppressed(e);
-            }
-            return first;
-        });
-    }
-
     private void onSeqNoCompleted(long seqNo) {
         checkpoint.markSeqNoAsProcessed(seqNo);
         if (checkpoint.getPersistedCheckpoint() < checkpoint.getProcessedCheckpoint()) {
             notifyIfBlocked();
         }
-        if (closed || failure.get() != null) {
+        if (closed || failureCollector.hasFailure()) {
             discardPages();
         }
     }
@@ -164,7 +143,7 @@ public abstract class AsyncOperator implements Operator {
     }
 
     private void checkFailure() {
-        Exception e = failure.get();
+        Exception e = failureCollector.getFailure();
         if (e != null) {
             discardPages();
             throw ExceptionsHelper.convertToElastic(e);

--- a/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FailureCollector.java
+++ b/x-pack/plugin/esql/compute/src/main/java/org/elasticsearch/compute/operator/FailureCollector.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.transport.TransportException;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * {@code FailureCollector} is responsible for collecting exceptions that occur in the compute engine.
+ * The collected exceptions are categorized into task-cancelled and non-task-cancelled exceptions.
+ * To limit memory usage, this class collects only the first 10 exceptions in each category by default.
+ * When returning the accumulated failure to the caller, this class prefers non-task-cancelled exceptions
+ * over task-cancelled ones as they are more useful for diagnosing issues.
+ */
+public final class FailureCollector {
+    private final Queue<Exception> cancelledExceptions = ConcurrentCollections.newQueue();
+    private final AtomicInteger cancelledExceptionsCount = new AtomicInteger();
+
+    private final Queue<Exception> nonCancelledExceptions = ConcurrentCollections.newQueue();
+    private final AtomicInteger nonCancelledExceptionsCount = new AtomicInteger();
+
+    private final int maxExceptions;
+    private volatile boolean hasFailure = false;
+    private Exception finalFailure = null;
+
+    public FailureCollector() {
+        this(10);
+    }
+
+    public FailureCollector(int maxExceptions) {
+        if (maxExceptions <= 0) {
+            throw new IllegalArgumentException("maxExceptions must be at least one");
+        }
+        this.maxExceptions = maxExceptions;
+    }
+
+    public void unwrapAndCollect(Exception originEx) {
+        final Exception e = originEx instanceof TransportException
+            ? (originEx.getCause() instanceof Exception cause ? cause : new ElasticsearchException(originEx.getCause()))
+            : originEx;
+        if (ExceptionsHelper.unwrap(e, TaskCancelledException.class) != null) {
+            if (cancelledExceptionsCount.incrementAndGet() <= maxExceptions) {
+                cancelledExceptions.add(e);
+            }
+        } else {
+            if (nonCancelledExceptionsCount.incrementAndGet() <= maxExceptions) {
+                nonCancelledExceptions.add(e);
+            }
+        }
+        hasFailure = true;
+    }
+
+    /**
+     * @return {@code true} if any failure has been collected, {@code false} otherwise
+     */
+    public boolean hasFailure() {
+        return hasFailure;
+    }
+
+    /**
+     * Returns the accumulated failure, preferring non-task-cancelled exceptions over task-cancelled ones.
+     * Once this method builds the failure, incoming failures are discarded.
+     *
+     * @return the accumulated failure, or {@code null} if no failure has been collected
+     */
+    public Exception getFailure() {
+        if (hasFailure == false) {
+            return null;
+        }
+        synchronized (this) {
+            if (finalFailure == null) {
+                finalFailure = buildFailure();
+            }
+            return finalFailure;
+        }
+    }
+
+    private Exception buildFailure() {
+        assert hasFailure;
+        assert Thread.holdsLock(this);
+        int total = 0;
+        Exception first = null;
+        for (var exceptions : List.of(nonCancelledExceptions, cancelledExceptions)) {
+            for (Exception e : exceptions) {
+                if (first == null) {
+                    first = e;
+                    total++;
+                } else if (first != e) {
+                    first.addSuppressed(e);
+                    total++;
+                }
+                if (total >= maxExceptions) {
+                    return first;
+                }
+            }
+        }
+        assert first != null;
+        return first;
+    }
+}

--- a/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FailureCollectorTests.java
+++ b/x-pack/plugin/esql/compute/src/test/java/org/elasticsearch/compute/operator/FailureCollectorTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.compute.operator;
+
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.RemoteTransportException;
+import org.hamcrest.Matchers;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.lessThan;
+
+public class FailureCollectorTests extends ESTestCase {
+
+    public void testCollect() throws Exception {
+        int maxExceptions = between(1, 100);
+        FailureCollector collector = new FailureCollector(maxExceptions);
+        List<Exception> cancelledExceptions = List.of(
+            new TaskCancelledException("user request"),
+            new TaskCancelledException("cross "),
+            new TaskCancelledException("on failure")
+        );
+        List<Exception> nonCancelledExceptions = List.of(
+            new IOException("i/o simulated"),
+            new IOException("disk broken"),
+            new CircuitBreakingException("low memory", CircuitBreaker.Durability.TRANSIENT),
+            new CircuitBreakingException("over limit", CircuitBreaker.Durability.TRANSIENT)
+        );
+        List<Exception> failures = Stream.concat(
+            IntStream.range(0, between(1, 500)).mapToObj(n -> randomFrom(cancelledExceptions)),
+            IntStream.range(0, between(1, 500)).mapToObj(n -> randomFrom(nonCancelledExceptions))
+        ).collect(Collectors.toList());
+        Randomness.shuffle(failures);
+        Queue<Exception> queue = new ConcurrentLinkedQueue<>(failures);
+        Thread[] threads = new Thread[between(1, 4)];
+        CyclicBarrier carrier = new CyclicBarrier(threads.length);
+        for (int i = 0; i < threads.length; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    carrier.await(10, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+                Exception ex;
+                while ((ex = queue.poll()) != null) {
+                    if (randomBoolean()) {
+                        collector.unwrapAndCollect(ex);
+                    } else {
+                        collector.unwrapAndCollect(new RemoteTransportException("disconnect", ex));
+                    }
+                    if (randomBoolean()) {
+                        assertTrue(collector.hasFailure());
+                    }
+                }
+            });
+            threads[i].start();
+        }
+        for (Thread thread : threads) {
+            thread.join();
+        }
+        assertTrue(collector.hasFailure());
+        Exception failure = collector.getFailure();
+        assertNotNull(failure);
+        assertThat(failure, Matchers.in(nonCancelledExceptions));
+        assertThat(failure.getSuppressed().length, lessThan(maxExceptions));
+    }
+
+    public void testEmpty() {
+        FailureCollector collector = new FailureCollector(5);
+        assertFalse(collector.hasFailure());
+        assertNull(collector.getFailure());
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeListener.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.compute.operator.DriverProfile;
+import org.elasticsearch.compute.operator.FailureCollector;
+import org.elasticsearch.compute.operator.ResponseHeadersCollector;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A variant of {@link RefCountingListener} with the following differences:
+ * 1. Automatically cancels sub tasks on failure.
+ * 2. Collects driver profiles from sub tasks.
+ * 3. Collects response headers from sub tasks, specifically warnings emitted during compute
+ * 4. Collects failures and returns the most appropriate exception to the caller.
+ */
+final class ComputeListener implements Releasable {
+    private static final Logger LOGGER = LogManager.getLogger(ComputeService.class);
+
+    private final RefCountingListener refs;
+    private final FailureCollector failureCollector = new FailureCollector();
+    private final AtomicBoolean cancelled = new AtomicBoolean();
+    private final CancellableTask task;
+    private final TransportService transportService;
+    private final List<DriverProfile> collectedProfiles;
+    private final ResponseHeadersCollector responseHeaders;
+
+    ComputeListener(TransportService transportService, CancellableTask task, ActionListener<ComputeResponse> delegate) {
+        this.transportService = transportService;
+        this.task = task;
+        this.responseHeaders = new ResponseHeadersCollector(transportService.getThreadPool().getThreadContext());
+        this.collectedProfiles = Collections.synchronizedList(new ArrayList<>());
+        this.refs = new RefCountingListener(1, ActionListener.wrap(ignored -> {
+            responseHeaders.finish();
+            var result = new ComputeResponse(collectedProfiles.isEmpty() ? List.of() : collectedProfiles.stream().toList());
+            delegate.onResponse(result);
+        }, e -> delegate.onFailure(failureCollector.getFailure())));
+    }
+
+    /**
+     * Acquires a new listener that doesn't collect result
+     */
+    ActionListener<Void> acquireAvoid() {
+        return refs.acquire().delegateResponse((l, e) -> {
+            failureCollector.unwrapAndCollect(e);
+            try {
+                if (cancelled.compareAndSet(false, true)) {
+                    LOGGER.debug("cancelling ESQL task {} on failure", task);
+                    transportService.getTaskManager().cancelTaskAndDescendants(task, "cancelled on failure", false, ActionListener.noop());
+                }
+            } finally {
+                l.onFailure(e);
+            }
+        });
+    }
+
+    /**
+     * Acquires a new listener that collects compute result. This listener will also collects warnings emitted during compute
+     */
+    ActionListener<ComputeResponse> acquireCompute() {
+        return acquireAvoid().map(resp -> {
+            responseHeaders.collect();
+            if (resp != null && resp.getProfiles().isEmpty() == false) {
+                collectedProfiles.addAll(resp.getProfiles());
+            }
+            return null;
+        });
+    }
+
+    @Override
+    public void close() {
+        refs.close();
+    }
+}

--- a/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
+++ b/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/plugin/ComputeService.java
@@ -29,7 +29,6 @@ import org.elasticsearch.compute.data.Page;
 import org.elasticsearch.compute.operator.Driver;
 import org.elasticsearch.compute.operator.DriverProfile;
 import org.elasticsearch.compute.operator.DriverTaskRunner;
-import org.elasticsearch.compute.operator.ResponseHeadersCollector;
 import org.elasticsearch.compute.operator.exchange.ExchangeService;
 import org.elasticsearch.compute.operator.exchange.ExchangeSink;
 import org.elasticsearch.compute.operator.exchange.ExchangeSinkHandler;
@@ -81,7 +80,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 import static org.elasticsearch.xpack.esql.plugin.EsqlPlugin.ESQL_WORKER_THREAD_POOL_NAME;
 
@@ -172,13 +170,16 @@ public class ComputeService {
                 null,
                 null
             );
-            runCompute(
-                rootTask,
-                computeContext,
-                coordinatorPlan,
-                listener.map(driverProfiles -> new Result(collectedPages, driverProfiles))
-            );
-            return;
+            try (
+                var computeListener = new ComputeListener(
+                    transportService,
+                    rootTask,
+                    listener.map(r -> new Result(collectedPages, r.getProfiles()))
+                )
+            ) {
+                runCompute(rootTask, computeContext, coordinatorPlan, computeListener.acquireCompute());
+                return;
+            }
         } else {
             if (clusterToConcreteIndices.values().stream().allMatch(v -> v.indices().length == 0)) {
                 var error = "expected concrete indices with data node plan but got empty; data node plan " + dataNodePlan;
@@ -191,31 +192,25 @@ public class ComputeService {
             .groupIndices(SearchRequest.DEFAULT_INDICES_OPTIONS, PlannerUtils.planOriginalIndices(physicalPlan));
         var localOriginalIndices = clusterToOriginalIndices.remove(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
         var localConcreteIndices = clusterToConcreteIndices.remove(RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY);
-        final var responseHeadersCollector = new ResponseHeadersCollector(transportService.getThreadPool().getThreadContext());
-        listener = ActionListener.runBefore(listener, responseHeadersCollector::finish);
-        final AtomicBoolean cancelled = new AtomicBoolean();
-        final List<DriverProfile> collectedProfiles = configuration.profile() ? Collections.synchronizedList(new ArrayList<>()) : List.of();
         final var exchangeSource = new ExchangeSourceHandler(
             queryPragmas.exchangeBufferSize(),
             transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
         );
         try (
             Releasable ignored = exchangeSource.addEmptySink();
-            RefCountingListener refs = new RefCountingListener(listener.map(unused -> new Result(collectedPages, collectedProfiles)))
+            var computeListener = new ComputeListener(
+                transportService,
+                rootTask,
+                listener.map(r -> new Result(collectedPages, r.getProfiles()))
+            )
         ) {
             // run compute on the coordinator
-            exchangeSource.addCompletionListener(refs.acquire());
+            exchangeSource.addCompletionListener(computeListener.acquireAvoid());
             runCompute(
                 rootTask,
                 new ComputeContext(sessionId, RemoteClusterAware.LOCAL_CLUSTER_GROUP_KEY, List.of(), configuration, exchangeSource, null),
                 coordinatorPlan,
-                cancelOnFailure(rootTask, cancelled, refs.acquire()).map(driverProfiles -> {
-                    responseHeadersCollector.collect();
-                    if (configuration.profile()) {
-                        collectedProfiles.addAll(driverProfiles);
-                    }
-                    return null;
-                })
+                computeListener.acquireCompute()
             );
             // starts computes on data nodes on the main cluster
             if (localConcreteIndices != null && localConcreteIndices.indices().length > 0) {
@@ -228,17 +223,10 @@ public class ComputeService {
                     Set.of(localConcreteIndices.indices()),
                     localOriginalIndices.indices(),
                     exchangeSource,
-                    ActionListener.releaseAfter(refs.acquire(), exchangeSource.addEmptySink()),
-                    () -> cancelOnFailure(rootTask, cancelled, refs.acquire()).map(response -> {
-                        responseHeadersCollector.collect();
-                        if (configuration.profile()) {
-                            collectedProfiles.addAll(response.getProfiles());
-                        }
-                        return null;
-                    })
+                    computeListener
                 );
             }
-            // starts computes on remote cluster
+            // starts computes on remote clusters
             startComputeOnRemoteClusters(
                 sessionId,
                 rootTask,
@@ -246,13 +234,7 @@ public class ComputeService {
                 dataNodePlan,
                 exchangeSource,
                 getRemoteClusters(clusterToConcreteIndices, clusterToOriginalIndices),
-                () -> cancelOnFailure(rootTask, cancelled, refs.acquire()).map(response -> {
-                    responseHeadersCollector.collect();
-                    if (configuration.profile()) {
-                        collectedProfiles.addAll(response.getProfiles());
-                    }
-                    return null;
-                })
+                computeListener
             );
         }
     }
@@ -288,8 +270,7 @@ public class ComputeService {
         Set<String> concreteIndices,
         String[] originalIndices,
         ExchangeSourceHandler exchangeSource,
-        ActionListener<Void> parentListener,
-        Supplier<ActionListener<ComputeResponse>> dataNodeListenerSupplier
+        ComputeListener computeListener
     ) {
         var planWithReducer = configuration.pragmas().nodeLevelReduction() == false
             ? dataNodePlan
@@ -303,12 +284,12 @@ public class ComputeService {
         // Since it's used only for @timestamp, it is relatively safe to assume it's not needed
         // but it would be better to have a proper impl.
         QueryBuilder requestFilter = PlannerUtils.requestFilter(planWithReducer, x -> true);
+        var lookupListener = ActionListener.releaseAfter(computeListener.acquireAvoid(), exchangeSource.addEmptySink());
         lookupDataNodes(parentTask, clusterAlias, requestFilter, concreteIndices, originalIndices, ActionListener.wrap(dataNodes -> {
-            try (RefCountingRunnable refs = new RefCountingRunnable(() -> parentListener.onResponse(null))) {
+            try (RefCountingListener refs = new RefCountingListener(lookupListener)) {
                 // For each target node, first open a remote exchange on the remote node, then link the exchange source to
                 // the new remote exchange sink, and initialize the computation on the target node via data-node-request.
                 for (DataNode node : dataNodes) {
-                    var dataNodeListener = ActionListener.releaseAfter(dataNodeListenerSupplier.get(), refs.acquire());
                     var queryPragmas = configuration.pragmas();
                     ExchangeService.openExchange(
                         transportService,
@@ -316,9 +297,10 @@ public class ComputeService {
                         sessionId,
                         queryPragmas.exchangeBufferSize(),
                         esqlExecutor,
-                        dataNodeListener.delegateFailureAndWrap((delegate, unused) -> {
+                        refs.acquire().delegateFailureAndWrap((l, unused) -> {
                             var remoteSink = exchangeService.newRemoteSink(parentTask, sessionId, transportService, node.connection);
                             exchangeSource.addRemoteSink(remoteSink, queryPragmas.concurrentExchangeClients());
+                            var dataNodeListener = ActionListener.runBefore(computeListener.acquireCompute(), () -> l.onResponse(null));
                             transportService.sendChildRequest(
                                 node.connection,
                                 DATA_ACTION_NAME,
@@ -332,13 +314,13 @@ public class ComputeService {
                                 ),
                                 parentTask,
                                 TransportRequestOptions.EMPTY,
-                                new ActionListenerResponseHandler<>(delegate, ComputeResponse::new, esqlExecutor)
+                                new ActionListenerResponseHandler<>(dataNodeListener, ComputeResponse::new, esqlExecutor)
                             );
                         })
                     );
                 }
             }
-        }, parentListener::onFailure));
+        }, lookupListener::onFailure));
     }
 
     private void startComputeOnRemoteClusters(
@@ -348,19 +330,19 @@ public class ComputeService {
         PhysicalPlan plan,
         ExchangeSourceHandler exchangeSource,
         List<RemoteCluster> clusters,
-        Supplier<ActionListener<ComputeResponse>> listener
+        ComputeListener computeListener
     ) {
-        try (RefCountingRunnable refs = new RefCountingRunnable(exchangeSource.addEmptySink()::close)) {
+        var queryPragmas = configuration.pragmas();
+        var linkExchangeListeners = ActionListener.releaseAfter(computeListener.acquireAvoid(), exchangeSource.addEmptySink());
+        try (RefCountingListener refs = new RefCountingListener(linkExchangeListeners)) {
             for (RemoteCluster cluster : clusters) {
-                var targetNodeListener = ActionListener.releaseAfter(listener.get(), refs.acquire());
-                var queryPragmas = configuration.pragmas();
                 ExchangeService.openExchange(
                     transportService,
                     cluster.connection,
                     sessionId,
                     queryPragmas.exchangeBufferSize(),
                     esqlExecutor,
-                    targetNodeListener.delegateFailureAndWrap((l, unused) -> {
+                    refs.acquire().delegateFailureAndWrap((l, unused) -> {
                         var remoteSink = exchangeService.newRemoteSink(rootTask, sessionId, transportService, cluster.connection);
                         exchangeSource.addRemoteSink(remoteSink, queryPragmas.concurrentExchangeClients());
                         var clusterRequest = new ClusterComputeRequest(
@@ -371,13 +353,14 @@ public class ComputeService {
                             cluster.concreteIndices,
                             cluster.originalIndices
                         );
+                        var clusterListener = ActionListener.runBefore(computeListener.acquireCompute(), () -> l.onResponse(null));
                         transportService.sendChildRequest(
                             cluster.connection,
                             CLUSTER_ACTION_NAME,
                             clusterRequest,
                             rootTask,
                             TransportRequestOptions.EMPTY,
-                            new ActionListenerResponseHandler<>(l, ComputeResponse::new, esqlExecutor)
+                            new ActionListenerResponseHandler<>(clusterListener, ComputeResponse::new, esqlExecutor)
                         );
                     })
                 );
@@ -385,17 +368,7 @@ public class ComputeService {
         }
     }
 
-    private ActionListener<Void> cancelOnFailure(CancellableTask task, AtomicBoolean cancelled, ActionListener<Void> listener) {
-        return listener.delegateResponse((l, e) -> {
-            l.onFailure(e);
-            if (cancelled.compareAndSet(false, true)) {
-                LOGGER.debug("cancelling ESQL task {} on failure", task);
-                transportService.getTaskManager().cancelTaskAndDescendants(task, "cancelled", false, ActionListener.noop());
-            }
-        });
-    }
-
-    void runCompute(CancellableTask task, ComputeContext context, PhysicalPlan plan, ActionListener<List<DriverProfile>> listener) {
+    void runCompute(CancellableTask task, ComputeContext context, PhysicalPlan plan, ActionListener<ComputeResponse> listener) {
         listener = ActionListener.runBefore(listener, () -> Releasables.close(context.searchContexts));
         List<EsPhysicalOperationProviders.ShardContext> contexts = new ArrayList<>(context.searchContexts.size());
         for (int i = 0; i < context.searchContexts.size(); i++) {
@@ -445,9 +418,10 @@ public class ComputeService {
         }
         ActionListener<Void> listenerCollectingStatus = listener.map(ignored -> {
             if (context.configuration.profile()) {
-                return drivers.stream().map(Driver::profile).toList();
+                return new ComputeResponse(drivers.stream().map(Driver::profile).toList());
+            } else {
+                return new ComputeResponse(List.of());
             }
-            return null;
         });
         listenerCollectingStatus = ActionListener.releaseAfter(listenerCollectingStatus, () -> Releasables.close(drivers));
         driverRunner.executeDrivers(
@@ -612,8 +586,7 @@ public class ComputeService {
         private final DataNodeRequest request;
         private final CancellableTask parentTask;
         private final ExchangeSinkHandler exchangeSink;
-        private final ActionListener<Void> listener;
-        private final List<DriverProfile> driverProfiles;
+        private final ComputeListener computeListener;
         private final int maxConcurrentShards;
         private final ExchangeSink blockingSink; // block until we have completed on all shards or the coordinator has enough data
 
@@ -622,14 +595,12 @@ public class ComputeService {
             CancellableTask parentTask,
             ExchangeSinkHandler exchangeSink,
             int maxConcurrentShards,
-            List<DriverProfile> driverProfiles,
-            ActionListener<Void> listener
+            ComputeListener computeListener
         ) {
             this.request = request;
             this.parentTask = parentTask;
             this.exchangeSink = exchangeSink;
-            this.listener = listener;
-            this.driverProfiles = driverProfiles;
+            this.computeListener = computeListener;
             this.maxConcurrentShards = maxConcurrentShards;
             this.blockingSink = exchangeSink.createExchangeSink();
         }
@@ -647,39 +618,45 @@ public class ComputeService {
             final var sessionId = request.sessionId();
             final int endBatchIndex = Math.min(startBatchIndex + maxConcurrentShards, request.shardIds().size());
             List<ShardId> shardIds = request.shardIds().subList(startBatchIndex, endBatchIndex);
+            ActionListener<ComputeResponse> batchListener = new ActionListener<>() {
+                final ActionListener<ComputeResponse> ref = computeListener.acquireCompute();
+
+                @Override
+                public void onResponse(ComputeResponse result) {
+                    try {
+                        onBatchCompleted(endBatchIndex);
+                    } finally {
+                        ref.onResponse(result);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    try {
+                        exchangeService.finishSinkHandler(request.sessionId(), e);
+                    } finally {
+                        ref.onFailure(e);
+                    }
+                }
+            };
             acquireSearchContexts(clusterAlias, shardIds, configuration, request.aliasFilters(), ActionListener.wrap(searchContexts -> {
                 assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.SEARCH, ESQL_WORKER_THREAD_POOL_NAME);
                 var computeContext = new ComputeContext(sessionId, clusterAlias, searchContexts, configuration, null, exchangeSink);
-                runCompute(
-                    parentTask,
-                    computeContext,
-                    request.plan(),
-                    ActionListener.wrap(profiles -> onBatchCompleted(endBatchIndex, profiles), this::onFailure)
-                );
-            }, this::onFailure));
+                runCompute(parentTask, computeContext, request.plan(), batchListener);
+            }, batchListener::onFailure));
         }
 
-        private void onBatchCompleted(int lastBatchIndex, List<DriverProfile> batchProfiles) {
-            if (request.configuration().profile()) {
-                driverProfiles.addAll(batchProfiles);
-            }
+        private void onBatchCompleted(int lastBatchIndex) {
             if (lastBatchIndex < request.shardIds().size() && exchangeSink.isFinished() == false) {
                 runBatch(lastBatchIndex);
             } else {
-                blockingSink.finish();
                 // don't return until all pages are fetched
+                var completionListener = computeListener.acquireAvoid();
                 exchangeSink.addCompletionListener(
-                    ContextPreservingActionListener.wrapPreservingContext(
-                        ActionListener.runBefore(listener, () -> exchangeService.finishSinkHandler(request.sessionId(), null)),
-                        transportService.getThreadPool().getThreadContext()
-                    )
+                    ActionListener.runAfter(completionListener, () -> exchangeService.finishSinkHandler(request.sessionId(), null))
                 );
+                blockingSink.finish();
             }
-        }
-
-        private void onFailure(Exception e) {
-            exchangeService.finishSinkHandler(request.sessionId(), e);
-            listener.onFailure(e);
         }
     }
 
@@ -688,17 +665,10 @@ public class ComputeService {
         String externalId,
         PhysicalPlan reducePlan,
         DataNodeRequest request,
-        ActionListener<ComputeResponse> listener
+        ComputeListener computeListener
     ) {
-        final List<DriverProfile> collectedProfiles = request.configuration().profile()
-            ? Collections.synchronizedList(new ArrayList<>())
-            : List.of();
-        final var responseHeadersCollector = new ResponseHeadersCollector(transportService.getThreadPool().getThreadContext());
-        final RefCountingListener listenerRefs = new RefCountingListener(
-            ActionListener.runBefore(listener.map(unused -> new ComputeResponse(collectedProfiles)), responseHeadersCollector::finish)
-        );
+        var parentListener = computeListener.acquireAvoid();
         try {
-            final AtomicBoolean cancelled = new AtomicBoolean();
             // run compute with target shards
             var internalSink = exchangeService.createSinkHandler(request.sessionId(), request.pragmas().exchangeBufferSize());
             DataNodeRequestExecutor dataNodeRequestExecutor = new DataNodeRequestExecutor(
@@ -706,17 +676,16 @@ public class ComputeService {
                 task,
                 internalSink,
                 request.configuration().pragmas().maxConcurrentShardsPerNode(),
-                collectedProfiles,
-                ActionListener.runBefore(cancelOnFailure(task, cancelled, listenerRefs.acquire()), responseHeadersCollector::collect)
+                computeListener
             );
             dataNodeRequestExecutor.start();
             // run the node-level reduction
             var externalSink = exchangeService.getSinkHandler(externalId);
             task.addListener(() -> exchangeService.finishSinkHandler(externalId, new TaskCancelledException(task.getReasonCancelled())));
             var exchangeSource = new ExchangeSourceHandler(1, esqlExecutor);
-            exchangeSource.addCompletionListener(listenerRefs.acquire());
+            exchangeSource.addCompletionListener(computeListener.acquireAvoid());
             exchangeSource.addRemoteSink(internalSink::fetchPageAsync, 1);
-            ActionListener<Void> reductionListener = cancelOnFailure(task, cancelled, listenerRefs.acquire());
+            ActionListener<ComputeResponse> reductionListener = computeListener.acquireCompute();
             runCompute(
                 task,
                 new ComputeContext(
@@ -728,26 +697,22 @@ public class ComputeService {
                     externalSink
                 ),
                 reducePlan,
-                ActionListener.wrap(driverProfiles -> {
-                    responseHeadersCollector.collect();
-                    if (request.configuration().profile()) {
-                        collectedProfiles.addAll(driverProfiles);
-                    }
+                ActionListener.wrap(resp -> {
                     // don't return until all pages are fetched
-                    externalSink.addCompletionListener(
-                        ActionListener.runBefore(reductionListener, () -> exchangeService.finishSinkHandler(externalId, null))
-                    );
+                    externalSink.addCompletionListener(ActionListener.running(() -> {
+                        exchangeService.finishSinkHandler(externalId, null);
+                        reductionListener.onResponse(resp);
+                    }));
                 }, e -> {
                     exchangeService.finishSinkHandler(externalId, e);
                     reductionListener.onFailure(e);
                 })
             );
+            parentListener.onResponse(null);
         } catch (Exception e) {
             exchangeService.finishSinkHandler(externalId, e);
             exchangeService.finishSinkHandler(request.sessionId(), e);
-            listenerRefs.acquire().onFailure(e);
-        } finally {
-            listenerRefs.close();
+            parentListener.onFailure(e);
         }
     }
 
@@ -784,7 +749,9 @@ public class ComputeService {
                 request.aliasFilters(),
                 request.plan()
             );
-            runComputeOnDataNode((CancellableTask) task, sessionId, reducePlan, request, listener);
+            try (var computeListener = new ComputeListener(transportService, (CancellableTask) task, listener)) {
+                runComputeOnDataNode((CancellableTask) task, sessionId, reducePlan, request, computeListener);
+            }
         }
     }
 
@@ -798,16 +765,18 @@ public class ComputeService {
                 listener.onFailure(new IllegalStateException("expected exchange sink for a remote compute; got " + request.plan()));
                 return;
             }
-            runComputeOnRemoteCluster(
-                request.clusterAlias(),
-                request.sessionId(),
-                (CancellableTask) task,
-                request.configuration(),
-                (ExchangeSinkExec) request.plan(),
-                Set.of(request.indices()),
-                request.originalIndices(),
-                listener
-            );
+            try (var computeListener = new ComputeListener(transportService, (CancellableTask) task, listener)) {
+                runComputeOnRemoteCluster(
+                    request.clusterAlias(),
+                    request.sessionId(),
+                    (CancellableTask) task,
+                    request.configuration(),
+                    (ExchangeSinkExec) request.plan(),
+                    Set.of(request.indices()),
+                    request.originalIndices(),
+                    computeListener
+                );
+            }
         }
     }
 
@@ -828,28 +797,20 @@ public class ComputeService {
         ExchangeSinkExec plan,
         Set<String> concreteIndices,
         String[] originalIndices,
-        ActionListener<ComputeResponse> listener
+        ComputeListener computeListener
     ) {
         final var exchangeSink = exchangeService.getSinkHandler(globalSessionId);
         parentTask.addListener(
             () -> exchangeService.finishSinkHandler(globalSessionId, new TaskCancelledException(parentTask.getReasonCancelled()))
         );
-        ThreadPool threadPool = transportService.getThreadPool();
-        final var responseHeadersCollector = new ResponseHeadersCollector(threadPool.getThreadContext());
-        listener = ActionListener.runBefore(listener, responseHeadersCollector::finish);
-        final AtomicBoolean cancelled = new AtomicBoolean();
-        final List<DriverProfile> collectedProfiles = configuration.profile() ? Collections.synchronizedList(new ArrayList<>()) : List.of();
         final String localSessionId = clusterAlias + ":" + globalSessionId;
         var exchangeSource = new ExchangeSourceHandler(
             configuration.pragmas().exchangeBufferSize(),
             transportService.getThreadPool().executor(ThreadPool.Names.SEARCH)
         );
-        try (
-            Releasable ignored = exchangeSource.addEmptySink();
-            RefCountingListener refs = new RefCountingListener(listener.map(unused -> new ComputeResponse(collectedProfiles)))
-        ) {
-            exchangeSink.addCompletionListener(refs.acquire());
-            exchangeSource.addCompletionListener(refs.acquire());
+        try (Releasable ignored = exchangeSource.addEmptySink()) {
+            exchangeSink.addCompletionListener(computeListener.acquireAvoid());
+            exchangeSource.addCompletionListener(computeListener.acquireAvoid());
             PhysicalPlan coordinatorPlan = new ExchangeSinkExec(
                 plan.source(),
                 plan.output(),
@@ -860,13 +821,7 @@ public class ComputeService {
                 parentTask,
                 new ComputeContext(localSessionId, clusterAlias, List.of(), configuration, exchangeSource, exchangeSink),
                 coordinatorPlan,
-                cancelOnFailure(parentTask, cancelled, refs.acquire()).map(driverProfiles -> {
-                    responseHeadersCollector.collect();
-                    if (configuration.profile()) {
-                        collectedProfiles.addAll(driverProfiles);
-                    }
-                    return null;
-                })
+                computeListener.acquireCompute()
             );
             startComputeOnDataNodes(
                 localSessionId,
@@ -877,14 +832,7 @@ public class ComputeService {
                 concreteIndices,
                 originalIndices,
                 exchangeSource,
-                ActionListener.releaseAfter(refs.acquire(), exchangeSource.addEmptySink()),
-                () -> cancelOnFailure(parentTask, cancelled, refs.acquire()).map(r -> {
-                    responseHeadersCollector.collect();
-                    if (configuration.profile()) {
-                        collectedProfiles.addAll(r.getProfiles());
-                    }
-                    return null;
-                })
+                computeListener
             );
         }
     }

--- a/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
+++ b/x-pack/plugin/esql/src/test/java/org/elasticsearch/xpack/esql/plugin/ComputeListenerTests.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.esql.plugin;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.node.VersionInformation;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.compute.operator.DriverProfile;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskCancellationService;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.tasks.TaskId;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.After;
+import org.junit.Before;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.elasticsearch.test.tasks.MockTaskManager.SPY_TASK_MANAGER_SETTING;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+public class ComputeListenerTests extends ESTestCase {
+    private ThreadPool threadPool;
+    private TransportService transportService;
+
+    @Before
+    public void setUpTransportService() {
+        threadPool = new TestThreadPool(getTestName());
+        transportService = MockTransportService.createNewService(
+            Settings.builder().put(SPY_TASK_MANAGER_SETTING.getKey(), true).build(),
+            VersionInformation.CURRENT,
+            TransportVersionUtils.randomVersion(),
+            threadPool
+        );
+        transportService.start();
+        TaskCancellationService cancellationService = new TaskCancellationService(transportService);
+        transportService.getTaskManager().setTaskCancellationService(cancellationService);
+        Mockito.clearInvocations(transportService.getTaskManager());
+    }
+
+    @After
+    public void shutdownTransportService() {
+        transportService.close();
+        terminate(threadPool);
+    }
+
+    private CancellableTask newTask() {
+        return new CancellableTask(
+            randomIntBetween(1, 100),
+            "test-type",
+            "test-action",
+            "test-description",
+            TaskId.EMPTY_TASK_ID,
+            Map.of()
+        );
+    }
+
+    private ComputeResponse randomResponse() {
+        int numProfiles = randomIntBetween(0, 2);
+        List<DriverProfile> profiles = new ArrayList<>(numProfiles);
+        for (int i = 0; i < numProfiles; i++) {
+            profiles.add(new DriverProfile(randomNonNegativeLong(), randomNonNegativeLong(), randomNonNegativeLong(), List.of()));
+        }
+        return new ComputeResponse(profiles);
+    }
+
+    public void testEmpty() {
+        PlainActionFuture<ComputeResponse> results = new PlainActionFuture<>();
+        try (ComputeListener ignored = new ComputeListener(transportService, newTask(), results)) {
+            assertFalse(results.isDone());
+        }
+        assertTrue(results.isDone());
+        assertThat(results.actionGet(10, TimeUnit.SECONDS).getProfiles(), empty());
+    }
+
+    public void testCollectComputeResults() {
+        PlainActionFuture<ComputeResponse> future = new PlainActionFuture<>();
+        List<DriverProfile> allProfiles = new ArrayList<>();
+        try (ComputeListener computeListener = new ComputeListener(transportService, newTask(), future)) {
+            int tasks = randomIntBetween(1, 100);
+            for (int t = 0; t < tasks; t++) {
+                if (randomBoolean()) {
+                    ActionListener<Void> subListener = computeListener.acquireAvoid();
+                    threadPool.schedule(
+                        ActionRunnable.wrap(subListener, l -> l.onResponse(null)),
+                        TimeValue.timeValueNanos(between(0, 100)),
+                        threadPool.generic()
+                    );
+                } else {
+                    ComputeResponse resp = randomResponse();
+                    allProfiles.addAll(resp.getProfiles());
+                    ActionListener<ComputeResponse> subListener = computeListener.acquireCompute();
+                    threadPool.schedule(
+                        ActionRunnable.wrap(subListener, l -> l.onResponse(resp)),
+                        TimeValue.timeValueNanos(between(0, 100)),
+                        threadPool.generic()
+                    );
+                }
+            }
+        }
+        ComputeResponse result = future.actionGet(10, TimeUnit.SECONDS);
+        assertThat(
+            result.getProfiles().stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)),
+            equalTo(allProfiles.stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)))
+        );
+        Mockito.verifyNoInteractions(transportService.getTaskManager());
+    }
+
+    public void testCancelOnFailure() throws Exception {
+        Queue<Exception> rootCauseExceptions = ConcurrentCollections.newQueue();
+        IntStream.range(0, between(1, 100))
+            .forEach(
+                n -> rootCauseExceptions.add(new CircuitBreakingException("breaking exception " + n, CircuitBreaker.Durability.TRANSIENT))
+            );
+        int successTasks = between(1, 50);
+        int failedTasks = between(1, 100);
+        PlainActionFuture<ComputeResponse> rootListener = new PlainActionFuture<>();
+        CancellableTask rootTask = newTask();
+        try (ComputeListener computeListener = new ComputeListener(transportService, rootTask, rootListener)) {
+            for (int i = 0; i < successTasks; i++) {
+                ActionListener<ComputeResponse> subListener = computeListener.acquireCompute();
+                threadPool.schedule(
+                    ActionRunnable.wrap(subListener, l -> l.onResponse(randomResponse())),
+                    TimeValue.timeValueNanos(between(0, 100)),
+                    threadPool.generic()
+                );
+            }
+            for (int i = 0; i < failedTasks; i++) {
+                ActionListener<?> subListener = randomBoolean() ? computeListener.acquireAvoid() : computeListener.acquireCompute();
+                threadPool.schedule(ActionRunnable.wrap(subListener, l -> {
+                    Exception ex = rootCauseExceptions.poll();
+                    if (ex == null) {
+                        ex = new TaskCancelledException("task was cancelled");
+                    }
+                    l.onFailure(ex);
+                }), TimeValue.timeValueNanos(between(0, 100)), threadPool.generic());
+            }
+        }
+        assertBusy(rootListener::isDone);
+        ExecutionException failure = expectThrows(ExecutionException.class, () -> rootListener.get(1, TimeUnit.SECONDS));
+        Throwable cause = failure.getCause();
+        assertNotNull(failure);
+        assertThat(cause, instanceOf(CircuitBreakingException.class));
+        assertThat(failure.getSuppressed().length, lessThan(10));
+        Mockito.verify(transportService.getTaskManager(), Mockito.times(1))
+            .cancelTaskAndDescendants(eq(rootTask), eq("cancelled on failure"), eq(false), any());
+    }
+
+    public void testCollectWarnings() throws Exception {
+        List<DriverProfile> allProfiles = new ArrayList<>();
+        Map<String, Set<String>> allWarnings = new HashMap<>();
+        ActionListener<ComputeResponse> rootListener = new ActionListener<>() {
+            @Override
+            public void onResponse(ComputeResponse result) {
+                assertThat(
+                    result.getProfiles().stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)),
+                    equalTo(allProfiles.stream().collect(Collectors.toMap(p -> p, p -> 1, Integer::sum)))
+                );
+                Map<String, Set<String>> responseHeaders = threadPool.getThreadContext()
+                    .getResponseHeaders()
+                    .entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, e -> new HashSet<>(e.getValue())));
+                assertThat(responseHeaders, equalTo(allWarnings));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError(e);
+            }
+        };
+        CountDownLatch latch = new CountDownLatch(1);
+        try (
+            ComputeListener computeListener = new ComputeListener(
+                transportService,
+                newTask(),
+                ActionListener.runAfter(rootListener, latch::countDown)
+            )
+        ) {
+            int tasks = randomIntBetween(1, 100);
+            for (int t = 0; t < tasks; t++) {
+                if (randomBoolean()) {
+                    ActionListener<Void> subListener = computeListener.acquireAvoid();
+                    threadPool.schedule(
+                        ActionRunnable.wrap(subListener, l -> l.onResponse(null)),
+                        TimeValue.timeValueNanos(between(0, 100)),
+                        threadPool.generic()
+                    );
+                } else {
+                    ComputeResponse resp = randomResponse();
+                    allProfiles.addAll(resp.getProfiles());
+                    int numWarnings = randomIntBetween(1, 5);
+                    Map<String, String> warnings = new HashMap<>();
+                    for (int i = 0; i < numWarnings; i++) {
+                        warnings.put("key" + between(1, 10), "value" + between(1, 10));
+                    }
+                    for (Map.Entry<String, String> e : warnings.entrySet()) {
+                        allWarnings.computeIfAbsent(e.getKey(), v -> new HashSet<>()).add(e.getValue());
+                    }
+                    ActionListener<ComputeResponse> subListener = computeListener.acquireCompute();
+                    threadPool.schedule(ActionRunnable.wrap(subListener, l -> {
+                        for (Map.Entry<String, String> e : warnings.entrySet()) {
+                            threadPool.getThreadContext().addResponseHeader(e.getKey(), e.getValue());
+                        }
+                        l.onResponse(resp);
+                    }), TimeValue.timeValueNanos(between(0, 100)), threadPool.generic());
+                }
+            }
+        }
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
+        Mockito.verifyNoInteractions(transportService.getTaskManager());
+    }
+}


### PR DESCRIPTION
Backport of #110400 to 8.15

Currently, if a child request fails, we automatically trigger  cancellation for ES|QL requests. This can result in TaskCancelledException being collected by the RefCountingListener first, which then returns that exception to the caller. For example, if we encounter a CircuitBreakingException (429), we might incorrectly return a TaskCancelledException (400) instead.

This change introduces the ComputeListener, a variant of RefCountingListener, which selects the most appropriate exception to return to the caller. I also integrated the following features into ComputeListener to simplify ComputeService:

- Automatic cancellation of sub-tasks on failure.
- Collection of profiles from sub-tasks.
- Collection of response headers from sub-tasks.
