### PR TITLE
Add ref docs links to allocation explain text

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/TransportClusterAllocationExplainAction.java
@@ -28,6 +28,8 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation.DebugMode;
 import org.elasticsearch.cluster.routing.allocation.ShardAllocationDecision;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.snapshots.SnapshotsInfoService;
 import org.elasticsearch.tasks.Task;
@@ -160,11 +162,10 @@ public class TransportClusterAllocationExplainAction extends TransportMasterNode
                 }
             }
             if (foundShard == null) {
-                throw new IllegalArgumentException(
-                    "No shard was specified in the request which means the response should explain a randomly-chosen unassigned shard, "
-                        + "but there are no unassigned shards in this cluster. To explain the allocation of an assigned shard you must "
-                        + "specify the target shard in the request."
-                );
+                throw new IllegalArgumentException(Strings.format("""
+                    No shard was specified in the request which means the response should explain a randomly-chosen unassigned shard, but \
+                    there are no unassigned shards in this cluster. To explain the allocation of an assigned shard you must specify the \
+                    target shard in the request. See %s for more information.""", ReferenceDocs.ALLOCATION_EXPLAIN_API));
             }
         } else {
             String index = request.getIndex();

--- a/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
+++ b/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
@@ -73,6 +73,7 @@ public enum ReferenceDocs {
     UNASSIGNED_SHARDS,
     EXECUTABLE_JNA_TMPDIR,
     NETWORK_THREADING_MODEL,
+    ALLOCATION_EXPLAIN_API,
     // this comment keeps the ';' on the next line so every entry above has a trailing ',' which makes the diff for adding new links cleaner
     ;
 

--- a/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
+++ b/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
@@ -33,5 +33,6 @@
   "CONTACT_SUPPORT": "troubleshooting.html#troubleshooting-contact-support",
   "UNASSIGNED_SHARDS": "red-yellow-cluster-status.html",
   "EXECUTABLE_JNA_TMPDIR": "executable-jna-tmpdir.html",
-  "NETWORK_THREADING_MODEL": "modules-network.html#modules-network-threading-model"
+  "NETWORK_THREADING_MODEL": "modules-network.html#modules-network-threading-model",
+  "ALLOCATION_EXPLAIN_API": "cluster-allocation-explain.html"
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainActionTests.java
@@ -188,7 +188,9 @@ public class ClusterAllocationExplainActionTests extends ESTestCase {
             allOf(
                 // no point in asserting the precise wording of the message into this test, but we care that it contains these bits:
                 containsString("No shard was specified in the request"),
-                containsString("specify the target shard in the request")
+                containsString("specify the target shard in the request"),
+                containsString("https://www.elastic.co/guide/en/elasticsearch/reference"),
+                containsString("cluster-allocation-explain.html")
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplanationTests.java
@@ -149,7 +149,9 @@ public final class ClusterAllocationExplanationTests extends ESTestCase {
             allOf(
                 // no point in asserting the precise wording of the message into this test, but we care that the note contains these bits:
                 containsString("No shard was specified in the explain API request"),
-                containsString("specify the target shard in the request")
+                containsString("specify the target shard in the request"),
+                containsString("https://www.elastic.co/guide/en/elasticsearch/reference"),
+                containsString("cluster-allocation-explain.html")
             )
         );
 


### PR DESCRIPTION
We say "specify the target shard in the request" but this doesn't in
itself help users work out how to do this. Linking to the docs should
help.