### PR TITLE
Clarify logs/errors re. publish addresses

### DIFF
--- a/docs/reference/modules/network.asciidoc
+++ b/docs/reference/modules/network.asciidoc
@@ -153,6 +153,8 @@ The only requirements are that each node must be:
   cluster, and by any remote clusters that will discover it using
   <<sniff-mode>>.
 
+Each node must have its own distinct publish address.
+
 If you specify the transport publish address using a hostname then {es} will
 resolve this hostname to an IP address once during startup, and other nodes
 will use the resulting IP address instead of resolving the name again

--- a/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
+++ b/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
@@ -73,6 +73,7 @@ public enum ReferenceDocs {
     UNASSIGNED_SHARDS,
     EXECUTABLE_JNA_TMPDIR,
     NETWORK_THREADING_MODEL,
+    NETWORK_BINDING_AND_PUBLISHING,
     // this comment keeps the ';' on the next line so every entry above has a trailing ',' which makes the diff for adding new links cleaner
     ;
 

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.VersionInformation;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -154,10 +155,15 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                                             // publish address.
                                             logger.warn(
                                                 () -> format(
-                                                    "completed handshake with [%s] at [%s] but followup connection to [%s] failed",
+                                                    """
+                                                        Successfully discovered master-eligible node [%s] at address [%s] but could not \
+                                                        connect to it at its publish address of [%s]. Each node in a cluster must be \
+                                                        accessible at its publish address to all other nodes in the cluster. See %s for \
+                                                        more information.""",
                                                     remoteNode.descriptionWithoutAttributes(),
                                                     transportAddress,
-                                                    remoteNode.getAddress()
+                                                    remoteNode.getAddress(),
+                                                    ReferenceDocs.NETWORK_BINDING_AND_PUBLISHING
                                                 ),
                                                 e
                                             );

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -158,7 +158,7 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                                                     """
                                                         Successfully discovered master-eligible node [%s] at address [%s] but could not \
                                                         connect to it at its publish address of [%s]. Each node in a cluster must be \
-                                                        accessible at its publish address to all other nodes in the cluster. See %s for \
+                                                        accessible at its publish address by all other nodes in the cluster. See %s for \
                                                         more information.""",
                                                     remoteNode.descriptionWithoutAttributes(),
                                                     transportAddress,

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.io.stream.RecyclerBytesStreamOutput;
@@ -518,7 +519,19 @@ public class TransportService extends AbstractLifecycleComponent
             handshake(newConnection, actualProfile.getHandshakeTimeout(), Predicates.always(), listener.map(resp -> {
                 final DiscoveryNode remote = resp.discoveryNode;
                 if (node.equals(remote) == false) {
-                    throw new ConnectTransportException(node, "handshake failed. unexpected remote node " + remote);
+                    throw new ConnectTransportException(
+                        node,
+                        Strings.format(
+                            """
+                                Connecting to [%s] failed: expected to connect to [%s] but found [%s] instead. Ensure that each node has \
+                                its own distinct publish address, and that your network is configured so that every connection to a node's \
+                                publish address is routed to the correct node. See %s for more information.""",
+                            node.getAddress(),
+                            node.descriptionWithoutAttributes(),
+                            remote.descriptionWithoutAttributes(),
+                            ReferenceDocs.NETWORK_BINDING_AND_PUBLISHING
+                        )
+                    );
                 }
                 return null;
             }));

--- a/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
+++ b/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
@@ -33,5 +33,6 @@
   "CONTACT_SUPPORT": "troubleshooting.html#troubleshooting-contact-support",
   "UNASSIGNED_SHARDS": "red-yellow-cluster-status.html",
   "EXECUTABLE_JNA_TMPDIR": "executable-jna-tmpdir.html",
-  "NETWORK_THREADING_MODEL": "modules-network.html#modules-network-threading-model"
+  "NETWORK_THREADING_MODEL": "modules-network.html#modules-network-threading-model",
+  "NETWORK_BINDING_AND_PUBLISHING": "modules-network.html#modules-network-binding-publishing"
 }

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -164,7 +164,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
                     Strings.format(
                         """
                             Successfully discovered master-eligible node [%s] at address [%s] but could not connect to it at its publish \
-                            address of [%s]. Each node in a cluster must be accessible at its publish address to all other nodes in the \
+                            address of [%s]. Each node in a cluster must be accessible at its publish address by all other nodes in the \
                             cluster. See %s for more information.""",
                         remoteNode.descriptionWithoutAttributes(),
                         discoveryAddress,

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -18,6 +18,8 @@ import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.Nullable;
@@ -159,13 +161,16 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
                     "message",
                     HandshakingTransportAddressConnector.class.getCanonicalName(),
                     Level.WARN,
-                    "completed handshake with ["
-                        + remoteNode.descriptionWithoutAttributes()
-                        + "] at ["
-                        + discoveryAddress
-                        + "] but followup connection to ["
-                        + remoteNodeAddress
-                        + "] failed"
+                    Strings.format(
+                        """
+                            Successfully discovered master-eligible node [%s] at address [%s] but could not connect to it at its publish \
+                            address of [%s]. Each node in a cluster must be visible at its publish address to all other nodes in the \
+                            cluster. See %s for more information.""",
+                        remoteNode.descriptionWithoutAttributes(),
+                        discoveryAddress,
+                        remoteNodeAddress,
+                        ReferenceDocs.NETWORK_BINDING_AND_PUBLISHING
+                    )
                 )
             );
 

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -164,7 +164,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
                     Strings.format(
                         """
                             Successfully discovered master-eligible node [%s] at address [%s] but could not connect to it at its publish \
-                            address of [%s]. Each node in a cluster must be visible at its publish address to all other nodes in the \
+                            address of [%s]. Each node in a cluster must be accessible at its publish address to all other nodes in the \
                             cluster. See %s for more information.""",
                         remoteNode.descriptionWithoutAttributes(),
                         discoveryAddress,

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.transport.AbstractSimpleTransportTestCase.IGNORE_DESERIALIZATION_ERRORS_SETTING;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -306,7 +307,18 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             ConnectTransportException.class,
             () -> AbstractSimpleTransportTestCase.connectToNode(transportServiceA, discoveryNode, TestProfiles.LIGHT_PROFILE)
         );
-        assertThat(ex.getMessage(), containsString("unexpected remote node"));
+        assertThat(
+            ex.getMessage(),
+            allOf(
+                containsString("Connecting to [" + discoveryNode.getAddress() + "] failed"),
+                containsString("expected to connect to [" + discoveryNode.descriptionWithoutAttributes() + "]"),
+                containsString("found [" + transportServiceB.getLocalNode().descriptionWithoutAttributes() + "] instead"),
+                containsString("Ensure that each node has its own distinct publish address"),
+                containsString("routed to the correct node"),
+                containsString("https://www.elastic.co/guide/en/elasticsearch/reference/"),
+                containsString("modules-network.html")
+            )
+        );
         assertFalse(transportServiceA.nodeConnected(discoveryNode));
     }
 


### PR DESCRIPTION
These warning logs and error messages assume some level of understanding
of Elasticsearch's networking config and are not particularly
actionable. This commit adds links to the relevant section of the
manual, rewords them a little to match the terminology used in the
manual, and also documents that each node must have its own publish
address, distinct from those of all other nodes.